### PR TITLE
Use relaxed instead of memory_order_consume for all CPUs

### DIFF
--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -25,18 +25,13 @@
 #include <intrin.h>
 #endif
 
-
 // FIXME: Workaround for rdar://problem/18889711. 'Consume' does not require
 // a barrier on ARM64, but LLVM doesn't know that. Although 'relaxed'
 // is formally UB by C++11 language rules, we should be OK because neither
 // the processor model nor the optimizer can realistically reorder our uses
-// of 'consume'.
-#if defined(__arm__) || defined(_M_ARM) || defined(__arm64__) || defined(__aarch64__) || defined(_M_ARM64)
-#  define SWIFT_MEMORY_ORDER_CONSUME (std::memory_order_relaxed)
-#else
-#  define SWIFT_MEMORY_ORDER_CONSUME (std::memory_order_consume)
-#endif
-
+// of 'consume'. It also only really affects ARM in practice, as the other
+// CPUs automatically keep track of data dependencies.
+#define SWIFT_MEMORY_ORDER_CONSUME (std::memory_order_relaxed)
 
 #if defined(_M_ARM) || defined(_M_ARM64) || defined(__arm__) || defined(__aarch64__)
 #define SWIFT_HAS_MSVC_ARM_ATOMICS 1


### PR DESCRIPTION
The purpose of memory_order_consume, at least on paper, is to enforce data ordering dependencies on platforms where memory is weak, but not on other platforms where memory dependency ordering is automatic.

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0098r0.pdf

https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0371r1.html

Because we use std::memory_order_relaxed anyway, there is no need for memory_order_consume, which compiler manufacturers just map to memory_order_acquire in practice, which does put barriers on all platforms.

For now, those barriers are desirable on any platform, we can just use memory_order_acquire.