### PR TITLE
[ClangImporter] Augment type import to support SwiftAttr in type contexts

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1991,7 +1991,9 @@ private:
   VISIT(ModuleType, pass)
   VISIT(DynamicSelfType, pass)
 
-  NEVER_VISIT(SubstitutableType)
+  // Ignore attributes placed on generic parameter references and
+  // other substitutable types.
+  VISIT(SubstitutableType, pass)
   NEVER_VISIT(DependentMemberType)
 
   Result visitAnyFunctionType(AnyFunctionType *ty) {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1633,7 +1633,7 @@ static ImportedType adjustTypeForConcreteImport(
   return {importedType, isIUO};
 }
 
-static void applyTypeAttributes(ASTContext &SwiftContext,
+void swift::getConcurrencyAttrs(ASTContext &SwiftContext,
                                 ImportTypeKind importKind,
                                 ImportTypeAttrs &attrs, clang::QualType type) {
   bool isMainActor = false;
@@ -1728,7 +1728,7 @@ ImportedType ClangImporter::Implementation::importType(
     optionality = translateNullability(*nullability, stripNonResultOptionality);
   }
 
-  applyTypeAttributes(SwiftContext, importKind, attrs, type);
+  getConcurrencyAttrs(SwiftContext, importKind, attrs, type);
 
   // If this is a completion handler parameter, record the function type whose
   // parameters will act as the results of the completion handler.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -229,6 +229,15 @@ using ImportTypeAttrs = OptionSet<ImportTypeAttr>;
 ///        attributes will be imported.
 ImportTypeAttrs getImportTypeAttrs(const clang::Decl *D, bool isParam = false);
 
+/// Extract concurrency related attributes from a type.
+///
+/// \param SwiftContext The context.
+/// \param importKind The kind of import being performed.
+/// \param attrs The list to add the new attributes to.
+/// \param type The type to extract attributes from.
+void getConcurrencyAttrs(ASTContext &SwiftContext, ImportTypeKind importKind,
+                         ImportTypeAttrs &attrs, clang::QualType type);
+
 struct ImportDiagnostic {
   ImportDiagnosticTarget target;
   Diagnostic diag;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -157,18 +157,6 @@ enum class ImportTypeKind {
   /// * _Nullable_result is treated as _Nonnull rather than _Nullable_result.
   CompletionHandlerResultParameter,
 
-  /// Import the type of a parameter declared with
-  /// \c CF_RETURNS_RETAINED.
-  ///
-  /// This ensures that the parameter is not marked as Unmanaged.
-  CFRetainedOutParameter,
-
-  /// Import the type of a parameter declared with
-  /// \c CF_RETURNS_NON_RETAINED.
-  ///
-  /// This ensures that the parameter is not marked as Unmanaged.
-  CFUnretainedOutParameter,
-
   /// Import the type of an ObjC property.
   ///
   /// This enables the conversion of bridged types. Properties are always
@@ -210,7 +198,19 @@ enum class ImportTypeAttr : uint8_t {
   /// Type is in a declaration where it would be imported as Sendable by
   /// default. This comes directly from the parameters to
   /// \c getImportTypeAttrs() and merely affects diagnostics.
-  DefaultsToSendable = 1 << 3
+  DefaultsToSendable = 1 << 3,
+
+  /// Import the type of a parameter declared with
+  /// \c CF_RETURNS_RETAINED.
+  ///
+  /// This ensures that the parameter is not marked as Unmanaged.
+  CFRetainedOutParameter = 1 << 4,
+
+  /// Import the type of a parameter declared with
+  /// \c CF_RETURNS_NON_RETAINED.
+  ///
+  /// This ensures that the parameter is not marked as Unmanaged.
+  CFUnretainedOutParameter = 1 << 5,
 };
 
 /// Attributes which were set on the declaration and affect how its type is

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -216,6 +216,12 @@ enum class ImportTypeAttr : uint8_t {
   CFUnretainedOutParameter = 1 << 5,
 };
 
+/// Find and iterate over swift attributes embedded in the type
+/// without looking through typealiases.
+void findSwiftAttributes(
+    clang::QualType type,
+    llvm::function_ref<void(const clang::SwiftAttrAttr *)> callback);
+
 /// Attributes which were set on the declaration and affect how its type is
 /// imported.
 ///

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -227,11 +227,7 @@ using ImportTypeAttrs = OptionSet<ImportTypeAttr>;
 /// \param D The declaration to extract attributes from.
 /// \param isParam Is the declaration a function parameter? If so, additional
 ///        attributes will be imported.
-/// \param sendableByDefault If the sendability of the declaration is not
-///        specified, should the \c \@Sendable attribute be added implicitly?
-///        Used for e.g. completion handlers.
-ImportTypeAttrs getImportTypeAttrs(const clang::Decl *D, bool isParam = false,
-                                   bool sendableByDefault = false);
+ImportTypeAttrs getImportTypeAttrs(const clang::Decl *D, bool isParam = false);
 
 struct ImportDiagnostic {
   ImportDiagnosticTarget target;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -150,6 +150,9 @@ enum class ImportTypeKind {
   /// Parameters are always considered CF-audited.
   Parameter,
 
+  /// Import the type of a special "completion handler" function parameter.
+  CompletionHandlerParameter,
+
   /// Import the type of a parameter to a completion handler that can indicate
   /// a thrown error.
   ///

--- a/lib/ClangImporter/Serializability.cpp
+++ b/lib/ClangImporter/Serializability.cpp
@@ -315,6 +315,8 @@ namespace {
       if (loc.isValid())
         IsSerializable = false;
     }
+
+    void writeAttr(const clang::Attr *attr) {}
   };
 }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -40,7 +40,9 @@
 #include "swift/ClangImporter/SwiftAbstractBasicReader.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
 #include "clang/AST/DeclTemplate.h"
+#include "clang/AST/Attr.h"
 #include "clang/Basic/SourceManager.h"
+#include "clang/Basic/AttributeCommonInfo.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Debug.h"
@@ -7619,6 +7621,44 @@ public:
 
     // Unknown kind?
     return nullptr;
+  }
+
+  const clang::Attr *readAttr() {
+    auto rawKind = readUInt32();
+    if (!rawKind)
+      return nullptr;
+
+    clang::attr::Kind attrKind = static_cast<clang::attr::Kind>(rawKind - 1);
+    auto name = readIdentifier();
+    auto scopeName = readIdentifier();
+
+    auto rangeStart = readSourceLocation();
+    auto rangeEnd = readSourceLocation();
+    auto scopeLoc = readSourceLocation();
+
+    auto parsedKind = readEnum<clang::AttributeCommonInfo::Kind>();
+    auto syntax = readEnum<clang::AttributeCommonInfo::Syntax>();
+    unsigned spellingListIndex = readUInt64();
+
+    bool isRegularKeywordAttribute = readBool();
+
+    clang::AttributeCommonInfo info(
+        name, scopeName, {rangeStart, rangeEnd}, scopeLoc, parsedKind,
+        {syntax, spellingListIndex, /*IsAlignas=*/false,
+         isRegularKeywordAttribute});
+
+    bool isInherited = readBool();
+    bool isImplicit = readBool();
+    bool isPackExpansion = readBool();
+    StringRef attribute = MF.getIdentifierText(readUInt64());
+
+    auto *attr =
+        clang::SwiftAttrAttr::Create(getASTContext(), attribute.str(), info);
+    cast<clang::InheritableAttr>(attr)->setInherited(isInherited);
+    attr->setImplicit(isImplicit);
+    attr->setPackExpansion(isPackExpansion);
+
+    return attr;
   }
 };
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5765,6 +5765,29 @@ public:
         Record.push_back(S.addDeclBaseNameRef(elt.second));
     }
   }
+
+  void writeAttr(const clang::Attr *attr) {
+    auto *swiftAttr = dyn_cast_or_null<clang::SwiftAttrAttr>(attr);
+    if (!swiftAttr) {
+      writeUInt32(/*no attribute*/0);
+      return;
+    }
+
+    writeEnum(swiftAttr->getKind() + 1);
+    writeIdentifier(swiftAttr->getAttrName());
+    writeIdentifier(swiftAttr->getScopeName());
+    writeSourceLocation(swiftAttr->getRange().getBegin());
+    writeSourceLocation(swiftAttr->getRange().getEnd());
+    writeSourceLocation(swiftAttr->getScopeLoc());
+    writeEnum(swiftAttr->getParsedKind());
+    writeEnum(swiftAttr->getSyntax());
+    writeUInt64(swiftAttr->getAttributeSpellingListIndex());
+    writeBool(swiftAttr->isRegularKeywordAttribute());
+    writeBool(swiftAttr->isInherited());
+    writeBool(swiftAttr->isImplicit());
+    writeBool(swiftAttr->isPackExpansion());
+    writeUInt64(S.addUniquedStringRef(swiftAttr->getAttribute()));
+  }
 };
 
 }

--- a/test/Concurrency/sendable_objc_attr_in_type_context.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context.swift
@@ -1,0 +1,75 @@
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -strict-concurrency=complete \
+// RUN:   -enable-experimental-feature SendableCompletionHandlers \
+// RUN:   -module-name main -I %t -verify
+
+// REQUIRES: objc_interop
+
+//--- Test.h
+#define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))
+#define NONSENDABLE __attribute__((__swift_attr__("@_nonSendable")))
+
+#pragma clang assume_nonnull begin
+
+@import Foundation;
+
+@interface MyValue : NSObject
+@end
+
+typedef void (^CompletionHandler)(void (^ SWIFT_SENDABLE)(void)) SWIFT_SENDABLE;
+
+@interface Test : NSObject
+-(void) makeRequest:
+          (NSString *)typeIdentifier
+          loadHandler:(void (^SWIFT_SENDABLE )(void (SWIFT_SENDABLE ^)(void)))loadHandler;
+-(void) withSendableId: (void (^)(SWIFT_SENDABLE id)) handler;
+-(void) withSendableCustom: (void (^)(MyValue *_Nullable SWIFT_SENDABLE)) handler;
+-(void) withNonSendable:(NSString *)operation completionHandler:(void (^ _Nullable NONSENDABLE)(NSString *_Nullable, NSError * _Nullable)) handler;
+-(void) withAliasCompletionHandler:(CompletionHandler)handler;
+@end
+
+// Placement of SWIFT_SENDABLE matters here
+void doSomethingConcurrently(__attribute__((noescape)) void SWIFT_SENDABLE (^block)(void));
+
+#pragma clang assume_nonnull end
+
+//--- main.swift
+
+func test_sendable_attr_in_type_context(test: Test) {
+  let fn: (String?, (any Error)?) -> Void = { _,_ in }
+
+  test.withNonSendable("", completionHandler: fn) // Ok
+
+  test.makeRequest("id") {
+    doSomethingConcurrently($0) // Ok
+  }
+
+  test.makeRequest("id") { callback in
+    _ = { @Sendable in
+      callback() // Ok
+    }
+  }
+
+  test.withSendableId { id in
+    _ = { @Sendable in
+      print(id) // Ok
+    }
+  }
+
+  test.withSendableCustom { val in
+    _ = { @Sendable in
+      print(val!)
+    }
+  }
+
+  let _: (@escaping @Sendable (@escaping @Sendable () -> Void) -> Void) -> Void = test.withAliasCompletionHandler
+
+  test.withAliasCompletionHandler { callback in
+    doSomethingConcurrently(callback) // Ok
+  }
+}


### PR DESCRIPTION
clang-side change: https://github.com/apple/llvm-project/pull/7918

Teach `importType` that `clang::AttributedType` now carries an optional `clang::Attr *`
that could be used to express concurrency attributes in type context. 

This PR adds support for the following:

- `__attribute__((swft_attr(...)))` is recognized in nested type contexts i.e. blocks, pointers etc.
- Lightweight generics now support `Sendable` conformance requirement.

There are a couple of refactoring here that make things easier to handle:

- ImportTypeKind::CF{Un}retainedOutParameter became attributes instead.
- New `CompletionHandlerParameter` import kind has been introduced to
  denote completion handler function parameters.
- `SendableCompletionHandlers` is now handled based on type attributes.

Resolves: rdar://119341589
Resolves: rdar://104246144
Fixes #58150

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
