### PR TITLE
Fixed too short abbreviation length for the DeclsAndTypes block

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5787,7 +5787,7 @@ bool Serializer::writeASTBlockEntitiesIfNeeded(
 }
 
 void Serializer::writeAllDeclsAndTypes() {
-  BCBlockRAII restoreBlock(Out, DECLS_AND_TYPES_BLOCK_ID, 8);
+  BCBlockRAII restoreBlock(Out, DECLS_AND_TYPES_BLOCK_ID, DeclTypeAbbrBits);
   using namespace decls_block;
   registerDeclTypeAbbr<BuiltinAliasTypeLayout>();
   registerDeclTypeAbbr<TypeAliasTypeLayout>();

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -308,7 +308,7 @@ private:
   /// This is for Named Lazy Member Loading.
   DeclMemberNamesTable DeclMemberNames;
 
-  enum {NumDeclTypeAbbrCodes = 512};
+  enum { DeclTypeAbbrBits = 9, NumDeclTypeAbbrCodes = (1 << DeclTypeAbbrBits) };
 
   /// The abbreviation code for each record in the "decls-and-types" block.
   ///


### PR DESCRIPTION
Fixes an assertion when serialising SIL, caused by too short abbreviation length for the DeclsAndTypes block.

```
Assertion failed: ((Val & ~(~0U >> (32-NumBits))) == 0 && "High bits set!"), function Emit, file BitstreamWriter.h, line 209.
...
0  swift-frontend           0x00000001088a8440 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 56
1  swift-frontend           0x00000001088a67f8 llvm::sys::RunSignalHandlers() + 112
2  swift-frontend           0x00000001088a8ae4 SignalHandler(int) + 352
3  libsystem_platform.dylib 0x00000001834f5a24 _sigtramp + 56
4  libsystem_pthread.dylib  0x00000001834c5cc0 pthread_kill + 288
5  libsystem_c.dylib        0x00000001833d1a40 abort + 180
6  libsystem_c.dylib        0x00000001833d0d30 err + 0
7  swift-frontend           0x00000001088ebf38 emitBlockID(unsigned int, char const*, llvm::BitstreamWriter&, llvm::SmallVectorImpl<unsigned long long>&) (.cold.1) + 0
8  swift-frontend           0x000000010338f288 emitBlockID(unsigned int, char const*, llvm::BitstreamWriter&, llvm::SmallVectorImpl<unsigned long long>&) + 0
9  swift-frontend           0x000000010339095c void llvm::BitstreamWriter::EmitRecordWithAbbrevImpl<unsigned long long>(unsigned int, llvm::ArrayRef<unsigned long long>, llvm::StringRef, std::__1::optional<unsigned int>) + 92
10 swift-frontend           0x0000000103de27fc swift::serialization::Serializer::DeclSerializer::writeDeclAttribute(swift::Decl const*, swift::DeclAttribute const*) + 5332
11 swift-frontend           0x0000000103dd7980 swift::serialization::Serializer::DeclSerializer::visit(swift::Decl const*) + 112
12 swift-frontend           0x0000000103dd787c swift::serialization::Serializer::writeASTBlockEntity(swift::Decl const*) + 480
13 swift-frontend           0x0000000103dd90f8 swift::serialization::Serializer::writeAllDeclsAndTypes() + 3400
...
```

Make sure that abbreviation length and length of the `DeclTypeAbbrCodes` array remain consistent in the future.