### PR TITLE
Diagnose a conflicting silgen_name/extern(c) name instead of asserting/crashing

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -121,6 +121,11 @@ ERROR(unsupported_variadic_function_abstraction,none,
       "convention; try wrapping it in a struct",
       (Type))
 
+ERROR(function_type_mismatch,none,
+      "function type mismatch, declared as %0 but used as %1", (Type, Type))
+NOTE(function_declared_here,none,
+     "function declared here", ())
+
 // Capture before declaration diagnostics.
 ERROR(capture_before_declaration,none,
       "closure captures %0 before it is declared", (Identifier))

--- a/test/SILGen/silgen_name_conflict.swift
+++ b/test/SILGen/silgen_name_conflict.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen %s -enable-experimental-feature Extern -verify
+
+@_silgen_name("my_extern_func")
+func my_extern_func1() // expected-note {{function declared here}}
+
+@_silgen_name("my_extern_func")
+func my_extern_func2(x: Int)
+
+@_extern(c, "my_other_extern_func")
+func my_other_extern_func1() // expected-note {{function declared here}}
+
+@_extern(c, "my_other_extern_func")
+func my_other_extern_func2(x: Int)
+
+public func foo() {
+    my_extern_func1()
+    my_extern_func2(x: 42) // expected-error {{function type mismatch, declared as '@convention(thin) () -> ()' but used as '@convention(thin) (Int) -> ()'}}
+
+    my_other_extern_func1()
+    my_other_extern_func2(x: 42) // expected-error {{function type mismatch, declared as '@convention(c) () -> ()' but used as '@convention(c) (Int) -> ()'}}
+}


### PR DESCRIPTION
Today, if we have a multiple conflicting forward-declarations using the name `@_extern(c)` or `@_silgen_name` name, the compiler asserts (in asserts-on builds) or crashes in SIL verifier. Let's turn the assert into a diagnostic instead.