### PR TITLE
stdlib/public/CMakeLists.txt: Enable embedded Wasm

### DIFF
--- a/cmake/modules/SwiftSetIfArchBitness.cmake
+++ b/cmake/modules/SwiftSetIfArchBitness.cmake
@@ -30,7 +30,8 @@ function(set_if_arch_bitness var_name)
          "${SIA_ARCH}" STREQUAL "powerpc64" OR
          "${SIA_ARCH}" STREQUAL "powerpc64le" OR
          "${SIA_ARCH}" STREQUAL "s390x" OR
-         "${SIA_ARCH}" STREQUAL "riscv64")
+         "${SIA_ARCH}" STREQUAL "riscv64" OR
+         "${SIA_ARCH}" STREQUAL "wasm64")
     set("${var_name}" "${SIA_CASE_64_BIT}" PARENT_SCOPE)
   else()
     message(FATAL_ERROR "Unknown architecture: ${SIA_ARCH}")

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -194,6 +194,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   if("WebAssembly" IN_LIST LLVM_TARGETS_TO_BUILD)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
       "wasm32    wasm32-unknown-none-wasm    wasm32-unknown-none-wasm"
+      "wasm64    wasm64-unknown-none-wasm    wasm64-unknown-none-wasm"
     )
   endif()
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -193,7 +193,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
   if("WebAssembly" IN_LIST LLVM_TARGETS_TO_BUILD)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
-      "wasm32    wasm32-none-none-wasm    wasm32-none-none-wasm"
+      "wasm32    wasm32-unknown-none-wasm    wasm32-unknown-none-wasm"
     )
   endif()
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -193,7 +193,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
   if("WebAssembly" IN_LIST LLVM_TARGETS_TO_BUILD)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
-      "wasm32    wasm32-none-none-wasm    wasm32-none-none-wasm
+      "wasm32    wasm32-none-none-wasm    wasm32-none-none-wasm"
     )
   endif()
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -193,7 +193,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
 
   if("WebAssembly" IN_LIST LLVM_TARGETS_TO_BUILD)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
-      "arm64    wasm32-none-none-wasm    wasm32-none-none-wasm
+      "wasm32    wasm32-none-none-wasm    wasm32-none-none-wasm
     )
   endif()
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -191,6 +191,12 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     )
   endif()
 
+  if("WebAssembly" IN_LIST LLVM_TARGETS_TO_BUILD)
+    list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "arm64    wasm32-none-none-wasm    wasm32-none-none-wasm
+    )
+  endif()
+
   if (SWIFT_HOST_VARIANT STREQUAL "linux")
     set(EMBEDDED_STDLIB_TARGET_TRIPLES ${EMBEDDED_STDLIB_TARGET_TRIPLES}
       "${SWIFT_HOST_VARIANT_ARCH} ${SWIFT_HOST_VARIANT_ARCH}-unknown-linux-gnu ${SWIFT_HOST_VARIANT_ARCH}-unknown-linux-gnu"


### PR DESCRIPTION
Running `swiftc` with `wasm32-none-none` or `wasm32-unknown-none` currently fails, as this embedded target is not built. Let's include it in the list of embedded targets.
