### PR TITLE
build: update for cmark build revamp and split the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -784,11 +784,17 @@ if (CMAKE_Swift_COMPILER)
 else()
   message(STATUS "Swift Compiler (None).")
 endif()
+
+set(THREADS_PREFER_PTHREAD_FLAG YES)
+include(FindThreads)
+
 if(SWIFT_PATH_TO_CMARK_BUILD)
   execute_process(COMMAND ${SWIFT_PATH_TO_CMARK_BUILD}/src/cmark --version
     OUTPUT_VARIABLE _CMARK_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   message(STATUS "CMark Version: ${_CMARK_VERSION}")
+elseif(SWIFT_INCLUDE_TOOLS)
+  find_package(cmark-gfm CONFIG REQUIRED)
 endif()
 message(STATUS "")
 

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -278,24 +278,6 @@ macro(swift_common_unified_build_config product)
 
   include_directories(${CLANG_INCLUDE_DIRS})
 
-  # If cmark was checked out into tools/cmark, expect to build it as
-  # part of the unified build.
-  if(EXISTS "${LLVM_EXTERNAL_CMARK_SOURCE_DIR}")
-    set(${product}_PATH_TO_CMARK_SOURCE "${LLVM_EXTERNAL_CMARK_SOURCE_DIR}")
-    set(${product}_PATH_TO_CMARK_BUILD "${CMAKE_BINARY_DIR}/tools/cmark")
-    set(${product}_CMARK_LIBRARY_DIR "${CMAKE_BINARY_DIR}/lib")
-
-    get_filename_component(CMARK_MAIN_SRC_DIR "${${product}_PATH_TO_CMARK_SOURCE}"
-      ABSOLUTE)
-    get_filename_component(PATH_TO_CMARK_BUILD "${${product}_PATH_TO_CMARK_BUILD}"
-      ABSOLUTE)
-    get_filename_component(CMARK_LIBRARY_DIR "${${product}_CMARK_LIBRARY_DIR}"
-      ABSOLUTE)
-
-    include_directories(${PATH_TO_CMARK_BUILD}/src
-      ${CMARK_MAIN_SRC_DIR}/src/include)
-  endif()
-
   include(AddSwiftTableGen) # This imports TableGen from LLVM.
 endmacro()
 

--- a/lib/Markup/CMakeLists.txt
+++ b/lib/Markup/CMakeLists.txt
@@ -3,8 +3,4 @@ add_swift_host_library(swiftMarkup STATIC
   LineList.cpp
   Markup.cpp)
 target_link_libraries(swiftMarkup PRIVATE
-  libcmark-gfm_static)
-target_compile_definitions(swiftMarkup
-                           PRIVATE
-                           CMARK_GFM_STATIC_DEFINE)
-
+  libcmark-gfm)

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -843,6 +843,22 @@ function Build-WiXProject() {
   Invoke-Program $msbuild @MSBuildArgs
 }
 
+function Build-CMark($Arch) {
+  $ArchName = $Arch.ShortName
+
+  Build-CMakeProject `
+    -Src $SourceCache\cmark `
+    -Bin "$($Arch.BinaryCache)\cmark-gfm-0.29.0.gfm.13" `
+    -InstallTo "$LibraryRoot\cmark-0.29.0.gfm.13\usr" `
+    -Arch $Arch `
+    -BuildTargets default `
+    -Defines @{
+      BUILD_SHARED_LIBS = "NO";
+      BUILD_TESTING = "NO";
+      CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP = "YES";
+    }
+}
+
 function Build-BuildTools($Arch) {
   Build-CMakeProject `
     -Src $SourceCache\llvm-project\llvm `
@@ -874,6 +890,7 @@ function Build-BuildTools($Arch) {
       SWIFT_INCLUDE_APINOTES = "NO";
       SWIFT_INCLUDE_DOCS = "NO";
       SWIFT_INCLUDE_TESTS = "NO";
+      "cmark-gfm_DIR" = "$($HostArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13";
     }
 }
 
@@ -937,7 +954,6 @@ function Build-Compilers() {
         LLDB_PYTHON_RELATIVE_PATH = "lib/site-packages";
         LLDB_TABLEGEN = "$BinaryCache\0\bin\lldb-tblgen.exe";
         LLVM_CONFIG_PATH = "$BinaryCache\0\bin\llvm-config.exe";
-        LLVM_EXTERNAL_CMARK_SOURCE_DIR = "$SourceCache\cmark";
         LLVM_EXTERNAL_SWIFT_SOURCE_DIR = "$SourceCache\swift";
         LLVM_NATIVE_TOOL_DIR = "$BinaryCache\0\bin";
         LLVM_TABLEGEN = "$BinaryCache\0\bin\llvm-tblgen.exe";
@@ -955,6 +971,7 @@ function Build-Compilers() {
         SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE = "$SourceCache\swift-syntax";
         SWIFT_PATH_TO_STRING_PROCESSING_SOURCE = "$SourceCache\swift-experimental-string-processing";
         SWIFT_PATH_TO_SWIFT_SDK = (Get-PinnedToolchainSDK);
+        "cmark-gfm_DIR" = "$($HostArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13";
       })
   }
 }
@@ -1739,6 +1756,7 @@ if (-not $SkipBuild) {
 }
 
 if (-not $SkipBuild) {
+  Invoke-BuildStep Build-CMark $HostArch
   Invoke-BuildStep Build-BuildTools $HostArch
   Invoke-BuildStep Build-Compilers $HostArch
 }


### PR DESCRIPTION
Extricate cmark from the unified build system. This is preparatory work to support building CMark GFM with dynamic linkage for sharing it across swift-markdown and the compiler. It also simplifies the build logic for the unified build.