### PR TITLE
[region-isolation] Add support for transferring parameters.

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1235,6 +1235,7 @@ enum ENUM_EXTENSIBILITY_ATTR(open) BridgedAttributedTypeSpecifier : size_t {
   BridgedAttributedTypeSpecifierConst,
   BridgedAttributedTypeSpecifierIsolated,
   BridgedAttributedTypeSpecifierResultDependsOn,
+  BridgedAttributedTypeSpecifierTransferring,
 };
 
 SWIFT_NAME("BridgedSimpleIdentTypeRepr.createParsed(_:loc:name:)")

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -549,6 +549,10 @@ SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
 CONTEXTUAL_SIMPLE_DECL_ATTR(_resultDependsOn, ResultDependsOn,
   OnParam | DeclModifier | UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
   156)
+CONTEXTUAL_SIMPLE_DECL_ATTR(transferring, Transferring,
+  OnParam | DeclModifier | UserInaccessible | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIStableToRemove,
+  157)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6727,6 +6727,7 @@ public:
       return true;
     case Specifier::Consuming:
     case Specifier::InOut:
+    case Specifier::Transferring:
       return false;
     }
     llvm_unreachable("unhandled specifier");
@@ -6744,6 +6745,7 @@ public:
     case ParamSpecifier::LegacyShared:
       return ValueOwnership::Shared;
     case ParamSpecifier::Consuming:
+    case ParamSpecifier::Transferring:
     case ParamSpecifier::LegacyOwned:
       return ValueOwnership::Owned;
     case ParamSpecifier::Default:

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -898,6 +898,9 @@ WARNING(regionbasedisolation_transfer_yields_race_no_isolation, none,
 WARNING(regionbasedisolation_transfer_yields_race_with_isolation, none,
         "passing argument of non-sendable type %0 from %1 context to %2 context at this call site could yield a race with accesses later in this function",
         (Type, ActorIsolation, ActorIsolation))
+WARNING(regionbasedisolation_transfer_yields_race_transferring_parameter, none,
+        "transferred value of non-Sendable type %0 into transferring parameter; later accesses could result in races",
+        (Type))
 NOTE(regionbasedisolation_maybe_race, none,
      "access here could race", ())
 ERROR(regionbasedisolation_unknown_pattern, none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -901,6 +901,9 @@ WARNING(regionbasedisolation_transfer_yields_race_with_isolation, none,
 WARNING(regionbasedisolation_transfer_yields_race_transferring_parameter, none,
         "transferred value of non-Sendable type %0 into transferring parameter; later accesses could result in races",
         (Type))
+WARNING(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, none,
+        "binding of non-Sendable type %0 accessed after being transferred; later accesses could result in races",
+        (Type))
 NOTE(regionbasedisolation_maybe_race, none,
      "access here could race", ())
 ERROR(regionbasedisolation_unknown_pattern, none,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2211,7 +2211,11 @@ enum class ParamSpecifier : uint8_t {
   /// `__shared`, a legacy spelling of `borrowing`.
   LegacyShared = 4,
   /// `__owned`, a legacy spelling of `consuming`.
-  LegacyOwned = 5
+  LegacyOwned = 5,
+
+  /// `transferring`. Indicating the transfer of a value from one isolation
+  /// domain to another.
+  Transferring = 6,
 };
 
 /// Provide parameter type relevant flags, i.e. variadic, autoclosure, and
@@ -2228,7 +2232,8 @@ class ParameterTypeFlags {
     Isolated = 1 << 7,
     CompileTimeConst = 1 << 8,
     ResultDependsOn = 1 << 9,
-    NumBits = 10
+    Transferring = 1 << 10,
+    NumBits = 11
   };
   OptionSet<ParameterFlags> value;
   static_assert(NumBits <= 8*sizeof(OptionSet<ParameterFlags>), "overflowed");
@@ -2243,20 +2248,22 @@ public:
 
   ParameterTypeFlags(bool variadic, bool autoclosure, bool nonEphemeral,
                      ParamSpecifier specifier, bool isolated, bool noDerivative,
-                     bool compileTimeConst, bool hasResultDependsOn)
+                     bool compileTimeConst, bool hasResultDependsOn,
+                     bool isTransferring)
       : value((variadic ? Variadic : 0) | (autoclosure ? AutoClosure : 0) |
               (nonEphemeral ? NonEphemeral : 0) |
               uint8_t(specifier) << SpecifierShift | (isolated ? Isolated : 0) |
               (noDerivative ? NoDerivative : 0) |
               (compileTimeConst ? CompileTimeConst : 0) |
-              (hasResultDependsOn ? ResultDependsOn : 0)) {}
+              (hasResultDependsOn ? ResultDependsOn : 0) |
+              (isTransferring ? Transferring : 0)) {}
 
   /// Create one from what's present in the parameter type
   inline static ParameterTypeFlags
   fromParameterType(Type paramTy, bool isVariadic, bool isAutoClosure,
                     bool isNonEphemeral, ParamSpecifier ownership,
                     bool isolated, bool isNoDerivative, bool compileTimeConst,
-                    bool hasResultDependsOn);
+                    bool hasResultDependsOn, bool isTransferring);
 
   bool isNone() const { return !value; }
   bool isVariadic() const { return value.contains(Variadic); }
@@ -2269,6 +2276,7 @@ public:
   bool isCompileTimeConst() const { return value.contains(CompileTimeConst); }
   bool isNoDerivative() const { return value.contains(NoDerivative); }
   bool hasResultDependsOn() const { return value.contains(ResultDependsOn); }
+  bool isTransferring() const { return value.contains(Transferring); }
 
   /// Get the spelling of the parameter specifier used on the parameter.
   ParamSpecifier getOwnershipSpecifier() const {
@@ -2329,6 +2337,12 @@ public:
     return ParameterTypeFlags(noDerivative
                                   ? value | ParameterTypeFlags::NoDerivative
                                   : value - ParameterTypeFlags::NoDerivative);
+  }
+
+  ParameterTypeFlags withTransferring(bool withTransferring) const {
+    return ParameterTypeFlags(withTransferring
+                                  ? value | ParameterTypeFlags::Transferring
+                                  : value - ParameterTypeFlags::Transferring);
   }
 
   bool operator ==(const ParameterTypeFlags &other) const {
@@ -2424,7 +2438,8 @@ public:
                               /*nonEphemeral*/ false, getOwnershipSpecifier(),
                               /*isolated*/ false, /*noDerivative*/ false,
                               /*compileTimeConst*/ false,
-                              /*hasResultDependsOn*/ false);
+                              /*hasResultDependsOn*/ false,
+                              /*is transferring*/ false);
   }
 
   bool operator ==(const YieldTypeFlags &other) const {
@@ -4111,6 +4126,9 @@ public:
     /// - If the function type is `@differentiable`, the function is
     ///   differentiable with respect to this parameter.
     NotDifferentiable = 0x1,
+
+    /// Set if the given parameter is transferring.
+    Transferring = 0x2,
   };
 
   using Options = OptionSet<Flag>;
@@ -7627,7 +7645,7 @@ inline TupleTypeElt TupleTypeElt::getWithType(Type T) const {
 inline ParameterTypeFlags ParameterTypeFlags::fromParameterType(
     Type paramTy, bool isVariadic, bool isAutoClosure, bool isNonEphemeral,
     ParamSpecifier ownership, bool isolated, bool isNoDerivative,
-    bool compileTimeConst, bool hasResultDependsOn) {
+    bool compileTimeConst, bool hasResultDependsOn, bool isTransferring) {
   // FIXME(Remove InOut): The last caller that needs this is argument
   // decomposition.  Start by enabling the assertion there and fixing up those
   // callers, then remove this, then remove
@@ -7637,8 +7655,9 @@ inline ParameterTypeFlags ParameterTypeFlags::fromParameterType(
            ownership == ParamSpecifier::InOut);
     ownership = ParamSpecifier::InOut;
   }
-  return {isVariadic, isAutoClosure,  isNonEphemeral,   ownership,
-          isolated,   isNoDerivative, compileTimeConst, hasResultDependsOn};
+  return {isVariadic,       isAutoClosure,      isNonEphemeral,
+          ownership,        isolated,           isNoDerivative,
+          compileTimeConst, hasResultDependsOn, isTransferring};
 }
 
 inline const Type *BoundGenericType::getTrailingObjectsPointer() const {

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -434,6 +434,10 @@ public:
     sharedUInt32().SILFunctionArgument.hasResultDependsOn = flag;
   }
 
+  bool isTransferring() const {
+    return getKnownParameterInfo().hasOption(SILParameterInfo::Transferring);
+  }
+
   Lifetime getLifetime() const {
     return getType()
         .getLifetime(*getFunction())

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3009,6 +3009,10 @@ public:
     return getArguments().slice(getNumIndirectResults());
   }
 
+  MutableArrayRef<Operand> getOperandsWithoutIndirectResults() const {
+    return getArgumentOperands().slice(getNumIndirectResults());
+  }
+
   /// Returns all `@inout` and `@inout_aliasable` arguments passed to the
   /// instruction.
   InoutArgumentRange getInoutArguments() const {

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1655,6 +1655,15 @@ namespace llvm {
     enum { NumLowBitsAvailable = swift::SILValue::NumLowBitsAvailable };
   };
 
+  /// A SILValue can be checked if a value is present, so we can use it with
+  /// dyn_cast_or_null.
+  template <>
+  struct ValueIsPresent<swift::SILValue> {
+    using SILValue = swift::SILValue;
+    using UnwrappedType = SILValue;
+    static inline bool isPresent(const SILValue &t) { return bool(t); }
+    static inline decltype(auto) unwrapValue(SILValue &t) { return t; }
+  };
 } // end namespace llvm
 
 #endif

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -254,6 +254,10 @@ public:
 
   TrackableValueState getValueState() const { return valueState; }
 
+  /// Returns true if this TrackableValue is an alloc_stack from a transferring
+  /// parameter.
+  bool isTransferringParameter() const;
+
   void print(llvm::raw_ostream &os) const {
     os << "TrackableValue. State: ";
     valueState.print(os);

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -1704,6 +1704,10 @@ BridgedSpecifierTypeRepr BridgedSpecifierTypeRepr_createParsed(
     return new (context)
         OwnershipTypeRepr(baseType, ParamSpecifier::LegacyOwned, loc);
   }
+  case BridgedAttributedTypeSpecifierTransferring: {
+    return new (context)
+        OwnershipTypeRepr(baseType, ParamSpecifier::Transferring, loc);
+  }
   case BridgedAttributedTypeSpecifierConst: {
     return new (context) CompileTimeConstTypeRepr(baseType, loc);
   }

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2875,7 +2875,8 @@ getParameterFlagsForMangling(ParameterTypeFlags flags,
   // `inout` should already be specified in the flags.
   case ParamSpecifier::InOut:
     return flags;
-  
+
+  case ParamSpecifier::Transferring:
   case ParamSpecifier::Consuming:
   case ParamSpecifier::Borrowing:
     // Only mangle the ownership if it diverges from the default.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7746,6 +7746,7 @@ void ParamDecl::setSpecifier(Specifier specifier) {
   // `inout` and `consuming` parameters are locally mutable.
   case ParamSpecifier::InOut:
   case ParamSpecifier::Consuming:
+  case ParamSpecifier::Transferring:
     introducer = VarDecl::Introducer::Var;
     break;
   }
@@ -7809,6 +7810,8 @@ StringRef ParamDecl::getSpecifierSpelling(ParamSpecifier specifier) {
     return "__shared";
   case ParamSpecifier::LegacyOwned:
     return "__owned";
+  case ParamSpecifier::Transferring:
+    return "transferring";
   }
   llvm_unreachable("invalid ParamSpecifier");
 }
@@ -8410,7 +8413,8 @@ AnyFunctionType::Param ParamDecl::toFunctionParam(Type type) const {
   auto flags = ParameterTypeFlags::fromParameterType(
       type, isVariadic(), isAutoClosure(), isNonEphemeral(), getSpecifier(),
       isIsolated(), /*isNoDerivative*/ false, isCompileTimeConst(),
-      hasResultDependsOn());
+      hasResultDependsOn(),
+      getSpecifier() == ParamDecl::Specifier::Transferring /*is transferring*/);
   return AnyFunctionType::Param(type, label, flags, internalLabel);
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5137,6 +5137,7 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
            Tok.isContextualKeyword("isolated") ||
            Tok.isContextualKeyword("consuming") ||
            Tok.isContextualKeyword("borrowing") ||
+           Tok.isContextualKeyword("transferring") ||
            Tok.isContextualKeyword("_const") ||
            Tok.isContextualKeyword("_resultDependsOn")))) {
 
@@ -5164,6 +5165,15 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
       continue;
     }
 
+    // Perform an extra check for transferring. Since it is a specifier, we use
+    // the actual parsing logic below.
+    if (Tok.isContextualKeyword("transferring")) {
+      if (!P.Context.LangOpts.hasFeature(Feature::TransferringArgsAndResults)) {
+        P.diagnose(Tok, diag::requires_experimental_feature, "transferring",
+                   false, getFeatureName(Feature::TransferringArgsAndResults));
+      }
+    }
+
     if (SpecifierLoc.isValid()) {
       P.diagnose(Tok, diag::parameter_specifier_repeated)
           .fixItRemove(SpecifierLoc);
@@ -5177,6 +5187,8 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
           Specifier = ParamDecl::Specifier::LegacyOwned;
         } else if (Tok.getRawText().equals("borrowing")) {
           Specifier = ParamDecl::Specifier::Borrowing;
+        } else if (Tok.getRawText().equals("transferring")) {
+          Specifier = ParamDecl::Specifier::Transferring;
         } else if (Tok.getRawText().equals("consuming")) {
           Specifier = ParamDecl::Specifier::Consuming;
         }
@@ -7539,6 +7551,8 @@ static ParserStatus parseAccessorIntroducer(Parser &P,
       P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Consuming);
     } else if (P.Tok.isContextualKeyword("borrowing")) {
       P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Borrowing);
+    } else if (P.Tok.isContextualKeyword("transferring")) {
+      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Transferring);
     }
   }
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -163,7 +163,9 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
         Tok.getRawText().equals("consuming") ||
         Tok.getRawText().equals("borrowing") ||
         (Context.LangOpts.hasFeature(Feature::NonescapableTypes) &&
-         Tok.getRawText().equals("resultDependsOn"))))) {
+         Tok.getRawText().equals("resultDependsOn")) ||
+        (Context.LangOpts.hasFeature(Feature::TransferringArgsAndResults) &&
+         Tok.getRawText().equals("transferring"))))) {
     // Type specifier should already be parsed before here. This only happens
     // for construct like 'P1 & inout P2'.
     diagnose(Tok.getLoc(), diag::attr_only_on_parameters, Tok.getRawText());

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3008,6 +3008,8 @@ public:
         case ParamSpecifier::InOut:
         case ParamSpecifier::LegacyShared:
         case ParamSpecifier::LegacyOwned:
+        // For now, transferring isn't implicitly copyable.
+        case ParamSpecifier::Transferring:
           return false;
         }
         if (pd->hasResultDependsOn()) {

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -860,6 +860,7 @@ private:
           argrv = ManagedValue::forBorrowedAddressRValue(
               SGF.B.createCopyableToMoveOnlyWrapperAddr(pd, argrv.getValue()));
           break;
+        case swift::ParamSpecifier::Transferring:
         case swift::ParamSpecifier::Consuming:
         case swift::ParamSpecifier::Default:
         case swift::ParamSpecifier::InOut:

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -762,7 +762,8 @@ void InferredCallerArgumentTypeInfo::initForApply(
 
 void InferredCallerArgumentTypeInfo::initForApply(const Operand *op,
                                                   ApplyExpr *sourceApply) {
-  auto isolationCrossing = *sourceApply->getIsolationCrossing();
+  auto isolationCrossing = sourceApply->getIsolationCrossing();
+  assert(isolationCrossing && "Should have valid isolation crossing?!");
 
   // Grab out full apply site and see if we can find a better expr.
   SILInstruction *i = const_cast<SILInstruction *>(op->getUser());

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -127,6 +127,7 @@ public:
   UseDiagnosticInfoKind getKind() const { return kind; }
 
   ApplyIsolationCrossing getIsolationCrossing() const {
+    assert(isolationCrossing && "Isolation crossing must be non-null");
     return *isolationCrossing;
   }
 
@@ -189,7 +190,8 @@ void InferredCallerArgumentTypeInfo::initForApply(
 
 void InferredCallerArgumentTypeInfo::initForApply(const Operand *op,
                                                   ApplyExpr *sourceApply) {
-  auto isolationCrossing = *sourceApply->getIsolationCrossing();
+  auto isolationCrossing = sourceApply->getIsolationCrossing();
+  assert(isolationCrossing);
 
   // Grab out full apply site and see if we can find a better expr.
   SILInstruction *i = const_cast<SILInstruction *>(op->getUser());
@@ -215,7 +217,7 @@ void InferredCallerArgumentTypeInfo::initForApply(const Operand *op,
       foundExpr ? foundExpr->findOriginalType() : baseInferredType;
   applyUses.emplace_back(
       inferredArgType,
-      UseDiagnosticInfo::forIsolationCrossing(isolationCrossing));
+      UseDiagnosticInfo::forIsolationCrossing(*isolationCrossing));
 }
 
 namespace {

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -41,6 +41,7 @@
 using namespace swift;
 using namespace swift::PartitionPrimitives;
 using namespace swift::PatternMatch;
+using namespace swift::regionanalysisimpl;
 
 namespace {
 using TransferringOperandSetFactory = Partition::TransferringOperandSetFactory;
@@ -86,13 +87,65 @@ static InFlightDiagnostic diagnose(const SILInstruction *inst, Diag<T...> diag,
 
 namespace {
 
-struct InferredCallerArgumentTypeInfo {
-  Type baseInferredType;
-  SmallVector<std::pair<Type, std::optional<ApplyIsolationCrossing>>, 4>
-      applyUses;
+enum class UseDiagnosticInfoKind {
+  Invalid = 0,
 
+  /// Used if we have an isolation crossing for our error.
+  IsolationCrossing = 1,
+
+  /// In certain cases, we think a race can happen, but we couldn't find the
+  /// isolation crossing specifically to emit a better error. Still emit an
+  /// error though.
+  RaceWithoutKnownIsolationCrossing = 2,
+
+  /// Used if the error is due to a transfer into an assignment into a
+  /// transferring parameter.
+  AssignmentIntoTransferringParameter = 3,
+};
+
+class UseDiagnosticInfo {
+  UseDiagnosticInfoKind kind;
+  std::optional<ApplyIsolationCrossing> isolationCrossing;
+
+public:
+  static UseDiagnosticInfo
+  forIsolationCrossing(ApplyIsolationCrossing isolationCrossing) {
+    return UseDiagnosticInfo(UseDiagnosticInfoKind::IsolationCrossing,
+                             isolationCrossing);
+  }
+
+  static UseDiagnosticInfo forIsolationCrossingWithUnknownIsolation() {
+    return UseDiagnosticInfo(
+        UseDiagnosticInfoKind::RaceWithoutKnownIsolationCrossing, {});
+  }
+
+  static UseDiagnosticInfo forAssignmentIntoTransferringParameter() {
+    return UseDiagnosticInfo(
+        UseDiagnosticInfoKind::AssignmentIntoTransferringParameter, {});
+  }
+
+  UseDiagnosticInfoKind getKind() const { return kind; }
+
+  ApplyIsolationCrossing getIsolationCrossing() const {
+    return *isolationCrossing;
+  }
+
+private:
+  UseDiagnosticInfo(UseDiagnosticInfoKind kind,
+                    std::optional<ApplyIsolationCrossing> isolationCrossing)
+      : kind(kind), isolationCrossing(isolationCrossing) {}
+};
+
+struct InferredCallerArgumentTypeInfo {
+  RegionAnalysisValueMap &valueMap;
+  Type baseInferredType;
+  SmallVector<std::pair<Type, UseDiagnosticInfo>, 4> applyUses;
+
+  InferredCallerArgumentTypeInfo(RegionAnalysisValueMap &valueMap)
+      : valueMap(valueMap) {}
   void init(const Operand *op);
 
+private:
   /// Init for an apply that does not have an associated apply expr.
   ///
   /// This should only occur when writing SIL test cases today. In the future,
@@ -102,7 +155,8 @@ struct InferredCallerArgumentTypeInfo {
 
   void initForApply(const Operand *op, ApplyExpr *expr);
   void initForAutoclosure(const Operand *op, AutoClosureExpr *expr);
-
+  void initForAssignmentToTransferringParameter(const Operand *op,
+                                                TrackableValue trackedValue);
   Expr *getFoundExprForSelf(ApplyExpr *sourceApply) {
     if (auto callExpr = dyn_cast<CallExpr>(sourceApply))
       if (auto calledExpr =
@@ -128,7 +182,9 @@ struct InferredCallerArgumentTypeInfo {
 
 void InferredCallerArgumentTypeInfo::initForApply(
     ApplyIsolationCrossing isolationCrossing) {
-  applyUses.emplace_back(baseInferredType, isolationCrossing);
+  applyUses.emplace_back(
+      baseInferredType,
+      UseDiagnosticInfo::forIsolationCrossing(isolationCrossing));
 }
 
 void InferredCallerArgumentTypeInfo::initForApply(const Operand *op,
@@ -157,7 +213,9 @@ void InferredCallerArgumentTypeInfo::initForApply(const Operand *op,
 
   auto inferredArgType =
       foundExpr ? foundExpr->findOriginalType() : baseInferredType;
-  applyUses.emplace_back(inferredArgType, isolationCrossing);
+  applyUses.emplace_back(
+      inferredArgType,
+      UseDiagnosticInfo::forIsolationCrossing(isolationCrossing));
 }
 
 namespace {
@@ -203,8 +261,9 @@ struct Walker : ASTWalker {
       if (!visitedCallExprDeclRefExprs.count(declRef)) {
         if (declRef->getDecl() == targetDecl) {
           visitedCallExprDeclRefExprs.insert(declRef);
-          foundTypeInfo.applyUses.emplace_back(declRef->findOriginalType(),
-                                               std::nullopt);
+          foundTypeInfo.applyUses.emplace_back(
+              declRef->findOriginalType(),
+              UseDiagnosticInfo::forIsolationCrossingWithUnknownIsolation());
           return Action::Continue(expr);
         }
       }
@@ -220,8 +279,9 @@ struct Walker : ASTWalker {
             if (declRef->getDecl() == targetDecl) {
               // Found our target!
               visitedCallExprDeclRefExprs.insert(declRef);
-              foundTypeInfo.applyUses.emplace_back(declRef->findOriginalType(),
-                                                   isolationCrossing);
+              foundTypeInfo.applyUses.emplace_back(
+                  declRef->findOriginalType(),
+                  UseDiagnosticInfo::forIsolationCrossing(*isolationCrossing));
               return Action::Continue(expr);
             }
           }
@@ -235,9 +295,36 @@ struct Walker : ASTWalker {
 
 } // namespace
 
+static SILValue getDestOfStoreOrCopyAddr(Operand *op) {
+  if (auto *si = dyn_cast<StoreInst>(op->getUser()))
+    return si->getDest();
+
+  if (auto *copyAddr = dyn_cast<CopyAddrInst>(op->getUser()))
+    return copyAddr->getDest();
+
+  return SILValue();
+}
+
+void InferredCallerArgumentTypeInfo::initForAssignmentToTransferringParameter(
+    const Operand *op, TrackableValue trackedValue) {
+  applyUses.emplace_back(
+      op->get()->getType().getASTType(),
+      UseDiagnosticInfo::forAssignmentIntoTransferringParameter());
+}
+
 void InferredCallerArgumentTypeInfo::init(const Operand *op) {
   baseInferredType = op->get()->getType().getASTType();
   auto *nonConstOp = const_cast<Operand *>(op);
+
+  // Before we do anything, see if the transfer instruction was into a
+  // transferring parameter alloc_stack. In such a case, we emit a special
+  // message.
+  if (auto destValue = getDestOfStoreOrCopyAddr(nonConstOp)) {
+    auto trackedValue = valueMap.getTrackableValue(destValue);
+    if (trackedValue.isTransferringParameter()) {
+      return initForAssignmentToTransferringParameter(op, trackedValue);
+    }
+  }
 
   auto loc = op->getUser()->getLoc();
   if (auto *sourceApply = loc.getAsASTNode<ApplyExpr>()) {
@@ -252,7 +339,7 @@ void InferredCallerArgumentTypeInfo::init(const Operand *op) {
 
   auto *autoClosureExpr = loc.getAsASTNode<AutoClosureExpr>();
   if (!autoClosureExpr) {
-    llvm::report_fatal_error("Unknown node");
+    llvm::report_fatal_error("Transfer error emission missing a case?!");
   }
 
   auto *i = const_cast<SILInstruction *>(op->getUser());
@@ -599,7 +686,7 @@ static void emitDiagnostics(RegionAnalysisFunctionInfo *regionInfo) {
     ++blockLivenessInfoGeneration;
     liveness.process(requireInsts);
 
-    InferredCallerArgumentTypeInfo argTypeInfo;
+    InferredCallerArgumentTypeInfo argTypeInfo(regionInfo->getValueMap());
     argTypeInfo.init(transferOp);
 
     // If we were supposed to emit an error and we failed to do so, emit a
@@ -614,17 +701,32 @@ static void emitDiagnostics(RegionAnalysisFunctionInfo *regionInfo) {
     }
 
     for (auto &info : argTypeInfo.applyUses) {
-      if (auto isolation = info.second) {
+      switch (info.second.getKind()) {
+      case UseDiagnosticInfoKind::Invalid:
+        llvm_unreachable("Should never see this!");
+      case UseDiagnosticInfoKind::IsolationCrossing: {
+        auto isolation = info.second.getIsolationCrossing();
         diagnose(transferOp,
                  diag::regionbasedisolation_transfer_yields_race_with_isolation,
-                 info.first, isolation->getCallerIsolation(),
-                 isolation->getCalleeIsolation())
+                 info.first, isolation.getCallerIsolation(),
+                 isolation.getCalleeIsolation())
             .highlight(transferOp->get().getLoc().getSourceRange());
-      } else {
+        break;
+      }
+      case UseDiagnosticInfoKind::RaceWithoutKnownIsolationCrossing:
         diagnose(transferOp,
                  diag::regionbasedisolation_transfer_yields_race_no_isolation,
                  info.first)
             .highlight(transferOp->get().getLoc().getSourceRange());
+        break;
+      case UseDiagnosticInfoKind::AssignmentIntoTransferringParameter:
+        diagnose(
+            transferOp,
+            diag::
+                regionbasedisolation_transfer_yields_race_transferring_parameter,
+            info.first)
+            .highlight(transferOp->get().getLoc().getSourceRange());
+        break;
       }
 
       // Ok, we now have our requires... emit the errors.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -206,6 +206,7 @@ public:
   void visitNonMutatingAttr(NonMutatingAttr *attr) { visitMutationAttr(attr); }
   void visitBorrowingAttr(BorrowingAttr *attr) { visitMutationAttr(attr); }
   void visitConsumingAttr(ConsumingAttr *attr) { visitMutationAttr(attr); }
+  void visitTransferringAttr(TransferringAttr *attr) {}
   void visitLegacyConsumingAttr(LegacyConsumingAttr *attr) { visitMutationAttr(attr); }
   void visitResultDependsOnSelfAttr(ResultDependsOnSelfAttr *attr) {
     FuncDecl *FD = cast<FuncDecl>(D);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1559,6 +1559,7 @@ namespace  {
     UNINTERESTING_ATTR(PrivateImport)
     UNINTERESTING_ATTR(MainType)
     UNINTERESTING_ATTR(Preconcurrency)
+    UNINTERESTING_ATTR(Transferring)
 
     // Differentiation-related attributes.
     UNINTERESTING_ATTR(Differentiable)

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 837; // @preconcurrency conformances
+const uint16_t SWIFTMODULE_VERSION_MINOR = 838; // transferring param
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -359,6 +359,7 @@ enum class ParamDeclSpecifier : uint8_t {
   Consuming = 3,
   LegacyShared = 4,
   LegacyOwned = 5,
+  Transferring = 6,
 };
 using ParamDeclSpecifierField = BCFixed<3>;
 
@@ -1227,7 +1228,8 @@ namespace decls_block {
                      BCFixed<1>,              // isolated
                      BCFixed<1>,              // noDerivative?
                      BCFixed<1>,              // compileTimeConst
-                     BCFixed<1>               // _resultDependsOn
+                     BCFixed<1>,              // _resultDependsOn
+                     BCFixed<1>               // transferring
                      >;
 
   TYPE_LAYOUT(MetatypeTypeLayout,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2551,6 +2551,8 @@ static uint8_t getRawStableParamDeclSpecifier(swift::ParamDecl::Specifier sf) {
     return uint8_t(serialization::ParamDeclSpecifier::LegacyShared);
   case swift::ParamDecl::Specifier::LegacyOwned:
     return uint8_t(serialization::ParamDeclSpecifier::LegacyOwned);
+  case swift::ParamDecl::Specifier::Transferring:
+    return uint8_t(serialization::ParamDeclSpecifier::Transferring);
   }
   llvm_unreachable("bad param decl specifier kind");
 }
@@ -5426,7 +5428,8 @@ public:
           S.addTypeRef(param.getPlainType()), paramFlags.isVariadic(),
           paramFlags.isAutoClosure(), paramFlags.isNonEphemeral(), rawOwnership,
           paramFlags.isIsolated(), paramFlags.isNoDerivative(),
-          paramFlags.isCompileTimeConst(), paramFlags.hasResultDependsOn());
+          paramFlags.isCompileTimeConst(), paramFlags.hasResultDependsOn(),
+          paramFlags.isTransferring());
     }
   }
 

--- a/test/Concurrency/transfernonsendable_strong_transferring.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring.swift
@@ -32,9 +32,16 @@ func transferArgWithOtherParam2(_ x: Klass, _ y: transferring Klass) {
 // MARK: Tests //
 /////////////////
 
-func testSimpleTransfer() {
+func testSimpleTransferLet() {
   let k = Klass()
-  transferArg(k) // expected-warning {{passing argument of non-sendable type 'Klass' from nonisolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  transferArg(k) // expected-warning {{binding of non-Sendable type 'Klass' accessed after being transferred; later accesses could result in races}}
+  useValue(k) // expected-note {{access here could race}}
+}
+
+func testSimpleTransferVar() {
+  var k = Klass()
+  k = Klass()
+  transferArg(k) // expected-warning {{binding of non-Sendable type 'Klass' accessed after being transferred; later accesses could result in races}}
   useValue(k) // expected-note {{access here could race}}
 }
 

--- a/test/Concurrency/transfernonsendable_strong_transferring.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring.swift
@@ -1,0 +1,127 @@
+// RUN: %target-swift-frontend -emit-sil -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify -enable-experimental-feature RegionBasedIsolation %s
+
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class Klass {}
+
+func useValue<T>(_ t: T) {}
+@MainActor func transferToMain<T>(_ t: T) {}
+
+func transferArg(_ x: transferring Klass) {
+}
+
+func transferArgWithOtherParam(_ x: transferring Klass, _ y: Klass) {
+}
+
+func transferArgWithOtherParam2(_ x: Klass, _ y: transferring Klass) {
+}
+
+@MainActor var globalKlass = Klass()
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+func testSimpleTransfer() {
+  let k = Klass()
+  transferArg(k) // expected-warning {{passing argument of non-sendable type 'Klass' from nonisolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  useValue(k) // expected-note {{access here could race}}
+}
+
+func testSimpleTransferUseOfOtherParamNoError() {
+  let k = Klass()
+  let k2 = Klass()
+  transferArgWithOtherParam(k, k2)
+  useValue(k2)
+}
+
+func testSimpleTransferUseOfOtherParamNoError2() {
+  let k = Klass()
+  let k2 = Klass()
+  transferArgWithOtherParam2(k, k2)
+  useValue(k)
+}
+
+@MainActor func transferToMain2(_ x: transferring Klass, _ y: Klass, _ z: Klass) async {
+
+}
+
+// TODO: How to test this?
+func testNonStrongTransferDoesntMerge() async {
+}
+
+//////////////////////////////////
+// MARK: Transferring Parameter //
+//////////////////////////////////
+
+func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) async {
+  await transferToMain(x)
+  await transferToMain(y) // expected-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+}
+
+func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
+  await transferToMain(x) // expected-warning {{passing argument of non-sendable type 'Klass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(x) // expected-note {{access here could race}}
+}
+
+func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
+  await transferToMain(x) // expected-warning {{passing argument of non-sendable type 'Klass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  useValue(x) // expected-note {{access here could race}}
+}
+
+actor MyActor {
+  var field = Klass()
+
+  func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
+    await transferToMain(x)
+    await transferToMain(y) // expected-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  }
+
+  func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
+    await transferToMain(x) // expected-warning {{passing argument of non-sendable type 'Klass' from actor-isolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(x) // expected-note {{access here could race}}
+  }
+
+  func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
+    await transferToMain(x)  // expected-warning {{passing argument of non-sendable type 'Klass' from actor-isolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    useValue(x) // expected-note {{access here could race}}
+  }
+
+  // After assigning into the actor, we can still use x in the actor as long as
+  // we don't transfer it.
+  func assignTransferringIntoActor(_ x: transferring Klass) async {
+    field = x
+    useValue(x)
+  }
+
+  // Once we assign into the actor, we cannot transfer further.
+  func assignTransferringIntoActor2(_ x: transferring Klass) async {
+    field = x
+    await transferToMain(x) // expected-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  }
+}
+
+@MainActor func canAssignTransferringIntoGlobalActor(_ x: transferring Klass) async {
+  globalKlass = x
+}
+
+func canTransferAssigningIntoLocal(_ x: transferring Klass) async {
+  let _ = x
+  await transferToMain(x)
+}
+
+//////////////////////////////////////
+// MARK: Transferring is "var" like //
+//////////////////////////////////////
+
+// Assigning into a transferring parameter is a transfer!
+func assigningIsATransfer(_ x: transferring Klass) async {
+  // Ok, this is disconnected.
+  x = Klass()
+}
+
+

--- a/test/Parse/transferring.swift
+++ b/test/Parse/transferring.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults
+
+// REQUIRES: asserts
+
+func testArg(_ x: transferring String) {
+}
+
+// Error only on results.
+func testResult() -> transferring String {
+  // expected-error @-1 {{'transferring' may only be used on parameter}}
+  ""
+}
+
+// Error on the result.
+func testArgResult(_ x: transferring String) -> transferring String {
+  // expected-error @-1 {{'transferring' may only be used on parameter}}
+}
+
+func testVarDeclDoesntWork() {
+  var x: transferring String // expected-error {{'transferring' may only be used on parameter}}
+}
+


### PR DESCRIPTION
A transferring parameter is a consuming like param modifier that can be used to transfer values to an async function such that you can transfer the value further.

Since it is consuming, one can assign into it. When one assigns into it, one has transferred the new value into the transferred parameter.