### PR TITLE
Sema: Associated type inference fixes [5.10]

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -7172,10 +7172,11 @@ void TypeChecker::inferDefaultWitnesses(ProtocolDecl *proto) {
   DefaultWitnessChecker checker(proto);
 
   // Find the default for the given associated type.
-  auto findAssociatedTypeDefault = [](AssociatedTypeDecl *assocType)
+  auto findAssociatedTypeDefault = [proto](AssociatedTypeDecl *assocType)
       -> std::pair<Type, AssociatedTypeDecl *> {
     auto defaultedAssocType =
-        AssociatedTypeInference::findDefaultedAssociatedType(assocType);
+        AssociatedTypeInference::findDefaultedAssociatedType(
+            proto, proto, assocType);
     if (!defaultedAssocType)
       return {Type(), nullptr};
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -1271,7 +1271,8 @@ public:
 
   /// Find an associated type declaration that provides a default definition.
   static AssociatedTypeDecl *findDefaultedAssociatedType(
-                                                 AssociatedTypeDecl *assocType);
+      DeclContext *dc, NominalTypeDecl *adoptee,
+      AssociatedTypeDecl *assocType);
 };
 
 /// Match the given witness to the given requirement.

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -165,27 +165,25 @@ namespace {
 /// Try to avoid situations where resolving the type of a witness calls back
 /// into associated type inference.
 struct TypeReprCycleCheckWalker : ASTWalker {
+  ASTContext &ctx;
   llvm::SmallDenseSet<Identifier, 2> circularNames;
   ValueDecl *witness;
   bool found;
 
   TypeReprCycleCheckWalker(
+      ASTContext &ctx,
       const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved)
-    : witness(nullptr), found(false) {
+    : ctx(ctx), witness(nullptr), found(false) {
     for (auto *assocType : allUnresolved) {
       circularNames.insert(assocType->getName());
     }
   }
 
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-    // FIXME: We should still visit any generic arguments of this member type.
-    // However, we want to skip 'Foo.Element' because the 'Element' reference is
-    // not unqualified.
-    if (auto *memberTyR = dyn_cast<MemberTypeRepr>(T)) {
-      return Action::SkipChildren();
-    }
+    // FIXME: Visit generic arguments.
 
     if (auto *identTyR = dyn_cast<SimpleIdentTypeRepr>(T)) {
+      // If we're inferring `Foo`, don't look at a witness mentioning `Foo`.
       if (circularNames.count(identTyR->getNameRef().getBaseIdentifier()) > 0) {
         // If unqualified lookup can find a type with this name without looking
         // into protocol members, don't skip the witness, since this type might
@@ -194,7 +192,6 @@ struct TypeReprCycleCheckWalker : ASTWalker {
             identTyR->getNameRef(), witness->getDeclContext(),
             identTyR->getLoc(), UnqualifiedLookupOptions());
 
-        auto &ctx = witness->getASTContext();
         auto results =
             evaluateOrDefault(ctx.evaluator, UnqualifiedLookupRequest{desc}, {});
 
@@ -205,6 +202,34 @@ struct TypeReprCycleCheckWalker : ASTWalker {
           return Action::Stop();
         }
       }
+    }
+
+    if (auto *memberTyR = dyn_cast<MemberTypeRepr>(T)) {
+      // If we're looking at a member type`Foo.Bar`, check `Foo` recursively.
+      auto *baseTyR = memberTyR->getBaseComponent();
+      baseTyR->walk(*this);
+
+      // If we're inferring `Foo`, don't look at a witness mentioning `Self.Foo`.
+      if (auto *identTyR = dyn_cast<SimpleIdentTypeRepr>(baseTyR)) {
+        if (identTyR->getNameRef().getBaseIdentifier() == ctx.Id_Self) {
+          // But if qualified lookup can find a type with this name without
+          // looking into protocol members, don't skip the witness, since this
+          // type might be a candidate witness.
+          SmallVector<ValueDecl *, 2> results;
+          witness->getInnermostDeclContext()->lookupQualified(
+              witness->getDeclContext()->getSelfTypeInContext(),
+              identTyR->getNameRef(), SourceLoc(), NLOptions(), results);
+
+          // Ok, resolving this member type would trigger associated type
+          // inference recursively. We're going to skip this witness.
+          if (results.empty()) {
+            found = true;
+            return Action::Stop();
+          }
+        }
+      }
+
+      return Action::SkipChildren();
     }
 
     return Action::Continue();
@@ -296,7 +321,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     abort();
   }
 
-  TypeReprCycleCheckWalker cycleCheck(allUnresolved);
+  TypeReprCycleCheckWalker cycleCheck(dc->getASTContext(), allUnresolved);
 
   InferredAssociatedTypesByWitnesses result;
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -942,26 +942,31 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitness(ValueDecl *req,
 }
 
 AssociatedTypeDecl *AssociatedTypeInference::findDefaultedAssociatedType(
+                                             DeclContext *dc,
+                                             NominalTypeDecl *adoptee,
                                              AssociatedTypeDecl *assocType) {
   // If this associated type has a default, we're done.
   if (assocType->hasDefaultDefinitionType())
     return assocType;
 
-  // Look at overridden associated types.
+  // Otherwise, look for all associated types with the same name along all the
+  // protocols that the adoptee conforms to.
+  SmallVector<ValueDecl *, 4> decls;
+  auto options = NL_ProtocolMembers | NL_OnlyTypes;
+  dc->lookupQualified(adoptee, DeclNameRef(assocType->getName()),
+                      SourceLoc(), options, decls);
+
   SmallPtrSet<CanType, 4> canonicalTypes;
   SmallVector<AssociatedTypeDecl *, 2> results;
-  for (auto overridden : assocType->getOverriddenDecls()) {
-    auto overriddenDefault = findDefaultedAssociatedType(overridden);
-    if (!overriddenDefault) continue;
+  for (auto *decl : decls) {
+    if (auto *assocDecl = dyn_cast<AssociatedTypeDecl>(decl)) {
+      auto defaultType = assocDecl->getDefaultDefinitionType();
+      if (!defaultType) continue;
 
-    Type overriddenType =
-      overriddenDefault->getDefaultDefinitionType();
-    assert(overriddenType);
-    if (!overriddenType) continue;
-
-    CanType key = overriddenType->getCanonicalType();
+      CanType key = defaultType->getCanonicalType();
     if (canonicalTypes.insert(key).second)
-      results.push_back(overriddenDefault);
+      results.push_back(assocDecl);
+    }
   }
 
   // If there was a single result, return it.
@@ -1022,7 +1027,8 @@ llvm::Optional<AbstractTypeWitness>
 AssociatedTypeInference::computeDefaultTypeWitness(
     AssociatedTypeDecl *assocType) const {
   // Go find a default definition.
-  auto *const defaultedAssocType = findDefaultedAssociatedType(assocType);
+  auto *const defaultedAssocType = findDefaultedAssociatedType(
+      dc, dc->getSelfNominalTypeDecl(), assocType);
   if (!defaultedAssocType)
     return llvm::None;
 

--- a/test/decl/protocol/req/assoc_type_inference_cycle.swift
+++ b/test/decl/protocol/req/assoc_type_inference_cycle.swift
@@ -95,3 +95,39 @@ public enum CaseWitness: CaseProtocol {
   case b(_: A)
   case c(_: A)
 }
+
+// rdar://119499800 #1
+public typealias A8 = Batch.Iterator
+
+public struct Batch: Collection {
+  public typealias Element = Int
+  public typealias Index = Array<Element>.Index
+
+  var elements: [Element]
+
+  init(_ elements: some Collection<Element>) {
+    self.elements = Array(elements)
+  }
+
+  public var startIndex: Index { return elements.startIndex }
+  public var endIndex: Index { return elements.endIndex }
+
+  public subscript(index: Index) -> Iterator.Element {
+    return elements[index]
+  }
+
+  public func index(after i: Index) -> Index {
+    return elements.index(after: i)
+  }
+}
+
+// rdar://119499800 #2
+public typealias A9 = LogTypes.RawValue
+
+public struct LogTypes: OptionSet {
+  public init(rawValue: Self.RawValue) {
+    self.rawValue = rawValue
+  }
+
+  public let rawValue: Int
+}

--- a/test/decl/protocol/req/associated_type_default_lookup.swift
+++ b/test/decl/protocol/req/associated_type_default_lookup.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P1 {
+  associatedtype A
+
+  func f(_: A)
+}
+
+protocol P2: P1 {
+  associatedtype A = Int
+}
+
+func foo<T: P1>(_: T.Type) -> T.A.Type {}
+
+_ = foo(S.self)
+
+struct S: P2 {
+  func f(_: A) {}
+}

--- a/test/decl/protocol/req/associated_type_tuple.swift
+++ b/test/decl/protocol/req/associated_type_tuple.swift
@@ -9,16 +9,16 @@ protocol P1 {
 extension Tuple: P1 where repeat each T: P1 {} // expected-error {{type '(repeat each T)' does not conform to protocol 'P1'}}
 
 protocol P2 {
-  associatedtype A = Int // expected-note {{default type 'Int' for associated type 'A' (from protocol 'P2') is unsuitable for tuple conformance; the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).A)'}}
+  associatedtype B = Int // expected-note {{default type 'Int' for associated type 'B' (from protocol 'P2') is unsuitable for tuple conformance; the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).B)'}}
 }
 
 extension Tuple: P2 where repeat each T: P2 {} // expected-error {{type '(repeat each T)' does not conform to protocol 'P2'}}
 
 protocol P3 {
-  associatedtype A // expected-note {{unable to infer associated type 'A' for protocol 'P3'}}
-  func f() -> A
+  associatedtype C // expected-note {{unable to infer associated type 'C' for protocol 'P3'}}
+  func f() -> C
 }
 
 extension Tuple: P3 where repeat each T: P3 { // expected-error {{type '(repeat each T)' does not conform to protocol 'P3'}}
-  func f() -> Int {} // expected-note {{cannot infer 'A' = 'Int' in tuple conformance because the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).A)'}}
+  func f() -> Int {} // expected-note {{cannot infer 'C' = 'Int' in tuple conformance because the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).C)'}}
 }


### PR DESCRIPTION
* Cherry-pick of #70241 and #70378 to the 5.10 branch.

* Description: An earlier fix (https://github.com/apple/swift/pull/69952) exposed an existing issue where we didn't look hard enough for default type witnesses (`associatedtype T = Int`).

* Origination: The problem was there forever, but we started hitting it on existing projects.

* Radar: rdar://120437392.

* Risk: Medium. Any change to associated type inference runs the risk of regressing existing marginal code that used to work. However these changes have been on `main` for a while and I believe they're relatively safe.

* Reviewed by: @hborla