### PR TITLE
Sema: Allow some references to declarations that are unavailable-in-Swift

### DIFF
--- a/test/ModuleInterface/Inputs/inherited-objc-initializers/InheritedObjCInits.h
+++ b/test/ModuleInterface/Inputs/inherited-objc-initializers/InheritedObjCInits.h
@@ -1,7 +1,14 @@
 #import <Foundation/Foundation.h>
 
-@interface FrameworkObject : NSObject
-- (nonnull instancetype)initWithInvocation:(nullable NSInvocation *)invocation NS_SWIFT_UNAVAILABLE("unavailable");
-- (nonnull instancetype)initWithSelector:(nonnull SEL)selector;
-- (nonnull instancetype)initWithInteger:(NSInteger)integer;
+NS_SWIFT_UNAVAILABLE("unavailable")
+@interface UnavailableInSwift : NSObject
 @end
+
+@interface HasAvailableInit : NSObject
+- (nonnull instancetype)initWithUnavailable:(nonnull UnavailableInSwift *)unavailable;
+@end
+
+@interface HasUnavailableInit : NSObject
+- (nonnull instancetype)initWithUnavailable:(nonnull UnavailableInSwift *)unavailable NS_SWIFT_UNAVAILABLE("unavailable");
+@end
+

--- a/test/ModuleInterface/inherited-objc-superclass-initializers.swift
+++ b/test/ModuleInterface/inherited-objc-superclass-initializers.swift
@@ -1,15 +1,21 @@
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -I %S/Inputs/inherited-objc-initializers/
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/inherited-objc-initializers/
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -I %S/Inputs/inherited-objc-initializers/ -module-name Test
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -I %S/Inputs/inherited-objc-initializers/ -module-name Test
 // RUN: %FileCheck %s < %t.swiftinterface
 
 // REQUIRES: objc_interop
 
 import InheritedObjCInits
 
-// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass : InheritedObjCInits.FrameworkObject {
-public class Subclass: FrameworkObject {
-  // CHECK-NEXT: @objc override dynamic public init(selector: ObjectiveC.Selector)
-  // CHECK-NEXT: @objc override dynamic public init(integer: Swift.Int)
+// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass2 : InheritedObjCInits.HasAvailableInit {
+public class Subclass2: HasAvailableInit {
+  // CHECK-NEXT: @objc override dynamic public init(unavailable: InheritedObjCInits.UnavailableInSwift)
+  // CHECK-NEXT: @objc override dynamic public init()
+  // CHECK-NEXT: @objc deinit
+} // CHECK-NEXT:{{^}$}}
+
+// CHECK: @objc @_inheritsConvenienceInitializers public class Subclass1 : InheritedObjCInits.HasUnavailableInit {
+public class Subclass1: HasUnavailableInit {
+  // CHECK-NOT: InheritedObjCInits.UnavailableInSwift
   // CHECK-NEXT: @objc override dynamic public init()
   // CHECK-NEXT: @objc deinit
 } // CHECK-NEXT:{{^}$}}


### PR DESCRIPTION
Swift generates implicit constructors for inherited designated initializers in case some implicit initialization (such as running property initializer expressions) needs to run after calling the initializer on the superclass. These implicit initializers are printed in .swiftinterfaces and previously they could cause the interface to fail to typecheck when one of the parameters is declared to be unavailable-in-Swift. These initializers need to be generated because they may be called from Objective-C where the unavailable-in-Swift designation is irrelevant. To account for this possibility, relax availability checking to allow this narrow exception only in .swiftinterfaces.

Another possible but more complicated solution would be to print the initializers with an attribute that indicates that the initializer is inherited and implicit. This would allow the typechecking exception to be more precise but seems unnecessarily complicated given that the exception is only needed in .swiftinterfaces, which are already compiler generated.

Resolves rdar://77221357
