### PR TITLE
[5.10][NFC] Workaround MSVC miscompile in the autodiff attribute typechecki…

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4887,7 +4887,7 @@ enum class AbstractFunctionDeclLookupErrorKind {
 /// Used for resolving the referenced declaration in `@derivative` and
 /// `@transpose` attributes.
 static AbstractFunctionDecl *findAutoDiffOriginalFunctionDecl(
-    DeclAttribute *attr, Type baseType, DeclNameRefWithLoc funcNameWithLoc,
+    DeclAttribute *attr, Type baseType, const DeclNameRefWithLoc &funcNameWithLoc,
     DeclContext *lookupContext, NameLookupOptions lookupOptions,
     const llvm::function_ref<
         llvm::Optional<AbstractFunctionDeclLookupErrorKind>(


### PR DESCRIPTION
…ng code

This miscompile leads to incorrect name being passed into the funcNameWithLoc parameter. It's reported here: https://developercommunity.visualstudio.com/t/miscompile-MSVC-C-compiler-incorrect/10546525

(cherry picked from commit 652aaa416676eed56d6317df348757b5a80f0a5d)
