### PR TITLE
Emit private interfaces on all swift libraries

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -207,6 +207,7 @@ function(add_pure_swift_host_library name)
     set(module_base "${module_dir}/${name}.swiftmodule")
     set(module_file "${module_base}/${module_triple}.swiftmodule")
     set(module_interface_file "${module_base}/${module_triple}.swiftinterface")
+    set(module_private_interface_file "${module_base}/${module_triple}.private.swiftinterface")
     set(module_sourceinfo_file "${module_base}/${module_triple}.swiftsourceinfo")
 
     set_target_properties(${name} PROPERTIES
@@ -231,7 +232,8 @@ function(add_pure_swift_host_library name)
         -enable-library-evolution;
         -emit-module-path;${module_file};
         -emit-module-source-info-path;${module_sourceinfo_file};
-        -emit-module-interface-path;${module_interface_file}
+        -emit-module-interface-path;${module_interface_file};
+        -emit-private-module-interface-path;${module_private_interface_file}
         >)
   else()
     # Emit a swiftmodule in the current directory.


### PR DESCRIPTION
Swift-driver PR [1043](https://github.com/apple/swift-driver/pull/1043) updated the new driver to always emit private swiftinterface files. This was not carried back to the old driver, so attempting to bootstrap the toolchain on a system that does not have the new driver fails to install because we try to install the private swiftinterface on all Swift targets.
