### PR TITLE
[5.10][TypeCheckEffects] Stage in new effects checker errors for statement expressions as warnings until Swift 6.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1244,8 +1244,8 @@ ERROR(single_value_stmt_branch_must_end_in_result,none,
 ERROR(cannot_jump_in_single_value_stmt,none,
       "cannot '%0' in '%1' when used as expression",
       (StmtKind, StmtKind))
-ERROR(effect_marker_on_single_value_stmt,none,
-      "'%0' may not be used on '%1' expression", (StringRef, StmtKind))
+WARNING(effect_marker_on_single_value_stmt,none,
+      "'%0' has no effect on '%1' expression", (StringRef, StmtKind))
 ERROR(out_of_place_then_stmt,none,
       "'then' may only appear as the last statement in an 'if' or 'switch' "
       "expression", ())

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2902,7 +2902,7 @@ private:
 
   void diagnoseRedundantTry(AnyTryExpr *E) const {
     if (auto *SVE = SingleValueStmtExpr::tryDigOutSingleValueStmtExpr(E)) {
-      // For an if/switch expression, produce an error instead of a warning.
+      // For an if/switch expression, produce a tailored warning.
       Ctx.Diags.diagnose(E->getTryLoc(),
                          diag::effect_marker_on_single_value_stmt,
                          "try", SVE->getStmt()->getKind())
@@ -2914,7 +2914,7 @@ private:
 
   void diagnoseRedundantAwait(AwaitExpr *E) const {
     if (auto *SVE = SingleValueStmtExpr::tryDigOutSingleValueStmtExpr(E)) {
-      // For an if/switch expression, produce an error instead of a warning.
+      // For an if/switch expression, produce a tailored warning.
       Ctx.Diags.diagnose(E->getAwaitLoc(),
                          diag::effect_marker_on_single_value_stmt,
                          "await", SVE->getStmt()->getKind())

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2051,6 +2051,9 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       
       /// Do we have any 'await's in this context?
       HasAnyAwait = 0x80,
+
+      /// Are we in an 'async let' initializer context?
+      InAsyncLet = 0x100,
     };
   private:
     unsigned Bits;
@@ -2196,8 +2199,7 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
     }
 
     void enterAsyncLet() {
-      Self.Flags.set(ContextFlags::IsTryCovered);
-      Self.Flags.set(ContextFlags::IsAsyncCovered);
+      Self.Flags.set(ContextFlags::InAsyncLet);
     }
 
     void refineLocalContext(Context newContext) {
@@ -2234,6 +2236,11 @@ class CheckEffectsCoverage : public EffectsHandlingWalker<CheckEffectsCoverage> 
       // "await" doesn't work this way; the "await" needs to be part of
       // the autoclosure expression itself, and the autoclosure must be
       // 'async'.
+    }
+
+    void setCoverageForSingleValueStmtExpr() {
+      resetCoverage();
+      Self.Flags.mergeFrom(ContextFlags::InAsyncLet, OldFlags);
     }
 
     void preserveCoverageFromSingleValueStmtExpr() {
@@ -2393,7 +2400,7 @@ private:
     // For an if/switch expression, we reset coverage such that a 'try'/'await'
     // does not cover the branches.
     ContextScope scope(*this, /*newContext*/ llvm::None);
-    scope.resetCoverage();
+    scope.setCoverageForSingleValueStmtExpr();
     SVE->getStmt()->walk(*this);
     scope.preserveCoverageFromSingleValueStmtExpr();
     return ShouldNotRecurse;
@@ -2734,7 +2741,8 @@ private:
                                               classification.getAsyncReason());
       }
       // Diagnose async calls that are outside of an await context.
-      else if (!Flags.has(ContextFlags::IsAsyncCovered)) {
+      else if (!(Flags.has(ContextFlags::IsAsyncCovered) ||
+                 Flags.has(ContextFlags::InAsyncLet))) {
         Expr *expr = E.dyn_cast<Expr*>();
         Expr *anchor = walkToAnchor(expr, parentMap,
                                     CurContext.isWithinInterpolatedString());
@@ -2770,7 +2778,8 @@ private:
             break;
 
       bool isTryCovered =
-        (!requiresTry || Flags.has(ContextFlags::IsTryCovered));
+        (!requiresTry || Flags.has(ContextFlags::IsTryCovered) ||
+         Flags.has(ContextFlags::InAsyncLet));
       if (!CurContext.handlesThrows(throwsKind)) {
         CurContext.diagnoseUnhandledThrowSite(Ctx.Diags, E, isTryCovered,
                                               classification.getThrowReason());

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -548,7 +548,7 @@ func stmts() {
 
   if try if .random() { true } else { false } {}
   // expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
-  // expected-error@-2 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-2 {{'try' has no effect on 'if' expression}}
 
   // expected-error@+1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}
   guard if .random() { true } else { false } else {
@@ -988,28 +988,28 @@ func return4() throws -> Int {
 
 func tryIf1() -> Int {
   try if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf2() -> Int {
   let x = try if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   return x
 }
 
 func tryIf3() -> Int {
   return try if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf4() throws -> Int {
   return try if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf5() throws -> Int {
   return try if .random() { tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1018,7 +1018,7 @@ func tryIf5() throws -> Int {
 
 func tryIf6() throws -> Int {
   try if .random() { tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1027,7 +1027,7 @@ func tryIf6() throws -> Int {
 
 func tryIf7() throws -> Int {
   let x = try if .random() { tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1037,23 +1037,23 @@ func tryIf7() throws -> Int {
 
 func tryIf8() throws -> Int {
   return try if .random() { try tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf9() throws -> Int {
   try if .random() { try tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf10() throws -> Int {
   let x = try if .random() { try tryIf4() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   return x
 }
 
 func tryIf11() throws -> Int {
   let x = try if .random() { try tryIf4() } else { tryIf4() }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1063,7 +1063,7 @@ func tryIf11() throws -> Int {
 
 func tryIf12() throws -> Int {
   let x = try if .random() { tryIf4() } else { tryIf4() }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 2{{call can throw but is not marked with 'try'}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
@@ -1072,7 +1072,7 @@ func tryIf12() throws -> Int {
 }
 
 func tryIf13() throws -> Int {
-  let x = try if .random() { // expected-error {{'try' may not be used on 'if' expression}}
+  let x = try if .random() { // expected-warning {{'try' has no effect on 'if' expression}}
     tryIf4() // expected-warning {{result of call to 'tryIf4()' is unused}}
     // expected-error@-1 {{call can throw but is not marked with 'try'}}
     // expected-note@-2 {{did you mean to use 'try'?}}
@@ -1104,7 +1104,7 @@ func throwsBool() throws -> Bool { true }
 
 func tryIf14() throws -> Int {
   try if throwsBool() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1113,7 +1113,7 @@ func tryIf14() throws -> Int {
 
 func tryIf15() throws -> Int {
   try if try throwsBool() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
 }
 
 func tryIf16() throws -> Int {
@@ -1223,42 +1223,42 @@ func tryIf29(_ fn: () throws -> Int) rethrows -> Int {
 
 func awaitIf1() async -> Int {
   await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf2() async -> Int {
   let x = await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   return x
 }
 
 func awaitIf3() async -> Int {
   return await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf4() async -> Int {
   return await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf5() async -> Int {
   return await if .random() { awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf6() async -> Int {
   await if .random() { awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf7() async -> Int {
   let x = await if .random() { awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1266,23 +1266,23 @@ func awaitIf7() async -> Int {
 
 func awaitIf8() async -> Int {
   return await if .random() { await awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf9() async -> Int {
   await if .random() { await awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf10() async -> Int {
   let x = await if .random() { await awaitIf4() } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   return x
 }
 
 func awaitIf11() async -> Int {
   let x = await if .random() { await awaitIf4() } else { awaitIf4() }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1290,14 +1290,14 @@ func awaitIf11() async -> Int {
 
 func awaitIf12() async -> Int {
   let x = await if .random() { awaitIf4() } else { awaitIf4() }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
 
 func awaitIf13() async throws -> Int {
-  let x = await if .random() { // expected-error {{'await' may not be used on 'if' expression}}
+  let x = await if .random() { // expected-warning {{'await' has no effect on 'if' expression}}
     awaitIf4() // expected-warning {{result of call to 'awaitIf4()' is unused}}
     // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
     // expected-note@-2 {{call is 'async'}}
@@ -1325,14 +1325,14 @@ func asyncBool() async -> Bool { true }
 
 func awaitIf14() async -> Int {
   await if asyncBool() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf15() async -> Int {
   await if await asyncBool() { 0 } else { 1 }
-  // expected-error@-1 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'if' expression}}
 }
 
 func awaitIf16() async -> Int {
@@ -1364,20 +1364,20 @@ func awaitIf20() async -> Int {
 
 func tryAwaitIf1() async throws -> Int {
   try await if .random() { 0 } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
 }
 
 func tryAwaitIf2() async throws -> Int {
   try await if .random() { 0 } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
 }
 
 func tryAwaitIf3() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1388,16 +1388,16 @@ func tryAwaitIf3() async throws -> Int {
 
 func tryAwaitIf4() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitIf5() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1406,14 +1406,14 @@ func tryAwaitIf5() async throws -> Int {
 
 func tryAwaitIf6() async throws -> Int {
   try await if .random() { try await tryAwaitIf2() } else { 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
 }
 
 func tryAwaitIf7() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1424,16 +1424,16 @@ func tryAwaitIf7() async throws -> Int {
 
 func tryAwaitIf8() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitIf9() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1442,8 +1442,8 @@ func tryAwaitIf9() async throws -> Int {
 
 func tryAwaitIf10() async throws -> Int {
   try await if .random() { try await tryAwaitIf2() } else { 1 }
-  // expected-error@-1 {{'try' may not be used on 'if' expression}}
-  // expected-error@-2 {{'await' may not be used on 'if' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'if' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'if' expression}}
 }
 
 func tryAwaitIf11(_ fn: () async throws -> Int) async rethrows -> Int {

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -1491,6 +1491,16 @@ func tryAwaitIf15(_ fn: () async throws -> Int) async rethrows -> Int {
   }
 }
 
+func asyncLetIf(cond: Bool, _ fn: () async throws -> Int) async throws -> Int {
+  async let x = if cond {
+    fn()
+  } else {
+    0
+  }
+
+  return try await x
+}
+
 struct AnyEraserP: EraserP {
   init<T: EraserP>(erasing: T) {}
 }

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -1010,7 +1010,7 @@ func tryIf4() throws -> Int {
 func tryIf5() throws -> Int {
   return try if .random() { tryIf4() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1019,7 +1019,7 @@ func tryIf5() throws -> Int {
 func tryIf6() throws -> Int {
   try if .random() { tryIf4() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1028,7 +1028,7 @@ func tryIf6() throws -> Int {
 func tryIf7() throws -> Int {
   let x = try if .random() { tryIf4() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1054,7 +1054,7 @@ func tryIf10() throws -> Int {
 func tryIf11() throws -> Int {
   let x = try if .random() { try tryIf4() } else { tryIf4() }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1064,7 +1064,7 @@ func tryIf11() throws -> Int {
 func tryIf12() throws -> Int {
   let x = try if .random() { tryIf4() } else { tryIf4() }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 2{{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
   // expected-note@-5 2{{did you mean to disable error propagation?}}
@@ -1074,13 +1074,13 @@ func tryIf12() throws -> Int {
 func tryIf13() throws -> Int {
   let x = try if .random() { // expected-warning {{'try' has no effect on 'if' expression}}
     tryIf4() // expected-warning {{result of call to 'tryIf4()' is unused}}
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
 
     _ = tryIf4()
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
@@ -1105,7 +1105,7 @@ func throwsBool() throws -> Bool { true }
 func tryIf14() throws -> Int {
   try if throwsBool() { 0 } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1245,21 +1245,21 @@ func awaitIf4() async -> Int {
 func awaitIf5() async -> Int {
   return await if .random() { awaitIf4() } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf6() async -> Int {
   await if .random() { awaitIf4() } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf7() async -> Int {
   let x = await if .random() { awaitIf4() } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1283,7 +1283,7 @@ func awaitIf10() async -> Int {
 func awaitIf11() async -> Int {
   let x = await if .random() { await awaitIf4() } else { awaitIf4() }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1291,7 +1291,7 @@ func awaitIf11() async -> Int {
 func awaitIf12() async -> Int {
   let x = await if .random() { awaitIf4() } else { awaitIf4() }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
@@ -1299,11 +1299,11 @@ func awaitIf12() async -> Int {
 func awaitIf13() async throws -> Int {
   let x = await if .random() { // expected-warning {{'await' has no effect on 'if' expression}}
     awaitIf4() // expected-warning {{result of call to 'awaitIf4()' is unused}}
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = awaitIf4()
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = await awaitIf4() // Okay.
@@ -1326,7 +1326,7 @@ func asyncBool() async -> Bool { true }
 func awaitIf14() async -> Int {
   await if asyncBool() { 0 } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
@@ -1378,11 +1378,11 @@ func tryAwaitIf3() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1390,7 +1390,7 @@ func tryAwaitIf4() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1398,7 +1398,7 @@ func tryAwaitIf5() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
@@ -1414,11 +1414,11 @@ func tryAwaitIf7() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1426,7 +1426,7 @@ func tryAwaitIf8() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1434,7 +1434,7 @@ func tryAwaitIf9() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -1281,7 +1281,7 @@ func trySwitch4() throws -> Int {
 func trySwitch5() throws -> Int {
   return try switch Bool.random() { case true: trySwitch4() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1290,7 +1290,7 @@ func trySwitch5() throws -> Int {
 func trySwitch6() throws -> Int {
   try switch Bool.random() { case true: trySwitch4() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1299,7 +1299,7 @@ func trySwitch6() throws -> Int {
 func trySwitch7() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1325,7 +1325,7 @@ func trySwitch10() throws -> Int {
 func trySwitch11() throws -> Int {
   let x = try switch Bool.random() { case true: try trySwitch4() case false: trySwitch4() }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1335,7 +1335,7 @@ func trySwitch11() throws -> Int {
 func trySwitch12() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: trySwitch4() }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 2{{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
   // expected-note@-5 2{{did you mean to disable error propagation?}}
@@ -1346,13 +1346,13 @@ func trySwitch13() throws -> Int {
   let x = try switch Bool.random() { // expected-warning {{'try' has no effect on 'switch' expression}}
   case true:
     trySwitch4() // expected-warning {{result of call to 'trySwitch4()' is unused}}
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
 
     _ = trySwitch4()
-    // expected-error@-1 {{call can throw but is not marked with 'try'}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
@@ -1377,7 +1377,7 @@ func throwsBool() throws -> Bool { true }
 func trySwitch14() throws -> Int {
   try switch throwsBool() { case true: 0 case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-error@-2 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1517,21 +1517,21 @@ func awaitSwitch4() async -> Int {
 func awaitSwitch5() async -> Int {
   return await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch6() async -> Int {
   await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch7() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1555,7 +1555,7 @@ func awaitSwitch10() async -> Int {
 func awaitSwitch11() async -> Int {
   let x = await switch Bool.random() { case true: await awaitSwitch4() case false: awaitSwitch4() }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1563,7 +1563,7 @@ func awaitSwitch11() async -> Int {
 func awaitSwitch12() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: awaitSwitch4() }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
@@ -1572,11 +1572,11 @@ func awaitSwitch13() async throws -> Int {
   let x = await switch Bool.random() { // expected-warning {{'await' has no effect on 'switch' expression}}
   case true:
     awaitSwitch4() // expected-warning {{result of call to 'awaitSwitch4()' is unused}}
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = awaitSwitch4()
-    // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = await awaitSwitch4() // Okay.
@@ -1599,7 +1599,7 @@ func asyncBool() async -> Bool { true }
 func awaitSwitch14() async -> Int {
   await switch asyncBool() { case true: 0 case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-3 {{call is 'async'}}
 }
 
@@ -1651,11 +1651,11 @@ func tryAwaitSwitch3() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1663,7 +1663,7 @@ func tryAwaitSwitch4() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1671,7 +1671,7 @@ func tryAwaitSwitch5() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
@@ -1687,11 +1687,11 @@ func tryAwaitSwitch7() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-error@-7 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1699,7 +1699,7 @@ func tryAwaitSwitch8() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1707,7 +1707,7 @@ func tryAwaitSwitch9() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-error@-3 {{call can throw but is not marked with 'try'}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -700,7 +700,7 @@ func stmts() {
   // expected-error@-1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
   if try switch Bool.random() { case true: true case false: true } {}
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
 
   // expected-error@+1 {{'switch' may only be used as expression in return, throw, or as the source of an assignment}}
@@ -1259,28 +1259,28 @@ struct Err: Error {}
 
 func trySwitch1() -> Int {
   try switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch2() -> Int {
   let x = try switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   return x
 }
 
 func trySwitch3() -> Int {
   return try switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch4() throws -> Int {
   return try switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch5() throws -> Int {
   return try switch Bool.random() { case true: trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1289,7 +1289,7 @@ func trySwitch5() throws -> Int {
 
 func trySwitch6() throws -> Int {
   try switch Bool.random() { case true: trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1298,7 +1298,7 @@ func trySwitch6() throws -> Int {
 
 func trySwitch7() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1308,23 +1308,23 @@ func trySwitch7() throws -> Int {
 
 func trySwitch8() throws -> Int {
   return try switch Bool.random() { case true: try trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch9() throws -> Int {
   try switch Bool.random() { case true: try trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch10() throws -> Int {
   let x = try switch Bool.random() { case true: try trySwitch4() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   return x
 }
 
 func trySwitch11() throws -> Int {
   let x = try switch Bool.random() { case true: try trySwitch4() case false: trySwitch4() }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1334,7 +1334,7 @@ func trySwitch11() throws -> Int {
 
 func trySwitch12() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: trySwitch4() }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 2{{call can throw but is not marked with 'try'}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
@@ -1343,7 +1343,7 @@ func trySwitch12() throws -> Int {
 }
 
 func trySwitch13() throws -> Int {
-  let x = try switch Bool.random() { // expected-error {{'try' may not be used on 'switch' expression}}
+  let x = try switch Bool.random() { // expected-warning {{'try' has no effect on 'switch' expression}}
   case true:
     trySwitch4() // expected-warning {{result of call to 'trySwitch4()' is unused}}
     // expected-error@-1 {{call can throw but is not marked with 'try'}}
@@ -1376,7 +1376,7 @@ func throwsBool() throws -> Bool { true }
 
 func trySwitch14() throws -> Int {
   try switch throwsBool() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-error@-2 {{call can throw but is not marked with 'try'}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
@@ -1385,7 +1385,7 @@ func trySwitch14() throws -> Int {
 
 func trySwitch15() throws -> Int {
   try switch try throwsBool() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
 }
 
 func trySwitch16() throws -> Int {
@@ -1495,42 +1495,42 @@ func trySwitch29(_ fn: () throws -> Int) rethrows -> Int {
 
 func awaitSwitch1() async -> Int {
   await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch2() async -> Int {
   let x = await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   return x
 }
 
 func awaitSwitch3() async -> Int {
   return await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch4() async -> Int {
   return await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch5() async -> Int {
   return await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch6() async -> Int {
   await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch7() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1538,23 +1538,23 @@ func awaitSwitch7() async -> Int {
 
 func awaitSwitch8() async -> Int {
   return await switch Bool.random() { case true: await awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch9() async -> Int {
   await switch Bool.random() { case true: await awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch10() async -> Int {
   let x = await switch Bool.random() { case true: await awaitSwitch4() case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   return x
 }
 
 func awaitSwitch11() async -> Int {
   let x = await switch Bool.random() { case true: await awaitSwitch4() case false: awaitSwitch4() }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
   return x
@@ -1562,14 +1562,14 @@ func awaitSwitch11() async -> Int {
 
 func awaitSwitch12() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: awaitSwitch4() }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 2{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
 
 func awaitSwitch13() async throws -> Int {
-  let x = await switch Bool.random() { // expected-error {{'await' may not be used on 'switch' expression}}
+  let x = await switch Bool.random() { // expected-warning {{'await' has no effect on 'switch' expression}}
   case true:
     awaitSwitch4() // expected-warning {{result of call to 'awaitSwitch4()' is unused}}
     // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
@@ -1598,14 +1598,14 @@ func asyncBool() async -> Bool { true }
 
 func awaitSwitch14() async -> Int {
   await switch asyncBool() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
   // expected-error@-2 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch15() async -> Int {
   await switch await asyncBool() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
 }
 
 func awaitSwitch16() async -> Int {
@@ -1637,20 +1637,20 @@ func awaitSwitch20() async -> Int {
 
 func tryAwaitSwitch1() async throws -> Int {
   try await switch Bool.random() { case true: 0 case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
 }
 
 func tryAwaitSwitch2() async throws -> Int {
   try await switch Bool.random() { case true: 0 case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
 }
 
 func tryAwaitSwitch3() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1661,16 +1661,16 @@ func tryAwaitSwitch3() async throws -> Int {
 
 func tryAwaitSwitch4() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitSwitch5() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1679,14 +1679,14 @@ func tryAwaitSwitch5() async throws -> Int {
 
 func tryAwaitSwitch6() async throws -> Int {
   try await switch Bool.random() { case true: try await tryAwaitSwitch2() case false: 1 } as Int
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
 }
 
 func tryAwaitSwitch7() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1697,16 +1697,16 @@ func tryAwaitSwitch7() async throws -> Int {
 
 func tryAwaitSwitch8() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{expression is 'async' but is not marked with 'await'}}
   // expected-note@-4 {{call is 'async'}}
 }
 
 func tryAwaitSwitch9() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
   // expected-error@-3 {{call can throw but is not marked with 'try'}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
@@ -1715,8 +1715,8 @@ func tryAwaitSwitch9() async throws -> Int {
 
 func tryAwaitSwitch10() async throws -> Int {
   try await switch Bool.random() { case true: try await tryAwaitSwitch2() case false: 1 }
-  // expected-error@-1 {{'try' may not be used on 'switch' expression}}
-  // expected-error@-2 {{'await' may not be used on 'switch' expression}}
+  // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
+  // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
 }
 
 func tryAwaitSwitch11(_ fn: () async throws -> Int) async rethrows -> Int {


### PR DESCRIPTION
* **Explanation**: 

https://github.com/apple/swift/pull/68801 fixed a bug where a `try` or `await` on an `if` or `switch` expression would consider the branch expressions as covered by that effect marker. However, this is a source breaking change, so these diagnostics need to be staged in as warnings until Swift 6.

Missing `try` or `await` errors in statement expression branches will be downgraded to warnings if the enclosing statement expression has the respective effect marker. A redundant effect marker on a statement expression is also unconditionally diagnosed as a warning instead of an error; redundant `try`s or `await`s are never invalid, and there's no reason to make them invalid specifically for statement expressions.

This change also fixes an issue where `async let` required `try`/`await` in statement expressions.

* **Scope**: Only impacts effects checking for `if` and `switch` expressions.
* **Risk**: Very low; the only impact of this change is downgrading errors to warnings in cases that either don't matter (redundant `try` or `await`) or were already accepted by the Swift 5.9 compiler (missing `try` or `await` in an `if` or `switch` expression branch where the expression statement itself is covered by the respective effect marker). If we don't take this change, the Swift 5.10 compiler will break code that is accepted by the Swift 5.9 compiler.
* **Testing**: Updated many tests to expect warnings instead of errors.
* **Reviewer**: TBD
* **Main branch PR**: https://github.com/apple/swift/pull/70820