### PR TITLE
Sema: Fix logic error in TypeReprCycleCheckWalker handling of 'Self.Foo'

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -212,7 +212,8 @@ struct TypeReprCycleCheckWalker : ASTWalker {
 
       // If we're inferring `Foo`, don't look at a witness mentioning `Self.Foo`.
       if (auto *identTyR = dyn_cast<SimpleIdentTypeRepr>(baseTyR)) {
-        if (identTyR->getNameRef().getBaseIdentifier() == ctx.Id_Self) {
+        if (identTyR->getNameRef().getBaseIdentifier() == ctx.Id_Self &&
+            circularNames.count(memberTyR->getNameRef().getBaseIdentifier()) > 0) {
           // But if qualified lookup can find a type with this name without
           // looking into protocol members, don't skip the witness, since this
           // type might be a candidate witness.

--- a/test/decl/protocol/req/assoc_type_inference_cycle.swift
+++ b/test/decl/protocol/req/assoc_type_inference_cycle.swift
@@ -131,3 +131,19 @@ public struct LogTypes: OptionSet {
 
   public let rawValue: Int
 }
+
+// rdar://120743365
+public struct G<T> {}
+
+public protocol HasAlias {
+  typealias A = G<Self>
+  associatedtype B
+
+  func f1(_: Self.A, _: Self.B)
+  func f2(_: Self.A, _: Self.B)
+}
+
+public struct ConformsHasAlias: HasAlias {
+  public func f1(_: Self.A, _: Self.B) {}
+  public func f2(_: Self.A, _: Int) {}
+}


### PR DESCRIPTION
We don't want to throw out a witness if it has any mention of 'Self.Foo'; we must also check that 'Foo' is one of the associated types being inferred. Otherwise, it may be a protocol type alias, in which case we want to proceed with the witness.

This fixes a regression from a recent change, a576984e2f7910760.

Fixes rdar://problem/120743365.