### PR TITLE
Insert member-attribute macros right before modifiers

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -895,7 +895,7 @@ static CharSourceRange getExpansionInsertionRange(MacroRole role,
   case MacroRole::MemberAttribute: {
     SourceLoc startLoc;
     if (auto valueDecl = dyn_cast<ValueDecl>(target.get<Decl *>()))
-      startLoc = valueDecl->getAttributeInsertionLoc(/*forModifier=*/false);
+      startLoc = valueDecl->getAttributeInsertionLoc(/*forModifier=*/true);
     else
       startLoc = target.getStartLoc();
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2274,3 +2274,13 @@ public struct _AddPeerMacro: PeerMacro {
         return ["static let \(raw: name)_special = 41"]
     }
 }
+
+public struct WrapperMacro: PeerMacro {
+  public static func expansion(
+      of node: SwiftSyntax.AttributeSyntax,
+      providingPeersOf declaration: some SwiftSyntax.DeclSyntaxProtocol,
+      in context: some SwiftSyntaxMacros.MacroExpansionContext
+  ) throws -> [SwiftSyntax.DeclSyntax] {
+    []
+  }
+}

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -257,3 +257,35 @@ func fDeprecated(a: Int, for b: String, _ value: Double) async -> String {
 }
 
 #endif
+
+protocol MyType {
+  associatedtype Value
+  associatedtype Entity
+}
+
+@attached(peer, names: named(bar))
+macro Wrapper<Value>(
+    get: (Value.Entity) async throws -> Value.Value
+) = #externalMacro(module: "MacroDefinition", type: "WrapperMacro")
+where Value: MyType
+
+@attached(peer)
+macro _AddPeer() = #externalMacro(module: "MacroDefinition", type: "WrapperMacro")
+
+@attached(memberAttribute)
+public macro AddMemberPeers() = #externalMacro(module: "MacroDefinition", type: "AddMemberPeersMacro")
+
+struct Thing: MyType {
+  typealias Entity = [Int]
+  typealias Value = Int
+}
+
+@AddMemberPeers
+struct Test {
+    @Wrapper<Thing>(
+        get: { p1 in
+            p1.count // Error: Cannot find 'p1' in scope
+        }
+    )
+    var doesNotWork: Thing
+}


### PR DESCRIPTION
The insertion position of member-attribute macros was right before the first attribute. However, ASTScope would visit the as-written attributes first, so the scope tree entries would be out of order, causing name lookup to fail.

Move the insertion position to where a new modifier would go, i.e., after the explicitly-written attributes. Fixes rdar://120496864.
