### PR TITLE
[stdlib] Correct String initializer reference in `print` docs

### DIFF
--- a/stdlib/public/core/Print.swift
+++ b/stdlib/public/core/Print.swift
@@ -17,9 +17,9 @@
 ///
 /// You can pass zero or more items to the `print(_:separator:terminator:)`
 /// function. The textual representation for each item is the same as that
-/// obtained by calling `String(item)`. The following example prints a string,
-/// a closed range of integers, and a group of floating-point values to
-/// standard output:
+/// obtained by calling `String(describing: item)`. The following example
+/// prints a string, a closed range of integers, and a group of floating-point
+/// values to standard output:
 ///
 ///     print("One two three four five")
 ///     // Prints "One two three four five"
@@ -128,8 +128,8 @@ public func debugPrint(
 ///
 /// You can pass zero or more items to the `print(_:separator:terminator:to:)`
 /// function. The textual representation for each item is the same as that
-/// obtained by calling `String(item)`. The following example prints a closed
-/// range of integers to a string:
+/// obtained by calling `String(describing: item)`. The following example
+/// prints a closed range of integers to a string:
 ///
 ///     var range = "My range: "
 ///     print(1...5, to: &range)


### PR DESCRIPTION
I noticed the docs for `print` say it invokes `String(item)`, but that should probably read `String(describing: item)`. For reference, the docs for `debugPrint` reference `String(reflecting: item)`.