### PR TITLE
[embedded] Don't emit __swift_reflection_version symbol

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1748,6 +1748,9 @@ void IRGenModule::emitFieldDescriptor(const NominalTypeDecl *D) {
 }
 
 void IRGenModule::emitReflectionMetadataVersion() {
+  if (IRGen.Opts.ReflectionMetadata == ReflectionMetadataMode::None)
+    return;
+
   auto Init =
     llvm::ConstantInt::get(Int16Ty, SWIFT_REFLECTION_METADATA_VERSION);
   auto Version = new llvm::GlobalVariable(Module, Int16Ty, /*constant*/ true,

--- a/test/embedded/internalize-no-stdlib.swift
+++ b/test/embedded/internalize-no-stdlib.swift
@@ -25,11 +25,9 @@ public func main() {
   start(p: Concrete())
 }
 
-// CHECK-ELF: @__swift_reflection_version =
 // CHECK-ELF: @_swift1_autolink_entries =
-// CHECK-ELF: @llvm.compiler.used = appending global [2 x ptr] [ptr @__swift_reflection_version, ptr @_swift1_autolink_entries], section "llvm.metadata"
+// CHECK-ELF: @llvm.compiler.used = appending global [1 x ptr] [ptr @_swift1_autolink_entries], section "llvm.metadata"
 // CHECK-ELF-NOT: @llvm.used
 
-// CHECK-MACHO: @__swift_reflection_version =
 // CHECK-MACHO-NOT: @llvm.compiler.used
-// CHECK-MACHO: @llvm.used = appending global [1 x ptr] [ptr @__swift_reflection_version], section "llvm.metadata"
+// CHECK-MACHO-NOT: @llvm.used


### PR DESCRIPTION
We don't have reflection in embedded Swift, so let's not even emit the `__swift_reflection_version` symbol and save a couple bytes.