### PR TITLE
LICM: don't let cond_fail prevent hoisting initializations of global variables

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -231,6 +231,8 @@ static bool mayConflictWithGlobalInit(AliasAnalysis *AA,
   if (auto *LI = dyn_cast<LoadInst>(sideEffectInst)) {
     return AA->mayWriteToMemory(globalInitCall, LI->getOperand());
   }
+  if (isa<CondFailInst>(sideEffectInst))
+    return false;
   return true;
 }
 

--- a/test/SILOptimizer/inline_addressor.swift
+++ b/test/SILOptimizer/inline_addressor.swift
@@ -9,14 +9,16 @@ var totalsum = nonTrivialInit(true)
 // 1) hoisted out of the loop (by GlobalOpt) and
 // 2) inlined
 
-//CHECK-LABEL: sil {{.*}}testit 
-//CHECK: {{^bb0}}
-//CHECK: WZ
-//CHECK-NOT: {{^bb0}}
-//CHECK: {{^bb1}}
-//CHECK-NOT: WZ
-//CHECK-NOT: totalsum
-//CHECK-NOT: inputval
+// CHECK-LABEL: sil hidden @$s16inline_addressor6testityySiF :
+// CHECK:       {{^bb0(.*):}}
+// CHECK-DAG:     function_ref @$s16inline_addressor8totalsum_WZ :
+// CHECK-DAG:     builtin "once"
+// CHECK-DAG:     function_ref @$s16inline_addressor8inputval_WZ :
+// CHECK-DAG:     builtin "once"
+// CHECK:       {{^bb1:}}
+// CHECK-NOT:     "once"
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function '$s16inline_addressor6testityySiF'
 func testit(_ x: Int) {
 	for _ in 0...10000000 {
 		totalsum += inputval


### PR DESCRIPTION
And fix the corresponding test file
