### PR TITLE
🍒Revert "Revert "[cxx-interop] Look up `NSNotificationName` in C++ language mode properly""

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -555,7 +555,9 @@ clang::TypedefNameDecl *importer::findSwiftNewtype(const clang::NamedDecl *decl,
     clang::LookupResult lookupResult(clangSema, notificationName,
                                      clang::SourceLocation(),
                                      clang::Sema::LookupOrdinaryName);
-    if (!clangSema.LookupName(lookupResult, clangSema.TUScope))
+    if (!clangSema.LookupQualifiedName(
+            lookupResult,
+            /*LookupCtx*/ clangSema.getASTContext().getTranslationUnitDecl()))
       return nullptr;
     auto nsDecl = lookupResult.getAsSingle<clang::TypedefNameDecl>();
     if (!nsDecl)

--- a/test/Interop/Cxx/objc-correctness/Inputs/nsnotification-bridging.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/nsnotification-bridging.h
@@ -1,3 +1,4 @@
 #import <Foundation/Foundation.h>
 
 extern NSString * const SpaceShipNotification;
+extern "C" NSString * const CExternNotification;

--- a/test/Interop/Cxx/objc-correctness/nsnotification-bridging-ide-test.swift
+++ b/test/Interop/Cxx/objc-correctness/nsnotification-bridging-ide-test.swift
@@ -5,3 +5,4 @@
 // CHECK: import Foundation
 
 // CHECK: let SpaceShipNotification: String
+// CHECK: let CExternNotification: String

--- a/test/Interop/Cxx/objc-correctness/nsnotification-typechecker.swift
+++ b/test/Interop/Cxx/objc-correctness/nsnotification-typechecker.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -I %S/Inputs -enable-objc-interop -enable-experimental-cxx-interop
+// REQUIRES: objc_interop
+
+import Foundation
+import NSNotificationBridging
+
+func test(_ n: NSNotification.Name) {}
+
+test(NSNotification.Name.SpaceShip)
+test(NSNotification.Name.CExtern)


### PR DESCRIPTION
This reverts commit 80448d2f1cf6167adffddb8581c724e72ea2d3a2.

(cherry picked from commit be24236bea6009e9bc2fa7ec986369595365984d)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
