### PR TITLE
[IRGen] Pack metadata may be allocated based on type layouts.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -853,7 +853,7 @@ public:
 
   /// Whether IRGen lowering of this instruction may result in emitting packs of
   /// metadata or witness tables.
-  bool mayRequirePackMetadata() const;
+  bool mayRequirePackMetadata(SILFunction const &F) const;
 
   /// Create a new copy of this instruction, which retains all of the operands
   /// and other information of this one.  If an insertion point is specified,

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -395,6 +395,9 @@ public:
   /// Whether the type contains any flavor of pack.
   bool hasAnyPack() const { return getASTType()->hasAnyPack(); }
 
+  /// Whether the type's layout is known to include some flavor of pack.
+  bool isOrContainsPack(const SILFunction &F) const;
+
   /// True if the type is an empty tuple or an empty struct or a tuple or
   /// struct containing only empty types.
   bool isEmpty(const SILFunction &F) const;

--- a/lib/IRGen/PackMetadataMarkerInserter.cpp
+++ b/lib/IRGen/PackMetadataMarkerInserter.cpp
@@ -94,7 +94,9 @@ Inserter::shouldInsertMarkersForInstruction(SILInstruction *inst) {
     LLVM_FALLTHROUGH;
   }
   default:
-    return inst->mayRequirePackMetadata() ? FindResult::Some : FindResult::None;
+    return inst->mayRequirePackMetadata(*inst->getFunction())
+               ? FindResult::Some
+               : FindResult::None;
   }
 }
 

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -128,6 +128,11 @@ bool SILType::isNonTrivialOrContainsRawPointer(const SILFunction *f) const {
   return result;
 }
 
+bool SILType::isOrContainsPack(const SILFunction &F) const {
+  auto contextType = hasTypeParameter() ? F.mapTypeIntoContext(*this) : *this;
+  return F.getTypeLowering(contextType).isOrContainsPack();
+}
+
 bool SILType::isEmpty(const SILFunction &F) const {
   // Infinite types are never empty.
   if (F.getTypeLowering(*this).getRecursiveProperties().isInfinite()) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6270,7 +6270,7 @@ public:
   }
 
   void checkAllocPackMetadataInst(AllocPackMetadataInst *apmi) {
-    require(apmi->getIntroducer()->mayRequirePackMetadata(),
+    require(apmi->getIntroducer()->mayRequirePackMetadata(*apmi->getFunction()),
             "Introduces instruction of kind which cannot emit on-stack pack "
             "metadata");
     require(F.getModule().getStage() == SILStage::Lowered,

--- a/test/IRGen/pack_metadata_marker_inserter_onone.swift
+++ b/test/IRGen/pack_metadata_marker_inserter_onone.swift
@@ -1,0 +1,103 @@
+// RUN: %target-swift-frontend -Onone -disable-availability-checking -emit-ir -primary-file %s -enable-pack-metadata-stack-promotion=false -enable-pack-metadata-stack-promotion=true -Xllvm -sil-print-after=pack-metadata-marker-inserter 2>&1 | %FileCheck %s --check-prefixes CHECK-SIL
+// RUN: %target-swift-frontend -Onone -disable-availability-checking -emit-ir -primary-file %s -enable-pack-metadata-stack-promotion=false -enable-pack-metadata-stack-promotion=true | %IRGenFileCheck %s --check-prefixes CHECK-LLVM
+
+public struct G<each T> {
+  var pack: (repeat each T)
+}
+
+public struct S<T> {
+  let g: G<T>
+}
+
+// CHECK-SIL-LABEL: sil @consumeS : {{.*}} {
+// CHECK-SIL:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK-SIL:         alloc_pack_metadata
+// CHECK-SIL:         [[METADATA:%[^,]+]] = alloc_pack_metadata
+// CHECK-SIL:         destroy_addr [[INSTANCE]]
+// CHECK-SIL:         dealloc_pack_metadata [[METADATA]]
+// CHECK-SIL-LABEL: } // end sil function 'consumeS'
+// CHECK-LLVM-LABEL: define{{.*}} swiftcc void @consumeS(
+// CHECK-LLVM-SAME:      ptr noalias [[INSTANCE:%[^,]+]], 
+// CHECK-LLVM-SAME:      ptr [[T_METADATA:%[^)]+]]
+// CHECK-LLVM-SAME:  ) {{.*}} {
+// CHECK-LLVM:         [[G_METADATA_PACK:%[^,]+]] = alloca [1 x ptr]
+// CHECK-LLVM:         call void @llvm.lifetime.start.p0(
+// CHECK-LLVM-SAME:        ptr [[G_METADATA_PACK]])
+// CHECK-LLVM:         [[G_METADATA_PACK_T_SLOT:%[^,]+]] = getelementptr inbounds [1 x ptr], ptr [[G_METADATA_PACK]]
+// CHECK-LLVM:         store ptr [[T_METADATA]], ptr [[G_METADATA_PACK_T_SLOT]]
+// CHECK-LLVM:         [[G_METADATA_RESPONSE:%[^,]+]] = call swiftcc %swift.metadata_response @"$s35pack_metadata_marker_inserter_onone1GVMa"(
+// CHECK-LLVM-SAME:        ptr [[G_METADATA_PACK]])
+// CHECK-LLVM:         [[G_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[G_METADATA_RESPONSE]]
+// CHECK-LLVM:         [[S_METADATA_RESPONSE:%[^,]+]] = call swiftcc %swift.metadata_response @"$s35pack_metadata_marker_inserter_onone1SVMa"(
+// CHECK-LLVM-SAME:        ptr [[T_METADATA]])
+// CHECK-LLVM:         [[S_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[S_METADATA_RESPONSE]]
+//                     The metadata for G<T> is passed to the outlined destroy for S.
+// CHECK-LLVM:         @"$s35pack_metadata_marker_inserter_onone1SVyxGlWOh"(ptr [[INSTANCE]], ptr [[T_METADATA]], ptr [[G_METADATA]], ptr [[S_METADATA]])
+// CHECK-LLVM:         call void @llvm.lifetime.end.p0(
+// CHECK-LLVM-SAME:        ptr [[G_METADATA_PACK]])
+// CHECK-LLVM:       }
+@_silgen_name("consumeS")
+public func consumeS<T>(_: consuming S<T>) {}
+
+public func callConsumeS<T>(_ s: consuming S<T>) {
+  consumeS(s)
+}
+
+@_silgen_name("consume2S")
+public func consume2S<T>(_: consuming S<T>, _: consuming S<T>) {}
+
+// CHECK-SIL-LABEL: sil @callConsume2S : {{.*}} {
+// CHECK-SIL:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK-SIL:         alloc_pack_metadata
+// CHECK-SIL:         [[COPY2:%[^,]+]] = alloc_stack
+// CHECK-SIL:         alloc_pack_metadata
+// CHECK-SIL:         [[COPY1:%[^,]+]] = alloc_stack
+// CHECK-SIL:         alloc_pack_metadata
+// CHECK-SIL:         [[COPY_ADDR_1_METADATA:%[^,]+]] = alloc_pack_metadata
+// CHECK-SIL:         copy_addr [[INSTANCE]] to [init] [[COPY1]]
+// CHECK-SIL:         [[COPY_ADDR_2_METADATA:%[^,]+]] = alloc_pack_metadata
+// CHECK-SIL:         copy_addr [[INSTANCE]] to [init] [[COPY2]]
+// CHECK-SIL:         [[CONSUME_2_S:%[^,]+]] = function_ref @consume2S
+// CHECK-SIL:         apply [[CONSUME_2_S]]<T>([[COPY1]], [[COPY2]])
+// CHECK-SIL:         dealloc_pack_metadata [[COPY_ADDR_2_METADATA]]
+// CHECK-SIL:         dealloc_pack_metadata [[COPY_ADDR_1_METADATA]]
+// CHECK-SIL-LABEL: } // end sil function 'callConsume2S'
+// CHECK-LLVM-LABEL: define{{.*}} swiftcc void @callConsume2S(
+// CHECK-LLVM-SAME:      ptr noalias [[INSTANCE:%[^,]+]], 
+// CHECK-LLVM-SAME:      ptr [[T_METADATA:%[^)]+]]
+// CHECK-LLVM-SAME:  ) {{.*}} {
+// CHECK-LLVM:         [[G_METADATA_PACK:%[^,]+]] = alloca [1 x ptr]
+// CHECK-LLVM:         [[S_METADATA_RESPONSE:%[^,]+]] = call swiftcc %swift.metadata_response @"$s35pack_metadata_marker_inserter_onone1SVMa"(
+// CHECK-LLVM-SAME:        ptr [[T_METADATA]])
+// CHECK-LLVM:         [[S_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[S_METADATA_RESPONSE]]
+// CHECK-LLVM:         [[S_VWT_ADDR:%[^,]+]] = getelementptr inbounds ptr, ptr [[S_METADATA]], [[INT]] -1
+// CHECK-LLVM:         [[S_VWT:%[^,]+]] = load ptr, ptr [[S_VWT_ADDR]]
+// CHECK-LLVM:         [[S_SIZE_ADDR:%[^,]+]] = getelementptr inbounds %swift.vwtable, ptr [[S_VWT]]
+// CHECK-LLVM:         [[S_SIZE:%[^,]+]] = load [[INT]], ptr [[S_SIZE_ADDR]]
+// CHECK-LLVM:         [[COPY_1_ADDR:%[^,]+]] = alloca i8, [[INT]] [[S_SIZE]]
+// CHECK-LLVM:         call void @llvm.lifetime.start.p0(
+// CHECK-LLVM-SAME:        ptr [[COPY_1_ADDR]])
+// CHECK-LLVM:         [[COPY_2_ADDR:%[^,]+]] = alloca i8, [[INT]] [[S_SIZE]]
+// CHECK-LLVM:         call void @llvm.lifetime.start.p0(
+// CHECK-LLVM-SAME:        ptr [[COPY_2_ADDR]])
+// CHECK-LLVM:         call void @llvm.lifetime.start.p0(
+// CHECK-LLVM-SAME:        ptr [[G_METADATA_PACK]])
+// CHECK-LLVM:         [[G_METADATA_PACK_T_SLOT:%[^,]+]] = getelementptr inbounds [1 x ptr], ptr [[G_METADATA_PACK]]
+// CHECK-LLVM:         store ptr [[T_METADATA]], ptr [[G_METADATA_PACK_T_SLOT]]
+// CHECK-LLVM:         [[G_METADATA_RESPONSE:%[^,]+]] = call swiftcc %swift.metadata_response @"$s35pack_metadata_marker_inserter_onone1GVMa"(
+// CHECK-LLVM-SAME:        ptr [[G_METADATA_PACK]])
+// CHECK-LLVM:         [[G_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[G_METADATA_RESPONSE]], 0
+// CHECK-LLVM:         call ptr @"$s35pack_metadata_marker_inserter_onone1SVyxGlWOc"(ptr [[INSTANCE]], ptr [[COPY_2_ADDR]], ptr [[T_METADATA]], ptr [[G_METADATA]], ptr [[S_METADATA]])
+// CHECK-LLVM:         call ptr @"$s35pack_metadata_marker_inserter_onone1SVyxGlWOc"(ptr [[INSTANCE]], ptr [[COPY_1_ADDR]], ptr [[T_METADATA]], ptr [[G_METADATA]], ptr [[S_METADATA]])
+// CHECK-LLVM:         call swiftcc void @consume2S(ptr noalias [[COPY_2_ADDR]], ptr noalias [[COPY_1_ADDR]], ptr [[T_METADATA]])
+// CHECK-LLVM:         call void @llvm.lifetime.end.p0(
+// CHECK-LLVM-SAME:        ptr [[G_METADATA_PACK]])
+// CHECK-LLVM:         call void @llvm.lifetime.end.p0(
+// CHECK-LLVM-SAME:        ptr [[COPY_2_ADDR]])
+// CHECK-LLVM:         call void @llvm.lifetime.end.p0(
+// CHECK-LLVM-SAME:        ptr [[COPY_1_ADDR]])
+// CHECK-LLVM-LABEL: }
+@_silgen_name("callConsume2S")
+public func callConsume2S<T>(_ s: S<T>) {
+  consume2S(s, s)
+}

--- a/test/SIL/type_lowering_unit.sil
+++ b/test/SIL/type_lowering_unit.sil
@@ -16,3 +16,81 @@ bb0(%0 : @owned $S):
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin {{.*}} print-type-lowering with: @argument[0]
+// CHECK:       isOrContainsPack: true
+// CHECK-LABEL: end {{.*}} print-type-lowering with: @argument[0]
+sil @pack_argument : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat each T}) -> () {
+bb0(%0 : $*Pack{repeat each T}):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+public struct VG<each T> {
+  var value: (repeat each T)
+}
+
+public struct VGS<T> {
+  let g: VG<T>
+}
+
+public enum VGE<T> {
+  case one(VG<T>)
+  case two(VG<T, T>, VG<T>)
+  case three(VG<T, T, T>)
+}
+
+// CHECK-LABEL: begin {{.*}} pack_field: print-type-lowering with: %instance
+// CHECK:       isOrContainsPack: true
+// CHECK-LABEL: end {{.*}} pack_field: print-type-lowering with: %instance
+sil @pack_field : $@convention(thin) <T> (@in_guaranteed VGS<T>) -> () {
+entry(%instance : $*VGS<T>):
+  specify_test "print-type-lowering %instance"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin {{.*}} pack_element: print-type-lowering with: %instance
+// CHECK:       isOrContainsPack: true
+// CHECK-LABEL: end {{.*}} pack_element: print-type-lowering with: %instance
+sil @pack_element : $@convention(thin) <T> (@in_guaranteed VGE<T>) -> () {
+entry(%instance : $*VGE<T>):
+  specify_test "print-type-lowering %instance"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+public struct G<T> {
+  var value: (T, T)
+}
+
+public struct GS<T> {
+  let g: G<T>
+}
+
+public enum GE<T> {
+  case one(G<T>)
+  case two(G<T>, G<T>)
+  case three(G<T>)
+}
+
+// CHECK-LABEL: begin {{.*}} nonpack_field: print-type-lowering with: %instance
+// CHECK:       isOrContainsPack: false
+// CHECK-LABEL: end {{.*}} nonpack_field: print-type-lowering with: %instance
+sil @nonpack_field : $@convention(thin) <T> (@in_guaranteed GS<T>) -> () {
+entry(%instance : $*GS<T>):
+  specify_test "print-type-lowering %instance"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin {{.*}} nonpack_element: print-type-lowering with: %instance
+// CHECK:       isOrContainsPack: false
+// CHECK-LABEL: end {{.*}} nonpack_element: print-type-lowering with: %instance
+sil @nonpack_element : $@convention(thin) <T> (@in_guaranteed GE<T>) -> () {
+entry(%instance : $*GE<T>):
+  specify_test "print-type-lowering %instance"
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Previously, `mayRequirePackMetadata` only considered whether a type involved a pack.  That failed to account for the case of outlined value functions that require pack metadata when the type involves a pack in its layout.  Here, `mayRequirePackMetadata` now considers also whether the layout corresponding to a type involves a pack.

rdar://119829826
