### PR TITLE
AST: Fix ReplaceOpaqueTypesWithUnderlyingTypes to consider the current resilience expansion in non resilient mode

### DIFF
--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -1016,6 +1016,7 @@ static Type substOpaqueTypesWithUnderlyingTypesRec(
 /// opaque substitutions are or are not allowed.
 static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
                                   OpaqueSubstitutionKind kind,
+                                  ResilienceExpansion contextExpansion,
                                   bool isContextWholeModule) {
   TypeDecl *typeDecl = ty->getAnyNominal();
   if (!typeDecl) {
@@ -1056,7 +1057,8 @@ static bool canSubstituteTypeInto(Type ty, const DeclContext *dc,
 
   case OpaqueSubstitutionKind::SubstituteNonResilientModule:
     // Can't access types that are not public from a different module.
-    if (dc->getParentModule() == typeDecl->getDeclContext()->getParentModule())
+    if (dc->getParentModule() == typeDecl->getDeclContext()->getParentModule() &&
+        contextExpansion != ResilienceExpansion::Minimal)
       return typeDecl->getEffectiveAccess() > AccessLevel::FilePrivate;
 
     return typeDecl->getEffectiveAccess() > AccessLevel::Internal;
@@ -1100,10 +1102,13 @@ operator()(SubstitutableType *maybeOpaqueType) const {
   // context.
   auto inContext = this->getContext();
   auto isContextWholeModule = this->isWholeModule();
+  auto contextExpansion = this->contextExpansion;
   if (inContext &&
       partialSubstTy.findIf(
-          [inContext, substitutionKind, isContextWholeModule](Type t) -> bool {
+          [inContext, substitutionKind, isContextWholeModule,
+           contextExpansion](Type t) -> bool {
             if (!canSubstituteTypeInto(t, inContext, substitutionKind,
+                                       contextExpansion,
                                        isContextWholeModule))
               return true;
             return false;
@@ -1211,9 +1216,12 @@ operator()(CanType maybeOpaqueType, Type replacementType,
   // context.
   auto inContext = this->getContext();
   auto isContextWholeModule = this->isWholeModule();
+  auto contextExpansion = this->contextExpansion;
   if (partialSubstTy.findIf(
-          [inContext, substitutionKind, isContextWholeModule](Type t) -> bool {
+          [inContext, substitutionKind, isContextWholeModule,
+          contextExpansion](Type t) -> bool {
             if (!canSubstituteTypeInto(t, inContext, substitutionKind,
+                                       contextExpansion,
                                        isContextWholeModule))
               return true;
             return false;

--- a/test/IRGen/Inputs/opaque_result_type_internal_inlinable.swift
+++ b/test/IRGen/Inputs/opaque_result_type_internal_inlinable.swift
@@ -1,0 +1,36 @@
+public protocol P {}
+
+public struct G<T, V> : P {
+
+  var t: T
+  var v: V
+
+  public init(_ t: T, _ v: V) {
+    self.t = t
+    self.v = v
+  }
+}
+
+struct I {
+  public init() {
+  }
+}
+
+public struct E : P {
+  public init() {}
+
+  @inlinable
+  public static var a : some P {
+    return G(E(), C().b())
+  }
+}
+
+public struct C {
+  public init() {}
+
+  @usableFromInline
+  internal func b() -> some P {
+    return G(self, I())
+  }
+}
+

--- a/test/IRGen/oapque_result_type_internal.swift
+++ b/test/IRGen/oapque_result_type_internal.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -O -disable-availability-checking -emit-module -emit-module-path=%t/R.swiftmodule -module-name=R %S/Inputs/opaque_result_type_internal_inlinable.swift
+// RUN: %target-swift-frontend -O -I %t -disable-availability-checking -c -primary-file %s
+
+import R
+
+// This used to crash because when we were importing E.a the serialized sil
+// contained underlying types that this module does not have access to (internal type `I`).
+
+public func testIt() {
+    var e = E.a
+    print(e)
+}


### PR DESCRIPTION
When we decide which access level we can allow for types we need to consider the resilience expansion context. 'internal' visibility cannot be allowed to be looked through in inlineable code as an external module does not have visiblity to such a symbol.

rdar://119725428