### PR TITLE
[Dependency Scanning] Use VFS-remapped paths for Clang Module Dependencies' `.modulemap` files

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2175,6 +2175,7 @@ NOTE(dependency_as_imported_by_main_module,none,
 NOTE(dependency_as_imported_by, none,
      "a dependency of %select{Swift|Clang}2 module '%0': '%1'", (StringRef, StringRef, bool))
 ERROR(clang_dependency_scan_error, none, "Clang dependency scanner failure: %0", (StringRef))
+WARNING(clang_dependency_no_modulemap_fileref, none, "Unable to verify Clang dependency module map '%0': $1", (StringRef, StringRef))
 
 // Enum annotations
 ERROR(indirect_case_without_payload,none,

--- a/test/ScanDependencies/modulemap_vfs_remap.swift
+++ b/test/ScanDependencies/modulemap_vfs_remap.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/inputs)
+// RUN: %empty-directory(%t/remapped)
+
+// RUN: split-file %s %t
+// RUN: sed -e "s|TMPDIR|%/t|g" %t/vfs.json.template > %t/inputs/vfs.json
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %/t/inputs -Xcc -ivfsoverlay -Xcc %/t/inputs/vfs.json -vfsoverlay %/t/inputs/vfs.json
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+//--- remapped/X.h
+void funcX(void);
+
+//--- remapped/RedirectedX.modulemap
+module RedirectedX {
+  header "X.h"
+  export *
+}
+
+//--- vfs.json.template
+{
+  "case-sensitive": false,
+  "version": 0,
+  "roots": [
+    {
+      "type": "directory",
+      "name": "TMPDIR/inputs",
+      "contents": [
+        {
+          "type": "file",
+          "name": "module.modulemap",
+          "external-contents": "TMPDIR/remapped/RedirectedX.modulemap",
+        },
+        {
+          "type": "file",
+          "name": "X.h",
+          "external-contents": "TMPDIR/remapped/X.h",
+        }
+      ]
+    }
+  ]
+}
+
+//--- test.swift
+import RedirectedX
+
+// CHECK: "clang": "RedirectedX"
+// CHECK: "clang": "RedirectedX"
+// CHECK:   "moduleMapPath": "{{.*}}{{/|\\}}remapped{{/|\\}}RedirectedX.modulemap",


### PR DESCRIPTION
These files are used as an explicit input for the resulting compilation task

Resolves rdar://120554985
