### PR TITLE
[cxx-interop] Initial tests for `std::function` usage

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2959,9 +2959,7 @@ namespace {
         if (notInstantiated)
           return nullptr;
       }
-      if (!clangSema.isCompleteType(
-              decl->getLocation(),
-              Impl.getClangASTContext().getRecordType(decl))) {
+      if (!decl->getDefinition()) {
         // If we got nullptr definition now it means the type is not complete.
         // We don't import incomplete types.
         return nullptr;

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -33,3 +33,8 @@ module StdUniquePtr {
   header "std-unique-ptr.h"
   requires cplusplus
 }
+
+module StdFunction {
+  header "std-function.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -1,26 +1,31 @@
 module StdVector {
   header "std-vector.h"
   requires cplusplus
+  export *
 }
 
 module StdMap {
   header "std-map.h"
   requires cplusplus
+  export *
 }
 
 module StdOptional {
   header "std-optional.h"
   requires cplusplus
+  export *
 }
 
 module StdSet {
   header "std-set.h"
   requires cplusplus
+  export *
 }
 
 module StdPair {
   header "std-pair.h"
   requires cplusplus
+  export *
 }
 
 module MsvcUseVecIt {
@@ -32,9 +37,11 @@ module MsvcUseVecIt {
 module StdUniquePtr {
   header "std-unique-ptr.h"
   requires cplusplus
+  export *
 }
 
 module StdFunction {
   header "std-function.h"
   requires cplusplus
+  export *
 }

--- a/test/Interop/Cxx/stdlib/Inputs/std-function.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-function.h
@@ -1,0 +1,16 @@
+#ifndef TEST_INTEROP_CXX_STDLIB_INPUTS_STD_FUNCTION_H
+#define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_FUNCTION_H
+
+#include <functional>
+
+using FunctionIntToInt = std::function<int(int)>;
+
+FunctionIntToInt getIdentityFunction() {
+  return [](int x) { return x; };
+}
+
+bool isEmptyFunction(FunctionIntToInt f) { return !(bool)f; }
+
+int invokeFunction(FunctionIntToInt f, int x) { return f(x); }
+
+#endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_FUNCTION_H

--- a/test/Interop/Cxx/stdlib/Inputs/std-pair.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-pair.h
@@ -35,7 +35,7 @@ struct __attribute__((swift_attr("import_iterator"))) Iterator {};
 using PairUnsafeStructInt = std::pair<UnsafeStruct, int>;
 using PairIteratorInt = std::pair<Iterator, int>;
 
-struct HasMethodThatReturnsUnsafePair {
+struct __attribute__((swift_attr("import_owned"))) HasMethodThatReturnsUnsafePair {
     PairUnsafeStructInt getUnsafePair() const { return {}; }
     PairIteratorInt getIteratorPair() const { return {}; }
 };

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import StdFunction
+
+var StdFunctionTestSuite = TestSuite("StdFunction")
+
+StdFunctionTestSuite.test("init empty") {
+  let f = FunctionIntToInt()
+  expectTrue(isEmptyFunction(f))
+
+  let copied = f
+  expectTrue(isEmptyFunction(copied))
+}
+
+StdFunctionTestSuite.test("call") {
+  let f = getIdentityFunction()
+  expectEqual(123, f(123))
+}
+
+StdFunctionTestSuite.test("retrieve and pass back as parameter") {
+  let res = invokeFunction(getIdentityFunction(), 456)
+  expectEqual(456, res)
+}
+
+runAllTests()

--- a/test/Interop/Cxx/stdlib/use-std-pair-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair-typechecker.swift
@@ -1,7 +1,12 @@
-// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
 
 import StdPair
 
 let u = HasMethodThatReturnsUnsafePair()
-u.getUnsafePair() // expected-error {{value of type 'HasMethodThatReturnsUnsafePair' has no member 'getUnsafePair'}}
-u.getIteratorPair() // expected-error {{value of type 'HasMethodThatReturnsUnsafePair' has no member 'getIteratorPair'}}
+u.getUnsafePair()
+// CHECK: error: value of type 'HasMethodThatReturnsUnsafePair' has no member 'getUnsafePair'
+// CHECK: note: C++ method 'getUnsafePair' may return an interior pointer
+
+u.getIteratorPair()
+// CHECK: error: value of type 'HasMethodThatReturnsUnsafePair' has no member 'getIteratorPair'
+// CHECK: note: C++ method 'getIteratorPair' may return an interior pointer


### PR DESCRIPTION
This makes sure that `std::function` is imported consistently on supported platforms, and that it allows basic usage: calling a function with `callAsFunction`, initializing an empty function, and passing a function retrieved from C++ back to C++ as a parameter.

rdar://103979602