### PR TITLE
[ConstraintSystem] Teach inference to never select unresolved key path types

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -576,7 +576,10 @@ public:
 
   /// Finalize binding computation for this type variable by
   /// inferring bindings from context e.g. transitive bindings.
-  void finalize(
+  ///
+  /// \returns true if finalization successful (which makes binding set viable),
+  /// and false otherwise.
+  bool finalize(
       llvm::SmallDenseMap<TypeVariableType *, BindingSet> &inferredBindings);
 
   static BindingScore formBindingScore(const BindingSet &b);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -12207,13 +12207,6 @@ ConstraintSystem::simplifyKeyPathConstraint(
       assert(contextualTy);
     }
 
-    // If there are no other options the solver might end up picking
-    // `AnyKeyPath` or `PartialKeyPath` based on a contextual conversion.
-    // This is an error during normal type-checking but okay in
-    // diagnostic mode because root and value are allowed to be holes.
-    if (contextualTy->isAnyKeyPath() || contextualTy->isPartialKeyPath())
-      return shouldAttemptFixes();
-
     if (auto bgt = contextualTy->getAs<BoundGenericType>()) {
       // We can get root and value from a concrete key path type.
       assert(bgt->isKeyPath() || bgt->isWritableKeyPath() ||

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7648,6 +7648,13 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
   if (keyPath->hasSingleInvalidComponent())
     return fail();
 
+  // If root is determined to be a hole it means that none of the components
+  // are resolvable and key path is not viable.
+  auto rootTy =
+      getFixedTypeRecursive(getKeyPathRootType(keyPath), /*wantRValue=*/false);
+  if (rootTy->isPlaceholder())
+    return fail();
+
   auto mutability = KeyPathMutability::Writable;
   for (unsigned i : indices(keyPath->getComponents())) {
     auto &component = keyPath->getComponents()[i];

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -914,13 +914,13 @@ func testKeyPathHole() {
 
   func f(_ i: Int) {}
   f(\.x) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}} {{6-6=<#Root#>}}
-  // expected-error@-1 {{cannot convert value of key path type to expected argument type 'Int'}}
   f(\.x.y) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}} {{6-6=<#Root#>}}
-  // expected-error@-1 {{cannot convert value of key path type to expected argument type 'Int'}}
 
-  func provideValueButNotRoot<T>(_ fn: (T) -> String) {} 
+func provideValueButNotRoot<T>(_ fn: (T) -> String) {} // expected-note 2 {{in call to function 'provideValueButNotRoot'}}
   provideValueButNotRoot(\.x) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
   provideValueButNotRoot(\.x.y) // expected-error {{cannot infer key path type from context; consider explicitly specifying a root type}}
+// expected-error@-1 {{generic parameter 'T' could not be inferred}}
   provideValueButNotRoot(\String.foo) // expected-error {{value of type 'String' has no member 'foo'}}
 
   func provideKPValueButNotRoot<T>(_ kp: KeyPath<T, String>) {} 
@@ -1236,4 +1236,10 @@ func test_keypath_coercion_to_function() {
 
 func test_keypath_application_with_composition(v: String, kp: any KeyPath<String, Int> & PP) {
   _ = v[keyPath: kp] // Ok
+}
+
+func test_leading_dot_key_path_without_context() {
+  func test(_: AnyKeyPath?) {}
+  test(\.utf8)
+  // expected-error@-1 {{cannot infer key path type from context; consider explicitly specifying a root type}}
 }

--- a/validation-test/Sema/SwiftUI/rdar84580119.swift
+++ b/validation-test/Sema/SwiftUI/rdar84580119.swift
@@ -16,7 +16,6 @@ extension EnvironmentValues {
     set { self[\.MyHorizontalAlignmentEnvironmentKey.self] = newValue }
     // expected-error@-1 {{generic parameter 'K' could not be inferred}}
     // expected-error@-2 {{cannot infer key path type from context; consider explicitly specifying a root type}}
-    // expected-error@-3 {{cannot convert value of key path type to expected argument type 'K.Type'}}
   }
 }
 


### PR DESCRIPTION
This fixes a crash in `simplifyKeyPathConstraint` and makes handling of key paths more robust in general.

- Prevent `determineBestBindings` from selecting unresolved key path type by failing finalization
- Fail key path capability inference if root is a placeholder because none of the components are
  inferrable  in situations like that.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
