### PR TITLE
Fix variadic-generic class method dispatch

### DIFF
--- a/include/swift/AST/ConcreteDeclRef.h
+++ b/include/swift/AST/ConcreteDeclRef.h
@@ -68,6 +68,9 @@ public:
   /// Retrieve a reference to the declaration this one overrides.
   ConcreteDeclRef getOverriddenDecl() const;
 
+  /// Retrieve a reference to the given declaration that this one overrides.
+  ConcreteDeclRef getOverriddenDecl(ValueDecl *overriddenDecl) const;
+
   /// Determine whether this reference specializes the declaration to which
   /// it refers.
   bool isSpecialized() const { return !substitutions.empty(); }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2697,6 +2697,11 @@ public:
   GenericEnvironment *
   createOpenedElementValueEnvironment(ArrayRef<SILType> packExpansionTys,
                                       ArrayRef<SILType*> eltTys);
+  GenericEnvironment *
+  createOpenedElementValueEnvironment(ArrayRef<SILType> packExpansionTys,
+                                      ArrayRef<SILType*> eltTys,
+                                      ArrayRef<CanType> formalPackExpansionTys,
+                                      ArrayRef<CanType*> formalEltTys);
 
   /// Emit a dynamic loop over a single pack-expansion component of a pack.
   ///

--- a/lib/SILGen/SILGenPack.cpp
+++ b/lib/SILGen/SILGenPack.cpp
@@ -452,42 +452,61 @@ GenericEnvironment *
 SILGenFunction::createOpenedElementValueEnvironment(
                                           ArrayRef<SILType> expansionTys,
                                           ArrayRef<SILType*> eltTys) {
-  // The element-types output array should be the same size as the
-  // expansion-types input array.  We don't currently have a reason
-  // to allow them to be empty --- we never do this with a dynamic
-  // set of types --- but maybe it's justifiable.
-  assert(expansionTys.size() == eltTys.size());
-  assert(!expansionTys.empty());
-  if (expansionTys.empty()) return nullptr;
+  return createOpenedElementValueEnvironment(expansionTys, eltTys, {}, {});
+}
 
-  auto countArchetype = cast<PackArchetypeType>(
-    expansionTys[0].castTo<PackExpansionType>().getCountType());
+
+GenericEnvironment *
+SILGenFunction::createOpenedElementValueEnvironment(
+                                          ArrayRef<SILType> expansionTys,
+                                          ArrayRef<SILType*> eltTys,
+                                          ArrayRef<CanType> formalExpansionTypes,
+                                          ArrayRef<CanType*> formalEltTypes) {
+  // The element-types output arrays should be the same size as their
+  // corresponding expansion-types input arrays.
+  assert(expansionTys.size() == eltTys.size());
+  assert(formalExpansionTypes.size() == formalEltTypes.size());
+
+  assert(!expansionTys.empty() || !formalExpansionTypes.empty());
+  auto countArchetype =
+    cast<PackArchetypeType>(
+      (expansionTys.empty()
+         ? cast<PackExpansionType>(formalExpansionTypes[0])
+         : expansionTys[0].castTo<PackExpansionType>()).getCountType());
 
   GenericEnvironment *env = nullptr;
-  for (auto i : indices(expansionTys)) {
-    auto exp = expansionTys[i].castTo<PackExpansionType>();
-    assert((i == 0 ||
-            countArchetype->getReducedShape() ==
-              cast<PackArchetypeType>(exp.getCountType())->getReducedShape())
+  auto processExpansion = [&](CanPackExpansionType expansion) -> CanType {
+    assert(countArchetype->getReducedShape() ==
+             cast<PackArchetypeType>(expansion.getCountType())->getReducedShape()
            && "expansions are over packs with different shapes");
 
-    // The lowered element type is the lowered pattern type, if that's
-    // invariant to expansion, or else the expansion mapping of that in
-    // the opened-element environment.
-    auto loweredPatternTy = exp.getPatternType();
-    auto loweredEltTy = loweredPatternTy;
-    if (!isPatternInvariantToExpansion(loweredPatternTy, countArchetype)) {
-      // Lazily create the opened-element environment if we find a
-      // pattern type that's not invariant to expansion.
-      if (!env) {
-        auto context = OpenedElementContext::
-            createForContextualExpansion(SGM.getASTContext(), exp);
-        env = context.environment;
-      }
-      loweredEltTy =
-        env->mapContextualPackTypeIntoElementContext(loweredPatternTy);
+    // The element type is the pattern type, if that's invariant to
+    // expansion, or else the expansion mapping of that in the
+    // opened-element environment.
+    auto patternType = expansion.getPatternType();
+    if (isPatternInvariantToExpansion(patternType, countArchetype))
+      return patternType;
+
+    // Lazily create the opened-element environment if we find a
+    // pattern type that's not invariant to expansion.
+    if (!env) {
+      auto context = OpenedElementContext::
+          createForContextualExpansion(SGM.getASTContext(), expansion);
+      env = context.environment;
     }
+    return env->mapContextualPackTypeIntoElementContext(patternType);
+  };
+
+  for (auto i : indices(expansionTys)) {
+    auto exp = expansionTys[i].castTo<PackExpansionType>();
+    auto loweredEltTy = processExpansion(exp);
     *eltTys[i] = SILType::getPrimitiveAddressType(loweredEltTy);
+  }
+
+  for (auto i : indices(formalExpansionTypes)) {
+    auto exp = cast<PackExpansionType>(formalExpansionTypes[i]);
+    auto eltType = processExpansion(exp);
+    *formalEltTypes[i] = eltType;
   }
 
   return env;

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3638,9 +3638,12 @@ void ResultPlanner::Operation::emitReabstractTupleIntoPackExpansion(
                               outerComponentIndex);
 
   SILType innerEltTy, outerEltTy;
+  CanType innerSubstEltType, outerSubstEltType;
   auto openedEnv = SGF.createOpenedElementValueEnvironment(
                    { innerPackExpansionTy, outerPackExpansionTy },
-                   { &innerEltTy, &outerEltTy });
+                   { &innerEltTy, &outerEltTy },
+                   { InnerSubstType, OuterSubstType },
+                   { &innerSubstEltType, &outerSubstEltType });
 
   auto innerFormalPackType = PackExpansion.InnerFormalPackType;
   auto outerFormalPackType = PackExpansion.OuterFormalPackType;
@@ -3675,20 +3678,11 @@ void ResultPlanner::Operation::emitReabstractTupleIntoPackExpansion(
                                          CleanupHandle::invalid());
     auto outerResultCtxt = SGFContext(&outerEltInit);
 
-    CanType innerSubstType = InnerSubstType;
-    CanType outerSubstType = OuterSubstType;
-    if (openedEnv) {
-      innerSubstType =
-        openedEnv->mapContextualPackTypeIntoElementContext(innerSubstType);
-      outerSubstType =
-        openedEnv->mapContextualPackTypeIntoElementContext(outerSubstType);
-    }
-
     // Reabstract.
     auto outerEltValue =
       SGF.emitTransformedValue(loc, innerEltValue,
-                               InnerOrigType, innerSubstType,
-                               OuterOrigType, outerSubstType,
+                               InnerOrigType, innerSubstEltType,
+                               OuterOrigType, outerSubstEltType,
                                outerEltTy, outerResultCtxt);
 
     // Force the value into the outer result address if necessary.

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2124,18 +2124,18 @@ TupleElementAddressGenerator::projectElementAddress(SILGenFunction &SGF,
       SGF.B.createTupleElementAddr(loc, tupleAddr, eltIndex, eltTy));
   } else if (isSubstPackExpansion()) {
     eltValue = cloner.cloneForTuplePackExpansionComponent(tupleAddr,
-                                                         inducedPackType,
-                                                         eltIndex);
+                                                          getInducedPackType(),
+                                                          eltIndex);
   } else {
     auto packIndex =
-      SGF.B.createScalarPackIndex(loc, eltIndex, inducedPackType);
+      SGF.B.createScalarPackIndex(loc, eltIndex, getInducedPackType());
     auto eltAddr =
       SGF.B.createTuplePackElementAddr(loc, packIndex, tupleAddr, eltTy);
     eltValue = cloner.clone(eltAddr);
   }
 
   tupleValue = cloner.cloneForRemainingTupleComponents(tupleAddr,
-                                                       inducedPackType,
+                                                       getInducedPackTypeIfPresent(),
                                                        eltIndex + 1);
   this->tupleAddr = tupleValue;
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -540,9 +540,13 @@ public:
       assert(componentInit);
       assert(componentInit->canPerformPackExpansionInitialization());
 
-      auto opening = SGF.createOpenedElementValueEnvironment(packComponentTy);
-      auto openedEnv = opening.first;
-      auto eltTy = opening.second;
+      SILType eltTy;
+      CanType substEltType;
+      auto openedEnv =
+        SGF.createOpenedElementValueEnvironment({packComponentTy},
+                                                {&eltTy},
+                                                {substExpansionType},
+                                                {&substEltType});
 
       SGF.emitDynamicPackLoop(loc, inducedPackType, packComponentIndex,
                               openedEnv, [&](SILValue indexWithinComponent,
@@ -555,12 +559,6 @@ public:
           auto eltAddr =
             SGF.B.createPackElementGet(loc, packIndex, packAddr, eltTy);
           auto eltAddrMV = cloner.clone(eltAddr);
-
-          CanType substEltType = substExpansionType.getPatternType();
-          if (openedEnv) {
-            substEltType =
-              openedEnv->mapContextualPackTypeIntoElementContext(substEltType);
-          }
 
           auto result = handleScalar(eltAddrMV, origPatternType, substEltType,
                                      eltInit, /*inout*/ false);

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -568,21 +568,18 @@ func convTupleAny(_ f1: @escaping () -> (),
 // CHECK-NEXT:    return
 
 // CHECK-LABEL: sil shared [transparent] [serialized] [reabstraction_thunk] [ossa] @$sypSgIegn_S2iIegyy_TR : $@convention(thin) (Int, Int, @guaranteed @callee_guaranteed (@in_guaranteed Optional<Any>) -> ()) -> ()
-// CHECK:         [[ANY_VALUE:%.*]] = alloc_stack $Any
-// CHECK-NEXT:    [[ANY_PAYLOAD:%.*]] = init_existential_addr [[ANY_VALUE]]
-// CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
+// CHECK:         [[OPTIONAL_ADDR:%.*]] = alloc_stack $Optional<Any>
+// CHECK-NEXT:    [[OPTIONAL_PAYLOAD_ADDR:%.*]] = init_enum_data_addr [[OPTIONAL_ADDR]] : $*Optional<Any>, #Optional.some
+// CHECK-NEXT:    [[ANY_PAYLOAD_ADDR:%.*]] = init_existential_addr [[OPTIONAL_PAYLOAD_ADDR]] : $*Any, $(Int, Int)
+// CHECK-NEXT:    [[LEFT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD_ADDR]]
 // CHECK-NEXT:    store %0 to [trivial] [[LEFT_ADDR]]
-// CHECK-NEXT:    [[RIGHT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD]]
+// CHECK-NEXT:    [[RIGHT_ADDR:%.*]] = tuple_element_addr [[ANY_PAYLOAD_ADDR]]
 // CHECK-NEXT:    store %1 to [trivial] [[RIGHT_ADDR]]
-// CHECK-NEXT:    [[OPTIONAL_VALUE:%.*]] = alloc_stack $Optional<Any>
-// CHECK-NEXT:    [[OPTIONAL_PAYLOAD:%.*]] = init_enum_data_addr [[OPTIONAL_VALUE]]
-// CHECK-NEXT:    copy_addr [take] [[ANY_VALUE]] to [init] [[OPTIONAL_PAYLOAD]]
-// CHECK-NEXT:    inject_enum_addr [[OPTIONAL_VALUE]]
-// CHECK-NEXT:    apply %2([[OPTIONAL_VALUE]])
+// CHECK-NEXT:    inject_enum_addr [[OPTIONAL_ADDR]]
+// CHECK-NEXT:    apply %2([[OPTIONAL_ADDR]])
 // CHECK-NEXT:    tuple ()
-// CHECK-NEXT:    destroy_addr [[OPTIONAL_VALUE]]
-// CHECK-NEXT:    dealloc_stack [[OPTIONAL_VALUE]]
-// CHECK-NEXT:    dealloc_stack [[ANY_VALUE]]
+// CHECK-NEXT:    destroy_addr [[OPTIONAL_ADDR]]
+// CHECK-NEXT:    dealloc_stack [[OPTIONAL_ADDR]]
 // CHECK-NEXT:    return
 
 // ==== Support collection subtyping in function argument position

--- a/test/SILGen/variadic-generic-class-methods.swift
+++ b/test/SILGen/variadic-generic-class-methods.swift
@@ -1,0 +1,56 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+
+public class A<each T> {
+  public func f(_ action: (repeat each T) -> ()) {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main5test02fnyySi_SftXE_tF :
+// CHECK:       [[CTOR:%.*]] = function_ref @$s4main1ACACyxxQp_QPGycfC :
+// CHECK:       [[OBJECT:%.*]] = apply [[CTOR]]<Pack{Int, Float}>
+// CHECK:       [[METHOD:%.*]] = class_method [[OBJECT]] : $A<Int, Float>, #A.f : <each T> (A<repeat each T>) -> ((repeat each T) -> ()) -> ()
+// CHECK:       apply [[METHOD]]<Pack{Int, Float}>
+func test0(fn: (Int, Float) -> ()) {
+  A<Int, Float>().f(fn)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4main5test1yyF :
+// CHECK:       [[CTOR:%.*]] = function_ref @$s4main1ACACyxxQp_QPGycfC :
+// CHECK:       [[OBJECT:%.*]] = apply [[CTOR]]<Pack{Int, Float}>
+// CHECK:       [[METHOD:%.*]] = class_method [[OBJECT]] : $A<Int, Float>, #A.f : <each T> (A<repeat each T>) -> ((repeat each T) -> ()) -> ()
+// CHECK:       apply [[METHOD]]<Pack{Int, Float}>
+func test1() {
+  A<Int, Float>().f { a, b in }
+}
+
+// These are all currently forbidden
+#if false
+public class B<each T> : A<repeat each T> {
+  public override func f(_ action: (repeat each T) -> ()) {
+    super.f(action)
+  }
+}
+
+func test2() {
+  B<Int, Float>().f { a, b in }
+}
+
+public class C<T, each U> : A<T, repeat each U> {
+  public override func f(_ action: (T, repeat each U) -> ()) {
+    super.f(action)
+  }
+}
+
+func test3() {
+  C<Int, Float>().f { a, b in }
+}
+
+public class D : A<Int, Float> {
+  public override func f(_ action: (Int, Float) -> ()) {
+    super.f(action)
+  }
+}
+
+func test4() {
+  D().f { a, b in }
+}
+#endif

--- a/test/SILGen/variadic-generic-reabstract-tuple-arg.swift
+++ b/test/SILGen/variadic-generic-reabstract-tuple-arg.swift
@@ -1,0 +1,123 @@
+// RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
+
+func takeEscapingFunction<each Input, Output>(function: @escaping ((repeat each Input)) -> Output) {}
+func returnFunction<each Input, Output>(args: (repeat each Input).Type, result: Output.Type) -> (_: (repeat each Input)) -> Output {}
+
+// Issue #69028: Vanishing tuple in a reabstraction into a more abstract context
+func catFact(num: Int) -> String { "there are more than 10 cats" }
+func test0() {
+  takeEscapingFunction(function: catFact)
+}
+// CHECK-LABEL: sil hidden [ossa] @$s4main5test0yyF :
+// CHECK:         [[THUNK:%.*]] = function_ref @$sSiSSIegyo_Si_QSiSSIegpr_TR : $@convention(thin) (@pack_guaranteed Pack{Int}, @guaranteed @callee_guaranteed (Int) -> @owned String) -> @out String
+// CHECK-NEXT:    partial_apply [callee_guaranteed] [[THUNK]]
+
+// CHECK-LABEL: sil shared {{.*}} @$sSiSSIegyo_Si_QSiSSIegpr_TR : $@convention(thin) (@pack_guaranteed Pack{Int}, @guaranteed @callee_guaranteed (Int) -> @owned String) -> @out String {
+// CHECK:       bb0(%0 : $*String, %1 : $*Pack{Int}, %2 : @guaranteed $@callee_guaranteed (Int) -> @owned String):
+// CHECK-NEXT:    [[INDEX:%.*]] = scalar_pack_index 0 of $Pack{Int}
+// CHECK-NEXT:    [[ARG_ADDR:%.*]] = pack_element_get [[INDEX]] of %1 : $*Pack{Int} as $*Int
+// CHECK-NEXT:    [[ARG:%.*]] = load [trivial] [[ARG_ADDR]] : $*Int
+// CHECK-NEXT:    [[RESULT:%.*]] = apply %2([[ARG]]) : $@callee_guaranteed (Int) -> @owned String
+// CHECK-NEXT:    store [[RESULT]] to [init] %0 : $*String
+// CHECK-NEXT:    [[RESULT:%.*]] = tuple ()
+// CHECK-NEXT:    return [[RESULT]] : $()
+// CHECK-NEXT:  }
+
+// Vanishing tuple in a reabstraction out of a more abstract context
+func test1() {
+  _ = returnFunction(args: String.self, result: [String].self)
+}
+// CHECK-LABEL: sil hidden [ossa] @$s4main5test1yyF :
+// CHECK:         [[THUNK:%.*]] = function_ref @$sSS_QSiSaySSGIegpr_SSAAIeggo_TR : $@convention(thin) (@guaranteed String, @guaranteed @callee_guaranteed (@pack_guaranteed Pack{String}) -> @out Array<String>) -> @owned Array<String>
+// CHECK-NEXT:    partial_apply [callee_guaranteed] [[THUNK]]
+
+// CHECK-LABEL: sil shared {{.*}} @$sSS_QSiSaySSGIegpr_SSAAIeggo_TR : $@convention(thin) (@guaranteed String, @guaranteed @callee_guaranteed (@pack_guaranteed Pack{String}) -> @out Array<String>) -> @owned Array<String> {
+// CHECK:       bb0(%0 : @guaranteed $String, %1 : @guaranteed $@callee_guaranteed (@pack_guaranteed Pack{String}) -> @out Array<String>):
+// CHECK-NEXT:    [[PACK:%.*]] = alloc_pack $Pack{String}
+// CHECK-NEXT:    [[ARG_TEMP:%.*]] = alloc_stack $String
+//   It'd be nice to avoid this unnecessary copy.
+// CHECK-NEXT:    [[ARG_COPY:%.*]] = copy_value %0 : $String
+// CHECK-NEXT:    store [[ARG_COPY]] to [init] [[ARG_TEMP]] : $*String
+// CHECK-NEXT:    [[INDEX:%.*]] = scalar_pack_index 0 of $Pack{String}
+// CHECK-NEXT:    pack_element_set [[ARG_TEMP]] : $*String into [[INDEX]] of [[PACK]] : $*Pack{String}
+// CHECK-NEXT:    [[RESULT_TEMP:%.*]] = alloc_stack $Array<String>
+// CHECK-NEXT:    apply %1([[RESULT_TEMP]], [[PACK]]) : $@callee_guaranteed (@pack_guaranteed Pack{String}) -> @out Array<String>
+// CHECK-NEXT:    [[RESULT:%.*]] = load [take] [[RESULT_TEMP]] : $*Array<String>
+// CHECK-NEXT:    dealloc_stack [[RESULT_TEMP]] : $*Array<String>
+// CHECK-NEXT:    destroy_addr [[ARG_TEMP]] : $*String
+// CHECK-NEXT:    dealloc_stack [[ARG_TEMP]] : $*String
+// CHECK-NEXT:    dealloc_pack [[PACK]] : $*Pack{String}
+// CHECK-NEXT:    return [[RESULT]] : $Array<String>
+// CHECK-NEXT:  }
+
+// A non-vanishing tuple in a reabstraction into a more abstract context
+func lionFact(label: (String, Int)) -> String { "all lions are cats" }
+func test2() {
+  takeEscapingFunction(function: lionFact)
+}
+// CHECK-LABEL: sil hidden [ossa] @$s4main5test2yyF :
+// CHECK:         [[THUNK:%.*]] = function_ref @$sSSSiSSIeggyo_SS_SiQSiSSIegpr_TR : $@convention(thin) (@pack_guaranteed Pack{String, Int}, @guaranteed @callee_guaranteed (@guaranteed String, Int) -> @owned String) -> @out String
+// CHECK-NEXT:    partial_apply [callee_guaranteed] [[THUNK]]
+
+// CHECK-LABEL: sil shared {{.*}} @$sSSSiSSIeggyo_SS_SiQSiSSIegpr_TR : $@convention(thin) (@pack_guaranteed Pack{String, Int}, @guaranteed @callee_guaranteed (@guaranteed String, Int) -> @owned String) -> @out String {
+// CHECK:       bb0(%0 : $*String, %1 : $*Pack{String, Int}, %2 : @guaranteed $@callee_guaranteed (@guaranteed String, Int) -> @owned String):
+// CHECK-NEXT:    [[ARG0_INDEX:%.*]] = scalar_pack_index 0 of $Pack{String, Int}
+// CHECK-NEXT:    [[ARG0_ADDR:%.*]] = pack_element_get [[ARG0_INDEX]] of %1 : $*Pack{String, Int} as $*String
+// CHECK-NEXT:    [[ARG0:%.*]] = load_borrow [[ARG0_ADDR]] : $*String
+// CHECK-NEXT:    [[ARG1_INDEX:%.*]] = scalar_pack_index 1 of $Pack{String, Int}
+// CHECK-NEXT:    [[ARG1_ADDR:%.*]] = pack_element_get [[ARG1_INDEX]] of %1 : $*Pack{String, Int} as $*Int
+// CHECK-NEXT:    [[ARG1:%.*]] = load [trivial] [[ARG1_ADDR]] : $*Int
+// CHECK-NEXT:    [[RESULT:%.*]] = apply %2([[ARG0]], [[ARG1]]) : $@callee_guaranteed (@guaranteed String, Int) -> @owned String
+// CHECK-NEXT:    store [[RESULT]] to [init] %0 : $*String
+// CHECK-NEXT:    [[RESULT:%.*]] = tuple ()
+// CHECK-NEXT:    end_borrow [[ARG0]] : $String
+// CHECK-NEXT:    return [[RESULT]] : $()
+// CHECK-NEXT:  }
+
+struct Args<each T> {
+  static func take(function: @escaping (_: (repeat each T)) -> ()) {}
+}
+
+#if false
+// For some reason, this doesn't type-check
+func test3(function: @escaping (_: (Int, String)?) -> ()) {
+  Args<Int, String>.take(function: function)
+}
+#endif
+
+func test4<each T>(function: @escaping (_: Any) -> (), type: (repeat each T).Type) {
+  Args<repeat each T>.take(function: function)
+}
+// CHECK-LABEL: sil hidden [ossa] @$s4main5test48function4typeyyypc_xxQp_tmtRvzlF :
+// CHECK:         [[THUNK:%.*]] = function_ref @$sypIegn_xxQp_QSiIegp_RvzlTR : $@convention(thin) <each τ_0_0> (@pack_guaranteed Pack{repeat each τ_0_0}, @guaranteed @callee_guaranteed (@in_guaranteed Any) -> ()) -> ()
+// CHECK-NEXT:    partial_apply [callee_guaranteed] [[THUNK]]
+
+// CHECK-LABEL: sil shared {{.*}} @$sypIegn_xxQp_QSiIegp_RvzlTR : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat each T}, @guaranteed @callee_guaranteed (@in_guaranteed Any) -> ()) -> () {
+// CHECK:       bb0(%0 : $*Pack{repeat each T}, %1 : @guaranteed $@callee_guaranteed (@in_guaranteed Any) -> ()):
+//   - Set up for emitting into a temporary Any object.
+// CHECK-NEXT:    [[ANY_TEMP:%.*]] = alloc_stack $Any
+// CHECK-NEXT:    [[PAYLOAD_ADDR:%.*]] = init_existential_addr [[ANY_TEMP]] : $*Any, $(repeat each T)
+//   - Loop over the pack and copy the elements into the Any.
+// CHECK-NEXT:    [[ZERO:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK-NEXT:    [[ONE:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK-NEXT:    [[LEN:%.*]] = pack_length $Pack{repeat each T}
+// CHECK-NEXT:    br bb1([[ZERO]] : $Builtin.Word)
+// CHECK:       bb1([[IDX:%.*]] : $Builtin.Word)
+// CHECK-NEXT:    [[IDX_EQ_LEN:%.*]] = builtin "cmp_eq_Word"([[IDX]] : $Builtin.Word, [[LEN]] : $Builtin.Word) : $Builtin.Int1
+// CHECK-NEXT:     cond_br [[IDX_EQ_LEN]], bb3, bb2
+// CHECK:       bb2:
+// CHECK-NEXT:    [[EXPANSION_INDEX:%.*]] = dynamic_pack_index [[IDX]] of $Pack{repeat each T}
+// CHECK-NEXT:    open_pack_element [[EXPANSION_INDEX]] of <each T> at <Pack{repeat each T}>, shape $each T, uuid [[UUID:".*"]]
+// CHECK-NEXT:    [[SRC_ELT_ADDR:%.*]] = pack_element_get [[EXPANSION_INDEX]] of %0 : $*Pack{repeat each T} as $*@pack_element([[UUID]]) each T
+// CHECK-NEXT:    [[DEST_ELT_ADDR:%.*]] = tuple_pack_element_addr [[EXPANSION_INDEX]] of [[PAYLOAD_ADDR]] : $*(repeat each T) as $*@pack_element([[UUID]]) each T
+// CHECK-NEXT:    copy_addr [[SRC_ELT_ADDR]] to [init] [[DEST_ELT_ADDR]] : $*@pack_element([[UUID]]) each T
+// CHECK-NEXT:    [[NEXT_IDX:%.*]] = builtin "add_Word"([[IDX]] : $Builtin.Word, [[ONE]] : $Builtin.Word) : $Builtin.Word
+// CHECK-NEXT:    br bb1([[NEXT_IDX]] : $Builtin.Word)
+// CHECK:       bb3:
+//   - Call the thunked function.
+// CHECK-NEXT:    apply %1([[ANY_TEMP]])
+//   - Epilogue.
+// CHECK-NEXT:    [[VOID:%.*]] = tuple ()
+// CHECK-NEXT:    destroy_addr [[ANY_TEMP]] : $*Any
+// CHECK-NEXT:    dealloc_stack [[ANY_TEMP]] : $*Any
+// CHECK-NEXT:    return [[VOID]] : $()

--- a/test/Sema/package_resilience_bypass_exhaustive_switch.swift
+++ b/test/Sema/package_resilience_bypass_exhaustive_switch.swift
@@ -79,10 +79,10 @@ package func f(_ arg: PkgEnum) -> Int {
 
 // CHECK: // f(_:)
 // CHECK-NEXT: sil @$s6Client1fySi5Utils7PkgEnumOF : $@convention(thin) (PkgEnum) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
+// CHECK-NEXT: // %0 "arg"
 // CHECK-NEXT: bb0(%0 : $PkgEnum):
-// CHECK-NEXT:   debug_value %0 : $PkgEnum, let, name "arg", argno 1 // id: %1
-// CHECK-NEXT:   switch_enum %0 : $PkgEnum, case #PkgEnum.one!enumelt: bb1, case #PkgEnum.two!enumelt: bb2 // id: %2
+// CHECK-NEXT:   debug_value %0 : $PkgEnum, let, name "arg", argno 1
+// CHECK-NEXT:   switch_enum %0 : $PkgEnum, case #PkgEnum.one!enumelt: bb1, case #PkgEnum.two!enumelt: bb2
 
 package func g1(_ arg: PkgEnumWithPublicCase) -> Int {
   switch arg { // no-warning
@@ -95,12 +95,12 @@ package func g1(_ arg: PkgEnumWithPublicCase) -> Int {
 
 // CHECK: // g1(_:)
 // CHECK-NEXT: sil @$s6Client2g1ySi5Utils21PkgEnumWithPublicCaseOF : $@convention(thin) (@in_guaranteed PkgEnumWithPublicCase) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %3, %1
+// CHECK-NEXT: // %0 "arg"
 // CHECK-NEXT: bb0(%0 : $*PkgEnumWithPublicCase):
-// CHECK-NEXT:   debug_value %0 : $*PkgEnumWithPublicCase, let, name "arg", argno 1, expr op_deref // id: %1
-// CHECK-NEXT:   %2 = alloc_stack $PkgEnumWithPublicCase         // users: %29, %9, %7, %4, %3
-// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PkgEnumWithPublicCase // id: %3
-// CHECK-NEXT:   switch_enum_addr %2 : $*PkgEnumWithPublicCase, case #PkgEnumWithPublicCase.one!enumelt: bb1, case #PkgEnumWithPublicCase.two!enumelt: bb2 // id: %4
+// CHECK-NEXT:   debug_value %0 : $*PkgEnumWithPublicCase, let, name "arg", argno 1, expr op_deref
+// CHECK-NEXT:   %2 = alloc_stack $PkgEnumWithPublicCase
+// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PkgEnumWithPublicCase
+// CHECK-NEXT:   switch_enum_addr %2 : $*PkgEnumWithPublicCase, case #PkgEnumWithPublicCase.one!enumelt: bb1, case #PkgEnumWithPublicCase.two!enumelt: bb2
 
 package func g2(_ arg: PkgEnumWithExistentialCase) -> any StringProtocol {
   switch arg { // no-warning
@@ -113,13 +113,13 @@ package func g2(_ arg: PkgEnumWithExistentialCase) -> any StringProtocol {
 
 // CHECK: // g2(_:)
 // CHECK-NEXT: sil @$s6Client2g2ySy_p5Utils26PkgEnumWithExistentialCaseOF : $@convention(thin) (@in_guaranteed PkgEnumWithExistentialCase) -> @out any StringProtocol {
-// CHECK-NEXT: // %0 "$return_value"                             // users: %20, %12
-// CHECK-NEXT: // %1 "arg"                                       // users: %4, %2
+// CHECK-NEXT: // %0 "$return_value"
+// CHECK-NEXT: // %1 "arg"
 // CHECK-NEXT: bb0(%0 : $*any StringProtocol, %1 : $*PkgEnumWithExistentialCase):
-// CHECK-NEXT:   debug_value %1 : $*PkgEnumWithExistentialCase, let, name "arg", argno 1, expr op_deref // id: %2
-// CHECK-NEXT:   %3 = alloc_stack $PkgEnumWithExistentialCase    // users: %23, %16, %14, %5, %4
-// CHECK-NEXT:   copy_addr %1 to [init] %3 : $*PkgEnumWithExistentialCase // id: %4
-// CHECK-NEXT:   switch_enum_addr %3 : $*PkgEnumWithExistentialCase, case #PkgEnumWithExistentialCase.one!enumelt: bb1, case #PkgEnumWithExistentialCase.two!enumelt: bb2 // id: %5
+// CHECK-NEXT:   debug_value %1 : $*PkgEnumWithExistentialCase, let, name "arg", argno 1, expr op_deref
+// CHECK-NEXT:   %3 = alloc_stack $PkgEnumWithExistentialCase
+// CHECK-NEXT:   copy_addr %1 to [init] %3 : $*PkgEnumWithExistentialCase
+// CHECK-NEXT:   switch_enum_addr %3 : $*PkgEnumWithExistentialCase, case #PkgEnumWithExistentialCase.one!enumelt: bb1, case #PkgEnumWithExistentialCase.two!enumelt: bb2
 
 
 @inlinable
@@ -134,13 +134,13 @@ package func h(_ arg: UfiPkgEnum) -> Int {
 
 // CHECK: // h(_:)
 // CHECK-NEXT: sil @$s6Client1hySi5Utils10UfiPkgEnumOF : $@convention(thin) (@in_guaranteed UfiPkgEnum) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %3, %1
+// CHECK-NEXT: // %0 "arg"
 // CHECK-NEXT: bb0(%0 : $*UfiPkgEnum):
-// CHECK-NEXT:   debug_value %0 : $*UfiPkgEnum, let, name "arg", argno 1, expr op_deref // id: %1
-// CHECK-NEXT:   %2 = alloc_stack $UfiPkgEnum                    // users: %21, %10, %8, %5, %4, %3
-// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*UfiPkgEnum        // id: %3
-// CHECK-NEXT:   %4 = value_metatype $@thick UfiPkgEnum.Type, %2 : $*UfiPkgEnum // user: %24
-// CHECK-NEXT:   switch_enum_addr %2 : $*UfiPkgEnum, case #UfiPkgEnum.one!enumelt: bb1, case #UfiPkgEnum.two!enumelt: bb2, default bb3 // id: %5
+// CHECK-NEXT:   debug_value %0 : $*UfiPkgEnum, let, name "arg", argno 1, expr op_deref
+// CHECK-NEXT:   %2 = alloc_stack $UfiPkgEnum
+// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*UfiPkgEnum
+// CHECK-NEXT:   %4 = value_metatype $@thick UfiPkgEnum.Type, %2 : $*UfiPkgEnum
+// CHECK-NEXT:   switch_enum_addr %2 : $*UfiPkgEnum, case #UfiPkgEnum.one!enumelt: bb1, case #UfiPkgEnum.two!enumelt: bb2, default bb3
 
 public func k(_ arg: PublicEnum) -> Int {
   switch arg { // expected-warning {{switch covers known cases, but 'PublicEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
@@ -152,13 +152,13 @@ public func k(_ arg: PublicEnum) -> Int {
 }
 // CHECK: // k(_:)
 // CHECK-NEXT: sil @$s6Client1kySi5Utils10PublicEnumOF : $@convention(thin) (@in_guaranteed PublicEnum) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %3, %1
+// CHECK-NEXT: // %0 "arg"
 // CHECK-NEXT: bb0(%0 : $*PublicEnum):
-// CHECK-NEXT:   debug_value %0 : $*PublicEnum, let, name "arg", argno 1, expr op_deref // id: %1
-// CHECK-NEXT:   %2 = alloc_stack $PublicEnum                    // users: %21, %10, %8, %5, %4, %3
-// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PublicEnum        // id: %3
-// CHECK-NEXT:   %4 = value_metatype $@thick PublicEnum.Type, %2 : $*PublicEnum // user: %24
-// CHECK-NEXT:   switch_enum_addr %2 : $*PublicEnum, case #PublicEnum.one!enumelt: bb1, case #PublicEnum.two!enumelt: bb2, default bb3 // id: %5
+// CHECK-NEXT:   debug_value %0 : $*PublicEnum, let, name "arg", argno 1, expr op_deref
+// CHECK-NEXT:   %2 = alloc_stack $PublicEnum
+// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PublicEnum
+// CHECK-NEXT:   %4 = value_metatype $@thick PublicEnum.Type, %2 : $*PublicEnum
+// CHECK-NEXT:   switch_enum_addr %2 : $*PublicEnum, case #PublicEnum.one!enumelt: bb1, case #PublicEnum.two!enumelt: bb2, default bb3
 
 public func m(_ arg: FrozenPublicEnum) -> Int {
   switch arg { // no-warning
@@ -171,9 +171,9 @@ public func m(_ arg: FrozenPublicEnum) -> Int {
 
 // CHECK: // m(_:)
 // CHECK-NEXT: sil @$s6Client1mySi5Utils16FrozenPublicEnumOF : $@convention(thin) (FrozenPublicEnum) -> Int {
-// CHECK-NEXT: // %0 "arg"                                       // users: %2, %1
+// CHECK-NEXT: // %0 "arg"
 // CHECK-NEXT: bb0(%0 : $FrozenPublicEnum):
-// CHECK-NEXT:   debug_value %0 : $FrozenPublicEnum, let, name "arg", argno 1 // id: %1
-// CHECK-NEXT:   switch_enum %0 : $FrozenPublicEnum, case #FrozenPublicEnum.one!enumelt: bb1, case #FrozenPublicEnum.two!enumelt: bb2 // id: %2
+// CHECK-NEXT:   debug_value %0 : $FrozenPublicEnum, let, name "arg", argno 1
+// CHECK-NEXT:   switch_enum %0 : $FrozenPublicEnum, case #FrozenPublicEnum.one!enumelt: bb1, case #FrozenPublicEnum.two!enumelt: bb2
 
 


### PR DESCRIPTION
It's important to set substitutions on generic abstraction patterns so that we can maintain the parallel structure with the substituted type properly.

Builds on top of #70681.

Part of the fix for rdar://119899063