### PR TITLE
Add mark_dependence [nonescaping] flag.

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -375,4 +375,9 @@ public struct Builder {
     let endMutation = bridged.createEndCOWMutation(instance.bridged, keepUnique)
     return notifyNew(endMutation.getAs(EndCOWMutationInst.self))
   }
+
+  public func createMarkDependence(value: Value, base: Value, isNonEscaping: Bool) -> MarkDependenceInst {
+    let markDependence = bridged.createMarkDependence(value.bridged, base.bridged, isNonEscaping)
+    return notifyNew(markDependence.getAs(MarkDependenceInst.self))
+  }
 }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -824,13 +824,13 @@ class GetAsyncContinuationInst : SingleValueInstruction {}
 final public
 class GetAsyncContinuationAddrInst : SingleValueInstruction, UnaryInstruction {}
 
-
 final public
 class MarkDependenceInst : SingleValueInstruction, ForwardingInstruction {
   public var valueOperand: Operand { operands[0] }
   public var baseOperand: Operand { operands[1] }
   public var value: Value { return valueOperand.value }
   public var base: Value { return baseOperand.value }
+  public var isNonEscaping: Bool { bridged.MarkDependenceInst_isNonEscaping() }
 }
 
 final public class RefToBridgeObjectInst : SingleValueInstruction, ForwardingInstruction {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -794,6 +794,7 @@ struct BridgedInstruction {
   BRIDGED_INLINE SwiftInt SwitchEnumInst_getCaseIndex(SwiftInt idx) const;
   BRIDGED_INLINE SwiftInt StoreInst_getStoreOwnership() const;
   BRIDGED_INLINE SwiftInt AssignInst_getAssignOwnership() const;
+  BRIDGED_INLINE bool MarkDependenceInst_isNonEscaping() const;
   BRIDGED_INLINE AccessKind BeginAccessInst_getAccessKind() const;
   BRIDGED_INLINE bool BeginAccessInst_isStatic() const;
   BRIDGED_INLINE bool CopyAddrInst_isTakeOfSrc() const;
@@ -1118,6 +1119,7 @@ struct BridgedBuilder{
                                           BridgedType::MetatypeRepresentation representation) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createEndCOWMutation(BridgedValue instance,
                                                                              bool keepUnique) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMarkDependence(BridgedValue value, BridgedValue base, bool isNonEscaping) const;
 };
 
 // Passmanager and Context

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1040,6 +1040,10 @@ SwiftInt BridgedInstruction::AssignInst_getAssignOwnership() const {
   return (SwiftInt)getAs<swift::AssignInst>()->getOwnershipQualifier();
 }
 
+bool BridgedInstruction::MarkDependenceInst_isNonEscaping() const {
+  return getAs<swift::MarkDependenceInst>()->isNonEscaping();
+}
+
 BridgedInstruction::AccessKind BridgedInstruction::BeginAccessInst_getAccessKind() const {
   return (AccessKind)getAs<swift::BeginAccessInst>()->getAccessKind();
 }
@@ -1597,6 +1601,10 @@ BridgedInstruction BridgedBuilder::createMetatype(BridgedType type,
 BridgedInstruction BridgedBuilder::createEndCOWMutation(BridgedValue instance, bool keepUnique) const {
   return {unbridged().createEndCOWMutation(regularLoc(), instance.getSILValue(),
                                            keepUnique)};
+}
+
+BridgedInstruction BridgedBuilder::createMarkDependence(BridgedValue value, BridgedValue base, bool isNonEscaping) const {
+  return {unbridged().createMarkDependence(regularLoc(), value.getSILValue(), base.getSILValue(), isNonEscaping)};
 }
 
 SWIFT_END_NULLABILITY_ANNOTATIONS

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2284,15 +2284,18 @@ public:
                                                        SILValue value);
 
   MarkDependenceInst *createMarkDependence(SILLocation Loc, SILValue value,
-                                           SILValue base) {
-    return createMarkDependence(Loc, value, base, value->getOwnershipKind());
+                                           SILValue base, bool isNonEscaping) {
+    return createMarkDependence(Loc, value, base, value->getOwnershipKind(),
+                                isNonEscaping);
   }
 
   MarkDependenceInst *
   createMarkDependence(SILLocation Loc, SILValue value, SILValue base,
-                       ValueOwnershipKind forwardingOwnershipKind) {
+                       ValueOwnershipKind forwardingOwnershipKind,
+                       bool isNonEscaping) {
     return insert(new (getModule()) MarkDependenceInst(
-        getSILDebugLocation(Loc), value, base, forwardingOwnershipKind));
+                    getSILDebugLocation(Loc), value, base,
+                    forwardingOwnershipKind, isNonEscaping));
   }
 
   IsUniqueInst *createIsUnique(SILLocation Loc, SILValue operand) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2950,8 +2950,9 @@ void SILCloner<ImplClass>::visitMarkDependenceInst(MarkDependenceInst *Inst) {
                 getOpLocation(Inst->getLoc()), getOpValue(Inst->getValue()),
                 getOpValue(Inst->getBase()),
                 getBuilder().hasOwnership()
-                    ? Inst->getForwardingOwnershipKind()
-                    : ValueOwnershipKind(OwnershipKind::None)));
+                ? Inst->getForwardingOwnershipKind()
+                : ValueOwnershipKind(OwnershipKind::None),
+                /*isNonEscaping*/false));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -276,6 +276,9 @@ protected:
                  pointerEscape : 1,
                  fromVarDecl : 1);
 
+    SHARED_FIELD(MarkDependenceInst, uint8_t
+                 nonEscaping : 1);
+
   // Do not use `_sharedUInt8_private` outside of SILNode.
   } _sharedUInt8_private;
   // clang-format on

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2840,7 +2840,8 @@ bool LoadableByAddress::recreateConvInstr(SILInstruction &I,
   case SILInstructionKind::MarkDependenceInst: {
     auto instr = cast<MarkDependenceInst>(convInstr);
     newInstr = convBuilder.createMarkDependence(
-        instr->getLoc(), instr->getValue(), instr->getBase());
+      instr->getLoc(), instr->getValue(), instr->getBase(),
+      instr->isNonEscaping());
     break;
   }
   case SILInstructionKind::DifferentiableFunctionInst: {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2526,6 +2526,9 @@ public:
     *this << getIDAndType(CBOI->getOperand());
   }
   void visitMarkDependenceInst(MarkDependenceInst *MDI) {
+    if (MDI->isNonEscaping()) {
+      *this << "[nonescaping] ";
+    }
     *this << getIDAndType(MDI->getValue()) << " on "
           << getIDAndType(MDI->getBase());
     printForwardingOwnershipKind(MDI, MDI->getValue());

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3756,9 +3756,11 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
   }
 
   case SILInstructionKind::MarkDependenceInst: {
+    bool nonEscaping = false;
     SILValue Base;
-    if (parseTypedValueRef(Val, B) || parseVerbatim("on") ||
-        parseTypedValueRef(Base, B))
+    if (parseSILOptional(nonEscaping, *this, "nonescaping")
+        || parseTypedValueRef(Val, B) || parseVerbatim("on")
+        || parseTypedValueRef(Base, B))
       return true;
 
     ValueOwnershipKind forwardingOwnership = Val->getOwnershipKind();
@@ -3766,7 +3768,8 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
         || parseSILDebugLocation(InstLoc, B))
       return true;
 
-    ResultVal = B.createMarkDependence(InstLoc, Val, Base, forwardingOwnership);
+    ResultVal = B.createMarkDependence(InstLoc, Val, Base, forwardingOwnership,
+                                       nonEscaping);
     break;
   }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2908,7 +2908,7 @@ private:
       if (valueTL.isTrivial()) {
         SILValue dependentValue =
           SGF.B.createMarkDependence(eval, value.forward(SGF),
-                                     owner.getValue());
+                                     owner.getValue(), /*isNonEscaping*/false);
         value = SGF.emitManagedRValueWithCleanup(dependentValue, valueTL);
       }
     }
@@ -6352,7 +6352,8 @@ SILGenFunction::emitUninitializedArrayAllocation(Type ArrayTy,
 
   // Add a mark_dependence between the interior pointer and the array value
   auto dependentValue = B.createMarkDependence(Loc, resultElts[1].getValue(),
-                                               resultElts[0].getValue());
+                                               resultElts[0].getValue(),
+                                               /*isNonEscaping*/false);
   return {resultElts[0], dependentValue};
 }
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -1024,10 +1024,12 @@ ManagedValue SILGenBuilder::createProjectBox(SILLocation loc, ManagedValue mv,
 
 ManagedValue SILGenBuilder::createMarkDependence(SILLocation loc,
                                                  ManagedValue value,
-                                                 ManagedValue base) {
+                                                 ManagedValue base,
+                                                 bool isNonEscaping) {
   CleanupCloner cloner(*this, value);
   auto *mdi = createMarkDependence(loc, value.forward(getSILGenFunction()),
-                                   base.forward(getSILGenFunction()));
+                                   base.forward(getSILGenFunction()),
+                                   isNonEscaping);
   return cloner.clone(mdi);
 }
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -461,7 +461,7 @@ public:
 
   using SILBuilder::createMarkDependence;
   ManagedValue createMarkDependence(SILLocation loc, ManagedValue value,
-                                    ManagedValue base);
+                                    ManagedValue base, bool isNonEscaping);
 
   using SILBuilder::createBeginBorrow;
   ManagedValue createBeginBorrow(SILLocation loc, ManagedValue value,

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1442,7 +1442,8 @@ static ManagedValue emitBuiltinConvertUnownedUnsafeToGuaranteed(
   auto guaranteedNonTrivialRefMV =
       SGF.emitManagedBorrowedRValueWithCleanup(guaranteedNonTrivialRef);
   // Now create a mark dependence on our base and return the result.
-  return SGF.B.createMarkDependence(loc, guaranteedNonTrivialRefMV, baseMV);
+  return SGF.B.createMarkDependence(loc, guaranteedNonTrivialRefMV, baseMV,
+                                    /*isNonEscaping*/false);
 }
 
 // Emit SIL for the named builtin: getCurrentAsyncTask.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5876,7 +5876,8 @@ public:
     // is important to ensure that the destroy of the assign is not hoisted
     // above the retain. We are doing unmanaged things here so we need to be
     // extra careful.
-    ownedMV = SGF.B.createMarkDependence(loc, ownedMV, base);
+    ownedMV = SGF.B.createMarkDependence(loc, ownedMV, base,
+                                         /*isNonEscaping*/false);
 
     // Then reassign the mark dependence into the +1 storage.
     ownedMV.assignInto(SGF, loc, base.getUnmanagedValue());
@@ -6191,7 +6192,8 @@ SILGenFunction::emitArrayToPointer(SILLocation loc, ManagedValue array,
   // Mark the dependence of the pointer on the owner value.
   auto owner = resultScalars[0];
   auto pointer = resultScalars[1].forward(*this);
-  pointer = B.createMarkDependence(loc, pointer, owner.getValue());
+  pointer = B.createMarkDependence(loc, pointer, owner.getValue(),
+                                   /*isNonEscaping*/false);
 
   // The owner's already in its own cleanup.  Return the pointer.
   return {ManagedValue::forObjectRValueWithoutOwnership(pointer), owner};
@@ -6226,7 +6228,8 @@ SILGenFunction::emitStringToPointer(SILLocation loc, ManagedValue stringValue,
   // Mark the dependence of the pointer on the owner value.
   auto owner = results[0];
   auto pointer = results[1].forward(*this);
-  pointer = B.createMarkDependence(loc, pointer, owner.getValue());
+  pointer = B.createMarkDependence(loc, pointer, owner.getValue(),
+                                   /*isNonEscaping*/false);
 
   return {ManagedValue::forObjectRValueWithoutOwnership(pointer), owner};
 }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -5707,7 +5707,8 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
   // long as we represent these captures by the same value the following works.
   thunkedFn = emitManagedRValueWithCleanup(
     B.createMarkDependence(loc, thunkedFn.forward(*this),
-                           noEscapingFunctionValue.getValue()));
+                           noEscapingFunctionValue.getValue(),
+                           /*isNonEscaping*/false));
 
   return thunkedFn;
 }

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -783,7 +783,8 @@ SILValue ClosureSpecCloner::cloneCalleeConversion(
     return addToOldToNewClosureMap(
         origCalleeValue,
         Builder.createMarkDependence(CallSiteDesc.getLoc(), calleeValue,
-                                     CapturedMap[MD->getBase()]));
+                                     CapturedMap[MD->getBase()],
+                                     /*isNonEscaping*/false));
   }
 
 

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -277,7 +277,9 @@ static void extendLifetimeToEndOfFunction(SILFunction &fn,
   // Create a borrow scope and a mark_dependence to prevent the enum being
   // optimized away.
   auto *borrow = lifetimeExtendBuilder.createBeginBorrow(loc, optionalSome);
-  auto *mdi = lifetimeExtendBuilder.createMarkDependence(loc, cvt, borrow);
+  auto *mdi =
+    lifetimeExtendBuilder.createMarkDependence(loc, cvt, borrow,
+                                               /*isNonEscaping*/false);
 
   // Replace all uses of the non escaping closure with mark_dependence
   SmallVector<Operand *, 4> convertUses;
@@ -402,7 +404,8 @@ static SILValue insertMarkDependenceForCapturedArguments(PartialApplyInst *pai,
     if (auto *m = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(arg.get()))
       if (m->hasGuaranteedInitialKind())
         continue;
-    curr = b.createMarkDependence(pai->getLoc(), curr, arg.get());
+    curr = b.createMarkDependence(pai->getLoc(), curr, arg.get(),
+                                  /*isNonEscaping*/false);
   }
 
   return curr;

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -228,7 +228,8 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
 
   // Mark the dependence of the resulting value on the actor value to
   // force the actor to stay alive.
-  executor = B.createMarkDependence(loc, unmarkedExecutor, actor);
+  executor = B.createMarkDependence(loc, unmarkedExecutor, actor,
+                                    /*isNonEscaping*/false);
 
   // Cache the non-optional result for later.
   ExecutorForActor.insert(actor, executor);

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -450,7 +450,8 @@ bool OwnershipModelEliminatorVisitor::visitPartialApplyInst(
       }
       
       // If this is a nontrivial value argument, insert the mark_dependence.
-      auto mdi = b.createMarkDependence(loc, newValue, op);
+      auto mdi = b.createMarkDependence(loc, newValue, op,
+                                        /*isNonEscaping*/false);
       if (!firstNewMDI)
         firstNewMDI = mdi;
       newValue = mdi;

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -847,7 +847,9 @@ TempRValueOptPass::tryOptimizeStoreIntoTemp(StoreInst *si) {
       assert(mdi->getBase() == tempObj);
       SILBuilderWithScope builder(user);
       auto newInst = builder.createMarkDependence(user->getLoc(),
-                       mdi->getValue(), si->getSrc());
+                                                  mdi->getValue(),
+                                                  si->getSrc(),
+                                                  mdi->isNonEscaping());
       mdi->replaceAllUsesWith(newInst);
       toDelete.push_back(mdi);
       break;

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1979,7 +1979,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         Loc,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         getLocalValue(ValID2,
-                      getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)));
+                      getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)),
+        /*nonEscaping*/Attr);
     break;
   }
   case SILInstructionKind::BeginDeallocRefInst: {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 830; // transferring
+const uint16_t SWIFTMODULE_VERSION_MINOR = 831; // mark_dependence [nonescaping]
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1680,6 +1680,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       const MarkDependenceInst *MDI = cast<MarkDependenceInst>(&SI);
       operand = MDI->getValue();
       operand2 = MDI->getBase();
+      Attr = (MDI->isNonEscaping() ? 1 : 0);
     } else {
       const IndexAddrInst *IAI = cast<IndexAddrInst>(&SI);
       operand = IAI->getBase();

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -287,3 +287,17 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   %9999 = tuple ()
   return %9999 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @test_mark_dependence : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: [[MD1:%.*]] = mark_dependence %1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+// CHECK: mark_dependence [nonescaping] [[MD1]] : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+// CHECK: } // end sil function 'test_mark_dependence'
+sil [ossa] @test_mark_dependence : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %md1 = mark_dependence %1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+  %md2 = mark_dependence [nonescaping] %md1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+  destroy_value %md2 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SIL/Serialization/basic2.sil
+++ b/test/SIL/Serialization/basic2.sil
@@ -89,6 +89,20 @@ bb0(%0 : @owned $Builtin.NativeObject):
   return %9999 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_mark_dependence : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: [[MD1:%.*]] = mark_dependence %1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+// CHECK: mark_dependence [nonescaping] [[MD1]] : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+// CHECK: } // end sil function 'test_mark_dependence'
+sil [ossa] @test_mark_dependence : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
+  %md1 = mark_dependence %1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+  %md2 = mark_dependence [nonescaping] %md1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+  destroy_value %md2 : $Builtin.NativeObject
+  destroy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
 // CHECK-LABEL: sil [ossa] @test_moveonlywrapper_to_copyable_addr : $@convention(thin) (@in Builtin.NativeObject) -> () {
 // CHECK: moveonlywrapper_to_copyable_addr
 // CHECK: } // end sil function 'test_moveonlywrapper_to_copyable_addr'
@@ -116,7 +130,6 @@ bb0:
   %9999 = tuple ()
   return %9999 : $()
 }
-
 
 // CHECK-LABEL: sil [ossa] @tuple_addr_constructor_assign : $@convention(thin) (@in Builtin.NativeObject, @in (Builtin.NativeObject, Builtin.NativeObject)) -> () {
 // CHECK: bb0([[LHS:%.*]] : $*Builtin.NativeObject,


### PR DESCRIPTION
The dependent 'value' may be marked 'nonescaping', which guarantees that the lifetime dependence is statically enforceable. In this case, the compiler must be able to follow all values forwarded from the dependent 'value', and recognize all final (non-forwarded, non-escaping) use points. This implies that `findPointerEscape` is false. A diagnostic pass checks that the incoming SIL to verify that these use points are all initially within the 'base' lifetime. Regular 'mark_dependence' semantics ensure that optimizations cannot violate the lifetime dependence after diagnostics.

[SIL] bridge mark_dependence [nonescaping] flag
