### PR TITLE
[Docs] Add details for `addMaterializePackExpansionConstraint`

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -219,7 +219,7 @@ enum class ConstraintKind : char {
   /// Both (first and second) pack types should have the same reduced shape.
   SameShape,
   /// The first type is a tuple containing a single unlabeled element that is a
-  /// pack expansion. The second type is that pack expansion.
+  /// pack expansion. The second type is its pattern type.
   MaterializePackExpansion,
 };
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3823,14 +3823,17 @@ public:
   /// Given a tuple with a single unlabeled element that represents a pack
   /// expansion (either directly via \c PackExpansionType or through a type
   /// variable constrained to a pack expansion), materialize the pack expansion
-  /// and return its pattern type as a result. The result is a type variable
-  /// because element of the tuple is not required to be resolved at the time of
-  /// the call and operation is delayed until the element is sufficiently
-  /// resolved (see \c simplifyMaterializePackExpansionConstraint)
+  /// and return its pattern type as a result. The result is a type
+  /// variable because element of the tuple is not required to be resolved at
+  /// the time of the call and operation is delayed until the element is
+  /// sufficiently resolved (see \c simplifyMaterializePackExpansionConstraint)
   ///
   /// \param tupleType A tuple with a single unlabeled element that represents a
-  /// pack expansion. 
+  /// pack expansion.
   /// \param locator The locator.
+  ///
+  /// \returns A type variable type that represents the pattern type of the pack
+  /// expansion.
   TypeVariableType *
   addMaterializePackExpansionConstraint(Type tupleType,
                                         ConstraintLocatorBuilder locator);


### PR DESCRIPTION
Follow-up for #70355 🙂

* Add `\returns`
* Since the type variable represents the pack expansion type, not its pattern type, change that wording as well.
