### PR TITLE
Un-deprecate _StringGuts._isContiguousASCII

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -402,7 +402,6 @@ extension _StringGuts {
 
 // Old SPI(corelibs-foundation)
 extension _StringGuts {
-  @available(*, deprecated)
   public // SPI(corelibs-foundation)
   var _isContiguousASCII: Bool {
     return !isSmall && isFastUTF8 && isASCII


### PR DESCRIPTION
This property is used as an implementation detail from within swift-corelibs-foundation and the new swift-foundation repo. Since it is deprecated, it produces numerous warnings when building these projects despite this being a valid use case within Foundation. Rather than avoid performance improvements to "silence" the warning (by not using this property) or dealing with large amounts of warnings, we should just un-deprecate this property since it is already underscored indicating it is not for stable/public use. We can still find a better public API for this in the future that we can migrate Foundation to when it is ready.