### PR TITLE
Add methods to determine the ownership behavior of patterns.

### DIFF
--- a/include/swift/AST/Ownership.h
+++ b/include/swift/AST/Ownership.h
@@ -118,14 +118,22 @@ optionalityOf(ReferenceOwnership ownership) {
 }
 
 /// Different kinds of value ownership supported by Swift.
+///
+/// The order of these constants is significant. Ascending order indicates
+/// stricter requirements on the value to be used with the given ownership
+/// kind: any value can be accessed with a shared borrow (so long as there
+/// are no exclusive accesses overlapping). An exclusive `inout` borrow is
+/// only possible for mutable values which the caller already has exclusive
+/// access to or ownership of. Consumption of an owned value requires sole
+/// ownership of that value.
 enum class ValueOwnership : uint8_t {
   /// the context-dependent default ownership (sometimes shared,
   /// sometimes owned)
   Default,
-  /// an 'inout' exclusive, mutating borrow
-  InOut,
   /// a 'borrowing' nonexclusive, usually nonmutating borrow
   Shared,
+  /// an 'inout' exclusive, mutating borrow
+  InOut,
   /// a 'consuming' ownership transfer
   Owned,
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -928,7 +928,7 @@ namespace {
     using PrintBase::PrintBase;
 
     void printCommon(Pattern *P, const char *Name, StringRef Label) {
-     printHead(Name, PatternColor, Label);
+      printHead(Name, PatternColor, Label);
 
       printFlag(P->isImplicit(), "implicit", ExprModifierColor);
 
@@ -990,6 +990,22 @@ namespace {
     }
     void visitExprPattern(ExprPattern *P, StringRef label) {
       printCommon(P, "pattern_expr", label);
+      switch (P->getCachedMatchOperandOwnership()) {
+      case ValueOwnership::Default:
+        break;
+      case ValueOwnership::Shared:
+        printFieldRaw([](llvm::raw_ostream &os) { os << "borrowing"; },
+                      "ownership");
+        break;
+      case ValueOwnership::InOut:
+        printFieldRaw([](llvm::raw_ostream &os) { os << "mutating"; },
+                      "ownership");
+        break;
+      case ValueOwnership::Owned:
+        printFieldRaw([](llvm::raw_ostream &os) { os << "consuming"; },
+                      "ownership");
+        break;
+      }
       if (auto m = P->getCachedMatchExpr())
         printRec(m);
       else
@@ -2011,6 +2027,22 @@ public:
         printFlag(LabelItem.isDefault(), "default");
         
         if (auto *CasePattern = LabelItem.getPattern()) {
+          switch (CasePattern->getOwnership()) {
+          case ValueOwnership::Default:
+            break;
+          case ValueOwnership::Shared:
+            printFieldRaw([](llvm::raw_ostream &os) { os << "borrowing"; },
+                          "ownership");
+            break;
+          case ValueOwnership::InOut:
+            printFieldRaw([](llvm::raw_ostream &os) { os << "mutating"; },
+                          "ownership");
+            break;
+          case ValueOwnership::Owned:
+            printFieldRaw([](llvm::raw_ostream &os) { os << "consuming"; },
+                          "ownership");
+            break;
+          }
           printRec(CasePattern);
         }
         if (auto *Guard = LabelItem.getGuardExpr()) {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1029,13 +1029,13 @@ ExprPatternMatchRequest::getCachedResult() const {
   if (!EP->MatchVar)
     return llvm::None;
 
-  return ExprPatternMatchResult(EP->MatchVar, EP->MatchExpr);
+  return ExprPatternMatchResult(EP->MatchVar, EP->getCachedMatchExpr());
 }
 
 void ExprPatternMatchRequest::cacheResult(ExprPatternMatchResult result) const {
   auto *EP = std::get<0>(getStorage());
   EP->MatchVar = result.getMatchVar();
-  EP->MatchExpr = result.getMatchExpr();
+  EP->MatchExprAndOperandOwnership.setPointer(result.getMatchExpr());
 }
 
 //----------------------------------------------------------------------------//

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 831; // mark_dependence [nonescaping]
+const uint16_t SWIFTMODULE_VERSION_MINOR = 832; // reorder ValueOwnership
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/Sema/switch-ownership.swift
+++ b/test/Sema/switch-ownership.swift
@@ -1,0 +1,58 @@
+// RUN: %target-swift-frontend -typecheck -dump-ast %s | %FileCheck %s
+
+struct A {
+    static func ~=(pattern: B, subject: A) -> Bool { return true }
+    static func ~=(pattern: C, subject: borrowing A) -> Bool { return true }
+    static func ~=(pattern: D, subject: consuming A) -> Bool { return true }
+}
+struct B { }
+struct C { }
+struct D { }
+struct E { }
+struct F { }
+struct G { }
+
+func ~=(pattern: E, subject: A) -> Bool { return true }
+func ~=(pattern: F, subject: borrowing A) -> Bool { return true }
+func ~=(pattern: G, subject: consuming A) -> Bool { return true }
+
+// CHECK-LABEL: (func_decl{{.*}} "test(value:)"
+func test(value: A) {
+    // CHECK: (switch_stmt
+    switch value {
+    // CHECK: (case_stmt
+    // CHECK:   (case_label_item ownership=borrowing
+    // CHECK:     (pattern_expr type="A" ownership=borrowing
+    case B():
+        break
+    // CHECK: (case_stmt
+    // CHECK:   (case_label_item ownership=borrowing
+    // CHECK:     (pattern_expr type="A" ownership=borrowing
+    case C():
+        break
+    // CHECK: (case_stmt
+    // CHECK:   (case_label_item ownership=consuming
+    // CHECK:     (pattern_expr type="A" ownership=consuming
+    case D():
+        break
+    // CHECK: (case_stmt
+    // CHECK:   (case_label_item ownership=borrowing
+    // CHECK:     (pattern_expr type="A" ownership=borrowing
+    case E():
+        break
+    // CHECK: (case_stmt
+    // CHECK:   (case_label_item ownership=borrowing
+    // CHECK:     (pattern_expr type="A" ownership=borrowing
+    case F():
+        break
+    // CHECK: (case_stmt
+    // CHECK:   (case_label_item ownership=consuming
+    // CHECK:     (pattern_expr type="A" ownership=consuming
+    case G():
+        break
+    // CHECK: (case_stmt
+    // CHECK:   (case_label_item default ownership=borrowing
+    default:
+        break
+    }
+}


### PR DESCRIPTION
When matching against a noncopyable value, whether the match operation can borrow the value in-place or needs to take ownership of it is significant. This can generally be determined from the kind of pattern being used, except in the case of expr patterns, where it depends on type-checking the `~=` operator that was used.