### PR TITLE
[Parse] Remove unused parameters and return value of lexTrivia function

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -598,12 +598,7 @@ private:
   void lexHexNumber();
   void lexNumber();
 
-  /// Skip over trivia and return characters that were skipped over in a \c
-  /// StringRef. \p AllTriviaStart determines the start of the trivia. In nearly
-  /// all cases, this should be \c CurPtr. If other trivia has already been
-  /// skipped over (like a BOM), this can be used to point to the start of the
-  /// BOM. The returned \c StringRef will always start at \p AllTriviaStart.
-  StringRef lexTrivia(bool IsForTrailingTrivia, const char *AllTriviaStart);
+  void lexTrivia();
   static unsigned lexUnicodeEscape(const char *&CurPtr, Lexer *Diags);
 
   unsigned lexCharacter(const char *&CurPtr, char StopQuote,


### PR DESCRIPTION
It appears that we may not have been consistently tracking leading and trailing trivia in the Lexer since the removal of libSyntax (see #62145).
Consequently, it seems unnecessary to consider leading or trailing trivia in the lexTrivia function. 
To align with this decision, I have modified the lexTrivia function's signature to ensure adherence to the new criteria.



P.S. As I am super new to this project, please feel free to correct me if I have any misunderstandings on this topic.