### PR TITLE
[embedded] Add Dictionary to embedded stdlib

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -65,12 +65,12 @@ split_embedded_sources(
     NORMAL CString.swift
   EMBEDDED CTypes.swift
     NORMAL DebuggerSupport.swift
-    NORMAL Dictionary.swift
-    NORMAL DictionaryBridging.swift
-    NORMAL DictionaryBuilder.swift
-    NORMAL DictionaryCasting.swift
-    NORMAL DictionaryStorage.swift
-    NORMAL DictionaryVariant.swift
+  EMBEDDED Dictionary.swift
+  EMBEDDED DictionaryBridging.swift
+  EMBEDDED DictionaryBuilder.swift
+  EMBEDDED DictionaryCasting.swift
+  EMBEDDED DictionaryStorage.swift
+  EMBEDDED DictionaryVariant.swift
     NORMAL DiscontiguousSlice.swift
     NORMAL DropWhile.swift
     NORMAL Dump.swift
@@ -99,8 +99,8 @@ split_embedded_sources(
     NORMAL Join.swift
     NORMAL KeyPath.swift
     NORMAL KeyValuePairs.swift
-    NORMAL LazyCollection.swift
-    NORMAL LazySequence.swift
+  EMBEDDED LazyCollection.swift
+  EMBEDDED LazySequence.swift
     NORMAL LegacyABI.swift
   EMBEDDED LifetimeManager.swift
     NORMAL Macros.swift
@@ -111,7 +111,7 @@ split_embedded_sources(
     NORMAL Mirrors.swift
   EMBEDDED Misc.swift
   EMBEDDED MutableCollection.swift
-    NORMAL NativeDictionary.swift
+  EMBEDDED NativeDictionary.swift
   EMBEDDED NativeSet.swift
     NORMAL NewtypeWrapper.swift
     NORMAL NFC.swift

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1284,9 +1284,7 @@ extension Dictionary {
 
   /// A view of a dictionary's keys.
   @frozen
-  public struct Keys
-    : Collection, Equatable,
-      CustomStringConvertible, CustomDebugStringConvertible {
+  public struct Keys: Collection, Equatable {
     public typealias Element = Key
     public typealias SubSequence = Slice<Dictionary.Keys>
 
@@ -1399,20 +1397,11 @@ extension Dictionary {
 
       return true
     }
-
-    public var description: String {
-      return _makeCollectionDescription()
-    }
-
-    public var debugDescription: String {
-      return _makeCollectionDescription(withTypeName: "Dictionary.Keys")
-    }
   }
 
   /// A view of a dictionary's values.
   @frozen
-  public struct Values
-    : MutableCollection, CustomStringConvertible, CustomDebugStringConvertible {
+  public struct Values: MutableCollection {
     public typealias Element = Value
 
     @usableFromInline
@@ -1482,14 +1471,6 @@ extension Dictionary {
       return count == 0
     }
 
-    public var description: String {
-      return _makeCollectionDescription()
-    }
-
-    public var debugDescription: String {
-      return _makeCollectionDescription(withTypeName: "Dictionary.Values")
-    }
-
     @inlinable
     public mutating func swapAt(_ i: Index, _ j: Index) {
       guard i != j else { return }
@@ -1504,6 +1485,30 @@ extension Dictionary {
       let b = native.validatedBucket(for: j)
       _variant.asNative.swapValuesAt(a, b, isUnique: isUnique)
     }
+  }
+}
+
+@_unavailableInEmbedded
+extension Dictionary.Keys
+  : CustomStringConvertible, CustomDebugStringConvertible {
+  public var description: String {
+    return _makeCollectionDescription()
+  }
+
+  public var debugDescription: String {
+    return _makeCollectionDescription(withTypeName: "Dictionary.Keys")
+  }
+}
+
+@_unavailableInEmbedded
+extension Dictionary.Values
+  : CustomStringConvertible, CustomDebugStringConvertible {
+  public var description: String {
+    return _makeCollectionDescription()
+  }
+
+  public var debugDescription: String {
+    return _makeCollectionDescription(withTypeName: "Dictionary.Values")
   }
 }
 
@@ -1614,6 +1619,7 @@ extension Dictionary: Hashable where Value: Hashable {
   }
 }
 
+@_unavailableInEmbedded
 extension Dictionary: _HasCustomAnyHashableRepresentation
 where Value: Hashable {
   public __consuming func _toCustomAnyHashable() -> AnyHashable? {
@@ -1621,6 +1627,7 @@ where Value: Hashable {
   }
 }
 
+@_unavailableInEmbedded
 internal struct _DictionaryAnyHashableBox<Key: Hashable, Value: Hashable>
   : _AnyHashableBox {
   internal let _value: Dictionary<Key, Value>
@@ -1673,6 +1680,7 @@ internal struct _DictionaryAnyHashableBox<Key: Hashable, Value: Hashable>
   }
 }
 
+@_unavailableInEmbedded
 extension Collection {
   // Utility method for KV collections that wish to implement
   // CustomStringConvertible and CustomDebugStringConvertible using a bracketed
@@ -1706,6 +1714,7 @@ extension Collection {
   }
 }
 
+@_unavailableInEmbedded
 extension Dictionary: CustomStringConvertible, CustomDebugStringConvertible {
   /// A string that represents the contents of the dictionary.
   public var description: String {

--- a/stdlib/public/core/DictionaryCasting.swift
+++ b/stdlib/public/core/DictionaryCasting.swift
@@ -42,6 +42,7 @@ extension Dictionary {
 ///   protocols (such as `AnyObject`) of `DerivedKey` and `DerivedValue`,
 ///   respectively.
 @inlinable
+@_unavailableInEmbedded
 public func _dictionaryUpCast<DerivedKey, DerivedValue, BaseKey, BaseValue>(
     _ source: Dictionary<DerivedKey, DerivedValue>
 ) -> Dictionary<BaseKey, BaseValue> {
@@ -58,6 +59,7 @@ public func _dictionaryUpCast<DerivedKey, DerivedValue, BaseKey, BaseValue>(
 
 /// Called by the casting machinery.
 @_silgen_name("_swift_dictionaryDownCastIndirect")
+@_unavailableInEmbedded
 internal func _dictionaryDownCastIndirect<SourceKey, SourceValue,
                                           TargetKey, TargetValue>(
   _ source: UnsafePointer<Dictionary<SourceKey, SourceValue>>,
@@ -73,6 +75,7 @@ internal func _dictionaryDownCastIndirect<SourceKey, SourceValue,
 /// - Precondition: `DerivedKey` is a subtype of `BaseKey`, `DerivedValue` is
 ///   a subtype of `BaseValue`, and all of these types are reference types.
 @inlinable
+@_unavailableInEmbedded
 public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
   _ source: Dictionary<BaseKey, BaseValue>
 ) -> Dictionary<DerivedKey, DerivedValue> {
@@ -111,6 +114,7 @@ public func _dictionaryDownCast<BaseKey, BaseValue, DerivedKey, DerivedValue>(
 
 /// Called by the casting machinery.
 @_silgen_name("_swift_dictionaryDownCastConditionalIndirect")
+@_unavailableInEmbedded
 internal func _dictionaryDownCastConditionalIndirect<SourceKey, SourceValue,
                                                      TargetKey, TargetValue>(
   _ source: UnsafePointer<Dictionary<SourceKey, SourceValue>>,
@@ -132,6 +136,7 @@ internal func _dictionaryDownCastConditionalIndirect<SourceKey, SourceValue,
 /// - Precondition: `DerivedKey` is a subtype of `BaseKey`, `DerivedValue` is
 ///   a subtype of `BaseValue`, and all of these types are reference types.
 @inlinable
+@_unavailableInEmbedded
 public func _dictionaryDownCastConditional<
   BaseKey, BaseValue, DerivedKey, DerivedValue
 >(

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -187,6 +187,29 @@ extension __EmptyDictionarySingleton: _NSDictionaryCore {
 }
 #endif
 
+#if $Embedded
+// In embedded Swift, the stdlib is a .swiftmodule only without any .o/.a files,
+// to allow consuming it by clients with different LLVM codegen setting (-mcpu
+// flags, etc.), which means we cannot declare the singleton in a C/C++ file.
+//
+// TODO: We should figure out how to make this a constant so that it's placed in
+// non-writable memory (can't be a let, Builtin.addressof below requires a var).
+public var _swiftEmptyDictionarySingleton: (Int, Int, Int, Int, UInt8, UInt8, UInt16, UInt32, Int, Int, Int, Int) =
+    (
+      /*isa*/0, /*refcount*/-1, // HeapObject header
+      /*count*/0,
+      /*capacity*/0,
+      /*scale*/0,
+      /*reservedScale*/0,
+      /*extra*/0,
+      /*age*/0,
+      /*seed*/0,
+      /*rawKeys*/1,
+      /*rawValues*/1,
+      /*metadata*/~1
+    )
+#endif
+
 extension __RawDictionaryStorage {
   /// The empty singleton that is used for every single Dictionary that is
   /// created without any elements. The contents of the storage should never

--- a/stdlib/public/core/DictionaryVariant.swift
+++ b/stdlib/public/core/DictionaryVariant.swift
@@ -46,9 +46,9 @@ extension Dictionary {
     @inlinable
     @inline(__always)
     init(dummy: Void) {
-#if _pointerBitWidth(_64)
+#if _pointerBitWidth(_64) && !$Embedded
       self.object = _BridgeStorage(taggedPayload: 0)
-#elseif _pointerBitWidth(_32)
+#elseif _pointerBitWidth(_32) || $Embedded
       self.init(native: _NativeDictionary())
 #else
 #error("Unknown platform")

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -145,7 +145,7 @@ public var _swiftEmptySetSingleton: (Int, Int, Int, Int, UInt8, UInt8, UInt16, U
       /*age*/0, 
       /*seed*/0, 
       /*rawElements*/1, 
-      /*metadata*/-1
+      /*metadata*/~1
     )
 #endif
 

--- a/test/IDE/complete_embedded.swift
+++ b/test/IDE/complete_embedded.swift
@@ -11,5 +11,5 @@ func test() {
 // GLOBAL: Literal[Nil]/None:                  nil;
 // GLOBAL: Literal[String]/None:               "{#(abc)#}"[#String#];
 // GLOBAL: Literal[Array]/None:                [{#(values)#}][#Array#];
-// GLOBAL: Literal[Dictionary]/None:           [{#(key)#}: {#(value)#}];
+// GLOBAL: Literal[Dictionary]/None:           [{#(key)#}: {#(value)#}][#Dictionary#];
 }

--- a/test/embedded/dictionary-runtime.swift
+++ b/test/embedded/dictionary-runtime.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+
+@main
+struct Main {
+  static func main() {
+    var dict: [Int: StaticString] = [:]
+    dict[11] = "hello"
+    dict[33] = "!"
+    dict[22] = "world"
+    for key in dict.keys.sorted() {
+      print(dict[key]!, terminator: " ")
+    }
+    print("")
+  }
+}
+
+// CHECK: hello world !

--- a/test/embedded/dictionary-runtime.swift
+++ b/test/embedded/dictionary-runtime.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
 // RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/dictionary-runtime.swift
+++ b/test/embedded/dictionary-runtime.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
-// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/dictionary-runtime.swift
+++ b/test/embedded/dictionary-runtime.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-parse-as-library -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
-// RUN: %target-run-simple-swift(-parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/embedded/stdlib-dictionary.swift
+++ b/test/embedded/stdlib-dictionary.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+
+public func test() {
+  var d: [Int:Int] = [1: 2, 3: 4, 5: 6]
+  d[8] = 9
+  d.keys.sorted()
+  d.values.allSatisfy { $0 > 0 }
+  d.keys.contains { $0 > 0 }
+  d.values.map { $0 * 2 }
+}
+
+test()
+
+// CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)


### PR DESCRIPTION
This is a straightforward addition of Dictionary to the embedded stdlib, same as how Array and Set is done. Namely:
- Carve out CustomStringConvertible, CustomDebugStringConvertible conformances
- Disallow casting, bridging, and non-native representations
- Define the empty singleton as a Swift global variable (with the same caveats as Array and Set have)
- Dumb down the error reporting in `KEY_TYPE_OF_DICTIONARY_VIOLATES_HASHABLE_REQUIREMENTS`
- Add tests