### PR TITLE
[Caching] Don't parse LLVMArgs in cache replay instance

### DIFF
--- a/test/CAS/swift-scan-test-llvm-args.swift
+++ b/test/CAS/swift-scan-test-llvm-args.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
+// RUN:   -allow-unstable-cache-key-for-testing -Xllvm -aarch64-use-tbi > %t/key.casid
+
+// RUN: not %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=CHECK-QUERY-NOT-FOUND
+
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing -Xllvm -aarch64-use-tbi
+
+// RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
+
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -threads 10 -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
+// RUN:   -allow-unstable-cache-key-for-testing -Xllvm -aarch64-use-tbi
+
+// CHECK-QUERY-NOT-FOUND: cached output not found
+// CHECK-QUERY: Cached Compilation for key "llvmcas://{{.*}}" has 4 outputs:
+// CHECK-QUERY-NEXT: object: llvmcas://
+// CHECK-QUERY-NEXT: dependencies: llvmcas://
+// CHECK-QUERY-NEXT: swiftmodule: llvmcas://
+// CHECK-QUERY-NEXT: cached-diagnostics: llvmcas://
+
+func testFunc() {}

--- a/tools/libSwiftScan/SwiftCaching.cpp
+++ b/tools/libSwiftScan/SwiftCaching.cpp
@@ -778,6 +778,12 @@ swiftscan_cache_replay_instance_create(int argc, const char **argv,
     return nullptr;
   }
 
+  // Clear the LLVMArgs as `llvm::cl::ParseCommandLineOptions` is not
+  // thread-safe to be called in libSwiftScan. The replay instance should not be
+  // used to do compilation so clearing `-Xllvm` should not affect replay
+  // result.
+  Instance->Invocation.getFrontendOptions().LLVMArgs.clear();
+
   return wrap(Instance);
 }
 


### PR DESCRIPTION
`llvm::cl::ParseCommandLineOptions()` is not thread-safe to be called from libSwiftScan so replaying multiple commands in parallel can crash the build system. Since the replay instance is not used for compilation and only need information from command-line arguments to create outputs and diagnostics, ignore LLVMArgs when replaying.

rdar://120423882
