### PR TITLE
[TaskExecutors] Task initializer and withTaskExecutor parameter changes

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -107,6 +107,7 @@ set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_SOURCES
   AsyncThrowingMapSequence.swift
   AsyncThrowingPrefixWhileSequence.swift
   GlobalActor.swift
+  GlobalConcurrentExecutor.swift
   MainActor.swift
   PartialAsyncTask.swift
   SourceCompatibilityShims.swift

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -113,8 +113,8 @@ public protocol SerialExecutor: Executor {
 /// requirements.
 ///
 /// By setting a task executor preference, either with a
-/// ``_withTaskExecutor(_:operation:)``, creating a task with a preference
-/// (`Task(_on:)`, or `group.addTask(on:)`), the task and all of its child
+/// ``_withTaskExecutorPreference(_:operation:)``, creating a task with a preference
+/// (`Task(_executorPreference:)`, or `group.addTask(executorPreference:)`), the task and all of its child
 /// tasks (unless a new preference is set) will be preferring to execute on
 /// the provided task executor.
 ///
@@ -375,9 +375,8 @@ internal func _task_serialExecutor_getExecutorRef<E>(_ executor: E) -> Builtin.E
 @_unavailableInEmbedded
 @available(SwiftStdlib 9999, *)
 @_silgen_name("_task_executor_getTaskExecutorRef")
-internal func _task_executor_getTaskExecutorRef<E>(_ executor: E) -> Builtin.Executor
-    where E: _TaskExecutor {
-  return executor.asUnownedTaskExecutor().executor
+internal func _task_executor_getTaskExecutorRef(_ taskExecutor: any _TaskExecutor) -> Builtin.Executor {
+  return taskExecutor.asUnownedTaskExecutor().executor
 }
 
 // Used by the concurrency runtime

--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -32,6 +32,7 @@ import Swift
 ///
 /// Customizing the global concurrent executor is currently not supported.
 @available(SwiftStdlib 9999, *)
+nonisolated(unsafe)
 public var globalConcurrentExecutor: any _TaskExecutor {
   get {
     _DefaultGlobalConcurrentExecutor.shared

--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Swift
+@_implementationOnly import _SwiftConcurrencyShims
+
+// None of _TaskExecutor APIs are available in task-to-thread concurrency model.
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+
+/// The global concurrent executor that is used by default for Swift Concurrency
+/// tasks.
+///
+/// The executor's implementation is platform dependent.
+/// By default it uses a fixed size pool of threads and should not be used for
+/// blocking operations which do not guarantee forward progress as doing so may
+/// prevent other tasks from being executed and render the system unresponsive.
+///
+/// You may pass this executor explicitly to a ``Task`` initializer as a task
+/// executor preference, in order to ensure and document that task be executed
+/// on the global executor, instead e.g. inheriting the enclosing actor's
+/// executor. Refer to ``_withTaskExecutorPreference(_:operation:)`` for a
+/// detailed discussion of task executor preferences.
+///
+/// Customizing the global concurrent executor is currently not supported.
+@available(SwiftStdlib 9999, *)
+public var globalConcurrentExecutor: any _TaskExecutor {
+  get {
+    _DefaultGlobalConcurrentExecutor.shared
+  }
+  // TODO: introduce a set {} once we are ready to allow customizing the
+  //       default global executor. This should be done the same for main actor
+}
+
+/// A task executor which enqueues all work on the default global concurrent
+/// thread pool that is used as the default executor for Swift concurrency
+/// tasks.
+@available(SwiftStdlib 9999, *)
+internal final class _DefaultGlobalConcurrentExecutor: _TaskExecutor {
+  public static let shared: _DefaultGlobalConcurrentExecutor = .init()
+
+  private init() {}
+
+  public func enqueue(_ job: consuming ExecutorJob) {
+    _enqueueJobGlobal(job.context)
+  }
+
+  public func asUnownedTaskExecutor() {
+    // The "default global concurrent executor" is simply the "undefined" one.
+    // We represent it as the `(0, 0)` ExecutorRef and it is handled properly
+    // by the runtime, without having to call through to the
+    // `_DefaultGlobalConcurrentExecutor` declared in Swift.
+    UnownedTaskExecutor(_getUndefinedTaskExecutor())
+  }
+}
+
+#endif

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -121,7 +121,7 @@ public struct UnownedJob: Sendable {
   @available(SwiftStdlib 9999, *)
   @_alwaysEmitIntoClient
   @inlinable
-  public func runSynchronously(isolated serialExecutor: UnownedSerialExecutor,
+  public func runSynchronously(isolatedTo serialExecutor: UnownedSerialExecutor,
                                taskExecutor: UnownedTaskExecutor) {
     _swiftJobRunOnTaskExecutor(self, serialExecutor, taskExecutor)
   }

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -53,7 +53,10 @@ import Swift
 ///
 ///         // child tasks execute on 'specific' task executor:
 ///         async let x = ...
-///         await withTaskGroup(of: Int.self) { group in g.addTask { 7 } }
+///         await withTaskGroup(of: Int.self) { group in
+///           group.addTask { 7 } // child task executes on 'specific' executor
+///           group.addTask(on: .default) { 13 } // child task executes on default executor
+///         }
 ///
 ///         // disable the task executor preference:
 ///         await withTaskExecutor(.default) {
@@ -81,7 +84,7 @@ import Swift
 @available(SwiftStdlib 9999, *)
 @_unsafeInheritExecutor // calling withTaskExecutor MUST NOT perform the "usual" hop to global
 public func _withTaskExecutor<T: Sendable>(
-  _ taskExecutorPreference: any _TaskExecutor,
+  _ taskExecutorPreference: some _TaskExecutor,
   operation: @Sendable () async throws -> T
   ) async rethrows -> T {
   let taskExecutorBuiltin: Builtin.Executor =
@@ -173,7 +176,7 @@ extension Task where Failure == Never {
   @discardableResult
   @_alwaysEmitIntoClient
   public init(
-    _on executor: any _TaskExecutor,
+    _on executor: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> Success
   ) {
@@ -201,7 +204,7 @@ extension Task where Failure == Error {
   @discardableResult
   @_alwaysEmitIntoClient
   public init(
-    _on executor: any _TaskExecutor,
+    _on executor: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Success
   ) {
@@ -233,7 +236,7 @@ extension Task where Failure == Never {
   @_alwaysEmitIntoClient
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public static func _detached(
-    on executor: any _TaskExecutor,
+    on executor: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> Success
   ) -> Task<Success, Failure> {
@@ -264,7 +267,7 @@ extension Task where Failure == Never {
   @discardableResult
   @_alwaysEmitIntoClient
   public static func _detached(
-    on executor: any _TaskExecutor,
+    on executor: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> Success
   ) -> Task<Success, Failure> {
@@ -296,7 +299,7 @@ extension Task where Failure == Error {
   @_alwaysEmitIntoClient
   @available(*, unavailable, message: "Unavailable in task-to-thread concurrency model")
   public static func _detached(
-    on executor: any _TaskExecutor,
+    on executor: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Success
   ) -> Task<Success, Failure> {
@@ -329,7 +332,7 @@ extension Task where Failure == Error {
   @discardableResult
   @_alwaysEmitIntoClient
   public static func _detached(
-    on executor: any _TaskExecutor,
+    on executor: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Success
   ) -> Task<Success, Failure> {

--- a/stdlib/public/Concurrency/Task+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/Task+TaskExecutor.swift
@@ -87,7 +87,7 @@ import Swift
 ///       async let x = ...
 ///       await withTaskGroup(of: Int.self) { group in g.addTask { 7 } }
 ///
-///       await withTaskExecutor(specific) {
+///       await withTaskExecutorPreference(specific) {
 ///         // case 1) 'specific' task executor preference
 ///
 ///         // 'specific' task executor
@@ -103,8 +103,8 @@ import Swift
 ///         }
 ///
 ///         // disable the task executor preference:
-///         await withTaskExecutor(.default) {
-///           // equivalent to case 0) preference is "default"
+///         await withTaskExecutorPreference(globalConcurrentExecutor) {
+///           // equivalent to case 0) preference is globalConcurrentExecutor
 ///
 ///           // default task executor
 ///           // ...

--- a/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
@@ -22,7 +22,7 @@ extension TaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor.
   ///
   /// - Parameters:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -33,7 +33,7 @@ extension TaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutor: (any _TaskExecutor)?,
+    on taskExecutorPreference: any _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
@@ -45,11 +45,7 @@ extension TaskGroup {
       isDiscardingTask: false)
 
     let executorBuiltin: Builtin.Executor =
-      if let taskExecutor {
-        taskExecutor.asUnownedTaskExecutor().executor
-      } else {
-        _getUndefinedTaskExecutor()
-      }
+      taskExecutorPreference.asUnownedTaskExecutor().executor
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -61,7 +57,7 @@ extension TaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor, unless the group has been canceled.
   ///
   /// - Parameters:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTaskUnlessCancelled()` without passing a value to the `taskExecutor` parameter,
@@ -74,7 +70,7 @@ extension TaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutor: (any _TaskExecutor)?,
+    on taskExecutorPreference: any _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
@@ -92,11 +88,7 @@ extension TaskGroup {
       isDiscardingTask: false)
 
     let executorBuiltin: Builtin.Executor =
-      if let taskExecutor {
-        taskExecutor.asUnownedTaskExecutor().executor
-      } else {
-        _getUndefinedTaskExecutor()
-      }
+        taskExecutorPreference.asUnownedTaskExecutor().executor
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -115,7 +107,7 @@ extension ThrowingTaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor.
   ///
   /// - Parameters:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -126,7 +118,7 @@ extension ThrowingTaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutor: (any _TaskExecutor)?,
+    on taskExecutorPreference: any _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
@@ -138,11 +130,7 @@ extension ThrowingTaskGroup {
       isDiscardingTask: false)
 
     let executorBuiltin: Builtin.Executor =
-      if let taskExecutor {
-        taskExecutor.asUnownedTaskExecutor().executor
-      } else {
-        _getUndefinedTaskExecutor()
-      }
+        taskExecutorPreference.asUnownedTaskExecutor().executor
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -154,7 +142,7 @@ extension ThrowingTaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor, unless the group has been canceled.
   ///
   /// - Parameters:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTaskUnlessCancelled()` without passing a value to the `taskExecutor` parameter,
@@ -167,7 +155,7 @@ extension ThrowingTaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutor: (any _TaskExecutor)?,
+    on taskExecutorPreference: any _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {
@@ -185,11 +173,7 @@ extension ThrowingTaskGroup {
       isDiscardingTask: false)
 
     let executorBuiltin: Builtin.Executor =
-      if let taskExecutor {
-        taskExecutor.asUnownedTaskExecutor().executor
-      } else {
-        _getUndefinedTaskExecutor()
-      }
+        taskExecutorPreference.asUnownedTaskExecutor().executor
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -208,7 +192,7 @@ extension DiscardingTaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor.
   ///
   /// - Parameters:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -219,7 +203,7 @@ extension DiscardingTaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutor: (any _TaskExecutor)?,
+    on taskExecutorPreference: any _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) {
@@ -231,11 +215,7 @@ extension DiscardingTaskGroup {
       isDiscardingTask: true)
 
     let executorBuiltin: Builtin.Executor =
-      if let taskExecutor {
-        taskExecutor.asUnownedTaskExecutor().executor
-      } else {
-        _getUndefinedTaskExecutor()
-      }
+        taskExecutorPreference.asUnownedTaskExecutor().executor
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncDiscardingTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -248,7 +228,7 @@ extension DiscardingTaskGroup {
   /// unless the group has been canceled.
   ///
   /// - Parameters:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -261,7 +241,7 @@ extension DiscardingTaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutor: (any _TaskExecutor)?,
+    on taskExecutorPreference: any _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> Void
   ) -> Bool {
@@ -279,11 +259,7 @@ extension DiscardingTaskGroup {
     )
 
     let executorBuiltin: Builtin.Executor =
-    if let taskExecutor {
-      taskExecutor.asUnownedTaskExecutor().executor
-    } else {
-      _getUndefinedTaskExecutor()
-    }
+        taskExecutorPreference.asUnownedTaskExecutor().executor
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncDiscardingTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -302,7 +278,7 @@ extension ThrowingDiscardingTaskGroup {
   /// Adds a child task to the group and set it up with the passed in task executor preference.
   ///
   /// - Parameters:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -313,7 +289,7 @@ extension ThrowingDiscardingTaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutor: (any _TaskExecutor)?,
+    on taskExecutorPreference: any _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) {
@@ -325,11 +301,7 @@ extension ThrowingDiscardingTaskGroup {
       isDiscardingTask: true)
 
     let executorBuiltin: Builtin.Executor =
-    if let taskExecutor {
-      taskExecutor.asUnownedTaskExecutor().executor
-    } else {
-      _getUndefinedTaskExecutor()
-    }
+      taskExecutorPreference.asUnownedTaskExecutor().executor
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncDiscardingTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -342,7 +314,7 @@ extension ThrowingDiscardingTaskGroup {
   /// unless the group has been canceled.
   ///
   /// - Parameters:
-  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -355,7 +327,7 @@ extension ThrowingDiscardingTaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutor: (any _TaskExecutor)?,
+    on taskExecutorPreference: any _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) -> Bool {
@@ -373,11 +345,7 @@ extension ThrowingDiscardingTaskGroup {
     )
 
     let executorBuiltin: Builtin.Executor =
-    if let taskExecutor {
-      taskExecutor.asUnownedTaskExecutor().executor
-    } else {
-      _getUndefinedTaskExecutor()
-    }
+        taskExecutorPreference.asUnownedTaskExecutor().executor
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncDiscardingTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)

--- a/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
@@ -33,7 +33,7 @@ extension TaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutorPreference: any _TaskExecutor,
+    on taskExecutorPreference: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
@@ -70,7 +70,7 @@ extension TaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutorPreference: any _TaskExecutor,
+    on taskExecutorPreference: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
@@ -118,7 +118,7 @@ extension ThrowingTaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutorPreference: any _TaskExecutor,
+    on taskExecutorPreference: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
@@ -155,7 +155,7 @@ extension ThrowingTaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutorPreference: any _TaskExecutor,
+    on taskExecutorPreference: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {
@@ -203,7 +203,7 @@ extension DiscardingTaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutorPreference: any _TaskExecutor,
+    on taskExecutorPreference: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) {
@@ -241,7 +241,7 @@ extension DiscardingTaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutorPreference: any _TaskExecutor,
+    on taskExecutorPreference: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> Void
   ) -> Bool {
@@ -289,7 +289,7 @@ extension ThrowingDiscardingTaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutorPreference: any _TaskExecutor,
+    on taskExecutorPreference: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) {
@@ -327,7 +327,7 @@ extension ThrowingDiscardingTaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutorPreference: any _TaskExecutor,
+    on taskExecutorPreference: some _TaskExecutor,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) -> Bool {

--- a/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
@@ -22,7 +22,7 @@ extension TaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor.
   ///
   /// - Parameters:
-  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -33,7 +33,7 @@ extension TaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutorPreference: some _TaskExecutor,
+    executorPreference taskExecutor: (any _TaskExecutor)?,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) {
@@ -45,7 +45,11 @@ extension TaskGroup {
       isDiscardingTask: false)
 
     let executorBuiltin: Builtin.Executor =
-      taskExecutorPreference.asUnownedTaskExecutor().executor
+    if let taskExecutor {
+      taskExecutor.asUnownedTaskExecutor().executor
+    } else {
+      globalConcurrentExecutor.asUnownedTaskExecutor().executor
+    }
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -57,7 +61,7 @@ extension TaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor, unless the group has been canceled.
   ///
   /// - Parameters:
-  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTaskUnlessCancelled()` without passing a value to the `taskExecutor` parameter,
@@ -70,7 +74,7 @@ extension TaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutorPreference: some _TaskExecutor,
+    executorPreference taskExecutor: (any _TaskExecutor)?,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> ChildTaskResult
   ) -> Bool {
@@ -88,7 +92,11 @@ extension TaskGroup {
       isDiscardingTask: false)
 
     let executorBuiltin: Builtin.Executor =
-        taskExecutorPreference.asUnownedTaskExecutor().executor
+      if let taskExecutor {
+        taskExecutor.asUnownedTaskExecutor().executor
+      } else {
+        globalConcurrentExecutor.asUnownedTaskExecutor().executor
+      }
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -107,7 +115,7 @@ extension ThrowingTaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor.
   ///
   /// - Parameters:
-  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -118,7 +126,7 @@ extension ThrowingTaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutorPreference: some _TaskExecutor,
+    executorPreference taskExecutor: (any _TaskExecutor)?,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) {
@@ -130,7 +138,11 @@ extension ThrowingTaskGroup {
       isDiscardingTask: false)
 
     let executorBuiltin: Builtin.Executor =
-        taskExecutorPreference.asUnownedTaskExecutor().executor
+      if let taskExecutor {
+        taskExecutor.asUnownedTaskExecutor().executor
+      } else {
+        globalConcurrentExecutor.asUnownedTaskExecutor().executor
+      }
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -142,7 +154,7 @@ extension ThrowingTaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor, unless the group has been canceled.
   ///
   /// - Parameters:
-  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTaskUnlessCancelled()` without passing a value to the `taskExecutor` parameter,
@@ -155,7 +167,7 @@ extension ThrowingTaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutorPreference: some _TaskExecutor,
+    executorPreference taskExecutor: (any _TaskExecutor)?,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> ChildTaskResult
   ) -> Bool {
@@ -173,7 +185,11 @@ extension ThrowingTaskGroup {
       isDiscardingTask: false)
 
     let executorBuiltin: Builtin.Executor =
-        taskExecutorPreference.asUnownedTaskExecutor().executor
+      if let taskExecutor {
+        taskExecutor.asUnownedTaskExecutor().executor
+      } else {
+        globalConcurrentExecutor.asUnownedTaskExecutor().executor
+      }
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -192,7 +208,7 @@ extension DiscardingTaskGroup {
   /// Adds a child task to the group and enqueue it on the specified executor.
   ///
   /// - Parameters:
-  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -203,7 +219,7 @@ extension DiscardingTaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutorPreference: some _TaskExecutor,
+    executorPreference taskExecutor: (any _TaskExecutor)?,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) {
@@ -215,7 +231,11 @@ extension DiscardingTaskGroup {
       isDiscardingTask: true)
 
     let executorBuiltin: Builtin.Executor =
-        taskExecutorPreference.asUnownedTaskExecutor().executor
+      if let taskExecutor {
+        taskExecutor.asUnownedTaskExecutor().executor
+      } else {
+        globalConcurrentExecutor.asUnownedTaskExecutor().executor
+      }
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncDiscardingTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -228,7 +248,7 @@ extension DiscardingTaskGroup {
   /// unless the group has been canceled.
   ///
   /// - Parameters:
-  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -241,7 +261,7 @@ extension DiscardingTaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutorPreference: some _TaskExecutor,
+    executorPreference taskExecutor: (any _TaskExecutor)?,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> Void
   ) -> Bool {
@@ -259,7 +279,11 @@ extension DiscardingTaskGroup {
     )
 
     let executorBuiltin: Builtin.Executor =
-        taskExecutorPreference.asUnownedTaskExecutor().executor
+      if let taskExecutor {
+        taskExecutor.asUnownedTaskExecutor().executor
+      } else {
+        globalConcurrentExecutor.asUnownedTaskExecutor().executor
+      }
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncDiscardingTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -278,7 +302,7 @@ extension ThrowingDiscardingTaskGroup {
   /// Adds a child task to the group and set it up with the passed in task executor preference.
   ///
   /// - Parameters:
-  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -289,7 +313,7 @@ extension ThrowingDiscardingTaskGroup {
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
   public mutating func _addTask(
-    on taskExecutorPreference: some _TaskExecutor,
+    executorPreference taskExecutor: (any _TaskExecutor)?,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) {
@@ -301,7 +325,11 @@ extension ThrowingDiscardingTaskGroup {
       isDiscardingTask: true)
 
     let executorBuiltin: Builtin.Executor =
-      taskExecutorPreference.asUnownedTaskExecutor().executor
+      if let taskExecutor {
+        taskExecutor.asUnownedTaskExecutor().executor
+      } else {
+        globalConcurrentExecutor.asUnownedTaskExecutor().executor
+      }
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncDiscardingTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)
@@ -314,7 +342,7 @@ extension ThrowingDiscardingTaskGroup {
   /// unless the group has been canceled.
   ///
   /// - Parameters:
-  ///   - taskExecutorPreference: The task executor that the child task should be started on and keep using.
+  ///   - taskExecutor: The task executor that the child task should be started on and keep using.
   ///                   If `nil` is passed explicitly, tht parent task's executor preference (if any),
   ///                   will be ignored. In order to inherit the parent task's executor preference
   ///                   invoke `_addTask()` without passing a value to the `taskExecutor` parameter,
@@ -327,7 +355,7 @@ extension ThrowingDiscardingTaskGroup {
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
   public mutating func _addTaskUnlessCancelled(
-    on taskExecutorPreference: some _TaskExecutor,
+    executorPreference taskExecutor: (any _TaskExecutor)?,
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) -> Bool {
@@ -345,7 +373,11 @@ extension ThrowingDiscardingTaskGroup {
     )
 
     let executorBuiltin: Builtin.Executor =
-        taskExecutorPreference.asUnownedTaskExecutor().executor
+      if let taskExecutor {
+        taskExecutor.asUnownedTaskExecutor().executor
+      } else {
+        globalConcurrentExecutor.asUnownedTaskExecutor().executor
+      }
 
     // Create the task in this group with an executor preference.
     _ = Builtin.createAsyncDiscardingTaskInGroupWithExecutor(flags, _group, executorBuiltin, operation)

--- a/test/Concurrency/Runtime/async_task_executor_and_serial_executor_nonisolated_async_func.swift
+++ b/test/Concurrency/Runtime/async_task_executor_and_serial_executor_nonisolated_async_func.swift
@@ -22,7 +22,7 @@ final class NaiveQueueExecutor: _TaskExecutor, SerialExecutor {
     let job = UnownedJob(_job)
     queue.async {
       job.runSynchronously(
-        isolated: self.asUnownedSerialExecutor(),
+        isolatedTo: self.asUnownedSerialExecutor(),
         taskExecutor: self.asUnownedTaskExecutor())
     }
   }
@@ -83,7 +83,7 @@ actor Worker {
     let queue = DispatchQueue(label: "example-queue")
     let executor = NaiveQueueExecutor(queue)
 
-    await Task(_on: executor) {
+    await Task(_executorPreference: executor) {
       let worker = Worker(on: executor)
       await worker.test(executor)
     }.value

--- a/test/Concurrency/Runtime/async_task_executor_default_actor_funcs.swift
+++ b/test/Concurrency/Runtime/async_task_executor_default_actor_funcs.swift
@@ -41,12 +41,12 @@ actor ThreaddyTheDefaultActor {
 
     let defaultActor = ThreaddyTheDefaultActor()
 
-    await Task(_on: executor) {
+    await Task(_executorPreference: executor) {
       dispatchPrecondition(condition: .onQueue(executor.queue))
       await defaultActor.actorIsolated(expectedExecutor: executor)
     }.value
 
-    await _withTaskExecutor(executor) {
+    await _withTaskExecutorPreference(executor) {
       await defaultActor.actorIsolated(expectedExecutor: executor)
     }
   }

--- a/test/Concurrency/Runtime/async_task_executor_nonisolated_async_func.swift
+++ b/test/Concurrency/Runtime/async_task_executor_nonisolated_async_func.swift
@@ -39,7 +39,7 @@ nonisolated func nonisolatedFunc(expectedExecutor: NaiveQueueExecutor) async {
       let queue = DispatchQueue(label: "example-queue")
       let executor = NaiveQueueExecutor(queue)
 
-      await Task(_on: executor) {
+      await Task(_executorPreference: executor) {
         await nonisolatedFunc(expectedExecutor: executor)
       }.value
     }

--- a/test/Concurrency/Runtime/async_task_executor_structured_concurrency.swift
+++ b/test/Concurrency/Runtime/async_task_executor_structured_concurrency.swift
@@ -83,7 +83,7 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
       return await withTaskGroup(of: Int.self) { inner in
-        inner._addTask(on: nil) {
+        inner._addTask(on: .default) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -97,7 +97,7 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
       return await withTaskGroup(of: Int.self) { inner in
-        inner._addTask(on: nil) {
+        inner._addTask(on: .default) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -111,12 +111,12 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
       await withDiscardingTaskGroup { inner in
-        inner._addTask(on: nil) {
+        inner._addTask(on: .default) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
         }
-        _ = inner._addTaskUnlessCancelled(on: nil) {
+        _ = inner._addTaskUnlessCancelled(on: .default) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -129,12 +129,12 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
       try! await withThrowingDiscardingTaskGroup { inner in
-        inner._addTask(on: nil) {
+        inner._addTask(on: .default) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
         }
-        _ = inner._addTaskUnlessCancelled(on: nil) {
+        _ = inner._addTaskUnlessCancelled(on: .default) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))

--- a/test/Concurrency/Runtime/async_task_executor_structured_concurrency.swift
+++ b/test/Concurrency/Runtime/async_task_executor_structured_concurrency.swift
@@ -31,27 +31,27 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
                    _ secondExecutor: MyTaskExecutor) async {
   // 1 level of child tasks
   await withTaskGroup(of: Int.self) { group in
-    group._addTask(on: firstExecutor) {
+    group._addTask(executorPreference: firstExecutor) {
       dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
       return 1
     }
   }
   await withThrowingTaskGroup(of: Int.self) { group in
-    group._addTask(on: firstExecutor) {
+    group._addTask(executorPreference: firstExecutor) {
       dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
       return 2
     }
   }
   await withDiscardingTaskGroup() { group in
-    group._addTask(on: firstExecutor) {
+    group._addTask(executorPreference: firstExecutor) {
       dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
     }
   }
   try! await withThrowingDiscardingTaskGroup() { group in
-    group._addTask(on: firstExecutor) {
+    group._addTask(executorPreference: firstExecutor) {
       dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
     }
@@ -59,12 +59,12 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
 
   // Multiple levels of child tasks
   await withTaskGroup(of: Int.self) { group in
-    group._addTask(on: firstExecutor) {
+    group._addTask(executorPreference: firstExecutor) {
       dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
 
       return await withTaskGroup(of: Int.self) { group in
-        group._addTask(on: secondExecutor) {
+        group._addTask(executorPreference: secondExecutor) {
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
           return 12
@@ -79,11 +79,11 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
     dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
     dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
 
-    group._addTask(on: secondExecutor) {
+    group._addTask(executorPreference: secondExecutor) {
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
       return await withTaskGroup(of: Int.self) { inner in
-        inner._addTask(on: .default) {
+        inner._addTask(executorPreference: globalConcurrentExecutor) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -93,11 +93,11 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
       }
     }
 
-    _ = group._addTaskUnlessCancelled(on: secondExecutor) {
+    _ = group._addTaskUnlessCancelled(executorPreference: secondExecutor) {
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
       return await withTaskGroup(of: Int.self) { inner in
-        inner._addTask(on: .default) {
+        inner._addTask(executorPreference: globalConcurrentExecutor) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -107,16 +107,16 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
       }
     }
 
-    group._addTask(on: secondExecutor) {
+    group._addTask(executorPreference: secondExecutor) {
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
       await withDiscardingTaskGroup { inner in
-        inner._addTask(on: .default) {
+        inner._addTask(executorPreference: globalConcurrentExecutor) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
         }
-        _ = inner._addTaskUnlessCancelled(on: .default) {
+        _ = inner._addTaskUnlessCancelled(executorPreference: globalConcurrentExecutor) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -125,16 +125,16 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
       return 0
     }
 
-    group._addTask(on: secondExecutor) {
+    group._addTask(executorPreference: secondExecutor) {
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
       try! await withThrowingDiscardingTaskGroup { inner in
-        inner._addTask(on: .default) {
+        inner._addTask(executorPreference: globalConcurrentExecutor) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
         }
-        _ = inner._addTaskUnlessCancelled(on: .default) {
+        _ = inner._addTaskUnlessCancelled(executorPreference: globalConcurrentExecutor) {
           // disabled the preference
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
           dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -149,7 +149,7 @@ func testTaskGroup(_ firstExecutor: MyTaskExecutor,
 
 func testAsyncLet(_ firstExecutor: MyTaskExecutor,
                   _ secondExecutor: MyTaskExecutor) async {
-  await _withTaskExecutor(firstExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
     async let first: Int = {
       dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -157,8 +157,8 @@ func testAsyncLet(_ firstExecutor: MyTaskExecutor,
     }()
     _ = await first
   }
-  await _withTaskExecutor(firstExecutor) {
-    await _withTaskExecutor(secondExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
+    await _withTaskExecutorPreference(secondExecutor) {
       async let first: Int = {
         dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
         dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
@@ -168,8 +168,8 @@ func testAsyncLet(_ firstExecutor: MyTaskExecutor,
     }
   }
 
-  await _withTaskExecutor(firstExecutor) {
-    await _withTaskExecutor(secondExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
+    await _withTaskExecutorPreference(secondExecutor) {
       async let first: Int = {
         async let firstInside: Int = {
           dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
@@ -186,14 +186,14 @@ func testAsyncLet(_ firstExecutor: MyTaskExecutor,
 func testGroupAsyncLet(_ firstExecutor: MyTaskExecutor,
                        _ secondExecutor: MyTaskExecutor) async {
   await withTaskGroup(of: Void.self) { group in
-    group._addTask(on: firstExecutor) {
+    group._addTask(executorPreference: firstExecutor) {
       dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
 
       async let first: () = expect(firstExecutor)
       _ = await first
 
-      await _withTaskExecutor(secondExecutor) {
+      await _withTaskExecutorPreference(secondExecutor) {
         async let second: () = expect(secondExecutor)
         _ = await second
       }

--- a/test/Concurrency/Runtime/async_task_executor_withExecutor.swift
+++ b/test/Concurrency/Runtime/async_task_executor_withExecutor.swift
@@ -135,7 +135,7 @@ func testDisablingTaskExecutorPreference(_ firstExecutor: MyTaskExecutor,
   await _withTaskExecutor(firstExecutor) {
     dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
     dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
-    await _withTaskExecutor(nil) {
+    await _withTaskExecutor(.default) {
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))

--- a/test/Concurrency/Runtime/async_task_executor_withExecutor.swift
+++ b/test/Concurrency/Runtime/async_task_executor_withExecutor.swift
@@ -137,13 +137,11 @@ func testDisablingTaskExecutorPreference(_ firstExecutor: MyTaskExecutor,
     dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
     await _withTaskExecutorPreference(globalConcurrentExecutor) {
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
-      dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
       print("OK: _withTaskExecutorPreference(globalConcurrentExecutor) { ... }")
     } // on second
-    await _withTaskExecutorPreference(nil) {
-      dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
-      dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
+    await _withTaskExecutorPreference(nil) { // no specific preference == okey to inherit
+      dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
       print("OK: _withTaskExecutorPreference(nil) { ... }")
     } // on second

--- a/test/Concurrency/Runtime/async_task_executor_withExecutor.swift
+++ b/test/Concurrency/Runtime/async_task_executor_withExecutor.swift
@@ -39,7 +39,7 @@ func testNestingWithExecutorMainActor(_ firstExecutor: MyTaskExecutor,
   MainActor.preconditionIsolated()
   dispatchPrecondition(condition: .onQueue(DispatchQueue.main))
 
-  await _withTaskExecutor(firstExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
     // the block immediately hops to the expected executor
     dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
     print("OK: withTaskExecutor body")
@@ -47,8 +47,8 @@ func testNestingWithExecutorMainActor(_ firstExecutor: MyTaskExecutor,
   }
   MainActor.preconditionIsolated()
 
-  await _withTaskExecutor(firstExecutor) {
-    await _withTaskExecutor(secondExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
+    await _withTaskExecutorPreference(secondExecutor) {
       // the block immediately hops to the expected executor
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
@@ -58,13 +58,13 @@ func testNestingWithExecutorMainActor(_ firstExecutor: MyTaskExecutor,
   }
   MainActor.preconditionIsolated()
 
-  await _withTaskExecutor(firstExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
     dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
     dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
-    await _withTaskExecutor(secondExecutor) {
+    await _withTaskExecutorPreference(secondExecutor) {
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
-      await _withTaskExecutor(firstExecutor) {
+      await _withTaskExecutorPreference(firstExecutor) {
         // the block immediately hops to the expected executor
         dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
         dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -86,15 +86,15 @@ func testNestingWithExecutorMainActor(_ firstExecutor: MyTaskExecutor,
 
 func testNestingWithExecutorNonisolated(_ firstExecutor: MyTaskExecutor,
                                         _ secondExecutor: MyTaskExecutor) async {
-  await _withTaskExecutor(firstExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
     // the block immediately hops to the expected executor
     dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
     print("OK: withTaskExecutor body")
     await nonisolatedAsyncMethod(expectedOn: firstExecutor)
   }
 
-  await _withTaskExecutor(firstExecutor) {
-    await _withTaskExecutor(secondExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
+    await _withTaskExecutorPreference(secondExecutor) {
       // the block immediately hops to the expected executor
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
@@ -103,13 +103,13 @@ func testNestingWithExecutorNonisolated(_ firstExecutor: MyTaskExecutor,
     }
   }
 
-  await _withTaskExecutor(firstExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
     dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
     dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
-    await _withTaskExecutor(secondExecutor) {
+    await _withTaskExecutorPreference(secondExecutor) {
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .onQueue(secondExecutor.queue))
-      await _withTaskExecutor(firstExecutor) {
+      await _withTaskExecutorPreference(firstExecutor) {
         // the block immediately hops to the expected executor
         dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
         dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -132,14 +132,20 @@ func testDisablingTaskExecutorPreference(_ firstExecutor: MyTaskExecutor,
   dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
   dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
 
-  await _withTaskExecutor(firstExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
     dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
     dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
-    await _withTaskExecutor(.default) {
+    await _withTaskExecutorPreference(globalConcurrentExecutor) {
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
       dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
-      print("OK: _withTaskExecutor(nil) { ... }")
+      print("OK: _withTaskExecutorPreference(globalConcurrentExecutor) { ... }")
+    } // on second
+    await _withTaskExecutorPreference(nil) {
+      dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
+      dispatchPrecondition(condition: .notOnQueue(firstExecutor.queue))
+      dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
+      print("OK: _withTaskExecutorPreference(nil) { ... }")
     } // on second
     dispatchPrecondition(condition: .onQueue(firstExecutor.queue))
     dispatchPrecondition(condition: .notOnQueue(secondExecutor.queue))
@@ -155,7 +161,7 @@ func testGetCurrentTaskExecutor(_ firstExecutor: MyTaskExecutor,
     }
   }.value
 
-  await _withTaskExecutor(firstExecutor) {
+  await _withTaskExecutorPreference(firstExecutor) {
     withUnsafeCurrentTask { task in
       guard let task else {
         fatalError("Missing task?")
@@ -177,7 +183,7 @@ func testGetCurrentTaskExecutor(_ firstExecutor: MyTaskExecutor,
     let secondExecutor = MyTaskExecutor(queue: DispatchQueue(label: "second"))
 
     // === nonisolated func
-    await Task(_on: firstExecutor) {
+    await Task(_executorPreference: firstExecutor) {
       await nonisolatedAsyncMethod(expectedOn: firstExecutor)
     }.value
 

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_from_id.swift
@@ -28,7 +28,7 @@ typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 distributed actor Worker {
   nonisolated var unownedExecutor: UnownedSerialExecutor {
     print("get unowned 'local' executor via ID")
-    return self.id.executorPreference ?? buildDefaultDistributedRemoteActorExecutor(self)
+    return self.id.preferredTaskExecutor ?? buildDefaultDistributedRemoteActorExecutor(self)
   }
 
   distributed func test(x: Int) {
@@ -46,7 +46,7 @@ distributed actor Worker {
 
 @available(SwiftStdlib 5.7, *)
 extension DefaultDistributedActorSystem.ActorID {
-  var executorPreference: UnownedSerialExecutor? {
+  var preferredTaskExecutor: UnownedSerialExecutor? {
     MainActor.sharedUnownedExecutor
   }
 }

--- a/test/Distributed/Runtime/distributed_actor_task_executor.swift
+++ b/test/Distributed/Runtime/distributed_actor_task_executor.swift
@@ -66,7 +66,7 @@ distributed actor Worker {
     // CHECK: | assign id
     // CHECK: | actor ready
 
-    await _withTaskExecutor(executor) {
+    await _withTaskExecutorPreference(executor) {
       try! await worker.test(x: 42)
       // CHECK: test: executed on expected queue
     }


### PR DESCRIPTION
Follow up to https://github.com/apple/swift/pull/68793/ bases on SE input.

This API revision allows passing `(any TaskExecutor)?` to all the new APIs. Passing `nil` as a preference means "no preference" which means that the parent's executor preference is used for structured concurrency, and the means no change in unstructured tasks but is a simple way to pass around an optional preference through APIs if necessary.

We also introduce a new global `nonisolated(unsafe) var globalConcurrentExecutor: any TaskExecutor { get }`.

<details>
<summary>Previous revision</summary>

Previous API shape required the `nil` value to be used as "no preference".

During review we came up with an idea that if we make the "default global concurrent executor" an accessible value, we can express it as: `withTaskExecutor(.default)` and therefore avoid the `nil` which can be a bit cryptic.

It does mean we have to add `public final class DefaultConcurrentExecutor` which delegates to the "default global executor" but the APIs can then use it.

The `Task(on: .default)` reads a bit weird now though. Perhaps we should change it to `Task(executorPreference: .default)`, and do the same to the `addTask(executorPreference: ...)` and friends now that the `.default` can be passed?


</details>