### PR TITLE
Frontend: Hide and deprecate options for Swift 3 @objc inference

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -677,12 +677,12 @@ def report_errors_to_debugger : Flag<["-"], "report-errors-to-debugger">,
 
 def enable_swift3_objc_inference : Flag<["-"], "enable-swift3-objc-inference">,
   Flags<[FrontendOption, HelpHidden]>,
-HelpText<"Enable Swift 3's @objc inference rules for NSObject-derived classes and 'dynamic' members (emulates Swift 3 behavior)">;
+HelpText<"Deprecated">;
 
 def disable_swift3_objc_inference :
   Flag<["-"], "disable-swift3-objc-inference">,
   Flags<[FrontendOption, HelpHidden]>,
-  HelpText<"Disable Swift 3's @objc inference rules for NSObject-derived classes and 'dynamic' members (emulates Swift 4 behavior)">;
+  HelpText<"Deprecated">;
 
 def enable_implicit_dynamic : Flag<["-"], "enable-implicit-dynamic">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -787,13 +787,13 @@ def continue_building_after_errors : Flag<["-"], "continue-building-after-errors
 
 def warn_swift3_objc_inference_complete :
   Flag<["-"], "warn-swift3-objc-inference-complete">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Warn about deprecated @objc inference in Swift 3 for every declaration that will no longer be inferred as @objc in Swift 4">;
+  Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Deprecated">;
 
 def warn_swift3_objc_inference_minimal :
   Flag<["-"], "warn-swift3-objc-inference-minimal">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Warn about deprecated @objc inference in Swift 3 based on direct uses of the Objective-C entrypoint">;
+  Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Deprecated">;
 
 def enable_actor_data_race_checks :
   Flag<["-"], "enable-actor-data-race-checks">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -920,6 +920,14 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Args.hasFlag(OPT_enable_swift3_objc_inference,
                  OPT_disable_swift3_objc_inference, false);
 
+  if (Args.hasArg(OPT_enable_swift3_objc_inference))
+    Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
+                   "-enable-swift3-objc-inference");
+
+  if (Args.hasArg(OPT_disable_swift3_objc_inference))
+    Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
+                   "-disable-swift3-objc-inference");
+
   if (const Arg *A = Args.getLastArg(OPT_library_level)) {
     StringRef contents = A->getValue();
     if (contents == "api") {
@@ -982,6 +990,14 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
         Opts.WarnSwift3ObjCInference = Swift3ObjCInferenceWarnings::Complete;
     }
   }
+
+  if (Args.hasArg(OPT_warn_swift3_objc_inference_minimal))
+    Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
+                   "-warn-swift3-objc-inference-minimal");
+
+  if (Args.hasArg(OPT_warn_swift3_objc_inference_complete))
+    Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
+                   "-warn-swift3-objc-inference-complete");
 
   // Swift 6+ uses the strictest concurrency level.
   if (Opts.isSwiftVersionAtLeast(6)) {


### PR DESCRIPTION
The compiler has not supported migrating Swift 3 code to Swift 4 for a long time. The `-enable-swift3-objc-inference` option and related options were originally designed to aid that transition and should be deprecated and no longer advertised.

Resolves rdar://120490061
