### PR TITLE
Ensure that freestanding macros get consistent discriminators

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -792,10 +792,6 @@ protected:
     NumberOfVTableEntries : 2
   );
 
-  SWIFT_INLINE_BITFIELD(MacroExpansionDecl, Decl, 16,
-    Discriminator : 16
-  );
-
   } Bits;
   // Turn back on clang-format now that we have defined our inline bitfields.
   // clang-format on
@@ -9008,8 +9004,6 @@ public:
 class MacroExpansionDecl : public Decl, public FreestandingMacroExpansion {
 
 public:
-  enum : unsigned { InvalidDiscriminator = 0xFFFF };
-
   MacroExpansionDecl(DeclContext *dc, MacroExpansionInfo *info);
 
   static MacroExpansionDecl *create(DeclContext *dc, SourceLoc poundLoc,
@@ -9028,24 +9022,6 @@ public:
 
   /// Enumerate the nodes produced by expanding this macro expansion.
   void forEachExpandedNode(llvm::function_ref<void(ASTNode)> callback) const;
-
-  /// Returns a discriminator which determines this macro expansion's index
-  /// in the sequence of macro expansions within the current function.
-  unsigned getDiscriminator() const;
-
-  /// Retrieve the raw discriminator, which may not have been computed yet.
-  ///
-  /// Only use this for queries that are checking for (e.g.) reentrancy or
-  /// intentionally do not want to initiate verification.
-  unsigned getRawDiscriminator() const {
-    return Bits.MacroExpansionDecl.Discriminator;
-  }
-
-  void setDiscriminator(unsigned discriminator) {
-    assert(getRawDiscriminator() == InvalidDiscriminator);
-    assert(discriminator != InvalidDiscriminator);
-    Bits.MacroExpansionDecl.Discriminator = discriminator;
-  }
 
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::MacroExpansion;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -369,11 +369,6 @@ protected:
     NumElements : 32
   );
 
-  SWIFT_INLINE_BITFIELD(MacroExpansionExpr, Expr, (16-NumExprBits)+16,
-    : 16 - NumExprBits, // Align and leave room for subclasses
-    Discriminator : 16
-  );
-
   } Bits;
   // clang-format on
 
@@ -6309,7 +6304,6 @@ public:
       : Expr(ExprKind::MacroExpansion, isImplicit, ty),
         FreestandingMacroExpansion(FreestandingMacroKind::Expr, info), DC(dc),
         Rewritten(nullptr), Roles(roles), SubstituteDecl(nullptr) {
-    Bits.MacroExpansionExpr.Discriminator = InvalidDiscriminator;
   }
 
   static MacroExpansionExpr *
@@ -6332,24 +6326,6 @@ public:
 
   DeclContext *getDeclContext() const { return DC; }
   void setDeclContext(DeclContext *dc) { DC = dc; }
-
-  /// Returns a discriminator which determines this macro expansion's index
-  /// in the sequence of macro expansions within the current function.
-  unsigned getDiscriminator() const;
-
-  /// Retrieve the raw discriminator, which may not have been computed yet.
-  ///
-  /// Only use this for queries that are checking for (e.g.) reentrancy or
-  /// intentionally do not want to initiate verification.
-  unsigned getRawDiscriminator() const {
-    return Bits.MacroExpansionExpr.Discriminator;
-  }
-
-  void setDiscriminator(unsigned discriminator) {
-    assert(getRawDiscriminator() == InvalidDiscriminator);
-    assert(discriminator != InvalidDiscriminator);
-    Bits.MacroExpansionExpr.Discriminator = discriminator;
-  }
 
   SourceRange getSourceRange() const {
     return getExpansionInfo()->getSourceRange();

--- a/include/swift/AST/FreestandingMacroExpansion.h
+++ b/include/swift/AST/FreestandingMacroExpansion.h
@@ -45,6 +45,10 @@ struct MacroExpansionInfo : ASTAllocated<MacroExpansionInfo> {
   /// The referenced macro.
   ConcreteDeclRef macroRef;
 
+  enum : unsigned { InvalidDiscriminator = 0xFFFF };
+
+  unsigned Discriminator = InvalidDiscriminator;
+
   MacroExpansionInfo(SourceLoc sigilLoc, DeclNameRef moduleName,
                      DeclNameLoc moduleNameLoc, DeclNameRef macroName,
                      DeclNameLoc macroNameLoc, SourceLoc leftAngleLoc,
@@ -71,12 +75,12 @@ enum class FreestandingMacroKind {
 /// A base class of either 'MacroExpansionExpr' or 'MacroExpansionDecl'.
 class FreestandingMacroExpansion {
   llvm::PointerIntPair<MacroExpansionInfo *, 1, FreestandingMacroKind>
-      infoAndKind;
+    infoAndKind;
 
 protected:
   FreestandingMacroExpansion(FreestandingMacroKind kind,
                              MacroExpansionInfo *info)
-      : infoAndKind(info, kind) {}
+  : infoAndKind(info, kind) {}
 
 public:
   MacroExpansionInfo *getExpansionInfo() const {
@@ -114,7 +118,13 @@ public:
 
   DeclContext *getDeclContext() const;
   SourceRange getSourceRange() const;
+
+  /// Returns a discriminator which determines this macro expansion's index
+  /// in the sequence of macro expansions within the current context.
   unsigned getDiscriminator() const;
+
+  /// Returns the raw discriminator, for debugging purposes only.
+  unsigned getRawDiscriminator() const;
 };
 
 } // namespace swift

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2472,6 +2472,10 @@ public:
     }
 
     void verifyChecked(MacroExpansionExpr *expansion) {
+      // If there is a substitute decl, we'll end up checking that instead.
+      if (expansion->getSubstituteDecl())
+        return;
+
       MacroExpansionDiscriminatorKey key{
         MacroDiscriminatorContext::getParentOf(expansion).getOpaqueValue(),
         expansion->getMacroName().getBaseName().getIdentifier()

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11680,7 +11680,6 @@ MacroExpansionDecl::MacroExpansionDecl(DeclContext *dc,
                                        MacroExpansionInfo *info)
     : Decl(DeclKind::MacroExpansion, dc),
       FreestandingMacroExpansion(FreestandingMacroKind::Decl, info) {
-  Bits.MacroExpansionDecl.Discriminator = InvalidDiscriminator;
 }
 
 MacroExpansionDecl *
@@ -11702,23 +11701,6 @@ MacroExpansionDecl::create(
                          genericArgs,
                          args ? args : ArgumentList::createImplicit(ctx, {})};
   return new (ctx) MacroExpansionDecl(dc, info);
-}
-
-unsigned MacroExpansionDecl::getDiscriminator() const {
-  if (getRawDiscriminator() != InvalidDiscriminator)
-    return getRawDiscriminator();
-
-  auto mutableThis = const_cast<MacroExpansionDecl *>(this);
-  auto dc = getDeclContext();
-  ASTContext &ctx = dc->getASTContext();
-  auto discriminatorContext =
-      MacroDiscriminatorContext::getParentOf(mutableThis);
-  mutableThis->setDiscriminator(
-      ctx.getNextMacroDiscriminator(
-          discriminatorContext, getMacroName().getBaseName()));
-
-  assert(getRawDiscriminator() != InvalidDiscriminator);
-  return getRawDiscriminator();
 }
 
 void MacroExpansionDecl::forEachExpandedNode(

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2786,23 +2786,6 @@ MacroExpansionExpr *MacroExpansionExpr::create(
   return new (ctx) MacroExpansionExpr(dc, info, roles, isImplicit, ty);
 }
 
-unsigned MacroExpansionExpr::getDiscriminator() const {
-  if (getRawDiscriminator() != InvalidDiscriminator)
-    return getRawDiscriminator();
-
-  auto mutableThis = const_cast<MacroExpansionExpr *>(this);
-  auto dc = getDeclContext();
-  ASTContext &ctx = dc->getASTContext();
-  auto discriminatorContext =
-      MacroDiscriminatorContext::getParentOf(mutableThis);
-  mutableThis->setDiscriminator(
-      ctx.getNextMacroDiscriminator(
-          discriminatorContext, getMacroName().getBaseName()));
-
-  assert(getRawDiscriminator() != InvalidDiscriminator);
-  return getRawDiscriminator();
-}
-
 MacroExpansionDecl *MacroExpansionExpr::createSubstituteDecl() {
   auto dc = DC;
   if (auto *tlcd = dyn_cast_or_null<TopLevelCodeDecl>(dc->getAsDecl()))

--- a/test/Macros/Inputs/AnonTypes1.swift
+++ b/test/Macros/Inputs/AnonTypes1.swift
@@ -1,0 +1,1 @@
+#anonymousTypes(public: true) { "hello" }

--- a/test/Macros/Inputs/AnonTypes2.swift
+++ b/test/Macros/Inputs/AnonTypes2.swift
@@ -1,0 +1,1 @@
+#anonymousTypes(public: true) { "hello" }

--- a/test/Macros/freestanding_multifile.swift
+++ b/test/Macros/freestanding_multifile.swift
@@ -1,0 +1,14 @@
+// REQUIRES: swift_swift_parser, executable_test
+
+// RUN: %empty-directory(%t)
+// RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift
+
+@freestanding(declaration)
+macro anonymousTypes(public: Bool, _: () -> String) = #externalMacro(module: "MacroDefinition", type: "DefineAnonymousTypesMacro")
+
+// RUN: %target-swift-frontend -swift-version 5 -emit-ir -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser %S/Inputs/AnonTypes1.swift %S/Inputs/AnonTypes2.swift %s -o - -g | %FileCheck --check-prefix CHECK-IR %s
+
+// CHECK-IR: $s9MacroUser33{{.*}}14anonymousTypesfMf_4namefMu_
+// CHECK-IR-NOT: $s9MacroUser33{{.*}}14anonymousTypesfMf0_4namefMu_
+// CHECK-IR: $s9MacroUser33{{.*}}14anonymousTypesfMf_4namefMu_
+// CHECK-IR: $s9MacroUser33{{.*}}14anonymousTypesfMf0_4namefMu_

--- a/test/Macros/freestanding_multifile.swift
+++ b/test/Macros/freestanding_multifile.swift
@@ -11,4 +11,4 @@ macro anonymousTypes(public: Bool, _: () -> String) = #externalMacro(module: "Ma
 // CHECK-IR: $s9MacroUser33{{.*}}14anonymousTypesfMf_4namefMu_
 // CHECK-IR-NOT: $s9MacroUser33{{.*}}14anonymousTypesfMf0_4namefMu_
 // CHECK-IR: $s9MacroUser33{{.*}}14anonymousTypesfMf_4namefMu_
-// CHECK-IR: $s9MacroUser33{{.*}}14anonymousTypesfMf0_4namefMu_
+// CHECK-IR-NOT: $s9MacroUser33{{.*}}14anonymousTypesfMf0_4namefMu_

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -71,7 +71,7 @@ struct MemberNotCovered {
   // expected-note@-1 {{in expansion of macro 'NotCovered' here}}
 
   // CHECK-DIAGS: error: declaration name 'value' is not covered by macro 'NotCovered'
-  // CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser16MemberNotCoveredV33_4361AD9339943F52AE6186DD51E04E91Ll0dE0fMf0_.swift
+  // CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser16MemberNotCoveredV33_4361AD9339943F52AE6186DD51E04E91Ll0dE0fMf_.swift
   // CHECK-DIAGS: var value: Int
   // CHECK-DIAGS: END CONTENTS OF FILE
 }
@@ -137,7 +137,7 @@ macro AccidentalCodeItem() = #externalMacro(module: "MacroDefinition", type: "Fa
 func invalidDeclarationMacro() {
   #accidentalCodeItem
   // expected-note@-1 {{in expansion of macro 'accidentalCodeItem' here}}
-  // CHECK-DIAGS: @__swiftmacro_9MacroUser018invalidDeclarationA0yyF18accidentalCodeItemfMf0_.swift:1:1: error: expected macro expansion to produce a declaration
+  // CHECK-DIAGS: @__swiftmacro_9MacroUser018invalidDeclarationA0yyF18accidentalCodeItemfMf_.swift:1:1: error: expected macro expansion to produce a declaration
 
   @AccidentalCodeItem struct S {}
   // expected-note@-1 {{in expansion of macro 'AccidentalCodeItem' on struct 'S' here}}
@@ -373,7 +373,7 @@ func testNestedDeclInExpr() {
 macro defineDeclsWithKnownNames() = #externalMacro(module: "MacroDefinition", type: "DefineDeclsWithKnownNamesMacro")
 
 // Freestanding macros are not in inlined scopes.
-// CHECK-SIL: sil_scope {{.*}} { loc "@__swiftmacro_9MacroUser016testFreestandingA9ExpansionyyF4Foo2L_V25defineDeclsWithKnownNamesfMf0_.swift"{{.*}} -> Int }
+// CHECK-SIL: sil_scope {{.*}} { loc "@__swiftmacro_9MacroUser016testFreestandingA9ExpansionyyF4Foo2L_V25defineDeclsWithKnownNamesfMf_.swift"{{.*}} -> Int }
 
 // FIXME: Macros producing arbitrary names are not supported yet
 #if false
@@ -436,10 +436,10 @@ func testFreestandingMacroExpansion() {
   struct Foo3 {
     #bitwidthNumberedStructs("BUG", blah: false)
     // expected-note@-1 4{{in expansion of macro 'bitwidthNumberedStructs' here}}
-    // CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf0_.swift
+    // CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_.swift
     // CHECK-DIAGS: struct BUG {
-    // CHECK-DIAGS:   func $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf0_6methodfMu_()
-    // CHECK-DIAGS:   func $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf0_6methodfMu0{{_?}}()
+    // CHECK-DIAGS:   func $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu_()
+    // CHECK-DIAGS:   func $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0{{_?}}()
   }
   #endif
 

--- a/test/Macros/macro_expand_codeitems.swift
+++ b/test/Macros/macro_expand_codeitems.swift
@@ -21,7 +21,7 @@ func testFreestandingMacroExpansion() {
   // CHECK: from stmt
   // CHECK: from usedInExpandedStmt
   // CHECK: from expr
-  // CHECK-DIAGS: struct $s9MacroUser016testFreestandingA9ExpansionyyF9codeItemsfMf0_3foofMu_ {
+  // CHECK-DIAGS: struct $s9MacroUser016testFreestandingA9ExpansionyyF9codeItemsfMf_3foofMu_ {
   // CHECK-DIAGS: END CONTENTS OF FILE
   #codeItems
 

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -97,8 +97,8 @@ func testGlobalVariable() {
 
 // expected-note @+1 6 {{in expansion of macro 'anonymousTypes' here}}
 #anonymousTypes(causeErrors: true) { "foo" }
-// DIAG_BUFFERS-DAG: @__swiftmacro_9MacroUser33{{.*}}anonymousTypesfMf2_{{.*}}error: use of protocol 'Equatable' as a type must be written 'any Equatable'
-// DIAG_BUFFERS-DAG: @__swiftmacro_9MacroUser03{{.*}}anonymousTypes{{.*}}introduceTypeCheckingErrorsfMf0_{{.*}}error: use of protocol 'Hashable' as a type must be written 'any Hashable'
+// DIAG_BUFFERS-DAG: @__swiftmacro_9MacroUser33{{.*}}anonymousTypesfMf0_{{.*}}error: use of protocol 'Equatable' as a type must be written 'any Equatable'
+// DIAG_BUFFERS-DAG: @__swiftmacro_9MacroUser03{{.*}}anonymousTypes{{.*}}introduceTypeCheckingErrorsfMf_{{.*}}error: use of protocol 'Hashable' as a type must be written 'any Hashable'
 
 // expected-note @+1 2 {{in expansion of macro 'anonymousTypes' here}}
 #anonymousTypes { () -> String in

--- a/test/SourceKit/Macros/macro_semantic_token.swift
+++ b/test/SourceKit/Macros/macro_semantic_token.swift
@@ -12,7 +12,7 @@ macro anonymousTypes(_: () -> String) = #externalMacro(module: "MacroDefinition"
 // RUN: %host-build-swift -swift-version 5 -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/../../Macros/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
 // Check the output of the the `#anonymousTypes` macro
-// RUN: %sourcekitd-test -req=semantic-tokens @__swiftmacro_9MacroUser33_8C2BB8A10AE555140C0EDFDEB4A9572DLl14anonymousTypesfMf0_.swift -primary-file %s -- -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser %s | %FileCheck %s --check-prefix IN_BUFFER
+// RUN: %sourcekitd-test -req=semantic-tokens @__swiftmacro_9MacroUser33_8C2BB8A10AE555140C0EDFDEB4A9572DLl14anonymousTypesfMf_.swift -primary-file %s -- -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -module-name MacroUser %s | %FileCheck %s --check-prefix IN_BUFFER
 
 // Check that we get some semantic tokens. Checking exact offsets is brittle.
 // IN_BUFFER: source.lang.swift.ref.struct


### PR DESCRIPTION
Due to the duality between the expression and declaration forms of freestanding macros, we could end up assigning two different discriminators to what is effectively the same freestanding macro expansion. Across different source files, this could lead to inconsistent discriminators in different translation units. Unify the storage of the discriminator to avoid this issue.

Fixes rdar://116259748
