### PR TITLE
Sema: Fix logic error in TypeReprCycleCheckWalker handling of 'Self.Foo' [5.10]

### DIFF
--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -211,7 +211,8 @@ struct TypeReprCycleCheckWalker : ASTWalker {
 
       // If we're inferring `Foo`, don't look at a witness mentioning `Self.Foo`.
       if (auto *identTyR = dyn_cast<SimpleIdentTypeRepr>(baseTyR)) {
-        if (identTyR->getNameRef().getBaseIdentifier() == ctx.Id_Self) {
+        if (identTyR->getNameRef().getBaseIdentifier() == ctx.Id_Self &&
+            circularNames.count(memberTyR->getNameRef().getBaseIdentifier()) > 0) {
           // But if qualified lookup can find a type with this name without
           // looking into protocol members, don't skip the witness, since this
           // type might be a candidate witness.

--- a/test/decl/protocol/req/assoc_type_inference_cycle.swift
+++ b/test/decl/protocol/req/assoc_type_inference_cycle.swift
@@ -131,3 +131,19 @@ public struct LogTypes: OptionSet {
 
   public let rawValue: Int
 }
+
+// rdar://120743365
+public struct G<T> {}
+
+public protocol HasAlias {
+  typealias A = G<Self>
+  associatedtype B
+
+  func f1(_: Self.A, _: Self.B)
+  func f2(_: Self.A, _: Self.B)
+}
+
+public struct ConformsHasAlias: HasAlias {
+  public func f1(_: Self.A, _: Self.B) {}
+  public func f2(_: Self.A, _: Int) {}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/70830

* Description: Fixes a regression where associated type inference did not consider any witness whose type contains `Self.Foo`, where `Foo` is a member of a protocol (usually you can write `Foo` instead of `Self.Foo`, but the latter is more explicit). The correct behavior is that such witnesses should only be discarded if `Foo` is one of the associated types being inferred. 

* Scope of the issue: Anyone impacted would have to explicitly declare a type alias instead of letting the compiler infer it.

* Origination: Regression from the second cherry-pick in https://github.com/apple/swift/pull/70696.

* Radar: Fixes rdar://problem/120743365.

* Tested: Reduced test case added from impacted project.

* Risk: Sigh. Unfortunately this is the second follow-up PR fixing issues in the original change from November (https://github.com/apple/swift/pull/69952), but I hope this particular change is safe since the new code path (ignoring a witness that "might cause a cycle") will now execute in strictly fewer situations than it did previously.

* Reviewed by: @hborla 
