### PR TITLE
Sema: Error for potentially unavailable conformances in Swift 6

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6714,10 +6714,6 @@ ERROR(conformance_availability_only_version_newer, none,
       "conformance of %0 to %1 is only available in %2 %3 or newer",
       (Type, Type, StringRef, llvm::VersionTuple))
 
-WARNING(conformance_availability_only_version_newer_warn, none,
-        "conformance of %0 to %1 is only available in %2 %3 or newer",
-        (Type, Type, StringRef, llvm::VersionTuple))
-
 //------------------------------------------------------------------------------
 // MARK: @discardableResult
 //------------------------------------------------------------------------------

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -204,9 +204,6 @@ namespace swift {
     /// declarations introduced at the deployment target.
     bool WeakLinkAtTarget = false;
 
-    /// Should conformance availability violations be diagnosed as errors?
-    bool EnableConformanceAvailabilityErrors = false;
-
     /// Should the editor placeholder error be downgraded to a warning?
     bool WarnOnEditorPlaceholder = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -664,14 +664,6 @@ def disable_availability_checking : Flag<["-"],
   "disable-availability-checking">,
   HelpText<"Disable checking for potentially unavailable APIs">;
 
-def enable_conformance_availability_errors : Flag<["-"],
-  "enable-conformance-availability-errors">,
-  HelpText<"Diagnose conformance availability violations as errors">;
-
-def disable_conformance_availability_errors : Flag<["-"],
-  "disable-conformance-availability-errors">,
-  HelpText<"Diagnose conformance availability violations as warnings">;
-
 def warn_on_potentially_unavailable_enum_case : Flag<["-"],
   "warn-on-potentially-unavailable-enum-case">,
   HelpText<"Deprecated, will be removed in future versions">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -677,12 +677,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.WeakLinkAtTarget |= Args.hasArg(OPT_weak_link_at_target);
 
-  if (auto A = Args.getLastArg(OPT_enable_conformance_availability_errors,
-                               OPT_disable_conformance_availability_errors)) {
-    Opts.EnableConformanceAvailabilityErrors
-      = A->getOption().matches(OPT_enable_conformance_availability_errors);
-  }
-
   Opts.WarnOnEditorPlaceholder |= Args.hasArg(OPT_warn_on_editor_placeholder);
 
   if (auto A = Args.getLastArg(OPT_disable_typo_correction,

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -347,7 +347,7 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
                                               const RootProtocolConformance *rootConf,
                                               const ExtensionDecl *ext,
                                               const ExportContext &where,
-                                              bool useConformanceAvailabilityErrorsOption) {
+                                              bool warnIfConformanceUnavailablePreSwift6) {
   if (!where.mustOnlyReferenceExportedDecls())
     return false;
 
@@ -390,8 +390,7 @@ TypeChecker::diagnoseConformanceExportability(SourceLoc loc,
                      static_cast<unsigned>(*reason),
                      M->getName(),
                      static_cast<unsigned>(originKind))
-      .warnUntilSwiftVersionIf((useConformanceAvailabilityErrorsOption &&
-                                !ctx.LangOpts.EnableConformanceAvailabilityErrors &&
+      .warnUntilSwiftVersionIf((warnIfConformanceUnavailablePreSwift6 &&
                                 originKind != DisallowedOriginKind::SPIOnly &&
                                 originKind != DisallowedOriginKind::NonPublicImport) ||
                                originKind == DisallowedOriginKind::MissingImport,

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -227,7 +227,7 @@ diagnoseConformanceAvailability(SourceLoc loc,
                                 const ExportContext &context,
                                 Type depTy=Type(),
                                 Type replacementTy=Type(),
-                                bool useConformanceAvailabilityErrorsOption = false);
+                                bool warnIfConformanceUnavailablePreSwift6 = false);
 
 bool diagnoseSubstitutionMapAvailability(
     SourceLoc loc,
@@ -235,7 +235,7 @@ bool diagnoseSubstitutionMapAvailability(
     const ExportContext &context,
     Type depTy = Type(),
     Type replacementTy = Type(),
-    bool useConformanceAvailabilityErrorsOption = false,
+    bool warnIfConformanceUnavailablePreSwift6 = false,
     bool suppressParameterizationCheckForOptional = false);
 
 /// Diagnose uses of unavailable declarations. Returns true if a diagnostic
@@ -273,7 +273,7 @@ bool diagnoseExplicitUnavailability(
     const RootProtocolConformance *rootConf,
     const ExtensionDecl *ext,
     const ExportContext &where,
-    bool useConformanceAvailabilityErrorsOption = false);
+    bool warnIfConformanceUnavailablePreSwift6 = false);
 
 /// Diagnose uses of the runtime features of parameterized protools. Returns
 /// \c true if a diagnostic was emitted.

--- a/test/Sema/conformance_availability.swift
+++ b/test/Sema/conformance_availability.swift
@@ -1,6 +1,8 @@
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-conformance-availability-errors
+// RUN: %target-typecheck-verify-swift -swift-version 6
 
 // REQUIRES: OS=macosx
+// REQUIRES: asserts
 
 public protocol Horse {}
 func takesHorse<T : Horse>(_: T) {}

--- a/test/Sema/conformance_availability.swift
+++ b/test/Sema/conformance_availability.swift
@@ -1,4 +1,3 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-conformance-availability-errors
 // RUN: %target-typecheck-verify-swift -swift-version 6
 
 // REQUIRES: OS=macosx
@@ -247,9 +246,9 @@ public struct HasAvailableConformance1 {}
 extension HasAvailableConformance1 : Horse {}
 
 // These availability violations are errors because this test passes the
-// -enable-conformance-availability-errors flag. See the other test case
-// in test/Sema/conformance_availability_warn.swift for the same example
-// but without this flag.
+// -swift-version 6.
+// See the other test case in test/Sema/conformance_availability_warn.swift for
+// the same example for -swift-version 5.
 
 func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 6{{add @available attribute to enclosing global function}}
   takesHorse(x) // expected-error {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}

--- a/test/Sema/conformance_availability_warn.swift
+++ b/test/Sema/conformance_availability_warn.swift
@@ -19,10 +19,10 @@ public struct HasAvailableConformance1 {}
 @available(macOS 100, *)
 extension HasAvailableConformance1 : Horse {}
 
-// These availability violations are warnings because this test does not
-// pass the -enable-conformance-availability-errors flag. See the other
-// test case in test/Sema/conformance_availability.swift for the same
-// example but with this flag.
+// These availability violations are warnings because this test does not pass
+// -swift-version 6.
+// See the other test case in test/Sema/conformance_availability.swift for the
+// same example but with -swift-version 6.
 
 func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 6{{add @available attribute to enclosing global function}}
   takesHorse(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
@@ -60,9 +60,9 @@ public struct HasAvailableConformance2 {}
 extension HasAvailableConformance2 : Horse {} // expected-note 6 {{conformance of 'HasAvailableConformance2' to 'Horse' has been explicitly marked unavailable here}}
 
 // Some availability diagnostics become warnings in Swift 5 mode without
-// -enable-conformance-availability-errors because they were incorrectly
-// accepted before and rejecting them would break source compatibility. Others
-// are unaffected because they have always been rejected.
+// because they were incorrectly accepted before and rejecting them would break
+// source compatibility. Others are unaffected because they have always been
+// rejected.
 
 func passAvailableConformance2(x: HasAvailableConformance2) {
   takesHorse(x) // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}

--- a/test/Sema/conformance_availability_warn.swift
+++ b/test/Sema/conformance_availability_warn.swift
@@ -25,22 +25,22 @@ extension HasAvailableConformance1 : Horse {}
 // example but with this flag.
 
 func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 6{{add @available attribute to enclosing global function}}
-  takesHorse(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  takesHorse(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
   // expected-note@-1 {{add 'if #available' version check}}
 
-  takesHorseExistential(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  takesHorseExistential(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
   // expected-note@-1 {{add 'if #available' version check}}
   
-  x.giddyUp() // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  x.giddyUp() // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
   // expected-note@-1 {{add 'if #available' version check}}
   
-  _ = x.isGalloping // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  _ = x.isGalloping // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
   // expected-note@-1 {{add 'if #available' version check}}
   
-  _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
   // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = UsesHorse<HasAvailableConformance1>.self // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer}}
+  _ = UsesHorse<HasAvailableConformance1>.self // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
   // expected-note@-1 {{add 'if #available' version check}}
 }
 


### PR DESCRIPTION
Diagnostics about use of potentially unavailable conformances had to be downgraded to warnings in Swift 5 in order to preserve source compatibility. These diagnostics should be errors by default in Swift 6.

Now that the diagnostics are automatically errors in Swift 6, we don't need an `-enable-conformance-availability-errors` flag to control whether unavailable conformances are diagnosed as errors. Nobody was using the flag so it should be safe to remove.

Resolves rdar://88210812
