### PR TITLE
[embedded] Default all ELF compilations to -function-sections enabled

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -571,6 +571,10 @@ def function_sections: Flag<["-"], "function-sections">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Emit functions to separate sections.">;
 
+def no_function_sections: Flag<["-"], "no-function-sections">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Do not emit functions to separate sections.">;
+
 def enable_single_module_llvm_emission: Flag<["-"], "enable-single-module-llvm-emission">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Emit LLVM IR into a single LLVM module in multithreaded mode.">;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2658,7 +2658,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_trap_function))
     Opts.TrapFuncName = Args.getLastArgValue(OPT_trap_function).str();
 
-  Opts.FunctionSections = Args.hasArg(OPT_function_sections);
+  Opts.FunctionSections =
+      (Triple.getObjectFormat() == llvm::Triple::ObjectFormatType::ELF);
+  Opts.FunctionSections = Args.hasFlag(
+      OPT_function_sections, OPT_no_function_sections, Opts.FunctionSections);
 
   if (Args.hasArg(OPT_autolink_force_load))
     Opts.ForceLoadSymbolName = Args.getLastArgValue(OPT_module_link_name).str();


### PR DESCRIPTION
The `-function-sections`, which is the equivalent to Clang's `-ffunction-sections`, is necessary to enable section-based link-time garbage collection in ELF (aka "dead code stripping" on Mach-O binaries). This is extremely useful for embedded use cases, but desktop/server compilation can benefit from it just as well. Let's enable it by default on ELF.