### PR TITLE
Weaken memory fences for objects we do not care about

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -645,7 +645,9 @@ AsyncTask *TaskGroupBase::claimWaitingTask() {
          "task is present!");
 
   auto waitingTask = waitQueue.load(std::memory_order_acquire);
-  if (!waitQueue.compare_exchange_strong(waitingTask, nullptr)) {
+  if (!waitQueue.compare_exchange_strong(waitingTask, nullptr,
+                                         std::memory_order_release,
+                                         std::memory_order_relaxed)) {
     swift_Concurrency_fatalError(0, "Failed to claim waitingTask!");
   }
   return waitingTask;
@@ -1390,7 +1392,9 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
     // allows a single task to get the waiting task and attempt to complete it.
     // As another offer gets to run, it will have either a different waiting task, or no waiting task at all.
     auto waitingTask = waitQueue.load(std::memory_order_acquire);
-    if (!waitQueue.compare_exchange_strong(waitingTask, nullptr)) {
+    if (!waitQueue.compare_exchange_strong(waitingTask, nullptr,
+                                           std::memory_order_release,
+                                           std::memory_order_relaxed)) {
       swift_Concurrency_fatalError(0, "Failed to claim waitingTask!");
     }
     assert(waitingTask && "status claimed to have waitingTask but waitQueue was empty!");
@@ -1712,7 +1716,7 @@ reevaluate_if_taskgroup_has_results:;
     if (status.compare_exchange_strong(
         assumedStatus, newStatus.completingPendingReadyWaiting(this).status,
         /*success*/ std::memory_order_release,
-        /*failure*/ std::memory_order_acquire)) {
+        /*failure*/ std::memory_order_relaxed)) {
 
       // We're going back to running the task, so if we suspended before,
       // we need to flag it as running again.
@@ -1786,7 +1790,7 @@ reevaluate_if_taskgroup_has_results:;
     }
     // Put the waiting task at the beginning of the wait queue.
     SWIFT_TASK_GROUP_DEBUG_LOG(this, "WATCH OUT, SET WAITER ONTO waitQueue.head = %p", waitQueue.load(std::memory_order_relaxed));
-    if (waitQueue.compare_exchange_strong(
+    if (waitQueue.compare_exchange_weak(
         waitHead, waitingTask,
         /*success*/ std::memory_order_release,
         /*failure*/ std::memory_order_acquire)) {
@@ -1947,7 +1951,7 @@ void TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
       waitingTask->flagAsSuspendedOnTaskGroup(asAbstract(this));
     }
     // Put the waiting task at the beginning of the wait queue.
-    if (waitQueue.compare_exchange_strong(
+    if (waitQueue.compare_exchange_weak(
         waitHead, waitingTask,
         /*success*/ std::memory_order_release,
         /*failure*/ std::memory_order_acquire)) {

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -733,7 +733,7 @@ extension __SharedStringStorage {
 extension _StringGuts {
   /// Atomically load and return breadcrumbs, populating them if necessary.
   ///
-  /// This emits aquire/release barriers to avoid access reordering trouble.
+  /// This emits acquire/release barriers to avoid access reordering trouble.
   ///
   /// This returns an unmanaged +0 reference to allow accessing breadcrumbs
   /// without incurring retain/release operations.

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1068,15 +1068,14 @@ namespace {
             std::forward<ArgTys>(args)...);
         if (cache.Private.compare_exchange_strong(existingEntry,
                                                   allocatedEntry,
-                                                  std::memory_order_acq_rel,
-                                                  std::memory_order_acquire)) {
+                                                  std::memory_order_release,
+                                                  std::memory_order_relaxed)) {
           // If that succeeded, return the entry we allocated and tell the
           // caller we allocated it.
           return { allocatedEntry, true };
         }
 
         // Otherwise, use the new entry and destroy the one we allocated.
-        assert(existingEntry && "spurious failure of strong compare-exchange?");
         swift_cxx_deleteObject(allocatedEntry);
       }
 


### PR DESCRIPTION
In the case where we discard the value of expected after the compare and exchange, we can make the failure memory order for them std::memory_order_relaxed, as the value no longer matters in these cases. Furthermore, memory_order_acq_rel is not necessary for most of these operations anyway, as the value being assigned to the atomic variable does not depend on the current exact value of said atomic variable.