### PR TITLE
build-presets: temporarily disable swift-docc for linux

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -808,7 +808,8 @@ swiftpm
 swift-driver
 xctest
 libicu
-swiftdocc
+# TODO: re-enable once rdar://120716498 is resolved
+#swiftdocc
 
 build-ninja
 install-llvm
@@ -823,15 +824,16 @@ install-libicu
 install-prefix=/usr
 install-sourcekit-lsp
 install-swiftformat
-install-swiftdocc
+# TODO: re-enable once rdar://120716498 is resolved
+#install-swiftdocc
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
 
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-integration-tests repo is checked out
-
-test-installable-package
+# TODO: re-enable once rdar://120716498 is resolved
+# test-installable-package
 
 # Build the benchmarks against the toolchain.
 toolchain-benchmarks
@@ -864,7 +866,8 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
-swiftdocc
+# TODO: re-enable once rdar://120716498 is resolved
+#swiftdocc
 lit-args=-v --time-tests
 
 # rdar://problem/31454823


### PR DESCRIPTION
To unblock linux CI

rdar://120716498

subsumes https://github.com/apple/swift/pull/70790