### PR TITLE
Enable availability attributes for associated types

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -108,7 +108,7 @@ DECL_ATTR(_silgen_name, SILGenName,
   OnAbstractFunction | OnVar | LongAttribute | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   0)
 DECL_ATTR(available, Available,
-  OnAbstractFunction | OnGenericType | OnVar | OnSubscript | OnEnumElement | OnMacro | OnExtension | AllowMultipleAttributes | LongAttribute | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
+  OnAbstractFunction | OnAssociatedType | OnGenericType | OnVar | OnSubscript | OnEnumElement | OnMacro | OnExtension | AllowMultipleAttributes | LongAttribute | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   1)
 DECL_ATTR(objc, ObjC,
   OnAbstractFunction | OnClass | OnProtocol | OnExtension | OnVar | OnSubscript | OnEnum | OnEnumElement | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2851,7 +2851,6 @@ WARNING(assoc_type_default_conformance_failed,none,
 NOTE(assoc_type_default_here,none,
      "associated type %0 has default type %1 written here",
      (const AssociatedTypeDecl *, Type))
-
 ERROR(protocol_access,none,
       "%select{protocol must be declared %select{"
       "%select{private|fileprivate|internal|package|%error|%error}1"
@@ -6840,6 +6839,10 @@ ERROR(inlinable_decl_not_public,
 
 ERROR(inlinable_resilient_deinit,
       none, "deinitializer can only be '@inlinable' if the class is '@_fixed_layout'", ())
+
+ERROR(resilient_associated_type_less_available_requires_default,none,
+      "associated type %0 that is less available than its protocol must have a "
+      "default", (const AssociatedTypeDecl *))
 
 //------------------------------------------------------------------------------
 // MARK: @_specialize diagnostics

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3880,10 +3880,16 @@ class TypeReprAvailabilityWalker : public ASTWalker {
   DeclAvailabilityFlags flags;
 
   bool checkIdentTypeRepr(IdentTypeRepr *ITR) {
+    ArrayRef<AssociatedTypeDecl *> primaryAssociatedTypes;
+
     if (auto *typeDecl = ITR->getBoundDecl()) {
       auto range = ITR->getNameLoc().getSourceRange();
       if (diagnoseDeclAvailability(typeDecl, range, nullptr, where, flags))
         return true;
+
+      if (auto protocol = dyn_cast<ProtocolDecl>(typeDecl)) {
+        primaryAssociatedTypes = protocol->getPrimaryAssociatedTypes();
+      }
     }
 
     bool foundAnyIssues = false;
@@ -3895,6 +3901,17 @@ class TypeReprAvailabilityWalker : public ASTWalker {
       for (auto *genericArg : GTR->getGenericArgs()) {
         if (diagnoseTypeReprAvailability(genericArg, where, genericFlags))
           foundAnyIssues = true;
+
+        // The associated type that is being specified must be available as
+        // well.
+        if (!primaryAssociatedTypes.empty()) {
+          auto primaryAssociatedType = primaryAssociatedTypes.front();
+          primaryAssociatedTypes = primaryAssociatedTypes.drop_front();
+          if (diagnoseDeclAvailability(
+                  primaryAssociatedType, genericArg->getSourceRange(),
+                  nullptr, where, genericFlags))
+            foundAnyIssues = true;
+        }
       }
     }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2866,6 +2866,16 @@ public:
         AT->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
       }
     }
+
+    // An associated type that was introduced after the protocol
+    auto module = AT->getDeclContext()->getParentModule();
+    if (!defaultType &&
+        module->getResilienceStrategy() == ResilienceStrategy::Resilient &&
+        AvailabilityInference::availableRange(proto, Ctx)
+          .isSupersetOf(AvailabilityInference::availableRange(AT, Ctx))) {
+      AT->diagnose(
+          diag::resilient_associated_type_less_available_requires_default, AT);
+    }
   }
 
   void checkUnsupportedNestedType(NominalTypeDecl *NTD) {

--- a/test/IRGen/weak_import_associated_conformance_descriptor.swift
+++ b/test/IRGen/weak_import_associated_conformance_descriptor.swift
@@ -19,6 +19,13 @@ public protocol StrongProtoWithWeakLinkedAssoc {
   @_weakLinked associatedtype Assoc: P
 }
 
+public struct LibConformsToP: P { }
+
+public protocol StrongProtoWithNewAssoc {
+  @available(macOS 10.50, *)
+  associatedtype NewerAssoc: P = LibConformsToP
+}
+
 @available(macOS 10.50, *)
 public protocol WeakProtoWithAssoc {
   associatedtype Assoc: P
@@ -40,9 +47,16 @@ struct ConformsToStrongProtoWithAssoc: StrongProtoWithAssoc {
   typealias Assoc = ConformsToP
 }
 
+
 // CHECK: @"$s7Library30StrongProtoWithWeakLinkedAssocP0G0AC_AA1PTn" = extern_weak global %swift.protocol_requirement, align 4
 struct ConformsToStrongProtoWithWeakLinkedAssoc: StrongProtoWithWeakLinkedAssoc {
   typealias Assoc = ConformsToP
+}
+
+// CHECK: @"$s7Library23StrongProtoWithNewAssocP05NewerF0AC_AA1PTn" = extern_weak global %swift.protocol_requirement, align 4
+// CHECK: @"$s10NewerAssoc7Library018StrongProtoWithNewB0PTl" = extern_weak global %swift.protocol_requirement, align 4
+struct ConformsToStrongProtoWithNewAssoc: StrongProtoWithNewAssoc {
+  typealias NewAssoc = ConformsToP
 }
 
 // CHECK: @"$s7Library18WeakProtoWithAssocP0E0AC_AA1PTn" = extern_weak global %swift.protocol_requirement, align 4

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -148,5 +148,5 @@ class C_50734<@NSApplicationMain T: AnyObject> {} // expected-error {{@NSApplica
 func f6_50734<@discardableResult T>(x: T) {} // expected-error {{'@discardableResult' attribute cannot be applied to this declaration}}
 enum E_50734<@indirect T> {} // expected-error {{'indirect' is a declaration modifier, not an attribute}} expected-error {{'indirect' modifier cannot be applied to this declaration}}
 protocol P {
-  @available(swift, introduced: 4.2) associatedtype Assoc // expected-error {{'@available' attribute cannot be applied to this declaration}}
+  @available(swift, introduced: 4) associatedtype Assoc
 }

--- a/test/api-digester/Outputs/Cake-abi.txt
+++ b/test/api-digester/Outputs/Cake-abi.txt
@@ -61,6 +61,8 @@ cake: Accessor GlobalLetChangedToVar.Modify() is a new API without @available at
 cake: Accessor GlobalLetChangedToVar.Set() is a new API without @available attribute
 cake: Accessor fixedLayoutStruct2.BecomeFixedBinaryOrder.Modify() is a new API without @available attribute
 cake: Accessor fixedLayoutStruct2.BecomeFixedBinaryOrder.Set() is a new API without @available attribute
+cake: AssociatedType RequirementChanges.addedTypeWithDefault is a new API without @available attribute
+cake: AssociatedType RequirementChanges.addedTypeWithoutDefault is a new API without @available attribute
 cake: Class C0 is a new API without @available attribute
 cake: Class C8 is a new API without @available attribute
 cake: Constructor AddingNewDesignatedInit.init(_:) is a new API without @available attribute

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -1467,8 +1467,11 @@ public protocol NoAvailableProtoWithAssoc { // expected-note 3 {{add @available 
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
   associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
   associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
 }
 
 @available(macOS 10.9, *)
@@ -1477,8 +1480,11 @@ public protocol BeforeInliningTargetProtoWithAssoc {
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
   associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
   associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
 }
 
 @available(macOS 10.10, *)
@@ -1487,8 +1493,11 @@ public protocol AtInliningTargetProtoWithAssoc {
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
   associatedtype D: BetweenTargetsProto // expected-error {{'BetweenTargetsProto' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
   associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
 }
 
 @available(macOS 10.14.5, *)
@@ -1498,7 +1507,9 @@ public protocol BetweenTargetsProtoWithAssoc {
   associatedtype C: AtInliningTargetProto
   associatedtype D: BetweenTargetsProto
   associatedtype E: AtDeploymentTargetProto // expected-error {{'AtDeploymentTargetProto' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
 }
 
 @available(macOS 10.15, *)
@@ -1509,6 +1520,7 @@ public protocol AtDeploymentTargetProtoWithAssoc {
   associatedtype D: BetweenTargetsProto
   associatedtype E: AtDeploymentTargetProto
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
 }
 
 @available(macOS 11, *)
@@ -1529,6 +1541,7 @@ public protocol UnavailableProtoWithAssoc {
   associatedtype D: BetweenTargetsProto
   associatedtype E: AtDeploymentTargetProto
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
   associatedtype G: UnavailableProto
 }
 
@@ -1540,6 +1553,7 @@ public protocol SPINoAvailableProtoWithAssoc { // expected-note 1 {{add @availab
   associatedtype D: BetweenTargetsProto
   associatedtype E: AtDeploymentTargetProto
   associatedtype F: AfterDeploymentTargetProto // expected-error {{'AfterDeploymentTargetProto' is only available in}}
+  // expected-note@-1{{add @available attribute to enclosing associated type}}
 }
 
 // MARK: - Type aliases

--- a/test/decl/protocol/associated_type_availability.swift
+++ b/test/decl/protocol/associated_type_availability.swift
@@ -1,0 +1,55 @@
+// RUN: %swift -typecheck -verify -target %target-cpu-apple-macosx12 %s
+// REQUIRES: OS=macosx
+
+
+protocol P { }
+extension Int: P { }
+
+protocol P1<A, B> {
+  associatedtype A
+
+  @available(macOS 13, *)
+  associatedtype B: P
+}
+
+@available(macOS 13, *)
+struct ModelP1<A, B: P>: P1 {
+}
+
+// Associated types in where clauses
+func testWhereBad<T: P1, U>(_: T) where T.B == U { }
+// expected-error@-1{{'B' is only available in macOS 13 or newer}}
+// expected-note@-2{{add @available attribute to enclosing global function}}
+
+@available(macOS 13, *)
+func testWhereGood<T: P1, U>(_: T) where T.B == U { }
+
+// Associated types in opaque parameter position
+func testPrimaryOpaqueParamBad<U>(_: some P1<some Any, U>) {}
+// expected-error@-1 2{{'B' is only available in macOS 13 or newer}}
+// expected-note@-2 2{{add @available attribute to enclosing global function}}
+
+@available(macOS 13, *)
+func testPrimaryOpaqueParamGood<U: P>(_: some P1<some Any, U>) {}
+
+// Associated types in opaque result position
+func testPrimaryOpaqueResultBad<U: P>() -> some P1<String, U> {
+// expected-error@-1{{'B' is only available in macOS 13 or newer}}
+// expected-note@-2 2{{add @available attribute to enclosing global function}}
+  return ModelP1<String, U>()
+  // expected-error@-1{{'ModelP1' is only available in macOS 13 or newer}}
+  // expected-note@-2{{add 'if #available' version check}}
+}
+
+@available(macOS 13, *)
+func testPrimaryOpaqueResultGood<U: P>() -> some P1<String, U> {
+  return ModelP1<String, U>()
+}
+
+// Associated types in existentials
+func testPrimaryExistentialBad<U>(_: any P1<Int, U>) {}
+// expected-error@-1{{'B' is only available in macOS 13 or newer}}
+// expected-note@-2{{add @available attribute to enclosing global function}}
+
+@available(macOS 13, *)
+func testPrimaryExistentialGood<U>(_: any P1<Int, U>) {}

--- a/test/decl/protocol/associated_type_availability_resilient.swift
+++ b/test/decl/protocol/associated_type_availability_resilient.swift
@@ -1,0 +1,18 @@
+// RUN: %swift -typecheck -verify -target %target-cpu-apple-macosx12 %s -enable-library-evolution
+// REQUIRES: OS=macosx
+
+
+protocol P { }
+extension Int: P { }
+
+@available(macOS 12, *)
+protocol P1 {
+  associatedtype A
+
+  @available(macOS 13, *)
+  associatedtype B: P
+  // expected-error@-1{{associated type 'B' that is less available than its protocol must have a default}}
+
+  @available(macOS 13, *)
+  associatedtype C: P = Int
+}


### PR DESCRIPTION
Allow `@available` on associated types, which can be introduced after the protocol was introduced. These work precisely how on expects, because all of the infrastructure for introducing associated types later on has been available for a while, with two small restrictions:

1. If one uses the primary associated type syntax (e.g., `P<A, B>`), then the primary associated types must also be available in the current context.
2. Adding a new associated type to a resilient protocol requires that associated type to have a default.

Fixes rdar://108409322 and rdar://117586830
