### PR TITLE
ModuleInterface: write down the -no-verify-emitted-module-interface flag in swiftinterfaces

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -599,7 +599,8 @@ def verify_emitted_module_interface :
   HelpText<"Check that module interfaces emitted during compilation typecheck">;
 def no_verify_emitted_module_interface :
   Flag<["-"], "no-verify-emitted-module-interface">,
-  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild,
+        FrontendOption, ModuleInterfaceOptionIgnorable]>,
   HelpText<"Don't check that module interfaces emitted during compilation typecheck">;
 
 def avoid_emit_module_source_info :

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -375,6 +375,14 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
 
   addPluginArguments(inputArgs, arguments);
 
+  // Pass along -no-verify-emitted-module-interface only if it's effective.
+  // Assume verification by default as we want to know only when the user skips
+  // the verification.
+  if (!inputArgs.hasFlag(options::OPT_verify_emitted_module_interface,
+                         options::OPT_no_verify_emitted_module_interface,
+                         true))
+    arguments.push_back("-no-verify-emitted-module-interface");
+
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);
   inputArgs.AddAllArgs(arguments, options::OPT_Xcc);

--- a/test/ModuleInterface/preserve-no-verify-flag.swift
+++ b/test/ModuleInterface/preserve-no-verify-flag.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// REQUIRES: swift-driver-change
+
+/// Check that the flag -no-verify-emitted-module-interface is written down in the swiftinterface.
+// RUN: %target-build-swift -emit-library -enable-library-evolution -emit-module-interface -emit-module -swift-version 5 -o %t/NoVerified.o -no-verify-emitted-module-interface -module-name NoVerified %s
+// RUN: cat %t/NoVerified.swiftinterface | %FileCheck --check-prefix FLAG %s
+// FLAG: swift-module-flags-ignorable:
+// FLAG-SAME: -no-verify-emitted-module-interface
+
+/// Check that there's no skip flag in the swiftinterface.
+// RUN: %target-build-swift -emit-library -enable-library-evolution -emit-module-interface -emit-module -swift-version 5 -o %t/Verified.o -verify-emitted-module-interface -module-name Verified %s
+// RUN: cat %t/Verified.swiftinterface | %FileCheck --check-prefix NO-FLAG %s
+// NO-FLAG-NOT: verify-emitted-module-interface
+
+/// Check last flag priority.
+// RUN: %target-build-swift -emit-library -enable-library-evolution -emit-module-interface -emit-module -swift-version 5 -o %t/VerifiedManyFlags.o -no-verify-emitted-module-interface -module-name VerifiedManyFlags %s -verify-emitted-module-interface
+// RUN: cat %t/VerifiedManyFlags.swiftinterface | %FileCheck --check-prefix NO-FLAG %s
+
+// RUN: %target-build-swift -emit-library -enable-library-evolution -emit-module-interface -emit-module -swift-version 5 -o %t/NoVerifiedManyFlags.o -verify-emitted-module-interface -module-name NoVerifiedManyFlags %s -no-verify-emitted-module-interface
+// RUN: cat %t/NoVerifiedManyFlags.swiftinterface | %FileCheck --check-prefix FLAG %s
+
+public struct MyStruct {}


### PR DESCRIPTION
The flag -no-verify-emitted-module-interface tells the driver to skip verifying the swiftinterfaces emitted by the compiler. It used to be passed only to the driver.

Let's pass it down to the frontend as well and write it in the swiftinterfaces. This will help understand them from the reader side.

rdar://120445543

---

The test is disabled until the new driver is updated to support the same logic.