### PR TITLE
[Concurrency] Suppress diagnostics about non-`Sendable` async iterator arguments in implicit calls to `next()`.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -448,6 +448,10 @@ public:
     return const_cast<Expr *>(this)->getValueProvidingExpr();
   }
 
+  /// Find the original expression value, looking through various
+  /// implicit conversions.
+  const Expr *findOriginalValue() const;
+
   /// Find the original type of a value, looking through various implicit
   /// conversions.
   Type findOriginalType() const;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2875,7 +2875,7 @@ FrontendStatsTracer::getTraceFormatter<const Expr *>() {
   return &TF;
 }
 
-Type Expr::findOriginalType() const {
+const Expr *Expr::findOriginalValue() const {
   auto *expr = this;
   do {
     expr = expr->getSemanticsProvidingExpr();
@@ -2898,6 +2898,11 @@ Type Expr::findOriginalType() const {
     break;
   } while (true);
 
+  return expr;
+}
+
+Type Expr::findOriginalType() const {
+  auto *expr = findOriginalValue();
   return expr->getType()->getRValueType();
 }
 

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation %s
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify -verify-additional-prefix region-isolation- -enable-experimental-feature RegionBasedIsolation %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -83,4 +83,17 @@ func testLocalNonisolatedUnsafe() async {
     return value
   }
   print(await task.value)
+}
+
+@MainActor
+func iterate(stream: AsyncStream<Int>) async {
+  nonisolated(unsafe) var it = stream.makeAsyncIterator()
+  // FIXME: Region isolation should consider a value from a 'nonisolated(unsafe)'
+  // declaration to be in a disconnected region
+
+  // expected-region-isolation-warning@+2 {{passing argument of non-sendable type 'AsyncStream<Int>.Iterator' from main actor-isolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  // expected-region-isolation-note@+1 {{access here could race}}
+  while let element = await it.next() {
+    print(element)
+  }
 }

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -96,4 +96,10 @@ func iterate(stream: AsyncStream<Int>) async {
   while let element = await it.next() {
     print(element)
   }
+
+  // expected-region-isolation-warning@+2 {{passing argument of non-sendable type 'AsyncStream<Int>.Iterator' from main actor-isolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  // expected-region-isolation-note@+1 {{access here could race}}
+  for await x in stream {
+    print(x)
+  }
 }


### PR DESCRIPTION
Async iterators are not `Sendable`; they're only meant to be used from the isolation domain that creates them. But the `next()` method runs on the generic executor, so calling it from an actor-isolated context passes non-`Sendable` state across the isolation boundary. `next()` should inherit the isolation of the caller (Swift evolution pitch incoming!), but for now, use the `nonisolated(unsafe)` opt out on the local iterator variable.

Resolves rdar://119613738