### PR TITLE
[Macros] Expression macro as caller-side default argument

### DIFF
--- a/include/swift/AST/DefaultArgumentKind.h
+++ b/include/swift/AST/DefaultArgumentKind.h
@@ -51,6 +51,8 @@ enum class DefaultArgumentKind : uint8_t {
   // Magic identifier literals expanded at the call site:
 #define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) NAME,
 #include "swift/AST/MagicIdentifierKinds.def"
+  /// An expression macro.
+  ExpressionMacro
 };
 enum { NumDefaultArgumentKindBits = 4 };
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7530,8 +7530,8 @@ ERROR(conformance_macro,none,
 ERROR(macro_as_default_argument, none,
       "non-built-in macro cannot be used as default argument",
       ())
-ERROR(macro_as_default_argument_has_arguments, none,
-      "macro used as default argument cannot have arguments",
+ERROR(macro_as_default_argument_arguments_must_be_literal, none,
+      "argument to macro used as default argument must be literal",
       ())
 
 ERROR(macro_resolve_circular_reference, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7526,9 +7526,6 @@ ERROR(macro_attached_to_invalid_decl,none,
 ERROR(macro_as_default_argument, none,
       "non-built-in macro cannot be used as default argument",
       ())
-ERROR(macro_as_default_argument_arguments_must_be_literal, none,
-      "argument to macro used as default argument must be literal",
-      ())
 ERROR(conformance_macro,none,
       "conformance macros are replaced by extension macros",
       ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7523,11 +7523,15 @@ ERROR(extension_macro_invalid_conformance,none,
 ERROR(macro_attached_to_invalid_decl,none,
       "'%0' macro cannot be attached to %1 (%base2)",
       (StringRef, DescriptiveDeclKind, const Decl *))
+ERROR(conformance_macro,none,
+      "conformance macros are replaced by extension macros",
+      ())
+
 ERROR(macro_as_default_argument, none,
       "non-built-in macro cannot be used as default argument",
       ())
-ERROR(conformance_macro,none,
-      "conformance macros are replaced by extension macros",
+ERROR(macro_as_default_argument_has_arguments, none,
+      "macro used as default argument cannot have arguments",
       ())
 
 ERROR(macro_resolve_circular_reference, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7523,15 +7523,14 @@ ERROR(extension_macro_invalid_conformance,none,
 ERROR(macro_attached_to_invalid_decl,none,
       "'%0' macro cannot be attached to %1 (%base2)",
       (StringRef, DescriptiveDeclKind, const Decl *))
-ERROR(conformance_macro,none,
-      "conformance macros are replaced by extension macros",
-      ())
-
 ERROR(macro_as_default_argument, none,
       "non-built-in macro cannot be used as default argument",
       ())
 ERROR(macro_as_default_argument_arguments_must_be_literal, none,
       "argument to macro used as default argument must be literal",
+      ())
+ERROR(conformance_macro,none,
+      "conformance macros are replaced by extension macros",
       ())
 
 ERROR(macro_resolve_circular_reference, none,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -106,6 +106,7 @@ enum class SourceFileKind {
   SIL,      ///< Came from a .sil file.
   Interface, ///< Came from a .swiftinterface file, representing another module.
   MacroExpansion, ///< Came from a macro expansion.
+  DefaultArgument, ///< Came from default argument at caller side
 };
 
 /// Contains information about where a particular path is used in

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -674,6 +674,7 @@ public:
     case SourceFileKind::Interface:
     case SourceFileKind::SIL:
     case SourceFileKind::MacroExpansion:
+    case SourceFileKind::DefaultArgument:
       return false;
     }
     llvm_unreachable("bad SourceFileKind");

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -135,6 +135,7 @@ EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(BodyMacros, true)
+EXPERIMENTAL_FEATURE(ExpressionMacroDefaultArguments, false)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
 
 // Whether to enable @_used and @_section attributes

--- a/include/swift/Basic/MacroRoles.def
+++ b/include/swift/Basic/MacroRoles.def
@@ -70,6 +70,9 @@ ATTACHED_MACRO_ROLE(Conformance, "conformance", "c")
 /// declarations in a code block.
 EXPERIMENTAL_FREESTANDING_MACRO_ROLE(CodeItem, "codeItem", CodeItemMacros)
 
+/// A freestanding macro that is used as the default argument
+EXPERIMENTAL_FREESTANDING_MACRO_ROLE(DefaultArgument, "defaultArgument", ExpressionMacroDefaultArguments)
+
 /// An attached macro that adds extensions to the declaration the
 /// macro is attached to.
 ATTACHED_MACRO_ROLE(Extension, "extension", "e")

--- a/include/swift/Basic/MacroRoles.def
+++ b/include/swift/Basic/MacroRoles.def
@@ -70,9 +70,6 @@ ATTACHED_MACRO_ROLE(Conformance, "conformance", "c")
 /// declarations in a code block.
 EXPERIMENTAL_FREESTANDING_MACRO_ROLE(CodeItem, "codeItem", CodeItemMacros)
 
-/// A freestanding macro that is used as the default argument
-EXPERIMENTAL_FREESTANDING_MACRO_ROLE(DefaultArgument, "defaultArgument", ExpressionMacroDefaultArguments)
-
 /// An attached macro that adds extensions to the declaration the
 /// macro is attached to.
 ATTACHED_MACRO_ROLE(Extension, "extension", "e")

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -43,6 +43,9 @@ public:
 
     /// Pretty-printed declarations that have no source location.
     PrettyPrinted,
+
+    /// The expansion of default argument at caller side
+    DefaultArgument,
   } kind;
 
   /// The source range in the enclosing buffer where this source was generated.

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -68,6 +68,10 @@ void *_Nonnull swift_ASTGen_resolveExecutableMacro(
     void *_Nonnull opaquePluginHandle);
 void swift_ASTGen_destroyExecutableMacro(void *_Nonnull macro);
 
+bool swift_ASTGen_checkDefaultArgumentMacroExpression(
+    void *_Nonnull diagEngine, void *_Nonnull sourceFile,
+    const void *_Nonnull macroSourceLocation);
+
 ptrdiff_t swift_ASTGen_checkMacroDefinition(
     void *_Nonnull diagEngine, void *_Nonnull sourceFile,
     const void *_Nonnull macroSourceLocation,

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -85,7 +85,7 @@ llvm::Optional<constraints::SyntacticElementTarget>
 typeCheckTarget(constraints::SyntacticElementTarget &target,
                 OptionSet<TypeCheckExprFlags> options);
 
-Type typeCheckParameterDefault(Expr *&, DeclContext *, Type, bool);
+Type typeCheckParameterDefault(Expr *&, DeclContext *, Type, bool, bool);
 
 } // end namespace TypeChecker
 
@@ -2970,7 +2970,7 @@ private:
 
   friend Type swift::TypeChecker::typeCheckParameterDefault(Expr *&,
                                                             DeclContext *, Type,
-                                                            bool);
+                                                            bool, bool);
 
   /// Emit the fixes computed as part of the solution, returning true if we were
   /// able to emit an error message, or false if none of the fixits worked out.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -309,6 +309,8 @@ static StringRef getDumpString(DefaultArgumentKind value) {
     case DefaultArgumentKind::EmptyDictionary: return "[:]";
     case DefaultArgumentKind::Normal: return "normal";
     case DefaultArgumentKind::StoredProperty: return "stored property";
+    case DefaultArgumentKind::ExpressionMacro:
+    return "expression macro";
   }
 
   llvm_unreachable("Unhandled DefaultArgumentKind in switch.");

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3877,6 +3877,8 @@ void ASTMangler::appendMacroExpansionContext(
 
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
+  // TODO: ApolloZhu check if this correct?
+  case GeneratedSourceInfo::DefaultArgument:
     return appendContext(origDC, StringRef());
   }
   

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3877,7 +3877,6 @@ void ASTMangler::appendMacroExpansionContext(
 
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
-  // TODO: ApolloZhu check if this correct?
   case GeneratedSourceInfo::DefaultArgument:
     return appendContext(origDC, StringRef());
   }
@@ -3929,6 +3928,7 @@ void ASTMangler::appendMacroExpansionContext(
 
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
+  case GeneratedSourceInfo::DefaultArgument:
     llvm_unreachable("Exited above");
   }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3042,6 +3042,18 @@ static bool usesFeatureFreestandingMacros(Decl *decl) {
   return macro->getMacroRoles().contains(MacroRole::Declaration);
 }
 
+static bool usesFeatureExpressionMacroDefaultArguments(Decl *decl) {
+  if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
+    for (auto param : *func->getParameters()) {
+      if (param->getDefaultArgumentKind() ==
+          DefaultArgumentKind::ExpressionMacro)
+        return true;
+    }
+  }
+
+  return false;
+}
+
 static bool usesFeatureCodeItemMacros(Decl *decl) {
   auto macro = dyn_cast<MacroDecl>(decl);
   if (!macro)

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -272,6 +272,14 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
 
     // Determine the parent source location based on the macro role.
     AbstractFunctionDecl *bodyForDecl = nullptr;
+
+    if (SF->Kind == SourceFileKind::DefaultArgument) {
+      auto genInfo = *SF->getASTContext().SourceMgr.getGeneratedSourceInfo(
+          *SF->getBufferID());
+      parentLoc = ASTNode::getFromOpaqueValue(genInfo.astNode).getStartLoc();
+      goto setParent;
+    }
+
     switch (*macroRole) {
     case MacroRole::Expression:
     case MacroRole::Declaration:
@@ -301,6 +309,7 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
     }
     }
 
+  setParent:
     if (auto parentScope = findStartingScopeForLookup(enclosingSF, parentLoc)) {
       if (bodyForDecl) {
         auto bodyScope = new (bodyForDecl->getASTContext()) FunctionBodyScope(bodyForDecl);

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1392,6 +1392,7 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
       case GeneratedSourceInfo::Name##MacroExpansion:
 #include "swift/Basic/MacroRoles.def"
       case GeneratedSourceInfo::PrettyPrinted:
+      case GeneratedSourceInfo::DefaultArgument:
         fixIts = {};
         break;
       case GeneratedSourceInfo::ReplacedFunctionBody:
@@ -1465,6 +1466,7 @@ DiagnosticEngine::getGeneratedSourceBufferNotes(SourceLoc loc) {
     case GeneratedSourceInfo::PrettyPrinted:
       break;
 
+    case GeneratedSourceInfo::DefaultArgument:
     case GeneratedSourceInfo::ReplacedFunctionBody:
       return childNotes;
     }
@@ -1648,6 +1650,7 @@ swift::getGeneratedSourceInfoMacroName(const GeneratedSourceInfo &info) {
 
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
-    return DeclName();
+  case GeneratedSourceInfo::DefaultArgument:
+      return DeclName();
   }
 }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1214,6 +1214,7 @@ llvm::Optional<MacroRole> SourceFile::getFulfilledMacroRole() const {
 
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::PrettyPrinted:
+  case GeneratedSourceInfo::DefaultArgument:
     return llvm::None;
   }
 }
@@ -3308,7 +3309,8 @@ SourceFile::SourceFile(ModuleDecl &M, SourceFileKind K,
     (void)problem;
   }
 
-  if (Kind == SourceFileKind::MacroExpansion)
+  if (Kind == SourceFileKind::MacroExpansion ||
+      Kind == SourceFileKind::DefaultArgument)
     M.addAuxiliaryFile(*this);
 }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1222,7 +1222,8 @@ llvm::Optional<MacroRole> SourceFile::getFulfilledMacroRole() const {
 }
 
 SourceFile *SourceFile::getEnclosingSourceFile() const {
-  if (Kind != SourceFileKind::MacroExpansion)
+  if (Kind != SourceFileKind::MacroExpansion &&
+      Kind != SourceFileKind::DefaultArgument)
     return nullptr;
 
   auto genInfo =

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -920,6 +920,8 @@ ModuleDecl::getOriginalLocation(SourceLoc loc) const {
       bufferID = SM.findBufferContainingLoc(loc);
       break;
     }
+    case GeneratedSourceInfo::DefaultArgument:
+      // TODO: ApolloZhu
     case GeneratedSourceInfo::ReplacedFunctionBody:
       // There's not really any "original" location for locations within
       // replaced function bodies. The body is actually different code to the

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -921,7 +921,7 @@ ModuleDecl::getOriginalLocation(SourceLoc loc) const {
       break;
     }
     case GeneratedSourceInfo::DefaultArgument:
-      // TODO: ApolloZhu
+      // No original location as it's not actually in any source file
     case GeneratedSourceInfo::ReplacedFunctionBody:
       // There's not really any "original" location for locations within
       // replaced function bodies. The body is actually different code to the

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2123,6 +2123,7 @@ UniqueUnderlyingTypeSubstitutionsRequest::evaluate(
       switch (sf->Kind) {
       case SourceFileKind::Interface:
       case SourceFileKind::MacroExpansion:
+      case SourceFileKind::DefaultArgument:
       case SourceFileKind::SIL:
         return true;
       case SourceFileKind::Main:

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -17,7 +17,7 @@ import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntax
 import SwiftSyntaxBuilder
-@_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacroExpansion
+@_spi(ExperimentalLanguageFeature) @_spi(Compiler) import SwiftSyntaxMacroExpansion
 @_spi(ExperimentalLanguageFeature) import SwiftSyntaxMacros
 
 /// Describes a macro that has been "exported" to the C++ part of the

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -179,6 +179,53 @@ fileprivate func identifierFromStringLiteral(_ node: ExprSyntax) -> String? {
   return stringSegment.content.text
 }
 
+/// Checks if the macro expression used as an default argument has any issues.
+///
+/// - Returns: `true` if all restrictions are satisfied, `false` if diagnostics
+/// are emitted.
+@_cdecl("swift_ASTGen_checkDefaultArgumentMacroExpression")
+func checkDefaultArgumentMacroExpression(
+  diagEnginePtr: UnsafeMutableRawPointer,
+  sourceFilePtr: UnsafeRawPointer,
+  macroLocationPtr: UnsafePointer<UInt8>
+) -> Bool {
+  let sourceFilePtr = sourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
+
+  // Find the macro expression.
+  guard
+    let macroExpr = findSyntaxNodeInSourceFile(
+      sourceFilePtr: sourceFilePtr,
+      sourceLocationPtr: macroLocationPtr,
+      type: MacroExpansionExprSyntax.self
+    )
+  else {
+    // FIXME: Produce an error
+    return false
+  }
+
+  do {
+    try macroExpr.checkDefaultArgumentMacroExpression()
+    return true
+  } catch let errDiags as DiagnosticsError {
+    let srcMgr = SourceManager(cxxDiagnosticEngine: diagEnginePtr)
+    srcMgr.insert(sourceFilePtr)
+    for diag in errDiags.diagnostics {
+      srcMgr.diagnose(diagnostic: diag)
+    }
+    return false
+  } catch let error {
+    let srcMgr = SourceManager(cxxDiagnosticEngine: diagEnginePtr)
+    srcMgr.insert(sourceFilePtr)
+    srcMgr.diagnose(
+      diagnostic: .init(
+        node: macroExpr,
+        message: ASTGenMacroDiagnostic.thrownError(error)
+      )
+    )
+    return false
+  }
+}
+
 /// Check a macro definition, producing a description of that macro definition
 /// for use in macro expansion.
 ///

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -289,7 +289,8 @@ StringRef SourceManager::getIdentifierForBuffer(
     if (auto generatedInfo = getGeneratedSourceInfo(bufferID)) {
       // We only care about macros, so skip everything else.
       if (generatedInfo->kind == GeneratedSourceInfo::ReplacedFunctionBody ||
-          generatedInfo->kind == GeneratedSourceInfo::PrettyPrinted)
+          generatedInfo->kind == GeneratedSourceInfo::PrettyPrinted ||
+          generatedInfo->kind == GeneratedSourceInfo::DefaultArgument)
         return buffer->getBufferIdentifier();
 
       if (generatedInfo->onDiskBufferCopyFileName.empty()) {
@@ -382,6 +383,7 @@ void SourceManager::setGeneratedSourceInfo(
   case GeneratedSourceInfo::Name##MacroExpansion:
 #include "swift/Basic/MacroRoles.def"
   case GeneratedSourceInfo::PrettyPrinted:
+  case GeneratedSourceInfo::DefaultArgument:
     break;
 
   case GeneratedSourceInfo::ReplacedFunctionBody:

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1784,6 +1784,11 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   StringRef explicitSwiftModuleMap = searchPathOpts.ExplicitSwiftModuleMap;
   genericSubInvocation.getSearchPathOptions().ExplicitSwiftModuleMap =
     explicitSwiftModuleMap.str();
+
+  // Load plugin libraries for macro expression as default arguments
+  genericSubInvocation.getSearchPathOptions().PluginSearchOpts =
+      searchPathOpts.PluginSearchOpts;
+
   auto &subClangImporterOpts = genericSubInvocation.getClangImporterOptions();
   // Respect the detailed-record preprocessor setting of the parent context.
   // This, and the "raw" clang module format it implicitly enables, are

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1006,6 +1006,7 @@ bool CompletionLookup::hasInterestingDefaultValue(const ParamDecl *param) {
 #define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND)                            \
   case DefaultArgumentKind::NAME:
 #include "swift/AST/MagicIdentifierKinds.def"
+  case DefaultArgumentKind::ExpressionMacro:
     return false;
   }
 }

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -658,6 +658,7 @@ adjustMacroExpansionWhitespace(GeneratedSourceInfo::Kind kind,
   case GeneratedSourceInfo::BodyMacroExpansion:
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::PrettyPrinted:
+  case GeneratedSourceInfo::DefaultArgument:
     return expandedCode;
   }
 }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -218,6 +218,7 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
       break;
 
     case SourceFileKind::MacroExpansion:
+    case SourceFileKind::DefaultArgument:
       braceItemListKind = BraceItemListKind::MacroExpansion;
       break;
     }
@@ -9932,6 +9933,7 @@ parseDeclDeinit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     case SourceFileKind::Library:
     case SourceFileKind::Main:
     case SourceFileKind::MacroExpansion:
+    case SourceFileKind::DefaultArgument:
       if (Tok.is(tok::identifier)) {
         diagnose(Tok, diag::destructor_has_name).fixItRemove(Tok.getLoc());
         consumeToken();

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -183,7 +183,8 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
     case GeneratedSourceInfo::ExpressionMacroExpansion:
     case GeneratedSourceInfo::PreambleMacroExpansion:
     case GeneratedSourceInfo::ReplacedFunctionBody:
-    case GeneratedSourceInfo::PrettyPrinted: {
+    case GeneratedSourceInfo::PrettyPrinted:
+    case GeneratedSourceInfo::DefaultArgument: {
       parser.parseTopLevelItems(items);
       break;
     }

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -325,6 +325,7 @@ static LexerMode sourceFileKindToLexerMode(SourceFileKind kind) {
     case swift::SourceFileKind::Library:
     case swift::SourceFileKind::Main:
     case swift::SourceFileKind::MacroExpansion:
+    case swift::SourceFileKind::DefaultArgument:
       return LexerMode::Swift;
   }
   llvm_unreachable("covered switch");

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -155,7 +155,8 @@ swift::ide::collectRefactorings(SourceFile *SF, RangeConfig Range,
                                        DiagConsumers);
 
   // No refactorings are available within generated buffers
-  if (SF->Kind == SourceFileKind::MacroExpansion)
+  if (SF->Kind == SourceFileKind::MacroExpansion ||
+      SF->Kind == SourceFileKind::DefaultArgument)
     return {};
 
   // Prepare the tool box.

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1617,6 +1617,7 @@ void SILGenModule::emitDefaultArgGenerator(SILDeclRef constant,
   case DefaultArgumentKind::NilLiteral:
   case DefaultArgumentKind::EmptyArray:
   case DefaultArgumentKind::EmptyDictionary:
+  case DefaultArgumentKind::ExpressionMacro:
     break;
   }
 }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -344,6 +344,7 @@ static MacroInfo getMacroInfo(GeneratedSourceInfo &Info,
   }
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
+  case GeneratedSourceInfo::DefaultArgument:
     break;
   }
   return Result;

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -785,6 +785,7 @@ addDistributedActorCodableConformance(
         case SourceFileKind::Main:
         case SourceFileKind::MacroExpansion:
         case SourceFileKind::SIL:
+        case SourceFileKind::DefaultArgument:
           break;
         }
       }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -615,6 +615,7 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       case DefaultArgumentKind::EmptyArray:
       case DefaultArgumentKind::EmptyDictionary:
       case DefaultArgumentKind::StoredProperty:
+      case DefaultArgumentKind::ExpressionMacro:
         return llvm::None;
       }
 

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -299,6 +299,7 @@ bool DeriveImplicitBitwiseCopyableConformance::allowedForFile() {
 
     case SourceFileKind::Library:
     case SourceFileKind::MacroExpansion:
+    case SourceFileKind::DefaultArgument:
     case SourceFileKind::Main:
     case SourceFileKind::SIL:
       return true;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -45,6 +45,7 @@ static bool shouldInferAttributeInContext(const DeclContext *dc) {
           // Interfaces have explicitly called-out Sendable conformances.
           return false;
 
+        case SourceFileKind::DefaultArgument:
         case SourceFileKind::Library:
         case SourceFileKind::MacroExpansion:
         case SourceFileKind::Main:
@@ -868,6 +869,7 @@ static bool shouldDiagnosePreconcurrencyImports(SourceFile &sf) {
   case SourceFileKind::SIL:
       return false;
 
+  case SourceFileKind::DefaultArgument:
   case SourceFileKind::Library:
   case SourceFileKind::Main:
   case SourceFileKind::MacroExpansion:
@@ -5615,6 +5617,7 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
           // Interfaces have explicitly called-out Sendable conformances.
           return nullptr;
 
+        case SourceFileKind::DefaultArgument:
         case SourceFileKind::Library:
         case SourceFileKind::MacroExpansion:
         case SourceFileKind::Main:

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1037,7 +1037,8 @@ static bool checkExpressionMacroDefaultValueRestrictions(ParamDecl *param) {
   // only allow arguments that are literals
   auto args = macroExpansionExpr->getArgs();
   for (auto arg : *args)
-    if (!dyn_cast<LiteralExpr>(arg.getExpr())) {
+    if (!isa<LiteralExpr>(arg.getExpr()) ||
+        isa<InterpolatedStringLiteralExpr>(arg.getExpr())) {
       ctx.Diags.diagnose(
           arg.getExpr()->getLoc(),
           diag::macro_as_default_argument_arguments_must_be_literal);

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2196,6 +2196,10 @@ public:
     return getContextForPatternBinding(binding);
   }
 
+  static Context forDefaultArgument(DeclContext *dc) {
+    return Context(Kind::DefaultArgument, dc);
+  }
+
   static Context forEnumElementInitializer(EnumElementDecl *elt) {
     return Context(Kind::EnumElementInitializer, elt);
   }
@@ -3693,6 +3697,14 @@ void TypeChecker::checkInitializerEffects(Initializer *initCtx,
                                                 Expr *init) {
   auto &ctx = initCtx->getASTContext();
   CheckEffectsCoverage checker(ctx, Context::forInitializer(initCtx));
+  init->walk(checker);
+  init->walk(LocalFunctionEffectsChecker());
+}
+
+void TypeChecker::checkCallerSideDefaultArgumentEffects(DeclContext *initCtx,
+                                                        Expr *init) {
+  auto &ctx = initCtx->getASTContext();
+  CheckEffectsCoverage checker(ctx, Context::forDefaultArgument(initCtx));
   init->walk(checker);
   init->walk(LocalFunctionEffectsChecker());
 }

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -719,9 +719,7 @@ static SourceFile *createDefaultArgumentSourceFile(StringRef macroExpression,
 
   llvm::SmallString<256> builder;
   unsigned line, column;
-  // TODO: ApolloZhu check getPresumedLineAndColumnForLoc
   std::tie(line, column) = sourceMgr.getLineAndColumnInBuffer(insertionPoint);
-  // TODO: ApolloZhu check getVirtualFile/getOutermostParentSourceFile
   auto file = dc->getParentSourceFile()->getFilename();
 
   // find a way to pass the file:line:column to macro expansion

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -710,8 +710,60 @@ Expr *TypeChecker::foldSequence(SequenceExpr *expr, DeclContext *dc) {
   return Result;
 }
 
+static SourceFile *createDefaultArgumentSourceFile(StringRef macroExpression,
+                                                   SourceLoc insertionPoint,
+                                                   ASTNode target,
+                                                   DeclContext *dc) {
+  ASTContext &ctx = dc->getASTContext();
+  SourceManager &sourceMgr = ctx.SourceMgr;
+
+  llvm::SmallString<256> builder;
+  unsigned line, column;
+  std::tie(line, column) =
+      sourceMgr.getPresumedLineAndColumnForLoc(insertionPoint);
+  auto file = dc->getOutermostParentSourceFile()->getFilename();
+
+  // find a way to pass the file:line:column to macro expansion
+  // so that we can share same buffer for the same default argument
+  builder.append(line - 1, '\n');
+  builder.append(column - 1, ' ');
+  builder.append(macroExpression);
+
+  std::unique_ptr<llvm::MemoryBuffer> buffer;
+  buffer = llvm::MemoryBuffer::getMemBufferCopy(builder.str(), file);
+
+  // Dump default argument to standard output, if requested.
+  if (ctx.LangOpts.DumpMacroExpansions) {
+    llvm::errs() << buffer->getBufferIdentifier()
+                 << "\n------------------------------\n"
+                 << buffer->getBuffer()
+                 << "\n------------------------------\n";
+  }
+
+  // Create a new source buffer with the contents of the default argument
+  unsigned macroBufferID = sourceMgr.addNewSourceBuffer(std::move(buffer));
+  auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
+  GeneratedSourceInfo sourceInfo{GeneratedSourceInfo::DefaultArgument,
+                                 {insertionPoint, 0},
+                                 macroBufferRange,
+                                 target.getOpaqueValue(),
+                                 dc,
+                                 nullptr};
+  sourceMgr.setGeneratedSourceInfo(macroBufferID, sourceInfo);
+
+  // Create a source file to hold the macro buffer. This is automatically
+  // registered with the enclosing module.
+  auto sourceFile = new (ctx) SourceFile(
+      *dc->getParentModule(), SourceFileKind::DefaultArgument, macroBufferID,
+      /*parsingOpts=*/{}, /*isPrimary=*/false);
+  sourceFile->setImports(dc->getParentSourceFile()->getImports());
+  return sourceFile;
+}
+
 static Expr *synthesizeCallerSideDefault(const ParamDecl *param,
-                                         SourceLoc loc) {
+                                         DefaultArgumentExpr *defaultExpr,
+                                         DeclContext *dc) {
+  SourceLoc loc = defaultExpr->getLoc();
   auto &ctx = param->getASTContext();
   switch (param->getDefaultArgumentKind()) {
 #define MAGIC_IDENTIFIER(NAME, STRING, SYNTAX_KIND) \
@@ -720,6 +772,26 @@ static Expr *synthesizeCallerSideDefault(const ParamDecl *param,
         MagicIdentifierLiteralExpr(MagicIdentifierLiteralExpr::NAME, loc, \
                                    /*implicit=*/true);
 #include "swift/AST/MagicIdentifierKinds.def"
+
+  case DefaultArgumentKind::ExpressionMacro: {
+    // FIXME: ApolloZhu what is macro has parameters that references
+    // other things in decl context?
+    SmallString<128> scratch;
+    const StringRef text = param->getDefaultValueStringRepresentation(scratch);
+    SourceFile *defaultArgSourceFile =
+        createDefaultArgumentSourceFile(text, loc, defaultExpr, dc);
+    auto topLevelItems = defaultArgSourceFile->getTopLevelItems();
+    for (auto item : topLevelItems) {
+      if (auto *expr = item.dyn_cast<Expr *>())
+        if (auto *callerSideMacroExpansionExpr =
+                dyn_cast<MacroExpansionExpr>(expr)) {
+          callerSideMacroExpansionExpr->setImplicit();
+          return callerSideMacroExpansionExpr;
+        }
+    }
+    llvm_unreachable("default argument source file missing caller side macro "
+                     "expansion expression");
+  }
 
   case DefaultArgumentKind::NilLiteral:
     return new (ctx) NilLiteralExpr(loc, /*Implicit=*/true);
@@ -750,15 +822,15 @@ Expr *CallerSideDefaultArgExprRequest::evaluate(
   auto paramTy = defaultExpr->getType();
 
   // Re-create the default argument using the location info of the call site.
-  auto *initExpr =
-      synthesizeCallerSideDefault(param, defaultExpr->getLoc());
   auto *dc = defaultExpr->ContextOrCallerSideExpr.get<DeclContext *>();
+  auto *initExpr = synthesizeCallerSideDefault(param, defaultExpr, dc);
   assert(dc && "Expected a DeclContext before type-checking caller-side arg");
 
   auto &ctx = param->getASTContext();
   DiagnosticTransaction transaction(ctx.Diags);
   if (!TypeChecker::typeCheckParameterDefault(initExpr, dc, paramTy,
-                                              param->isAutoClosure())) {
+                                              param->isAutoClosure(),
+                                              /*atCallerSide=*/true)) {
     if (param->hasDefaultExpr()) {
       // HACK: If we were unable to type-check the default argument in context,
       // then retry by type-checking it within the parameter decl, which should
@@ -769,6 +841,10 @@ Expr *CallerSideDefaultArgExprRequest::evaluate(
       assert(ctx.Diags.hadAnyError());
     }
     return new (ctx) ErrorExpr(initExpr->getSourceRange(), paramTy);
+  }
+  if (param->getDefaultArgumentKind() == DefaultArgumentKind::ExpressionMacro) {
+    TypeChecker::contextualizeCallSideDefaultArgument(dc, initExpr);
+    TypeChecker::checkCallerSideDefaultArgumentEffects(dc, initExpr);
   }
   return initExpr;
 }

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -719,9 +719,10 @@ static SourceFile *createDefaultArgumentSourceFile(StringRef macroExpression,
 
   llvm::SmallString<256> builder;
   unsigned line, column;
-  std::tie(line, column) =
-      sourceMgr.getPresumedLineAndColumnForLoc(insertionPoint);
-  auto file = dc->getOutermostParentSourceFile()->getFilename();
+  // TODO: ApolloZhu check getPresumedLineAndColumnForLoc
+  std::tie(line, column) = sourceMgr.getLineAndColumnInBuffer(insertionPoint);
+  // TODO: ApolloZhu check getVirtualFile/getOutermostParentSourceFile
+  auto file = dc->getParentSourceFile()->getFilename();
 
   // find a way to pass the file:line:column to macro expansion
   // so that we can share same buffer for the same default argument

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -774,8 +774,6 @@ static Expr *synthesizeCallerSideDefault(const ParamDecl *param,
 #include "swift/AST/MagicIdentifierKinds.def"
 
   case DefaultArgumentKind::ExpressionMacro: {
-    // FIXME: ApolloZhu what is macro has parameters that references
-    // other things in decl context?
     SmallString<128> scratch;
     const StringRef text = param->getDefaultValueStringRepresentation(scratch);
     SourceFile *defaultArgSourceFile =

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -774,6 +774,7 @@ static Expr *synthesizeCallerSideDefault(const ParamDecl *param,
 #include "swift/AST/MagicIdentifierKinds.def"
 
   case DefaultArgumentKind::ExpressionMacro: {
+    // FIXME: ApolloZhu serialize and deserialize expressions instead
     SmallString<128> scratch;
     const StringRef text = param->getDefaultValueStringRepresentation(scratch);
     SourceFile *defaultArgSourceFile =

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2819,6 +2819,7 @@ static bool requiresDefinition(Decl *decl) {
     case SourceFileKind::Library:
     case SourceFileKind::Main:
     case SourceFileKind::MacroExpansion:
+    case SourceFileKind::DefaultArgument:
       break;
     }
   }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -122,9 +122,7 @@ namespace {
         if (DAE->isCallerSide() &&
             (DAE->getParamDecl()->isAutoClosure() ||
              (DAE->getParamDecl()->getDefaultArgumentKind() ==
-                  DefaultArgumentKind::ExpressionMacro &&
-              ParentDC->getASTContext().LangOpts.hasFeature(
-                  Feature::ExpressionMacroDefaultArguments))))
+              DefaultArgumentKind::ExpressionMacro)))
           DAE->getCallerSideDefaultExpr()->walk(*this);
 
       // Macro expansion expressions require a DeclContext as well.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -372,6 +372,7 @@ void swift::performWholeModuleTypeChecking(SourceFile &SF) {
   FrontendStatsTracer tracer(Ctx.Stats,
                              "perform-whole-module-type-checking");
   switch (SF.Kind) {
+  case SourceFileKind::DefaultArgument:
   case SourceFileKind::Library:
   case SourceFileKind::Main:
   case SourceFileKind::MacroExpansion:
@@ -418,6 +419,7 @@ void swift::loadDerivativeConfigurations(SourceFile &SF) {
   };
 
   switch (SF.Kind) {
+  case SourceFileKind::DefaultArgument:
   case SourceFileKind::Library:
   case SourceFileKind::MacroExpansion:
   case SourceFileKind::Main: {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -467,7 +467,8 @@ bool typeCheckClosureBody(ClosureExpr *closure);
 bool typeCheckTapBody(TapExpr *expr, DeclContext *DC);
 
 Type typeCheckParameterDefault(Expr *&defaultValue, DeclContext *DC,
-                               Type paramType, bool isAutoClosure);
+                               Type paramType, bool isAutoClosure,
+                               bool atCallerSide);
 
 void typeCheckTopLevelCodeDecl(TopLevelCodeDecl *TLCD);
 
@@ -760,6 +761,7 @@ void checkPatternBindingCaptures(IterableDeclContext *DC);
 /// Change the context of closures in the given initializer
 /// expression to the given context.
 void contextualizeInitializer(Initializer *DC, Expr *init);
+void contextualizeCallSideDefaultArgument(DeclContext *DC, Expr *init);
 void contextualizeTopLevelCode(TopLevelCodeDecl *TLCD);
 
 /// Retrieve the default type for the given protocol.
@@ -1135,6 +1137,7 @@ void checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name);
 void checkTopLevelEffects(TopLevelCodeDecl *D);
 void checkFunctionEffects(AbstractFunctionDecl *D);
 void checkInitializerEffects(Initializer *I, Expr *E);
+void checkCallerSideDefaultArgumentEffects(DeclContext *I, Expr *E);
 void checkEnumElementEffects(EnumElementDecl *D, Expr *expr);
 void checkPropertyWrapperEffects(PatternBindingDecl *binding, Expr *expr);
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -452,6 +452,7 @@ getActualDefaultArgKind(uint8_t raw) {
   CASE(EmptyArray)
   CASE(EmptyDictionary)
   CASE(StoredProperty)
+  CASE(ExpressionMacro)
 #undef CASE
   }
   return llvm::None;

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -537,6 +537,7 @@ enum class DefaultArgumentKind : uint8_t {
   EmptyArray,
   EmptyDictionary,
   StoredProperty,
+  ExpressionMacro,
 };
 using DefaultArgumentField = BCFixed<4>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1415,6 +1415,7 @@ static uint8_t getRawStableDefaultArgumentKind(swift::DefaultArgumentKind kind) 
   CASE(EmptyArray)
   CASE(EmptyDictionary)
   CASE(StoredProperty)
+  CASE(ExpressionMacro)
 #undef CASE
   }
 
@@ -4402,12 +4403,14 @@ public:
 
     swift::DefaultArgumentKind argKind = param->getDefaultArgumentKind();
     if (argKind == swift::DefaultArgumentKind::Normal ||
-        argKind == swift::DefaultArgumentKind::StoredProperty) {
+        argKind == swift::DefaultArgumentKind::StoredProperty ||
+        argKind == swift::DefaultArgumentKind::ExpressionMacro) {
       defaultArgumentText =
         param->getDefaultValueStringRepresentation(scratch);
 
       // Serialize the type of the default expression (if any).
-      defaultExprType = param->getTypeOfDefaultExpr();
+      if (!param->hasCallerSideDefaultExpr())
+        defaultExprType = param->getTypeOfDefaultExpr();
     }
 
     auto isolation = param->getInitializerIsolation();

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1986,6 +1986,74 @@ public struct NestedMagicLiteralMacro: ExpressionMacro {
   }
 }
 
+public struct NativeFileIDMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return context.location(
+        of: node, at: .afterLeadingTrivia, filePathMode: .fileID
+    )!.file
+  }
+}
+
+public struct NativeFilePathMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return context.location(
+        of: node, at: .afterLeadingTrivia, filePathMode: .filePath
+    )!.file
+  }
+}
+
+public struct NativeLineMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return context.location(of: node)!.line
+  }
+}
+
+public struct NativeColumnMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    return context.location(of: node)!.column
+  }
+}
+
+public struct ClosureCallerMacro: ExpressionMacro {
+    public static func expansion(
+      of node: some FreestandingMacroExpansionSyntax,
+      in context: some MacroExpansionContext
+    ) -> ExprSyntax {
+        let location = context.location(of: node)!
+        return #"""
+        ClosureCaller({ (value, then) in
+            #sourceLocation(file: \#(location.file), line: \#(location.line))
+            print("\(value)@\(\#(location.file))#\(\#(location.line))")
+            then()
+            #sourceLocation()
+        })
+        """#
+    }
+}
+
+public struct FirstArgumentConcatStringMacro: ExpressionMacro {
+    public static func expansion(
+      of node: some FreestandingMacroExpansionSyntax,
+      in context: some MacroExpansionContext
+    ) -> ExprSyntax {
+        """
+        \(node.arguments.first!.expression) + " world"
+        """
+    }
+}
+
 public struct InvalidIfExprMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2043,37 +2043,14 @@ public struct ClosureCallerMacro: ExpressionMacro {
     }
 }
 
-public struct PrependHelloMacro: ExpressionMacro {
+public struct PrependHelloToShadowedMacro: ExpressionMacro {
     public static func expansion(
       of node: some FreestandingMacroExpansionSyntax,
       in context: some MacroExpansionContext
     ) -> ExprSyntax {
-        """
-        "hello " + \(node.arguments.first!.expression)
-        """
-    }
-}
-
-public struct AsIsMacro: ExpressionMacro {
-    public static func expansion(
-      of node: some FreestandingMacroExpansionSyntax,
-      in context: some MacroExpansionContext
-    ) -> ExprSyntax {
-        node.arguments.first!.expression
-    }
-}
-
-public struct IntroduceShadowedMacro: ExpressionMacro {
-    public static func expansion(
-      of node: some FreestandingMacroExpansionSyntax,
-      in context: some MacroExpansionContext
-    ) -> ExprSyntax {
-        """
-        {
-            let shadowed = "from shadow"
-            return \(node.arguments.first!.expression)
-        }()
-        """
+        #"""
+        "hello \(shadowed)"
+        """#
     }
 }
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2043,13 +2043,36 @@ public struct ClosureCallerMacro: ExpressionMacro {
     }
 }
 
-public struct FirstArgumentConcatStringMacro: ExpressionMacro {
+public struct PrependHelloMacro: ExpressionMacro {
     public static func expansion(
       of node: some FreestandingMacroExpansionSyntax,
       in context: some MacroExpansionContext
     ) -> ExprSyntax {
         """
-        \(node.arguments.first!.expression) + " world"
+        "hello " + \(node.arguments.first!.expression)
+        """
+    }
+}
+
+public struct AsIsMacro: ExpressionMacro {
+    public static func expansion(
+      of node: some FreestandingMacroExpansionSyntax,
+      in context: some MacroExpansionContext
+    ) -> ExprSyntax {
+        node.arguments.first!.expression
+    }
+}
+
+public struct IntroduceShadowedMacro: ExpressionMacro {
+    public static func expansion(
+      of node: some FreestandingMacroExpansionSyntax,
+      in context: some MacroExpansionContext
+    ) -> ExprSyntax {
+        """
+        {
+            let shadowed = "from shadow"
+            return \(node.arguments.first!.expression)
+        }()
         """
     }
 }

--- a/test/Macros/Inputs/with_macro_default_arg_interface.swift
+++ b/test/Macros/Inputs/with_macro_default_arg_interface.swift
@@ -4,18 +4,8 @@ public macro FileID<T: ExpressibleByStringLiteral>() -> T = #externalMacro(
 )
 
 @freestanding(expression)
-public macro PrependHello(_ param: String) -> String = #externalMacro(
-    module: "MacroDefinition", type: "PrependHelloMacro"
-)
-
-@freestanding(expression)
-public macro AsIs<T>(_ param: T) -> T = #externalMacro(
-    module: "MacroDefinition", type: "AsIsMacro"
-)
-
-@freestanding(expression)
-public macro IntroduceShadowed<T>(_ param: T) -> T = #externalMacro(
-    module: "MacroDefinition", type: "IntroduceShadowedMacro"
+public macro PrependHelloToShadowed() -> String = #externalMacro(
+    module: "MacroDefinition", type: "PrependHelloToShadowedMacro"
 )
 
 @freestanding(expression)
@@ -43,26 +33,8 @@ public struct ClosureCaller {
 
 public let shadowed = "world"
 
-public func testParameterUseVariableFromOriginalDeclContext(
-    param: String = #PrependHello(shadowed)
-) {
-    print(param)
-}
-
-public func testMacroUseMacro(
-    param: String = #PrependHello(#fileID)
-) {
-    print(param)
-}
-
-public func testUseShadowedFromOuterExpansion(
-    param: String = #IntroduceShadowed(#PrependHello(shadowed))
-) {
-    print(param)
-}
-
-public func testNestedStillInOriginalDeclContext(
-    param: String = #AsIs(#PrependHello(shadowed))
+public func preferVariableFromLocalScope(
+    param: String = #PrependHelloToShadowed
 ) {
     print(param)
 }

--- a/test/Macros/Inputs/with_macro_default_arg_interface.swift
+++ b/test/Macros/Inputs/with_macro_default_arg_interface.swift
@@ -1,0 +1,49 @@
+@freestanding(expression)
+public macro FileID<T: ExpressibleByStringLiteral>() -> T = #externalMacro(
+    module: "MacroDefinition", type: "NativeFileIDMacro"
+)
+
+@freestanding(expression)
+public macro HasParam(_ param: String) -> String = #externalMacro(
+    module: "MacroDefinition", type: "FirstArgumentConcatStringMacro"
+)
+
+@freestanding(expression)
+public macro MakeClosureCaller() -> ClosureCaller = #externalMacro(
+    module: "MacroDefinition", type: "ClosureCallerMacro"
+)
+
+public func printCurrentFileDefinedInAnotherModuleInterface(
+    file: String = #FileID
+) {
+    print(file)
+}
+
+public struct ClosureCaller {
+    private let callback: @convention(thin) (Any, () -> Void) -> Void
+
+    public init(_ callback: @convention(thin) (Any, () -> Void) -> Void) {
+        self.callback = callback
+    }
+
+    public func callAsFunction(context: Any, then: () -> Void = {}) {
+        callback(context, then)
+    }
+}
+
+public let shadowed = "hello"
+
+public func testParameterUseVariableFromOriginalDeclContext(
+    param: String = #HasParam(shadowed)
+) {
+    print(param)
+}
+
+@resultBuilder
+public enum ClosureCallerBuilder {
+    public static func buildBlock(
+        closureCaller: ClosureCaller = #MakeClosureCaller
+    ) -> ClosureCaller {
+        closureCaller
+    }
+}

--- a/test/Macros/Inputs/with_macro_default_arg_interface.swift
+++ b/test/Macros/Inputs/with_macro_default_arg_interface.swift
@@ -4,8 +4,18 @@ public macro FileID<T: ExpressibleByStringLiteral>() -> T = #externalMacro(
 )
 
 @freestanding(expression)
-public macro HasParam(_ param: String) -> String = #externalMacro(
-    module: "MacroDefinition", type: "FirstArgumentConcatStringMacro"
+public macro PrependHello(_ param: String) -> String = #externalMacro(
+    module: "MacroDefinition", type: "PrependHelloMacro"
+)
+
+@freestanding(expression)
+public macro AsIs<T>(_ param: T) -> T = #externalMacro(
+    module: "MacroDefinition", type: "AsIsMacro"
+)
+
+@freestanding(expression)
+public macro IntroduceShadowed<T>(_ param: T) -> T = #externalMacro(
+    module: "MacroDefinition", type: "IntroduceShadowedMacro"
 )
 
 @freestanding(expression)
@@ -31,10 +41,28 @@ public struct ClosureCaller {
     }
 }
 
-public let shadowed = "hello"
+public let shadowed = "world"
 
 public func testParameterUseVariableFromOriginalDeclContext(
-    param: String = #HasParam(shadowed)
+    param: String = #PrependHello(shadowed)
+) {
+    print(param)
+}
+
+public func testMacroUseMacro(
+    param: String = #PrependHello(#fileID)
+) {
+    print(param)
+}
+
+public func testUseShadowedFromOuterExpansion(
+    param: String = #IntroduceShadowed(#PrependHello(shadowed))
+) {
+    print(param)
+}
+
+public func testNestedStillInOriginalDeclContext(
+    param: String = #AsIs(#PrependHello(shadowed))
 ) {
     print(param)
 }

--- a/test/Macros/Inputs/with_macro_default_arg_module.swift
+++ b/test/Macros/Inputs/with_macro_default_arg_module.swift
@@ -1,0 +1,8 @@
+@freestanding(expression)
+public macro Line<T : ExpressibleByIntegerLiteral>() -> T = #externalMacro(
+    module: "MacroDefinition", type: "NativeLineMacro"
+)
+
+public func printCurrentLineDefinedAtAnotherModule(line: Int = #Line) {
+    print(line)
+}

--- a/test/Macros/Inputs/with_macro_default_arg_same_module.swift
+++ b/test/Macros/Inputs/with_macro_default_arg_same_module.swift
@@ -1,0 +1,29 @@
+import WithMacroDefaultArg
+import WithMacroDefaultArgInterface
+
+@freestanding(expression)
+macro MagicLine() -> Int = #externalMacro(
+    module: "MacroDefinition", type: "MagicLineMacro"
+)
+
+@freestanding(expression)
+macro Column<T : ExpressibleByIntegerLiteral>() -> T = #externalMacro(
+    module: "MacroDefinition", type: "NativeColumnMacro"
+)
+
+@freestanding(expression)
+macro FilePath<T: ExpressibleByStringLiteral>() -> T = #externalMacro(
+    module: "MacroDefinition", type: "NativeFilePathMacro"
+)
+
+func printAnotherFileName(file: String = (#FileID)) {
+    print(file)
+}
+
+func printCurrentFileDefinedAtAnotherFile(file: String = #FileID) {
+    print(file)
+}
+
+func printCurrentLineDefinedAtAnotherFile(line: Int = #Line) {
+    print(line)
+}

--- a/test/Macros/macro_default_argument_access_level.swift
+++ b/test/Macros/macro_default_argument_access_level.swift
@@ -1,0 +1,26 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -enable-experimental-feature ExpressionMacroDefaultArguments
+
+public typealias Stringified<T> = (T, String)
+
+@freestanding(expression)
+public macro publicStringify<T>(_ value: T) -> Stringified<T> = #externalMacro(
+    module: "MacroDefinition", type: "StringifyMacro"
+)
+
+public func publicUsePublic(okay: Stringified<Int> = #publicStringify(0)) {}
+func internalUsePublic(okay: Stringified<Int> = #publicStringify(0)) {}
+
+// expected-note@+2{{macro 'stringify' is not '@usableFromInline' or public}}
+@freestanding(expression)
+macro stringify<T>(_ value: T) -> Stringified<T> = #externalMacro(
+    module: "MacroDefinition", type: "StringifyMacro"
+)
+
+// expected-error@+1{{macro 'stringify' is internal and cannot be referenced from a default argument value}}
+public func publicUseInternal(fail: Stringified<Int> = #stringify(0)) {}
+func internalUseInternal(okay: Stringified<Int> = #stringify(0)) {}

--- a/test/Macros/macro_default_argument_diagnostics.swift
+++ b/test/Macros/macro_default_argument_diagnostics.swift
@@ -5,7 +5,9 @@
 
 // RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -enable-experimental-feature ExpressionMacroDefaultArguments -enable-bare-slash-regex
 
-typealias Stringified<T> = (T, String)
+public typealias Stringified<T> = (T, String)
+
+// expected-note@+2{{macro 'stringify' is not '@usableFromInline' or public}}
 @freestanding(expression)
 macro stringify<T>(_ value: T) -> Stringified<T> = #externalMacro(
     module: "MacroDefinition", type: "StringifyMacro"
@@ -53,3 +55,9 @@ func testIdentifier(notOkay: Stringified<String> = #stringify(myString)) {}
 
 // expected-error@+1{{argument to macro used as default argument must be literal}}
 func testString(interpolated: Stringified<String> = #stringify("Hello \(0b10001)")) {}
+
+// expected-error@+1{{macro 'stringify' is internal and cannot be referenced from a default argument value}}
+public func testAccess(internal: Stringified<Int> = #stringify(0)) {}
+
+// expected-error@+1{{default argument value of type '(Int, String)' cannot be converted to type 'Int'}}
+func testReturn(wrongType: Int = #stringify(0)) {}

--- a/test/Macros/macro_default_argument_diagnostics.swift
+++ b/test/Macros/macro_default_argument_diagnostics.swift
@@ -30,8 +30,7 @@ func testInt(positive: Stringified<UInt64> = #stringify(1_000_001),
              negative: Stringified<Int32> = #stringify(-0o21)) {}
 func testFloat(double: Stringified<Double> = #stringify(-0xC.3p0),
                float: Stringified<Float> = #stringify(00003.14159)) {}
-func testString(literal: Stringified<MyLiteral> = #stringify("🐨"),
-                interpolated: Stringified<String> = #stringify("Hello \(0b10001)")) {}
+func testString(literal: Stringified<MyLiteral> = #stringify("🐨")) {}
 func testMagic(fileID: Stringified<String> = #stringify(#fileID),
                filePath: Stringified<String> = #stringify(#filePath),
                file: Stringified<String> = #stringify(#file),
@@ -51,3 +50,6 @@ let myString = "oops"
 
 // expected-error@+1{{argument to macro used as default argument must be literal}}
 func testIdentifier(notOkay: Stringified<String> = #stringify(myString)) {}
+
+// expected-error@+1{{argument to macro used as default argument must be literal}}
+func testString(interpolated: Stringified<String> = #stringify("Hello \(0b10001)")) {}

--- a/test/Macros/macro_default_argument_diagnostics.swift
+++ b/test/Macros/macro_default_argument_diagnostics.swift
@@ -50,10 +50,10 @@ func testObject(color: Stringified<MyLiteral> = #stringify(#colorLiteral(red: 0.
 
 let myString = "oops"
 
-// expected-error@+1{{argument to macro used as default argument must be literal}}
+// expected-error@+1{{only literals are permitted}}
 func testIdentifier(notOkay: Stringified<String> = #stringify(myString)) {}
 
-// expected-error@+1{{argument to macro used as default argument must be literal}}
+// expected-error@+1{{only literals are permitted}}
 func testString(interpolated: Stringified<String> = #stringify("Hello \(0b10001)")) {}
 
 // expected-error@+1{{macro 'stringify' is internal and cannot be referenced from a default argument value}}

--- a/test/Macros/macro_default_argument_diagnostics.swift
+++ b/test/Macros/macro_default_argument_diagnostics.swift
@@ -1,0 +1,53 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -enable-experimental-feature ExpressionMacroDefaultArguments -enable-bare-slash-regex
+
+typealias Stringified<T> = (T, String)
+@freestanding(expression)
+macro stringify<T>(_ value: T) -> Stringified<T> = #externalMacro(
+    module: "MacroDefinition", type: "StringifyMacro"
+)
+
+struct MyType { }
+typealias MyInt = Int
+struct MyLiteral: ExpressibleByStringLiteral, _ExpressibleByColorLiteral, _ExpressibleByImageLiteral, _ExpressibleByFileReferenceLiteral {
+    init(stringLiteral value: StringLiteralType) {}
+    init(_colorLiteralRed: Float, green: Float, blue: Float, alpha: Float) {}
+    init(imageLiteralResourceName: String) {}
+    init(fileReferenceLiteralResourceName: String) {}
+}
+
+// MARK: literals
+
+func testNil(nil: Stringified<MyLiteral?> = #stringify(nil)) {}
+func testBool(true: Stringified<Bool> = #stringify(true),
+              false: Stringified<Bool> = #stringify(false)) {}
+func testInt(positive: Stringified<UInt64> = #stringify(1_000_001),
+             zero: Stringified<MyInt> = #stringify(0x0),
+             negative: Stringified<Int32> = #stringify(-0o21)) {}
+func testFloat(double: Stringified<Double> = #stringify(-0xC.3p0),
+               float: Stringified<Float> = #stringify(00003.14159)) {}
+func testString(literal: Stringified<MyLiteral> = #stringify("🐨"),
+                interpolated: Stringified<String> = #stringify("Hello \(0b10001)")) {}
+func testMagic(fileID: Stringified<String> = #stringify(#fileID),
+               filePath: Stringified<String> = #stringify(#filePath),
+               file: Stringified<String> = #stringify(#file),
+               function: Stringified<String> = #stringify(#function),
+               line: Stringified<Int> = #stringify(#line),
+               column: Stringified<Int> = #stringify(#column),
+               dso: Stringified<UnsafeRawPointer> = #stringify(#dsohandle)) {}
+@available(SwiftStdlib 5.7, *)
+func testRegex(literal: Stringified<Regex<Substring>> = #stringify(/foo/)) {}
+func testObject(color: Stringified<MyLiteral> = #stringify(#colorLiteral(red: 0.4, green: 0.8, blue: 1, alpha: 1)),
+                image: Stringified<MyLiteral> = #stringify(#imageLiteral(resourceName: "swift.png")),
+                file: Stringified<MyLiteral> = #stringify(#fileLiteral(resourceName: "main.swift"))) {}
+
+// MARK: not literal
+
+let myString = "oops"
+
+// expected-error@+1{{argument to macro used as default argument must be literal}}
+func testIdentifier(notOkay: Stringified<String> = #stringify(myString)) {}

--- a/test/Macros/macro_default_argument_diagnostics.swift
+++ b/test/Macros/macro_default_argument_diagnostics.swift
@@ -7,7 +7,6 @@
 
 public typealias Stringified<T> = (T, String)
 
-// expected-note@+2{{macro 'stringify' is not '@usableFromInline' or public}}
 @freestanding(expression)
 macro stringify<T>(_ value: T) -> Stringified<T> = #externalMacro(
     module: "MacroDefinition", type: "StringifyMacro"
@@ -55,9 +54,6 @@ func testIdentifier(notOkay: Stringified<String> = #stringify(myString)) {}
 
 // expected-error@+1{{only literals are permitted}}
 func testString(interpolated: Stringified<String> = #stringify("Hello \(0b10001)")) {}
-
-// expected-error@+1{{macro 'stringify' is internal and cannot be referenced from a default argument value}}
-public func testAccess(internal: Stringified<Int> = #stringify(0)) {}
 
 // expected-error@+1{{default argument value of type '(Int, String)' cannot be converted to type 'Int'}}
 func testReturn(wrongType: Int = #stringify(0)) {}

--- a/test/Macros/macro_default_argument_enabled.swift
+++ b/test/Macros/macro_default_argument_enabled.swift
@@ -1,0 +1,138 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(WithMacroDefaultArg)) %S/Inputs/with_macro_default_arg_module.swift -module-name WithMacroDefaultArg -emit-module -emit-module-path %t/WithMacroDefaultArg.swiftmodule -load-plugin-library %t/%target-library-name(MacroDefinition) -enable-experimental-feature ExpressionMacroDefaultArguments -I %t -swift-version 5
+// RUN: %target-codesign %t/%target-library-name(WithMacroDefaultArg)
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(WithMacroDefaultArgInterface)) %S/Inputs/with_macro_default_arg_interface.swift -module-name WithMacroDefaultArgInterface -enable-library-evolution -emit-module-interface-path %t/WithMacroDefaultArgInterface.swiftinterface -load-plugin-library %t/%target-library-name(MacroDefinition) -enable-experimental-feature ExpressionMacroDefaultArguments -I %t -swift-version 5
+// RUN: %target-codesign %t/%target-library-name(WithMacroDefaultArgInterface)
+
+// RUN: %target-build-swift -enable-experimental-feature ExpressionMacroDefaultArguments -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %S/Inputs/with_macro_default_arg_same_module.swift %s -o %t/main -module-name MacroUser -emit-tbd -emit-tbd-path %t/MacroUser.tbd -I %t -L %t -lWithMacroDefaultArg -lWithMacroDefaultArgInterface
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+import WithMacroDefaultArg
+import WithMacroDefaultArgInterface
+
+struct SourceLocation: CustomStringConvertible {
+    let line: Int
+    let column: Int
+
+    var description: String {
+        "\(line):\(column)"
+    }
+}
+
+func partOfDefaultArgumentOkay(
+    // CHECK: [[# @LINE + 1]]:59
+    location: SourceLocation = .init(line: #Line, column: #Column)
+) {
+    print(location)
+}
+
+// CHECK: [[# @LINE + 1]]
+func parenthesizedExpansionAtDeclOkay(line: Int = (#Line)) {
+    print(line)
+}
+
+func asDefaultArgument(line: Int = #Line) {
+    print(line)
+}
+
+func asDefaultArgumentExpandingToBuiltInLine(line: Int = #MagicLine) {
+    print(line)
+}
+
+@resultBuilder
+enum SourceLocationBuilder {
+    static func buildExpression<T>(
+        _ expression: T, line: Int = #Line, column: Int = #Column
+    ) -> SourceLocation {
+        SourceLocation(line: line, column: column)
+    }
+
+    static func buildBlock(_ location: SourceLocation) -> SourceLocation {
+        location
+    }
+}
+
+func build(@SourceLocationBuilder body: () -> SourceLocation) -> SourceLocation {
+    body()
+}
+
+let result = build {
+    // CHECK: [[# @LINE + 1]]:5
+    0
+}
+
+func sameFileID(builtIn: String = #fileID, expressionMacro: String = #FileID) {
+    print(builtIn == expressionMacro)
+}
+
+func sameFilePath(builtIn: String = #filePath, expressionMacro: String = #FilePath) {
+    print(builtIn == expressionMacro)
+}
+
+func sameLine(builtIn: Int = #line, expressionMacro: Int = #Line) {
+    print(builtIn == expressionMacro)
+}
+
+func sameColumn(builtIn: Int = #column, expressionMacro: Int = #Column) {
+    print(builtIn == expressionMacro)
+}
+
+func buildPrinter(
+    @ClosureCallerBuilder makeCaller: () -> ClosureCaller
+) -> ClosureCaller {
+    makeCaller()
+}
+
+// CHECK: macro@MacroUser/macro_default_argument_enabled.swift#[[# @LINE + 1]]
+let printWithFileLine = buildPrinter { }
+
+@main struct Main {
+    static func main() {
+        partOfDefaultArgumentOkay()
+        parenthesizedExpansionAtDeclOkay()
+        print(result)
+        printWithFileLine(context: "macro")
+        
+        do {
+            let shadowed: Int = 1
+            // CHECK: hello world
+            testParameterUseVariableFromOriginalDeclContext()
+        }
+        
+        do {
+            let shadowed: String = "not this"
+            // CHECK: hello world
+            testParameterUseVariableFromOriginalDeclContext()
+        }
+        
+        // CHECK: [[# @LINE + 1]]
+        asDefaultArgument()
+        // CHECK: [[# @LINE + 1]]
+        asDefaultArgumentExpandingToBuiltInLine()
+        // CHECK: [[# @LINE + 1]]
+        printCurrentLineDefinedAtAnotherFile()
+        // CHECK: [[# @LINE + 1]]
+        printCurrentLineDefinedAtAnotherModule()
+        // CHECK: MacroUser/with_macro_default_arg_same_module.swift
+        printAnotherFileName()
+        // CHECK: MacroUser/macro_default_argument_enabled.swift
+        printCurrentFileDefinedAtAnotherFile()
+        // CHECK: MacroUser/macro_default_argument_enabled.swift
+        printCurrentFileDefinedInAnotherModuleInterface()
+        // CHECK: true
+        sameFileID()
+        // CHECK: true
+        sameFilePath()
+        // CHECK: true
+        sameLine()
+        // CHECK: true
+        sameColumn()
+    }
+}

--- a/test/Macros/macro_default_argument_enabled.swift
+++ b/test/Macros/macro_default_argument_enabled.swift
@@ -112,6 +112,17 @@ let printWithFileLine = buildPrinter { }
             testParameterUseVariableFromOriginalDeclContext()
         }
         
+        do {
+            let shadowed: String = "not this either"
+            // CHECK: hello world
+            testNestedStillInOriginalDeclContext()
+        }
+        
+        // CHECK: hello from shadow
+        testUseShadowedFromOuterExpansion()
+        // CHECK: hello MacroUser/macro_default_argument_enabled.swift
+        testMacroUseMacro()
+        
         // CHECK: [[# @LINE + 1]]
         asDefaultArgument()
         // CHECK: [[# @LINE + 1]]

--- a/test/Macros/macro_default_argument_enabled.swift
+++ b/test/Macros/macro_default_argument_enabled.swift
@@ -99,29 +99,15 @@ let printWithFileLine = buildPrinter { }
         parenthesizedExpansionAtDeclOkay()
         print(result)
         printWithFileLine(context: "macro")
-        
+      
+        // CHECK: hello world
+        preferVariableFromLocalScope()
+      
         do {
-            let shadowed: Int = 1
-            // CHECK: hello world
-            testParameterUseVariableFromOriginalDeclContext()
+            let shadowed = 42
+            // CHECK: hello 42
+            preferVariableFromLocalScope()
         }
-        
-        do {
-            let shadowed: String = "not this"
-            // CHECK: hello world
-            testParameterUseVariableFromOriginalDeclContext()
-        }
-        
-        do {
-            let shadowed: String = "not this either"
-            // CHECK: hello world
-            testNestedStillInOriginalDeclContext()
-        }
-        
-        // CHECK: hello from shadow
-        testUseShadowedFromOuterExpansion()
-        // CHECK: hello MacroUser/macro_default_argument_enabled.swift
-        testMacroUseMacro()
         
         // CHECK: [[# @LINE + 1]]
         asDefaultArgument()

--- a/test/Macros/macro_default_argument_library.swift
+++ b/test/Macros/macro_default_argument_library.swift
@@ -1,0 +1,20 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name CheckInterface -load-plugin-library %t/%target-library-name(MacroDefinition) -enable-experimental-feature ExpressionMacroDefaultArguments -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name CheckInterface -load-plugin-library %t/%target-library-name(MacroDefinition) -I %t
+
+// RUN: %FileCheck %s < %t.swiftinterface
+
+@freestanding(expression)
+public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(
+    module: "MacroDefinition", type: "StringifyMacro"
+)
+
+// CHECK: public func foo(param: (Swift.String, Swift.String) = #stringify(#fileID))
+public func foo(param: (String, String) = #stringify(#fileID)) {
+    print(param)
+}

--- a/test/Macros/macro_default_argument_serialized.swift
+++ b/test/Macros/macro_default_argument_serialized.swift
@@ -1,0 +1,17 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: executable_test
+
+// RUN: %empty-directory(%t)
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Serialized)) %S/macro_default_argument_library.swift -module-name Serialized -emit-module -emit-module-path %t/Serialized.swiftmodule -load-plugin-library %t/%target-library-name(MacroDefinition) -enable-experimental-feature ExpressionMacroDefaultArguments -I %t -swift-version 5
+
+// RUN: %target-build-swift -enable-experimental-feature ExpressionMacroDefaultArguments -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -emit-tbd -emit-tbd-path %t/MacroUser.tbd -I %t -L %t %target-rpath(%t) -lSerialized
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+import Serialized
+
+// CHECK: ("MacroUser/macro_default_argument_serialized.swift", "#fileID")
+print(foo())

--- a/test/Macros/macro_default_argument_source_location.swift
+++ b/test/Macros/macro_default_argument_source_location.swift
@@ -1,16 +1,15 @@
 // REQUIRES: swift_swift_parser
+// REQUIRES: executable_test
 
 // RUN: %empty-directory(%t)
 
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(WithMacroDefaultArg)) %S/Inputs/with_macro_default_arg_module.swift -module-name WithMacroDefaultArg -emit-module -emit-module-path %t/WithMacroDefaultArg.swiftmodule -load-plugin-library %t/%target-library-name(MacroDefinition) -enable-experimental-feature ExpressionMacroDefaultArguments -I %t -swift-version 5
-// RUN: %target-codesign %t/%target-library-name(WithMacroDefaultArg)
 
 // RUN: %target-build-swift-dylib(%t/%target-library-name(WithMacroDefaultArgInterface)) %S/Inputs/with_macro_default_arg_interface.swift -module-name WithMacroDefaultArgInterface -enable-library-evolution -emit-module-interface-path %t/WithMacroDefaultArgInterface.swiftinterface -load-plugin-library %t/%target-library-name(MacroDefinition) -enable-experimental-feature ExpressionMacroDefaultArguments -I %t -swift-version 5
-// RUN: %target-codesign %t/%target-library-name(WithMacroDefaultArgInterface)
 
-// RUN: %target-build-swift -enable-experimental-feature ExpressionMacroDefaultArguments -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %S/Inputs/with_macro_default_arg_same_module.swift %s -o %t/main -module-name MacroUser -emit-tbd -emit-tbd-path %t/MacroUser.tbd -I %t -L %t -lWithMacroDefaultArg -lWithMacroDefaultArgInterface
+// RUN: %target-build-swift -enable-experimental-feature ExpressionMacroDefaultArguments -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %S/Inputs/with_macro_default_arg_same_module.swift %s -o %t/main -module-name MacroUser -emit-tbd -emit-tbd-path %t/MacroUser.tbd -I %t -L %t %target-rpath(%t) -lWithMacroDefaultArg -lWithMacroDefaultArgInterface
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Macros/macro_default_argument_source_location.swift
+++ b/test/Macros/macro_default_argument_source_location.swift
@@ -90,7 +90,7 @@ func buildPrinter(
     makeCaller()
 }
 
-// CHECK: macro@MacroUser/macro_default_argument_enabled.swift#[[# @LINE + 1]]
+// CHECK: macro@MacroUser/macro_default_argument_source_location.swift#[[# @LINE + 1]]
 let printWithFileLine = buildPrinter { }
 
 @main struct Main {
@@ -119,9 +119,9 @@ let printWithFileLine = buildPrinter { }
         printCurrentLineDefinedAtAnotherModule()
         // CHECK: MacroUser/with_macro_default_arg_same_module.swift
         printAnotherFileName()
-        // CHECK: MacroUser/macro_default_argument_enabled.swift
+        // CHECK: MacroUser/macro_default_argument_source_location.swift
         printCurrentFileDefinedAtAnotherFile()
-        // CHECK: MacroUser/macro_default_argument_enabled.swift
+        // CHECK: MacroUser/macro_default_argument_source_location.swift
         printCurrentFileDefinedInAnotherModuleInterface()
         // CHECK: true
         sameFileID()

--- a/test/Macros/macro_default_argument_swiftinterface.swift
+++ b/test/Macros/macro_default_argument_swiftinterface.swift
@@ -1,0 +1,17 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: executable_test
+
+// RUN: %empty-directory(%t)
+
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Interface)) %S/macro_default_argument_library.swift -module-name Interface -enable-library-evolution -emit-module-interface-path %t/Interface.swiftinterface -load-plugin-library %t/%target-library-name(MacroDefinition) -enable-experimental-feature ExpressionMacroDefaultArguments -I %t -swift-version 5
+
+// RUN: %target-build-swift -enable-experimental-feature ExpressionMacroDefaultArguments -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main -module-name MacroUser -emit-tbd -emit-tbd-path %t/MacroUser.tbd -I %t -L %t %target-rpath(%t) -lInterface
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+import Interface
+
+// CHECK: ("MacroUser/macro_default_argument_swiftinterface.swift", "#fileID")
+print(foo())

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -963,6 +963,7 @@ public:
 #include "swift/Basic/MacroRoles.def"
         IsWalkingMacroExpansionBuffer = true;
         break;
+      case GeneratedSourceInfo::DefaultArgument:
       case GeneratedSourceInfo::ReplacedFunctionBody:
       case GeneratedSourceInfo::PrettyPrinted:
         break;


### PR DESCRIPTION
Implementation for [[Pitch] Expression macro as caller-side default argument](https://forums.swift.org/t/pitch-expression-macro-as-caller-side-default-argument/69019)

Corresponding Swift Syntax PR: https://github.com/apple/swift-syntax/pull/2447

Resolves rdar://112031348