### PR TITLE
Add `m68k` to `SwiftSetIfArchBitness.cmake`

### DIFF
--- a/cmake/modules/SwiftSetIfArchBitness.cmake
+++ b/cmake/modules/SwiftSetIfArchBitness.cmake
@@ -18,6 +18,7 @@ function(set_if_arch_bitness var_name)
      "${SIA_ARCH}" STREQUAL "armv7m" OR
      "${SIA_ARCH}" STREQUAL "armv7em" OR
      "${SIA_ARCH}" STREQUAL "armv7s" OR
+     "${SIA_ARCH}" STREQUAL "m68k" OR
      "${SIA_ARCH}" STREQUAL "riscv32" OR
      "${SIA_ARCH}" STREQUAL "wasm32" OR
      "${SIA_ARCH}" STREQUAL "powerpc")


### PR DESCRIPTION
`m68k` is a 32-bit architecture and should be defined as such in that file.