### PR TITLE
[Concurrency] Allow isolated parameters to have optional type.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -254,6 +254,9 @@ EXPERIMENTAL_FEATURE(Extern, true)
 // global functions and key paths.
 EXPERIMENTAL_FEATURE(InferSendableFromCaptures, false)
 
+// Allow optional isolated parameters.
+EXPERIMENTAL_FEATURE(OptionalIsolatedParameters, true)
+
 /// Enable the `@_staticExclusiveOnly` attribute.
 EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3829,6 +3829,25 @@ static bool usesFeatureInferSendableFromCaptures(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureOptionalIsolatedParameters(Decl *decl) {
+  auto *value = dyn_cast<ValueDecl>(decl);
+  if (!value)
+    return false;
+
+  auto *paramList = getParameterList(value);
+  if (!paramList)
+    return false;
+
+  for (auto param : *paramList) {
+    if (param->isIsolated()) {
+      auto paramType = param->getInterfaceType();
+      return !paramType->getOptionalObjectType().isNull();
+    }
+  }
+
+  return false;
+}
+
 static bool usesFeaturePlaygroundExtendedCallbacks(Decl *decl) {
   return false;
 }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1507,15 +1507,6 @@ SILValue SILGenFunction::emitLoadActorExecutor(SILLocation loc,
   else
     actorV = actor.borrow(*this, loc).getValue();
 
-  // Open an existential actor type.
-  CanType actorType = actor.getType().getASTType();
-  if (actorType->isExistentialType()) {
-    actorType = OpenedArchetypeType::get(
-        actorType, F.getGenericSignature())->getCanonicalType();
-    SILType loweredActorType = getLoweredType(actorType);
-    actorV = B.createOpenExistentialRef(loc, actorV, loweredActorType);
-  }
-
   // For now, we just want to emit a hop_to_executor directly to the
   // actor; LowerHopToActor will add the emission logic necessary later.
   return actorV;

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "insert-hop-to-executor"
+#include "swift/Basic/FrozenMultiMap.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/Dominance.h"
@@ -51,11 +52,18 @@ class LowerHopToActor {
   SILFunction *F;
   DominanceInfo *Dominance;
 
-  /// A map from an actor value to the executor we've derived for it.
-  llvm::ScopedHashTable<SILValue, SILValue> ExecutorForActor;
+  /// A map from an actor value to the dominating instruction that
+  /// will derive the executor.
+  llvm::ScopedHashTable<SILValue, SILInstruction *>
+      ExecutorDerivationForActor;
 
-  bool processHop(HopToExecutorInst *hop);
-  bool processExtract(ExtractExecutorInst *extract);
+  /// A multi-map from a dominating {hop_to_|extract_}executor instruction
+  /// to other reachable {hop_to_|extract_}executor instructions.
+  SmallFrozenMultiMap<SILInstruction *, SILInstruction *, 4>
+      DominatingActorHops;
+
+  void recordDominatingInstFor(SILInstruction *inst);
+  void rewriteInstructions();
 
   SILValue emitGetExecutor(SILBuilderWithScope &B,
                            SILLocation loc,
@@ -73,21 +81,24 @@ public:
 };
 
 bool LowerHopToActor::run() {
-  bool changed = false;
-
+  // Record all actor operands to hop_to_executor and extract_executor
+  // and the dominating instruction that will derive the executor.
   auto runOnBlock = [&](SILBasicBlock *block) {
     for (auto ii = block->begin(), ie = block->end(); ii != ie; ) {
       SILInstruction *inst = &*ii++;
-      if (auto *hop = dyn_cast<HopToExecutorInst>(inst)) {
-        changed |= processHop(hop);
-      } else if (auto *extract = dyn_cast<ExtractExecutorInst>(inst)) {
-        changed |= processExtract(extract);
-      }
+      recordDominatingInstFor(inst);
     }
   };
-  runInDominanceOrderWithScopes(Dominance, runOnBlock, ExecutorForActor);
+  runInDominanceOrderWithScopes(Dominance, runOnBlock,
+                                ExecutorDerivationForActor);
 
-  return changed;
+  // If we didn't record any dominating actor hops that need
+  // transformation, we're done.
+  if (DominatingActorHops.empty())
+    return false;
+
+  rewriteInstructions();
+  return true;
 }
 
 static bool isOptionalBuiltinExecutor(SILType type) {
@@ -96,49 +107,73 @@ static bool isOptionalBuiltinExecutor(SILType type) {
   return false;
 }
 
-/// Search for hop_to_executor instructions with actor-typed operands.
-bool LowerHopToActor::processHop(HopToExecutorInst *hop) {
-  auto actor = hop->getTargetExecutor();
-
-  // Ignore hops that are already to Optional<Builtin.Executor>.
-  if (isOptionalBuiltinExecutor(actor->getType()))
-    return false;
-
-  SILBuilderWithScope B(hop);
-  SILValue executor;
-  if (actor->getType().is<BuiltinExecutorType>()) {
-    // IRGen expects an optional Builtin.Executor, not a Builtin.Executor
-    // but we can wrap it nicely
-    executor = B.createOptionalSome(
-        hop->getLoc(), actor,
-        SILType::getOptionalType(actor->getType()));
+void LowerHopToActor::recordDominatingInstFor(SILInstruction *inst) {
+  SILValue actor;
+  if (auto *hop = dyn_cast<HopToExecutorInst>(inst)) {
+    actor = hop->getTargetExecutor();
+    // If hop_to_executor was emitted with an optional executor operand,
+    // there's nothing to derive.
+    if (isOptionalBuiltinExecutor(actor->getType())) {
+      return;
+    }
+  } else if (auto *extract = dyn_cast<ExtractExecutorInst>(inst)) {
+    actor = extract->getExpectedExecutor();
   } else {
-    // Get the dominating executor value for this actor, if available,
-    // or else emit code to derive it.
-    executor = emitGetExecutor(B, hop->getLoc(), actor, /*optional*/true);
+    return;
   }
-  assert(executor && "executor not set");
 
-  B.createHopToExecutor(hop->getLoc(), executor, /*mandatory*/ false);
+  if (isOptionalBuiltinExecutor(actor->getType()))
+    return;
 
-  hop->eraseFromParent();
+  auto *dominatingInst = ExecutorDerivationForActor.lookup(actor);
+  if (dominatingInst) {
+    DominatingActorHops.insert(dominatingInst, inst);
+  } else {
+    DominatingActorHops.insert(inst, inst);
+    ExecutorDerivationForActor.insert(actor, inst);
+  }
 
-  return true;
+  return;
 }
 
-bool LowerHopToActor::processExtract(ExtractExecutorInst *extract) {
-  // Dig out the executor.
-  auto executor = extract->getExpectedExecutor();
-  if (!isOptionalBuiltinExecutor(executor->getType())) {
-    SILBuilderWithScope B(extract);
-    executor =
-        emitGetExecutor(B, extract->getLoc(), executor, /*optional*/ false);
-  }
+void LowerHopToActor::rewriteInstructions() {
+  // Lower the actor operands to executors. Dominating instructions
+  // will perform the derivation, and the result will be reused in
+  // all reachable instructions.
+  DominatingActorHops.setFrozen();
+  for (auto domInst : DominatingActorHops.getRange()) {
+    auto derivationInst = domInst.first;
 
-  // Unconditionally replace the extract with the executor.
-  extract->replaceAllUsesWith(executor);
-  extract->eraseFromParent();
-  return true;
+    SILValue actor;
+    bool makeOptional;
+    if (auto *hop = dyn_cast<HopToExecutorInst>(derivationInst)) {
+      actor = hop->getTargetExecutor();
+      makeOptional = true;
+    } else if (auto *extract = dyn_cast<ExtractExecutorInst>(derivationInst)) {
+      actor = extract->getExpectedExecutor();
+      makeOptional = false;
+    } else {
+      continue;
+    }
+
+    // Emit the executor derivation at the dominating instruction.
+    SILBuilderWithScope builder(derivationInst);
+    auto executor = emitGetExecutor(
+        builder, derivationInst->getLoc(), actor, makeOptional);
+    derivationInst->setOperand(0, executor);
+
+    // Set the executor value as the operand for all reachable instructions.
+    auto reachableInsts = domInst.second;
+    for (auto inst : reachableInsts) {
+      if (auto *extract = dyn_cast<ExtractExecutorInst>(inst)) {
+        extract->replaceAllUsesWith(executor);
+        extract->eraseFromParent();
+        continue;
+      }
+
+      inst->setOperand(0, executor);
+    }
+  }
 }
 
 static bool isDefaultActorType(CanType actorType, ModuleDecl *M,
@@ -162,40 +197,40 @@ static AccessorDecl *getUnownedExecutorGetter(ASTContext &ctx,
 SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
                                           SILLocation loc, SILValue actor,
                                           bool makeOptional) {
-  // Get the dominating executor value for this actor, if available,
-  // or else emit code to derive it.
-  SILValue executor = ExecutorForActor.lookup(actor);
-  if (executor) {
-    if (makeOptional)
-      executor = B.createOptionalSome(loc, executor,
-                           SILType::getOptionalType(executor->getType()));
-    return executor;
-  }
-
   // This is okay because actor types have to be classes and so never
   // have multiple abstraction patterns.
   CanType actorType = actor->getType().getASTType();
 
+  // If the operand is already a BuiltinExecutorType, just wrap it
+  // in an optional.
+  if (makeOptional && actor->getType().is<BuiltinExecutorType>()) {
+    return B.createOptionalSome(
+        loc, actor,
+        SILType::getOptionalType(actor->getType()));
+  }
+
   auto &ctx = F->getASTContext();
-  auto resultType = SILType::getPrimitiveObjectType(ctx.TheExecutorType);
+  auto executorType = SILType::getPrimitiveObjectType(ctx.TheExecutorType);
+  auto optionalExecutorType = SILType::getOptionalType(executorType);
 
-  // If the actor type is a default actor, go ahead and devirtualize here.
-  auto module = F->getModule().getSwiftModule();
-  SILValue unmarkedExecutor;
+  /// Emit the instructions to derive an executor value from an actor value.
+  auto getExecutorFor = [&](SILValue actor) -> SILValue {
+    // If the actor type is a default actor, go ahead and devirtualize here.
+    auto module = F->getModule().getSwiftModule();
+    CanType actorType = actor->getType().getASTType();
 
-  // Determine if the actor is a "default actor" in which case we'll build a default
-  // actor executor ref inline, rather than calling out to the user-provided executor function.
-  if (isDefaultActorType(actorType, module, F->getResilienceExpansion())) {
-    auto builtinName = ctx.getIdentifier(
-      getBuiltinName(BuiltinValueKind::BuildDefaultActorExecutorRef));
-    auto builtinDecl = cast<FuncDecl>(getBuiltinValueDecl(ctx, builtinName));
-    auto subs = SubstitutionMap::get(builtinDecl->getGenericSignature(),
-                                     {actorType}, {});
-    unmarkedExecutor =
-      B.createBuiltin(loc, builtinName, resultType, subs, {actor});
+    // Determine if the actor is a "default actor" in which case we'll build a default
+    // actor executor ref inline, rather than calling out to the user-provided executor function.
+    if (isDefaultActorType(actorType, module, F->getResilienceExpansion())) {
+      auto builtinName = ctx.getIdentifier(
+        getBuiltinName(BuiltinValueKind::BuildDefaultActorExecutorRef));
+      auto builtinDecl = cast<FuncDecl>(getBuiltinValueDecl(ctx, builtinName));
+      auto subs = SubstitutionMap::get(builtinDecl->getGenericSignature(),
+                                       {actorType}, {});
+      return B.createBuiltin(loc, builtinName, executorType, subs, {actor});
+    }
 
     // Otherwise, go through (Distributed)Actor.unownedExecutor.
-  } else {
     auto actorKind = actorType->isDistributedActor() ?
                      KnownProtocolKind::DistributedActor :
                      KnownProtocolKind::Actor;
@@ -203,8 +238,6 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
     auto req = getUnownedExecutorGetter(ctx, actorProtocol);
     assert(req && "Concurrency library broken");
     SILDeclRef fn(req, SILDeclRef::Kind::Func);
-
-    // FIXME: Handle optional
 
     // Open an existential actor type.
     if (actorType->isExistentialType()) {
@@ -232,22 +265,64 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
     auto executorDecl = ctx.getUnownedSerialExecutorDecl();
     auto executorProps = executorDecl->getStoredProperties();
     assert(executorProps.size() == 1);
-    unmarkedExecutor =
-      B.createStructExtract(loc, witnessCall, executorProps[0]);
+    return B.createStructExtract(loc, witnessCall, executorProps[0]);
+  };
+
+  SILValue unmarkedExecutor;
+  if (auto wrappedActor = actorType->getOptionalObjectType()) {
+    assert(makeOptional);
+
+    // Unwrap the optional and call 'unownedExecutor'.
+    auto *someDecl = B.getASTContext().getOptionalSomeDecl();
+    auto *curBB = B.getInsertionPoint()->getParent();
+    auto *contBB = curBB->split(B.getInsertionPoint());
+    auto *someBB = B.getFunction().createBasicBlockAfter(curBB);
+    auto *noneBB = B.getFunction().createBasicBlockAfter(someBB);
+
+    unmarkedExecutor = contBB->createPhiArgument(
+        optionalExecutorType, actor->getOwnershipKind());
+
+    SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 1> caseBBs;
+    caseBBs.push_back(std::make_pair(someDecl, someBB));
+    B.setInsertionPoint(curBB);
+    auto *switchEnum = B.createSwitchEnum(loc, actor, noneBB, caseBBs);
+
+    SILValue unwrappedActor;
+    if (B.hasOwnership()) {
+      unwrappedActor = switchEnum->createOptionalSomeResult();
+      B.setInsertionPoint(someBB);
+    } else {
+      B.setInsertionPoint(someBB);
+      unwrappedActor = B.createUncheckedEnumData(loc, actor, someDecl);
+    }
+
+    // Call 'unownedExecutor' in the some block and wrap the result into
+    // an optional.
+    SILValue unwrappedExecutor = getExecutorFor(unwrappedActor);
+    SILValue someValue =
+        B.createOptionalSome(loc, unwrappedExecutor, optionalExecutorType);
+    B.createBranch(loc, contBB, {someValue});
+
+    // In the none case, create a nil executor value, which represents
+    // the generic executor.
+    B.setInsertionPoint(noneBB);
+    SILValue noneValue = B.createOptionalNone(loc, optionalExecutorType);
+    B.createBranch(loc, contBB, {noneValue});
+    B.setInsertionPoint(contBB->begin());
+  } else {
+    unmarkedExecutor = getExecutorFor(actor);
+
+    // Inject the result into an optional if requested.
+    if (makeOptional) {
+      unmarkedExecutor = B.createOptionalSome(loc, unmarkedExecutor,
+          SILType::getOptionalType(unmarkedExecutor->getType()));
+    }
   }
 
   // Mark the dependence of the resulting value on the actor value to
   // force the actor to stay alive.
-  executor = B.createMarkDependence(loc, unmarkedExecutor, actor,
-                                    /*isNonEscaping*/false);
-
-  // Cache the non-optional result for later.
-  ExecutorForActor.insert(actor, executor);
-
-  // Inject the result into an optional if requested.
-  if (makeOptional)
-    executor = B.createOptionalSome(loc, executor,
-                           SILType::getOptionalType(executor->getType()));
+  SILValue executor = B.createMarkDependence(loc, unmarkedExecutor, actor,
+                                             /*isNonEscaping*/false);
 
   return executor;
 }
@@ -260,7 +335,7 @@ class LowerHopToActorPass : public SILFunctionTransform {
     auto domTree = getAnalysis<DominanceAnalysis>()->get(fn);
     LowerHopToActor pass(getFunction(), domTree);
     if (pass.run())
-      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+      invalidateAnalysis(SILAnalysis::InvalidationKind::BranchesAndInstructions);
   }
 };
 

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -204,6 +204,16 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
     assert(req && "Concurrency library broken");
     SILDeclRef fn(req, SILDeclRef::Kind::Func);
 
+    // FIXME: Handle optional
+
+    // Open an existential actor type.
+    if (actorType->isExistentialType()) {
+      actorType = OpenedArchetypeType::get(
+          actorType, F->getGenericSignature())->getCanonicalType();
+      SILType loweredActorType = F->getLoweredType(actorType);
+      actor = B.createOpenExistentialRef(loc, actor, loweredActorType);
+    }
+
     auto actorConf = module->lookupConformance(actorType, actorProtocol);
     assert(actorConf &&
            "hop_to_executor with actor that doesn't conform to Actor or DistributedActor");

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4485,6 +4485,14 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
 
   // isolated parameters must be of actor type
   if (!type->hasTypeParameter() && !type->isActorType() && !type->hasError()) {
+    // Optional actor types are fine - `nil` represents `nonisolated`.
+    auto wrapped = type->getOptionalObjectType();
+    auto allowOptional = getASTContext().LangOpts
+        .hasFeature(Feature::OptionalIsolatedParameters);
+    if (allowOptional && wrapped && wrapped->isActorType()) {
+      return type;
+    }
+
     diagnoseInvalid(
         repr, repr->getSpecifierLoc(), diag::isolated_parameter_not_actor, type);
     return ErrorType::get(type);

--- a/test/Concurrency/optional_isolated_parameters.swift
+++ b/test/Concurrency/optional_isolated_parameters.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -enable-experimental-feature OptionalIsolatedParameters %s -o %t/main
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+
+actor MyActor: CustomStringConvertible {
+  let description = "MyActor"
+}
+
+func optionalIsolated(to actor: isolated (any Actor)?) {
+  actor?.assertIsolated()
+  if let actor {
+    print("isolated to \(actor)")
+  } else {
+    print("nonisolated")
+  }
+}
+
+// CHECK: nonisolated
+// CHECK: isolated to Swift.MainActor
+// CHECK: isolated to MyActor
+optionalIsolated(to: nil)
+await optionalIsolated(to: MainActor.shared)
+await optionalIsolated(to: MyActor())

--- a/test/SILGen/isolated_parameters.swift
+++ b/test/SILGen/isolated_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature OptionalIsolatedParameters %s -module-name test -swift-version 5 | %FileCheck %s
 // REQUIRES: concurrency
 
 @available(SwiftStdlib 5.1, *)
@@ -32,5 +32,36 @@ public func testIsolatedExistential(_ a: isolated Actor) async {
   // CHECK: [[ACTOR_COPY:%.*]] = copy_value [[ACTOR]] : $any Actor
   // CHECK: [[ACTOR_BORROW:%.*]] = begin_borrow [[ACTOR_COPY]] : $any Actor
   // CHECK: hop_to_executor [[ACTOR_BORROW]] : $any Actor
+  // CHECK: return
+}
+
+@available(SwiftStdlib 5.1, *)
+nonisolated func suspend() async {}
+
+// CHECK-LABEL: sil{{.*}} [ossa] @$s4test0A16OptionalIsolatedyyAA1ACSgYiYaF
+// CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<A>)
+@available(SwiftStdlib 5.1, *)
+public func testOptionalIsolated(_ a: isolated A?) async {
+  await suspend()
+  // CHECK: [[ACTOR_COPY:%.*]] = copy_value [[ACTOR]] : $Optional<A>
+  // CHECK: [[ACTOR_BORROW:%.*]] = begin_borrow [[ACTOR_COPY]] : $Optional<A>
+  // CHECK: hop_to_executor [[ACTOR_BORROW]] : $Optional<A>
+  // CHECK: [[SUSPEND:%.*]] = function_ref @$s4test7suspendyyYaF : $@convention(thin) @async () -> ()
+  // CHECK: apply [[SUSPEND]]() : $@convention(thin) @async () -> ()
+  // CHECK: hop_to_executor [[ACTOR_BORROW]] : $Optional<A>
+  // CHECK: return
+}
+
+// CHECK-LABEL: sil{{.*}} [ossa] @$s4test0A27OptionalIsolatedExistentialyyScA_pSgYiYaF
+// CHECK: bb0([[ACTOR:%.*]] : @guaranteed $Optional<any Actor>)
+@available(SwiftStdlib 5.1, *)
+public func testOptionalIsolatedExistential(_ a: isolated (any Actor)?) async {
+  await suspend()
+  // CHECK: [[ACTOR_COPY:%.*]] = copy_value [[ACTOR]] : $Optional<any Actor>
+  // CHECK: [[ACTOR_BORROW:%.*]] = begin_borrow [[ACTOR_COPY]] : $Optional<any Actor>
+  // CHECK: hop_to_executor [[ACTOR_BORROW]] : $Optional<any Actor>
+  // CHECK: [[SUSPEND:%.*]] = function_ref @$s4test7suspendyyYaF : $@convention(thin) @async () -> ()
+  // CHECK: apply [[SUSPEND]]() : $@convention(thin) @async () -> ()
+  // CHECK: hop_to_executor [[ACTOR_BORROW]] : $Optional<any Actor>
   // CHECK: return
 }

--- a/test/SILGen/isolated_parameters.swift
+++ b/test/SILGen/isolated_parameters.swift
@@ -31,7 +31,6 @@ public func testClosureWithIsolatedParam() {
 public func testIsolatedExistential(_ a: isolated Actor) async {
   // CHECK: [[ACTOR_COPY:%.*]] = copy_value [[ACTOR]] : $any Actor
   // CHECK: [[ACTOR_BORROW:%.*]] = begin_borrow [[ACTOR_COPY]] : $any Actor
-  // CHECK: [[ACTOR_OPENED:%.*]] = open_existential_ref [[ACTOR_BORROW]] : $any Actor to $@opened("{{.*}}", any Actor) Self
-  // CHECK: hop_to_executor [[ACTOR_OPENED]] : $@opened("{{.*}}", any Actor) Self
+  // CHECK: hop_to_executor [[ACTOR_BORROW]] : $any Actor
   // CHECK: return
 }

--- a/test/SILOptimizer/lower_hop_to_actor.sil
+++ b/test/SILOptimizer/lower_hop_to_actor.sil
@@ -260,3 +260,33 @@ bb0(%0 : @guaranteed $Optional<MyActor>):
   %r = tuple ()
   return %r : $()
 }
+
+// CHECK-LABEL: sil [ossa] @optional_existential_actor :
+sil [ossa] @optional_existential_actor : $@async (@guaranteed Optional<any Actor>) -> () {
+bb0(%0 : @guaranteed $Optional<any Actor>):
+// CHECK:      bb0(%0 : @guaranteed $Optional<any Actor>):
+// CHECK-NEXT: switch_enum %0 : $Optional<any Actor>, case #Optional.some!enumelt: bb1, default bb2
+
+// CHECK: bb1([[ACTOR:%.*]] : @guaranteed $any Actor):
+// CHECK-NEXT: [[OPENED:%.*]] = open_existential_ref [[ACTOR]] : $any Actor to $@opened("[[ID:.*]]", any Actor) Self
+// CHECK-NEXT: [[WITNESS:%.*]] = witness_method $@opened("[[ID]]", any Actor) Self, #Actor.unownedExecutor!getter : <Self where Self : Actor> (Self) -> () -> UnownedSerialExecutor
+// CHECK-NEXT: [[SERIAL_EXEC:%.*]] = apply [[WITNESS]]<@opened("[[ID]]", any Actor) Self>([[OPENED]])
+// CHECK-NEXT: [[EXECUTOR:%.*]] = struct_extract [[SERIAL_EXEC]] : $UnownedSerialExecutor, #UnownedSerialExecutor.executor
+// CHECK-NEXT: [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT: br bb3([[SOME]] : $Optional<Builtin.Executor>)
+
+// CHECK: bb2:
+// CHECK-NEXT: [[NONE:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+// CHECK-NEXT: br bb3([[NONE]] : $Optional<Builtin.Executor>)
+
+// CHECK: bb3([[OPT_EXEC:%.*]] : $Optional<Builtin.Executor>):
+// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[OPT_EXEC]] : $Optional<Builtin.Executor> on %0 : $Optional<any Actor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[RET:%.*]] = tuple ()
+// CHECK-NEXT:   return [[RET]] : $()
+  hop_to_executor %0 : $Optional<any Actor>
+  hop_to_executor %0 : $Optional<any Actor>
+  %r = tuple ()
+  return %r : $()
+}

--- a/test/SILOptimizer/lower_hop_to_actor.sil
+++ b/test/SILOptimizer/lower_hop_to_actor.sil
@@ -21,9 +21,9 @@ sil [ossa] @simple : $@async (@guaranteed MyActor) -> () {
 bb0(%0 : @guaranteed $MyActor):
 // CHECK:      bb0(%0 : @guaranteed $MyActor):
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>(%0 : $MyActor) : $Builtin.Executor
-// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %0 : $MyActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %0 : $MyActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   [[RET:%.*]] = tuple ()
 // CHECK-NEXT:   return [[RET]] : $()
   hop_to_executor %0 : $MyActor
@@ -36,13 +36,13 @@ sil [ossa] @pair : $@async (@guaranteed MyActor, @guaranteed MyActor) -> () {
 bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
 // CHECK:      bb0(%0 : @guaranteed $MyActor, %1 : @guaranteed $MyActor):
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>(%0 : $MyActor) : $Builtin.Executor
-// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %0 : $MyActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %0 : $MyActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>(%1 : $MyActor) : $Builtin.Executor
-// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %1 : $MyActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %1 : $MyActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   [[RET:%.*]] = tuple ()
 // CHECK-NEXT:   return [[RET]] : $()
   hop_to_executor %0 : $MyActor
@@ -56,11 +56,10 @@ sil [ossa] @immediate_dominance : $@async (@guaranteed MyActor) -> () {
 bb0(%0 : @guaranteed $MyActor):
 // CHECK:      bb0(%0 : @guaranteed $MyActor):
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>(%0 : $MyActor) : $Builtin.Executor
-// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %0 : $MyActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %0 : $MyActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   [[RET:%.*]] = tuple ()
 // CHECK-NEXT:   return [[RET]] : $()
   hop_to_executor %0 : $MyActor
@@ -76,15 +75,15 @@ bb0(%0 : @guaranteed $MyActor, %1 : $Builtin.Int1):
 // CHECK-NEXT:   cond_br %1, bb1, bb2
 // CHECK:      bb1:
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>(%0 : $MyActor) : $Builtin.Executor
-// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %0 : $MyActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %0 : $MyActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb3
 // CHECK:      bb2:
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>(%0 : $MyActor) : $Builtin.Executor
-// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %0 : $MyActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %0 : $MyActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb3
 // CHECK:      bb3:
 // CHECK-NEXT:   [[RET:%.*]] = tuple ()
@@ -109,24 +108,22 @@ bb0(%0 : @guaranteed $MyActor, %1 : $Builtin.Int1):
 // CHECK:      bb0(%0 : @guaranteed $MyActor, %1 : $Builtin.Int1):
 // CHECK-NEXT:   br bb5
 // CHECK:      bb1:
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND:%.*]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND:%.*]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb6
 // CHECK:      bb2:
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>(%0 : $MyActor) : $Builtin.Executor
-// CHECK-NEXT:   [[DEPEND]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %0 : $MyActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %0 : $MyActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb1
 // CHECK:      bb3:
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND:%.*]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND:%.*]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb6
 // CHECK:      bb4:
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>(%0 : $MyActor) : $Builtin.Executor
-// CHECK-NEXT:   [[DEPEND]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %0 : $MyActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %0 : $MyActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb3
 // CHECK:      bb5:
 // CHECK-NEXT:   cond_br %1, bb2, bb4
@@ -160,26 +157,22 @@ bb0(%0 : @guaranteed $MyActor, %1 : $Builtin.Int1):
 // CHECK:      bb0(%0 : @guaranteed $MyActor, %1 : $Builtin.Int1):
 // CHECK-NEXT:   br bb5
 // CHECK:      bb1:
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND:%.*]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND:%.*]]  : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb6
 // CHECK:      bb2:
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb1
 // CHECK:      bb3:
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb6
 // CHECK:      bb4:
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   br bb3
 // CHECK:      bb5:
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>(%0 : $MyActor) : $Builtin.Executor
-// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %0 : $MyActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %0 : $MyActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   cond_br %1, bb2, bb4
 // CHECK:      bb6:
 // CHECK-NEXT:   [[RET:%.*]] = tuple ()
@@ -212,9 +205,9 @@ bb0(%0 : @guaranteed $CustomActor):
 // CHECK-NEXT:   [[WITNESS_METHOD:%.*]] = witness_method $CustomActor, #Actor.unownedExecutor!getter
 // CHECK-NEXT:   [[WRAPPED_EXECUTOR:%.*]] = apply [[WITNESS_METHOD]]<CustomActor>(%0)
 // CHECK-NEXT:   [[EXECUTOR:%.*]] = struct_extract [[WRAPPED_EXECUTOR]] : $UnownedSerialExecutor, #UnownedSerialExecutor.executor
-// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[EXECUTOR]] : $Builtin.Executor on %0 : $CustomActor
-// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[DEPEND]] : $Builtin.Executor
-// CHECK-NEXT:   hop_to_executor [[SOME]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[SOME]] : $Optional<Builtin.Executor> on %0 : $CustomActor
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
 // CHECK-NEXT:   [[RET:%.*]] = tuple ()
 // CHECK-NEXT:   return [[RET]] : $()
   hop_to_executor %0 : $CustomActor
@@ -237,6 +230,33 @@ bb0:
   %0 = function_ref @get_raw_executor : $@convention(thin) () -> Builtin.Executor
   %1 = apply %0() : $@convention(thin) () -> Builtin.Executor
   hop_to_executor %1 : $Builtin.Executor
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil [ossa] @simple_optional_actor :
+sil [ossa] @simple_optional_actor : $@async (@guaranteed Optional<MyActor>) -> () {
+bb0(%0 : @guaranteed $Optional<MyActor>):
+// CHECK:      bb0(%0 : @guaranteed $Optional<MyActor>):
+// CHECK-NEXT: switch_enum %0 : $Optional<MyActor>, case #Optional.some!enumelt: bb1, default bb2
+
+// CHECK: bb1([[ACTOR:%.*]] : @guaranteed $MyActor):
+// CHECK-NEXT: [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>([[ACTOR]] : $MyActor) : $Builtin.Executor
+// CHECK-NEXT: [[SOME:%.*]] = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, [[EXECUTOR]] : $Builtin.Executor
+// CHECK-NEXT: br bb3([[SOME]] : $Optional<Builtin.Executor>)
+
+// CHECK: bb2:
+// CHECK-NEXT: [[NONE:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none!enumelt
+// CHECK-NEXT: br bb3([[NONE]] : $Optional<Builtin.Executor>)
+
+// CHECK: bb3([[OPT_EXEC:%.*]] : $Optional<Builtin.Executor>):
+// CHECK-NEXT:   [[DEPEND:%.*]] = mark_dependence [[OPT_EXEC]] : $Optional<Builtin.Executor> on %0 : $Optional<MyActor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   hop_to_executor [[DEPEND]] : $Optional<Builtin.Executor>
+// CHECK-NEXT:   [[RET:%.*]] = tuple ()
+// CHECK-NEXT:   return [[RET]] : $()
+  hop_to_executor %0 : $Optional<MyActor>
+  hop_to_executor %0 : $Optional<MyActor>
   %r = tuple ()
   return %r : $()
 }


### PR DESCRIPTION
Allow isolated parameters to have optional type. This is the primary generalization of isolated parameters described in https://github.com/apple/swift-evolution/blob/d4bfe25e12115f70b691f782a2dc99a7a7d1406a/proposals/NNNN-generalize-async-sequence.md#generalized-isolated-parameters.

This change requires the `hop_to_executor` instruction to handle optional actor operands in SILGen. The `LowerHopToActor` pass then projects out the optional executor value from the optional actor value. `LowerHopToActor` inserts the executor derivation in dominating position to allow reusing the executor value in reachable `hop_to_executor` instructions, but dominance analysis relies on the CFG not changing. This is handled by changing `LowerHopToActor` to perform two passes over the given function:

1. The first pass records all actor operands of `hop_to_executor` and `extract_executor` instructions and records the dominating instruction that will derive the executor value.
2. The second pass iterates over the multi-map of dominating instructions, derives the executor value (which can include switching over an optional actor), and rewrites the operands of all reachable `hop_to_executor` and `extract_executor` instructions to use that executor value.

Writing optional isolated parameters in source is currently gated behind `-enable-experimental-feature OptionalIsolatedParameters`.