### PR TITLE
[Concurrency] Fix the missing builtin guards for DiscardingTaskGroup

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -83,6 +83,7 @@ LANGUAGE_FEATURE(BuiltinBuildComplexEqualityExecutor, 0, "Executor-building for 
 LANGUAGE_FEATURE(BuiltinBuildMainExecutor, 0, "MainActor executor building builtin")
 LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroup, 0, "Task create in task group builtin with extra flags")
 LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroupWithExecutor, 0, "Task create in task group builtin with extra flags")
+LANGUAGE_FEATURE(BuiltinCreateAsyncDiscardingTaskInGroup, 0, "Task create in discarding task group builtin, accounting for the Void return type")
 LANGUAGE_FEATURE(BuiltinCreateAsyncTaskWithExecutor, 0, "Task create builtin with extra executor preference")
 LANGUAGE_FEATURE(BuiltinCopy, 0, "Builtin.copy()")
 LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc")

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3284,6 +3284,10 @@ static bool usesFeatureBuiltinCreateAsyncTaskInGroupWithExecutor(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBuiltinCreateAsyncDiscardingTaskInGroup(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureBuiltinCreateAsyncTaskWithExecutor(Decl *decl) {
   return false;
 }

--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -190,7 +190,20 @@ public struct DiscardingTaskGroup {
 #endif
 
     // Create the task in this group.
+    #if $BuiltinCreateAsyncDiscardingTaskInGroup
     _ = Builtin.createAsyncDiscardingTaskInGroup(flags, _group, operation)
+    #else
+    // This builtin happens to work, but the signature of the operation is
+    // incorrect, as the discarding group uses Void, and therefore has less
+    // generic parameters than the operation expected to be passed to
+    // createAsyncTaskInGroup. While this happened to work on some platforms,
+    // on others this causes issues, e.g. on wasm;
+    //
+    // Keep this branch for compatibility with old compilers, but use the
+    // correct 'createAsyncDiscardingTaskInGroup' when available (and a recent
+    // enough compiler is used).
+    _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
+    #endif
   }
 
   /// Adds a child task to the group, unless the group has been canceled.
@@ -231,7 +244,20 @@ public struct DiscardingTaskGroup {
 #endif
 
     // Create the task in this group.
+#if $BuiltinCreateAsyncDiscardingTaskInGroup
     _ = Builtin.createAsyncDiscardingTaskInGroup(flags, _group, operation)
+#else
+    // This builtin happens to work, but the signature of the operation is
+    // incorrect, as the discarding group uses Void, and therefore has less
+    // generic parameters than the operation expected to be passed to
+    // createAsyncTaskInGroup. While this happened to work on some platforms,
+    // on others this causes issues, e.g. on wasm;
+    //
+    // Keep this branch for compatibility with old compilers, but use the
+    // correct 'createAsyncDiscardingTaskInGroup' when available (and a recent
+    // enough compiler is used).
+    _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
+#endif
 
     return true
   }
@@ -247,7 +273,20 @@ public struct DiscardingTaskGroup {
     )
 
     // Create the task in this group.
+    #if $BuiltinCreateAsyncDiscardingTaskInGroup
     _ = Builtin.createAsyncDiscardingTaskInGroup(flags, _group, operation)
+    #else
+    // This builtin happens to work, but the signature of the operation is
+    // incorrect, as the discarding group uses Void, and therefore has less
+    // generic parameters than the operation expected to be passed to
+    // createAsyncTaskInGroup. While this happened to work on some platforms,
+    // on others this causes issues, e.g. on wasm;
+    //
+    // Keep this branch for compatibility with old compilers, but use the
+    // correct 'createAsyncDiscardingTaskInGroup' when available (and a recent
+    // enough compiler is used).
+    _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
+    #endif
   }
 
   /// Adds a child task to the group, unless the group has been canceled.
@@ -278,7 +317,20 @@ public struct DiscardingTaskGroup {
     )
 
     // Create the task in this group.
+    #if $BuiltinCreateAsyncDiscardingTaskInGroup
     _ = Builtin.createAsyncDiscardingTaskInGroup(flags, _group, operation)
+    #else
+    // This builtin happens to work, but the signature of the operation is
+    // incorrect, as the discarding group uses Void, and therefore has less
+    // generic parameters than the operation expected to be passed to
+    // createAsyncTaskInGroup. While this happened to work on some platforms,
+    // on others this causes issues, e.g. on wasm;
+    //
+    // Keep this branch for compatibility with old compilers, but use the
+    // correct 'createAsyncDiscardingTaskInGroup' when available (and a recent
+    // enough compiler is used).
+    _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
+    #endif
 
     return true
 #else
@@ -564,7 +616,20 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
     )
 
     // Create the task in this group.
+    #if $BuiltinCreateAsyncDiscardingTaskInGroup
     _ = Builtin.createAsyncDiscardingTaskInGroup(flags, _group, operation)
+    #else
+    // This builtin happens to work, but the signature of the operation is
+    // incorrect, as the discarding group uses Void, and therefore has less
+    // generic parameters than the operation expected to be passed to
+    // createAsyncTaskInGroup. While this happened to work on some platforms,
+    // on others this causes issues, e.g. on wasm;
+    //
+    // Keep this branch for compatibility with old compilers, but use the
+    // correct 'createAsyncDiscardingTaskInGroup' when available (and a recent
+    // enough compiler is used).
+    _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
+    #endif
 #else
     fatalError("Unsupported Swift compiler")
 #endif
@@ -593,7 +658,20 @@ public struct ThrowingDiscardingTaskGroup<Failure: Error> {
     )
 
     // Create the task in this group.
+    #if $BuiltinCreateAsyncDiscardingTaskInGroup
     _ = Builtin.createAsyncDiscardingTaskInGroup(flags, _group, operation)
+    #else
+    // This builtin happens to work, but the signature of the operation is
+    // incorrect, as the discarding group uses Void, and therefore has less
+    // generic parameters than the operation expected to be passed to
+    // createAsyncTaskInGroup. While this happened to work on some platforms,
+    // on others this causes issues, e.g. on wasm;
+    //
+    // Keep this branch for compatibility with old compilers, but use the
+    // correct 'createAsyncDiscardingTaskInGroup' when available (and a recent
+    // enough compiler is used).
+    _ = Builtin.createAsyncTaskInGroup(flags, _group, operation)
+    #endif
 
     return true
 #else


### PR DESCRIPTION
The PR https://github.com/apple/swift/pull/70537/ adjusted the way we create tasks for the discarding group by using a new builtin -- this builtin must be protected with a   `#if $BuiltinCreateAsyncDiscardingTaskInGroup` as otherwise we can get issues like `module 'Builtin' has no member named 'createAsyncDiscardingTaskInGroup'` when an old compiler without this builtin is used.

FYI @kateinoigakukun @MaxDesiatov 

Resolves rdar://120801949