### PR TITLE
[donotmerge] always bounds check in UnsafeBufferPointer

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -304,16 +304,15 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
 
   @inlinable // unsafe-performance
   public func _failEarlyRangeCheck(_ index: Int, bounds: Range<Int>) {
-    // NOTE: In release mode, this method is a no-op for performance reasons.
-    _debugPrecondition(index >= bounds.lowerBound)
-    _debugPrecondition(index < bounds.upperBound)
+    _precondition(index >= bounds.lowerBound && index < bounds.upperBound)
   }
 
   @inlinable // unsafe-performance
   public func _failEarlyRangeCheck(_ range: Range<Int>, bounds: Range<Int>) {
-    // NOTE: In release mode, this method is a no-op for performance reasons.
-    _debugPrecondition(range.lowerBound >= bounds.lowerBound)
-    _debugPrecondition(range.upperBound <= bounds.upperBound)
+    _precondition(
+      range.lowerBound >= bounds.lowerBound &&
+      range.upperBound <= bounds.upperBound
+    )
   }
 
   @inlinable // unsafe-performance
@@ -365,14 +364,14 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   @inlinable // unsafe-performance
   public subscript(i: Int) -> Element {
     get {
-      _debugPrecondition(i >= 0)
-      _debugPrecondition(i < endIndex)
+      _precondition(i >= 0)
+      _precondition(i < endIndex)
       return _position._unsafelyUnwrappedUnchecked[i]
     }
 %if Mutable:
     nonmutating _modify {
-      _debugPrecondition(i >= 0)
-      _debugPrecondition(i < endIndex)
+      _precondition(i >= 0)
+      _precondition(i < endIndex)
       yield &_position._unsafelyUnwrappedUnchecked[i]
     }
 %end
@@ -438,16 +437,16 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     -> Slice<Unsafe${Mutable}BufferPointer<Element>>
   {
     get {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
+      _precondition(bounds.lowerBound >= startIndex)
+      _precondition(bounds.upperBound <= endIndex)
       return Slice(
         base: self, bounds: bounds)
     }
 %  if Mutable:
     nonmutating set {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
-      _debugPrecondition(bounds.count == newValue.count)
+      _precondition(bounds.lowerBound >= startIndex)
+      _precondition(bounds.upperBound <= endIndex)
+      _precondition(bounds.count == newValue.count)
 
       // FIXME: swift-3-indexing-model: tests.
       if !newValue.isEmpty {
@@ -472,8 +471,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   @inlinable // unsafe-performance
   public func swapAt(_ i: Int, _ j: Int) {
     guard i != j else { return }
-    _debugPrecondition(i >= 0 && j >= 0)
-    _debugPrecondition(i < endIndex && j < endIndex)
+    _precondition(i >= 0 && j >= 0)
+    _precondition(i < endIndex && j < endIndex)
     let pi = (_position! + i)
     let pj = (_position! + j)
     let tmp = pi.move()
@@ -1029,7 +1028,7 @@ extension Unsafe${Mutable}BufferPointer {
   @inlinable
   @_alwaysEmitIntoClient
   public func initializeElement(at index: Index, to value: Element) {
-    _debugPrecondition(startIndex <= index && index < endIndex)
+    _precondition(startIndex <= index && index < endIndex)
     let p = baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index)
     p.initialize(to: value)
   }
@@ -1047,7 +1046,7 @@ extension Unsafe${Mutable}BufferPointer {
   @inlinable
   @_alwaysEmitIntoClient
   public func moveElement(from index: Index) -> Element {
-    _debugPrecondition(startIndex <= index && index < endIndex)
+    _precondition(startIndex <= index && index < endIndex)
     return baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index).move()
   }
 
@@ -1062,7 +1061,7 @@ extension Unsafe${Mutable}BufferPointer {
   @inlinable
   @_alwaysEmitIntoClient
   public func deinitializeElement(at index: Index) {
-    _debugPrecondition(startIndex <= index && index < endIndex)
+    _precondition(startIndex <= index && index < endIndex)
     let p = baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index)
     p.deinitialize(count: 1)
   }


### PR DESCRIPTION
The bounds-checking approach of `UnsafeBufferPointer` is to bounds-check only in debug mode. We wonder whether it would be more principled to bounds-check in all cases, with an available API to intentionally elide bounds-checking entirely in performance-sensitive cases. This PR enables release-mode bounds-checking in the functions and subscripts of `UnsafeBufferPointer` and `UnsafeMutableBufferPointer`. No API for unchecked access is added at this time.

Addresses rdar://93206377
