### PR TITLE
build: migrate to CMake based build of swift-format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,7 +798,7 @@ if(SWIFT_PATH_TO_CMARK_BUILD)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   message(STATUS "CMark Version: ${_CMARK_VERSION}")
 elseif(SWIFT_INCLUDE_TOOLS)
-  find_package(cmark-gfm CONFIG REQUIRED)
+  find_package(cmark-gfm REQUIRED)
 endif()
 message(STATUS "")
 

--- a/cmake/caches/Windows-aarch64.cmake
+++ b/cmake/caches/Windows-aarch64.cmake
@@ -6,7 +6,6 @@ set(LLVM_ENABLE_PROJECTS
     CACHE STRING "")
 
 set(LLVM_EXTERNAL_PROJECTS
-      cmark
       swift
     CACHE STRING "")
 

--- a/cmake/caches/Windows-x86_64.cmake
+++ b/cmake/caches/Windows-x86_64.cmake
@@ -6,7 +6,6 @@ set(LLVM_ENABLE_PROJECTS
     CACHE STRING "")
 
 set(LLVM_EXTERNAL_PROJECTS
-      cmark
       swift
     CACHE STRING "")
 

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -1042,7 +1042,8 @@ function(_compile_swift_files
   if (NOT SWIFTFILE_IS_MAIN)
     add_custom_command_target(
         module_dependency_target
-        COMMAND "${CMAKE_COMMAND}" -E make_directory ${dirs_to_create}
+        COMMAND
+          "${CMAKE_COMMAND}" -E make_directory ${dirs_to_create}
         COMMAND
           "${CMAKE_COMMAND}" "-E" "remove" "-f" ${module_outputs}
         COMMAND


### PR DESCRIPTION
This allows us to build swift-format with dynamic linking against the
toolchain build of the swift-syntax and swift-argument-parser packages.
Wire up the swift-markdown build and hoist the swift-format build prior
to sourcekit-lsp. This sets us up for supporting swift-format based
formatting in the LSP.