### PR TITLE
[SIL] Builtins that read or write memory may access pointers.

### DIFF
--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -439,6 +439,10 @@ bool swift::isLetAddress(SILValue address) {
 bool swift::mayAccessPointer(SILInstruction *instruction) {
   if (!instruction->mayReadOrWriteMemory())
     return false;
+  if (isa<BuiltinInst>(instruction)) {
+    // Consider all builtins that read/write memory to access pointers.
+    return true;
+  }
   bool retval = false;
   visitAccessedAddress(instruction, [&retval](Operand *operand) {
     auto accessStorage = AccessStorage::compute(operand->get());

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -139,3 +139,18 @@ entry:
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test {{.*}} on rdar120656227: is-deinit-barrier
+// CHECK:       builtin "int_memmove_RawPointer_RawPointer_Int64"
+// CHECK:       true
+// CHECK-LABEL: end running test {{.*}} on rdar120656227: is-deinit-barrier
+sil [ossa] @rdar120656227 : $@convention(thin) (Builtin.RawPointer, Builtin.RawPointer) -> () {
+bb0(%42 : $Builtin.RawPointer, %9 : $Builtin.RawPointer):
+  %14 = integer_literal $Builtin.Int64, 27
+  %28 = integer_literal $Builtin.Int1, 1
+  specify_test "is-deinit-barrier @instruction"
+  %43 = builtin "int_memmove_RawPointer_RawPointer_Int64"(%42 : $Builtin.RawPointer, %9 : $Builtin.RawPointer, %14 : $Builtin.Int64, %28 : $Builtin.Int1) : $()
+  %68 = tuple ()
+  return %68 : $()
+}
+


### PR DESCRIPTION
When an instruction `mayReadOrWriteMemory`, the `mayAccessPointer` predicate relies on the `visitAccessedAddress` utility to determine whether an instruction may access a pointer.  That utility doesn't (and can't, without changing the representation of the builtin) visit `RawPointer` operands as used by memmove/memcpy builtins.

Previously, this resulted `mayAccessPointer` returning `false` for such builtins.  Here, this is fixed by making the predicate handle `BuiltinInsts` separately.  Instead of just always returning `true` in the face of a builtin, rely on the BuiltinInfo associated with a BuiltinInst and use `mayReadOrWriteMemory`.

rdar://120656227

Resolves #70813
