### PR TITLE
[Completion] Use statically-known size for completion ordering

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -701,6 +701,13 @@ static ResultBucket getResultBucket(Item &item, bool hasRequiredTypes,
   }
 }
 
+template <class T, size_t N>
+static size_t getIndex(const T (&array)[N], T element) {
+  auto I = std::find(array, &array[N], element);
+  assert(I != &array[N]);
+  return std::distance(array, I);
+}
+
 static int compareHighPriorityKeywords(Item &a_, Item &b_) {
   static CodeCompletionKeywordKind order[] = {
     CodeCompletionKeywordKind::kw_let,
@@ -711,16 +718,9 @@ static int compareHighPriorityKeywords(Item &a_, Item &b_) {
     CodeCompletionKeywordKind::kw_return,
     CodeCompletionKeywordKind::kw_func,
   };
-  auto size = sizeof(order) / sizeof(order[0]);
 
-  auto getIndex = [=](Item &item) {
-     auto I = std::find(order, &order[size], cast<Result>(item).value->getKeywordKind());
-    assert(I != &order[size]);
-    return std::distance(order, I);
-  };
-
-  auto a = getIndex(a_);
-  auto b = getIndex(b_);
+  auto a = getIndex(order, cast<Result>(a_).value->getKeywordKind());
+  auto b = getIndex(order, cast<Result>(b_).value->getKeywordKind());
   return a < b ? -1 : (b < a ? 1 : 0);
 }
 
@@ -736,16 +736,9 @@ static int compareLiterals(Item &a_, Item &b_) {
     CodeCompletionLiteralKind::Tuple,
     CodeCompletionLiteralKind::NilLiteral,
   };
-  auto size = sizeof(order) / sizeof(order[0]);
 
-  auto getIndex = [=](Item &item) {
-    auto I = std::find(order, &order[size], cast<Result>(item).value->getLiteralKind());
-    assert(I != &order[size]);
-    return std::distance(order, I);
-  };
-
-  auto a = getIndex(a_);
-  auto b = getIndex(b_);
+  auto a = getIndex(order, cast<Result>(a_).value->getLiteralKind());
+  auto b = getIndex(order, cast<Result>(b_).value->getLiteralKind());
 
   if (a != b)
     return a < b ? -1 : 1;
@@ -816,17 +809,9 @@ static int compareOperators(Item &a_, Item &b_) {
       CCOK::NotEqEq, // !==
       CCOK::TildeEq, // ~=
   };
-  auto size = sizeof(order) / sizeof(order[0]);
 
-  auto getIndex = [=](Item &item) {
-    auto I = std::find(order, &order[size],
-                       cast<Result>(item).value->getOperatorKind());
-    assert(I != &order[size]);
-    return std::distance(order, I);
-  };
-
-  auto a = getIndex(a_);
-  auto b = getIndex(b_);
+  auto a = getIndex(order, cast<Result>(a_).value->getOperatorKind());
+  auto b = getIndex(order, cast<Result>(b_).value->getOperatorKind());
   return a < b ? -1 : (b < a ? 1 : 0);
 }
 


### PR DESCRIPTION
We know the size of these arrays statically, there's no point calculating them at runtime.

Resolves rdar://119938834.