### PR TITLE
build: simplify the unified build configuration

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -268,16 +268,13 @@ endmacro()
 #     cmake variables.
 macro(swift_common_unified_build_config product)
   set(${product}_PATH_TO_CLANG_BUILD "${CMAKE_BINARY_DIR}")
-  set(CLANG_MAIN_INCLUDE_DIR "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include")
-  set(CLANG_BUILD_INCLUDE_DIR "${CMAKE_BINARY_DIR}/tools/clang/include")
   set(${product}_NATIVE_LLVM_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
   set(${product}_NATIVE_CLANG_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
   set(LLVM_PACKAGE_VERSION ${PACKAGE_VERSION})
   set(LLVM_CMAKE_DIR "${CMAKE_SOURCE_DIR}/cmake/modules")
-  set(CLANG_INCLUDE_DIRS 
-    "${CLANG_MAIN_INCLUDE_DIR}"
-    "${CLANG_BUILD_INCLUDE_DIR}"
-  )
+
+  include_directories(${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include
+    ${CMAKE_BINARY_DIR}/tools/clang/include)
 
   # If cmark was checked out into tools/cmark, expect to build it as
   # part of the unified build.
@@ -293,15 +290,9 @@ macro(swift_common_unified_build_config product)
     get_filename_component(CMARK_LIBRARY_DIR "${${product}_CMARK_LIBRARY_DIR}"
       ABSOLUTE)
 
-    set(CMARK_BUILD_INCLUDE_DIR "${PATH_TO_CMARK_BUILD}/src")
-    set(CMARK_MAIN_INCLUDE_DIR "${CMARK_MAIN_SRC_DIR}/src/include")
+    include_directories(${PATH_TO_CMARK_BUILD}/src
+      ${CMARK_MAIN_SRC_DIR}/src/include)
   endif()
-
-  include_directories(
-      "${CLANG_BUILD_INCLUDE_DIR}"
-      "${CLANG_MAIN_INCLUDE_DIR}"
-      "${CMARK_MAIN_INCLUDE_DIR}"
-      "${CMARK_BUILD_INCLUDE_DIR}")
 
   include(AddSwiftTableGen) # This imports TableGen from LLVM.
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -857,21 +857,22 @@ function Build-BuildTools($Arch) {
       LLVM_ENABLE_LIBEDIT = "NO";
       LLVM_ENABLE_LIBXML2 = "NO";
       LLVM_ENABLE_PROJECTS = "clang;clang-tools-extra;lldb";
-      LLVM_EXTERNAL_PROJECTS = "cmark;swift";
-      LLVM_EXTERNAL_CMARK_SOURCE_DIR = "$SourceCache\cmark";
+      LLVM_EXTERNAL_PROJECTS = "swift";
       LLVM_EXTERNAL_SWIFT_SOURCE_DIR = "$SourceCache\swift";
       SWIFT_BUILD_DYNAMIC_SDK_OVERLAY = "NO";
       SWIFT_BUILD_DYNAMIC_STDLIB = "NO";
+      SWIFT_BUILD_HOST_DISPATCH = "NO";
       SWIFT_BUILD_LIBEXEC = "NO";
+      SWIFT_BUILD_REGEX_PARSER_IN_COMPILER = "NO";
       SWIFT_BUILD_REMOTE_MIRROR = "NO";
       SWIFT_BUILD_SOURCEKIT = "NO";
       SWIFT_BUILD_STATIC_SDK_OVERLAY = "NO";
       SWIFT_BUILD_STATIC_STDLIB = "NO";
+      SWIFT_BUILD_SWIFT_SYNTAX = "NO";
+      SWIFT_ENABLE_DISPATCH = "NO";
       SWIFT_INCLUDE_APINOTES = "NO";
       SWIFT_INCLUDE_DOCS = "NO";
       SWIFT_INCLUDE_TESTS = "NO";
-      SWIFT_PATH_TO_LIBDISPATCH_SOURCE = "$SourceCache\swift-corelibs-libdispatch";
-      SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE = "$SourceCache\swift-syntax";
     }
 }
 


### PR DESCRIPTION
Conditionalise the inclusion of directory paths. If the include directory is empty, CMake will raise an error. This allows us to disable larger portions of the Swift build to speed up some of the build tool configuration phase and prepares for consuming CMark GFM as a CMake project.