### PR TITLE
[embedded] Add a stop-gap print() for embedded Swift

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -193,7 +193,7 @@ FUNCTION(UnexpectedError, swift_unexpectedError, SwiftCC, AlwaysAvailable,
          RETURNS(VoidTy),
          ARGS(ErrorPtrTy),
          ATTRS(NoUnwind, NoReturn),
-         EFFECT(NoEffect),
+         EFFECT(NoEffect, Deallocating),
          UNKNOWN_MEMEFFECTS)
 
 // void *swift_copyPOD(void *dest, void *src, Metadata *self);

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -263,6 +263,7 @@ endif()
 list(APPEND SWIFTLIB_EMBEDDED_SOURCES
   EmbeddedRuntime.swift
   EmbeddedStubs.swift
+  EmbeddedPrint.swift
   )
 
 set(GROUP_INFO_JSON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/GroupInfo.json)

--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -1,8 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftShims
+
+// TODO: This is all a stop-gap so that at least some types are printable in
+// embedded Swift, in an embedded-programming friendly way (we mainly need
+// printing to not need to heap allocate).
+
 @_silgen_name("putchar")
 func putchar(_: UInt8)
 
-func print(_ s: StaticString, terminator: StaticString = "\n") {
-  var p = s.utf8Start
+public func print(_ string: StaticString, terminator: StaticString = "\n") {
+  var p = string.utf8Start
   while p.pointee != 0 {
     putchar(p.pointee)
     p += 1
@@ -43,7 +61,8 @@ extension BinaryInteger {
     withUnsafeTemporaryAllocation(byteCount: 64, alignment: 1) { buffer in
       var index = buffer.count - 1
       while value != 0 {
-        let (quotient, remainder) = value.quotientAndRemainder(dividingBy: Magnitude(radix))
+        let (quotient, remainder) =
+            value.quotientAndRemainder(dividingBy: Magnitude(radix))
         buffer[index] = _ascii(UInt8(truncatingIfNeeded: remainder))
         index -= 1
         value = quotient
@@ -55,18 +74,20 @@ extension BinaryInteger {
       let start = index + 1
       let end = buffer.count - 1
       let count = end - start + 1
-      printCharacters(UnsafeBufferPointer(start: buffer.baseAddress?.advanced(by: start).assumingMemoryBound(to: UInt8.self), count: count))
+
+      let pointerToPrint = buffer.baseAddress?.advanced(by: start).assumingMemoryBound(to: UInt8.self)
+      printCharacters(UnsafeBufferPointer(start: pointerToPrint, count: count))
     }
   }
 }
 
-func print(_ n: some BinaryInteger, terminator: StaticString = "\n") {
-  n.writeToStdout()
+public func print(_ integer: some BinaryInteger, terminator: StaticString = "\n") {
+  integer.writeToStdout()
   print("", terminator: terminator)
 }
 
-func print(_ b: Bool, terminator: StaticString = "\n") {
-  if b {
+public func print(_ boolean: Bool, terminator: StaticString = "\n") {
+  if boolean {
     print("true", terminator: terminator)
   } else {
     print("false", terminator: terminator)

--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -44,18 +44,14 @@ func printCharacters(_ buf: UnsafeBufferPointer<UInt8>) {
 }
 
 extension BinaryInteger {
-  func writeToStdout(radix: Int = 10) {
+  func writeToStdout() {
     if self == (0 as Self) {
       print("0", terminator: "")
       return
     }
-    
+
     func _ascii(_ digit: UInt8) -> UInt8 {
-      if digit < 10 {
-        UInt8(("0" as Unicode.Scalar).value) + digit
-      } else {
-        UInt8(("a" as Unicode.Scalar).value) + (digit - 10)
-      }
+      UInt8(("0" as Unicode.Scalar).value) + digit
     }
     let isNegative = Self.isSigned && self < (0 as Self)
     var value = magnitude
@@ -70,7 +66,7 @@ extension BinaryInteger {
     var index = buffer.count - 1
     while value != 0 {
       let (quotient, remainder) =
-          value.quotientAndRemainder(dividingBy: Magnitude(radix))
+          value.quotientAndRemainder(dividingBy: Magnitude(10))
       buffer[index] = _ascii(UInt8(truncatingIfNeeded: remainder))
       index -= 1
       value = quotient

--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -17,24 +17,25 @@ import SwiftShims
 // printing to not need to heap allocate).
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ string: StaticString, terminator: StaticString = "\n") {
   var p = string.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }
 
 func printCharacters(_ buf: UnsafeRawBufferPointer) {
   for c in buf {
-    putchar(c)
+    putchar(CInt(c))
   }
 }
 

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -248,7 +248,8 @@
     "DurationProtocol.swift",
     "Instant.swift",
     "EmbeddedRuntime.swift",
-    "EmbeddedStubs.swift"
+    "EmbeddedStubs.swift",
+    "EmbeddedPrint.swift"
   ],
   "Result": [
     "Result.swift"

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -99,6 +99,7 @@ public func _withUnprotectedUnsafeMutablePointer<T, Result>(
 #endif
 }
 
+#if !$Embedded
 /// Invokes the given closure with a pointer to the given argument.
 ///
 /// The `withUnsafePointer(to:_:)` function is useful for calling Objective-C
@@ -127,6 +128,17 @@ public func withUnsafePointer<T, Result>(
 {
   return try body(UnsafePointer<T>(Builtin.addressOfBorrow(value)))
 }
+#else
+// TODO: This should be unified with non-embedded Swift.
+@inlinable
+public func withUnsafePointer<T, E, Result>(
+  to value: T,
+  _ body: (UnsafePointer<T>) throws(E) -> Result
+) throws(E) -> Result
+{
+  return try body(UnsafePointer<T>(Builtin.addressOfBorrow(value)))
+}
+#endif
 
 /// Invokes the given closure with a pointer to the given argument.
 ///

--- a/test/SILOptimizer/devirt_deinits.swift
+++ b/test/SILOptimizer/devirt_deinits.swift
@@ -4,7 +4,7 @@
 // RUN: %target-run-simple-swift(-Xllvm -enable-deinit-devirtualizer -parse-as-library) | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 // Check if it works in embedded mode.
-// RUN: %target-run-simple-swift(%S/../embedded/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck -check-prefix CHECK-OUTPUT %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 // Run without the deinit-devirtualizer to verify that our CHECK-OUTPUT lines are correct.
 // TODO: currently disabled because of rdar://118449507

--- a/test/embedded/FixedArray.swift
+++ b/test/embedded/FixedArray.swift
@@ -1,11 +1,11 @@
 
-// RUN: %target-run-simple-swift(%S/Inputs/ExperimentalFixedArray.swift %S/Inputs/print.swift -enable-experimental-feature Embedded -enable-experimental-feature FixedArrays -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O %S/Inputs/ExperimentalFixedArray.swift %S/Inputs/print.swift -enable-experimental-feature Embedded -enable-experimental-feature FixedArrays -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/ExperimentalFixedArray.swift -enable-experimental-feature Embedded -enable-experimental-feature FixedArrays -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O %S/Inputs/ExperimentalFixedArray.swift -enable-experimental-feature Embedded -enable-experimental-feature FixedArrays -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // Also test in non-embedded mode
 
-// RUN: %target-run-simple-swift(%S/Inputs/ExperimentalFixedArray.swift %S/Inputs/print.swift -enable-experimental-feature FixedArrays -parse-as-library -wmo) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O %S/Inputs/ExperimentalFixedArray.swift %S/Inputs/print.swift -enable-experimental-feature FixedArrays -parse-as-library -wmo) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/ExperimentalFixedArray.swift -enable-experimental-feature FixedArrays -parse-as-library -wmo) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O %S/Inputs/ExperimentalFixedArray.swift -enable-experimental-feature FixedArrays -parse-as-library -wmo) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
@@ -37,18 +37,18 @@ struct IntByte: Printable {
   let b: Int8
 
   func print() {
-    main.print(i, terminator: "")
-    main.print(",", terminator: "")
-    main.print(b, terminator: "")
+    Swift.print(i, terminator: "")
+    Swift.print(",", terminator: "")
+    Swift.print(b, terminator: "")
   }
 }
 
 extension Optional: Printable where Wrapped == Int64 {
   func print() {
     if let x = self {
-      main.print(x, terminator: "")
+      Swift.print(x, terminator: "")
     } else {
-      main.print("nil", terminator: "")
+      Swift.print("nil", terminator: "")
     }
   }
 }
@@ -151,13 +151,13 @@ struct Matrix<T: Printable>: ~Copyable {
 
   func print() {
     for r in 0..<rows {
-      main.print("(", terminator: "")
+      Swift.print("(", terminator: "")
       for c in 0..<columns {
         self[r, c].print()
         if c < columns - 1 {
-          main.print(",", terminator: "")
+          Swift.print(",", terminator: "")
         } else {
-          main.print(")")
+          Swift.print(")")
         }
       }
     }
@@ -271,7 +271,7 @@ protocol Printable {
 
 extension Int: Printable {
   func print() {
-    main.print(self, terminator: "")
+    Swift.print(self, terminator: "")
   }
 }
 
@@ -290,13 +290,13 @@ final class CheckLifetime: Printable {
   }
 
   deinit {
-    main.print("deinit ", terminator: "")
-    main.print(x)
+    Swift.print("deinit ", terminator: "")
+    Swift.print(x)
   }
 
   func print() {
-    main.print("CheckLifetime(", terminator: "")
-    main.print(x, terminator: ")")
+    Swift.print("CheckLifetime(", terminator: "")
+    Swift.print(x, terminator: ")")
   }
 }
 

--- a/test/embedded/array-builtins-exec.swift
+++ b/test/embedded/array-builtins-exec.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s %S/Inputs/print.swift -enable-experimental-feature Embedded -enable-builtin-module -c -o %t/main.o
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -enable-builtin-module -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/array-to-pointer.swift
+++ b/test/embedded/array-to-pointer.swift
@@ -10,17 +10,18 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/arrays.swift
+++ b/test/embedded/arrays.swift
@@ -10,17 +10,18 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/class-func.swift
+++ b/test/embedded/class-func.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/classes-arrays.swift
+++ b/test/embedded/classes-arrays.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s %S/Inputs/print.swift -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/classes-stack-promotion.swift
+++ b/test/embedded/classes-stack-promotion.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s %S/Inputs/print.swift -enable-experimental-feature Embedded -module-name main -emit-irgen | %FileCheck %s --check-prefix CHECK-IR
-// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s %S/Inputs/print.swift -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s -parse-as-library -enable-experimental-feature Embedded -module-name main -emit-irgen | %FileCheck %s --check-prefix CHECK-IR
+// RUN: %target-swift-frontend -O -Xllvm -sil-disable-pass=function-signature-opts %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 
@@ -72,7 +72,7 @@ struct Main {
 
 // CHECK-IR:      define {{.*}}@"$s4main8MyStructVyAcA0B10FinalClassCcfC"
 // CHECK-IR-NEXT: entry:
-// CHECK-IR-NEXT:   call {{.*}}@"$s4main5print_10terminatorys12StaticStringV_AEtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$ss5print_10terminatorys12StaticStringV_ADtF"
 // CHECK-IR-NEXT:   call {{.*}}@swift_release
 // CHECK-IR-NEXT:   ret void
 // CHECK-IR-NEXT: }
@@ -82,17 +82,17 @@ struct Main {
 // CHECK-IR-NEXT:   alloca %T4main10MySubClassC
 // CHECK-IR-NEXT:   alloca %T4main12MyFinalClassC
 // CHECK-IR-NEXT:   call {{.*}}@swift_initStackObject
-// CHECK-IR-NEXT:   call {{.*}}@"$s4main5print_10terminatorys12StaticStringV_AEtF"
-// CHECK-IR-NEXT:   call {{.*}}@"$s4main5print_10terminatorys12StaticStringV_AEtF"
-// CHECK-IR-NEXT:   call {{.*}}@"$s4main5print_10terminatorys12StaticStringV_AEtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$ss5print_10terminatorys12StaticStringV_ADtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$ss5print_10terminatorys12StaticStringV_ADtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$ss5print_10terminatorys12StaticStringV_ADtF"
 // CHECK-IR-NEXT:   call {{.*}}@"$s4main3bar1oyAA7MyClassC_tF"
 // CHECK-IR-NEXT:   call {{.*}}@swift_setDeallocating
-// CHECK-IR-NEXT:   call {{.*}}@"$s4main5print_10terminatorys12StaticStringV_AEtF"
-// CHECK-IR-NEXT:   call {{.*}}@"$s4main5print_10terminatorys12StaticStringV_AEtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$ss5print_10terminatorys12StaticStringV_ADtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$ss5print_10terminatorys12StaticStringV_ADtF"
 // CHECK-IR-NEXT:   call {{.*}}@llvm.lifetime.end.p0
-// CHECK-IR-NEXT:   call {{.*}}@"$s4main5print_10terminatorys12StaticStringV_AEtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$ss5print_10terminatorys12StaticStringV_ADtF"
 // CHECK-IR-NEXT:   call {{.*}}@swift_initStackObject
-// CHECK-IR-NEXT:   call {{.*}}@"$s4main5print_10terminatorys12StaticStringV_AEtF"
+// CHECK-IR-NEXT:   call {{.*}}@"$ss5print_10terminatorys12StaticStringV_ADtF"
 // CHECK-IR-NEXT:   call {{.*}}@"$s4main8MyStructVyAcA0B10FinalClassCcfC"
 // CHECK-IR-NEXT:   call {{.*}}@llvm.lifetime.end.p0
 // CHECK-IR-NEXT:   ret {{.*}}0

--- a/test/embedded/classes.swift
+++ b/test/embedded/classes.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s %S/Inputs/print.swift -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/closures-heap.swift
+++ b/test/embedded/closures-heap.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s %S/Inputs/print.swift -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/collection.swift
+++ b/test/embedded/collection.swift
@@ -10,17 +10,18 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/concurrency-actors.swift
+++ b/test/embedded/concurrency-actors.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s %S/Inputs/print.swift -c -o %t/a.o
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/concurrency-async-let.swift
+++ b/test/embedded/concurrency-async-let.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s %S/Inputs/print.swift -c -o %t/a.o
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s %S/Inputs/print.swift -c -o %t/a.o
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -8,17 +8,18 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/darwin-bridging-header.swift
+++ b/test/embedded/darwin-bridging-header.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend %t/Main.swift %S/Inputs/print.swift -import-bridging-header %t/BridgingHeader.h -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend %t/Main.swift -parse-as-library -import-bridging-header %t/BridgingHeader.h -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/darwin.swift
+++ b/test/embedded/darwin.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s %S/Inputs/print.swift -enable-experimental-feature Embedded -throws-as-traps -enable-builtin-module -c -o %t/main.o
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -throws-as-traps -enable-builtin-module -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/dependencies-no-allocations.swift
+++ b/test/embedded/dependencies-no-allocations.swift
@@ -27,17 +27,18 @@
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/dependencies-print.swift
+++ b/test/embedded/dependencies-print.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -no-allocations %s -c -o %t/a.o
+
+// RUN: grep DEP\: %s | sed 's#// DEP\: ##' | sort > %t/allowed-dependencies.txt
+
+// Linux/ELF doesn't use the "_" prefix in symbol mangling.
+// RUN: if [ %target-os == "linux-gnu" ]; then sed -E -i -e 's/^_(.*)$/\1/' %t/allowed-dependencies.txt; fi
+
+// RUN: %llvm-nm --undefined-only --format=just-symbols %t/a.o | sort | tee %t/actual-dependencies.txt
+
+// Fail if there is any entry in actual-dependencies.txt that's not in allowed-dependencies.txt
+// RUN: test -z "`comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt`"
+
+// DEP: ___stack_chk_fail
+// DEP: ___stack_chk_guard
+// DEP: ___divti3
+// DEP: ___modti3
+// DEP: _memset
+// DEP: _putchar
+
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+
+print("Hello Embedded Swift!") // CHECK: Hello Embedded Swift!
+print(42) // CHECK: 42
+print(false) // CHECK: false

--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -29,17 +29,18 @@
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/deserialize-vtables.swift
+++ b/test/embedded/deserialize-vtables.swift
@@ -22,12 +22,13 @@ extension StaticString {
 }
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 extension Array<UInt8> {
     func print() {
         for byte in self {
-            putchar(byte)
+            putchar(CInt(byte))
         }
         putchar(10)
     }

--- a/test/embedded/fno-builtin.swift
+++ b/test/embedded/fno-builtin.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-ir %s %S/Inputs/print.swift -module-name main -Xcc -fno-builtin -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-emit-ir %s %S/Inputs/print.swift -module-name main -Xcc -ffreestanding -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -parse-as-library -module-name main -Xcc -fno-builtin -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -parse-as-library -module-name main -Xcc -ffreestanding -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/generic-classes-debuginfo.swift
+++ b/test/embedded/generic-classes-debuginfo.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-g %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-g -Osize %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-g -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-g -Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib

--- a/test/embedded/generic-classes.swift
+++ b/test/embedded/generic-classes.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-Osize %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/lto.swift
+++ b/test/embedded/lto.swift
@@ -13,17 +13,18 @@
 // REQUIRES: no_asan
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/modules-classes.swift
+++ b/test/embedded/modules-classes.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
 // RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out

--- a/test/embedded/modules-globals-exec.swift
+++ b/test/embedded/modules-globals-exec.swift
@@ -25,17 +25,18 @@ public func foo() {
 import MyModule
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/modules-print-exec.swift
+++ b/test/embedded/modules-print-exec.swift
@@ -14,17 +14,18 @@
 // BEGIN MyModule.swift
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
-public func print(_ s: StaticString, terminator: StaticString) {
+public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/once-dependent.swift
+++ b/test/embedded/once-dependent.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s %S/Inputs/print.swift -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/once-multithreaded.swift
+++ b/test/embedded/once-multithreaded.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// RUN: %target-swift-frontend %t/Main.swift %S/Inputs/print.swift -import-bridging-header %t/BridgingHeader.h -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend %t/Main.swift -parse-as-library -import-bridging-header %t/BridgingHeader.h -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip -pthreads
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/once.swift
+++ b/test/embedded/once.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -lto=llvm-full %lto_flags %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -lto=llvm-full %lto_flags -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/runtime-release.swift
+++ b/test/embedded/runtime-release.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/runtime.swift
+++ b/test/embedded/runtime.swift
@@ -8,17 +8,18 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 @_silgen_name("putchar")
-func putchar(_: UInt8)
+@discardableResult
+func putchar(_: CInt) -> CInt
 
 public func print(_ s: StaticString, terminator: StaticString = "\n") {
   var p = s.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
   p = terminator.utf8Start
   while p.pointee != 0 {
-    putchar(p.pointee)
+    putchar(CInt(p.pointee))
     p += 1
   }
 }

--- a/test/embedded/set-runtime.swift
+++ b/test/embedded/set-runtime.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/simd.swift
+++ b/test/embedded/simd.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend %s %S/Inputs/print.swift -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-swift-frontend %s -parse-as-library -enable-experimental-feature Embedded -c -o %t/main.o
 // RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s
 

--- a/test/embedded/specialize-attrs.swift
+++ b/test/embedded/specialize-attrs.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -Onone -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Onone -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/static-object.swift
+++ b/test/embedded/static-object.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -O -emit-irgen %s %S/Inputs/print.swift -module-name main -parse-as-library -enable-experimental-feature Embedded | %FileCheck %s --check-prefix CHECK-IR
-// RUN: %target-run-simple-swift(-O %S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-swift-frontend -O -emit-irgen %s -module-name main -parse-as-library -enable-experimental-feature Embedded | %FileCheck %s --check-prefix CHECK-IR
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/static-string-interpolation.swift
+++ b/test/embedded/static-string-interpolation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -Xfrontend -throws-as-traps -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -Xfrontend -throws-as-traps -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/throw-typed.swift
+++ b/test/embedded/throw-typed.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test


### PR DESCRIPTION
This is all a stop-gap so that at least some types are printable in embedded Swift, in an embedded-programming friendly way (we mainly need printing to not need to heap allocate). We should pursue an eventual long term solution that adds an allocation-free print() into both regular and embedded Swift, and makes all stdlib types stream-printable (via a new protocol).

But print()-ing is a basic need for everyone, so in the meantime, let's add this stop-gap.
