### PR TITLE
build: do not modify user variables

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -304,11 +304,6 @@ macro(swift_common_unified_build_config product)
       "${CMARK_BUILD_INCLUDE_DIR}")
 
   include(AddSwiftTableGen) # This imports TableGen from LLVM.
-
-  check_cxx_compiler_flag("-Werror -Wnested-anon-types" CXX_SUPPORTS_NO_NESTED_ANON_TYPES_FLAG)
-  if(CXX_SUPPORTS_NO_NESTED_ANON_TYPES_FLAG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nested-anon-types")
-  endif()
 endmacro()
 
 # Common cmake project config for additional warnings.
@@ -336,6 +331,11 @@ macro(swift_common_cxx_warnings)
 
   check_cxx_compiler_flag("-Werror -Woverloaded-virtual" CXX_SUPPORTS_OVERLOADED_VIRTUAL)
   append_if(CXX_SUPPORTS_OVERLOADED_VIRTUAL "-Woverloaded-virtual" CMAKE_CXX_FLAGS)
+
+  check_cxx_compiler_flag("-Werror -Wnested-anon-types" CXX_SUPPORTS_NO_NESTED_ANON_TYPES_FLAG)
+  if(CXX_SUPPORTS_NO_NESTED_ANON_TYPES_FLAG)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nested-anon-types")
+  endif()
 
   # Check for '-fapplication-extension'.  On OS X/iOS we wish to link all
   # dynamic libraries with this flag.

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -312,29 +312,41 @@ macro(swift_common_cxx_warnings)
   # Make unhandled switch cases be an error in assert builds
   if(DEFINED LLVM_ENABLE_ASSERTIONS)
     check_cxx_compiler_flag("-Werror=switch" CXX_SUPPORTS_WERROR_SWITCH_FLAG)
-    append_if(CXX_SUPPORTS_WERROR_SWITCH_FLAG "-Werror=switch" CMAKE_CXX_FLAGS)
+    if(CXX_SUPPORTS_WERROR_SWITCH_FLAG)
+      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Werror=switch>)
+    endif()
 
-    check_cxx_compiler_flag("/we4062" CXX_SUPPORTS_WE4062)
-    append_if(CXX_SUPPORTS_WE4062 "/we4062" CMAKE_CXX_FLAGS)
+    if(MSVC)
+      check_cxx_compiler_flag("/we4062" CXX_SUPPORTS_WE4062)
+      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/we4062>)
+    endif()
   endif()
 
   check_cxx_compiler_flag("-Werror -Wdocumentation" CXX_SUPPORTS_DOCUMENTATION_FLAG)
-  append_if(CXX_SUPPORTS_DOCUMENTATION_FLAG "-Wdocumentation" CMAKE_CXX_FLAGS)
+  if(CXX_SUPPORTS_DOCUMENTATION_FLAG)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wdocumentation>)
+  endif()
 
   check_cxx_compiler_flag("-Werror -Wimplicit-fallthrough" CXX_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG)
-  append_if(CXX_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG "-Wimplicit-fallthrough" CMAKE_CXX_FLAGS)
+  if(CXX_SUPPORTS_IMPLICIT_FALLTHROUGH_FLAG)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wimplicit-fallthrough>)
+  endif()
 
   # Check for -Wunreachable-code-aggressive instead of -Wunreachable-code, as that indicates
   # that we have the newer -Wunreachable-code implementation.
   check_cxx_compiler_flag("-Werror -Wunreachable-code-aggressive" CXX_SUPPORTS_UNREACHABLE_CODE_FLAG)
-  append_if(CXX_SUPPORTS_UNREACHABLE_CODE_FLAG "-Wunreachable-code" CMAKE_CXX_FLAGS)
+  if(CXX_SUPPORTS_UNREACHABLE_CODE_FLAG)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wunreachable-code>)
+  endif()
 
   check_cxx_compiler_flag("-Werror -Woverloaded-virtual" CXX_SUPPORTS_OVERLOADED_VIRTUAL)
-  append_if(CXX_SUPPORTS_OVERLOADED_VIRTUAL "-Woverloaded-virtual" CMAKE_CXX_FLAGS)
+  if(CXX_SUPPORTS_OVERLOADED_VIRTUAL)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Woverloaded-virtual>)
+  endif()
 
   check_cxx_compiler_flag("-Werror -Wnested-anon-types" CXX_SUPPORTS_NO_NESTED_ANON_TYPES_FLAG)
   if(CXX_SUPPORTS_NO_NESTED_ANON_TYPES_FLAG)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-nested-anon-types")
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wnested-anon-types>)
   endif()
 
   # Check for '-fapplication-extension'.  On OS X/iOS we wish to link all
@@ -344,16 +356,19 @@ macro(swift_common_cxx_warnings)
   # Disable C4068: unknown pragma. This means that MSVC doesn't report hundreds of warnings across
   # the repository for IDE features such as #pragma mark "Title".
   if("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4068")
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/wd4068>)
+
     check_cxx_compiler_flag("/permissive-" CXX_SUPPORTS_PERMISSIVE_FLAG)
-    append_if(CXX_SUPPORTS_PERMISSIVE_FLAG "/permissive-" CMAKE_CXX_FLAGS)
+    if(CXX_SUPPORTS_PERMISSIVE_FLAG)
+      add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/permissive->)
+    endif()
   endif()
 
   # Disallow calls to objc_msgSend() with no function pointer cast.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DOBJC_OLD_DISPATCH_PROTOTYPES=0")
+  add_compile_definitions($<$<COMPILE_LANGUAGE:CXX>:OBJC_OLD_DISPATCH_PROTOTYPES=0>)
 
   if(BRIDGING_MODE STREQUAL "PURE")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DPURE_BRIDGING_MODE")
+    add_compile_definitions($<$<COMPILE_LANGUAGE:CXX>:PURE_BRIDGING_MODE>)
   endif()
 endmacro()
 


### PR DESCRIPTION
`CMAKE_CXX_FLAGS` are not meant to be modified by the build system. If the build wishes to force certain flags, it should use the `add_compile_options` and `add_compile_definitions` (or preferably the target variants). This cleans up the handling in the shared configuration.