### PR TITLE
Enable `x86_64` and `i686` triples for embedded Swift

### DIFF
--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -77,7 +77,7 @@ public func getFloat32(_ x: Float32) -> Float32 { return _opaqueIdentity(x) }
 @inline(never)
 public func getFloat64(_ x: Float64) -> Float64 { return _opaqueIdentity(x) }
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 @inline(never)
 public func getFloat80(_ x: Float80) -> Float80 { return _opaqueIdentity(x) }
 #endif

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -77,7 +77,7 @@ public func getFloat32(_ x: Float32) -> Float32 { return _opaqueIdentity(x) }
 @inline(never)
 public func getFloat64(_ x: Float64) -> Float64 { return _opaqueIdentity(x) }
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 @inline(never)
 public func getFloat80(_ x: Float80) -> Float80 { return _opaqueIdentity(x) }
 #endif

--- a/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
+++ b/stdlib/private/StdlibUnittest/OpaqueIdentityFunctions.swift
@@ -77,7 +77,7 @@ public func getFloat32(_ x: Float32) -> Float32 { return _opaqueIdentity(x) }
 @inline(never)
 public func getFloat64(_ x: Float64) -> Float64 { return _opaqueIdentity(x) }
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 @inline(never)
 public func getFloat80(_ x: Float80) -> Float80 { return _opaqueIdentity(x) }
 #endif

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -192,6 +192,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   endif()
   if("X86" IN_LIST LLVM_TARGETS_TO_BUILD)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "i686    i686-none-none-eabi       i686-none-none-eabi"
       "x86_64  x86_64-none-none-eabi     x86_64-none-none-eabi"
     )
   endif()

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -192,8 +192,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   endif()
   if("X86" IN_LIST LLVM_TARGETS_TO_BUILD)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
-      "i686    i686-none-none-eabi       i686-none-none-eabi"
-      "x86_64  x86_64-none-none-eabi     x86_64-none-none-eabi"
+      "i686    i686-unknown-none-elf    i686-unknown-none-elf"
+      "i686    i686-unknown-none-coff    i686-unknown-none-coff"
+      "x86_64  x86_64-unknown-none-elf     x86_64-unknown-none-elf"
+      "x86_64  x86_64-unknown-none-coff     x86_64-unknown-none-coff"
     )
   endif()
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -192,10 +192,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
   endif()
   if("X86" IN_LIST LLVM_TARGETS_TO_BUILD)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
-      "i686    i686-unknown-none-elf    i686-unknown-none-elf"
-      "i686    i686-unknown-none-coff    i686-unknown-none-coff"
+      "i686    i686-unknown-none-elf       i686-unknown-none-elf"
       "x86_64  x86_64-unknown-none-elf     x86_64-unknown-none-elf"
-      "x86_64  x86_64-unknown-none-coff     x86_64-unknown-none-coff"
     )
   endif()
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -190,6 +190,11 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       "riscv64  riscv64-none-none-eabi    riscv64-none-none-eabi"
     )
   endif()
+  if("X86" IN_LIST LLVM_TARGETS_TO_BUILD)
+    list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
+      "x86_64  x86_64-none-none-eabi     x86_64-none-none-eabi"
+    )
+  endif()
 
   if("WebAssembly" IN_LIST LLVM_TARGETS_TO_BUILD)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -26,7 +26,7 @@ def Availability(bits):
 }%
 
 % if bits == 80:
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 % end
 % if bits == 16:
 #if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
@@ -62,7 +62,7 @@ extension ${Self} {
   }%
   
   % if other_bits == 80:
-  #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+  #if !(os(Windows) || os(Android) || $Embedded) && (arch(i386) || arch(x86_64))
   % end
   % if other_bits == 16:
   #if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -26,7 +26,7 @@ def Availability(bits):
 }%
 
 % if bits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 % end
 % if bits == 16:
 #if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))

--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -26,7 +26,7 @@ def Availability(bits):
 }%
 
 % if bits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 % end
 % if bits == 16:
 #if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -143,7 +143,7 @@ func _${derivative_kind}Trunc${generic_signature} (
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
 %  for T in ['Float', 'Double', 'Float80']:
 %    if T == 'Float80':
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 %    end
 @inlinable
 @derivative(of: exp)
@@ -284,7 +284,7 @@ func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${
 // Binary functions
 %for T in ['Float', 'Double', 'Float80']:
 %  if T == 'Float80':
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 %  end
 @inlinable
 @derivative(of: pow)

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -143,7 +143,7 @@ func _${derivative_kind}Trunc${generic_signature} (
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
 %  for T in ['Float', 'Double', 'Float80']:
 %    if T == 'Float80':
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 %    end
 @inlinable
 @derivative(of: exp)
@@ -284,7 +284,7 @@ func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${
 // Binary functions
 %for T in ['Float', 'Double', 'Float80']:
 %  if T == 'Float80':
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 %  end
 @inlinable
 @derivative(of: pow)

--- a/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
+++ b/stdlib/public/Differentiation/TgmathDerivatives.swift.gyb
@@ -143,7 +143,7 @@ func _${derivative_kind}Trunc${generic_signature} (
 %  linear_map_kind = 'differential' if derivative_kind == 'jvp' else 'pullback'
 %  for T in ['Float', 'Double', 'Float80']:
 %    if T == 'Float80':
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 %    end
 @inlinable
 @derivative(of: exp)
@@ -284,7 +284,7 @@ func _${derivative_kind}Erfc(_ x: ${T}) -> (value: ${T}, ${linear_map_kind}: (${
 // Binary functions
 %for T in ['Float', 'Double', 'Float80']:
 %  if T == 'Float80':
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 %  end
 @inlinable
 @derivative(of: pow)

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -222,7 +222,7 @@ def TypedBinaryFunctions():
 // Note these do not have a corresponding LLVM intrinsic
 % for T, CT, f, ufunc in TypedUnaryFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))))
 %  end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -239,7 +239,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 // Note these have a corresponding LLVM intrinsic
 % for T, ufunc in TypedUnaryIntrinsicFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))))
 %  end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -258,7 +258,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 % for ufunc in UnaryIntrinsicFunctions:
 %  for T, CT, f in OverlayFloatTypes():
 %   if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))))
 %   end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -275,7 +275,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 
 % for T, CT, f, bfunc in TypedBinaryFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))))
 %  end
 @_transparent
 public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
@@ -290,7 +290,7 @@ public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || os(OpenBSD) || ($Embedded && !os(Linux) && !canImport(Darwin)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || os(OpenBSD) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))))
 %  else:
 //  lgamma not available on Windows, apparently?
 #if !os(Windows)
@@ -308,7 +308,7 @@ public func lgamma(_ x: ${T}) -> (${T}, Int) {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))))
 %  end
 @_transparent
 public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
@@ -324,7 +324,7 @@ public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
 
 % for T, CT, f in OverlayFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))))
 %  end
 @available(swift, deprecated: 4.2/*, obsoleted: 5.1*/, message:
            "use ${T}(nan: ${T}.RawSignificand).")

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -222,7 +222,7 @@ def TypedBinaryFunctions():
 // Note these do not have a corresponding LLVM intrinsic
 % for T, CT, f, ufunc in TypedUnaryFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
 %  end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -239,7 +239,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 // Note these have a corresponding LLVM intrinsic
 % for T, ufunc in TypedUnaryIntrinsicFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
 %  end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -258,7 +258,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 % for ufunc in UnaryIntrinsicFunctions:
 %  for T, CT, f in OverlayFloatTypes():
 %   if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
 %   end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -275,7 +275,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 
 % for T, CT, f, bfunc in TypedBinaryFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
 %  end
 @_transparent
 public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
@@ -290,7 +290,7 @@ public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || os(OpenBSD) || ($Embedded && !os(Linux)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || os(OpenBSD) || ($Embedded && !os(Linux) && !canImport(Darwin)))
 %  else:
 //  lgamma not available on Windows, apparently?
 #if !os(Windows)
@@ -308,7 +308,7 @@ public func lgamma(_ x: ${T}) -> (${T}, Int) {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
 %  end
 @_transparent
 public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
@@ -324,7 +324,7 @@ public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
 
 % for T, CT, f in OverlayFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin)))
 %  end
 @available(swift, deprecated: 4.2/*, obsoleted: 5.1*/, message:
            "use ${T}(nan: ${T}.RawSignificand).")

--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -222,7 +222,7 @@ def TypedBinaryFunctions():
 // Note these do not have a corresponding LLVM intrinsic
 % for T, CT, f, ufunc in TypedUnaryFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
 %  end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -239,7 +239,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 // Note these have a corresponding LLVM intrinsic
 % for T, ufunc in TypedUnaryIntrinsicFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
 %  end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -258,7 +258,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 % for ufunc in UnaryIntrinsicFunctions:
 %  for T, CT, f in OverlayFloatTypes():
 %   if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
 %   end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
@@ -275,7 +275,7 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 
 % for T, CT, f, bfunc in TypedBinaryFunctions():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
 %  end
 @_transparent
 public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
@@ -290,7 +290,7 @@ public func ${bfunc}(_ lhs: ${T}, _ rhs: ${T}) -> ${T} {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || os(OpenBSD))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || os(OpenBSD) || ($Embedded && !os(Linux)))
 %  else:
 //  lgamma not available on Windows, apparently?
 #if !os(Windows)
@@ -308,7 +308,7 @@ public func lgamma(_ x: ${T}) -> (${T}, Int) {
 % # This is AllFloatTypes not OverlayFloatTypes because of the tuple return.
 % for T, CT, f in AllFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
 %  end
 @_transparent
 public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
@@ -324,7 +324,7 @@ public func remquo(_ x: ${T}, _ y: ${T}) -> (${T}, Int) {
 
 % for T, CT, f in OverlayFloatTypes():
 %  if T == 'Float80':
-#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android))
+#if (arch(i386) || arch(x86_64)) && !(os(Windows) || os(Android) || ($Embedded && !os(Linux)))
 %  end
 @available(swift, deprecated: 4.2/*, obsoleted: 5.1*/, message:
            "use ${T}(nan: ${T}.RawSignificand).")

--- a/stdlib/public/core/BuiltinMath.swift
+++ b/stdlib/public/core/BuiltinMath.swift
@@ -113,7 +113,7 @@ public func _rint(_ x: Double) -> Double {
 
 // Float80 Intrinsics (80 bits)
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 @_transparent
 public func _cos(_ x: Float80) -> Float80 {
   return Float80(Builtin.int_cos_FPIEEE80(x._value))

--- a/stdlib/public/core/BuiltinMath.swift
+++ b/stdlib/public/core/BuiltinMath.swift
@@ -113,7 +113,7 @@ public func _rint(_ x: Double) -> Double {
 
 // Float80 Intrinsics (80 bits)
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 @_transparent
 public func _cos(_ x: Float80) -> Float80 {
   return Float80(Builtin.int_cos_FPIEEE80(x._value))

--- a/stdlib/public/core/BuiltinMath.swift
+++ b/stdlib/public/core/BuiltinMath.swift
@@ -113,7 +113,7 @@ public func _rint(_ x: Double) -> Double {
 
 // Float80 Intrinsics (80 bits)
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 @_transparent
 public func _cos(_ x: Float80) -> Float80 {
   return Float80(Builtin.int_cos_FPIEEE80(x._value))

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -109,6 +109,10 @@ public typealias CLongDouble = Float80
 #else
 #error("CLongDouble needs to be defined for this FreeBSD architecture")
 #endif
+#elseif $Embedded
+#if arch(x86_64) || arch(i386)
+public typealias CLongDouble = Float80
+#endif
 #else
 // TODO: define CLongDouble for other OSes
 #endif

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -109,7 +109,7 @@ public typealias CLongDouble = Float80
 #else
 #error("CLongDouble needs to be defined for this FreeBSD architecture")
 #endif
-#elseif $Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
+#elseif $Embedded
 #if arch(x86_64) || arch(i386)
 public typealias CLongDouble = Double
 #endif

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -111,7 +111,7 @@ public typealias CLongDouble = Float80
 #endif
 #elseif $Embedded
 #if arch(x86_64) || arch(i386)
-public typealias CLongDouble = Float80
+public typealias CLongDouble = Double
 #endif
 #else
 // TODO: define CLongDouble for other OSes

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -109,7 +109,7 @@ public typealias CLongDouble = Float80
 #else
 #error("CLongDouble needs to be defined for this FreeBSD architecture")
 #endif
-#elseif $Embedded && !os(Linux) && !canImport(Darwin)
+#elseif $Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
 #if arch(x86_64) || arch(i386)
 public typealias CLongDouble = Double
 #endif

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -109,7 +109,7 @@ public typealias CLongDouble = Float80
 #else
 #error("CLongDouble needs to be defined for this FreeBSD architecture")
 #endif
-#elseif $Embedded
+#elseif $Embedded && !os(Linux) && !canImport(Darwin)
 #if arch(x86_64) || arch(i386)
 public typealias CLongDouble = Double
 #endif

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1516,7 +1516,7 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// - Parameter value: A floating-point value to be converted.
   init(_ value: Double)
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
   /// Creates a new instance from the given value, rounded to the closest
   /// possible representation.
   ///
@@ -1927,7 +1927,7 @@ extension BinaryFloatingPoint {
         significandBitPattern:
           UInt64(truncatingIfNeeded: value.significandBitPattern))
       self = Self(value_)
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
     case (15, 63):
       let value_ = value as? Float80 ?? Float80(
         sign: value.sign,

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1516,7 +1516,7 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// - Parameter value: A floating-point value to be converted.
   init(_ value: Double)
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
   /// Creates a new instance from the given value, rounded to the closest
   /// possible representation.
   ///
@@ -1927,7 +1927,7 @@ extension BinaryFloatingPoint {
         significandBitPattern:
           UInt64(truncatingIfNeeded: value.significandBitPattern))
       self = Self(value_)
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
     case (15, 63):
       let value_ = value as? Float80 ?? Float80(
         sign: value.sign,

--- a/stdlib/public/core/FloatingPoint.swift
+++ b/stdlib/public/core/FloatingPoint.swift
@@ -1516,7 +1516,7 @@ public protocol BinaryFloatingPoint: FloatingPoint, ExpressibleByFloatLiteral {
   /// - Parameter value: A floating-point value to be converted.
   init(_ value: Double)
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
   /// Creates a new instance from the given value, rounded to the closest
   /// possible representation.
   ///
@@ -1927,7 +1927,7 @@ extension BinaryFloatingPoint {
         significandBitPattern:
           UInt64(truncatingIfNeeded: value.significandBitPattern))
       self = Self(value_)
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
     case (15, 63):
       let value_ = value as? Float80 ?? Float80(
         sign: value.sign,

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -41,7 +41,7 @@ internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
 %   Self = floatName(bits)
 
 % if bits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -41,7 +41,7 @@ internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
 %   Self = floatName(bits)
 
 % if bits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -41,7 +41,7 @@ internal func _isspace_clocale(_ u: UTF16.CodeUnit) -> Bool {
 %   Self = floatName(bits)
 
 % if bits == 80:
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -66,7 +66,7 @@ else:
 }%
 
 % if bits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end
@@ -922,7 +922,7 @@ extension ${Self}: _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLite
 }
 
 % if bits != 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 % end
 
 % builtinFloatLiteralBits = 80
@@ -1129,7 +1129,7 @@ extension ${Self} {
 %   That = src_type.stdlib_name
 
 %   if srcBits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 %   elif srcBits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %   end

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -66,7 +66,7 @@ else:
 }%
 
 % if bits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end
@@ -922,7 +922,7 @@ extension ${Self}: _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLite
 }
 
 % if bits != 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 % end
 
 % builtinFloatLiteralBits = 80
@@ -1129,7 +1129,7 @@ extension ${Self} {
 %   That = src_type.stdlib_name
 
 %   if srcBits == 80:
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 %   elif srcBits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %   end

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -66,7 +66,7 @@ else:
 }%
 
 % if bits == 80:
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 % elif bits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 % end
@@ -922,7 +922,7 @@ extension ${Self}: _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLite
 }
 
 % if bits != 80:
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 % end
 
 % builtinFloatLiteralBits = 80
@@ -1129,7 +1129,7 @@ extension ${Self} {
 %   That = src_type.stdlib_name
 
 %   if srcBits == 80:
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 %   elif srcBits == 16:
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %   end

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1128,7 +1128,7 @@ public struct ${Self}
 %     (lower, upper) = getFtoIBounds(floatBits=FloatBits, intBits=int(bits), signed=signed)
 
 %     if FloatType == 'Float80':
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 %     elif FloatType == 'Float16':
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %     end

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1128,7 +1128,7 @@ public struct ${Self}
 %     (lower, upper) = getFtoIBounds(floatBits=FloatBits, intBits=int(bits), signed=signed)
 
 %     if FloatType == 'Float80':
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 %     elif FloatType == 'Float16':
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %     end

--- a/stdlib/public/core/IntegerTypes.swift.gyb
+++ b/stdlib/public/core/IntegerTypes.swift.gyb
@@ -1128,7 +1128,7 @@ public struct ${Self}
 %     (lower, upper) = getFtoIBounds(floatBits=FloatBits, intBits=int(bits), signed=signed)
 
 %     if FloatType == 'Float80':
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 %     elif FloatType == 'Float16':
 #if !((os(macOS) || targetEnvironment(macCatalyst)) && arch(x86_64))
 %     end

--- a/stdlib/public/core/Mirrors.swift
+++ b/stdlib/public/core/Mirrors.swift
@@ -252,7 +252,7 @@ extension Int: _CustomPlaygroundQuickLookable {
   }
 }
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 extension Float80: CustomReflectable {
   /// A mirror that reflects the Float80 instance.
   public var customMirror: Mirror {

--- a/stdlib/public/core/Mirrors.swift
+++ b/stdlib/public/core/Mirrors.swift
@@ -252,7 +252,7 @@ extension Int: _CustomPlaygroundQuickLookable {
   }
 }
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 extension Float80: CustomReflectable {
   /// A mirror that reflects the Float80 instance.
   public var customMirror: Mirror {

--- a/stdlib/public/core/Mirrors.swift
+++ b/stdlib/public/core/Mirrors.swift
@@ -252,7 +252,7 @@ extension Int: _CustomPlaygroundQuickLookable {
   }
 }
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 extension Float80: CustomReflectable {
   /// A mirror that reflects the Float80 instance.
   public var customMirror: Mirror {

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -166,7 +166,7 @@ public typealias StringLiteralType = String
 //===----------------------------------------------------------------------===//
 // Default types for unconstrained number literals
 //===----------------------------------------------------------------------===//
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 public typealias _MaxBuiltinFloatType = Builtin.FPIEEE80
 #else
 public typealias _MaxBuiltinFloatType = Builtin.FPIEEE64

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -166,7 +166,7 @@ public typealias StringLiteralType = String
 //===----------------------------------------------------------------------===//
 // Default types for unconstrained number literals
 //===----------------------------------------------------------------------===//
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 public typealias _MaxBuiltinFloatType = Builtin.FPIEEE80
 #else
 public typealias _MaxBuiltinFloatType = Builtin.FPIEEE64

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -166,7 +166,7 @@ public typealias StringLiteralType = String
 //===----------------------------------------------------------------------===//
 // Default types for unconstrained number literals
 //===----------------------------------------------------------------------===//
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 public typealias _MaxBuiltinFloatType = Builtin.FPIEEE80
 #else
 public typealias _MaxBuiltinFloatType = Builtin.FPIEEE64

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -418,7 +418,7 @@ internal func _float64ToString(
 }
 
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 
 // Returns a UInt64, but that value is the length of the string, so it's
 // guaranteed to fit into an Int. This is part of the ABI, so we can't

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -418,7 +418,7 @@ internal func _float64ToString(
 }
 
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 
 // Returns a UInt64, but that value is the length of the string, so it's
 // guaranteed to fit into an Int. This is part of the ABI, so we can't

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -418,7 +418,7 @@ internal func _float64ToString(
 }
 
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 
 // Returns a UInt64, but that value is the length of the string, so it's
 // guaranteed to fit into an Int. This is part of the ABI, so we can't

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -413,7 +413,7 @@ extension Double: _CVarArgPassedAsDouble, _CVarArgAligned {
   }
 }
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
 extension Float80: CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -413,7 +413,7 @@ extension Double: _CVarArgPassedAsDouble, _CVarArgAligned {
   }
 }
 
-#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !canImport(Darwin))) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux) && !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS)))) && (arch(i386) || arch(x86_64))
 extension Float80: CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -413,7 +413,7 @@ extension Double: _CVarArgPassedAsDouble, _CVarArgAligned {
   }
 }
 
-#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+#if !(os(Windows) || os(Android) || ($Embedded && !os(Linux))) && (arch(i386) || arch(x86_64))
 extension Float80: CVarArg, _CVarArgAligned {
   /// Transform `self` into a series of machine words that can be
   /// appropriately interpreted by C varargs.


### PR DESCRIPTION
This is just as useful for x86 bare metal as the already enabled `arm*-none-none-eabi` triples.
