### PR TITLE
[5.10] caches: enable static mirror lib on Windows

### DIFF
--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -150,6 +150,7 @@ set(SWIFT_INSTALL_COMPONENTS
       editor-integration
       tools
       sourcekit-inproc
+      static-mirror-lib
       swift-remote-mirror
       swift-remote-mirror-headers
       swift-syntax-lib

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -150,6 +150,7 @@ set(SWIFT_INSTALL_COMPONENTS
       editor-integration
       tools
       sourcekit-inproc
+      static-mirror-lib
       swift-remote-mirror
       swift-remote-mirror-headers
       swift-syntax-lib


### PR DESCRIPTION
Enable building and installation for the static mirror library on Windows.

**Explanation**: Include _InternalSwiftStaticMirror in the Windows builds for distribution
**Scope**: This simply is build configuration to enable the library to be built
**Issue**: 
**Risk**: Low risk, any failures would be caught by Swift CI ifit would fail to build
**Testing**: 
**Reviewer**: @etcwilde