### PR TITLE
[Basic] hasFeature should succeed for promoted language features

### DIFF
--- a/include/swift/Basic/BasicBridging.h
+++ b/include/swift/Basic/BasicBridging.h
@@ -178,8 +178,7 @@ void BridgedData_free(BridgedData data);
 //===----------------------------------------------------------------------===//
 
 enum ENUM_EXTENSIBILITY_ATTR(open) BridgedFeature {
-#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)           \
-  FeatureName,
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description) FeatureName,
 #include "swift/Basic/Features.def"
 };
 

--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -22,15 +22,13 @@ class LangOptions;
 
 /// Enumeration describing all of the named features.
 enum class Feature {
-#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
-FeatureName,
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description) FeatureName,
 #include "swift/Basic/Features.def"
 };
 
 constexpr unsigned numFeatures() {
   enum Features {
-#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
-FeatureName,
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description) FeatureName,
 #include "swift/Basic/Features.def"
     NumFeatures
   };

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -14,7 +14,7 @@
 // features.
 //
 //
-// LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
+// LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 //
 //   The LANGUAGE_FEATURE macro describes each named feature that is
 //   introduced in Swift. It allows Swift code to check for a particular
@@ -25,9 +25,6 @@
 //     SENumber: The number assigned to this feature in the Swift Evolution
 //       process, or 0 if there isn't one.
 //     Description: A string literal describing the feature.
-//     Option: either a reference to a language option in the form
-//       "langOpts.<option name>" or "true" to indicate that it's always
-//       enabled.
 //
 // Suppressible language features can be suppressed when printing
 // an interface without having to suppress the entire declaration they're
@@ -44,22 +41,20 @@
 #endif
 
 #ifndef SUPPRESSIBLE_LANGUAGE_FEATURE
-#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
-  LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
+#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description) \
+  LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #endif
 
 #ifndef UPCOMING_FEATURE
 #  define UPCOMING_FEATURE(FeatureName, SENumber, Version)   \
-     LANGUAGE_FEATURE(FeatureName, SENumber, #FeatureName, \
-                      langOpts.hasFeature(#FeatureName))
+     LANGUAGE_FEATURE(FeatureName, SENumber, #FeatureName)
 #endif
 
 #ifndef EXPERIMENTAL_FEATURE
 // Warning: setting `AvailableInProd` to `true` on a feature means that the flag
 //          cannot be dropped in the future.
 #  define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)  \
-     LANGUAGE_FEATURE(FeatureName, 0, #FeatureName, \
-                      langOpts.hasFeature(#FeatureName))
+     LANGUAGE_FEATURE(FeatureName, 0, #FeatureName)
 #endif
 
 #ifndef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
@@ -67,56 +62,55 @@
      EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
 #endif
 
-LANGUAGE_FEATURE(AsyncAwait, 296, "async/await", true)
-LANGUAGE_FEATURE(EffectfulProp, 310, "Effectful properties", true)
-LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol", true)
-LANGUAGE_FEATURE(Actors, 0, "actors", true)
-LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions", true)
-LANGUAGE_FEATURE(RethrowsProtocol, 0, "@rethrows protocol", true)
-LANGUAGE_FEATURE(GlobalActors, 316, "Global actors", true)
-LANGUAGE_FEATURE(BuiltinJob, 0, "Builtin.Job type", true)
-LANGUAGE_FEATURE(Sendable, 0, "Sendable and @Sendable", true)
-LANGUAGE_FEATURE(BuiltinExecutor, 0, "Builtin.Executor type", true)
-LANGUAGE_FEATURE(BuiltinContinuation, 0, "Continuation builtins", true)
-LANGUAGE_FEATURE(BuiltinHopToActor, 0, "Builtin.HopToActor", true)
-LANGUAGE_FEATURE(BuiltinTaskGroupWithArgument, 0, "TaskGroup builtins", true)
-LANGUAGE_FEATURE(InheritActorContext, 0, "@_inheritActorContext attribute", true)
-LANGUAGE_FEATURE(ImplicitSelfCapture, 0, "@_implicitSelfCapture attribute", true)
-LANGUAGE_FEATURE(BuiltinBuildTaskExecutor, 0, "TaskExecutor-building builtins", true)
-LANGUAGE_FEATURE(BuiltinBuildExecutor, 0, "Executor-building builtins", true)
-LANGUAGE_FEATURE(BuiltinBuildComplexEqualityExecutor, 0, "Executor-building for 'complexEquality executor' builtins", true)
-LANGUAGE_FEATURE(BuiltinBuildMainExecutor, 0, "MainActor executor building builtin", true)
-LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroup, 0, "Task create in task group builtin with extra flags", true)
-LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroupWithExecutor, 0, "Task create in task group builtin with extra flags", true)
-LANGUAGE_FEATURE(BuiltinCreateAsyncTaskWithExecutor, 0, "Task create builtin with extra executor preference", true)
-LANGUAGE_FEATURE(BuiltinCopy, 0, "Builtin.copy()", true)
-LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc", true)
-LANGUAGE_FEATURE(BuiltinUnprotectedStackAlloc, 0, "Builtin.unprotectedStackAlloc", true)
-LANGUAGE_FEATURE(BuiltinAllocVector, 0, "Builtin.allocVector", true)
-LANGUAGE_FEATURE(BuiltinTaskRunInline, 0, "Builtin.taskRunInline", true)
-LANGUAGE_FEATURE(BuiltinUnprotectedAddressOf, 0, "Builtin.unprotectedAddressOf", true)
-LANGUAGE_FEATURE(NewCxxMethodSafetyHeuristics, 0, "Only import C++ methods that return pointers (projections) on owned types as unsafe", true)
-SUPPRESSIBLE_LANGUAGE_FEATURE(SpecializeAttributeWithAvailability, 0, "@_specialize attribute with availability", true)
-LANGUAGE_FEATURE(BuiltinAssumeAlignment, 0, "Builtin.assumeAlignment", true)
-LANGUAGE_FEATURE(BuiltinCreateTaskGroupWithFlags, 0, "Builtin.createTaskGroupWithFlags", true)
-SUPPRESSIBLE_LANGUAGE_FEATURE(UnsafeInheritExecutor, 0, "@_unsafeInheritExecutor", true)
-SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes2, 346, "Primary associated types", true)
-SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync", true)
-SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)", true)
-LANGUAGE_FEATURE(BuiltinIntLiteralAccessors, 368, "Builtin.IntLiteral accessors", true)
-LANGUAGE_FEATURE(Macros, 0, "Macros", hasSwiftSwiftParser)
-LANGUAGE_FEATURE(
-    FreestandingExpressionMacros, 382, "Expression macros",
-        hasSwiftSwiftParser)
-LANGUAGE_FEATURE(AttachedMacros, 389, "Attached macros", hasSwiftSwiftParser)
-LANGUAGE_FEATURE(ExtensionMacros, 402, "Extension macros", hasSwiftSwiftParser)
-LANGUAGE_FEATURE(MoveOnly, 390, "noncopyable types", true)
-LANGUAGE_FEATURE(MoveOnlyResilientTypes, 390, "non-@frozen noncopyable types with library evolution", true)
-LANGUAGE_FEATURE(ParameterPacks, 393, "Value and type parameter packs", true)
-SUPPRESSIBLE_LANGUAGE_FEATURE(LexicalLifetimes, 0, "@_eagerMove/@_noEagerMove/@_lexicalLifetimes annotations", true)
-LANGUAGE_FEATURE(FreestandingMacros, 397, "freestanding declaration macros", true)
-SUPPRESSIBLE_LANGUAGE_FEATURE(RetroactiveAttribute, 364, "@retroactive", true)
-LANGUAGE_FEATURE(TypedThrows, 413, "Typed throws", true)
+LANGUAGE_FEATURE(AsyncAwait, 296, "async/await")
+LANGUAGE_FEATURE(EffectfulProp, 310, "Effectful properties")
+LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol")
+LANGUAGE_FEATURE(Actors, 0, "actors")
+LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions")
+LANGUAGE_FEATURE(RethrowsProtocol, 0, "@rethrows protocol")
+LANGUAGE_FEATURE(GlobalActors, 316, "Global actors")
+LANGUAGE_FEATURE(BuiltinJob, 0, "Builtin.Job type")
+LANGUAGE_FEATURE(Sendable, 0, "Sendable and @Sendable")
+LANGUAGE_FEATURE(BuiltinExecutor, 0, "Builtin.Executor type")
+LANGUAGE_FEATURE(BuiltinContinuation, 0, "Continuation builtins")
+LANGUAGE_FEATURE(BuiltinHopToActor, 0, "Builtin.HopToActor")
+LANGUAGE_FEATURE(BuiltinTaskGroupWithArgument, 0, "TaskGroup builtins")
+LANGUAGE_FEATURE(InheritActorContext, 0, "@_inheritActorContext attribute")
+LANGUAGE_FEATURE(ImplicitSelfCapture, 0, "@_implicitSelfCapture attribute")
+LANGUAGE_FEATURE(BuiltinBuildTaskExecutor, 0, "TaskExecutor-building builtins")
+LANGUAGE_FEATURE(BuiltinBuildExecutor, 0, "Executor-building builtins")
+LANGUAGE_FEATURE(BuiltinBuildComplexEqualityExecutor, 0, "Executor-building for 'complexEquality executor' builtins")
+LANGUAGE_FEATURE(BuiltinBuildMainExecutor, 0, "MainActor executor building builtin")
+LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroup, 0, "Task create in task group builtin with extra flags")
+LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroupWithExecutor, 0, "Task create in task group builtin with extra flags")
+LANGUAGE_FEATURE(BuiltinCreateAsyncTaskWithExecutor, 0, "Task create builtin with extra executor preference")
+LANGUAGE_FEATURE(BuiltinCopy, 0, "Builtin.copy()")
+LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc")
+LANGUAGE_FEATURE(BuiltinUnprotectedStackAlloc, 0, "Builtin.unprotectedStackAlloc")
+LANGUAGE_FEATURE(BuiltinAllocVector, 0, "Builtin.allocVector")
+LANGUAGE_FEATURE(BuiltinTaskRunInline, 0, "Builtin.taskRunInline")
+LANGUAGE_FEATURE(BuiltinUnprotectedAddressOf, 0, "Builtin.unprotectedAddressOf")
+LANGUAGE_FEATURE(NewCxxMethodSafetyHeuristics, 0, "Only import C++ methods that return pointers (projections) on owned types as unsafe")
+SUPPRESSIBLE_LANGUAGE_FEATURE(SpecializeAttributeWithAvailability, 0, "@_specialize attribute with availability")
+LANGUAGE_FEATURE(BuiltinAssumeAlignment, 0, "Builtin.assumeAlignment")
+LANGUAGE_FEATURE(BuiltinCreateTaskGroupWithFlags, 0, "Builtin.createTaskGroupWithFlags")
+SUPPRESSIBLE_LANGUAGE_FEATURE(UnsafeInheritExecutor, 0, "@_unsafeInheritExecutor")
+SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes2, 346, "Primary associated types")
+SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync")
+SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)")
+LANGUAGE_FEATURE(BuiltinIntLiteralAccessors, 368, "Builtin.IntLiteral accessors")
+LANGUAGE_FEATURE(Macros, 0, "Macros")
+LANGUAGE_FEATURE(FreestandingExpressionMacros, 382, "Expression macros")
+LANGUAGE_FEATURE(AttachedMacros, 389, "Attached macros")
+LANGUAGE_FEATURE(ExtensionMacros, 402, "Extension macros")
+LANGUAGE_FEATURE(MoveOnly, 390, "noncopyable types")
+LANGUAGE_FEATURE(MoveOnlyResilientTypes, 390, "non-@frozen noncopyable types with library evolution")
+LANGUAGE_FEATURE(ParameterPacks, 393, "Value and type parameter packs")
+SUPPRESSIBLE_LANGUAGE_FEATURE(LexicalLifetimes, 0, "@_eagerMove/@_noEagerMove/@_lexicalLifetimes annotations")
+LANGUAGE_FEATURE(FreestandingMacros, 397, "freestanding declaration macros")
+SUPPRESSIBLE_LANGUAGE_FEATURE(RetroactiveAttribute, 364, "@retroactive")
+SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)")
+LANGUAGE_FEATURE(TypedThrows, 413, "Typed throws")
 
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
 UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
@@ -136,8 +130,6 @@ EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(BodyMacros, true)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
-
-SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)", true)
 
 // Whether to enable @_used and @_section attributes
 EXPERIMENTAL_FEATURE(SymbolLinkageMarkers, true)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -429,12 +429,6 @@ namespace swift {
     /// behavior. This is a staging flag, and will be removed in the future.
     bool EnableNewOperatorLookup = false;
 
-    /// The set of features that have been enabled.
-    FixedBitSet<numFeatures(), Feature> Features;
-
-    /// Temporary flag to support LLDB's transition to using \c Features.
-    bool EnableBareSlashRegexLiterals = false;
-
     /// Use Clang function types for computing canonical types.
     /// If this option is false, the clang function types will still be computed
     /// but will not be used for checking type equality.
@@ -690,6 +684,12 @@ namespace swift {
     /// by name.
     bool hasFeature(llvm::StringRef featureName) const;
 
+    /// Enable the given feature.
+    void enableFeature(Feature feature) { Features.insert(feature); }
+
+    /// Disable the given feature.
+    void disableFeature(Feature feature) { Features.remove(feature); }
+
     /// Sets the "_hasAtomicBitWidth" conditional.
     void setHasAtomicBitWidth(llvm::Triple triple);
 
@@ -762,6 +762,11 @@ namespace swift {
     llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 10>
         PlatformConditionValues;
     llvm::SmallVector<std::string, 2> CustomConditionalCompilationFlags;
+
+    /// The set of features that have been enabled. Doesn't include upcoming
+    /// features, which are checked against the language version in
+    /// `hasFeature`.
+    FixedBitSet<numFeatures(), Feature> Features;
   };
 
   class TypeCheckerOptions final {

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3876,12 +3876,12 @@ static bool usesFeatureTransferringArgsAndResults(Decl *decl) { return false; }
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {
   switch (feature) {
-#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)  \
-  case Feature::FeatureName:                                          \
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
+  case Feature::FeatureName:                                                   \
     llvm_unreachable("not a suppressible feature");
-#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option) \
-  case Feature::FeatureName:                                          \
-    suppressingFeature##FeatureName(options, action);                 \
+#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description)      \
+  case Feature::FeatureName:                                                   \
+    suppressingFeature##FeatureName(options, action);                          \
     return;
 #include "swift/Basic/Features.def"
   }
@@ -3952,12 +3952,12 @@ public:
   void collectFeaturesUsed(Decl *decl, InsertOrRemove operation) {
     // Go through each of the features, checking whether the
     // declaration uses that feature.
-#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)  \
-    if (usesFeature##FeatureName(decl))                               \
-      collectRequiredFeature(Feature::FeatureName, operation);
-#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)  \
-    if (usesFeature##FeatureName(decl))                               \
-      collectSuppressibleFeature(Feature::FeatureName, operation);
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
+  if (usesFeature##FeatureName(decl))                                          \
+    collectRequiredFeature(Feature::FeatureName, operation);
+#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description)      \
+  if (usesFeature##FeatureName(decl))                                          \
+    collectSuppressibleFeature(Feature::FeatureName, operation);
 #include "swift/Basic/Features.def"
   }
 };

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -647,9 +647,9 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
       toOptionalBool(options.EnableExperimentalMoveOnly);
   if (enableExperimentalMoveOnly && *enableExperimentalMoveOnly) {
     // FIXME: drop addition of Feature::MoveOnly once its queries are gone.
-    Invocation.getLangOptions().Features.insert(Feature::MoveOnly);
-    Invocation.getLangOptions().Features.insert(Feature::NoImplicitCopy);
-    Invocation.getLangOptions().Features.insert(
+    Invocation.getLangOptions().enableFeature(Feature::MoveOnly);
+    Invocation.getLangOptions().enableFeature(Feature::NoImplicitCopy);
+    Invocation.getLangOptions().enableFeature(
         Feature::OldOwnershipOperatorSpellings);
   }
   Invocation.getLangOptions().BypassResilienceChecks =
@@ -658,7 +658,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
       options.DebugDiagnosticNames;
   for (auto &featureName : options.ExperimentalFeatures) {
     if (auto feature = getExperimentalFeature(featureName)) {
-      Invocation.getLangOptions().Features.insert(*feature);
+      Invocation.getLangOptions().enableFeature(*feature);
     } else {
       llvm::errs() << "error: unknown feature "
                    << QuotedString(featureName) << "\n";
@@ -670,7 +670,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
     options.EnableObjCInterop ? true :
     options.DisableObjCInterop ? false : llvm::Triple(options.Target).isOSDarwin();
 
-  Invocation.getLangOptions().Features.insert(Feature::LayoutPrespecialization);
+  Invocation.getLangOptions().enableFeature(Feature::LayoutPrespecialization);
 
   Invocation.getLangOptions().OptimizationRemarkPassedPattern =
       createOptRemarkRegex(options.PassRemarksPassed);
@@ -678,10 +678,10 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
       createOptRemarkRegex(options.PassRemarksMissed);
 
   if (options.EnableExperimentalStaticAssert)
-    Invocation.getLangOptions().Features.insert(Feature::StaticAssert);
+    Invocation.getLangOptions().enableFeature(Feature::StaticAssert);
 
   if (options.EnableExperimentalDifferentiableProgramming) {
-    Invocation.getLangOptions().Features.insert(
+    Invocation.getLangOptions().enableFeature(
         Feature::DifferentiableProgramming);
   }
 

--- a/lib/DriverTool/swift_parse_test_main.cpp
+++ b/lib/DriverTool/swift_parse_test_main.cpp
@@ -153,7 +153,7 @@ struct ASTGenExecutor {
     symbolgraphgen::SymbolGraphOptions symbolOpts;
 
     // Enable ASTGen.
-    langOpts.Features.insert(Feature::ParserASTGen);
+    langOpts.enableFeature(Feature::ParserASTGen);
 
     std::unique_ptr<ASTContext> ctx(
         ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1624,8 +1624,8 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
   });
 
   if (LangOpts.hasFeature(Feature::LayoutPrespecialization)) {
-    genericSubInvocation.getLangOptions().Features.insert(
-      Feature::LayoutPrespecialization);
+    genericSubInvocation.getLangOptions().enableFeature(
+        Feature::LayoutPrespecialization);
   }
 
   // Validate Clang modules once per-build session flags must be consistent

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4361,13 +4361,13 @@ int main(int argc, char *argv[]) {
 
   for (const auto &featureArg : options::EnableExperimentalFeatures) {
     if (auto feature = getExperimentalFeature(featureArg)) {
-      InitInvok.getLangOptions().Features.insert(*feature);
+      InitInvok.getLangOptions().enableFeature(*feature);
     }
   }
 
   for (const auto &featureArg : options::EnableUpcomingFeatures) {
     if (auto feature = getUpcomingFeature(featureArg)) {
-      InitInvok.getLangOptions().Features.insert(*feature);
+      InitInvok.getLangOptions().enableFeature(*feature);
     }
   }
 
@@ -4435,10 +4435,10 @@ int main(int argc, char *argv[]) {
   }
 
   if (options::EnableExperimentalNamedOpaqueTypes) {
-    InitInvok.getLangOptions().Features.insert(Feature::NamedOpaqueTypes);
+    InitInvok.getLangOptions().enableFeature(Feature::NamedOpaqueTypes);
   }
   if (options::EnableBareSlashRegexLiterals) {
-    InitInvok.getLangOptions().Features.insert(Feature::BareSlashRegexLiterals);
+    InitInvok.getLangOptions().enableFeature(Feature::BareSlashRegexLiterals);
     InitInvok.getLangOptions().EnableExperimentalStringProcessing = true;
   }
 


### PR DESCRIPTION
Merge `$<Feature>` and `hasFeature` implementations.
  - `$<Feature>` did not support upcoming language features.
  - `hasFeature` did not support promoted language features and also didn't take into account `Options` in `Features.def`.

Remove `Options` entirely, it was always one of three cases:
  - `true`
  - `langOpts.hasFeature`
  - `hasSwiftSwiftParser`

Since `LangOptions::hasFeature` should always be used anyway, it's no longer necessary. `hasSwiftSwiftParser` can be special cased when adding the default promoted language features (by removing those features).

Resolves rdar://117917456.