### PR TITLE
Fix the symbol visibility in Swift compatibility lib into default instead of hidden, solve auto-linking issue and match Apple's behavior

### DIFF
--- a/stdlib/toolchain/Compatibility50/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility50/Overrides.cpp
@@ -31,6 +31,9 @@ struct OverrideSection {
 #include "CompatibilityOverride.def"
 };
   
+// We must ensure visibility become global non-hidden
+// because auto-linking from dep dylibs need this symbol
+__attribute__((visibility("default")))
 OverrideSection Swift50Overrides
 __attribute__((used, section("__DATA,__swift_hooks"))) = {
   .version = 0,

--- a/stdlib/toolchain/Compatibility50/Overrides.h
+++ b/stdlib/toolchain/Compatibility50/Overrides.h
@@ -20,7 +20,9 @@ namespace swift {
 
 using ConformsToProtocol_t =
   const WitnessTable *(const Metadata *, const ProtocolDescriptor *);
-
+// We must ensure visibility become global non-hidden
+// because auto-linking from dep dylibs need this symbol
+__attribute__((visibility("default")))
 const WitnessTable *
 swift50override_conformsToProtocol(const Metadata * const type,
   const ProtocolDescriptor *protocol,

--- a/stdlib/toolchain/Compatibility51/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility51/Overrides.cpp
@@ -30,6 +30,9 @@ struct OverrideSection {
 #include "CompatibilityOverride.def"
 };
   
+// We must ensure visibility become global non-hidden
+// because auto-linking from dep dylibs need this symbol
+__attribute__((visibility("default")))
 OverrideSection Swift51Overrides
 __attribute__((used, section("__DATA,__swift51_hooks"))) = {
   .version = 0,

--- a/stdlib/toolchain/Compatibility51/Overrides.h
+++ b/stdlib/toolchain/Compatibility51/Overrides.h
@@ -23,7 +23,9 @@ using ConformsToSwiftProtocol_t =
   const ProtocolConformanceDescriptor *(const Metadata * const type,
                                         const ProtocolDescriptor *protocol,
                                         llvm::StringRef moduleName);
-
+// We must ensure visibility become global non-hidden
+// because auto-linking from dep dylibs need this symbol
+__attribute__((visibility("default")))
 const ProtocolConformanceDescriptor *
 swift51override_conformsToSwiftProtocol(const Metadata * const type,
                                         const ProtocolDescriptor *protocol,


### PR DESCRIPTION
## Changes

TLDR: Change the `Overrides.cpp` 2 symbols to explicit using the `default` visibility, instead of implicit `hidden` visibility from the compiler options (`-fvisibility=hidden`)

This matches Apple's Xcode toolchain bundled `libswiftCompatibility50.a` binary.

## Background

Swift's compatibility static lib (`libswiftCompatibility50.a`) is used for backport Swift runtime features to Swift ABI-stable OS, like iOS 12.4. The new compiler language feature may need some runtime compatibility layer to run on the lower swift runtime host.

However, we faced a issue when using the apple/swift with Xcode's bundled closed-source swift. The issues is because of the visibility for this symbol `__ZN5swift34swift50override_conformsToProtocolEPKNS_14TargetMetadataINS_9InProcessEEEPKNS_24TargetProtocolDescriptorIS1_EEPFPKNS_18TargetWitnessTableIS1_EES4_S8_E`


The crash is like this:

```
"Symbol not found: __ZN5swift34swift50override_conformsToProtocolEPKNS_14TargetMetadataINS_9InProcessEEEPKNS_24TargetProtocolDescriptorIS1_EEPFPKNS_18TargetWitnessTableIS1_EES4_S8_E",
"Referenced from: <42049861-CE9C-3353-ADD2-76C05302E30B> /Volumes/VOLUME/*/App.app/Frameworks/AppStorageCore.framework/AppStorageCore",
"Expected in:     <4A119B38-492C-3E7C-B249-E8F49F9D5B99> /Volumes/VOLUME/*/App.app/Frameworks/EEAtomic.framework/EEAtomic"
```

Our team is trying to solve this issue and found out the reason in the upstream.

## Issues

After some investigating of the dynamic library, we surprisingly found that this missing symbol is indeed missing. Following the crash message from dyld, this two dylibs contains a dependency relation (`AppStorageCore.framework` will load `EEAtomic`):

```
nm EEAtomic.framework.dSYM/Contents/Resources/DWARF/EEAtomic | grep __ZN5swift34swift50override_conformsToProtocolEPKNS_14TargetMetadataINS_9InProcessEEEPKNS_24TargetProtocolDescriptorIS1_EEPFPKNS_18TargetWitnessTableIS1_EES4_S8_E
000000000000c384 t __ZN5swift34swift50override_conformsToProtocolEPKNS_14TargetMetadataINS_9InProcessEEEPKNS_24TargetProtocolDescriptorIS1_EEPFPKNS_18TargetWitnessTableIS1_EES4_S8_E
```

```
nm AppStorageCore.framework/AppStorageCore | grep __ZN5swift34swift50override_conformsToProtocolEPKNS_14TargetMetadataINS_9InProcessEEEPKNS_24TargetProtocolDescriptorIS1_EEPFPKNS_18TargetWitnessTableIS1_EES4_S8_E
                 U __ZN5swift34swift50override_conformsToProtocolEPKNS_14TargetMetadataINS_9InProcessEEEPKNS_24TargetProtocolDescriptorIS1_EEPFPKNS_18TargetWitnessTableIS1_EES4_S8_EApp
```

In theory, the `AppStorageCore.framework` use `undefined` symbol for that is OK. But the `EEAtomic.framework` must export the symbol.

## Behavior differences

We start to search the toolchain codebase, and found that the symbol exists in toolchain's `libswiftCompatibility50.a`. The symbols introduced from `stdlib/toolchain/Compatibility50/Overrides.cpp`

### Xcode toolchain

We use `llvm-objdump -Ct` to compare between the binaries of these two toolchains.

```
llvm-objdump -Ct /Applications/Xcode-15.0.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/iphoneos/libswiftCompatibility50.a
```


The results shows it's a `external` symbol

```
0000000000000000 g     F __TEXT,__text swift::swift50override_conformsToProtocol(swift::TargetMetadata<swift::InProcess> const*, swift::TargetProtocolDescriptor<swift::InProcess> const*, swift::TargetWitnessTable<swift::InProcess> const* (*)(swift::TargetMetadata<swift::InProcess> const*, swift::TargetProtocolDescriptor<swift::InProcess> const*))
```


### Swift.org toolchain

However, when compared to the Xcode toolchain, the Swift.org open-sourced toolchain use `external hidden` symbol

```
0000000000000000 g     F __TEXT,__text .hidden swift::swift50override_conformsToProtocol(swift::TargetMetadata<swift::InProcess> const*, swift::TargetProtocolDescriptor<swift::InProcess> const*, swift::TargetWitnessTable<swift::InProcess> const* (*)(swift::TargetMetadata<swift::InProcess> const*, swift::TargetProtocolDescriptor<swift::InProcess> const*))
```

### Compare

![output](https://github.com/apple/swift/assets/6919743/b406f52d-518f-4f22-8536-7f3eeea50ce4)

So why this use `hidden` visibility ?

### Compiler insert `-fvisibility=hidden`

From the toolchain build log (using `./build-script -verbose-build`), we can see the `Overrides.cpp` compile unit use the hidden visibility as defaults

![1](https://github.com/apple/swift/assets/6919743/99b31483-e3f1-4a86-9f33-6accff7a81fd)

So, we must explicit declare the visibility in source code. Or it will use `hidden` but not `default` visibility.

This MR just used to change for this. After changes, our new built toolchain can successfully run the same use case without dyld runtime crash. And solve the problem.

I think this issue is suitable to upstream, so I fire this PR here. Hope someone can help to review and merge-in, or provide better solution.

