### PR TITLE
[NFC] SIL: Clarified deinit barrier APIs.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
@@ -112,7 +112,7 @@ extension Instruction {
     if let site = self as? FullApplySite {
       return site.isBarrier(analysis)
     }
-    return maySynchronizeNotConsideringSideEffects
+    return maySynchronize
   }
 
   /// Whether lifetime ends of lexical values may safely be hoisted over this

--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/CalleeAnalysis.swift
@@ -98,30 +98,50 @@ public struct CalleeAnalysis {
   }
 }
 
-extension FullApplySite {
+extension Value {
   fileprivate func isBarrier(_ analysis: CalleeAnalysis) -> Bool {
-    guard let callees = analysis.getCallees(callee: callee) else {
+    guard let callees = analysis.getCallees(callee: self) else {
       return true
     }
     return callees.contains { $0.isDeinitBarrier }
   }
 }
 
-extension Instruction {
-  public final func maySynchronize(_ analysis: CalleeAnalysis) -> Bool {
-    if let site = self as? FullApplySite {
-      return site.isBarrier(analysis)
-    }
-    return maySynchronize
+extension FullApplySite {
+  fileprivate func isBarrier(_ analysis: CalleeAnalysis) -> Bool {
+    return callee.isBarrier(analysis)
   }
+}
 
+extension EndApplyInst {
+  fileprivate func isBarrier(_ analysis: CalleeAnalysis) -> Bool {
+    return (operand.value.definingInstruction as! FullApplySite).isBarrier(analysis)
+  }
+}
+
+extension AbortApplyInst {
+  fileprivate func isBarrier(_ analysis: CalleeAnalysis) -> Bool {
+    return (operand.value.definingInstruction as! FullApplySite).isBarrier(analysis)
+  }
+}
+
+extension Instruction {
   /// Whether lifetime ends of lexical values may safely be hoisted over this
   /// instruction.
   ///
   /// Deinitialization barriers constrain variable lifetimes. Lexical
   /// end_borrow, destroy_value, and destroy_addr cannot be hoisted above them.
   public final func isDeinitBarrier(_ analysis: CalleeAnalysis) -> Bool {
-    return mayAccessPointer || mayLoadWeakOrUnowned || maySynchronize(analysis)
+    if let site = self as? FullApplySite {
+      return site.isBarrier(analysis)
+    }
+    if let eai = self as? EndApplyInst {
+      return eai.isBarrier(analysis)
+    }
+    if let aai = self as? AbortApplyInst {
+      return aai.isBarrier(analysis)
+    }
+    return mayAccessPointer || mayLoadWeakOrUnowned || maySynchronize
   }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -119,8 +119,8 @@ public class Instruction : CustomStringConvertible, Hashable {
     return bridged.mayLoadWeakOrUnowned()
   }
 
-  public final var maySynchronizeNotConsideringSideEffects: Bool {
-    return bridged.maySynchronizeNotConsideringSideEffects()
+  public final var maySynchronize: Bool {
+    return bridged.maySynchronize()
   }
 
   public final var mayBeDeinitBarrierNotConsideringSideEffects: Bool {

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -247,7 +247,7 @@ bool mayLoadWeakOrUnowned(SILInstruction* instruction);
 
 /// Conservatively, whether this instruction could involve a synchronization
 /// point like a memory barrier, lock or syscall.
-bool maySynchronizeNotConsideringSideEffects(SILInstruction* instruction);
+bool maySynchronize(SILInstruction* instruction);
 
 /// Conservatively, whether this instruction could be a barrier to hoisting
 /// destroys.

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -552,7 +552,7 @@ struct BridgedInstruction {
   BRIDGED_INLINE bool maySuspend() const;
   bool mayAccessPointer() const;
   bool mayLoadWeakOrUnowned() const;
-  bool maySynchronizeNotConsideringSideEffects() const;
+  bool maySynchronize() const;
   bool mayBeDeinitBarrierNotConsideringSideEffects() const;
 
   // =========================================================================//

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -437,6 +437,8 @@ bool swift::isLetAddress(SILValue address) {
 //===----------------------------------------------------------------------===//
 
 bool swift::mayAccessPointer(SILInstruction *instruction) {
+  assert(!FullApplySite::isa(instruction) && !isa<EndApplyInst>(instruction) &&
+         !isa<AbortApplyInst>(instruction));
   if (!instruction->mayReadOrWriteMemory())
     return false;
   if (isa<BuiltinInst>(instruction)) {
@@ -455,6 +457,8 @@ bool swift::mayAccessPointer(SILInstruction *instruction) {
 }
 
 bool swift::mayLoadWeakOrUnowned(SILInstruction *instruction) {
+  assert(!FullApplySite::isa(instruction) && !isa<EndApplyInst>(instruction) &&
+         !isa<AbortApplyInst>(instruction));
   if (isa<BuiltinInst>(instruction)) {
     return instruction->mayReadOrWriteMemory();
   }
@@ -467,16 +471,19 @@ bool swift::mayLoadWeakOrUnowned(SILInstruction *instruction) {
 /// Conservatively, whether this instruction could involve a synchronization
 /// point like a memory barrier, lock or syscall.
 bool swift::maySynchronize(SILInstruction *instruction) {
+  assert(!FullApplySite::isa(instruction) && !isa<EndApplyInst>(instruction) &&
+         !isa<AbortApplyInst>(instruction));
   if (isa<BuiltinInst>(instruction)) {
     return instruction->mayReadOrWriteMemory();
   }
-  return FullApplySite::isa(instruction) 
-      || isa<EndApplyInst>(instruction)
-      || isa<AbortApplyInst>(instruction)
-      || isa<HopToExecutorInst>(instruction);
+  return isa<HopToExecutorInst>(instruction);
 }
 
 bool swift::mayBeDeinitBarrierNotConsideringSideEffects(SILInstruction *instruction) {
+  if (FullApplySite::isa(instruction) || isa<EndApplyInst>(instruction) ||
+      isa<AbortApplyInst>(instruction)) {
+    return true;
+  }
   bool retval = mayAccessPointer(instruction)
              || mayLoadWeakOrUnowned(instruction)
              || maySynchronize(instruction);

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -463,7 +463,7 @@ bool swift::mayLoadWeakOrUnowned(SILInstruction *instruction) {
 
 /// Conservatively, whether this instruction could involve a synchronization
 /// point like a memory barrier, lock or syscall.
-bool swift::maySynchronizeNotConsideringSideEffects(SILInstruction *instruction) {
+bool swift::maySynchronize(SILInstruction *instruction) {
   return FullApplySite::isa(instruction) 
       || isa<EndApplyInst>(instruction)
       || isa<AbortApplyInst>(instruction)
@@ -473,7 +473,7 @@ bool swift::maySynchronizeNotConsideringSideEffects(SILInstruction *instruction)
 bool swift::mayBeDeinitBarrierNotConsideringSideEffects(SILInstruction *instruction) {
   bool retval = mayAccessPointer(instruction)
              || mayLoadWeakOrUnowned(instruction)
-             || maySynchronizeNotConsideringSideEffects(instruction);
+             || maySynchronize(instruction);
   assert(!retval || !isa<BranchInst>(instruction) && "br as deinit barrier!?");
   return retval;
 }

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -455,6 +455,9 @@ bool swift::mayAccessPointer(SILInstruction *instruction) {
 }
 
 bool swift::mayLoadWeakOrUnowned(SILInstruction *instruction) {
+  if (isa<BuiltinInst>(instruction)) {
+    return instruction->mayReadOrWriteMemory();
+  }
   return isa<LoadWeakInst>(instruction) 
       || isa<LoadUnownedInst>(instruction) 
       || isa<StrongCopyUnownedValueInst>(instruction)
@@ -464,6 +467,9 @@ bool swift::mayLoadWeakOrUnowned(SILInstruction *instruction) {
 /// Conservatively, whether this instruction could involve a synchronization
 /// point like a memory barrier, lock or syscall.
 bool swift::maySynchronize(SILInstruction *instruction) {
+  if (isa<BuiltinInst>(instruction)) {
+    return instruction->mayReadOrWriteMemory();
+  }
   return FullApplySite::isa(instruction) 
       || isa<EndApplyInst>(instruction)
       || isa<AbortApplyInst>(instruction)

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -439,6 +439,10 @@ bool swift::isLetAddress(SILValue address) {
 bool swift::mayAccessPointer(SILInstruction *instruction) {
   if (!instruction->mayReadOrWriteMemory())
     return false;
+  if (isa<BuiltinInst>(instruction)) {
+    // Consider all builtins that read/write memory to access pointers.
+    return true;
+  }
   bool retval = false;
   visitAccessedAddress(instruction, [&retval](Operand *operand) {
     auto accessStorage = AccessStorage::compute(operand->get());

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -443,8 +443,8 @@ bool BridgedInstruction::mayLoadWeakOrUnowned() const {
   return ::mayLoadWeakOrUnowned(unbridged());
 }
 
-bool BridgedInstruction::maySynchronizeNotConsideringSideEffects() const {
-  return ::maySynchronizeNotConsideringSideEffects(unbridged());
+bool BridgedInstruction::maySynchronize() const {
+  return ::maySynchronize(unbridged());
 }
 
 bool BridgedInstruction::mayBeDeinitBarrierNotConsideringSideEffects() const {

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -139,3 +139,18 @@ entry:
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test {{.*}} on rdar120656227: is-deinit-barrier
+// CHECK:       builtin "int_memmove_RawPointer_RawPointer_Int64"
+// CHECK:       true
+// CHECK-LABEL: end running test {{.*}} on rdar120656227: is-deinit-barrier
+sil [ossa] @rdar120656227 : $@convention(thin) (Builtin.RawPointer, Builtin.RawPointer) -> () {
+bb0(%42 : $Builtin.RawPointer, %9 : $Builtin.RawPointer):
+  %14 = integer_literal $Builtin.Int64, 27
+  %28 = integer_literal $Builtin.Int1, 1
+  specify_test "is-deinit-barrier @instruction"
+  %43 = builtin "int_memmove_RawPointer_RawPointer_Int64"(%42 : $Builtin.RawPointer, %9 : $Builtin.RawPointer, %14 : $Builtin.Int64, %28 : $Builtin.Int1) : $()
+  %68 = tuple ()
+  return %68 : $()
+}
+


### PR DESCRIPTION
This PR adds three commits on top of https://github.com/apple/swift/pull/70773 .

An instruction is a deinit barrier whenever one of three component predicates is true for it.  In the case of applies, it is true whenever one of those three predicates is true for any of the instructions in any of its callees; that fact is cached in the side-effect analysis of every function.

If side-effect analysis or callee analysis is unavailable, in order to define each of those three component predicates on a `FullApplySite`/`EndApplyInst`/`AbortApplyInst`, it would be necessary to define them to conservatively return true: it isn't known whether any of the instructions in any of the callees were deinit barriers.

Refactored the two versions of the deinit barrier predicate (namely `Instruction.isDeinitBarrier(_:)` and `swift::mayBeDeinitBarrierNotConsideringSideEffects`) to handle `FullApplySite`/`EndApplyInst`/`AbortApplyInst`s specially first (to look up the callees' side-effect and to conservatively bail, respectively).  Asserted that the three component predicates are not called with `FullApplySite`/`EndApplyInst`/`AbortApplyInst`s.  Callers should instead use the `isDeinitBarrier` APIs.

An alternative would be to conservatively return true from the three components.  That seems more likely to result in direct calls to these member predicates, however, and at the moment at least there is no reason for such calls to exist.  If some other caller besides the deinit-barrier predicates needs to call this function, side-effect analysis should be updated to cache these three properties separately at that point.