### PR TITLE
Macro expansion scopes are inserted at the last character in their insertion range

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -284,9 +284,13 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
     case MacroRole::Extension:
     case MacroRole::Member:
     case MacroRole::Peer:
-    case MacroRole::Preamble:
-      parentLoc = SF->getMacroInsertionRange().End;;
+    case MacroRole::Preamble: {
+      auto insertionRange = SF->getMacroInsertionRange();
+      parentLoc = insertionRange.End;
+      if (insertionRange.Start != insertionRange.End)
+        parentLoc = parentLoc.getAdvancedLoc(-1);
       break;
+    }
     case MacroRole::Body: {
       // Use the end location of the function decl itself as the parentLoc
       // for the new function body scope. This is different from the end

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -177,6 +177,11 @@ testFileID(a: 1, b: 2)
 @freestanding(expression) macro stringifyAndTry<T>(_ value: T) -> (T, String) =
     #externalMacro(module: "MacroDefinition", type: "StringifyAndTryMacro")
 
+enum Angle {
+case degrees(Double)
+case radians(Double)
+}
+
 func testStringify(a: Int, b: Int) {
   let s = #stringify(a + b)
   print(s)
@@ -196,6 +201,14 @@ func testStringify(a: Int, b: Int) {
   // CHECK-AST: tuple_expr type='(Double, String)' location=Macro expansion of #stringify
 
   _ = (b, b2, s2, s3)
+
+  let angle = Angle.degrees(17)
+  switch angle {
+  case .degrees(let value):
+    _ = #stringify(value)
+  case .radians(let value):
+    _ = #stringify(value)
+  }
 }
 
 func testAssert(a: Int, b: Int) {


### PR DESCRIPTION
Macro expansion scope ranges are in terms of characters, so the end of the insertion range is one past the last character of the insertion range. If the last character in the insertion range is also the last character in the enclosing scope, we would build the scope tree incorrectly.

Adjust the position for scope creation to the last character in the insertion range, not one past it. Fixes rdar://120559184, https://github.com/apple/swift/issues/70733.
