### PR TITLE
build: tweak the Windows build for clean builds

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -413,6 +413,7 @@ function Fetch-Dependencies {
 
   if (-not (Test-Path $BinaryCache\WiX-$WiXVersion.zip)) {
     Write-Output "WiX not found. Downloading from nuget.org ..."
+    New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache | Out-Null
     if ($ToBatch) {
       Write-Output "curl.exe -sL $WiXURL -o $BinaryCache\WiX-$WiXVersion.zip"
     } else {


### PR DESCRIPTION
Add a directory creation path prior to downloading. In the case that the build tree did not exist, we would fail to fetch the content. This allows us to build on a fresh setup.