### PR TITLE
[cxx-interop] Do not try to print empty namespaces in module interfaces

### DIFF
--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -665,10 +665,14 @@ void swift::ide::printModuleInterface(
         // An imported namespace decl will contain members from all redecls, so
         // make sure we add all the redecls.
         for (auto redecl : namespaceDecl->redecls()) {
+          if (redecl->decls_empty())
+            continue;
           // Namespace redecls may exist across mutliple modules. We want to
           // add the decl "D" to every module that has a redecl. But we only
           // want to add "D" once to prevent duplicate printing.
           clang::SourceLocation loc = redecl->getLocation();
+          assert(loc.isValid() &&
+                 "expected a valid SourceLocation for a non-empty namespace");
           auto *owningModule = Importer.getClangOwningModule(redecl);
           auto found = ClangDecls.find(owningModule);
           if (found != ClangDecls.end() &&


### PR DESCRIPTION
Clang sometimes generates implicit empty namespaces with no source location. We should not crash while trying to print them.

```
Assertion failed: (LHS.isValid() && RHS.isValid() && "Passed invalid source location!"), function isBeforeInTranslationUnit, file SourceManager.cpp
```

rdar://118534222