### PR TITLE
[TypeCheckEffects] Stage in new effects checker errors for statement expressions as warnings until Swift 6.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1288,8 +1288,8 @@ ERROR(single_value_stmt_branch_must_end_in_result,none,
 ERROR(cannot_jump_in_single_value_stmt,none,
       "cannot '%0' in '%1' when used as expression",
       (StmtKind, StmtKind))
-ERROR(effect_marker_on_single_value_stmt,none,
-      "'%0' may not be used on '%1' expression", (StringRef, StmtKind))
+WARNING(effect_marker_on_single_value_stmt,none,
+      "'%0' has no effect on '%1' expression", (StringRef, StmtKind))
 ERROR(out_of_place_then_stmt,none,
       "'then' may only appear as the last statement in an 'if', 'switch', or "
       "'do' expression", ())

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -3376,7 +3376,7 @@ private:
 
   void diagnoseRedundantTry(AnyTryExpr *E) const {
     if (auto *SVE = SingleValueStmtExpr::tryDigOutSingleValueStmtExpr(E)) {
-      // For an if/switch expression, produce an error instead of a warning.
+      // For an if/switch expression, produce a tailored warning.
       Ctx.Diags.diagnose(E->getTryLoc(),
                          diag::effect_marker_on_single_value_stmt,
                          "try", SVE->getStmt()->getKind())
@@ -3388,7 +3388,7 @@ private:
 
   void diagnoseRedundantAwait(AwaitExpr *E) const {
     if (auto *SVE = SingleValueStmtExpr::tryDigOutSingleValueStmtExpr(E)) {
-      // For an if/switch expression, produce an error instead of a warning.
+      // For an if/switch expression, produce a tailored warning.
       Ctx.Diags.diagnose(E->getAwaitLoc(),
                          diag::effect_marker_on_single_value_stmt,
                          "await", SVE->getStmt()->getKind())

--- a/test/expr/unary/do_expr.swift
+++ b/test/expr/unary/do_expr.swift
@@ -133,28 +133,28 @@ func testReturn2() -> Int {
 
 func tryDo1() -> Int {
   try do { 0 }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
 }
 
 func tryDo2() -> Int {
   let x = try do { 0 }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   return x
 }
 
 func tryDo3() -> Int {
   return try do { 0 }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
 }
 
 func tryDo4() throws -> Int {
   return try do { 0 }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
 }
 
 func tryDo5() throws -> Int {
   return try do { tryDo4() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -163,7 +163,7 @@ func tryDo5() throws -> Int {
 
 func tryDo6() throws -> Int {
   try do { tryDo4() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -172,7 +172,7 @@ func tryDo6() throws -> Int {
 
 func tryDo7() throws -> Int {
   let x = try do { tryDo4() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -182,23 +182,23 @@ func tryDo7() throws -> Int {
 
 func tryDo8() throws -> Int {
   return try do { try tryDo4() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
 }
 
 func tryDo9() throws -> Int {
   try do { try tryDo4() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
 }
 
 func tryDo10() throws -> Int {
   let x = try do { try tryDo4() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   return x
 }
 
 func tryDo11() throws -> Int {
   let x = try do { try tryDo4() } catch { tryDo4() }
-  // expected-error@-1 {{'try' may not be used on 'do-catch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do-catch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -208,7 +208,7 @@ func tryDo11() throws -> Int {
 
 func tryDo12() throws -> Int {
   let x = try do { tryDo4() } catch { tryDo4() }
-  // expected-error@-1 {{'try' may not be used on 'do-catch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do-catch' expression}}
   // expected-error@-2 2{{call can throw but is not marked with 'try'}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
@@ -217,7 +217,7 @@ func tryDo12() throws -> Int {
 }
 
 func tryDo13() throws -> Int {
-  let x = try do { // expected-error {{'try' may not be used on 'do-catch' expression}}
+  let x = try do { // expected-warning {{'try' has no effect on 'do-catch' expression}}
     tryDo4() // expected-warning {{result of call to 'tryDo4()' is unused}}
     // expected-error@-1 {{call can throw but is not marked with 'try'}}
     // expected-note@-2 {{did you mean to use 'try'?}}
@@ -251,13 +251,13 @@ func throwsBool() throws -> Bool { true }
 
 func tryDo14() throws -> Int {
   try do { try tryDo4() } catch _ where throwsBool() { 0 } catch { 1 }
-  // expected-error@-1 {{'try' may not be used on 'do-catch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do-catch' expression}}
   // expected-error@-2 {{call can throw, but errors cannot be thrown out of a catch guard expression}}
 }
 
 func tryDo15() throws -> Int {
   try do { try tryDo4() } catch _ where try throwsBool() { 1 } catch { 1 }
-  // expected-error@-1 {{'try' may not be used on 'do-catch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do-catch' expression}}
   // expected-error@-2 {{call can throw, but errors cannot be thrown out of a catch guard expression}}
 }
 
@@ -387,12 +387,12 @@ func tryDo30(_ fn: () throws -> Int) rethrows -> Int {
 
 func awaitDo1() async -> Int {
   await do { 0 }
-  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
 }
 
 func awaitDo2() async -> Int {
   let x = await do { 0 }
-  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
   return x
 }
 
@@ -403,26 +403,26 @@ func awaitDo3() -> Int { // expected-note {{add 'async' to function 'awaitDo3()'
 
 func awaitDo4() async -> Int {
   return await do { 0 }
-  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
 }
 
 func awaitDo5() async -> Int {
   return await do { awaitDo4() }
-  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitDo6() async -> Int {
   await do { awaitDo4() }
-  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitDo7() async -> Int {
   let x = await do { awaitDo4() }
-  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -430,23 +430,23 @@ func awaitDo7() async -> Int {
 
 func awaitDo8() async -> Int {
   return await do { await awaitDo4() }
-  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
 }
 
 func awaitDo9() async -> Int {
   await do { await awaitDo4() }
-  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
 }
 
 func awaitDo10() async -> Int {
   let x = await do { await awaitDo4() }
-  // expected-error@-1 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do' expression}}
   return x
 }
 
 func awaitDo11() async -> Int {
   let x = await do { try await tryAwaitDo1() } catch { awaitDo4() }
-  // expected-error@-1 {{'await' may not be used on 'do-catch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -454,14 +454,14 @@ func awaitDo11() async -> Int {
 
 func awaitDo12() async -> Int {
   let x = await do { try tryAwaitDo1() } catch { awaitDo4() }
-  // expected-error@-1 {{'await' may not be used on 'do-catch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
   // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
 
 func awaitDo13() async throws -> Int {
-  let x = await do { // expected-error {{'await' may not be used on 'do-catch' expression}}
+  let x = await do { // expected-warning {{'await' has no effect on 'do-catch' expression}}
     awaitDo4() // expected-warning {{result of call to 'awaitDo4()' is unused}}
     // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-2 {{call is 'async'}}
@@ -491,13 +491,13 @@ func asyncBool() async -> Bool { true }
 
 func awaitDo14() async -> Int {
   await do { try tryDo4() } catch _ where asyncBool() { 0 } catch { 1 }
-  // expected-error@-1 {{'await' may not be used on 'do-catch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
   // expected-error@-2 {{'async' call cannot occur in a catch guard expression}}
 }
 
 func awaitDo15() async -> Int {
   await do { try tryDo4() } catch _ where await asyncBool() { 0 } catch { 1 }
-  // expected-error@-1 {{'await' may not be used on 'do-catch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
   // expected-error@-2 {{'async' call cannot occur in a catch guard expression}}
 }
 
@@ -529,20 +529,20 @@ func awaitDo20() async -> Int {
 
 func tryAwaitDo1() async throws -> Int {
   try await do { 0 }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
 }
 
 func tryAwaitDo2() async throws -> Int {
   try await do { 0 } as Int
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
 }
 
 func tryAwaitDo3() async throws -> Int {
   try await do { tryAwaitDo2() } as Int
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -553,16 +553,16 @@ func tryAwaitDo3() async throws -> Int {
 
 func tryAwaitDo4() async throws -> Int {
   try await do { try tryAwaitDo2() } as Int
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitDo5() async throws -> Int {
   try await do { await tryAwaitDo2() } as Int
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -571,14 +571,14 @@ func tryAwaitDo5() async throws -> Int {
 
 func tryAwaitDo6() async throws -> Int {
   try await do { try await tryAwaitDo2() } as Int
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
 }
 
 func tryAwaitDo7() async throws -> Int {
   try await do { tryAwaitDo2() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -589,16 +589,16 @@ func tryAwaitDo7() async throws -> Int {
 
 func tryAwaitDo8() async throws -> Int {
   try await do { try tryAwaitDo2() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitDo9() async throws -> Int {
   try await do { await tryAwaitDo2() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -607,8 +607,8 @@ func tryAwaitDo9() async throws -> Int {
 
 func tryAwaitDo10() async throws -> Int {
   try await do { try await tryAwaitDo2() }
-  // expected-error@-1 {{'try' may not be used on 'do' expression}}
-  // expected-error@-2 {{'await' may not be used on 'do' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'do' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'do' expression}}
 }
 
 func tryAwaitDo11(_ fn: () async throws -> Int) async rethrows -> Int {

--- a/test/expr/unary/do_expr.swift
+++ b/test/expr/unary/do_expr.swift
@@ -155,7 +155,7 @@ func tryDo4() throws -> Int {
 func tryDo5() throws -> Int {
   return try do { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -164,7 +164,7 @@ func tryDo5() throws -> Int {
 func tryDo6() throws -> Int {
   try do { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -173,7 +173,7 @@ func tryDo6() throws -> Int {
 func tryDo7() throws -> Int {
   let x = try do { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -199,7 +199,7 @@ func tryDo10() throws -> Int {
 func tryDo11() throws -> Int {
   let x = try do { try tryDo4() } catch { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do-catch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -209,7 +209,7 @@ func tryDo11() throws -> Int {
 func tryDo12() throws -> Int {
   let x = try do { tryDo4() } catch { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do-catch' expression}}
-  // expected-error@-2 2{{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
   // expected-note@-5 2{{did you mean to disable error propagation?}}
@@ -219,13 +219,13 @@ func tryDo12() throws -> Int {
 func tryDo13() throws -> Int {
   let x = try do { // expected-warning {{'try' has no effect on 'do-catch' expression}}
     tryDo4() // expected-warning {{result of call to 'tryDo4()' is unused}}
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
 
     _ = tryDo4()
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
@@ -409,21 +409,21 @@ func awaitDo4() async -> Int {
 func awaitDo5() async -> Int {
   return await do { awaitDo4() }
   // expected-warning@-1 {{'await' has no effect on 'do' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitDo6() async -> Int {
   await do { awaitDo4() }
   // expected-warning@-1 {{'await' has no effect on 'do' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitDo7() async -> Int {
   let x = await do { awaitDo4() }
   // expected-warning@-1 {{'await' has no effect on 'do' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -447,7 +447,7 @@ func awaitDo10() async -> Int {
 func awaitDo11() async -> Int {
   let x = await do { try await tryAwaitDo1() } catch { awaitDo4() }
   // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -455,7 +455,7 @@ func awaitDo11() async -> Int {
 func awaitDo12() async -> Int {
   let x = await do { try tryAwaitDo1() } catch { awaitDo4() }
   // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
-  // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
@@ -463,11 +463,11 @@ func awaitDo12() async -> Int {
 func awaitDo13() async throws -> Int {
   let x = await do { // expected-warning {{'await' has no effect on 'do-catch' expression}}
     awaitDo4() // expected-warning {{result of call to 'awaitDo4()' is unused}}
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = awaitDo4()
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = await awaitDo4() // Okay.
@@ -543,11 +543,11 @@ func tryAwaitDo3() async throws -> Int {
   try await do { tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -555,7 +555,7 @@ func tryAwaitDo4() async throws -> Int {
   try await do { try tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -563,7 +563,7 @@ func tryAwaitDo5() async throws -> Int {
   try await do { await tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
@@ -579,11 +579,11 @@ func tryAwaitDo7() async throws -> Int {
   try await do { tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -591,7 +591,7 @@ func tryAwaitDo8() async throws -> Int {
   try await do { try tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -599,7 +599,7 @@ func tryAwaitDo9() async throws -> Int {
   try await do { await tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -1492,6 +1492,16 @@ func tryAwaitIf15(_ fn: () async throws -> Int) async rethrows -> Int {
   }
 }
 
+func asyncLetIf(cond: Bool, _ fn: () async throws -> Int) async throws -> Int {
+  async let x = if cond {
+    fn()
+  } else {
+    0
+  }
+
+  return try await x
+}
+
 struct AnyEraserP: EraserP {
   init<T: EraserP>(erasing: T) {}
 }

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -1011,7 +1011,7 @@ func tryIf4() throws -> Int {
 func tryIf5() throws -> Int {
   return try if .random() { tryIf4() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1020,7 +1020,7 @@ func tryIf5() throws -> Int {
 func tryIf6() throws -> Int {
   try if .random() { tryIf4() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1029,7 +1029,7 @@ func tryIf6() throws -> Int {
 func tryIf7() throws -> Int {
   let x = try if .random() { tryIf4() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1055,7 +1055,7 @@ func tryIf10() throws -> Int {
 func tryIf11() throws -> Int {
   let x = try if .random() { try tryIf4() } else { tryIf4() }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1065,7 +1065,7 @@ func tryIf11() throws -> Int {
 func tryIf12() throws -> Int {
   let x = try if .random() { tryIf4() } else { tryIf4() }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 2{{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
   // expected-note@-5 2{{did you mean to disable error propagation?}}
@@ -1075,13 +1075,13 @@ func tryIf12() throws -> Int {
 func tryIf13() throws -> Int {
   let x = try if .random() { // expected-warning {{'try' has no effect on 'if' expression}}
     tryIf4() // expected-warning {{result of call to 'tryIf4()' is unused}}
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
 
     _ = tryIf4()
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
@@ -1106,7 +1106,7 @@ func throwsBool() throws -> Bool { true }
 func tryIf14() throws -> Int {
   try if throwsBool() { 0 } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1246,21 +1246,21 @@ func awaitIf4() async -> Int {
 func awaitIf5() async -> Int {
   return await if .random() { awaitIf4() } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf6() async -> Int {
   await if .random() { awaitIf4() } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf7() async -> Int {
   let x = await if .random() { awaitIf4() } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1284,7 +1284,7 @@ func awaitIf10() async -> Int {
 func awaitIf11() async -> Int {
   let x = await if .random() { await awaitIf4() } else { awaitIf4() }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1292,7 +1292,7 @@ func awaitIf11() async -> Int {
 func awaitIf12() async -> Int {
   let x = await if .random() { awaitIf4() } else { awaitIf4() }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
@@ -1300,11 +1300,11 @@ func awaitIf12() async -> Int {
 func awaitIf13() async throws -> Int {
   let x = await if .random() { // expected-warning {{'await' has no effect on 'if' expression}}
     awaitIf4() // expected-warning {{result of call to 'awaitIf4()' is unused}}
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = awaitIf4()
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = await awaitIf4() // Okay.
@@ -1327,7 +1327,7 @@ func asyncBool() async -> Bool { true }
 func awaitIf14() async -> Int {
   await if asyncBool() { 0 } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
@@ -1379,11 +1379,11 @@ func tryAwaitIf3() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1391,7 +1391,7 @@ func tryAwaitIf4() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1399,7 +1399,7 @@ func tryAwaitIf5() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
@@ -1415,11 +1415,11 @@ func tryAwaitIf7() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1427,7 +1427,7 @@ func tryAwaitIf8() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1435,7 +1435,7 @@ func tryAwaitIf9() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -548,7 +548,7 @@ func stmts() {
 
   if try if .random() { true } else { false } {}
   // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-  // expected-error@-2 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-2 {{'try' has no effect on 'if' expression}}
 
   // expected-error@+1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
   guard if .random() { true } else { false } else {
@@ -989,28 +989,28 @@ func return4() throws -> Int {
 
 func tryIf1() -> Int {
   try if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf2() -> Int {
   let x = try if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   return x
 }
 
 func tryIf3() -> Int {
   return try if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf4() throws -> Int {
   return try if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf5() throws -> Int {
   return try if .random() { tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1019,7 +1019,7 @@ func tryIf5() throws -> Int {
 
 func tryIf6() throws -> Int {
   try if .random() { tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1028,7 +1028,7 @@ func tryIf6() throws -> Int {
 
 func tryIf7() throws -> Int {
   let x = try if .random() { tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1038,23 +1038,23 @@ func tryIf7() throws -> Int {
 
 func tryIf8() throws -> Int {
   return try if .random() { try tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf9() throws -> Int {
   try if .random() { try tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf10() throws -> Int {
   let x = try if .random() { try tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   return x
 }
 
 func tryIf11() throws -> Int {
   let x = try if .random() { try tryIf4() } else { tryIf4() }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1064,7 +1064,7 @@ func tryIf11() throws -> Int {
 
 func tryIf12() throws -> Int {
   let x = try if .random() { tryIf4() } else { tryIf4() }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 2{{call can throw but is not marked with 'try'}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
@@ -1073,7 +1073,7 @@ func tryIf12() throws -> Int {
 }
 
 func tryIf13() throws -> Int {
-  let x = try if .random() { // expected-error {{'try' may not be used on 'if' expression}}
+  let x = try if .random() { // expected-warning {{'try' has no effect on 'if' expression}}
     tryIf4() // expected-warning {{result of call to 'tryIf4()' is unused}}
     // expected-error@-1 {{call can throw but is not marked with 'try'}}
     // expected-note@-2 {{did you mean to use 'try'?}}
@@ -1105,7 +1105,7 @@ func throwsBool() throws -> Bool { true }
 
 func tryIf14() throws -> Int {
   try if throwsBool() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1114,7 +1114,7 @@ func tryIf14() throws -> Int {
 
 func tryIf15() throws -> Int {
   try if try throwsBool() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf16() throws -> Int {
@@ -1224,42 +1224,42 @@ func tryIf29(_ fn: () throws -> Int) rethrows -> Int {
 
 func awaitIf1() async -> Int {
   await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf2() async -> Int {
   let x = await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   return x
 }
 
 func awaitIf3() async -> Int {
   return await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf4() async -> Int {
   return await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf5() async -> Int {
   return await if .random() { awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf6() async -> Int {
   await if .random() { awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf7() async -> Int {
   let x = await if .random() { awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1267,23 +1267,23 @@ func awaitIf7() async -> Int {
 
 func awaitIf8() async -> Int {
   return await if .random() { await awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf9() async -> Int {
   await if .random() { await awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf10() async -> Int {
   let x = await if .random() { await awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   return x
 }
 
 func awaitIf11() async -> Int {
   let x = await if .random() { await awaitIf4() } else { awaitIf4() }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1291,14 +1291,14 @@ func awaitIf11() async -> Int {
 
 func awaitIf12() async -> Int {
   let x = await if .random() { awaitIf4() } else { awaitIf4() }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
 
 func awaitIf13() async throws -> Int {
-  let x = await if .random() { // expected-error {{'await' may not be used on 'if' expression}}
+  let x = await if .random() { // expected-warning {{'await' has no effect on 'if' expression}}
     awaitIf4() // expected-warning {{result of call to 'awaitIf4()' is unused}}
     // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-2 {{call is 'async'}}
@@ -1326,14 +1326,14 @@ func asyncBool() async -> Bool { true }
 
 func awaitIf14() async -> Int {
   await if asyncBool() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf15() async -> Int {
   await if await asyncBool() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf16() async -> Int {
@@ -1365,20 +1365,20 @@ func awaitIf20() async -> Int {
 
 func tryAwaitIf1() async throws -> Int {
   try await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
 }
 
 func tryAwaitIf2() async throws -> Int {
   try await if .random() { 0 } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
 }
 
 func tryAwaitIf3() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1389,16 +1389,16 @@ func tryAwaitIf3() async throws -> Int {
 
 func tryAwaitIf4() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitIf5() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1407,14 +1407,14 @@ func tryAwaitIf5() async throws -> Int {
 
 func tryAwaitIf6() async throws -> Int {
   try await if .random() { try await tryAwaitIf2() } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
 }
 
 func tryAwaitIf7() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1425,16 +1425,16 @@ func tryAwaitIf7() async throws -> Int {
 
 func tryAwaitIf8() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitIf9() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1443,8 +1443,8 @@ func tryAwaitIf9() async throws -> Int {
 
 func tryAwaitIf10() async throws -> Int {
   try await if .random() { try await tryAwaitIf2() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
 }
 
 func tryAwaitIf11(_ fn: () async throws -> Int) async rethrows -> Int {

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -1281,7 +1281,7 @@ func trySwitch4() throws -> Int {
 func trySwitch5() throws -> Int {
   return try switch Bool.random() { case true: trySwitch4() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1290,7 +1290,7 @@ func trySwitch5() throws -> Int {
 func trySwitch6() throws -> Int {
   try switch Bool.random() { case true: trySwitch4() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1299,7 +1299,7 @@ func trySwitch6() throws -> Int {
 func trySwitch7() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1325,7 +1325,7 @@ func trySwitch10() throws -> Int {
 func trySwitch11() throws -> Int {
   let x = try switch Bool.random() { case true: try trySwitch4() case false: trySwitch4() }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1335,7 +1335,7 @@ func trySwitch11() throws -> Int {
 func trySwitch12() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: trySwitch4() }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 2{{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
   // expected-note@-5 2{{did you mean to disable error propagation?}}
@@ -1346,13 +1346,13 @@ func trySwitch13() throws -> Int {
   let x = try switch Bool.random() { // expected-warning {{'try' has no effect on 'switch' expression}}
   case true:
     trySwitch4() // expected-warning {{result of call to 'trySwitch4()' is unused}}
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
 
     _ = trySwitch4()
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
@@ -1377,7 +1377,7 @@ func throwsBool() throws -> Bool { true }
 func trySwitch14() throws -> Int {
   try switch throwsBool() { case true: 0 case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1517,21 +1517,21 @@ func awaitSwitch4() async -> Int {
 func awaitSwitch5() async -> Int {
   return await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch6() async -> Int {
   await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch7() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1555,7 +1555,7 @@ func awaitSwitch10() async -> Int {
 func awaitSwitch11() async -> Int {
   let x = await switch Bool.random() { case true: await awaitSwitch4() case false: awaitSwitch4() }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1563,7 +1563,7 @@ func awaitSwitch11() async -> Int {
 func awaitSwitch12() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: awaitSwitch4() }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
@@ -1572,11 +1572,11 @@ func awaitSwitch13() async throws -> Int {
   let x = await switch Bool.random() { // expected-warning {{'await' has no effect on 'switch' expression}}
   case true:
     awaitSwitch4() // expected-warning {{result of call to 'awaitSwitch4()' is unused}}
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = awaitSwitch4()
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = await awaitSwitch4() // Okay.
@@ -1599,7 +1599,7 @@ func asyncBool() async -> Bool { true }
 func awaitSwitch14() async -> Int {
   await switch asyncBool() { case true: 0 case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
@@ -1651,11 +1651,11 @@ func tryAwaitSwitch3() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1663,7 +1663,7 @@ func tryAwaitSwitch4() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1671,7 +1671,7 @@ func tryAwaitSwitch5() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
@@ -1687,11 +1687,11 @@ func tryAwaitSwitch7() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1699,7 +1699,7 @@ func tryAwaitSwitch8() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1707,7 +1707,7 @@ func tryAwaitSwitch9() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -700,7 +700,7 @@ func stmts() {
   // expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
   if try switch Bool.random() { case true: true case false: true } {}
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
   // expected-error@+1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
@@ -1259,28 +1259,28 @@ struct Err: Error {}
 
 func trySwitch1() -> Int {
   try switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch2() -> Int {
   let x = try switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   return x
 }
 
 func trySwitch3() -> Int {
   return try switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch4() throws -> Int {
   return try switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch5() throws -> Int {
   return try switch Bool.random() { case true: trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1289,7 +1289,7 @@ func trySwitch5() throws -> Int {
 
 func trySwitch6() throws -> Int {
   try switch Bool.random() { case true: trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1298,7 +1298,7 @@ func trySwitch6() throws -> Int {
 
 func trySwitch7() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1308,23 +1308,23 @@ func trySwitch7() throws -> Int {
 
 func trySwitch8() throws -> Int {
   return try switch Bool.random() { case true: try trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch9() throws -> Int {
   try switch Bool.random() { case true: try trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch10() throws -> Int {
   let x = try switch Bool.random() { case true: try trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   return x
 }
 
 func trySwitch11() throws -> Int {
   let x = try switch Bool.random() { case true: try trySwitch4() case false: trySwitch4() }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1334,7 +1334,7 @@ func trySwitch11() throws -> Int {
 
 func trySwitch12() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: trySwitch4() }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 2{{call can throw but is not marked with 'try'}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
@@ -1343,7 +1343,7 @@ func trySwitch12() throws -> Int {
 }
 
 func trySwitch13() throws -> Int {
-  let x = try switch Bool.random() { // expected-error {{'try' may not be used on 'switch' expression}}
+  let x = try switch Bool.random() { // expected-warning {{'try' has no effect on 'switch' expression}}
   case true:
     trySwitch4() // expected-warning {{result of call to 'trySwitch4()' is unused}}
     // expected-error@-1 {{call can throw but is not marked with 'try'}}
@@ -1376,7 +1376,7 @@ func throwsBool() throws -> Bool { true }
 
 func trySwitch14() throws -> Int {
   try switch throwsBool() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1385,7 +1385,7 @@ func trySwitch14() throws -> Int {
 
 func trySwitch15() throws -> Int {
   try switch try throwsBool() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch16() throws -> Int {
@@ -1495,42 +1495,42 @@ func trySwitch29(_ fn: () throws -> Int) rethrows -> Int {
 
 func awaitSwitch1() async -> Int {
   await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch2() async -> Int {
   let x = await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   return x
 }
 
 func awaitSwitch3() async -> Int {
   return await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch4() async -> Int {
   return await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch5() async -> Int {
   return await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch6() async -> Int {
   await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch7() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1538,23 +1538,23 @@ func awaitSwitch7() async -> Int {
 
 func awaitSwitch8() async -> Int {
   return await switch Bool.random() { case true: await awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch9() async -> Int {
   await switch Bool.random() { case true: await awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch10() async -> Int {
   let x = await switch Bool.random() { case true: await awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   return x
 }
 
 func awaitSwitch11() async -> Int {
   let x = await switch Bool.random() { case true: await awaitSwitch4() case false: awaitSwitch4() }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1562,14 +1562,14 @@ func awaitSwitch11() async -> Int {
 
 func awaitSwitch12() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: awaitSwitch4() }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
 
 func awaitSwitch13() async throws -> Int {
-  let x = await switch Bool.random() { // expected-error {{'await' may not be used on 'switch' expression}}
+  let x = await switch Bool.random() { // expected-warning {{'await' has no effect on 'switch' expression}}
   case true:
     awaitSwitch4() // expected-warning {{result of call to 'awaitSwitch4()' is unused}}
     // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
@@ -1598,14 +1598,14 @@ func asyncBool() async -> Bool { true }
 
 func awaitSwitch14() async -> Int {
   await switch asyncBool() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch15() async -> Int {
   await switch await asyncBool() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch16() async -> Int {
@@ -1637,20 +1637,20 @@ func awaitSwitch20() async -> Int {
 
 func tryAwaitSwitch1() async throws -> Int {
   try await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
 }
 
 func tryAwaitSwitch2() async throws -> Int {
   try await switch Bool.random() { case true: 0 case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
 }
 
 func tryAwaitSwitch3() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1661,16 +1661,16 @@ func tryAwaitSwitch3() async throws -> Int {
 
 func tryAwaitSwitch4() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitSwitch5() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1679,14 +1679,14 @@ func tryAwaitSwitch5() async throws -> Int {
 
 func tryAwaitSwitch6() async throws -> Int {
   try await switch Bool.random() { case true: try await tryAwaitSwitch2() case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
 }
 
 func tryAwaitSwitch7() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1697,16 +1697,16 @@ func tryAwaitSwitch7() async throws -> Int {
 
 func tryAwaitSwitch8() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitSwitch9() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1715,8 +1715,8 @@ func tryAwaitSwitch9() async throws -> Int {
 
 func tryAwaitSwitch10() async throws -> Int {
   try await switch Bool.random() { case true: try await tryAwaitSwitch2() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
 }
 
 func tryAwaitSwitch11(_ fn: () async throws -> Int) async rethrows -> Int {


### PR DESCRIPTION
https://github.com/apple/swift/pull/68765 fixed a bug where a `try` or `await` on an `if` or `switch` expression would consider the branch expressions as covered by that effect marker. However, this is a source breaking change, so these diagnostics need to be staged in as warnings until Swift 6.

Missing `try` or `await` errors in statement expression branches will be downgraded to warnings if the enclosing statement expression has the respective effect marker. A redundant effect marker on a statement expression is also unconditionally diagnosed as a warning instead of an error; redundant `try`s or `await`s are never invalid, and there's no reason to make them invalid specifically for statement expressions.

This change also fixes an issue where `async let` required `try`/`await` in statement expressions.

Resolves: rdar://119858327, rdar://119858789