### PR TITLE
[Concurrency] Downgrade isolated call diagnostics when the callee has an inferred `@preconcurrency` annotation.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3303,7 +3303,7 @@ namespace {
         } else {
           if (calleeDecl) {
             auto preconcurrency = getContextIsolation().preconcurrency() ||
-            calleeDecl->preconcurrency();
+                getActorIsolation(calleeDecl).preconcurrency();
             ctx.Diags.diagnose(
                                apply->getLoc(), diag::actor_isolated_call_decl,
                                *unsatisfiedIsolation,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5093,7 +5093,8 @@ bool swift::contextRequiresStrictConcurrencyChecking(
       // features.
       if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
         auto *nominal = extension->getExtendedNominal();
-        if (nominal && hasExplicitIsolationAttribute(nominal))
+        if (nominal && hasExplicitIsolationAttribute(nominal) &&
+            !getActorIsolation(nominal).preconcurrency())
           return true;
       }
 


### PR DESCRIPTION
`Decl::preconcurrency()` only returns `true` if there is an explicit `@preconcurrency` annotation on the decl. Instead, compute the actor isolation of the decl and check whether the isolation is preconcurrency.

This change also suppresses concurrency diagnostics entirely in extensions of explicitly-annotated `@preconcurrency` types unless strict concurrency checking is enabled.

Resolves rdar://120554343