### PR TITLE
[OpaqueValues] Assign tuple into tuple-typed memory.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1672,6 +1672,7 @@ public:
   createTupleAddrConstructor(SILLocation Loc, SILValue DestAddr,
                              ArrayRef<SILValue> Elements,
                              IsInitialization_t IsInitOfDest) {
+    assert(getFunction().getModule().useLoweredAddresses());
     return insert(TupleAddrConstructorInst::create(getSILDebugLocation(Loc),
                                                    DestAddr, Elements,
                                                    IsInitOfDest, getModule()));

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -3338,6 +3338,8 @@ public:
   }
 
   void checkTupleAddrConstructorInst(TupleAddrConstructorInst *taci) {
+    require(F.getModule().useLoweredAddresses(),
+            "tuple_addr_constructor is invalid in opaque values");
     require(taci->getNumElements() > 0,
             "Cannot be applied to tuples that do not contain any real "
             "elements. E.x.: ((), ())");


### PR DESCRIPTION
In address-lowered mode, to initialize tuple-typed memory in a single step, `tuple_addr_constructor` must generally be used because it's not possible to construct a tuple any of whose fields are address-only.  In opaque values mode, there is no problem constructing such a tuple.  So construct the tuple and then assign it into the tuple-typed memory; the single instruction that initializes the memory will be the `assign`.
