### PR TITLE
[CSBindings] NFC: Fix a missing return warning in `BindingSet::finalize`

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -753,9 +753,9 @@ bool BindingSet::finalize(
         });
       }
     }
-
-    return true;
   }
+
+  return true;
 }
 
 void BindingSet::addBinding(PotentialBinding binding, bool isTransitive) {


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
