### PR TITLE
Clear out the SchedulerPrivate fields before enqueueing the task

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -2064,6 +2064,8 @@ static void swift_task_enqueueImpl(Job *job, SerialExecutorRef executor) {
                        executor.getIdentity());
 
   assert(job && "no job provided");
+  job->SchedulerPrivate[0] = NULL;
+  job->SchedulerPrivate[1] = NULL;
 
   _swift_tsan_release(job);
 


### PR DESCRIPTION
Clear out the SchedulerPrivate fields before enqueueing the task into the executor

