### PR TITLE
[Debug] Accept _debugDescription in DebugDescriptionMacro

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
@@ -47,7 +47,7 @@ extension DebugDescriptionMacro: MemberAttributeMacro {
       return []
     }
 
-    guard propertyName == "debugDescription" || propertyName == "description" else {
+    guard DESCRIPTION_PROPERTIES.contains(propertyName) else {
       return []
     }
 
@@ -72,8 +72,8 @@ extension DebugDescriptionMacro: MemberAttributeMacro {
       }
     }
 
-    // `debugDescription` takes priority: skip `description` if `debugDescription` also exists.
-    if propertyName == "description" && properties["debugDescription"] != nil {
+    // Skip if this description property is not prioritized.
+    guard propertyName == designatedProperty(properties) else {
       return []
     }
 
@@ -237,6 +237,23 @@ extension _DebugDescriptionPropertyMacro: PeerMacro {
 
     return [decl]
   }
+}
+
+/// The names of properties that can be converted to LLDB type summaries, in priority order.
+fileprivate let DESCRIPTION_PROPERTIES = [
+  "_debugDescription",
+  "debugDescription",
+  "description",
+]
+
+/// Identifies the prioritized description property, of available properties.
+fileprivate func designatedProperty(_ properties: [String: PatternBindingSyntax]) -> String? {
+  for name in DESCRIPTION_PROPERTIES {
+    if properties[name] != nil {
+      return name
+    }
+  }
+  return nil
 }
 
 // MARK: - Encoding

--- a/test/Macros/DebugDescription/supported_description.swift
+++ b/test/Macros/DebugDescription/supported_description.swift
@@ -17,12 +17,24 @@ struct MyStruct1: CustomStringConvertible {
 
 @_DebugDescription
 struct MyStruct2: CustomDebugStringConvertible {
-  var debugDescription: String { "thirty" }
+  var description: String { "thirty" }
+  var debugDescription: String { "eleven" }
 }
 // CHECK: static let _lldb_summary = (
 // CHECK:     /* version */ 1 as UInt8,
 // CHECK:     /* record size */ 24 as UInt8,
 // CHECK:     /* "main.MyStruct2" */ 15 as UInt8, 109 as UInt8, 97 as UInt8, 105 as UInt8, 110 as UInt8, 46 as UInt8, 77 as UInt8, 121 as UInt8, 83 as UInt8, 116 as UInt8, 114 as UInt8, 117 as UInt8, 99 as UInt8, 116 as UInt8, 50 as UInt8, 0 as UInt8,
-// CHECK:     /* "thirty" */ 7 as UInt8, 116 as UInt8, 104 as UInt8, 105 as UInt8, 114 as UInt8, 116 as UInt8, 121 as UInt8, 0 as UInt8
+// CHECK:     /* "eleven" */ 7 as UInt8, 101 as UInt8, 108 as UInt8, 101 as UInt8, 118 as UInt8, 101 as UInt8, 110 as UInt8, 0 as UInt8
 // CHECK: )
 
+@_DebugDescription
+struct MyStruct3: CustomDebugStringConvertible {
+  var description: String { "thirty" }
+  var debugDescription: String { "eleven" }
+  var _debugDescription: String { "two" }
+}
+// CHECK: static let _lldb_summary = (
+// CHECK:     /* version */ 1 as UInt8,
+// CHECK:     /* record size */ 21 as UInt8,
+// CHECK:     /* "main.MyStruct3" */ 15 as UInt8, 109 as UInt8, 97 as UInt8, 105 as UInt8, 110 as UInt8, 46 as UInt8, 77 as UInt8, 121 as UInt8, 83 as UInt8, 116 as UInt8, 114 as UInt8, 117 as UInt8, 99 as UInt8, 116 as UInt8, 51 as UInt8, 0 as UInt8,
+// CHECK:     /* "two" */ 4 as UInt8, 116 as UInt8, 119 as UInt8, 111 as UInt8, 0 as UInt8


### PR DESCRIPTION
Some data types cannot modify their `description` or `debugDescription` properties, as modification to those properties could result in breakage to their users. To support these conditions, `DebugDescriptionMacro` should support and prioritize an independent property (one that that is not being reused).

This change adds support for `_debugDescription`. The macro will now prioritize the description properties in this order:

1. `_debugDescription`
2. `debugDescription`
3. `debugDescription`

rdar://120498021