### PR TITLE
IRGen: get metadata symbol of class __StaticArrayStorage the correct way

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2046,8 +2046,23 @@ bool IRGenModule::canMakeStaticObjectsReadOnly() {
   if (!Triple.isOSDarwin())
     return false;
 
-  return getAvailabilityContext().isContainedIn(
-          Context.getStaticReadOnlyArraysAvailability());
+  if (!getAvailabilityContext().isContainedIn(Context.getStaticReadOnlyArraysAvailability()))
+    return false;
+
+  if (!getStaticArrayStorageDecl())
+    return false;
+
+  return true;
+}
+
+ClassDecl *IRGenModule::getStaticArrayStorageDecl() {
+  SmallVector<ValueDecl *, 1> results;
+  Context.lookupInSwiftModule("__StaticArrayStorage", results);
+
+  if (results.size() != 1)
+    return nullptr;
+
+  return dyn_cast<ClassDecl>(results[0]);
 }
 
 void IRGenerator::addGenModule(SourceFile *SF, IRGenModule *IGM) {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -927,6 +927,8 @@ public:
   
   bool canMakeStaticObjectsReadOnly();
 
+  ClassDecl *getStaticArrayStorageDecl();
+
   bool canUseObjCSymbolicReferences();
 
   Size getAtomicBoolSize() const { return AtomicBoolSize; }


### PR DESCRIPTION
Fixes an unresolved symbol error when building the stdlib on some platforms.

rdar://119991570
