### PR TITLE
[Sema] Allow static let properties in generic contexts

### DIFF
--- a/lib/SILGen/SILGenGlobalVariable.cpp
+++ b/lib/SILGen/SILGenGlobalVariable.cpp
@@ -211,9 +211,11 @@ void SILGenModule::emitGlobalInitialization(PatternBindingDecl *pd,
   // Generic and dynamic static properties require lazy initialization, which
   // isn't implemented yet.
   if (pd->isStatic()) {
-    assert(!pd->getDeclContext()->isGenericContext()
-           || pd->getDeclContext()->getGenericSignatureOfContext()
-                ->areAllParamsConcrete());
+    assert(!pd->getDeclContext()->isGenericContext() ||
+           pd->getAnchoringVarDecl(0)->isLet() ||
+           pd->getDeclContext()
+               ->getGenericSignatureOfContext()
+               ->areAllParamsConcrete());
   }
 
   // Force the executable init to be type checked before emission.

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -357,9 +357,10 @@ public:
 static void emitTypeMemberGlobalVariable(SILGenModule &SGM,
                                          VarDecl *var) {
   if (var->getDeclContext()->isGenericContext()) {
-    assert(var->getDeclContext()->getGenericSignatureOfContext()
-              ->areAllParamsConcrete()
-           && "generic static vars are not implemented yet");
+    assert((var->isLet() || var->getDeclContext()
+                                ->getGenericSignatureOfContext()
+                                ->areAllParamsConcrete()) &&
+           "generic static vars are not implemented yet");
   }
 
   if (var->getDeclContext()->getSelfClassDecl()) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2392,8 +2392,9 @@ public:
         // occur once per instantiation, which we don't yet handle.
         if (DC->getExtendedProtocolDecl()) {
           unimplementedStatic(ProtocolExtensions);
-        } else if (DC->isGenericContext()
-               && !DC->getGenericSignatureOfContext()->areAllParamsConcrete()) {
+        } else if (DC->isGenericContext() &&
+                   !(VD->isLet() || DC->getGenericSignatureOfContext()
+                                        ->areAllParamsConcrete())) {
           unimplementedStatic(GenericTypes);
         } else if (DC->getSelfClassDecl()) {
           auto StaticSpelling = PBD->getStaticSpelling();


### PR DESCRIPTION
Currently, static properties are allowed in generic types only when the type parameters are concrete. For example:

```swift
struct Generic<T> {}

extension Generic where T == Bool {
    static let prop: Int = 432
}

print(Generic<Bool>.prop)
```

In contrast, this produces a diagnostic:

```swift
struct Generic<T> {
    static let constant: Int = 909
}
```

> error: static stored properties not supported in generic types

This change adds to the use cases where a static property is allowed in a generic type: where the property is a static constant (`let`). The previous example works with this change. Static variables (`var`) will still result in a diagnostic.