### PR TITLE
[5.10][Tests] Disable 2 concurrency tests in swift_test_mode_optimize_size

### DIFF
--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -14,6 +14,7 @@
 
 // rdar://119743909 fails in optimze tests.
 // UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
 
 import StdlibUnittest
 

--- a/test/Concurrency/Runtime/custom_executors_complex_equality_crash.swift
+++ b/test/Concurrency/Runtime/custom_executors_complex_equality_crash.swift
@@ -9,6 +9,7 @@
 
 // rdar://119743909 fails in optimze tests.
 // UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
 
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime


### PR DESCRIPTION
Cherry-pick #70609 into release/5.10
rdar://119743909
(cherry picked from commit cea77b605a505e794173e42babed7d6b4f311713)
