### PR TITLE
[embedded] Ignore 'do not specialize' @_semantics attributes in embedded Swift mode

### DIFF
--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -500,6 +500,11 @@ static bool createsInfiniteSpecializationLoop(ApplySite Apply) {
 
 static bool shouldNotSpecialize(SILFunction *Callee, SILFunction *Caller,
                                 SubstitutionMap Subs = {}) {
+  // Ignore "do not specialize" markers in embedded Swift -- specialization is
+  // mandatory.
+  if (Callee->getModule().getOptions().EmbeddedSwift)
+    return false;
+
   if (Callee->hasSemanticsAttr(semantics::OPTIMIZE_SIL_SPECIALIZE_GENERIC_NEVER))
     return true;
 

--- a/test/embedded/specialize-attrs.swift
+++ b/test/embedded/specialize-attrs.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift(-parse-as-library -Onone -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx
+
+@_semantics("optimize.sil.specialize.generic.never")
+func foo<T>(_ t: T) -> Int {
+  return 42
+}
+
+@_semantics("optimize.sil.specialize.generic.size.never")
+func foo2<T>(_ t: T) -> Int {
+  return 42
+}
+
+@main
+struct Main {
+  static func main() {
+    foo(42)
+    foo2(42)
+    print("OK!")
+  }
+}
+
+// CHECK: OK!

--- a/test/embedded/specialize-attrs.swift
+++ b/test/embedded/specialize-attrs.swift
@@ -1,6 +1,6 @@
-// RUN: %target-run-simple-swift(-parse-as-library -Onone -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
-// RUN: %target-run-simple-swift(-parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
-// RUN: %target-run-simple-swift(-parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -Onone -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -O -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
+// RUN: %target-run-simple-swift(%S/Inputs/print.swift -parse-as-library -Osize -enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop -Xlinker -dead_strip) | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test


### PR DESCRIPTION
We cannot allow the 'do not specialize' @_semantics attributes in embedded Swift because specialization is mandatory for soundness of the resulting compilations. The attached test crashes (triggers a "unexpected unspecialized function found during IRGen" assert) without the fix.

We have been a bit lucky that so far the parts of the stdlib that we have for embedded Swift didn't use these attributes, but I have observed that some other parts (e.g. Dictionary implementation) do use them, so we need to fix this problem.