### PR TITLE
Revert "[cxx-interop] benchmark, disable ReadAccessor benchmark while investigating build regression after rebranch"

### DIFF
--- a/benchmark/cxx-source/ReadAccessor.swift
+++ b/benchmark/cxx-source/ReadAccessor.swift
@@ -15,8 +15,6 @@
 ///
 // -----------------------------------------------------------------------------
 
-#if FIXED117438849
-
 import TestsUtils
 import CxxSubscripts
 
@@ -44,5 +42,3 @@ public func run_ReadAccessor(_ N: Int) {
     }
   }
 }
-
-#endif


### PR DESCRIPTION
This reverts commit 157632fd9f9fb35e57fa273a49e6317f6de0f33d.

The test failure was caused by the libc++ modularization change (https://github.com/llvm/llvm-project/commit/571178a21a8bc105bf86cf4bf92f842e07792e1a)