### PR TITLE
 Skip setting type expansion context for captures of skipped functions 

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1430,14 +1430,14 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
 void SILGenModule::emitFunction(FuncDecl *fd) {
   assert(!shouldSkipDecl(fd));
 
-  Types.setCaptureTypeExpansionContext(SILDeclRef(fd), M);
-
   SILDeclRef::Loc decl = fd;
 
   emitAbstractFuncDecl(fd);
 
-  if (shouldEmitFunctionBody(fd))
+  if (shouldEmitFunctionBody(fd)) {
+    Types.setCaptureTypeExpansionContext(SILDeclRef(fd), M);
     emitOrDelayFunction(SILDeclRef(decl));
+  }
 }
 
 void SILGenModule::addGlobalVariable(VarDecl *global) {

--- a/test/SILGen/top_level_captures.swift
+++ b/test/SILGen/top_level_captures.swift
@@ -1,15 +1,19 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 // RUN: %target-swift-frontend -enable-experimental-async-top-level -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-inlinable-function-bodies-without-types -emit-silgen %s | %FileCheck -check-prefix=SKIPPED-FUNC-EMITTED %s
 
 guard let x: Int = nil else { while true { } }
 
 // CHECK-LABEL: sil hidden [ossa] @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> () {
+// SKIPPED-FUNC-EMITTED-LABEL-NOT: sil hidden [ossa] @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> () {
 func capturesX() {
   _ = x
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s18top_level_captures17transitiveCaptureyyF : $@convention(thin) (Int) -> () {
 // CHECK: [[FUNC:%.*]] = function_ref @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> ()
+// SKIPPED-FUNC-EMITTED-LABEL-NOT: sil hidden [ossa] @$s18top_level_captures17transitiveCaptureyyF : $@convention(thin) (Int) -> () {
+// SKIPPED-FUNC-EMITTED-NOT: [[FUNC:%.*]] = function_ref @$s18top_level_captures0C1XyyF : $@convention(thin) (Int) -> ()
 func transitiveCapture() {
   capturesX()
 }


### PR DESCRIPTION
Type-checking and SILGen for non-inlinable functions is skipped in the presence of `-experimental-skip-non-inlinable-function-bodies` and `-experimental-skip-non-inlinable-function-bodies-without-types` flags.

Such functions may be top-level and may contain captures (if they appear after a `guard` statement), for which we were setting the type expansion context during SILGen. Setting type expansion context however, relied on the capture info being computed -- which was never happening because of the abovementioned flags.

Changes in this commit make setting type expansion context, for captures, conditional on a flag that ensures that the function has already been typechecked.

Fixes #57646