### PR TITLE
[Dependency Scanning] Remove Swift overlay dependencies from the list of direct module dependencies

### DIFF
--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -765,29 +765,17 @@ void ModuleDependencyScanner::resolveSwiftOverlayDependencies(
   // Aggregate both previously-cached and freshly-scanned module results
   auto recordResult = [&cache, &swiftOverlayLookupResult,
                        &swiftOverlayDependencies,
-                       &directDependencies,
                        moduleID](const std::string &moduleName) {
     auto lookupResult = swiftOverlayLookupResult[moduleName];
     if (moduleName != moduleID.ModuleName) {
       if (lookupResult == llvm::None) {
         const ModuleDependencyInfo *cachedInfo = cache.findDependency(moduleName).value();
         swiftOverlayDependencies.insert({moduleName, cachedInfo->getKind()});
-        // FIXME: Once all clients know to fetch these dependencies from
-        // `swiftOverlayDependencies`, the goal is to no longer have them in
-        // `directDependencies` so the following will need to go away.
-	directDependencies.insert({moduleName, cachedInfo->getKind()});
       } else {
         // Cache discovered module dependencies.
         cache.recordDependencies(lookupResult.value());
-        if (!lookupResult.value().empty()) {
-          swiftOverlayDependencies.insert(
-                                          {moduleName, lookupResult.value()[0].first.Kind});
-          // FIXME: Once all clients know to fetch these dependencies from
-          // `swiftOverlayDependencies`, the goal is to no longer have them in
-          // `directDependencies` so the following will need to go away.
-	  directDependencies.insert(
-                                    {moduleName, lookupResult.value()[0].first.Kind});
-	}
+        if (!lookupResult.value().empty())
+          swiftOverlayDependencies.insert({moduleName, lookupResult.value()[0].first.Kind});
       }
     }
   };

--- a/test/ScanDependencies/module_deps_binary_dep_swift_overlay.swift
+++ b/test/ScanDependencies/module_deps_binary_dep_swift_overlay.swift
@@ -27,7 +27,6 @@ import BinaryModuleDep
 // CHECK-DAG:          "swift": "_StringProcessing"
 // CHECK-DAG:          "clang": "ClangModuleWithOverlayedDep"
 // CHECK-DAG:          "swiftPrebuiltExternal": "BinaryModuleDep"
-// CHECK-DAG:          "swift": "F"
 // CHECK:          ],
 // CHECK:          "swiftOverlayDependencies": [
 // CHECK-NEXT:       {
@@ -43,7 +42,6 @@ import BinaryModuleDep
 // CHECK-DAG:          "clang": "_SwiftConcurrencyShims"
 // CHECK-DAG:          "swift": "_StringProcessing"
 // CHECK-DAG:          "clang": "ClangModuleWithOverlayedDep"
-// CHECK-DAG:          "swift": "F"
 // CHECK:          ],
 // CHECK:          "swiftOverlayDependencies": [
 // CHECK-NEXT:       {


### PR DESCRIPTION
- Remove Swift overlay dependencies from the list of direct module dependencies
