### PR TITLE
[5.10][Concurrency] Suppress diagnostics about non-`Sendable` async iterator arguments in implicit calls to `next()`.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -448,6 +448,10 @@ public:
     return const_cast<Expr *>(this)->getValueProvidingExpr();
   }
 
+  /// Find the original expression value, looking through various
+  /// implicit conversions.
+  const Expr *findOriginalValue() const;
+
   /// Find the original type of a value, looking through various implicit
   /// conversions.
   Type findOriginalType() const;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2803,7 +2803,7 @@ FrontendStatsTracer::getTraceFormatter<const Expr *>() {
   return &TF;
 }
 
-Type Expr::findOriginalType() const {
+const Expr *Expr::findOriginalValue() const {
   auto *expr = this;
   do {
     expr = expr->getSemanticsProvidingExpr();
@@ -2826,5 +2826,10 @@ Type Expr::findOriginalType() const {
     break;
   } while (true);
 
+  return expr;
+}
+
+Type Expr::findOriginalType() const {
+  auto *expr = findOriginalValue();
   return expr->getType()->getRValueType();
 }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1624,6 +1624,7 @@ bool ActorIsolation::requiresSubstitution() const {
   switch (kind) {
   case ActorInstance:
   case Nonisolated:
+  case NonisolatedUnsafe:
   case Unspecified:
     return false;
 
@@ -1638,6 +1639,7 @@ ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
   switch (kind) {
   case ActorInstance:
   case Nonisolated:
+  case NonisolatedUnsafe:
   case Unspecified:
     return *this;
 

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -36,7 +36,6 @@ extension Parser.ExperimentalFeatures {
       }
     }
     mapFeature(.ThenStatements, to: .thenStatements)
-    mapFeature(.GlobalConcurrency, to: .globalConcurrency)
   }
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5344,8 +5344,7 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes,
   }
 
   // If this is 'nonisolated', check to see if it is valid.
-  if (Context.LangOpts.hasFeature(Feature::GlobalConcurrency) &&
-      Tok.isContextualKeyword("nonisolated") && Tok2.is(tok::l_paren) &&
+  if (Tok.isContextualKeyword("nonisolated") && Tok2.is(tok::l_paren) &&
       isParenthesizedNonisolated(*this)) {
     BacktrackingScope backtrack(*this);
     consumeToken(tok::identifier);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4413,6 +4413,19 @@ generateForEachStmtConstraints(ConstraintSystem &cs,
               sequenceExpr->getStartLoc(), ctx.getIdentifier(name), dc);
   makeIteratorVar->setImplicit();
 
+  // FIXME: Apply `nonisolated(unsafe)` to async iterators.
+  //
+  // Async iterators are not `Sendable`; they're only meant to be used from
+  // the isolation domain that creates them. But the `next()` method runs on
+  // the generic executor, so calling it from an actor-isolated context passes
+  // non-`Sendable` state across the isolation boundary. `next()` should
+  // inherit the isolation of the caller, but for now, use the opt out.
+  if (isAsync) {
+    auto *nonisolated = new (ctx)
+        NonisolatedAttr(/*unsafe=*/true, /*implicit=*/true);
+    makeIteratorVar->getAttrs().add(nonisolated);
+  }
+
   // First, let's form a call from sequence to `.makeIterator()` and save
   // that in a special variable which is going to be used by SILGen.
   {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6594,14 +6594,11 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
   auto dc = D->getDeclContext();
 
   if (auto var = dyn_cast<VarDecl>(D)) {
-    const bool isUnsafe =
-        attr->isUnsafe() && Ctx.LangOpts.hasFeature(Feature::GlobalConcurrency);
-
     // stored properties have limitations as to when they can be nonisolated.
     if (var->hasStorage()) {
       // 'nonisolated' can not be applied to mutable stored properties unless
       // qualified as 'unsafe'.
-      if (var->supportsMutation() && !isUnsafe) {
+      if (var->supportsMutation() && !attr->isUnsafe()) {
         diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage);
         return;
       }
@@ -6645,7 +6642,7 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
 
     // nonisolated can not be applied to local properties unless qualified as
     // 'unsafe'.
-    if (dc->isLocalContext() && !isUnsafe) {
+    if (dc->isLocalContext() && !attr->isUnsafe()) {
       diagnoseAndRemoveAttr(attr, diag::nonisolated_local_var);
       return;
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2813,8 +2813,7 @@ namespace {
         return false;
 
       if (auto attr = value->getAttrs().getAttribute<NonisolatedAttr>();
-          ctx.LangOpts.hasFeature(Feature::GlobalConcurrency) && attr &&
-          attr->isUnsafe()) {
+          attr && attr->isUnsafe()) {
         return false;
       }
 
@@ -3282,8 +3281,7 @@ namespace {
         }
 
         if (auto attr = var->getAttrs().getAttribute<NonisolatedAttr>();
-            ctx.LangOpts.hasFeature(Feature::GlobalConcurrency) && attr &&
-            attr->isUnsafe()) {
+            attr && attr->isUnsafe()) {
           return false;
         }
 

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -75,3 +75,12 @@ func f() {
   print(TestStatics.immutableInferredSendable)
   print(TestStatics.mutable) // expected-warning{{reference to static property 'mutable' is not concurrency-safe because it involves shared mutable state}}
 }
+
+func testLocalNonisolatedUnsafe() async {
+  nonisolated(unsafe) var value = 1
+  let task = Task {
+    value = 2
+    return value
+  }
+  print(await task.value)
+}

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -enable-experimental-feature StrictConcurrency=complete -enable-experimental-feature GlobalConcurrency -emit-sil -o /dev/null -verify -enable-experimental-feature SendNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -84,3 +84,11 @@ func testLocalNonisolatedUnsafe() async {
   }
   print(await task.value)
 }
+
+@MainActor
+func iterate(stream: AsyncStream<Int>) async {
+  nonisolated(unsafe) var it = stream.makeAsyncIterator()
+  while let element = await it.next() {
+    print(element)
+  }
+}

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -91,4 +91,8 @@ func iterate(stream: AsyncStream<Int>) async {
   while let element = await it.next() {
     print(element)
   }
+
+  for await x in stream {
+    print(x)
+  }
 }


### PR DESCRIPTION
* **Explanation**: 

https://github.com/apple/swift/pull/67730 closed a hole in strict concurrency checking that failed to diagnose non-`Sendable` self arguments crossing isolation boundaries. When that hole was closed, the compiler started diagnosing code that iterates over an `AsyncSequence` type from an actor isolated context (including global actors):

```swift
@MainActor func iterate(over stream: AsyncStream<Int>) async {
  for await element in stream { ... } // warning: Passing argument of non-sendable type 'inout AsyncStream<Int>.Iterator' outside of main actor-isolated context may introduce data races
}
```

This is correct - nearly all `AsyncIteratorProtocol` types are not `Sendable`, and `AsyncIteratorProtocol.next()` is `nonisolated async`, so any call to `next()` from an actor-isolated context will pass a non-`Sendable` iterator value over an isolation boundary! There's a whole big pitch discussion in Swift evolution right now about fixing this properly by making `next()` polymorphic over actor isolation.

However, in Swift 5.10, there's nothing that programmers can do to to resolve this warning. So instead, this change applies the `nonisolated(unsafe)` opt out to the generated iterator variable during constraint generation to suppress the warning. Note that I cherry picked the remainder of the implementation of `nonisolated(unsafe)` (most of the implementation had already been cherry picked) and enabled it in order to use this opt out. The feature has been accepted in Swift Evolution and enabled on `main`, and programmers will surely need `nonisolated(unsafe)` in Swift 5.10 given the vast number of `Sendable` checking holes that have been closed in Swift 5.10, leading to more warnings just like this one.
* **Scope**: Only impacts `Sendable` checking, and `async` iteration in particular
* **Risk**: Very low. The remaining implementation of `nonisolated(unsafe)` does not impact other language features, and the only effect of applying it to async iterator variables is a suppressed warning under `-strict-concurrency=complete`.
* **Testing**: Added new test cases to show that no warnings are produced for async iteration in an actor isolated context under `-stict-concurrency=complete`.
* **Reviewer**: @sophiapoirier
* **Main branch PR**:
  * https://github.com/apple/swift/pull/70135
  * https://github.com/apple/swift/pull/70453
  * https://github.com/apple/swift/pull/70697