### PR TITLE
Make @_cdecl @implementation support __asm__

### DIFF
--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -1041,11 +1041,42 @@ bool SILDeclRef::isBackDeploymentThunk() const {
 }
 
 /// Use the Clang importer to mangle a Clang declaration.
-static void mangleClangDecl(raw_ostream &buffer,
-                            const clang::NamedDecl *clangDecl,
-                            ASTContext &ctx) {
+static void mangleClangDeclViaImporter(raw_ostream &buffer,
+                                       const clang::NamedDecl *clangDecl,
+                                       ASTContext &ctx) {
   auto *importer = static_cast<ClangImporter *>(ctx.getClangModuleLoader());
   importer->getMangledName(buffer, clangDecl);
+}
+
+static std::string mangleClangDecl(Decl *decl, bool isForeign) {
+  auto clangDecl = decl->getClangDecl();
+
+  if (auto namedClangDecl = dyn_cast<clang::DeclaratorDecl>(clangDecl)) {
+    if (auto asmLabel = namedClangDecl->getAttr<clang::AsmLabelAttr>()) {
+      std::string s(1, '\01');
+      s += asmLabel->getLabel();
+      return s;
+    } else if (namedClangDecl->hasAttr<clang::OverloadableAttr>() ||
+               decl->getASTContext().LangOpts.EnableCXXInterop) {
+      std::string storage;
+      llvm::raw_string_ostream SS(storage);
+      mangleClangDeclViaImporter(SS, namedClangDecl, decl->getASTContext());
+      return SS.str();
+    }
+    return namedClangDecl->getName().str();
+  } else if (auto objcDecl = dyn_cast<clang::ObjCMethodDecl>(clangDecl)) {
+    if (objcDecl->isDirectMethod() && isForeign) {
+      std::string storage;
+      llvm::raw_string_ostream SS(storage);
+      clang::ASTContext &ctx = clangDecl->getASTContext();
+      std::unique_ptr<clang::MangleContext> mangler(ctx.createMangleContext());
+      mangler->mangleObjCMethodName(objcDecl, SS, /*includePrefixByte=*/true,
+                                    /*includeCategoryNamespace=*/false);
+      return SS.str();
+    }
+  }
+
+  return "";
 }
 
 std::string SILDeclRef::mangle(ManglingKind MKind) const {
@@ -1073,32 +1104,11 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
   // As a special case, Clang functions and globals don't get mangled at all
   // - except \c objc_direct decls.
   if (hasDecl()) {
-    if (auto clangDecl = getDecl()->getClangDecl()) {
+    if (getDecl()->getClangDecl()) {
       if (!isForeignToNativeThunk() && !isNativeToForeignThunk()) {
-        if (auto namedClangDecl = dyn_cast<clang::DeclaratorDecl>(clangDecl)) {
-          if (auto asmLabel = namedClangDecl->getAttr<clang::AsmLabelAttr>()) {
-            std::string s(1, '\01');
-            s += asmLabel->getLabel();
-            return s;
-          } else if (namedClangDecl->hasAttr<clang::OverloadableAttr>() ||
-                     getDecl()->getASTContext().LangOpts.EnableCXXInterop) {
-            std::string storage;
-            llvm::raw_string_ostream SS(storage);
-            mangleClangDecl(SS, namedClangDecl, getDecl()->getASTContext());
-            return SS.str();
-          }
-          return namedClangDecl->getName().str();
-        } else if (auto objcDecl = dyn_cast<clang::ObjCMethodDecl>(clangDecl)) {
-          if (objcDecl->isDirectMethod() && isForeign) {
-            std::string storage;
-            llvm::raw_string_ostream SS(storage);
-            clang::ASTContext &ctx = clangDecl->getASTContext();
-            std::unique_ptr<clang::MangleContext> mangler(ctx.createMangleContext());
-            mangler->mangleObjCMethodName(objcDecl, SS, /*includePrefixByte=*/true,
-                                          /*includeCategoryNamespace=*/false);
-            return SS.str();
-          }
-        }
+        auto clangMangling = mangleClangDecl(getDecl(), isForeign);
+        if (!clangMangling.empty())
+          return clangMangling;
       }
     }
   }
@@ -1156,6 +1166,13 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
     // Use a given cdecl name for native-to-foreign thunks.
     if (auto CDeclA = getDecl()->getAttrs().getAttribute<CDeclAttr>())
       if (isNativeToForeignThunk()) {
+        // If this is an @implementation @_cdecl, mangle it like the clang
+        // function it implements.
+        if (auto objcInterface = getDecl()->getImplementedObjCDecl()) {
+          auto clangMangling = mangleClangDecl(objcInterface, isForeign);
+          if (!clangMangling.empty())
+            return clangMangling;
+        }
         return CDeclA->Name.str();
       }
 

--- a/test/IRGen/Inputs/objc_implementation.h
+++ b/test/IRGen/Inputs/objc_implementation.h
@@ -25,6 +25,7 @@
 @end
 
 extern void implFunc(int param);
+extern void implFuncCName(int param) __asm__("_implFuncAsmName");
 
 
 @interface NoImplClass

--- a/test/IRGen/objc_implementation.m
+++ b/test/IRGen/objc_implementation.m
@@ -28,3 +28,10 @@ int printf(const char * restrict format, ...);
 
 @end
 
+void implFunc(int param) {
+  printf("implFunc");
+}
+
+void implFuncCName(int param) {
+  printf("implFuncCName");
+}

--- a/test/IRGen/objc_implementation.swift
+++ b/test/IRGen/objc_implementation.swift
@@ -142,10 +142,14 @@ open class SwiftSubclass: ImplClass {
 @_objcImplementation @_cdecl("implFunc")
 public func implFunc(_ param: Int32) {}
 
+@_objcImplementation @_cdecl("implFuncCName")
+public func implFuncCName(_ param: Int32) {}
+
 public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
   impl.mainMethod(0)
   swiftSub.mainMethod(1)
   implFunc(2)
+  implFuncCName(3)
 }
 
 // Swift calling convention -[ImplClass init]
@@ -247,6 +251,11 @@ public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
 // CHECK-LABEL: define void @implFunc
 // FIXME: We'd like this to be internal or hidden, not public.
 // CHECK: define swiftcc void @"$s19objc_implementation8implFuncyys5Int32VF"
+
+// inplFuncCName(_:)
+// CHECK-LABEL: define void @"\01_implFuncAsmName"
+// FIXME: We'd like this to be internal or hidden, not public.
+// CHECK: define swiftcc void @"$s19objc_implementation13implFuncCNameyys5Int32VF"
 
 // fn(impl:swiftSub:)
 // CHECK-LABEL: define swiftcc void @"$s19objc_implementation2fn4impl8swiftSubySo9ImplClassC_AA13SwiftSubclassCtF"


### PR DESCRIPTION
When `@_objcImplementation` is used to implement a C function marked with `__asm__`, take the attribute into account when mangling SIL references.

In theory this change should also make `clang::OverloadableAttr` functions mangle correctly, but in practice the matching logic for `@_cdecl @_objcImplementation` doesn’t currently support overloadable functions (and it’s not wise to try anyway, since clang doesn’t promise that their ABI won’t change).

Fixes rdar://120503717.