### PR TITLE
Sema: Allow _diagnoseUnavailableCodeReached() to not exist in the stdlib

### DIFF
--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -496,6 +496,7 @@ DerivedConformance::createBuiltinCall(ASTContext &ctx,
 CallExpr *DerivedConformance::createDiagnoseUnavailableCodeReachedCallExpr(
     ASTContext &ctx) {
   FuncDecl *diagnoseDecl = ctx.getDiagnoseUnavailableCodeReachedDecl();
+  assert(diagnoseDecl);
   auto diagnoseDeclRefExpr =
       new (ctx) DeclRefExpr(diagnoseDecl, DeclNameLoc(), true);
   diagnoseDeclRefExpr->setType(diagnoseDecl->getInterfaceType());
@@ -937,6 +938,12 @@ CaseStmt *DerivedConformance::unavailableEnumElementCaseStmt(
     return nullptr;
 
   if (!availableAttr->isUnconditionallyUnavailable())
+    return nullptr;
+
+  // If the stdlib isn't new enough to contain the helper function for
+  // diagnosing execution of unavailable code then just synthesize this case
+  // normally.
+  if (!C.getDiagnoseUnavailableCodeReachedDecl())
     return nullptr;
 
   auto createElementPattern = [&]() -> EnumElementPattern * {


### PR DESCRIPTION
Sometimes the compiler may need to build with an out-of-date standard library and we can't assume recently added well-known declarations are present. When synthesizing Hashable and Equatable conformances, if `_diagnoseUnavailableCodeReached()` isn't present then just generate the body of the case normally instead. This isn't ideal, but there isn't any existing infrastructure to generate a call to `fatalError()` at the AST level and this should be a rare edge case where we're simply falling back to the previous behavior where unavailable cases weren't handled at all.

No tests because it isn't straight forward to compile with an intentionally broken standard library that's missing some declarations.

Resolves rdar://120554183
