### PR TITLE
[ASTWalker] Continue post-walking with `Action::SkipChildren`

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -216,28 +216,27 @@ public:
       return {Continue(), std::move(node)};
     }
 
-    /// Continue the current walk, replacing the current node with \p node.
-    /// However, skip visiting the children of \p node, and instead resume the
-    /// walk of the parent node.
+    /// Skips visiting both the node's children and its post-visitation.
     template <typename T>
-    static _Detail::SkipChildrenIfWalkResult<T> SkipChildren(T node) {
-      return SkipChildrenIf(true, std::move(node));
+    static _Detail::SkipChildrenIfWalkResult<T>
+    SkipNode(T node) {
+      return SkipNodeIf(true, std::move(node));
     }
 
-    /// If \p cond is true, this is equivalent to \c Action::SkipChildren(node).
+    /// If \p cond is true, this is equivalent to \c Action::SkipNode(node).
     /// Otherwise, it is equivalent to \c Action::Continue(node).
     template <typename T>
     static _Detail::SkipChildrenIfWalkResult<T>
-    SkipChildrenIf(bool cond, T node) {
-      return {SkipChildrenIf(cond), std::move(node)};
+    SkipNodeIf(bool cond, T node) {
+      return {SkipNodeIf(cond), std::move(node)};
     }
 
     /// If \p cond is true, this is equivalent to \c Action::Continue(node).
-    /// Otherwise, it is equivalent to \c Action::SkipChildren(node).
+    /// Otherwise, it is equivalent to \c Action::SkipNode(node).
     template <typename T>
     static _Detail::SkipChildrenIfWalkResult<T>
-    VisitChildrenIf(bool cond, T node) {
-      return SkipChildrenIf(!cond, std::move(node));
+    VisitNodeIf(bool cond, T node) {
+      return SkipNodeIf(!cond, std::move(node));
     }
 
     /// If \p cond is true, this is equivalent to \c Action::Stop().
@@ -250,22 +249,23 @@ public:
     /// Continue the current walk.
     static _Detail::ContinueWalkAction Continue() { return {}; }
 
-    /// Continue the current walk, but do not visit the children of the current
-    /// node. Instead, resume at the parent's post-walk.
-    static _Detail::SkipChildrenIfWalkAction SkipChildren() {
-      return SkipChildrenIf(true);
+    /// Skips visiting both the node's children and its post-visitation.
+    static _Detail::SkipChildrenIfWalkAction SkipNode() {
+      return SkipNodeIf(true);
     }
 
-    /// If \p cond is true, this is equivalent to \c Action::SkipChildren().
+    /// If \p cond is true, this is equivalent to \c Action::SkipNode().
     /// Otherwise, it is equivalent to \c Action::Continue().
-    static _Detail::SkipChildrenIfWalkAction SkipChildrenIf(bool cond) {
+    static _Detail::SkipChildrenIfWalkAction
+    SkipNodeIf(bool cond) {
       return {cond};
     }
 
     /// If \p cond is true, this is equivalent to \c Action::Continue().
-    /// Otherwise, it is equivalent to \c Action::SkipChildren().
-    static _Detail::SkipChildrenIfWalkAction VisitChildrenIf(bool cond) {
-      return SkipChildrenIf(!cond);
+    /// Otherwise, it is equivalent to \c Action::SkipNode().
+    static _Detail::SkipChildrenIfWalkAction
+    VisitNodeIf(bool cond) {
+      return SkipNodeIf(!cond);
     }
 
     /// Terminate the walk, returning without visiting any other nodes.
@@ -281,14 +281,14 @@ public:
   /// A pre-visitation action for AST nodes that do not support being replaced
   /// while walking.
   struct PreWalkAction {
-    enum Kind { Stop, SkipChildren, Continue };
+    enum Kind { Stop, SkipNode, Continue };
     Kind Action;
 
     PreWalkAction(_Detail::ContinueWalkAction) : Action(Continue) {}
     PreWalkAction(_Detail::StopWalkAction) : Action(Stop) {}
 
     PreWalkAction(_Detail::SkipChildrenIfWalkAction action)
-        : Action(action.Cond ? SkipChildren : Continue) {}
+        : Action(action.Cond ? SkipNode : Continue) {}
 
     PreWalkAction(_Detail::StopIfWalkAction action)
         : Action(action.Cond ? Stop : Continue) {}

--- a/include/swift/AST/TypeWalker.h
+++ b/include/swift/AST/TypeWalker.h
@@ -22,7 +22,7 @@ class TypeWalker {
 public:
   enum class Action {
     Continue,
-    SkipChildren,
+    SkipNode,
     Stop
   };
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2685,12 +2685,12 @@ private:
 
     /// Ignore statements.
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
-      return Action::SkipChildren(stmt);
+      return Action::SkipNode(stmt);
     }
 
     /// Ignore declarations.
     PreWalkAction walkToDeclPre(Decl *decl) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
   };
 
@@ -6389,7 +6389,7 @@ public:
   PreWalkAction walkToDeclPre(Decl *D) override {
     // We only need to walk into PatternBindingDecls, other kinds of decls
     // cannot reference outer vars.
-    return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+    return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
   }
 
   ArrayRef<TypeVariableType *> getTypeVars() const {

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -2445,10 +2445,10 @@ class ConstExtractor: public ASTWalker {
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (E->isSemanticallyConstExpr()) {
       record(E, E);
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
     if (handleSimpleReference(E)) {
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
     return Action::Continue(E);
   }

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -115,47 +115,45 @@ public:
           scopeCreator
               .constructExpandAndInsert<ClosureParametersScope>(
                   parent, closure);
-          return Action::SkipChildren(E);
+          return Action::SkipNode(E);
         }
         if (auto *capture = dyn_cast<CaptureListExpr>(E)) {
           scopeCreator
               .constructExpandAndInsert<CaptureListScope>(
                   parent, capture);
-          return Action::SkipChildren(E);
+          return Action::SkipNode(E);
         }
 
         // If we have a single value statement expression, we need to add any
         // scopes in the underlying statement.
         if (auto *SVE = dyn_cast<SingleValueStmtExpr>(E)) {
           scopeCreator.addToScopeTree(SVE->getStmt(), parent);
-          return Action::SkipChildren(E);
+          return Action::SkipNode(E);
         }
 
         // If we have a try/try!/try?, we need to add a scope for it
         if (auto anyTry = dyn_cast<AnyTryExpr>(E)) {
           scopeCreator.constructExpandAndInsert<TryScope>(parent, anyTry);
-          return Action::SkipChildren(E);
+          return Action::SkipNode(E);
         }
 
         return Action::Continue(E);
       }
       PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
-        if (isa<BraceStmt>(S)) { // closures hidden in here
-          return Action::Continue(S);
-        }
-        return Action::SkipChildren(S);
+        // Closures can occur in BraceStmts.
+        return Action::VisitNodeIf(isa<BraceStmt>(S), S);
       }
       PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
-        return Action::SkipChildren(P);
+        return Action::SkipNode(P);
       }
       PreWalkAction walkToDeclPre(Decl *D) override {
-        return Action::SkipChildren();
+        return Action::SkipNode();
       }
       PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-        return Action::SkipChildren();
+        return Action::SkipNode();
       }
       PreWalkAction walkToParameterListPre(ParameterList *PL) override {
-        return Action::SkipChildren();
+        return Action::SkipNode();
       }
 
       MacroWalking getMacroWalkingBehavior() const override {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -125,7 +125,7 @@ ASTWalker::PreWalkResult<Expr *> dispatchVisitPreExprHelper(
     return ASTWalker::Action::Continue(node);
   }
   V.cleanup(node);
-  return ASTWalker::Action::SkipChildren(node);
+  return ASTWalker::Action::SkipNode(node);
 }
 
 template <typename Verifier, typename Kind>
@@ -141,7 +141,7 @@ ASTWalker::PreWalkResult<Expr *> dispatchVisitPreExprHelper(
     return ASTWalker::Action::Continue(node);
   }
   V.cleanup(node);
-  return ASTWalker::Action::SkipChildren(node);
+  return ASTWalker::Action::SkipNode(node);
 }
 
 template <typename Verifier, typename Kind>
@@ -157,7 +157,7 @@ ASTWalker::PreWalkResult<Expr *> dispatchVisitPreExprHelper(
     return ASTWalker::Action::Continue(node);
   }
   V.cleanup(node);
-  return ASTWalker::Action::SkipChildren(node);
+  return ASTWalker::Action::SkipNode(node);
 }
 
 template <typename Verifier, typename Kind>
@@ -170,7 +170,7 @@ ASTWalker::PreWalkResult<Expr *> dispatchVisitPreExprHelper(
     return ASTWalker::Action::Continue(node);
   }
   V.cleanup(node);
-  return ASTWalker::Action::SkipChildren(node);
+  return ASTWalker::Action::SkipNode(node);
 }
 
 namespace {
@@ -401,7 +401,7 @@ public:
       if (shouldVerify(node))
         return Action::Continue();
       cleanup(node);
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     /// Helper template for dispatching pre-visitation.
@@ -419,7 +419,7 @@ public:
       if (shouldVerify(node))
         return Action::Continue(node);
       cleanup(node);
-      return Action::SkipChildren(node);
+      return Action::SkipNode(node);
     }
 
     /// Helper template for dispatching pre-visitation.
@@ -430,7 +430,7 @@ public:
       if (shouldVerify(node))
         return Action::Continue(node);
       cleanup(node);
-      return Action::SkipChildren(node);
+      return Action::SkipNode(node);
     }
 
     /// Helper template for dispatching post-visitation.

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1457,11 +1457,13 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       return true;
     case PreWalkAction::SkipNode:
       return false;
+    case PreWalkAction::SkipChildren:
+      break;
     case PreWalkAction::Continue:
+      if (VisitChildren())
+        return true;
       break;
     }
-    if (VisitChildren())
-      return true;
     switch (WalkPost().Action) {
     case PostWalkAction::Stop:
       return true;
@@ -1476,21 +1478,25 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   T *traverse(PreWalkResult<T *> Pre,
               llvm::function_ref<T *(T *)> VisitChildren,
               llvm::function_ref<PostWalkResult<T *>(T *)> WalkPost) {
+    auto Node = Pre.Value;
+    assert(!Node || *Node && "Use Action::Stop instead of returning nullptr");
     switch (Pre.Action.Action) {
     case PreWalkAction::Stop:
       return nullptr;
     case PreWalkAction::SkipNode:
-      assert(*Pre.Value && "Use Action::Stop instead of returning nullptr");
-      return *Pre.Value;
-    case PreWalkAction::Continue:
+      return *Node;
+    case PreWalkAction::SkipChildren:
+      break;
+    case PreWalkAction::Continue: {
+      auto NewNode = VisitChildren(*Node);
+      if (!NewNode)
+        return nullptr;
+
+      Node = NewNode;
       break;
     }
-    assert(*Pre.Value && "Use Action::Stop instead of returning nullptr");
-    auto Value = VisitChildren(*Pre.Value);
-    if (!Value)
-      return nullptr;
-
-    auto Post = WalkPost(Value);
+    }
+    auto Post = WalkPost(*Node);
     switch (Post.Action.Action) {
     case PostWalkAction::Stop:
       return nullptr;

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1455,7 +1455,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     switch (Pre.Action) {
     case PreWalkAction::Stop:
       return true;
-    case PreWalkAction::SkipChildren:
+    case PreWalkAction::SkipNode:
       return false;
     case PreWalkAction::Continue:
       break;
@@ -1479,7 +1479,7 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
     switch (Pre.Action.Action) {
     case PreWalkAction::Stop:
       return nullptr;
-    case PreWalkAction::SkipChildren:
+    case PreWalkAction::SkipNode:
       assert(*Pre.Value && "Use Action::Stop instead of returning nullptr");
       return *Pre.Value;
     case PreWalkAction::Continue:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8645,11 +8645,11 @@ swift::findWrappedValuePlaceholder(Expr *init) {
 
     virtual PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (placeholder)
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       if (auto *value = dyn_cast<PropertyWrapperValuePlaceholderExpr>(E)) {
         placeholder = value;
-        return Action::SkipChildren(value);
+        return Action::SkipNode(value);
       }
 
       return Action::Continue(E);
@@ -9548,7 +9548,7 @@ AbstractFunctionDecl::getBodyFingerprintIncludingLocalTypeMembers() const {
 
     PreWalkAction walkToDeclPre(Decl *D) override {
       if (D->isImplicit())
-        return Action::SkipChildren();
+        return Action::SkipNode();
 
       if (auto *idc = dyn_cast<IterableDeclContext>(D)) {
         if (auto fp = idc->getBodyFingerprint())
@@ -9559,7 +9559,7 @@ AbstractFunctionDecl::getBodyFingerprintIncludingLocalTypeMembers() const {
         for (auto *d : idc->getParsedMembers())
           const_cast<Decl *>(d)->walk(*this);
 
-        return Action::SkipChildren();
+        return Action::SkipNode();
       }
 
       if (auto *afd = dyn_cast<AbstractFunctionDecl>(D)) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6269,7 +6269,7 @@ bool ClassDecl::walkSuperclasses(
     switch (fn(cls)) {
     case TypeWalker::Action::Stop:
       return true;
-    case TypeWalker::Action::SkipChildren:
+    case TypeWalker::Action::SkipNode:
       return false;
     case TypeWalker::Action::Continue:
       cls = cls->getSuperclassDecl();
@@ -6597,7 +6597,7 @@ bool ProtocolDecl::walkInheritedProtocols(
       }
       break;
 
-    case TypeWalker::Action::SkipChildren:
+    case TypeWalker::Action::SkipNode:
       break;
     }
   }

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -516,21 +516,21 @@ forEachImmediateChildExpr(llvm::function_ref<Expr *(Expr *)> callback) {
 
       // We're only interested in the immediate children, so don't walk any
       // further.
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
     
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
     }
 
     PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
-      return Action::SkipChildren(P);
+      return Action::SkipNode(P);
     }
     PreWalkAction walkToDeclPre(Decl *D) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
   };
   
@@ -562,17 +562,17 @@ void Expr::forEachChildExpr(llvm::function_ref<Expr *(Expr *)> callback) {
     }
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
     }
 
     PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
-      return Action::SkipChildren(P);
+      return Action::SkipNode(P);
     }
     PreWalkAction walkToDeclPre(Decl *D) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
   };
 

--- a/lib/AST/InlinableText.cpp
+++ b/lib/AST/InlinableText.cpp
@@ -69,7 +69,7 @@ public:
       }
     }
 
-    return Action::SkipChildrenIf(foundFeature, expr);
+    return Action::SkipNodeIf(foundFeature, expr);
   }
 };
 
@@ -145,13 +145,13 @@ struct ExtractInactiveRanges : public ASTWalker {
     // If there's no active clause, add the entire #if...#endif block.
     if (!clause) {
       addRange(start, end);
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     // If the clause is checking for a particular feature with $ or a compiler
     // version, keep the whole thing.
     if (anyClauseIsFeatureCheck(icd->getClauses())) {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     // Ignore range from beginning of '#if', '#elseif', or '#else' to the
@@ -174,7 +174,7 @@ struct ExtractInactiveRanges : public ASTWalker {
       if (elt.isDecl(DeclKind::IfConfig))
         elt.get<Decl *>()->walk(*this);
 
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 
   /// Gets the ignored ranges in source order.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3664,7 +3664,7 @@ public:
     default:
       break;
     }
-    return PreWalkAction::Continue;
+    return Action::Continue();
   }
 };
 } // namespace

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3364,27 +3364,27 @@ CollectedOpaqueReprs swift::collectOpaqueTypeReprs(TypeRepr *r, ASTContext &ctx,
 
       // Don't allow variadic opaque parameter or return types.
       if (isa<PackExpansionTypeRepr>(repr) || isa<VarargTypeRepr>(repr))
-        return Action::SkipChildren();
+        return Action::SkipNode();
 
       if (auto opaqueRepr = dyn_cast<OpaqueReturnTypeRepr>(repr)) {
         Reprs.push_back(opaqueRepr);
         if (Ctx.LangOpts.hasFeature(Feature::ImplicitSome))
-          return Action::SkipChildren();
+          return Action::SkipNode();
       }
 
       if (!Ctx.LangOpts.hasFeature(Feature::ImplicitSome))
         return Action::Continue();
       
       if (auto existential = dyn_cast<ExistentialTypeRepr>(repr)) {
-        return Action::SkipChildren();
+        return Action::SkipNode();
       } else if (auto composition = dyn_cast<CompositionTypeRepr>(repr)) {
         if (!composition->isTypeReprAny())
           Reprs.push_back(composition);
-        return Action::SkipChildren();
+        return Action::SkipNode();
       } else if (auto generic = dyn_cast<GenericIdentTypeRepr>(repr)) {
         if (generic->isProtocolOrProtocolComposition(dc)){
           Reprs.push_back(generic);
-          return Action::SkipChildren();
+          return Action::SkipNode();
         }
         return Action::Continue();
       } else if (auto declRef = dyn_cast<DeclRefTypeRepr>(repr)) {

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -109,7 +109,7 @@ struct PackReferenceCollector: TypeWalker {
       for (auto type : boundGenericType->getExpandedGenericArgs())
         type.walk(*this);
 
-      return Action::SkipChildren;
+      return Action::SkipNode;
     }
 
     if (auto *typeAliasType = dyn_cast<TypeAliasType>(t.getPointer())) {
@@ -120,7 +120,7 @@ struct PackReferenceCollector: TypeWalker {
         for (auto type : typeAliasType->getExpandedGenericArgs())
           type.walk(*this);
 
-        return Action::SkipChildren;
+        return Action::SkipNode;
       }
     }
 

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -211,23 +211,23 @@ namespace {
     // that is, don't walk into a closure body.
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (isa<ClosureExpr>(E)) {
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
       return Action::Continue(E);
     }
 
     // Don't walk into anything else.
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
     }
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
     PreWalkAction walkToParameterListPre(ParameterList *PL) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
     PreWalkAction walkToDeclPre(Decl *D) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
   };
 } // end anonymous namespace

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -305,7 +305,7 @@ bool RequirementMachine::isReducedType(Type type) const {
 
     Action walkToTypePre(Type component) override {
       if (!component->hasTypeParameter())
-        return Action::SkipChildren;
+        return Action::SkipNode;
 
       if (!component->isTypeParameter())
         return Action::Continue;
@@ -327,7 +327,7 @@ bool RequirementMachine::isReducedType(Type type) const {
 
       // The parent of a reduced type parameter might be non-reduced
       // because it is concrete.
-      return Action::SkipChildren;
+      return Action::SkipNode;
     }
   };
 

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -536,7 +536,7 @@ struct InferRequirementsWalker : public TypeWalker {
       return Action::Stop;
 
     if (!ty->hasTypeParameter())
-      return Action::SkipChildren;
+      return Action::SkipNode;
 
     return Action::Continue;
   }

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -262,7 +262,7 @@ ASTNode BraceStmt::findAsyncNode() {
 
       // Do not recurse into other closures.
       if (isa<ClosureExpr>(expr))
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
 
       return Action::Continue(expr);
     }
@@ -276,7 +276,7 @@ ASTNode BraceStmt::findAsyncNode() {
         return Action::Continue();
       }
 
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
@@ -818,17 +818,17 @@ struct FallthroughFinder : ASTWalker {
   // Expressions, patterns and decls cannot contain fallthrough statements, so
   // there is no reason to walk into them.
   PreWalkResult<Expr *> walkToExprPre(Expr *e) override {
-    return Action::SkipChildren(e);
+    return Action::SkipNode(e);
   }
   PreWalkResult<Pattern *> walkToPatternPre(Pattern *p) override {
-    return Action::SkipChildren(p);
+    return Action::SkipNode(p);
   }
 
   PreWalkAction walkToDeclPre(Decl *d) override {
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
   PreWalkAction walkToTypeReprPre(TypeRepr *t) override {
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 
   static FallthroughStmt *findFallthrough(Stmt *s) {

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -283,7 +283,7 @@ public:
     switch (Walker.walkToTypePre(ty)) {
     case TypeWalker::Action::Continue:
       break;
-    case TypeWalker::Action::SkipChildren:
+    case TypeWalker::Action::SkipNode:
       return false;
     case TypeWalker::Action::Stop:
       return true;
@@ -297,7 +297,7 @@ public:
     switch (Walker.walkToTypePost(ty)) {
     case TypeWalker::Action::Continue:
       return false;
-    case TypeWalker::Action::SkipChildren:
+    case TypeWalker::Action::SkipNode:
       llvm_unreachable("SkipChildren is not valid for a post-visit check");
     case TypeWalker::Action::Stop:
       return true;

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -693,7 +693,7 @@ public:
       proto->walkInheritedProtocols(
           [&](ProtocolDecl *inherited) -> TypeWalker::Action {
         if (!handledProtocols.insert(inherited).second)
-          return TypeWalker::Action::SkipChildren;
+          return TypeWalker::Action::SkipNode;
 
         // If 'nominal' is an actor, we do not synthesize its conformance
         // to the Actor protocol through a dummy extension.
@@ -702,14 +702,14 @@ public:
         // not extensions of that 'actor'.
         if (actorClass &&
             inherited->isSpecificProtocol(KnownProtocolKind::Actor))
-          return TypeWalker::Action::SkipChildren;
+          return TypeWalker::Action::SkipNode;
 
         // Do not synthesize an extension to print a conformance to an
         // invertible protocol, as their conformances are always re-inferred
         // using the interface itself.
         if (auto kp = inherited->getKnownProtocolKind())
           if (getInvertibleProtocolKind(*kp))
-            return TypeWalker::Action::SkipChildren;
+            return TypeWalker::Action::SkipNode;
 
         if (inherited->isSPI() && printOptions.printPublicInterface())
           return TypeWalker::Action::Continue;
@@ -721,7 +721,7 @@ public:
               inherited, availability, isUnchecked, otherAttrs);
           printSynthesizedExtension(out, extensionPrintOptions, M, nominal,
                                     protoAndAvailability);
-          return TypeWalker::Action::SkipChildren;
+          return TypeWalker::Action::SkipNode;
         }
 
         return TypeWalker::Action::Continue;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -202,14 +202,14 @@ bool swift::ide::canDeclContextHandleAsync(const DeclContext *DC) {
 
       PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
         if (E == Target)
-          return Action::SkipChildren(E);
+          return Action::SkipNode(E);
 
         if (auto conversionExpr = dyn_cast<FunctionConversionExpr>(E)) {
           if (conversionExpr->getSubExpr() == Target) {
             if (conversionExpr->getType()->is<AnyFunctionType>() &&
                 conversionExpr->getType()->castTo<AnyFunctionType>()->isAsync())
               Result = true;
-            return Action::SkipChildren(E);
+            return Action::SkipNode(E);
           }
         }
         return Action::Continue(E);
@@ -3388,7 +3388,7 @@ void CompletionLookup::getStmtLabelCompletions(SourceLoc Loc, bool isContinue) {
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (SM.isBeforeInBuffer(S->getEndLoc(), TargetLoc))
-        return Action::SkipChildren(S);
+        return Action::SkipNode(S);
 
       if (LabeledStmt *LS = dyn_cast<LabeledStmt>(S)) {
         if (LS->getLabelInfo()) {
@@ -3409,7 +3409,7 @@ void CompletionLookup::getStmtLabelCompletions(SourceLoc Loc, bool isContinue) {
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (SM.isBeforeInBuffer(E->getEndLoc(), TargetLoc))
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       return Action::Continue(E);
     }
   } Finder(CurrDeclContext->getASTContext().SourceMgr, Loc, isContinue);

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -175,7 +175,7 @@ private:
 
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (!rangeContainsLocToResolve(D->getSourceRangeIncludingAttrs())) {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     if (auto *newDC = dyn_cast<DeclContext>(D)) {

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -175,7 +175,7 @@ private:
 
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (!rangeContainsLocToResolve(D->getSourceRangeIncludingAttrs())) {
-      return PreWalkAction::SkipChildren;
+      return Action::SkipChildren();
     }
 
     if (auto *newDC = dyn_cast<DeclContext>(D)) {

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -129,19 +129,19 @@ public:
       FoundExpr = E;
       return Action::Stop();
     }
-    return Action::VisitChildrenIf(isInterstingRange(E), E);
+    return Action::VisitNodeIf(isInterstingRange(E), E);
   }
 
   PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
-    return Action::VisitChildrenIf(isInterstingRange(P), P);
+    return Action::VisitNodeIf(isInterstingRange(P), P);
   }
 
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
-    return Action::VisitChildrenIf(isInterstingRange(S), S);
+    return Action::VisitNodeIf(isInterstingRange(S), S);
   }
 
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 };
 } // anonymous namespace

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -481,7 +481,7 @@ private:
 
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (!walkCustomAttributes(D))
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     if (D->isImplicit())
       return Action::Continue();
@@ -492,7 +492,7 @@ private:
         for (auto Member : Clause.Elements)
           Member.walk(*this);
       }
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     SourceLoc ContextLoc = D->getStartLoc();
@@ -1362,7 +1362,7 @@ private:
 
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (!walkCustomAttributes(D))
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     auto Action = HandlePre(D, D->isImplicit());
     if (Action.shouldGenerateIndentContext()) {
@@ -1402,10 +1402,10 @@ private:
             Member.walk(*this);
         }
       }
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
-    return Action::VisitChildrenIf(Action.shouldVisitChildren());
+    return Action::VisitNodeIf(Action.shouldVisitChildren());
   }
 
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
@@ -1414,7 +1414,7 @@ private:
       if (auto IndentCtx = getIndentContextFrom(S, Action.Trailing))
         InnermostCtx = IndentCtx;
     }
-    return Action::VisitChildrenIf(Action.shouldVisitChildren(), S);
+    return Action::VisitNodeIf(Action.shouldVisitChildren(), S);
   }
 
   PreWalkResult<ArgumentList *>
@@ -1433,7 +1433,7 @@ private:
       if (auto Ctx = getIndentContextFrom(Args, Action.Trailing, ContextLoc))
         InnermostCtx = Ctx;
     }
-    return Action::VisitChildrenIf(Action.shouldVisitChildren(), Args);
+    return Action::VisitNodeIf(Action.shouldVisitChildren(), Args);
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -1491,7 +1491,7 @@ private:
           StringLiteralRange =
               Lexer::getCharSourceRangeFromSourceRange(SM, E->getSourceRange());
 
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
     }
 
@@ -1502,11 +1502,11 @@ private:
           llvm::SaveAndRestore<ASTWalker::ParentTy>(Parent, EE);
           OE->walk(*this);
         }
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
     }
 
-    return Action::VisitChildrenIf(Action.shouldVisitChildren(), E);
+    return Action::VisitNodeIf(Action.shouldVisitChildren(), E);
   }
 
   PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
@@ -1515,7 +1515,7 @@ private:
       if (auto IndentCtx = getIndentContextFrom(P, Action.Trailing))
         InnermostCtx = IndentCtx;
     }
-    return Action::VisitChildrenIf(Action.shouldVisitChildren(), P);
+    return Action::VisitNodeIf(Action.shouldVisitChildren(), P);
   }
 
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
@@ -1524,7 +1524,7 @@ private:
       if (auto IndentCtx = getIndentContextFrom(T, Action.Trailing))
         InnermostCtx = IndentCtx;
     }
-    return Action::VisitChildrenIf(Action.shouldVisitChildren());
+    return Action::VisitNodeIf(Action.shouldVisitChildren());
   }
 
   PostWalkAction walkToDeclPost(Decl *D) override {

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -1405,6 +1405,9 @@ private:
       return Action::SkipNode();
     }
 
+    // FIXME: We ought to be able to use Action::VisitChildrenIf here, but we'd
+    // need to ensure the AST is walked in source order (currently not the case
+    // for things like postfix operators).
     return Action::VisitNodeIf(Action.shouldVisitChildren());
   }
 
@@ -1414,6 +1417,9 @@ private:
       if (auto IndentCtx = getIndentContextFrom(S, Action.Trailing))
         InnermostCtx = IndentCtx;
     }
+    // FIXME: We ought to be able to use Action::VisitChildrenIf here, but we'd
+    // need to ensure the AST is walked in source order (currently not the case
+    // for things like postfix operators).
     return Action::VisitNodeIf(Action.shouldVisitChildren(), S);
   }
 
@@ -1433,6 +1439,9 @@ private:
       if (auto Ctx = getIndentContextFrom(Args, Action.Trailing, ContextLoc))
         InnermostCtx = Ctx;
     }
+    // FIXME: We ought to be able to use Action::VisitChildrenIf here, but we'd
+    // need to ensure the AST is walked in source order (currently not the case
+    // for things like postfix operators).
     return Action::VisitNodeIf(Action.shouldVisitChildren(), Args);
   }
 
@@ -1506,6 +1515,9 @@ private:
       }
     }
 
+    // FIXME: We ought to be able to use Action::VisitChildrenIf here, but we'd
+    // need to ensure the AST is walked in source order (currently not the case
+    // for things like postfix operators).
     return Action::VisitNodeIf(Action.shouldVisitChildren(), E);
   }
 
@@ -1515,6 +1527,9 @@ private:
       if (auto IndentCtx = getIndentContextFrom(P, Action.Trailing))
         InnermostCtx = IndentCtx;
     }
+    // FIXME: We ought to be able to use Action::VisitChildrenIf here, but we'd
+    // need to ensure the AST is walked in source order (currently not the case
+    // for things like postfix operators).
     return Action::VisitNodeIf(Action.shouldVisitChildren(), P);
   }
 
@@ -1524,6 +1539,9 @@ private:
       if (auto IndentCtx = getIndentContextFrom(T, Action.Trailing))
         InnermostCtx = IndentCtx;
     }
+    // FIXME: We ought to be able to use Action::VisitChildrenIf here, but we'd
+    // need to ensure the AST is walked in source order (currently not the case
+    // for things like postfix operators).
     return Action::VisitNodeIf(Action.shouldVisitChildren());
   }
 

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -350,7 +350,7 @@ public:
     // include its attribute ranges (because attributes are part of PBD.)
     if (!isa<VarDecl>(D) &&
         !rangeContainsLocToResolve(D->getSourceRangeIncludingAttrs())) {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     // Check the attributes.
@@ -380,7 +380,7 @@ public:
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (!rangeContainsLocToResolve(E->getSourceRange())) {
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
 
     // Check 'MacroExpansionExpr'.
@@ -398,26 +398,26 @@ public:
 
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (!rangeContainsLocToResolve(S->getSourceRange())) {
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
     }
     return Action::Continue(S);
   }
   PreWalkResult<ArgumentList *>
   walkToArgumentListPre(ArgumentList *AL) override {
     if (!rangeContainsLocToResolve(AL->getSourceRange())) {
-      return Action::SkipChildren(AL);
+      return Action::SkipNode(AL);
     }
     return Action::Continue(AL);
   }
   PreWalkAction walkToParameterListPre(ParameterList *PL) override {
     if (!rangeContainsLocToResolve(PL->getSourceRange())) {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
     return Action::Continue();
   }
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     // TypeRepr cannot have macro expansions in it.
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 };
 } // namespace

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1401,7 +1401,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
 	}
       }
       // We only handle top-level expressions, so avoid visiting further.
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
     }
   };
 

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -61,7 +61,7 @@ class ReferencedTypeFinder : public TypeDeclFinder {
 
   Action visitNominalType(NominalType *nominal) override {
     Callback(*this, nominal->getDecl());
-    return Action::SkipChildren;
+    return Action::SkipNode;
   }
 
   Action visitTypeAliasType(TypeAliasType *aliasTy) override {
@@ -71,7 +71,7 @@ class ReferencedTypeFinder : public TypeDeclFinder {
     } else {
       Type(aliasTy->getSinglyDesugaredType()).walk(*this);
     }
-    return Action::SkipChildren;
+    return Action::SkipNode;
   }
 
   /// Returns true if \p paramTy has any constraints other than being
@@ -103,7 +103,7 @@ class ReferencedTypeFinder : public TypeDeclFinder {
       argTy.walk(*this);
       NeedsDefinition = false;
     });
-    return Action::SkipChildren;
+    return Action::SkipNode;
   }
 
 public:

--- a/lib/Refactoring/AddExplicitCodableImplementation.cpp
+++ b/lib/Refactoring/AddExplicitCodableImplementation.cpp
@@ -89,7 +89,7 @@ public:
   PreWalkAction walkToDeclPre(Decl *D) override {
     auto *VD = dyn_cast<ValueDecl>(D);
     if (!VD)
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     if (!VD->isSynthesized()) {
       return Action::Continue();
@@ -102,7 +102,7 @@ public:
         isa<EnumDecl>(VD) || name == "init(from:)" || name == "encode(to:)";
     if (!shouldPrint) {
       // Some other synthesized decl that we don't want to print.
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     Printer.printNewline();
@@ -122,7 +122,7 @@ public:
       }
       Printer.printNewline();
       Printer << "}";
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     PrintOptions Options;
@@ -136,7 +136,7 @@ public:
     Printer.printNewline();
     D->print(Printer, Options);
 
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 };
 

--- a/lib/Refactoring/Async/CallbackClassifier.cpp
+++ b/lib/Refactoring/Async/CallbackClassifier.cpp
@@ -127,7 +127,7 @@ bool CallbackClassifier::hasForceUnwrappedErrorParam(ArrayRef<ASTNode> Nodes) {
       // Don't walk into ternary conditionals as they may have additional
       // conditions such as err != nil that make a force unwrap now valid.
       if (isa<TernaryExpr>(E))
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       auto *FVE = dyn_cast<ForceValueExpr>(E);
       if (!FVE)
@@ -150,13 +150,13 @@ bool CallbackClassifier::hasForceUnwrappedErrorParam(ArrayRef<ASTNode> Nodes) {
       // Don't walk into new explicit scopes, we only want to consider force
       // unwraps in the immediate conditional body.
       if (!S->isImplicit() && startsNewScope(S))
-        return Action::SkipChildren(S);
+        return Action::SkipNode(S);
       return Action::Continue(S);
     }
 
     PreWalkAction walkToDeclPre(Decl *D) override {
       // Don't walk into new explicit DeclContexts.
-      return Action::VisitChildrenIf(D->isImplicit() || !isa<DeclContext>(D));
+      return Action::VisitNodeIf(D->isImplicit() || !isa<DeclContext>(D));
     }
   };
   for (auto Node : Nodes) {

--- a/lib/Refactoring/SimplifyNumberLiteral.cpp
+++ b/lib/Refactoring/SimplifyNumberLiteral.cpp
@@ -45,7 +45,7 @@ static NumberLiteralExpr *getTrailingNumberLiteral(ResolvedCursorInfoPtr Tok) {
           found = literal;
         }
       }
-      return Action::SkipChildrenIf(found, expr);
+      return Action::SkipNodeIf(found, expr);
     }
   };
 

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -216,7 +216,7 @@ visitFunctionDecl(ASTWalker &Walker, AbstractFunctionDecl *AFD, F Func) {
     Func();
     return ASTWalker::Action::Continue();
   }
-  return ASTWalker::Action::SkipChildren();
+  return ASTWalker::Action::SkipNode();
 }
 
 /// Whether to walk the children of a given expression.
@@ -232,7 +232,7 @@ shouldWalkIntoExpr(Expr *E, ASTWalker::ParentTy Parent, SILDeclRef Constant) {
     // SILDeclRef is not for a closure, as it could be for a property
     // initializer instead.
     if (!Parent.isNull() || !Constant || !Constant.getAbstractClosureExpr())
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
   }
   return Action::Continue(E);
 }
@@ -328,7 +328,7 @@ struct MapRegionCounters : public ASTWalker {
       mapRegion(TLCD->getBody());
       return Action::Continue();
     }
-    return Action::VisitChildrenIf(shouldWalkIntoUnhandledDecl(D));
+    return Action::VisitNodeIf(shouldWalkIntoUnhandledDecl(D));
   }
 
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
@@ -352,7 +352,7 @@ struct MapRegionCounters : public ASTWalker {
     // We don't walk into parameter lists. Default arguments should be visited
     // directly.
     // FIXME: We don't yet profile default argument generators at all.
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -374,7 +374,7 @@ struct MapRegionCounters : public ASTWalker {
       mapRegion(E);
 
     auto WalkResult = shouldWalkIntoExpr(E, Parent, Constant);
-    if (WalkResult.Action.Action == PreWalkAction::SkipChildren) {
+    if (WalkResult.Action.Action == PreWalkAction::SkipNode) {
       // We need to manually do the post-visit here since the ASTWalker will
       // skip it.
       // FIXME: The ASTWalker should do a post-visit.
@@ -690,7 +690,7 @@ struct PGOMapping : public ASTWalker {
       setKnownExecutionCount(TLCD->getBody());
       return Action::Continue();
     }
-    return Action::VisitChildrenIf(shouldWalkIntoUnhandledDecl(D));
+    return Action::VisitNodeIf(shouldWalkIntoUnhandledDecl(D));
   }
 
   LazyInitializerWalking getLazyInitializerWalkingBehavior() override {
@@ -761,7 +761,7 @@ struct PGOMapping : public ASTWalker {
     // We don't walk into parameter lists. Default arguments should be visited
     // directly.
     // FIXME: We don't yet profile default argument generators at all.
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -796,7 +796,7 @@ struct PGOMapping : public ASTWalker {
       setKnownExecutionCount(E);
 
     auto WalkResult = shouldWalkIntoExpr(E, Parent, Constant);
-    if (WalkResult.Action.Action == PreWalkAction::SkipChildren) {
+    if (WalkResult.Action.Action == PreWalkAction::SkipNode) {
       // We need to manually do the post-visit here since the ASTWalker will
       // skip it.
       // FIXME: The ASTWalker should do a post-visit.
@@ -1202,7 +1202,7 @@ public:
       ImplicitTopLevelBody = TLCD->getBody();
       return Action::Continue();
     }
-    return Action::VisitChildrenIf(shouldWalkIntoUnhandledDecl(D));
+    return Action::VisitNodeIf(shouldWalkIntoUnhandledDecl(D));
   }
 
   PostWalkAction walkToDeclPost(Decl *D) override {
@@ -1328,7 +1328,7 @@ public:
       // Already visited the children.
       // FIXME: The ASTWalker should do a post-walk for SkipChildren.
       walkToStmtPost(S);
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
 
     } else if (auto *GS = dyn_cast<GuardStmt>(S)) {
       assignCounter(GS, CounterExpr::Zero());
@@ -1488,7 +1488,7 @@ public:
     // benefit in these cases, as they're unlikely to have side effects, and
     // the values can be exercized explicitly, but we should probably at least
     // have a consistent behavior for both no matter what we choose here.
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -1551,10 +1551,10 @@ public:
       // Already visited the children.
       // FIXME: The ASTWalker should do a post-walk for SkipChildren.
       walkToExprPost(TE);
-      return Action::SkipChildren(TE);
+      return Action::SkipNode(TE);
     }
     auto WalkResult = shouldWalkIntoExpr(E, Parent, Constant);
-    if (WalkResult.Action.Action == PreWalkAction::SkipChildren) {
+    if (WalkResult.Action.Action == PreWalkAction::SkipNode) {
       // We need to manually do the post-visit here since the ASTWalker will
       // skip it.
       // FIXME: The ASTWalker should do a post-visit.

--- a/lib/SILGen/SILGenPack.cpp
+++ b/lib/SILGen/SILGenPack.cpp
@@ -258,7 +258,7 @@ struct MaterializePackEmitter : public ASTWalker {
 
     // Don't walk into nested pack expansions.
     if (isa<PackExpansionExpr>(expr))
-      return Action::SkipChildren(expr);
+      return Action::SkipNode(expr);
 
     if (auto *packExpr = dyn_cast<MaterializePackExpr>(expr)) {
       auto *fromExpr = packExpr->getFromExpr();

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1193,7 +1193,7 @@ struct TypeReprCycleCheckWalker : ASTWalker {
         }
       }
 
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     return Action::Continue();

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -4400,7 +4400,7 @@ ReferencedAssociatedTypesRequest::evaluate(Evaluator &eval,
             assocTypes.push_back(assocType);
         }
 
-        return Action::SkipChildren;
+        return Action::SkipNode;
       }
 
       return Action::Continue;

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1297,7 +1297,7 @@ public:
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (SkipPrecheck)
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
 
     // Pre-check the expression.  If this fails, abort the walk immediately.
     // Otherwise, replace the expression with the result of pre-checking.
@@ -1323,7 +1323,7 @@ public:
       if (HasError)
         return Action::Stop();
 
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
   }
 
@@ -1332,7 +1332,7 @@ public:
     if (auto returnStmt = dyn_cast<ReturnStmt>(S)) {
       if (!returnStmt->isImplicit()) {
         ReturnStmts.push_back(returnStmt);
-        return Action::SkipChildren(S);
+        return Action::SkipNode(S);
       }
     }
 
@@ -1365,7 +1365,7 @@ public:
 
   /// Ignore patterns.
   PreWalkResult<Pattern *> walkToPatternPre(Pattern *pat) override {
-    return Action::SkipChildren(pat);
+    return Action::SkipNode(pat);
   }
 };
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8570,12 +8570,12 @@ namespace {
 
     /// Ignore statements.
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
-      return Action::SkipChildren(stmt);
+      return Action::SkipNode(stmt);
     }
 
     /// Ignore declarations.
     PreWalkAction walkToDeclPre(Decl *decl) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
   };
 
@@ -8651,20 +8651,20 @@ namespace {
         rewriteFunction(closure);
 
         if (AnyFunctionRef(closure).hasExternalPropertyWrapperParameters()) {
-          return Action::SkipChildren(rewriteClosure(closure));
+          return Action::SkipNode(rewriteClosure(closure));
         }
 
-        return Action::SkipChildren(closure);
+        return Action::SkipNode(closure);
       }
 
       if (auto *SVE = dyn_cast<SingleValueStmtExpr>(expr)) {
         rewriteSingleValueStmtExpr(SVE);
-        return Action::SkipChildren(SVE);
+        return Action::SkipNode(SVE);
       }
 
       if (auto tap = dyn_cast_or_null<TapExpr>(expr)) {
         rewriteTapExpr(tap);
-        return Action::SkipChildren(tap);
+        return Action::SkipNode(tap);
       }
 
       if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {
@@ -8688,12 +8688,12 @@ namespace {
 
     /// Ignore statements.
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
-      return Action::SkipChildren(stmt);
+      return Action::SkipNode(stmt);
     }
 
     /// Ignore declarations.
     PreWalkAction walkToDeclPre(Decl *decl) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     NullablePtr<Pattern>
@@ -9209,7 +9209,7 @@ static llvm::Optional<SequenceIterationInfo> applySolutionToForEachStmt(
                   C, /*tryLoc=*/call->getStartLoc(), call, call->getType());
               // Cannot stop here because we need to make sure that
               // the new expression gets injected into AST.
-              return Action::SkipChildren(tryExpr);
+              return Action::SkipNode(tryExpr);
             }
           }
 
@@ -9291,7 +9291,7 @@ static llvm::Optional<PackIterationInfo> applySolutionToForEachStmt(
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (isa<ForEachStmt>(S)) {
-        return Action::SkipChildren(S);
+        return Action::SkipNode(S);
       }
       return Action::Continue(S);
     }
@@ -9301,10 +9301,10 @@ static llvm::Optional<PackIterationInfo> applySolutionToForEachStmt(
         decl->setOpenedElementEnvironment(Environment);
       }
       if (isa<AbstractFunctionDecl>(D)) {
-        return Action::SkipChildren();
+        return Action::SkipNode();
       }
       if (isa<NominalTypeDecl>(D)) {
-        return Action::SkipChildren();
+        return Action::SkipNode();
       }
       return Action::Continue();
     }

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1072,7 +1072,7 @@ findInferableTypeVars(Type type,
 
     Action walkToTypePre(Type ty) override {
       if (ty->is<DependentMemberType>())
-        return Action::SkipChildren;
+        return Action::SkipNode;
 
       if (auto typeVar = ty->getAs<TypeVariableType>())
         typeVars.insert(typeVar);

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1151,7 +1151,7 @@ bool AttributedFuncToTypeConversionFailure::
   class TopLevelFuncReprFinder : public ASTWalker {
     PreWalkAction walkToTypeReprPre(TypeRepr *TR) override {
       FnRepr = dyn_cast<FunctionTypeRepr>(TR);
-      return Action::VisitChildrenIf(FnRepr == nullptr);
+      return Action::VisitNodeIf(FnRepr == nullptr);
     }
 
     /// Walk macro arguments.
@@ -6801,7 +6801,7 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
       if (Params.empty())
-        return Action::SkipChildren();
+        return Action::SkipNode();
 
       auto *ident = dyn_cast<IdentTypeRepr>(T);
       if (!ident)

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -124,11 +124,7 @@ namespace {
       
       return Action::Continue(expr);
     }
-    
-    PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
-      return Action::Continue(expr);
-    }
-    
+
     /// Ignore statements.
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
       return Action::SkipChildren(stmt);
@@ -848,11 +844,6 @@ namespace {
 
       return Action::Continue(expr);
     }
-    
-    PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
-      return Action::Continue(expr);
-    }
-    
     /// Ignore statements.
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {
       return Action::SkipChildren(stmt);

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1076,32 +1076,32 @@ void ConstraintSystem::shrink(Expr *expr) {
                             CS.getContextualType(expr, /*forConstraint=*/false),
                             CS.getContextualTypePurpose(expr));
         // Don't try to walk into the dictionary.
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
       }
 
       // Let's not attempt to type-check closures or expressions
       // which constrain closures, because they require special handling
       // when dealing with context and parameters declarations.
       if (isa<ClosureExpr>(expr)) {
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
       }
 
       // Similar to 'ClosureExpr', 'TapExpr' has a 'VarDecl' the type of which
       // is determined by type checking the parent interpolated string literal.
       if (isa<TapExpr>(expr)) {
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
       }
 
       // Same as TapExpr and ClosureExpr, we'll handle SingleValueStmtExprs
       // separately.
       if (isa<SingleValueStmtExpr>(expr))
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
 
       if (auto coerceExpr = dyn_cast<CoerceExpr>(expr)) {
         if (coerceExpr->isLiteralInit())
           ApplyExprs.push_back({coerceExpr, 1});
         visitCoerceExpr(coerceExpr);
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
       }
 
       if (auto OSR = dyn_cast<OverloadSetRefExpr>(expr)) {

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -181,7 +181,7 @@ public:
   PreWalkAction walkToDeclPre(Decl *D) override {
     /// Decls get type-checked separately, except for PatternBindingDecls,
     /// whose initializers we want to walk into.
-    return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+    return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
   }
 
 private:

--- a/lib/Sema/CompletionContextFinder.cpp
+++ b/lib/Sema/CompletionContextFinder.cpp
@@ -68,7 +68,7 @@ CompletionContextFinder::walkToExprPre(Expr *E) {
     }
     // Code completion in key paths is modelled by a code completion component
     // Don't walk the key path's parsed expressions.
-    return Action::SkipChildren(E);
+    return Action::SkipNode(E);
   }
 
   return Action::Continue(E);

--- a/lib/Sema/ConstantnessSemaDiagnostics.cpp
+++ b/lib/Sema/ConstantnessSemaDiagnostics.cpp
@@ -354,7 +354,7 @@ void swift::diagnoseConstantArgumentRequirement(
       }
 
       if (!expr || isa<ErrorExpr>(expr) || !expr->getType())
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
       if (auto *callExpr = dyn_cast<CallExpr>(expr)) {
         diagnoseConstantArgumentRequirementOfCall(callExpr, DC->getASTContext());
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -887,7 +887,7 @@ static void extendDepthMap(
           llvm::SaveAndRestore<ParentTy> SavedParent(Parent, Closures.back());
           auto E = RS->getResult();
           E->walk(*this);
-          return Action::SkipChildren(S);
+          return Action::SkipNode(S);
         }
       }
 
@@ -3278,19 +3278,19 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
 
       // Don't walk into a 'try!' or 'try?'.
       if (isa<ForceTryExpr>(expr) || isa<OptionalTryExpr>(expr)) {
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
       }
 
       // Do not recurse into other closures.
       if (isa<ClosureExpr>(expr))
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
 
       return Action::Continue(expr);
     }
 
     PreWalkAction walkToDeclPre(Decl *decl) override {
       // Do not walk into function or type declarations.
-      return Action::VisitChildrenIf(isa<PatternBindingDecl>(decl));
+      return Action::VisitNodeIf(isa<PatternBindingDecl>(decl));
     }
 
     bool isSyntacticallyExhaustive(DoCatchStmt *stmt) {
@@ -3400,7 +3400,7 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
         }
 
         // We've already walked all the children we care about.
-        return Action::SkipChildren(stmt);
+        return Action::SkipNode(stmt);
       }
 
       if (auto forEach = dyn_cast<ForEachStmt>(stmt)) {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7275,16 +7275,16 @@ static bool doesMemberHaveUnfulfillableConstraintsWithExistentialBase(
       }
 
       if (ty->getRootGenericParam()->getDepth() > 0) {
-        return Action::SkipChildren;
+        return Action::SkipNode;
       }
 
       if (!Sig->isValidTypeParameter(ty)) {
-        return Action::SkipChildren;
+        return Action::SkipNode;
       }
 
       const auto concreteTy = Sig->getConcreteType(ty);
       if (concreteTy && !concreteTy->hasTypeParameter()) {
-        return Action::SkipChildren;
+        return Action::SkipNode;
       }
 
       return Action::Stop;

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -83,18 +83,18 @@ public:
     // Skip implicit decls, because the debugger isn't used to step through
     // these.
     if (D->isImplicit())
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     // Whitelist the kinds of decls to transform.
     // TODO: Expand the set of decls visited here.
     if (auto *FD = dyn_cast<AbstractFunctionDecl>(D))
-      return Action::VisitChildrenIf(FD->getTypecheckedBody());
+      return Action::VisitNodeIf(FD->getTypecheckedBody());
     if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
-      return Action::VisitChildrenIf(TLCD->getBody());
+      return Action::VisitNodeIf(TLCD->getBody());
     if (isa<NominalTypeDecl>(D))
       return Action::Continue();
 
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 
   PostWalkAction walkToDeclPost(Decl *D) override {
@@ -296,7 +296,7 @@ private:
     // ensures that the type checker can infer <noescape> for captured values.
     TypeChecker::computeCaptures(Closure);
 
-    return Action::SkipChildren(FinalExpr);
+    return Action::SkipNode(FinalExpr);
   }
 };
 

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -70,8 +70,8 @@ protected:
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (isa<BraceStmt>(S)) {
-        return Action::SkipChildren(S); // don't walk into brace statements; we
-                           // need to respect nesting!
+        return Action::SkipNode(S); // don't walk into brace statements; we
+                                    // need to respect nesting!
       } else {
         return Action::Continue(S);
       }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -360,10 +360,6 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       return Action::Continue(E);
     }
 
-    PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
-      return Action::Continue(E);
-    }
-
     /// Visit each component of the keypath and emit a diagnostic if they
     /// refer to a member that has effects.
     void checkForEffectfulKeyPath(KeyPathExpr *keyPath) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -57,8 +57,8 @@ static Expr *isImplicitPromotionToOptional(Expr *E) {
 }
 
 ASTWalker::PreWalkAction BaseDiagnosticWalker::walkToDeclPre(Decl *D) {
-  return Action::VisitChildrenIf(isa<ClosureExpr>(D->getDeclContext()) &&
-                                 shouldWalkIntoDeclInClosureContext(D));
+  return Action::VisitNodeIf(isa<ClosureExpr>(D->getDeclContext()) &&
+                             shouldWalkIntoDeclInClosureContext(D));
 }
 
 bool BaseDiagnosticWalker::shouldWalkIntoDeclInClosureContext(Decl *D) {
@@ -125,7 +125,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
     }
 
     PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
-      return Action::SkipChildren(P);
+      return Action::SkipNode(P);
     }
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
@@ -1837,7 +1837,7 @@ static void diagnoseImplicitSelfUseInClosure(const Expr *E,
 
       if (memberLoc.isValid()) {
         emitFixIts(Diags, memberLoc, ACE);
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
       
       if (isImplicitSelfParamUseLikelyToCauseCycle(E, ACE))
@@ -2715,7 +2715,7 @@ public:
   // FIXME: peek into capture lists of nested functions.
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (isa<TypeDecl>(D))
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     // The body of #if clauses are not walked into, we need custom processing
     // for them.
@@ -2742,7 +2742,7 @@ public:
     // references the variable, but we don't want to consider it as a real
     // "use".
     if (isa<AccessorDecl>(D) && D->isImplicit())
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     if (auto *afd = dyn_cast<AbstractFunctionDecl>(D)) {
       // If this AFD is a setter, track the parameter and the getter for
@@ -2763,7 +2763,7 @@ public:
       // Don't walk into a body that has not yet been type checked. This should
       // only occur for top-level code.
       VarDecls.clear();
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
@@ -3153,7 +3153,7 @@ public:
       }
 
       Candidates.push_back({CurrentAvailability, candidate});
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
 
     return Action::Continue(E);
@@ -3204,7 +3204,7 @@ public:
           Else->walk(*this);
         }
 
-        return Action::SkipChildren(S);
+        return Action::SkipNode(S);
       }
     }
 
@@ -3223,7 +3223,7 @@ public:
 
   // Don't descend into nested decls.
   PreWalkAction walkToDeclPre(Decl *D) override {
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 };
 
@@ -3288,7 +3288,7 @@ public:
 
   // Don't descend into nested decls.
   PreWalkAction walkToDeclPre(Decl *D) override {
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 };
 
@@ -3713,7 +3713,7 @@ ASTWalker::PreWalkResult<Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
   // should replace them with ErrorExpr.
   if (E == nullptr || !E->getType() || E->getType()->hasError()) {
     sawError = true;
-    return Action::SkipChildren(E);
+    return Action::SkipNode(E);
   }
 
   assert(AllExprsSeen.insert(E).second && "duplicate traversal");
@@ -3734,13 +3734,13 @@ ASTWalker::PreWalkResult<Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
     if (auto VD = dyn_cast<VarDecl>(MRE->getMember().getDecl())) {
       AssociatedGetterRefExpr.insert(std::make_pair(VD, MRE));
       markBaseOfStorageUse(MRE->getBase(), MRE->getMember(), RK_Read);
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
   }
   if (auto SE = dyn_cast<SubscriptExpr>(E)) {
     SE->getArgs()->walk(*this);
     markBaseOfStorageUse(SE->getBase(), SE->getDecl(), RK_Read);
-    return Action::SkipChildren(E);
+    return Action::SkipNode(E);
   }
 
   // If this is an AssignExpr, see if we're mutating something that we know
@@ -3750,14 +3750,14 @@ ASTWalker::PreWalkResult<Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
     
     // Don't walk into the LHS of the assignment, only the RHS.
     assign->getSrc()->walk(*this);
-    return Action::SkipChildren(E);
+    return Action::SkipNode(E);
   }
   
   // '&x' is a read and write of 'x'.
   if (auto *io = dyn_cast<InOutExpr>(E)) {
     markStoredOrInOutExpr(io->getSubExpr(), RK_Read|RK_Written);
     // Don't bother walking into this.
-    return Action::SkipChildren(E);
+    return Action::SkipNode(E);
   }
   
   // If we see an OpenExistentialExpr, remember the mapping for its OpaqueValue
@@ -3765,14 +3765,14 @@ ASTWalker::PreWalkResult<Expr *> VarDeclUsageChecker::walkToExprPre(Expr *E) {
   if (auto *oee = dyn_cast<OpenExistentialExpr>(E)) {
     OpaqueValueMap[oee->getOpaqueValue()] = oee->getExistentialValue();
     oee->getSubExpr()->walk(*this);
-    return Action::SkipChildren(E);
+    return Action::SkipNode(E);
   }
 
   // Visit bindings.
   if (auto ove = dyn_cast<OpaqueValueExpr>(E)) {
     if (auto mapping = OpaqueValueMap.lookup(ove))
       mapping->walk(*this);
-    return Action::SkipChildren(E);
+    return Action::SkipNode(E);
   }
   
   // If we saw an ErrorExpr, take note of this.
@@ -4011,7 +4011,7 @@ private:
     }
     // We don't want to walk into any other decl, we will visit them as part of
     // typeCheckDecl.
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 };
 } // end anonymous namespace
@@ -4268,7 +4268,7 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
     walkToArgumentListPre(ArgumentList *args) override {
       // Don't walk into an explicit argument list, as trailing closures that
       // appear in child arguments are fine.
-      return Action::VisitChildrenIf(args->isImplicit(), args);
+      return Action::VisitNodeIf(args->isImplicit(), args);
     }
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -4281,7 +4281,7 @@ static void checkStmtConditionTrailingClosure(ASTContext &ctx, const Expr *E) {
       case ExprKind::Closure:
         // If a trailing closure appears as a child of one of these types of
         // expression, don't diagnose it as there is no ambiguity.
-        return Action::VisitChildrenIf(E->isImplicit(), E);
+        return Action::VisitNodeIf(E->isImplicit(), E);
       case ExprKind::Call:
         diagnoseIt(cast<CallExpr>(E));
         break;
@@ -5256,7 +5256,7 @@ static void diagnoseUnintendedOptionalBehavior(const Expr *E,
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       if (IgnoredExprs.count(E))
         return Action::Continue(E);
@@ -5335,7 +5335,7 @@ static void diagnoseDeprecatedWritableKeyPath(const Expr *E,
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       if (auto *KPAE = dyn_cast<KeyPathApplicationExpr>(E)) {
         visitKeyPathApplicationExpr(KPAE);
@@ -5415,11 +5415,11 @@ static void maybeDiagnoseCallToKeyValueObserveMethod(const Expr *E,
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       if (auto *CE = dyn_cast<CallExpr>(E)) {
         maybeDiagnoseCallExpr(CE);
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
 
       return Action::Continue(E);
@@ -5466,11 +5466,11 @@ static void diagnoseExplicitUseOfLazyVariableStorage(const Expr *E,
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       if (auto *MRE = dyn_cast<MemberRefExpr>(E)) {
         tryDiagnoseExplicitLazyStorageVariableUse(MRE);
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
 
       return Action::Continue(E);
@@ -5599,11 +5599,11 @@ static void diagnoseComparisonWithNaN(const Expr *E, const DeclContext *DC) {
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       if (auto *BE = dyn_cast<BinaryExpr>(E)) {
         tryDiagnoseComparisonWithNaN(BE);
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
 
       return Action::Continue(E);
@@ -5636,7 +5636,7 @@ static void diagUnqualifiedAccessToMethodNamedSelf(const Expr *E,
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E || isa<ErrorExpr>(E) || !E->getType())
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       auto *DRE = dyn_cast<DeclRefExpr>(E);
       // If this is not an explicit 'self' reference, let's keep searching.

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -687,7 +687,7 @@ void swift::performPCMacro(SourceFile &SF) {
           if (FD->getBody()) {
             Instrumenter I(ctx, FD, TmpNameIndex);
             I.transformDecl(FD);
-            return Action::SkipChildren();
+            return Action::SkipNode();
           }
         }
       } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
@@ -700,7 +700,7 @@ void swift::performPCMacro(SourceFile &SF) {
               TypeChecker::checkTopLevelEffects(TLCD);
               TypeChecker::contextualizeTopLevelCode(TLCD);
             }
-            return Action::SkipChildren();
+            return Action::SkipNode();
           }
         }
       }

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -933,7 +933,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, PlaygroundOptionSet Opts)
               FD->setBody(NewBody, AbstractFunctionDecl::BodyKind::TypeChecked);
               TypeChecker::checkFunctionEffects(FD);
             }
-            return Action::SkipChildren();
+            return Action::SkipNode();
           }
         }
       } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
@@ -945,7 +945,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, PlaygroundOptionSet Opts)
               TLCD->setBody(NewBody);
               TypeChecker::checkTopLevelEffects(TLCD);
             }
-            return Action::SkipChildren();
+            return Action::SkipNode();
           }
         }
       }

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1137,7 +1137,7 @@ namespace {
             SequenceExprDepth++;
           ExprStack.push_back(expr);
         }
-        return Action::VisitChildrenIf(recursive, expr);
+        return Action::VisitNodeIf(recursive, expr);
       };
 
       // Resolve 'super' references.
@@ -1446,14 +1446,14 @@ namespace {
     }
 
     PreWalkAction walkToDeclPre(Decl *D) override {
-      return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+      return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
     }
 
     PreWalkResult<Pattern *> walkToPatternPre(Pattern *pattern) override {
       // Constraint generation is responsible for pattern verification and
       // type-checking in the body of the closure and single value stmt expr,
       // so there is no need to walk into patterns.
-      return Action::SkipChildrenIf(
+      return Action::SkipNodeIf(
           isa<ClosureExpr>(DC) || SingleValueStmtExprDepth > 0, pattern);
     }
   };
@@ -1682,7 +1682,7 @@ bool PreCheckExpression::correctInterpolationIfStrange(
 
     virtual PreWalkAction walkToDeclPre(Decl *D) override {
       // We don't want to look inside decls.
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     virtual PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -1774,7 +1774,7 @@ bool PreCheckExpression::correctInterpolationIfStrange(
       // There is never a CallExpr between an InterpolatedStringLiteralExpr
       // and an un-typechecked appendInterpolation(...) call, so whether we
       // changed E or not, we don't need to recurse any deeper.
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
   };
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3188,11 +3188,6 @@ public:
 
     ExprStack.push_back(E);
 
-    auto skipChildren = [&]() {
-      ExprStack.pop_back();
-      return Action::SkipNode(E);
-    };
-
     if (auto DR = dyn_cast<DeclRefExpr>(E)) {
       diagnoseDeclRefAvailability(DR->getDeclRef(), DR->getSourceRange(),
                                   getEnclosingApplyExpr(), llvm::None);
@@ -3200,7 +3195,7 @@ public:
     }
     if (auto MR = dyn_cast<MemberRefExpr>(E)) {
       walkMemberRef(MR);
-      return skipChildren();
+      return Action::SkipChildren(E);
     }
     if (auto OCDR = dyn_cast<OtherConstructorDeclRefExpr>(E))
       diagnoseDeclRefAvailability(OCDR->getDeclRef(),
@@ -3252,11 +3247,11 @@ public:
     }
     if (auto A = dyn_cast<AssignExpr>(E)) {
       walkAssignExpr(A);
-      return skipChildren();
+      return Action::SkipChildren(E);
     }
     if (auto IO = dyn_cast<InOutExpr>(E)) {
       walkInOutExpr(IO);
-      return skipChildren();
+      return Action::SkipChildren(E);
     }
     if (auto T = dyn_cast<TypeExpr>(E)) {
       if (!T->isImplicit()) {
@@ -3282,7 +3277,7 @@ public:
     if (AbstractClosureExpr *closure = dyn_cast<AbstractClosureExpr>(E)) {
       if (shouldWalkIntoClosure(closure)) {
         walkAbstractClosure(closure);
-        return skipChildren();
+        return Action::SkipChildren(E);
       }
     }
     

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -507,7 +507,7 @@ private:
     // tree to indicate that the subtree should be expanded lazily when it
     // needs to be traversed.
     if (buildLazyContextForDecl(D))
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     // Adds in a TRC that covers the entire declaration.
     if (auto DeclTRC = getNewContextForSignatureOfDecl(D)) {
@@ -828,17 +828,17 @@ private:
 
     if (auto *IS = dyn_cast<IfStmt>(S)) {
       buildIfStmtRefinementContext(IS);
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
     }
 
     if (auto *RS = dyn_cast<GuardStmt>(S)) {
       buildGuardStmtRefinementContext(RS);
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
     }
 
     if (auto *WS = dyn_cast<WhileStmt>(S)) {
       buildWhileStmtRefinementContext(WS);
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
     }
 
     return Action::Continue(S);
@@ -1505,7 +1505,7 @@ public:
     // inside the target range. Once we have found such a node, there is no
     // need to traverse any deeper.
     if (FoundTarget)
-      return Action::SkipChildren(Node);
+      return Action::SkipNode(Node);
 
     // If we haven't found our target yet and the node we are pre-visiting
     // doesn't have a valid range, we still have to traverse it because its
@@ -1519,11 +1519,11 @@ public:
     FoundTarget = SM.rangeContains(TargetRange, Range);
 
     if (FoundTarget)
-      return Action::SkipChildren(Node);
+      return Action::SkipNode(Node);
 
     // Search the subtree if the target range is inside its range.
     if (!SM.rangeContains(Range, TargetRange))
-      return Action::SkipChildren(Node);
+      return Action::SkipNode(Node);
 
     return Action::Continue(Node);
   }
@@ -3190,7 +3190,7 @@ public:
 
     auto skipChildren = [&]() {
       ExprStack.pop_back();
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     };
 
     if (auto DR = dyn_cast<DeclRefExpr>(E)) {
@@ -3316,7 +3316,7 @@ public:
     // since these availability for these statements is not diagnosed from
     // typeCheckStmt() as usual.
     diagnoseStmtAvailability(S, Where.getDeclContext(), /*walkRecursively=*/true);
-    return Action::SkipChildren(S);
+    return Action::SkipNode(S);
   }
 
   bool
@@ -3834,7 +3834,7 @@ public:
 
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (!WalkRecursively && isa<BraceStmt>(S))
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
 
     return Action::Continue(S);
   }
@@ -3842,13 +3842,13 @@ public:
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (WalkRecursively)
       diagnoseExprAvailability(E, DC);
-    return Action::SkipChildren(E);
+    return Action::SkipNode(E);
   }
 
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     auto where = ExportContext::forFunctionBody(DC, T->getStartLoc());
     diagnoseTypeReprAvailability(T, where);
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 
   PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
@@ -3937,11 +3937,11 @@ public:
     if (auto *identBase = dyn_cast<IdentTypeRepr>(baseComp)) {
       if (checkIdentTypeRepr(identBase)) {
         foundAnyIssues = true;
-        return Action::SkipChildren();
+        return Action::SkipNode();
       }
     } else if (diagnoseTypeReprAvailability(baseComp, where, flags)) {
       foundAnyIssues = true;
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     if (auto *memberTR = dyn_cast<MemberTypeRepr>(T)) {
@@ -3958,7 +3958,7 @@ public:
 
     // We've already visited all the children above, so we don't
     // need to recurse.
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 };
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -230,7 +230,7 @@ public:
     // FIXME(TapExpr): This is probably caused by the scoping 
     // algorithm's ignorance of TapExpr. We should fix that.
     if (D->getBaseName() == Context.Id_dollarInterpolation)
-      return Action::SkipChildren(DRE);
+      return Action::SkipNode(DRE);
 
     // DC is the DeclContext where D was defined
     // CurDC is the DeclContext where D was referenced
@@ -251,11 +251,11 @@ public:
 
     // Don't "capture" type definitions at all.
     if (isa<TypeDecl>(D))
-      return Action::SkipChildren(DRE);
+      return Action::SkipNode(DRE);
 
     // A local reference is not a capture.
     if (CurDC == DC || isa<TopLevelCodeDecl>(CurDC))
-      return Action::SkipChildren(DRE);
+      return Action::SkipNode(DRE);
 
     auto TmpDC = CurDC;
     while (TmpDC != nullptr) {
@@ -309,7 +309,7 @@ public:
                           DescriptiveDeclKind::Type);
 
             D->diagnose(diag::decl_declared_here, D);
-            return Action::SkipChildren(DRE);
+            return Action::SkipNode(DRE);
           }
         }
       }
@@ -320,12 +320,12 @@ public:
     // We walked all the way up to the root without finding the declaration,
     // so this is not a capture.
     if (TmpDC == nullptr)
-      return Action::SkipChildren(DRE);
+      return Action::SkipNode(DRE);
 
     // Only capture var decls at global scope.  Other things can be captured
     // if they are local.
     if (!isa<VarDecl>(D) && !D->isLocalCapture())
-      return Action::SkipChildren(DRE);
+      return Action::SkipNode(DRE);
 
     // We're going to capture this, compute flags for the capture.
     unsigned Flags = 0;
@@ -348,7 +348,7 @@ public:
       Flags |= CapturedValue::IsNoEscape;
 
     addCapture(CapturedValue(D, Flags, DRE->getStartLoc()));
-    return Action::SkipChildren(DRE);
+    return Action::SkipNode(DRE);
   }
 
   void propagateCaptures(CaptureInfo captureInfo, SourceLoc loc) {
@@ -396,13 +396,13 @@ public:
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
       TypeChecker::computeCaptures(AFD);
       propagateCaptures(AFD->getCaptureInfo(), AFD->getLoc());
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     // Don't walk into local types; we'll walk their initializers when we check
     // the local type itself.
     if (isa<NominalTypeDecl>(D))
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     return Action::Continue();
   }
@@ -569,7 +569,7 @@ public:
     // Some kinds of expression don't really evaluate their subexpression,
     // so we don't need to traverse.
     if (isa<ObjCSelectorExpr>(E)) {
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
 
     if (auto *ECE = dyn_cast<ExplicitCastExpr>(E)) {
@@ -592,7 +592,7 @@ public:
         if (CurDC->isChildContextOf(selfDecl->getDeclContext()))
           addCapture(CapturedValue(selfDecl, 0, superE->getLoc()));
       }
-      return Action::SkipChildren(superE);
+      return Action::SkipNode(superE);
     }
 
     // Don't recur into child closures. They should already have a capture
@@ -601,7 +601,7 @@ public:
     if (auto *SubCE = dyn_cast<AbstractClosureExpr>(E)) {
       TypeChecker::computeCaptures(SubCE);
       propagateCaptures(SubCE->getCaptureInfo(), SubCE->getLoc());
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
 
     // Capture a placeholder opaque value.

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -109,7 +109,7 @@ public:
         if (ObjC) {
           if (auto clazz = dyn_cast_or_null<ClassDecl>(ty->getAnyNominal())) {
             if (clazz->isTypeErasedGenericClass()) {
-              return Action::SkipChildren;
+              return Action::SkipNode;
             }
           }
         }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2585,7 +2585,7 @@ namespace {
       // Skip expressions that didn't make it to solution application
       // because the constraint system diagnosed an error.
       if (!expr->getType())
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
 
       if (auto *openExistential = dyn_cast<OpenExistentialExpr>(expr)) {
         opaqueValues.push_back({
@@ -2654,7 +2654,7 @@ namespace {
 
             partialApply->base->walk(*this);
 
-            return Action::SkipChildren(expr);
+            return Action::SkipNode(expr);
           }
         }
 
@@ -2687,7 +2687,7 @@ namespace {
       // expressions tend to violate restrictions on the use of instance
       // methods.
       if (isa<ObjCSelectorExpr>(expr))
-        return Action::SkipChildren(expr);
+        return Action::SkipNode(expr);
 
       // Track the capture contexts for variables.
       if (auto captureList = dyn_cast<CaptureListExpr>(expr)) {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -350,7 +350,7 @@ public:
       }
     }
 
-    return Action::SkipChildren(expr);
+    return Action::SkipNode(expr);
   }
 
   PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
@@ -370,13 +370,13 @@ public:
   }
 
   PreWalkResult<Pattern *> walkToPatternPre(Pattern *pattern) override {
-    return Action::SkipChildren(pattern);
+    return Action::SkipNode(pattern);
   }
   PreWalkAction walkToTypeReprPre(TypeRepr *typeRepr) override {
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
   PreWalkAction walkToParameterListPre(ParameterList *params) override {
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 };
 } // end anonymous namespace
@@ -1118,7 +1118,7 @@ TypeChecker::addImplicitLoadExpr(ASTContext &Context, Expr *expr,
       if (isa<LoadExpr>(E))
         return Action::Stop();
 
-      return Action::SkipChildren(createLoadExpr(E));
+      return Action::SkipNode(createLoadExpr(E));
     }
 
     PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
@@ -2354,19 +2354,19 @@ void ConstraintSystem::forEachExpr(
 
       if (auto closure = dyn_cast<ClosureExpr>(E)) {
         if (!CS.participatesInInference(closure))
-          return Action::SkipChildren(NewE);
+          return Action::SkipNode(NewE);
       }
       return Action::Continue(NewE);
     }
 
     PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
-      return Action::SkipChildren(P);
+      return Action::SkipNode(P);
     }
     PreWalkAction walkToDeclPre(Decl *D) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
   };
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -510,14 +510,14 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
 
     PreWalkAction walkToDeclPre(class Decl *D) override {
       // Don't walk into further nominal decls.
-      return Action::SkipChildrenIf(isa<NominalTypeDecl>(D));
+      return Action::SkipNodeIf(isa<NominalTypeDecl>(D));
     }
     
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // Don't walk into closures.
       if (isa<ClosureExpr>(E))
-        return Action::SkipChildren(E);
-      
+        return Action::SkipNode(E);
+
       // Look for calls of a constructor on self or super.
       auto apply = dyn_cast<ApplyExpr>(E);
       if (!apply)

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2220,7 +2220,7 @@ computeOverriddenAssociatedTypes(AssociatedTypeDecl *assocType) {
       foundAny = true;
     }
 
-    return foundAny ? TypeWalker::Action::SkipChildren
+    return foundAny ? TypeWalker::Action::SkipNode
                     : TypeWalker::Action::Continue;
   });
 

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -501,7 +501,7 @@ public:
     } else {
       recurse = ShouldNotRecurse;
     }
-    return Action::VisitChildrenIf(bool(recurse));
+    return Action::VisitNodeIf(bool(recurse));
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -541,7 +541,7 @@ public:
     else if (isa<KIND##Expr>(E)) return Action::Stop();
 #include "swift/AST/ExprNodes.def"
 
-    return Action::VisitChildrenIf(bool(recurse), E);
+    return Action::VisitNodeIf(bool(recurse), E);
   }
 
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
@@ -554,7 +554,7 @@ public:
       recurse = asImpl().checkForEach(forEach);
     }
     if (!recurse)
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
 
     return Action::Continue(S);
   }
@@ -3641,7 +3641,7 @@ struct LocalFunctionEffectsChecker : ASTWalker {
       if (func->getDeclContext()->isLocalContext())
         TypeChecker::checkFunctionEffects(func);
 
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     return Action::Continue();

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -786,11 +786,11 @@ bool ClosureHasExplicitResultRequest::evaluate(Evaluator &evaluator,
     }
 
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
-      return Action::SkipChildren(expr);
+      return Action::SkipNode(expr);
     }
 
     PreWalkAction walkToDeclPre(Decl *decl) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *stmt) override {

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -336,10 +336,10 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
       // Find generic parameters or dependent member types.
       // Once such a type is found, don't recurse into its children.
       if (!ty->hasTypeParameter())
-        return Action::SkipChildren;
+        return Action::SkipNode;
       if (ty->isTypeParameter()) {
         ReferencedGenericParams.insert(ty->getCanonicalType());
-        return Action::SkipChildren;
+        return Action::SkipNode;
       }
 
       // Skip the count type, which is always a generic parameter;
@@ -347,7 +347,7 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
       // shape and not the metadata.
       if (auto *expansionTy = ty->getAs<PackExpansionType>()) {
         expansionTy->getPatternType().walk(*this);
-        return Action::SkipChildren;
+        return Action::SkipNode;
       }
 
       // Don't walk into generic type alias substitutions. This does
@@ -357,7 +357,7 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
       //   func foo<T>(_: Foo<T>) {}
       if (auto *aliasTy = dyn_cast<TypeAliasType>(ty.getPointer())) {
         Type(aliasTy->getSinglyDesugaredType()).walk(*this);
-        return Action::SkipChildren;
+        return Action::SkipNode;
       }
 
       return Action::Continue;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4610,7 +4610,7 @@ hasInvariantSelfRequirement(const ProtocolDecl *proto,
 
         // 'Self.A' is OK.
         if (ty->is<DependentMemberType>())
-          return Action::SkipChildren;
+          return Action::SkipNode;
 
         return Action::Continue;
       }
@@ -4889,7 +4889,7 @@ hasInvalidTypeInConformanceContext(const ValueDecl *requirement,
 
     Action walkToTypePre(Type ty) override {
       if (!ty->hasTypeParameter())
-        return Action::SkipChildren;
+        return Action::SkipNode;
 
       auto *const dmt = ty->getAs<DependentMemberType>();
       if (!dmt)
@@ -4897,11 +4897,11 @@ hasInvalidTypeInConformanceContext(const ValueDecl *requirement,
 
       // We only care about 'Self'-rooted type parameters.
       if (!dmt->getRootGenericParam()->isEqual(Proto->getSelfInterfaceType()))
-        return Action::SkipChildren;
+        return Action::SkipNode;
 
       if (ty.subst(Subs)->hasError())
         return Action::Stop;
-      return Action::SkipChildren;
+      return Action::SkipNode;
     }
   };
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -86,7 +86,7 @@ namespace {
         ParentDC = oldParentDC;
 
         TypeChecker::computeCaptures(CE);
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       } 
 
       if (auto CapE = dyn_cast<CaptureListExpr>(E)) {
@@ -114,7 +114,7 @@ namespace {
           CE->getBody()->walk(ContextualizeClosuresAndMacros(CE));
 
         TypeChecker::computeCaptures(CE);
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
 
       // Caller-side default arguments need their @autoclosures checked.
@@ -134,7 +134,7 @@ namespace {
     PreWalkAction walkToDeclPre(Decl *D) override {
       // But we do want to walk into the initializers of local
       // variables.
-      return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+      return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
     }
 
   private:
@@ -258,7 +258,7 @@ namespace {
       //   - non-local initializers
       if (auto CE = dyn_cast<AutoClosureExpr>(E)) {
         if (CE->getRawDiscriminator() != AutoClosureExpr::InvalidDiscriminator)
-          return Action::SkipChildren(E);
+          return Action::SkipNode(E);
 
         assert(
             CE->getRawDiscriminator() == AutoClosureExpr::InvalidDiscriminator);
@@ -268,7 +268,7 @@ namespace {
         // but parenting to the autoclosure instead of the outer closure.
         CE->getBody()->walk(*this);
 
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
 
       // Explicit closures start their own sequence.
@@ -289,7 +289,7 @@ namespace {
           CE->getBody()->walk(innerVisitor);
         }
 
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
 
       // Caller-side default arguments need their @autoclosures checked.
@@ -324,7 +324,7 @@ namespace {
 
       // But we do want to walk into the initializers of local
       // variables.
-      return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+      return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
     }
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
@@ -2460,7 +2460,7 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
             SM, brace->getSourceRange());
         // Unless this brace contains the loc, there's nothing to do.
         if (!braceCharRange.contains(Loc))
-          return Action::SkipChildren(S);
+          return Action::SkipNode(S);
 
         // Reset the node found in a parent context if it's not part of this
         // brace statement.
@@ -2520,16 +2520,16 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (SM.isBeforeInBuffer(Loc, E->getStartLoc()))
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       SourceLoc endLoc = Lexer::getLocForEndOfToken(SM, E->getEndLoc());
       if (SM.isBeforeInBuffer(endLoc, Loc))
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       // Don't walk into 'TapExpr'. They should be type checked with parent
       // 'InterpolatedStringLiteralExpr'.
       if (isa<TapExpr>(E))
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
 
       // If the location is within a result of a SingleValueStmtExpr, walk it
       // directly rather than as part of the brace. This ensures we type-check
@@ -2544,7 +2544,7 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
             if (!result->walk(*this))
               return Action::Stop();
 
-            return Action::SkipChildren(E);
+            return Action::SkipNode(E);
           }
         }
         return Action::Continue(E);
@@ -2554,7 +2554,7 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
         // NOTE: When a client wants to type check a closure signature, it
         // requests with closure's 'getLoc()' location.
         if (Loc == closure->getLoc())
-          return Action::SkipChildren(E);
+          return Action::SkipNode(E);
 
         DC = closure;
       }
@@ -3017,11 +3017,11 @@ public:
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     // We don't need to walk into closures, you can't jump out of them.
-    return Action::SkipChildrenIf(isa<AbstractClosureExpr>(E), E);
+    return Action::SkipNodeIf(isa<AbstractClosureExpr>(E), E);
   }
   PreWalkAction walkToDeclPre(Decl *D) override {
     // We don't need to walk into any nested local decls.
-    return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+    return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
   }
 };
 } // end anonymous namespace

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1576,7 +1576,7 @@ namespace {
       // If we find a closure, update its declcontext and do *not* walk into it.
       if (auto CE = dyn_cast<AbstractClosureExpr>(E)) {
         CE->setParent(NewDC);
-        return Action::SkipChildren(E);
+        return Action::SkipNode(E);
       }
 
       return Action::Continue(E);
@@ -1613,7 +1613,7 @@ namespace {
 
       // Skip walking the children of any Decls that are also DeclContexts,
       // they will already have the right parent.
-      return Action::SkipChildrenIf(isa<DeclContext>(D));
+      return Action::SkipNodeIf(isa<DeclContext>(D));
     }
   };
 } // end anonymous namespace

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5752,20 +5752,20 @@ public:
     reprStack.push_back(T);
 
     if (T->isInvalid())
-      return Action::SkipChildren();
+      return Action::SkipNode();
     if (auto memberTR = dyn_cast<MemberTypeRepr>(T)) {
       // Only visit the last component to check, because nested typealiases in
       // existentials are okay.
       visit(memberTR->getLastComponent());
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
     // Arbitrary protocol constraints are OK on opaque types.
     if (isa<OpaqueReturnTypeRepr>(T))
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     // Arbitrary protocol constraints are okay for 'any' types.
     if (isa<ExistentialTypeRepr>(T))
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     visit(T);
     return Action::Continue();
@@ -5782,11 +5782,11 @@ public:
       return Action::Continue(S);
     }
 
-    return Action::SkipChildren(S);
+    return Action::SkipNode(S);
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {
-    return Action::SkipChildrenIf(checkStatements);
+    return Action::SkipNodeIf(checkStatements);
   }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -386,7 +386,7 @@ static void writeDeclCommentTable(
       if (!shouldIncludeDecl(D, /*ForSourceInfo*/false)) {
         // Pattern binding decls don't have comments to serialize, but we should
         // still visit their vars.
-        return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+        return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
       }
       if (!shouldSerializeDoc(D))
         return Action::Continue();
@@ -414,16 +414,16 @@ static void writeDeclCommentTable(
     }
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
-      return Action::SkipChildren(S);
+      return Action::SkipNode(S);
     }
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
-      return Action::SkipChildren(E);
+      return Action::SkipNode(E);
     }
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
     PreWalkAction walkToParameterListPre(ParameterList *PL) override {
-      return Action::SkipChildren();
+      return Action::SkipNode();
     }
   };
 
@@ -666,16 +666,16 @@ struct BasicDeclLocsTableWriter : public ASTWalker {
                            DocWriter(DocWriter) {}
 
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
-    return Action::SkipChildren(S);
+    return Action::SkipNode(S);
   }
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
-    return Action::SkipChildren(E);
+    return Action::SkipNode(E);
   }
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
   PreWalkAction walkToParameterListPre(ParameterList *PL) override {
-    return Action::SkipChildren();
+    return Action::SkipNode();
   }
 
   MacroWalking getMacroWalkingBehavior() const override {
@@ -700,7 +700,7 @@ struct BasicDeclLocsTableWriter : public ASTWalker {
     if (!shouldIncludeDecl(D, /*ForSourceInfo*/true)) {
       // Pattern binding decls don't have comments to serialize, but we should
       // still visit their vars.
-      return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+      return Action::VisitNodeIf(isa<PatternBindingDecl>(D));
     }
     if (!shouldSerializeSourceLoc(D))
       return Action::Continue();

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -994,17 +994,17 @@ public:
 
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (D->isImplicit())
-      return Action::SkipChildren(); // Skip body.
+      return Action::SkipNode(); // Skip body.
 
     if (FuncEnts.empty())
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     if (!isa<AbstractFunctionDecl>(D) && !isa<SubscriptDecl>(D))
       return Action::Continue();
 
     // Ignore things that don't come from this buffer.
     if (!SM.getRangeForBuffer(BufferID).contains(D->getLoc()))
-      return Action::SkipChildren();
+      return Action::SkipNode();
 
     unsigned Offset = SM.getLocOffsetInBuffer(D->getLoc(), BufferID);
     auto Found = FuncEnts.end();
@@ -1017,14 +1017,14 @@ public:
         });
     }
     if (Found == FuncEnts.end() || (*Found)->LocOffset != Offset)
-      return Action::SkipChildren();
+      return Action::SkipNode();
     if (auto FD = dyn_cast<AbstractFunctionDecl>(D)) {
       addParameters(FD, **Found, SM, BufferID);
     } else {
       addParameters(cast<SubscriptDecl>(D), **Found, SM, BufferID);
     }
     FuncEnts = llvm::MutableArrayRef<TextEntity*>(Found+1, FuncEnts.end());
-    return Action::SkipChildren(); // skip body.
+    return Action::SkipNode(); // skip body.
   }
 };
 } // end anonymous namespace

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1608,7 +1608,7 @@ private:
             Elem.walk(*this);
           }
         }
-        return Action::SkipChildren();
+        return Action::SkipNode();
       }
       return Action::Continue();
     }


### PR DESCRIPTION
Previously we would skip the post-walk, which was not a particularly intuitive behavior. Introduce an `Action::SkipNode` variant for walkers that want to also skip the post-walk. This then lets up clean up some walkers that previously had to work around the old behavior by doing the post-walk manually.