### PR TITLE
Fix error message typo in `stdlib/public/core/StaticString.swift`

### DIFF
--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -206,7 +206,7 @@ public struct StaticString: Sendable {
         start: utf8Start, count: utf8CodeUnitCount))
     } else {
       #if $Embedded
-      fatalError("non-pointer representation not support in embedded Swift")
+      fatalError("non-pointer representation not supported in embedded Swift")
       #else
       return unicodeScalar.withUTF8CodeUnits { body($0) }
       #endif


### PR DESCRIPTION
`not support in embedded Swift` -> `not supported in embedded Swift`
