### PR TITLE
Use %target-swiftc_driver in objc_class_properties_runtime.swift

### DIFF
--- a/test/Interpreter/objc_class_properties_runtime.swift
+++ b/test/Interpreter/objc_class_properties_runtime.swift
@@ -2,15 +2,13 @@
 
 // RUN: %clang -arch %target-cpu -target %target-cpu-apple-macosx10.11 -isysroot %sdk -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o
 
-// RUN: %swiftc_driver -target $(echo '%target-triple' | sed -E -e 's/macosx10.(9|10).*/macosx10.11/') -sdk %sdk -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out
+// RUN: %target-swiftc_driver -sdk %sdk -I %S/Inputs/ObjCClasses/ %t/ObjCClasses.o %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 
 // REQUIRES: OS=macosx
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
-
-// REQUIRES: rdar119907089
 
 import Foundation
 import StdlibUnittest


### PR DESCRIPTION
This way we will compile the test program with `-Xlinker -headerpad_max_install_names`, which will allow
`swift-darwin-postprocess.py` to amend the install names without errors.

Take the chance to remove the `-target` parameter -- that is already
provided by %target-swiftc_driver, and we have no need to enforce it to
be at least `macosx10.11` (since by virtue of build-script defaults and
Xcode in CI we don't support anything lower than `macosx10.13`)

Addresses rdar://119907089