### PR TITLE
Sema: Fix openType() handling of parameter packs [5.10]

### DIFF
--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -453,8 +453,11 @@ PackType::getExpandedGenericArgs(ArrayRef<GenericTypeParamType *> params,
 }
 
 PackType *PackType::getSingletonPackExpansion(Type param) {
-  assert(param->isParameterPack() || param->is<PackArchetypeType>());
-  return get(param->getASTContext(), {PackExpansionType::get(param, param)});
+  SmallVector<Type, 2> rootParameterPacks;
+  param->getTypeParameterPacks(rootParameterPacks);
+  assert(rootParameterPacks.size() >= 1);
+  auto count = rootParameterPacks[0];
+  return get(param->getASTContext(), {PackExpansionType::get(param, count)});
 }
 
 CanPackType CanPackType::getSingletonPackExpansion(CanType param) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -449,7 +449,9 @@ class SameShapeExpansionFailure final : public FailureDiagnostic {
 public:
   SameShapeExpansionFailure(const Solution &solution, Type lhs, Type rhs,
                             ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator), lhs(lhs), rhs(rhs) {}
+      : FailureDiagnostic(solution, locator),
+        lhs(resolveType(lhs)),
+        rhs(resolveType(rhs)) {}
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13624,32 +13624,33 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySameShapeConstraint(
         auto argLoc =
             loc->castLastElementTo<LocatorPathElt::ApplyArgToParam>();
 
-        if (type1->getAs<PackArchetypeType>() &&
-            type2->getAs<PackArchetypeType>())
+        if (type1->is<PackArchetypeType>() &&
+            type2->is<PackArchetypeType>())
           return recordShapeMismatchFix();
 
-        auto argPack = type1->getAs<PackType>();
-        auto paramPack = type2->getAs<PackType>();
-
-        if (!(argPack && paramPack))
-          return SolutionKind::Error;
+        auto numArgs = (shape1->is<PackType>()
+                        ? shape1->castTo<PackType>()->getNumElements()
+                        : 1);
+        auto numParams = (shape2->is<PackType>()
+                          ? shape2->castTo<PackType>()->getNumElements()
+                          : 1);
 
         // Tailed diagnostic to explode tuples.
         // FIXME: This is very similar to
         // 'cannot_convert_single_tuple_into_multiple_arguments'; can we emit
         // both of these in the same place?
-        if (argPack->getNumElements() == 1) {
-          if (argPack->getElementType(0)->is<TupleType>() &&
-              paramPack->getNumElements() >= 1) {
+        if (numArgs == 1) {
+          if (type1->is<TupleType>() &&
+              numParams >= 1) {
             return recordShapeFix(
                 DestructureTupleToMatchPackExpansionParameter::create(
-                    *this, paramPack, loc),
-                /*impact=*/2 * paramPack->getNumElements());
+                    *this,
+                    (type2->is<PackType>()
+                     ? type2->castTo<PackType>()
+                     : PackType::getSingletonPackExpansion(type2)), loc),
+                /*impact=*/2 * numParams);
           }
         }
-
-        auto numArgs = shape1->castTo<PackType>()->getNumElements();
-        auto numParams = shape2->castTo<PackType>()->getNumElements();
 
         // Drops `ApplyArgToParam` and left with `ApplyArgument`.
         path.pop_back();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1807,7 +1807,14 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
         }
 
         auto *argPack = PackType::get(cs.getASTContext(), argTypes);
-        auto *argPackExpansion = PackExpansionType::get(argPack, argPack);
+        auto argPackExpansion = [&]() {
+          if (argPack->getNumElements() == 1 &&
+              argPack->getElementType(0)->is<PackExpansionType>()) {
+            return argPack->getElementType(0)->castTo<PackExpansionType>();
+          }
+
+          return PackExpansionType::get(argPack, argPack);
+        }();
 
         auto firstArgIdx =
             argTypes.empty() ? paramIdx : parameterBindings[paramIdx].front();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -855,25 +855,7 @@ Type ConstraintSystem::openUnboundGenericType(GenericTypeDecl *decl,
     result = DC->mapTypeIntoContext(result);
   }
 
-  return result.transform([&](Type type) -> Type {
-    // Although generic parameters are declared with just `each`
-    // their interface types introduce a pack expansion which
-    // means that the solver has to extact generic argument type
-    // variable from Pack{repeat ...} and drop that structure to
-    // make sure that generic argument gets inferred to a pack type.
-    if (auto *packTy = type->getAs<PackType>()) {
-      assert(packTy->getNumElements() == 1);
-      auto *expansion = packTy->getElementType(0)->castTo<PackExpansionType>();
-      auto *typeVar = expansion->getPatternType()->castTo<TypeVariableType>();
-      assert(typeVar->getImpl().getGenericParameter() &&
-             typeVar->getImpl().canBindToPack());
-      return typeVar;
-    }
-
-    if (auto *expansion = dyn_cast<PackExpansionType>(type.getPointer()))
-      return openPackExpansionType(expansion, replacements, locator);
-    return type;
-  });
+  return result;
 }
 
 static void checkNestedTypeConstraints(ConstraintSystem &cs, Type type,
@@ -1019,18 +1001,6 @@ Type ConstraintSystem::openType(Type type, OpenedTypeMap &replacements,
                     locator)},
                 tuple->getASTContext());
           }
-        }
-      }
-
-      // While opening variadic generic types that appear in other types
-      // we need to extract generic parameter from Pack{repeat ...} structure
-      // that gets introduced by the interface type, see
-      // \c openUnboundGenericType for more details.
-      if (auto *packTy = type->getAs<PackType>()) {
-        if (auto expansionTy = packTy->unwrapSingletonPackExpansion()) {
-          auto patternTy = expansionTy->getPatternType();
-          if (patternTy->isTypeParameter())
-            return openType(patternTy, replacements, locator);
         }
       }
 
@@ -3926,6 +3896,14 @@ struct TypeSimplifier {
       // Transform the count type, ignoring any active pack expansions.
       auto countType = expansion->getCountType().transform(
           TypeSimplifier(CS, GetFixedTypeFn));
+
+      if (!countType->is<PackType>() &&
+          !countType->is<PackArchetypeType>()) {
+        SmallVector<Type, 2> rootParameterPacks;
+        countType->getTypeParameterPacks(rootParameterPacks);
+        if (!rootParameterPacks.empty())
+          countType = rootParameterPacks[0];
+      }
 
       // If both pattern and count are resolves, let's just return
       // the pattern type for `transformWithPosition` to take care

--- a/test/Constraints/issue-67906.swift
+++ b/test/Constraints/issue-67906.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+struct G<each T>: Sequence {
+  typealias Element = Int
+  typealias Iterator = [Int].Iterator
+
+  consuming func makeIterator() -> Iterator {
+    fatalError()
+  }
+}
+
+// expected-note@+1 {{in call to function 'foo'}}
+func foo<each T>(_: repeat each T) -> G<repeat each T> {
+  .init()
+}
+
+// expected-error@+2 {{for-in loop requires '(repeat each T) -> G<repeat each T>' to conform to 'Sequence'}}
+// expected-error@+1 {{generic parameter 'each T' could not be inferred}}
+for a in foo {
+  print(a)
+}
+
+for a in foo() {
+  print(a)
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -139,7 +139,8 @@ func tupleExpansion<each T, each U>(
   _ = zip(repeat each tuple1, with: repeat each tuple1.element) // legacy syntax
 
   _ = zip(repeat each tuple1, with: repeat each tuple2)
-  // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'repeat each T' and 'repeat each U' have the same shape}}
+  // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'each T' and 'each U' have the same shape}}
+  // expected-error@-2 {{pack expansion requires that 'each U' and 'each T' have the same shape}}
 
   _ = forward(repeat each tuple3)
 }
@@ -349,37 +350,36 @@ func test_pack_expansions_with_closures() {
 func test_pack_expansion_specialization(tuple: (Int, String, Float)) {
   struct Data<each T> {
     init(_: repeat each T) {} // expected-note 4 {{'init(_:)' declared here}}
-    init(vals: repeat each T) {} // expected-note {{'init(vals:)' declared here}}
-    init<each U>(x: Int, _: repeat each T, y: repeat each U) {} // expected-note 3 {{'init(x:_:y:)' declared here}}
+    init(vals: repeat each T) {}
+    init<each U>(x: Int, _: repeat each T, y: repeat each U) {}
   }
 
   _ = Data<Int>() // expected-error {{missing argument for parameter #1 in call}}
   _ = Data<Int>(0) // Ok
   _ = Data<Int, String>(42, "") // Ok
-  _ = Data<Int>(42, "") // expected-error {{extra argument in call}}
+  _ = Data<Int>(42, "") // expected-error {{pack expansion requires that 'Int' and 'Int, String' have the same shape}}
   _ = Data<Int, String>((42, ""))
-  // expected-error@-1 {{value pack expansion at parameter #0 expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{25-26=}} {{32-33=}}
+  // expected-error@-1 {{initializer expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{25-26=}} {{32-33=}}
   _ = Data<Int, String, Float>(vals: (42, "", 0))
-  // expected-error@-1 {{value pack expansion at parameter #0 expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{38-39=}} {{48-49=}}
+  // expected-error@-1 {{pack expansion requires that 'Int, String, Float' and '(Int, String, Int)' have the same shape}}
   _ = Data<Int, String, Float>((vals: 42, "", 0))
-  // expected-error@-1 {{value pack expansion at parameter #0 expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{32-33=}} {{48-49=}}
+  // expected-error@-1 {{initializer expects 3 separate arguments; remove extra parentheses to change tuple into separate arguments}} {{32-33=}} {{48-49=}}
   _ = Data<Int, String, Float>(tuple)
-  // expected-error@-1 {{value pack expansion at parameter #0 expects 3 separate arguments}}
+  // expected-error@-1 {{initializer expects 3 separate arguments}}
   _ = Data<Int, String, Float>(x: 42, tuple)
-  // expected-error@-1 {{value pack expansion at parameter #1 expects 3 separate arguments}}
+  // expected-error@-1 {{pack expansion requires that 'Int, String, Float' and '(Int, String, Float)' have the same shape}}
   _ = Data<Int, String, Float>(x: 42, tuple, y: 1, 2, 3)
-  // expected-error@-1 {{value pack expansion at parameter #1 expects 3 separate arguments}}
+  // expected-error@-1 {{pack expansion requires that 'Int, String, Float' and '(Int, String, Float)' have the same shape}}
   _ = Data<Int, String, Float>(x: 42, (42, "", 0), y: 1, 2, 3)
-  // expected-error@-1 {{value pack expansion at parameter #1 expects 3 separate arguments}} {{39-40=}} {{49-50=}}
+  // expected-error@-1 {{pack expansion requires that 'Int, String, Float' and '(Int, String, Int)' have the same shape}}
 
   struct Ambiguity<each T> {
     func test(_: repeat each T) -> Int { 42 }
-    // expected-note@-1 {{value pack expansion at parameter #0 expects 3 separate arguments}}
+    // expected-note@-1 {{'test' declared here}}
     func test(_: repeat each T) -> String { "" }
-    // expected-note@-1 {{value pack expansion at parameter #0 expects 3 separate arguments}}
   }
 
-  _ = Ambiguity<Int, String, Float>().test(tuple) // expected-error {{no exact matches in call to instance method 'test'}}
+  _ = Ambiguity<Int, String, Float>().test(tuple) // expected-error {{instance method 'test' expects 3 separate arguments}}
 }
 
 // rdar://107280056 - "Ambiguous without more context" with opaque return type + variadics
@@ -621,44 +621,40 @@ do {
 // https://github.com/apple/swift/issues/66393
 do {
   struct S<each T> {
-    var property: (repeat each T) -> Void { // expected-note 4 {{'property' declared here}}
+    var property: (repeat each T) -> Void {
       get {}
     }
 
-    func method(_: repeat each T) {} // expected-note 4 {{'method' declared here}}
+    func method(_: repeat each T) {}
   }
   S<Int, Bool>().method((5, true))
-  // expected-error@-1 {{value pack expansion at parameter #0 expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{pack expansion requires that 'Int, Bool' and '(Int, Bool)' have the same shape}}
 
   S<Int, Bool>().method((5, true, 6))
-  // expected-error@-1 {{value pack expansion at parameter #0 expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{pack expansion requires that 'Int, Bool' and '(Int, Bool, Int)' have the same shape}}
 
   S<Int, Bool>().property((5, true))
-  // expected-error@-1 {{value pack expansion at parameter #0 expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{cannot pass value pack expansion to non-pack parameter of type 'repeat each T'}}
 
   S<Int, Bool>().property((5, true, 6))
-  // expected-error@-1 {{value pack expansion at parameter #0 expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+  // expected-error@-1 {{cannot pass value pack expansion to non-pack parameter of type 'repeat each T'}}
 
   func foo<each U>(u: repeat each U) {
     S<repeat each U>().property((3, 4, 5))
-    // expected-error@-1 {{value pack expansion at parameter #0 expects 1 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+    // expected-error@-1 {{cannot pass value pack expansion to non-pack parameter of type 'repeat each T'}}
 
     // FIXME: The count of 'repeat each U' is not statically known, but error suggests that it is 1.
     S<repeat each U>().method((3, 4, 5))
-    // expected-error@-1 {{value pack expansion at parameter #0 expects 1 separate arguments; remove extra parentheses to change tuple into separate arguments}}
-    // FIXME: Bad diagnostics
-    // expected-error@-3 {{pack expansion requires that 'each U' and '_' have the same shape}}
-    // expected-error@-4 {{pack expansion requires that 'each U' and '_.RawValue' have the same shape}}
+    // expected-error@-1 {{pack expansion requires that 'each U' and '(Int, Int, Int)' have the same shape}}
 
     // FIXME: The count of '(Int, Int), repeat each U' is not statically known, but error suggests that it is 2.
     S<(Int, Int), repeat each U>().method((3, 4))
-    // expected-error@-1 {{value pack expansion at parameter #0 expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}}
-    // FIXME: Duplicate diagnostics
-    // expected-error@-3 2 {{pack expansion requires that 'each U' and '' have the same shape}}
+    // expected-error@-1 {{pack expansion requires that '(Int, Int), repeat each U' and '(Int, Int)' have the same shape}}
+    // expected-error@-2 {{pack expansion requires that '' and 'each U' have the same shape}}
 
     // FIXME: The count of '(Int, Int), repeat each U' is not statically known, but error suggests that it is 2.
     S<(Int, Int), repeat each U>().property((3, 4))
-    // expected-error@-1 {{value pack expansion at parameter #0 expects 2 separate arguments; remove extra parentheses to change tuple into separate arguments}}
+    // expected-error@-1 {{cannot pass value pack expansion to non-pack parameter of type 'repeat each T'}}
   }
 }
 

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -73,5 +73,6 @@ func goodCallToZip<each T, each U>(t: repeat each T, u: repeat each U) where (re
 
 func badCallToZip<each T, each U>(t: repeat each T, u: repeat each U) {
   _ = zip(t: repeat each t, u: repeat each u)
-  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'repeat each T' and 'repeat each U' have the same shape}}
+  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'each T' and 'each U' have the same shape}}
+  // expected-error@-2 {{pack expansion requires that 'each U' and 'each T' have the same shape}}
 }

--- a/test/Constraints/variadic_generic_init.swift
+++ b/test/Constraints/variadic_generic_init.swift
@@ -1,0 +1,84 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+
+// These test cases exercise variants of rdar://problem/112785081
+// and https://github.com/apple/swift/issues/68160.
+
+protocol P {}
+
+protocol Q {
+  associatedtype A: Q
+
+  var a: A { get }
+}
+
+struct S1<each T: Q>: P {
+  init(_: repeat each T) {}
+}
+
+func foo1a<each T: Q>(_ t: repeat each T) -> some P {
+  return S1(repeat each t)
+}
+
+func foo2a<each T: Q>(_ t: repeat each T) -> S1<repeat each T> {
+  return S1(repeat each t)
+}
+
+func foo3a<each T: Q>(_ t: repeat each T) -> some P {
+  return S1(repeat (each t).a)
+}
+
+func foo4a<each T: Q>(_ t: repeat each T) -> S1<repeat (each T).A> {
+  return S1(repeat (each t).a)
+}
+
+func foo1b<each T: Q>(_ t: repeat each T) -> some P {
+  return S1.init(repeat each t)
+}
+
+func foo2b<each T: Q>(_ t: repeat each T) -> S1<repeat each T> {
+  return S1.init(repeat each t)
+}
+
+func foo3b<each T: Q>(_ t: repeat each T) -> some P {
+  return S1.init(repeat (each t).a)
+}
+
+func foo4b<each T: Q>(_ t: repeat each T) -> S1<repeat (each T).A> {
+  return S1.init(repeat (each t).a)
+}
+
+struct S2<each T: Q>: P {
+  init(arg: (repeat each T)) {}
+}
+
+func bar1a<each T: Q>(_ t: repeat each T) -> some P {
+  return S2(arg: (repeat each t))
+}
+
+func bar2a<each T: Q>(_ t: repeat each T) -> S2<repeat each T> {
+  return S2(arg: (repeat each t))
+}
+
+func bar3a<each T: Q>(_ t: repeat each T) -> some P {
+  return S2(arg: (repeat (each t).a))
+}
+
+func bar4a<each T: Q>(_ t: repeat each T) -> S2<repeat (each T).A> {
+  return S2(arg: (repeat (each t).a))
+}
+
+func bar1b<each T: Q>(_ t: repeat each T) -> some P {
+  return S2.init(arg: (repeat each t))
+}
+
+func bar2b<each T: Q>(_ t: repeat each T) -> S2<repeat each T> {
+  return S2.init(arg: (repeat each t))
+}
+
+func bar3b<each T: Q>(_ t: repeat each T) -> some P {
+  return S2.init(arg: (repeat (each t).a))
+}
+
+func bar4b<each T: Q>(_ t: repeat each T) -> S2<repeat (each T).A> {
+  return S2.init(arg: (repeat (each t).a))
+}

--- a/test/Constraints/variadic_generic_types.swift
+++ b/test/Constraints/variadic_generic_types.swift
@@ -56,6 +56,7 @@ do {
     return Test<String, Int, repeat each T>("a", 42, repeat each v) // Ok
   }
 }
+
 // rdar://107479662 - variadic tuple of Sendable elements does not conform to Sendable
 do {
   struct Test<each T> : Sendable {
@@ -63,5 +64,16 @@ do {
   }
 
   struct TestProperty<T> : Sendable {
+  }
+}
+
+// https://github.com/apple/swift/issues/68160
+do {
+  struct G<each T, U> {
+    let f: (repeat Optional<each T>) -> U
+
+    init(f: @escaping (repeat Optional<each T>) -> U) {
+      self.f = f
+    }
   }
 }

--- a/validation-test/compiler_crashers_2_fixed/rdar113463759.swift
+++ b/validation-test/compiler_crashers_2_fixed/rdar113463759.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+protocol SomeObjectProtocol {}
+
+struct SomeObject: SomeObjectProtocol {}
+
+protocol ObjectProviding {
+    associatedtype Object: SomeObjectProtocol
+    var object: Object { get }
+}
+
+struct ConformingObject<each B>: ObjectProviding {
+    var object: some SomeObjectProtocol {
+        SomeObject()
+    }
+}


### PR DESCRIPTION
5.10 cherry-pick of https://github.com/apple/swift/pull/70457.

* Description: Fixes some incorrect logic in the code path where we "open" a generic type to obtain a type with type variables. Manifests with various common usages of parameter packs as an assertion failure in an assert build, or various IRGen crashes otherwise.

  Some diagnostics change in a way that is still correct, but makes them less clear. We believe these regressions are acceptable for 5.10. On main, a follow-up PR will fix most of the regressions with a change that's too risky to take for 5.10.

* Origination: Fixes a bug in a new feature, parameter packs.

* Scope of the issue: Seems to impact many users with numerous dupes.

* Radar: 
   * rdar://112785081
   * Fixes #67906
   * Fixes #68160
   * Fixes #68369
   * Fixes #67984

* Tested: Various new test cases reduced from user reports.

* Risk: Low; worst case a regression here should only impact type checking of parameter packs.

* Reviewed by: @xedin