### PR TITLE
Fix lookahead for effects specifiers in function types

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1800,7 +1800,6 @@ bool Parser::isAtFunctionTypeArrow() {
     if (isEffectsSpecifier(peekToken())) {
       BacktrackingScope backtrack(*this);
       consumeToken();
-      consumeToken();
       return isAtFunctionTypeArrow();
     }
     // Don't look for '->' in code completion. The user may write it later.

--- a/test/Parse/typed_throws.swift
+++ b/test/Parse/typed_throws.swift
@@ -29,3 +29,8 @@ func testMissingError() throws() { }
 
 func testRethrowsWithThrownType() rethrows(MyError) { }
 // expected-error@-1{{'rethrows' cannot be combined with a specific thrown error type}}
+
+struct S<Element, Failure: Error> {
+  init(produce: @escaping () async throws(Failure) -> Element?) {
+  }
+}


### PR DESCRIPTION
We were failing to properly look past effect specifiers like async throws(X) in a function type starting with an attribute.

C++ version of the fix in https://github.com/apple/swift-syntax/pull/2418