### PR TITLE
Use a macro to initialize lazy mutex

### DIFF
--- a/include/swift/Threading/Impl/C11.h
+++ b/include/swift/Threading/Impl/C11.h
@@ -95,9 +95,8 @@ struct lazy_mutex_handle {
   std::int32_t once; // -1 = initialized, 0 = uninitialized, 1 = initializing
 };
 
-inline constexpr lazy_mutex_handle lazy_mutex_initializer() {
-  return (lazy_mutex_handle){};
-}
+#define SWIFT_LAZY_MUTEX_INITIALIZER ((lazy_mutex_handle){})
+
 inline void lazy_mutex_init(lazy_mutex_handle &handle) {
   // Sadly, we can't use call_once() for this as it doesn't have a context
   if (std::atomic_load_explicit((std::atomic<std::int32_t> *)&handle.once,

--- a/include/swift/Threading/Impl/Darwin.h
+++ b/include/swift/Threading/Impl/Darwin.h
@@ -108,9 +108,8 @@ inline void mutex_unsafe_unlock(mutex_handle &handle) {
 using lazy_mutex_handle = ::os_unfair_lock;
 
 // We don't need to be lazy here because Darwin has OS_UNFAIR_LOCK_INIT.
-inline constexpr lazy_mutex_handle lazy_mutex_initializer() {
-  return OS_UNFAIR_LOCK_INIT;
-}
+#define SWIFT_LAZY_MUTEX_INITIALIZER OS_UNFAIR_LOCK_INIT
+
 inline void lazy_mutex_destroy(lazy_mutex_handle &handle) {}
 
 inline void lazy_mutex_lock(lazy_mutex_handle &handle) {

--- a/include/swift/Threading/Impl/Linux.h
+++ b/include/swift/Threading/Impl/Linux.h
@@ -110,9 +110,8 @@ using lazy_mutex_handle = ::pthread_mutex_t;
 
 // We don't actually need to be lazy here because pthreads has
 // PTHREAD_MUTEX_INITIALIZER.
-inline constexpr lazy_mutex_handle lazy_mutex_initializer() {
-  return PTHREAD_MUTEX_INITIALIZER;
-}
+#define SWIFT_LAZY_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+
 inline void lazy_mutex_destroy(lazy_mutex_handle &handle) {
   SWIFT_LINUXTHREADS_CHECK(::pthread_mutex_destroy(&handle));
 }

--- a/include/swift/Threading/Impl/Nothreads.h
+++ b/include/swift/Threading/Impl/Nothreads.h
@@ -50,7 +50,8 @@ inline void mutex_unsafe_unlock(mutex_handle &handle) {}
 
 using lazy_mutex_handle = unsigned;
 
-inline constexpr lazy_mutex_handle lazy_mutex_initializer() { return 0; }
+#define SWIFT_LAZY_MUTEX_INITIALIZER 0
+
 inline void lazy_mutex_destroy(lazy_mutex_handle &handle) {}
 inline void lazy_mutex_lock(lazy_mutex_handle &handle) {}
 inline void lazy_mutex_unlock(lazy_mutex_handle &handle) {}

--- a/include/swift/Threading/Impl/Pthreads.h
+++ b/include/swift/Threading/Impl/Pthreads.h
@@ -107,9 +107,8 @@ using lazy_mutex_handle = ::pthread_mutex_t;
 
 // We don't actually need to be lazy here because pthreads has
 // PTHREAD_MUTEX_INITIALIZER.
-inline constexpr lazy_mutex_handle lazy_mutex_initializer() {
-  return PTHREAD_MUTEX_INITIALIZER;
-}
+#define SWIFT_LAZY_MUTEX_INITIALIZER PTHREAD_MUTEX_INITIALIZER
+
 inline void lazy_mutex_destroy(lazy_mutex_handle &handle) {
   SWIFT_PTHREADS_CHECK(::pthread_mutex_destroy(&handle));
 }

--- a/include/swift/Threading/Impl/Win32.h
+++ b/include/swift/Threading/Impl/Win32.h
@@ -66,9 +66,8 @@ inline void mutex_unsafe_unlock(mutex_handle &handle) {
 using lazy_mutex_handle = SWIFT_SRWLOCK;
 
 // We don't need to be lazy here because Win32 has SRWLOCK_INIT.
-inline constexpr lazy_mutex_handle lazy_mutex_initializer() {
-  return SRWLOCK_INIT;
-}
+#define SWIFT_LAZY_MUTEX_INITIALIZER SRWLOCK_INIT
+
 inline void lazy_mutex_destroy(lazy_mutex_handle &handle) {}
 
 inline void lazy_mutex_lock(lazy_mutex_handle &handle) {

--- a/include/swift/Threading/Mutex.h
+++ b/include/swift/Threading/Mutex.h
@@ -144,7 +144,7 @@ class LazyMutex {
   LazyMutex &operator=(LazyMutex &&) = delete;
 
 public:
-  constexpr LazyMutex() : Handle(threading_impl::lazy_mutex_initializer()) {}
+  constexpr LazyMutex() : Handle(SWIFT_LAZY_MUTEX_INITIALIZER) {}
 
   // No destructor; this is intentional; this class is for STATIC allocation
   // and you don't need to delete mutexes on termination.


### PR DESCRIPTION
Copying a mutex isn't really a supported thing. Use a macro to initialize the mutex directly rather than a function that returns the mutex.