### PR TITLE
[AutoDiff] Add missing vjp, jvp functions to existing FloatingPoint initializers

### DIFF
--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -54,21 +54,42 @@ extension ${Self}: Differentiable {
 /// Derivatives of constructors.
 ${Availability(bits)}
 extension ${Self} {
-  @inlinable
-  @_transparent
-  @derivative(of: init(_:))
-  static func _vjpInit(x: ${Self})
-    -> (value: ${Self}, pullback: (${Self}) -> ${Self}) {
-    return (x, { v in v })
-  }
 
+  % for other_type in all_floating_point_types():
+  %{
+  Other = other_type.stdlib_name
+  other_bits = other_type.bits
+  }%
+  
+  % if other_bits == 80:
+  #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+  % end
+  % if other_bits == 16:
+  #if !os(macOS) && !(os(iOS) && targetEnvironment(macCatalyst))
+  % end
+
+  ${Availability(other_bits)}
   @inlinable
   @_transparent
   @derivative(of: init(_:))
-  static func _jvpInit(x: ${Self})
-  -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
-    return (x, { dx in dx })
+  static func _vjpInit(x: ${Other})
+  -> (value: ${Self}, pullback: (${Self}) -> ${Other}) {
+    return (value: ${Self}(x), pullback: { v in ${Other}(v) })
   }
+  
+  ${Availability(other_bits)}
+  @inlinable
+  @_transparent
+  @derivative(of: init(_:))
+  static func _jvpInit(x: ${Other})
+  -> (value: ${Self}, differential: (${Other}) -> ${Self}) {
+    return (value: ${Self}(x), differential: { dx in ${Self}(dx) })
+  }
+  
+  % if other_bits == 80 or other_bits == 16:
+  #endif
+  % end
+  % end
 }
 
 /// Derivatives of standard unary operators.

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -34,13 +34,23 @@ func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %end
 
-FloatingPointDerivativeTests.test("${Self}.init") {
-  expectEqual(1, gradient(at: ${Self}(4), of: ${Self}.init(_:)))
-  expectEqual(10, pullback(at: ${Self}(4), of: ${Self}.init(_:))(${Self}(10)))
+%for Other in ['Float', 'Double', 'Float80']:
+%if Other == 'Float80':
+#if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
+%end
 
-  expectEqual(1, derivative(at: ${Self}(4), of: ${Self}.init(_:)))
-  expectEqual(10, differential(at: ${Self}(4), of: ${Self}.init(_:))(${Self}(10)))
+FloatingPointDerivativeTests.test("${Self}.init(_:${Other})") {
+  expectEqual(1, gradient(at: ${Other}(4), of: ${Self}.init(_:)))
+  expectEqual(10, pullback(at: ${Other}(4), of: ${Self}.init(_:))(${Self}(10)))
+
+  expectEqual(1, derivative(at: ${Other}(4), of: ${Self}.init(_:)))
+  expectEqual(10, differential(at: ${Other}(4), of: ${Self}.init(_:))(${Other}(10)))
 }
+
+%if Other == 'Float80':
+#endif
+%end
+%end # for Other in ['Float', 'Double', 'Float80']:
 
 FloatingPointDerivativeTests.test("${Self}.+") {
   expectEqual((1, 1), gradient(at: ${Self}(4), ${Self}(5), of: +))


### PR DESCRIPTION
This PR adds jvp's and vjp's to already existing FloatingPoint initializers that allow to convert between floating point types, making the example below differentiable: 
```swift
let f = Float(3.0)
let d = Double(f)
```

Previously jvp's and vjp's were added to the FloatingPoint initializers that took the same FP type as an argument in #64417 . But not to the initializers taking other FP types as arguments (for example converting from a Float to a Double). 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
