### PR TITLE
Added a note about hardware requirements for compiling on Linux 

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -53,9 +53,13 @@ toolchain as a one-off, there are a couple of differences:
 4. Disk space:
    Make sure that you have enough available disk space before starting.
    The source code, including full git history, requires about 3.5 GB.
-   Build artifacts take anywhere between 5 GB to 70 GB, depending on the
-   build settings.
-5. Time:
+   Build artifacts take anywhere between 5 GB to 100 GB, depending on the
+   build settings. It is recommended to have at least 150 GB of available disk space.
+5. RAM:
+   It is recommended to have at least 8 GB for building a toolchain and 16 GB 
+   for development. When building for development on a virtual machine or
+   emulator, you might need more than 32 GB.
+6. Time:
    Depending on your machine and build settings,
    a from-scratch build can take a few minutes to several hours,
    so you might want to grab a beverage while you follow the instructions.


### PR DESCRIPTION
<!-- What's in this pull request? -->

When I was setting up a Linux VM environment for debugging Swift compiler crash, I faced a number of issues due to low disk space (`update-checkout` would hang before starting concurrent checkouts) and due to low RAM size (linker would start failing when linking symbols for `bin/clang-17` and other binaries).

This PR adds a note about the minimal RAM requirements, and updates the recommended minimum available disk space.

My findings for when running a Linux VM and compiling the compiler are as follows:

1. 8 GB of RAM with `--release-debuginfo` flag
2. 32 GB of RAM with `--debug` flag
3. 150 GB of disk space

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
