### PR TITLE
[build] allow `--verbose-build` to apply to SwiftPM

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -112,6 +112,9 @@ class SwiftPM(product.Product):
                                     swift_toolchain=toolchain_path,
                                     resource_path=resource_dir)]
 
+        if self.args.verbose_build:
+            helper_cmd.append('--verbose')
+
         helper_cmd.extend(additional_params)
 
         shell.call(helper_cmd)


### PR DESCRIPTION
`--verbose-build` was respected in most products but wasn't in SwiftPM. This is a useful tool to debug more cryptic errors.