### PR TITLE
[Distributed] Destroy decoded parameters after executeDistributedTarget

### DIFF
--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -486,6 +486,7 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
     // The argument is +0, so we can use the address of the param in
     // the context directly.
     arguments.add(resultAddr);
+    LoadedArguments.push_back(std::make_pair(resultValue.getAddress(), argumentType));
     break;
   }
 

--- a/test/Distributed/Runtime/distributed_actor_encode_roundtrip.swift
+++ b/test/Distributed/Runtime/distributed_actor_encode_roundtrip.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeCodableForDistributedTests.swiftmodule -module-name FakeCodableForDistributedTests -disable-availability-checking %S/../Inputs/FakeCodableForDistributedTests.swift
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// XXX: %target-build-swift -emit-silgen -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color

--- a/test/Distributed/Runtime/distributed_actor_execute_doesnt_leak_arguments.swift
+++ b/test/Distributed/Runtime/distributed_actor_execute_doesnt_leak_arguments.swift
@@ -1,0 +1,107 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeCodableForDistributedTests.swiftmodule -module-name FakeCodableForDistributedTests -disable-availability-checking %S/../Inputs/FakeCodableForDistributedTests.swift
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// XXX: %target-build-swift -emit-silgen -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeCodableForDistributedTests.swift %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Distributed
+import FakeDistributedActorSystems
+import FakeCodableForDistributedTests
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+class Sentinel {
+  let str: String
+
+  init(_ str: String) {
+    self.str = str
+    print("\(str).init: \(Unmanaged.passUnretained(self).toOpaque())")
+  }
+
+  deinit {
+    print("\(str).deinit: \(Unmanaged.passUnretained(self).toOpaque())")
+  }
+}
+
+struct InnerStruct1 {
+  let sentinel: Sentinel
+  let innerStruct2: InnerStruct2
+
+  init() {
+    self.sentinel = Sentinel("\(Self.self)")
+    self.innerStruct2 = InnerStruct2()
+  }
+}
+
+struct InnerStruct2 {
+  let sentinel: Sentinel
+
+  init() {
+    self.sentinel = Sentinel("\(Self.self)")
+  }
+}
+
+enum InnerEnum {
+  case v1(String)
+  case v2(InnerStruct1)
+}
+
+struct ArgumentType: Codable {
+  let sentinel: Sentinel
+  let value: Int
+  let innerEnum: InnerEnum
+
+  init(_ value: Int) {
+    self.sentinel = Sentinel("ArgumentType")
+    self.value = value
+    self.innerEnum = .v2(InnerStruct1())
+  }
+
+  init(from decoder: Decoder) throws {
+    self.sentinel = Sentinel("ArgumentType")
+    self.value = 100
+    self.innerEnum = .v2(InnerStruct1())
+  }
+
+  func encode(to encoder: Encoder) throws {
+    print("ArgumentType.encode")
+  }
+}
+
+distributed actor TestActor {
+  public distributed func testFunc(arg: ArgumentType) {
+    print("value=\(arg.value)")
+  }
+}
+
+@main
+struct Main {
+
+  static func main() async throws {
+    let system = DefaultDistributedActorSystem()
+
+    let instance = TestActor(actorSystem: system)
+    let resolved = try TestActor.resolve(id: instance.id, using: system)
+
+    // CHECK: ArgumentType.init: [[P1:0x[0-9]+]]
+    // CHECK: InnerStruct1.init: [[P2:0x[0-9]+]]
+    // CHECK: InnerStruct2.init: [[P3:0x[0-9]+]]
+
+    // CHECK: ArgumentType.deinit: [[P1]]
+    // CHECK: InnerStruct1.deinit: [[P2]]
+    // CHECK: InnerStruct2.deinit: [[P3]]
+
+    let arg = ArgumentType(100)
+    try await resolved.testFunc(arg: arg)
+  }
+}


### PR DESCRIPTION
Description: We recently fixed a similar issue where the objects created from decodeNextArgument in a distributed thunk were not properly destroyed. The fix was in https://github.com/apple/swift/pull/65952

In that fix, we missed handling of Indirect_In_Guaranteed which also need to be destroyed, this patch corrects that omission.

**Risk:** Low, impacts only distributed methods, and only struct arguments. The specific shape of fix was previously done already, but was missing for one of the cases of parameter ownership kind.

**Impact:** The problem manifests in deinitialization not running as expected for decoded arguments. The memory for those parameters freed but destroy logic is not run on those. This results in memory leak detection triggering for distributed methods. All distributed actor adopters are impacted.

Resolves https://github.com/apple/swift/issues/70004 
Resolves rdar://119943672
Resolves rdar://119446012
