### PR TITLE
[TBDGen] Add back standalone OBJC_METACLASS symbols

### DIFF
--- a/include/swift/SIL/SILSymbolVisitor.h
+++ b/include/swift/SIL/SILSymbolVisitor.h
@@ -109,6 +109,7 @@ public:
   virtual void addMethodLookupFunction(ClassDecl *CD) {}
   virtual void addNominalTypeDescriptor(NominalTypeDecl *NTD) {}
   virtual void addObjCInterface(ClassDecl *CD) {}
+  virtual void addObjCMetaclass(ClassDecl *CD) {}
   virtual void addObjCMethod(AbstractFunctionDecl *AFD) {}
   virtual void addObjCResilientClassStub(ClassDecl *CD) {}
   virtual void addOpaqueTypeDescriptor(OpaqueTypeDecl *OTD) {}

--- a/lib/IRGen/IRSymbolVisitor.cpp
+++ b/lib/IRGen/IRSymbolVisitor.cpp
@@ -162,6 +162,10 @@ public:
     Visitor.addObjCInterface(CD);
   }
 
+  void addObjCMetaclass(ClassDecl *CD) override {
+    addLinkEntity(LinkEntity::forObjCMetaclass(CD));
+  }
+
   void addObjCMethod(AbstractFunctionDecl *AFD) override {
     // Pass through; Obj-C methods don't have linkable symbols.
     Visitor.addObjCMethod(AFD);

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -322,8 +322,12 @@ class SILSymbolVisitorImpl : public ASTVisitor<SILSymbolVisitorImpl> {
     // Metaclasses and ObjC classes (duh) are an ObjC thing, and so are not
     // needed in build artifacts/for classes which can't touch ObjC.
     if (objCCompatible) {
-      if (isObjC || CD->getMetaclassKind() == ClassDecl::MetaclassKind::ObjC)
+      if (isObjC)
         Visitor.addObjCInterface(CD);
+      else if (CD->getMetaclassKind() == ClassDecl::MetaclassKind::ObjC)
+        // If an ObjCInterface was not added, an external ObjC Metaclass can
+        // still be needed for subclassing.
+        Visitor.addObjCMetaclass(CD);
       else
         Visitor.addSwiftMetaclassStub(CD);
     }

--- a/test/TBD/implied_objc_symbols.swift
+++ b/test/TBD/implied_objc_symbols.swift
@@ -1,16 +1,35 @@
 // REQUIRES: VENDOR=apple
 // RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
-// RUN: echo "import Foundation" > %t/main.swift
-// RUN: echo "@objc(CApi) public class Api {}" >> %t/main.swift
 // RUN: %target-swift-frontend -emit-ir -o/dev/null -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module -emit-tbd -emit-tbd-path %t/main.tbd -tbd-install_name objc_classes
 
-// RUN: %validate-json %t/main.tbd |  %FileCheck %s
+// RUN: %validate-json %t/main.tbd |  %FileCheck %s --check-prefix FORMAT
+// RUN: %llvm-nm %t/main.tbd |  %FileCheck %s --check-prefix SYMS
 
-// CHECK-NOT: '_OBJC_CLASS_$_CApi'
-// CHECK-NOT: '_OBJC_METACLASS_$_CApi' 
+// FORMAT-NOT: '_OBJC_CLASS'
+// FORMAT: "objc_class"
 
-// CHECK: "objc_class": [
-// CHECK-NEXT:   "CApi"
-// CHECK-NEXT: ]
 
+// SYMS:  D _OBJC_CLASS_$_CApi
+// SYMS:  D _OBJC_CLASS_$__TtC4test11AnotherCAPI
+// SYMS:  D _OBJC_METACLASS_$_CApi
+// SYMS:  D _OBJC_METACLASS_$__TtC4test11AnotherCAPI
+
+/// Expect stand-alone metaclass for NotCAPIBase.
+// SYMS:  D _OBJC_METACLASS_$__TtC4test11NotCAPIBase
+
+// SYMS-NOT: _OBJC
+
+
+//--- main.swift
+import Foundation
+
+// These declarations imply direct obj-c availability.
+@objc(CApi) public class Api {}
+public class AnotherCAPI : NSObject {}
+
+public struct Empty {}
+// A generic one does not, however the obj-c metaclass should still be exported.
+public class NotCAPI<T> : AnotherCAPI {}
+public class NotCAPIBase : NotCAPI<Empty> {}

--- a/test/TBD/multimodule-implied-objc.swift
+++ b/test/TBD/multimodule-implied-objc.swift
@@ -23,10 +23,9 @@
 
 // RUN: %validate-json %t/client.tbd | %FileCheck %s
 
-// CHECK: "objc_class": 
-// CHECK: "_TtCO6client11extendedAPI6Square"
-// CHECK-NOT: _OBJC_CLASS_$
-// CHECK-NOT: _OBJC_METACLASS_$
+// CHECK: "_OBJC_METACLASS_$__TtCO6client11extendedAPI6Square"
+// CHECK-NOT: "objc_class"
+// CHECK-NOT: _OBJC_C
 
 //--- module.modulemap
 module IndirectMixedDependency {


### PR DESCRIPTION
It turns out there are valid usecases for exposing a standalone objc-metaclass symbols and tbd files must encode it correctly.
resolves: rdar://118499886