### PR TITLE
[5.10][SE-0411] Promote `IsolatedDefaultValues` from an experimental feature to an upcoming feature.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 > **Note**\
 > This is in reverse chronological order, so newer entries are added to the top.
 
+## Swift 5.10
+
+* [SE-0411][]:
+
+  Default value expressions can now have the same isolation as the enclosing
+  function or the corresponding stored property:
+
+  ```swift
+  @MainActor
+  func requiresMainActor() -> Int { ... }
+
+  class C {
+    @MainActor
+    var x: Int = requiresMainActor()
+  }
+
+  @MainActor func defaultArg(value: Int = requiresMainActor()) { ... }
+  ```
+
+  For isolated default values of stored properties, the implicit initialization
+  only happens in the body of an `init` with the same isolation. This closes
+  an important data-race safety hole where global-actor-isolated default values
+  could inadvertently run synchronously from outside the actor.
+
 ## Swift 5.9.2
 
 * [SE-0407][]:
@@ -9846,6 +9870,7 @@ using the `.dynamicType` member to retrieve the type of an expression should mig
 [SE-0394]: https://github.com/apple/swift-evolution/blob/main/proposals/0394-swiftpm-expression-macros.md
 [SE-0397]: https://github.com/apple/swift-evolution/blob/main/proposals/0397-freestanding-declaration-macros.md
 [SE-0407]: https://github.com/apple/swift-evolution/blob/main/proposals/0407-member-macro-conformances.md
+[SE-0411]: https://github.com/apple/swift-evolution/blob/main/proposals/0411-isolated-default-values.md
 [#64927]: <https://github.com/apple/swift/issues/64927>
 [#42697]: <https://github.com/apple/swift/issues/42697>
 [#42728]: <https://github.com/apple/swift/issues/42728>

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5200,6 +5200,12 @@ ERROR(distributed_actor_isolated_non_self_reference,none,
       "distributed actor-isolated %kind0 can not be accessed from a "
       "non-isolated context",
       (const ValueDecl *))
+ERROR(conflicting_stored_property_isolation,none,
+      "%select{default|memberwise}0 initializer for %1 cannot be both %2 and %3",
+      (bool, Type, ActorIsolation, ActorIsolation))
+NOTE(property_requires_actor,none,
+      "initializer for %0 %1 is %2",
+      (DescriptiveDeclKind, Identifier, ActorIsolation))
 ERROR(isolated_default_argument_context,none,
       "%0 default value in a %1 context", 
       (ActorIsolation, ActorIsolation))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5200,9 +5200,8 @@ ERROR(distributed_actor_isolated_non_self_reference,none,
       "distributed actor-isolated %kind0 can not be accessed from a "
       "non-isolated context",
       (const ValueDecl *))
-ERROR(isolated_default_argument,none,
-      "%0 default argument cannot be synchronously evaluated from a "
-      "%1 context",
+ERROR(isolated_default_argument_context,none,
+      "%0 default argument in a %1 context", 
       (ActorIsolation, ActorIsolation))
 ERROR(conflicting_default_argument_isolation,none,
       "default argument cannot be both %0 and %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5201,7 +5201,7 @@ ERROR(distributed_actor_isolated_non_self_reference,none,
       "non-isolated context",
       (const ValueDecl *))
 ERROR(isolated_default_argument_context,none,
-      "%0 default argument in a %1 context", 
+      "%0 default value in a %1 context", 
       (ActorIsolation, ActorIsolation))
 ERROR(conflicting_default_argument_isolation,none,
       "default argument cannot be both %0 and %1",

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4513,6 +4513,10 @@ class DefaultArgumentExpr final : public Expr {
   /// default expression.
   PointerUnion<DeclContext *, Expr *> ContextOrCallerSideExpr;
 
+  /// Whether this default argument is evaluated asynchronously because
+  /// it's isolated to the callee's isolation domain.
+  bool implicitlyAsync = false;
+
 public:
   explicit DefaultArgumentExpr(ConcreteDeclRef defaultArgsOwner,
                                unsigned paramIndex, SourceLoc loc, Type Ty,
@@ -4546,6 +4550,16 @@ public:
   /// synchronously. If the caller does not meet the required isolation, the
   /// argument must be written explicitly at the call-site.
   ActorIsolation getRequiredIsolation() const;
+
+  /// Whether this default argument is evaluated asynchronously because
+  /// it's isolated to the callee's isolation domain.
+  bool isImplicitlyAsync() const {
+    return implicitlyAsync;
+  }
+
+  void setImplicitlyAsync() {
+    implicitlyAsync = true;
+  }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::DefaultArgument;

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -118,6 +118,7 @@ UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
 UPCOMING_FEATURE(DeprecateApplicationMain, 383, 6)
 UPCOMING_FEATURE(ImportObjcForwardDeclarations, 384, 6)
 UPCOMING_FEATURE(DisableOutwardActorInference, 401, 6)
+UPCOMING_FEATURE(IsolatedDefaultValues, 411, 6)
 UPCOMING_FEATURE(GlobalConcurrency, 412, 6)
 
 UPCOMING_FEATURE(ExistentialAny, 335, 7)
@@ -221,9 +222,6 @@ EXPERIMENTAL_FEATURE(StrictConcurrency, true)
 
 /// Defer Sendable checking to SIL diagnostic phase.
 EXPERIMENTAL_FEATURE(SendNonSendable, false)
-
-/// Allow default values to require isolation at the call-site.
-EXPERIMENTAL_FEATURE(IsolatedDefaultValues, false)
 
 /// Enable extended callbacks (with additional parameters) to be used when the
 /// "playground transform" is enabled.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10289,6 +10289,7 @@ ActorIsolation swift::getActorIsolationOfContext(
     DeclContext *dc,
     llvm::function_ref<ActorIsolation(AbstractClosureExpr *)>
         getClosureActorIsolation) {
+  auto &ctx = dc->getASTContext();
   auto dcToUse = dc;
   // Defer bodies share actor isolation of their enclosing context.
   if (auto FD = dyn_cast<FuncDecl>(dcToUse)) {
@@ -10309,6 +10310,13 @@ ActorIsolation swift::getActorIsolationOfContext(
   //     actor isolation as the field itself. That default expression may only
   //     be used from inits that meet the required isolation.
   if (auto *var = dcToUse->getNonLocalVarDecl()) {
+    // If IsolatedDefaultValues are enabled, treat this context as having
+    // unspecified isolation. We'll compute the required isolation for
+    // the initializer and validate that it matches the isolation of the
+    // var itself in the DefaultInitializerIsolation request.
+    if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues))
+      return ActorIsolation::forUnspecified();
+
     return getActorIsolation(var);
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10300,22 +10300,15 @@ ActorIsolation swift::getActorIsolationOfContext(
     return getActorIsolation(vd);
 
   // In the context of the initializing or default-value expression of a
-  // stored property, the isolation varies between instance and type members:
+  // stored property:
   //   - For a static stored property, the isolation matches the VarDecl.
   //     Static properties are initialized upon first use, so the isolation
   //     of the initializer must match the isolation required to access the
   //     property.
-  //   - For a field of a nominal type, the expression can require a specific
-  //     actor isolation. That default expression may only be used from inits
-  //     that meet the required isolation.
+  //   - For a field of a nominal type, the expression can require the same
+  //     actor isolation as the field itself. That default expression may only
+  //     be used from inits that meet the required isolation.
   if (auto *var = dcToUse->getNonLocalVarDecl()) {
-    auto &ctx = dc->getASTContext();
-    if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues) &&
-        var->isInstanceMember() &&
-        !var->getAttrs().hasAttribute<LazyAttr>()) {
-      return ActorIsolation::forNonisolated(/*unsafe=*/false);
-    }
-
     return getActorIsolation(var);
   }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -976,8 +976,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.StrictConcurrencyLevel = StrictConcurrency::Minimal;
   }
 
-  // StrictConcurrency enables all data-race safety upcoming features.
-  if (Opts.hasFeature(Feature::StrictConcurrency)) {
+  // StrictConcurrency::Complete enables all data-race safety features.
+  if (Opts.StrictConcurrencyLevel == StrictConcurrency::Complete) {
+    Opts.Features.insert(Feature::IsolatedDefaultValues);
     Opts.Features.insert(Feature::GlobalConcurrency);
   }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2518,18 +2518,21 @@ private:
     AbstractionPattern origResultType;
     ClaimedParamsRef paramsToEmit;
     SILFunctionTypeRepresentation functionRepresentation;
-    
+    bool implicitlyAsync;
+
     DefaultArgumentStorage(SILLocation loc,
                            ConcreteDeclRef defaultArgsOwner,
                            unsigned destIndex,
                            CanType resultType,
                            AbstractionPattern origResultType,
                            ClaimedParamsRef paramsToEmit,
-                           SILFunctionTypeRepresentation functionRepresentation)
+                           SILFunctionTypeRepresentation functionRepresentation,
+                           bool implicitlyAsync)
       : loc(loc), defaultArgsOwner(defaultArgsOwner), destIndex(destIndex),
         resultType(resultType), origResultType(origResultType),
         paramsToEmit(paramsToEmit),
-        functionRepresentation(functionRepresentation)
+        functionRepresentation(functionRepresentation),
+        implicitlyAsync(implicitlyAsync)
     {}
   };
   struct BorrowedLValueStorage {
@@ -2656,13 +2659,15 @@ public:
                   CanType resultType,
                   AbstractionPattern origResultType,
                   ClaimedParamsRef params,
-                  SILFunctionTypeRepresentation functionTypeRepresentation)
+                  SILFunctionTypeRepresentation functionTypeRepresentation,
+                  bool implicitlyAsync)
     : Kind(DefaultArgument) {
     Value.emplace<DefaultArgumentStorage>(Kind, loc, defaultArgsOwner,
                                           destIndex,
                                           resultType,
                                           origResultType, params,
-                                          functionTypeRepresentation);
+                                          functionTypeRepresentation,
+                                          implicitlyAsync);
   }
 
   DelayedArgument(DelayedArgument &&other)
@@ -3261,7 +3266,7 @@ public:
                                     defArg->getParamIndex(),
                                     substParamType, origParamType,
                                     claimNextParameters(numParams),
-                                    Rep);
+                                    Rep, defArg->isImplicitlyAsync());
       Args.push_back(ManagedValue());
 
       maybeEmitForeignArgument();
@@ -4255,7 +4260,8 @@ void DelayedArgument::emitDefaultArgument(SILGenFunction &SGF,
   auto value = SGF.emitApplyOfDefaultArgGenerator(info.loc,
                                                   info.defaultArgsOwner,
                                                   info.destIndex,
-                                                  info.resultType);
+                                                  info.resultType,
+                                                  info.implicitlyAsync);
 
   SmallVector<ManagedValue, 4> loweredArgs;
   SmallVector<DelayedArgument, 4> delayedArgs;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2695,6 +2695,28 @@ public:
     return LV().Loc;
   }
 
+  bool isDefaultArg() const {
+    return Kind == DefaultArgument;
+  }
+
+  SILLocation getDefaultArgLoc() const {
+    assert(isDefaultArg());
+    auto storage = Value.get<DefaultArgumentStorage>(Kind);
+    return storage.loc;
+  }
+
+  llvm::Optional<ActorIsolation> getIsolation() const {
+    if (!isDefaultArg())
+      return llvm::None;
+
+    auto storage = Value.get<DefaultArgumentStorage>(Kind);
+    if (!storage.implicitlyAsync)
+      return llvm::None;
+
+    auto callee = storage.defaultArgsOwner.getDecl();
+    return getActorIsolation(callee);
+  }
+
   void emit(SILGenFunction &SGF, SmallVectorImpl<ManagedValue> &args,
             size_t &argIndex) {
     switch (Kind) {
@@ -2920,6 +2942,31 @@ static void emitDelayedArguments(SILGenFunction &SGF,
                          MutableArrayRef<SmallVector<ManagedValue, 4>> args) {
   assert(!delayedArgs.empty());
 
+  // If any of the delayed arguments are isolated default arguments,
+  // argument evaluation happens in the following order:
+  //
+  //   1. Left-to-right evalution of explicit r-value arguments
+  //   2. Left-to-right evaluation of formal access arguments
+  //   3. Hop to the callee's isolation domain
+  //   4. Left-to-right evaluation of default arguments
+
+  // So, if any delayed arguments are isolated, all default arguments
+  // are collected during the first pass over the delayed arguments,
+  // and emitted separately after a hop to the callee's isolation domain.
+
+  llvm::Optional<ActorIsolation> defaultArgIsolation;
+  for (auto &arg : delayedArgs) {
+    if (auto isolation = arg.getIsolation()) {
+      defaultArgIsolation = isolation;
+      break;
+    }
+  }
+
+  SmallVector<std::tuple<
+      /*delayedArgIt*/decltype(delayedArgs)::iterator,
+      /*siteArgsIt*/decltype(args)::iterator,
+      /*index*/size_t>, 2> isolatedArgs;
+
   SmallVector<std::pair<SILValue, SILLocation>, 4> emittedInoutArgs;
   auto delayedNext = delayedArgs.begin();
 
@@ -2928,7 +2975,8 @@ static void emitDelayedArguments(SILGenFunction &SGF,
   // wherever there's a delayed argument to insert.
   //
   // Note that this also begins the formal accesses in evaluation order.
-  for (auto &siteArgs : args) {
+  for (auto argsIt = args.begin(); argsIt != args.end(); ++argsIt) {
+    auto &siteArgs = *argsIt;
     // NB: siteArgs.size() may change during iteration
     for (size_t i = 0; i < siteArgs.size(); ) {
       auto &siteArg = siteArgs[i];
@@ -2940,6 +2988,15 @@ static void emitDelayedArguments(SILGenFunction &SGF,
 
       assert(delayedNext != delayedArgs.end());
       auto &delayedArg = *delayedNext;
+
+      if (defaultArgIsolation && delayedArg.isDefaultArg()) {
+        isolatedArgs.push_back(std::make_tuple(delayedNext, argsIt, i));
+        if (++delayedNext == delayedArgs.end()) {
+          goto done;
+        } else {
+          continue;
+        }
+      }
 
       // Emit the delayed argument and replace it in the arguments array.
       delayedArg.emit(SGF, siteArgs, i);
@@ -2960,6 +3017,45 @@ static void emitDelayedArguments(SILGenFunction &SGF,
   llvm_unreachable("ran out of null arguments before we ran out of inouts");
 
 done:
+
+  if (defaultArgIsolation) {
+    assert(SGF.F.isAsync());
+    assert(!isolatedArgs.empty());
+
+    auto &firstArg = *std::get<0>(isolatedArgs[0]);
+    auto loc = firstArg.getDefaultArgLoc();
+
+    SILValue executor;
+    switch (*defaultArgIsolation) {
+    case ActorIsolation::GlobalActor:
+    case ActorIsolation::GlobalActorUnsafe:
+      executor = SGF.emitLoadGlobalActorExecutor(
+          defaultArgIsolation->getGlobalActor());
+      break;
+
+    case ActorIsolation::ActorInstance:
+      llvm_unreachable("default arg cannot be actor instance isolated");
+
+    case ActorIsolation::Unspecified:
+    case ActorIsolation::Nonisolated:
+    case ActorIsolation::NonisolatedUnsafe:
+      llvm_unreachable("Not isolated");
+    }
+
+    // Hop to the target isolation domain once to evaluate all
+    // default arguments.
+    SGF.emitHopToTargetExecutor(loc, executor);
+
+    size_t argsEmitted = 0;
+    for (auto &isolatedArg : isolatedArgs) {
+      auto &delayedArg = *std::get<0>(isolatedArg);
+      auto &siteArgs = *std::get<1>(isolatedArg);
+      auto argIndex = std::get<2>(isolatedArg) + argsEmitted;
+      auto origIndex = argIndex;
+      delayedArg.emit(SGF, siteArgs, argIndex);
+      argsEmitted += (argIndex - origIndex);
+    }
+  }
 
   // Check to see if we have multiple inout arguments which obviously
   // alias.  Note that we could do this in a later SILDiagnostics pass

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2564,24 +2564,8 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
   emitCaptures(loc, generator, CaptureEmission::ImmediateApplication,
                captures);
 
-  // The default argument might require the callee's isolation. If so,
-  // make sure to emit an actor hop.
-  //
-  // FIXME: Instead of hopping back and forth for each individual isolated
-  // default argument, we should emit one hop for all default arguments if
-  // any of them are isolated, and immediately enter the function after.
-  llvm::Optional<ActorIsolation> implicitActorHopTarget = llvm::None;
-  if (implicitlyAsync) {
-    auto *param = getParameterAt(defaultArgsOwner.getDecl(), destIndex);
-    auto isolation = param->getInitializerIsolation();
-    if (isolation.isActorIsolated()) {
-      implicitActorHopTarget = isolation;
-    }
-  }
-
   return emitApply(std::move(resultPtr), std::move(argScope), loc, fnRef, subs,
-                   captures, calleeTypeInfo, ApplyOptions(), C,
-                   implicitActorHopTarget);
+                   captures, calleeTypeInfo, ApplyOptions(), C, llvm::None);
 }
 
 RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2533,6 +2533,7 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
                                                ConcreteDeclRef defaultArgsOwner,
                                                unsigned destIndex,
                                                CanType resultType,
+                                               bool implicitlyAsync,
                                                SGFContext C) {
   SILDeclRef generator 
     = SILDeclRef::getDefaultArgGenerator(defaultArgsOwner.getDecl(),
@@ -2563,8 +2564,24 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
   emitCaptures(loc, generator, CaptureEmission::ImmediateApplication,
                captures);
 
+  // The default argument might require the callee's isolation. If so,
+  // make sure to emit an actor hop.
+  //
+  // FIXME: Instead of hopping back and forth for each individual isolated
+  // default argument, we should emit one hop for all default arguments if
+  // any of them are isolated, and immediately enter the function after.
+  llvm::Optional<ActorIsolation> implicitActorHopTarget = llvm::None;
+  if (implicitlyAsync) {
+    auto *param = getParameterAt(defaultArgsOwner.getDecl(), destIndex);
+    auto isolation = param->getInitializerIsolation();
+    if (isolation.isActorIsolated()) {
+      implicitActorHopTarget = isolation;
+    }
+  }
+
   return emitApply(std::move(resultPtr), std::move(argScope), loc, fnRef, subs,
-                   captures, calleeTypeInfo, ApplyOptions(), C, llvm::None);
+                   captures, calleeTypeInfo, ApplyOptions(), C,
+                   implicitActorHopTarget);
 }
 
 RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1905,6 +1905,7 @@ public:
                                         ConcreteDeclRef defaultArgsOwner,
                                         unsigned destIndex,
                                         CanType resultType,
+                                        bool implicitlyAsync,
                                         SGFContext C = SGFContext());
 
   RValue emitApplyOfStoredPropertyInitializer(

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -338,7 +338,14 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
 
   if (ICK == ImplicitConstructorKind::Memberwise) {
     ctor->setIsMemberwiseInitializer();
-    addNonIsolatedToSynthesized(decl, ctor);
+
+    // FIXME: If 'IsolatedDefaultValues' is enabled, the memberwise init
+    // should be 'nonisolated' if none of the memberwise-initialized properties
+    // are global actor isolated and have non-Sendable type, and none of the
+    // initial values require global actor isolation.
+    if (!ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues)) {
+      addNonIsolatedToSynthesized(decl, ctor);
+    }
   }
 
   // If we are defining a default initializer for a class that has a superclass,

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -336,7 +336,8 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
   ctor->setSynthesized();
   ctor->setAccess(accessLevel);
 
-  if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues)) {
+  if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues) &&
+      !decl->isActor()) {
     // If any of the type's actor-isolated properties:
     //   1. Have non-Sendable type, or
     //   2. Have an isolated initial value

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -336,13 +336,64 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
   ctor->setSynthesized();
   ctor->setAccess(accessLevel);
 
+  if (ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues)) {
+    // If any of the type's actor-isolated properties:
+    //   1. Have non-Sendable type, or
+    //   2. Have an isolated initial value
+    // then the initializer must also be actor-isolated. If all
+    // isolated properties have Sendable type and a nonisolated
+    // default value, then the initializer can be nonisolated.
+    //
+    // These rules only apply for global actor isolation, because actor
+    // initializers apply Sendable checking to arguments at the call-site,
+    // and actor initializers do not run on the actor, so initial values
+    // cannot be actor-instance-isolated.
+    bool shouldAddNonisolated = true;
+    llvm::Optional<ActorIsolation> existingIsolation = llvm::None;
+    VarDecl *previousVar = nullptr;
+
+    // The memberwise init properties are also effectively what the
+    // default init uses, e.g. default initializers initialize via
+    // properties wrapped and init accessors.
+    for (auto var : decl->getMemberwiseInitProperties()) {
+      auto type = var->getTypeInContext();
+      auto isolation = getActorIsolation(var);
+      if (isolation.isGlobalActor()) {
+        if (!isSendableType(decl->getModuleContext(), type) ||
+            var->getInitializerIsolation().isGlobalActor()) {
+          // If different isolated stored properties require different
+          // global actors, it is impossible to initialize this type.
+          if (existingIsolation &&
+              *existingIsolation != isolation) {
+            ctx.Diags.diagnose(decl->getLoc(),
+                diag::conflicting_stored_property_isolation,
+                ICK == ImplicitConstructorKind::Memberwise,
+                decl->getDeclaredType(), *existingIsolation, isolation);
+            previousVar->diagnose(
+                diag::property_requires_actor,
+                previousVar->getDescriptiveKind(),
+                previousVar->getName(), *existingIsolation);
+            var->diagnose(
+                diag::property_requires_actor,
+                var->getDescriptiveKind(),
+                var->getName(), isolation);
+          }
+
+          existingIsolation = isolation;
+          previousVar = var;
+          shouldAddNonisolated = false;
+        }
+      }
+    }
+
+    if (shouldAddNonisolated) {
+      addNonIsolatedToSynthesized(decl, ctor);
+    }
+  }
+
   if (ICK == ImplicitConstructorKind::Memberwise) {
     ctor->setIsMemberwiseInitializer();
 
-    // FIXME: If 'IsolatedDefaultValues' is enabled, the memberwise init
-    // should be 'nonisolated' if none of the memberwise-initialized properties
-    // are global actor isolated and have non-Sendable type, and none of the
-    // initial values require global actor isolation.
     if (!ctx.LangOpts.hasFeature(Feature::IsolatedDefaultValues)) {
       addNonIsolatedToSynthesized(decl, ctor);
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6636,7 +6636,8 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
     // backing storage is a stored 'var' that is part of the internal state
     // of the actor which could only be accessed in actor's isolation context.
     if (var->hasAttachedPropertyWrapper()) {
-      diagnoseAndRemoveAttr(attr, diag::nonisolated_wrapped_property);
+      diagnoseAndRemoveAttr(attr, diag::nonisolated_wrapped_property)
+        .warnUntilSwiftVersionIf(attr->isImplicit(), 6);
       return;
     }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4818,8 +4818,11 @@ DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
       return ActorIsolation::forUnspecified();
 
     auto i = pbd->getPatternEntryIndexForVarDecl(var);
+    if (!pbd->isInitializerChecked(i))
+      TypeChecker::typeCheckPatternBinding(pbd, i);
+
     dc = cast<Initializer>(pbd->getInitContext(i));
-    initExpr = var->getParentInitializer();
+    initExpr = pbd->getInit(i);
     enclosingIsolation = getActorIsolation(var);
   } else if (auto *param = dyn_cast<ParamDecl>(var)) {
     // If this parameter corresponds to a stored property for a

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3188,7 +3188,10 @@ namespace {
       if (!unsatisfiedIsolation)
         return false;
 
-      if (refineRequiredIsolation(*unsatisfiedIsolation))
+      bool onlyArgsCrossIsolation = callOptions.contains(
+          ActorReferenceResult::Flags::OnlyArgsCrossIsolation);
+      if (!onlyArgsCrossIsolation &&
+          refineRequiredIsolation(*unsatisfiedIsolation))
         return false;
 
       // At this point, we know a jump is made to the callee that yields
@@ -4808,6 +4811,7 @@ DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
 
   Initializer *dc = nullptr;
   Expr *initExpr = nullptr;
+  ActorIsolation enclosingIsolation;
 
   if (auto *pbd = var->getParentPatternBinding()) {
     if (!var->isParentInitialized())
@@ -4816,6 +4820,7 @@ DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
     auto i = pbd->getPatternEntryIndexForVarDecl(var);
     dc = cast<Initializer>(pbd->getInitContext(i));
     initExpr = var->getParentInitializer();
+    enclosingIsolation = getActorIsolation(var);
   } else if (auto *param = dyn_cast<ParamDecl>(var)) {
     // If this parameter corresponds to a stored property for a
     // memberwise initializer, the default argument is the default
@@ -4833,13 +4838,27 @@ DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
 
     dc = param->getDefaultArgumentInitContext();
     initExpr = param->getTypeCheckedDefaultExpr();
+    enclosingIsolation =
+        getActorIsolationOfContext(param->getDeclContext());
   }
 
   if (!dc || !initExpr)
     return ActorIsolation::forUnspecified();
 
+  // If the default argument has isolation, it must match the
+  // isolation of the decl context.
   ActorIsolationChecker checker(dc);
-  return checker.computeRequiredIsolation(initExpr);
+  auto requiredIsolation = checker.computeRequiredIsolation(initExpr);
+  if (requiredIsolation.isActorIsolated()) {
+    if (enclosingIsolation != requiredIsolation) {
+      var->diagnose(
+          diag::isolated_default_argument_context,
+          requiredIsolation, enclosingIsolation);
+      return ActorIsolation::forUnspecified();
+    }
+  }
+
+  return requiredIsolation;
 }
 
 void swift::checkOverrideActorIsolation(ValueDecl *value) {
@@ -5955,8 +5974,8 @@ bool swift::isAccessibleAcrossActors(
 }
 
 ActorReferenceResult ActorReferenceResult::forSameConcurrencyDomain(
-    ActorIsolation isolation) {
-  return ActorReferenceResult{SameConcurrencyDomain, llvm::None, isolation};
+    ActorIsolation isolation, Options options) {
+  return ActorReferenceResult{SameConcurrencyDomain, options, isolation};
 }
 
 ActorReferenceResult ActorReferenceResult::forEntersActor(
@@ -5965,8 +5984,8 @@ ActorReferenceResult ActorReferenceResult::forEntersActor(
 }
 
 ActorReferenceResult ActorReferenceResult::forExitsActorToNonisolated(
-    ActorIsolation isolation) {
-  return ActorReferenceResult{ExitsActorToNonisolated, llvm::None, isolation};
+    ActorIsolation isolation, Options options) {
+  return ActorReferenceResult{ExitsActorToNonisolated, options, isolation};
 }
 
 // Determine if two actor isolation contexts are considered to be equivalent.
@@ -6002,10 +6021,24 @@ ActorReferenceResult ActorReferenceResult::forReference(
       declIsolation = declIsolation.subst(declRef.getSubstitutions());
   }
 
+  // Determine what adjustments we need to perform for cross-actor
+  // references.
+  Options options = llvm::None;
+
+  // FIXME: Actor constructors are modeled as isolated to the actor
+  // so that Sendable checking is applied to their arguments, but the
+  // call itself does not hop to another executor.
+  if (auto ctor = dyn_cast<ConstructorDecl>(declRef.getDecl())) {
+    if (auto nominal = ctor->getDeclContext()->getSelfNominalTypeDecl()) {
+      if (nominal->isAnyActor())
+        options |= Flags::OnlyArgsCrossIsolation;
+    }
+  }
+
   // If the entity we are referencing is not a value, we're in the same
   // concurrency domain.
   if (isNonValueReference(declRef.getDecl()))
-    return forSameConcurrencyDomain(declIsolation);
+    return forSameConcurrencyDomain(declIsolation, options);
 
   // Compute the isolation of the context, if not provided.
   ActorIsolation contextIsolation = ActorIsolation::forUnspecified();
@@ -6024,11 +6057,11 @@ ActorReferenceResult ActorReferenceResult::forReference(
     if (isAsyncDecl(declRef) && contextIsolation.isActorIsolated() &&
         !declRef.getDecl()->getAttrs()
             .hasAttribute<UnsafeInheritExecutorAttr>())
-      return forExitsActorToNonisolated(contextIsolation);
+      return forExitsActorToNonisolated(contextIsolation, options);
 
     // Otherwise, we stay in the same concurrency domain, whether on an actor
     // or in a task.
-    return forSameConcurrencyDomain(declIsolation);
+    return forSameConcurrencyDomain(declIsolation, options);
   }
 
   // The declaration we are accessing is actor-isolated. First, check whether
@@ -6037,11 +6070,11 @@ ActorReferenceResult ActorReferenceResult::forReference(
       declIsolation.getActorInstanceParameter() == 0) {
     // If this instance is isolated, we're in the same concurrency domain.
     if (actorInstance->isIsolated())
-      return forSameConcurrencyDomain(declIsolation);
+      return forSameConcurrencyDomain(declIsolation, options);
   } else if (equivalentIsolationContexts(declIsolation, contextIsolation)) {
     // The context isolation matches, so we are in the same concurrency
     // domain.
-    return forSameConcurrencyDomain(declIsolation);
+    return forSameConcurrencyDomain(declIsolation, options);
   }
 
   // Initializing an actor isolated stored property with a value effectively
@@ -6061,7 +6094,8 @@ ActorReferenceResult ActorReferenceResult::forReference(
         // Treat the decl isolation as 'preconcurrency' to downgrade violations
         // to warnings, because violating Sendable here is accepted by the
         // Swift 5.9 compiler.
-        return forEntersActor(declIsolation, Flags::Preconcurrency);
+        options |= Flags::Preconcurrency;
+        return forEntersActor(declIsolation, options);
       }
     }
   }
@@ -6071,7 +6105,7 @@ ActorReferenceResult ActorReferenceResult::forReference(
   if (actorInstance &&
       checkedByFlowIsolation(
           fromDC, *actorInstance, declRef.getDecl(), declRefLoc, useKind))
-    return forSameConcurrencyDomain(declIsolation);
+    return forSameConcurrencyDomain(declIsolation, options);
 
   // If we are delegating to another initializer, treat them as being in the
   // same concurrency domain.
@@ -6080,7 +6114,7 @@ ActorReferenceResult ActorReferenceResult::forReference(
   if (actorInstance && actorInstance->isSelf() &&
       isa<ConstructorDecl>(declRef.getDecl()) &&
       isa<ConstructorDecl>(fromDC))
-    return forSameConcurrencyDomain(declIsolation);
+    return forSameConcurrencyDomain(declIsolation, options);
 
   // If there is an instance that corresponds to 'self',
   // we are in a constructor or destructor, and we have a stored property of
@@ -6090,18 +6124,14 @@ ActorReferenceResult ActorReferenceResult::forReference(
       isNonInheritedStorage(declRef.getDecl(), fromDC) &&
       declIsolation.isGlobalActor() &&
       (isa<ConstructorDecl>(fromDC) || isa<DestructorDecl>(fromDC)))
-    return forSameConcurrencyDomain(declIsolation);
-
-  // Determine what adjustments we need to perform for cross-actor
-  // references.
-  Options options = llvm::None;
+    return forSameConcurrencyDomain(declIsolation, options);
 
   // At this point, we are accessing the target from outside the actor.
   // First, check whether it is something that can be accessed directly,
   // without any kind of promotion.
   if (isAccessibleAcrossActors(
           declRef.getDecl(), declIsolation, fromDC, options, actorInstance))
-    return forEntersActor(declIsolation, llvm::None);
+    return forEntersActor(declIsolation, options);
 
   // This is a cross-actor reference.
 

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -202,6 +202,10 @@ struct ActorReferenceResult {
 
     /// The declaration is being accessed from a @preconcurrency context.
     Preconcurrency = 1 << 3,
+
+    /// Only arguments cross an isolation boundary, e.g. because they
+    /// escape into an actor in a nonisolated actor initializer.
+    OnlyArgsCrossIsolation = 1 << 4,
   };
 
   using Options = OptionSet<Flags>;
@@ -212,13 +216,13 @@ struct ActorReferenceResult {
 
 private:
   static ActorReferenceResult forSameConcurrencyDomain(
-      ActorIsolation isolation);
+      ActorIsolation isolation, Options options = llvm::None);
 
   static ActorReferenceResult forEntersActor(
       ActorIsolation isolation, Options options);
 
   static ActorReferenceResult forExitsActorToNonisolated(
-      ActorIsolation isolation);
+      ActorIsolation isolation, Options options = llvm::None);
 
 public:
   /// Determine what happens when referencing the given declaration from the

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1085,7 +1085,18 @@ static void checkDefaultArguments(ParameterList *params) {
   for (auto *param : *params) {
     auto ifacety = param->getInterfaceType();
     auto *expr = param->getTypeCheckedDefaultExpr();
-    (void)param->getInitializerIsolation();
+
+    // If the default argument has isolation, it must match the
+    // isolation of the decl context.
+    auto defaultArgIsolation = param->getInitializerIsolation();
+    if (defaultArgIsolation.isActorIsolated()) {
+      auto *dc = param->getDeclContext();
+      auto enclosingIsolation = getActorIsolationOfContext(dc);
+      if (enclosingIsolation != defaultArgIsolation) {
+        param->diagnose(diag::isolated_default_argument_context,
+            defaultArgIsolation, enclosingIsolation);
+      }
+    }
 
     if (!ifacety->hasPlaceholder()) {
       continue;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1088,15 +1088,7 @@ static void checkDefaultArguments(ParameterList *params) {
 
     // If the default argument has isolation, it must match the
     // isolation of the decl context.
-    auto defaultArgIsolation = param->getInitializerIsolation();
-    if (defaultArgIsolation.isActorIsolated()) {
-      auto *dc = param->getDeclContext();
-      auto enclosingIsolation = getActorIsolationOfContext(dc);
-      if (enclosingIsolation != defaultArgIsolation) {
-        param->diagnose(diag::isolated_default_argument_context,
-            defaultArgIsolation, enclosingIsolation);
-      }
-    }
+    (void)param->getInitializerIsolation();
 
     if (!ifacety->hasPlaceholder()) {
       continue;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2165,6 +2165,7 @@ public:
     (void) VD->getPropertyWrapperAuxiliaryVariables();
     (void) VD->getPropertyWrapperInitializerInfo();
     (void) VD->getImplInfo();
+    (void) getActorIsolation(VD);
 
     // Visit auxiliary decls first
     VD->visitAuxiliaryDecls([&](VarDecl *var) {

--- a/test/Concurrency/Inputs/sendable_cycle_other.swift
+++ b/test/Concurrency/Inputs/sendable_cycle_other.swift
@@ -1,3 +1,3 @@
 struct Foo {
-  static let member = Bar()
+  static let member = Bar() // expected-complete-warning {{static property 'member' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6}}
 }

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -43,7 +43,7 @@ actor TestActor {
 }
 
 @available(SwiftStdlib 5.1, *)
-func modifyAsynchronously(_ foo: inout Int) async { foo += 1 }
+@Sendable func modifyAsynchronously(_ foo: inout Int) async { foo += 1 }
 @available(SwiftStdlib 5.1, *)
 enum Container {
   static let modifyAsyncValue = modifyAsynchronously

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -765,7 +765,6 @@ actor LocalFunctionIsolatedActor {
 @available(SwiftStdlib 5.1, *)
 actor LazyActor {
     var v: Int = 0
-    // expected-note@-1 6 {{property declared here}}
 
     let l: Int = 0
 
@@ -773,7 +772,7 @@ actor LazyActor {
     lazy var l12: Int = v
     lazy var l13: Int = { self.v }()
     lazy var l14: Int = self.v
-    lazy var l15: Int = { [unowned self] in self.v }() // expected-error{{actor-isolated property 'v' can not be referenced from a non-isolated context}}
+    lazy var l15: Int = { [unowned self] in self.v }()
 
     lazy var l21: Int = { l }()
     lazy var l22: Int = l
@@ -782,15 +781,15 @@ actor LazyActor {
     lazy var l25: Int = { [unowned self] in self.l }()
 
     nonisolated lazy var l31: Int = { v }()
-    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from a non-isolated context}}
+    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
     nonisolated lazy var l32: Int = v
-    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from a non-isolated context}}
+    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
     nonisolated lazy var l33: Int = { self.v }()
-    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from a non-isolated context}}
+    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
     nonisolated lazy var l34: Int = self.v
-    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from a non-isolated context}}
+    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
     nonisolated lazy var l35: Int = { [unowned self] in self.v }()
-    // expected-error@-1 {{actor-isolated property 'v' can not be referenced from a non-isolated context}}
+    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
 
     nonisolated lazy var l41: Int = { l }()
     nonisolated lazy var l42: Int = l

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -11,6 +11,9 @@
 import OtherActors // expected-remark{{add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'OtherActors'}}{{1-1=@preconcurrency }}
 
 let immutableGlobal: String = "hello"
+
+// expected-warning@+2 {{var 'mutableGlobal' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+// expected-note@+1 {{isolate 'mutableGlobal' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -8,8 +8,12 @@ class GlobalCounter {
   var counter: Int = 0
 }
 
-let rs = GlobalCounter()
-var globalInt = 17 // expected-note 2{{var declared here}}
+let rs = GlobalCounter() // expected-warning {{let 'rs' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6}}
+
+var globalInt = 17 // expected-warning {{var 'globalInt' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+// expected-note@-1 {{isolate 'globalInt' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
+// expected-note@-2 2{{var declared here}}
+
 
 class MyError: Error { // expected-warning{{non-final class 'MyError' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
   var storage = 0 // expected-warning{{stored property 'storage' of 'Sendable'-conforming class 'MyError' is mutable}}

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -271,7 +271,8 @@ typealias CF = @Sendable () -> NotConcurrent?
 typealias BadGenericCF<T> = @Sendable () -> T?
 typealias GoodGenericCF<T: Sendable> = @Sendable () -> T? // okay
 
-var concurrentFuncVar: (@Sendable (NotConcurrent) -> Void)? = nil
+var concurrentFuncVar: (@Sendable (NotConcurrent) -> Void)? = nil // expected-warning{{var 'concurrentFuncVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+// expected-note@-1 {{isolate 'concurrentFuncVar' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 
 // ----------------------------------------------------------------------
 // Sendable restriction on @Sendable closures.

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -518,7 +518,9 @@ struct CardboardBox<T> {
 
 
 @available(SwiftStdlib 5.1, *)
-var globalVar: EscapeArtist? // expected-note 2 {{var declared here}}
+var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+// expected-note@-1 {{isolate 'globalVar' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
+// expected-note@-2 2 {{var declared here}}
 
 @available(SwiftStdlib 5.1, *)
 actor EscapeArtist {

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -warn-concurrency %S/Inputs/other_global_actor_inference.swift
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-sns-
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable -verify-additional-prefix complete-sns-
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted-
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted-
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable -verify-additional-prefix complete-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -437,13 +437,15 @@ actor WrapperActorBad2<Wrapped: Sendable> {
 struct WrapperWithMainActorDefaultInit {
   var wrappedValue: Int { fatalError() }
 
-  @MainActor init() {} // expected-note 2 {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+  @MainActor init() {} // expected-note {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+  // expected-minimal-targeted-note@-1 {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
 }
 
 actor ActorWithWrapper {
   @WrapperOnActor var synced: Int = 0
   // expected-note@-1 3{{property declared here}}
-  @WrapperWithMainActorDefaultInit var property: Int // expected-error {{call to main actor-isolated initializer 'init()' in a synchronous actor-isolated context}}
+  @WrapperWithMainActorDefaultInit var property: Int // expected-minimal-targeted-error {{call to main actor-isolated initializer 'init()' in a synchronous actor-isolated context}}
+  // expected-complete-tns-error@-1 {{main actor-isolated default value in a actor-isolated context}}
   func f() {
     _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced on a different actor instance}}
     _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced on a different actor instance}}
@@ -557,8 +559,9 @@ struct WrapperOnUnsafeActor<Wrapped> {
   }
 }
 
+// HasWrapperOnUnsafeActor gets an inferred @MainActor attribute.
 struct HasWrapperOnUnsafeActor {
-  @WrapperOnUnsafeActor var synced: Int = 0
+  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-tns-error {{global actor 'OtherGlobalActor'-isolated default value in a main actor-isolated context}}
   // expected-note @-1 3{{property declared here}}
   // expected-complete-sns-note @-2 3{{property declared here}}
 
@@ -643,11 +646,11 @@ func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable 
 
 // defer bodies inherit global actor-ness
 @MainActor
-var statefulThingy: Bool = false // expected-note {{var declared here}}
-// expected-complete-sns-error @-1 {{top-level code variables cannot have a global actor}}
+var statefulThingy: Bool = false // expected-minimal-targeted-note {{var declared here}}
+// expected-complete-tns-error @-1 {{top-level code variables cannot have a global actor}}
 
 @MainActor
-func useFooInADefer() -> String { // expected-note {{calls to global function 'useFooInADefer()' from outside of its actor context are implicitly asynchronous}}
+func useFooInADefer() -> String { // expected-minimal-targeted-note {{calls to global function 'useFooInADefer()' from outside of its actor context are implicitly asynchronous}}
   defer {
     statefulThingy = true
   }
@@ -677,9 +680,11 @@ class Cutter {
 
 @SomeGlobalActor
 class Butter {
-  var a = useFooInADefer() // expected-error {{call to main actor-isolated global function 'useFooInADefer()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
+  var a = useFooInADefer() // expected-minimal-targeted-error {{call to main actor-isolated global function 'useFooInADefer()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
+  // expected-complete-tns-error@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context}}
 
-  nonisolated let b = statefulThingy // expected-error {{main actor-isolated var 'statefulThingy' can not be referenced from a non-isolated context}}
+  nonisolated let b = statefulThingy // expected-minimal-targeted-error {{main actor-isolated var 'statefulThingy' can not be referenced from a non-isolated context}}
+  // expected-complete-tns-error@-1 {{main actor-isolated default value in a nonisolated context}}
 
   var c: Int = {
     return getGlobal7()

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -390,7 +390,7 @@ struct HasWrapperOnActor {
     synced = 17
   }
 
-  @WrapperActor var actorSynced: Int = 0
+  @WrapperActor var actorSynced: Int = 0 // expected-warning{{'nonisolated' is not supported on properties with property wrappers}}
 
   func testActorSynced() {
     _ = actorSynced
@@ -491,10 +491,10 @@ struct SimplePropertyWrapper {
 class WrappedContainsNonisolatedAttr {
   @SimplePropertyWrapper nonisolated var value 
   // expected-error@-1 {{'nonisolated' is not supported on properties with property wrappers}}
-  // expected-note@-2 2{{property declared here}}
+  // expected-note@-2 {{property declared here}}
 
   nonisolated func test() {
-    _ = value // expected-error {{main actor-isolated property 'value' can not be referenced from a non-isolated context}}
+    _ = value
     _ = $value // expected-error {{main actor-isolated property '$value' can not be referenced from a non-isolated context}}
   }
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -3,8 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted-
 // RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted-
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-experimental-feature SendNonSendable -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-sns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -445,7 +444,7 @@ actor ActorWithWrapper {
   @WrapperOnActor var synced: Int = 0
   // expected-note@-1 3{{property declared here}}
   @WrapperWithMainActorDefaultInit var property: Int // expected-minimal-targeted-error {{call to main actor-isolated initializer 'init()' in a synchronous actor-isolated context}}
-  // expected-complete-tns-error@-1 {{main actor-isolated default value in a actor-isolated context}}
+  // expected-complete-sns-error@-1 {{main actor-isolated default value in a actor-isolated context}}
   func f() {
     _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced on a different actor instance}}
     _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced on a different actor instance}}
@@ -561,7 +560,7 @@ struct WrapperOnUnsafeActor<Wrapped> {
 
 // HasWrapperOnUnsafeActor gets an inferred @MainActor attribute.
 struct HasWrapperOnUnsafeActor {
-  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-tns-error {{global actor 'OtherGlobalActor'-isolated default value in a main actor-isolated context}}
+  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-sns-error {{global actor 'OtherGlobalActor'-isolated default value in a main actor-isolated context}}
   // expected-note @-1 3{{property declared here}}
   // expected-complete-sns-note @-2 3{{property declared here}}
 
@@ -647,7 +646,7 @@ func acceptAsyncSendableClosureInheriting<T>(@_inheritActorContext _: @Sendable 
 // defer bodies inherit global actor-ness
 @MainActor
 var statefulThingy: Bool = false // expected-minimal-targeted-note {{var declared here}}
-// expected-complete-tns-error @-1 {{top-level code variables cannot have a global actor}}
+// expected-complete-sns-error @-1 {{top-level code variables cannot have a global actor}}
 
 @MainActor
 func useFooInADefer() -> String { // expected-minimal-targeted-note {{calls to global function 'useFooInADefer()' from outside of its actor context are implicitly asynchronous}}
@@ -681,10 +680,10 @@ class Cutter {
 @SomeGlobalActor
 class Butter {
   var a = useFooInADefer() // expected-minimal-targeted-error {{call to main actor-isolated global function 'useFooInADefer()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
-  // expected-complete-tns-error@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context}}
+  // expected-complete-sns-error@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context}}
 
   nonisolated let b = statefulThingy // expected-minimal-targeted-error {{main actor-isolated var 'statefulThingy' can not be referenced from a non-isolated context}}
-  // expected-complete-tns-error@-1 {{main actor-isolated default value in a nonisolated context}}
+  // expected-complete-sns-error@-1 {{main actor-isolated default value in a nonisolated context}}
 
   var c: Int = {
     return getGlobal7()

--- a/test/Concurrency/global_actor_inference_swift6.swift
+++ b/test/Concurrency/global_actor_inference_swift6.swift
@@ -117,7 +117,7 @@ struct HasWrapperOnActor {
     synced = 17
   }
 
-  @WrapperActor var actorSynced: Int = 0
+  @WrapperActor var actorSynced: Int = 0 // expected-error{{'nonisolated' is not supported on properties with property wrappers}}
 
   func testActorSynced() {
     _ = actorSynced

--- a/test/Concurrency/isolated_default_argument_eval.swift
+++ b/test/Concurrency/isolated_default_argument_eval.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-emit-silgen -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library %s | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@MainActor
+func requiresMainActor() -> Int { 0 }
+
+@MainActor
+func mainActorDefaultArg(value: Int = requiresMainActor()) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30isolated_default_argument_eval15mainActorCalleryyF
+@MainActor func mainActorCaller() {
+  mainActorDefaultArg()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s30isolated_default_argument_eval22nonisolatedAsyncCalleryyYaF
+func nonisolatedAsyncCaller() async {
+  // CHECK: hop_to_executor {{.*}} : $Optional<Builtin.Executor>
+  // CHECK: [[GETARG:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval19mainActorDefaultArg5valueySi_tFfA_
+  // CHECK: hop_to_executor {{.*}} : $MainActor
+  // CHECK-NEXT: apply [[GETARG]]()
+  // CHECK-NEXT: hop_to_executor {{.*}} : $Optional<Builtin.Executor>
+  await mainActorDefaultArg()
+}

--- a/test/Concurrency/isolated_default_argument_eval.swift
+++ b/test/Concurrency/isolated_default_argument_eval.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-silgen -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -I %t  -disable-availability-checking -strict-concurrency=complete -enable-upcoming-feature IsolatedDefaultValues -parse-as-library %s | %FileCheck %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_argument_eval.swift
+++ b/test/Concurrency/isolated_default_argument_eval.swift
@@ -9,17 +9,62 @@ func requiresMainActor() -> Int { 0 }
 @MainActor
 func mainActorDefaultArg(value: Int = requiresMainActor()) {}
 
+@MainActor
+func mainActorMultiDefaultArg(x: Int = requiresMainActor(),
+                              y: Int = 0,
+                              tuple: (Int, Int) = (requiresMainActor(), 2),
+                              z: Int = 0) {}
+
 // CHECK-LABEL: sil hidden [ossa] @$s30isolated_default_argument_eval15mainActorCalleryyF
 @MainActor func mainActorCaller() {
   mainActorDefaultArg()
+  mainActorMultiDefaultArg()
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s30isolated_default_argument_eval22nonisolatedAsyncCalleryyYaF
 func nonisolatedAsyncCaller() async {
   // CHECK: hop_to_executor {{.*}} : $Optional<Builtin.Executor>
-  // CHECK: [[GETARG:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval19mainActorDefaultArg5valueySi_tFfA_
   // CHECK: hop_to_executor {{.*}} : $MainActor
-  // CHECK-NEXT: apply [[GETARG]]()
-  // CHECK-NEXT: hop_to_executor {{.*}} : $Optional<Builtin.Executor>
+  // CHECK: [[GET_VALUE:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval19mainActorDefaultArg5valueySi_tFfA_
+  // CHECK-NEXT: apply [[GET_VALUE]]()
+  // CHECK: hop_to_executor {{.*}} : $Optional<Builtin.Executor>
   await mainActorDefaultArg()
+
+  // CHECK: hop_to_executor {{.*}} : $MainActor
+  // CHECK: [[GET_X:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval24mainActorMultiDefaultArg1x1y5tuple1zySi_S2i_SitSitFfA_
+  // CHECK-NEXT: apply [[GET_X]]()
+  // CHECK-NOT: hop_to_executor
+  // CHECK: [[GET_Y:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval24mainActorMultiDefaultArg1x1y5tuple1zySi_S2i_SitSitFfA0_
+  // CHECK-NEXT: apply [[GET_Y]]()
+  // CHECK-NOT: hop_to_executor
+  // CHECK: [[GET_TUPLE:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval24mainActorMultiDefaultArg1x1y5tuple1zySi_S2i_SitSitFfA1_
+  // CHECK-NEXT: apply [[GET_TUPLE]]()
+  // CHECK-NOT: hop_to_executor
+  // CHECK: [[GET_Z:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval24mainActorMultiDefaultArg1x1y5tuple1zySi_S2i_SitSitFfA2_
+  // CHECK-NEXT: apply [[GET_Z]]()
+  // CHECK: hop_to_executor {{.*}} : $Optional<Builtin.Executor>
+  await mainActorMultiDefaultArg()
+}
+
+@MainActor
+func isolatedDefaultInoutMix(x: inout Int, y: Int, z: Int = requiresMainActor()) {}
+
+var argValue: Int { 0 }
+
+// CHECK-LABEL: sil hidden [ossa] @$s30isolated_default_argument_eval20passInoutWithDefaultyyYaF
+func passInoutWithDefault() async {
+  // CHECK: hop_to_executor {{.*}} : $Optional<Builtin.Executor>
+
+  var x = 0
+
+  // CHECK: [[GET_ARG_VALUE:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval8argValueSivg
+  // CHECK-NEXT: [[ARG_VALUE:%[0-9]+]] = apply [[GET_ARG_VALUE]]()
+  // CHECK-NEXT: [[INOUT_X:%[0-9]+]] = begin_access [modify]
+  // CHECK: hop_to_executor {{.*}} : $MainActor
+  // CHECK: [[GET_Z:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval0A15DefaultInoutMix1x1y1zySiz_S2itFfA1_
+  // CHECK-NEXT: [[Z:%[0-9]+]] = apply [[GET_Z]]()
+  // CHECK: [[FN:%[0-9]+]] = function_ref @$s30isolated_default_argument_eval0A15DefaultInoutMix1x1y1zySiz_S2itF : $@convention(thin) (@inout Int, Int, Int) -> ()
+  // CHECK: apply [[FN]]([[INOUT_X]], [[ARG_VALUE]], [[Z]])
+  // CHECK: hop_to_executor {{.*}} : $Optional<Builtin.Executor>
+  await isolatedDefaultInoutMix(x: &x, y: argValue)
 }

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-upcoming-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -20,11 +20,11 @@ func requiresMainActor() -> Int { 0 }
 @SomeGlobalActor
 func requiresSomeGlobalActor() -> Int { 0 }
 
-// expected-error@+1 {{main actor-isolated default argument in a nonisolated context}}
+// expected-error@+1 {{main actor-isolated default value in a nonisolated context}}
 func mainActorDefaultArgInvalid(value: Int = requiresMainActor()) {}
 
 func mainActorClosureInvalid(
-  closure: () -> Int = { // expected-error {{main actor-isolated default argument in a nonisolated context}}
+  closure: () -> Int = { // expected-error {{main actor-isolated default value in a nonisolated context}}
     requiresMainActor()
   }
 ) {}
@@ -41,7 +41,7 @@ func mainActorDefaultArg(value: Int = requiresMainActor()) {}
 ) {}
 
 func mainActorClosureCall(
-  closure: Int = { // expected-error {{main actor-isolated default argument in a nonisolated context}}
+  closure: Int = { // expected-error {{main actor-isolated default value in a nonisolated context}}
     requiresMainActor()
   }()
 ) {}
@@ -153,6 +153,11 @@ struct S2 {
 struct S3 {
   // expected-error@+1 {{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
   var (x, y, z) = (requiresMainActor(), requiresSomeGlobalActor(), 10)
+}
+
+struct S4 {
+  // expected-error@+1 {{main actor-isolated default value in a nonisolated context}}
+  var x: Int = requiresMainActor()
 }
 
 @MainActor

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -195,3 +195,37 @@ extension A {
     _ = S2(required: 10)
   }
 }
+
+// expected-error@+1 {{default initializer for 'C1' cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+class C1 {
+  // expected-note@+1 {{initializer for property 'x' is main actor-isolated}}
+  @MainActor var x = requiresMainActor()
+  // expected-note@+1 {{initializer for property 'y' is global actor 'SomeGlobalActor'-isolated}}
+  @SomeGlobalActor var y = requiresSomeGlobalActor()
+}
+
+class NonSendable {}
+
+// expected-error@+1 {{default initializer for 'C2' cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+class C2 {
+  // expected-note@+1 {{initializer for property 'x' is main actor-isolated}}
+  @MainActor var x = NonSendable()
+  // expected-note@+1 {{initializer for property 'y' is global actor 'SomeGlobalActor'-isolated}}
+  @SomeGlobalActor var y = NonSendable()
+}
+
+class C3 {
+  @MainActor var x = 1
+  @SomeGlobalActor var y = 2
+}
+
+@MainActor struct NonIsolatedInit {
+  var x = 0
+  var y = 0
+}
+
+func callDefaultInit() async {
+  _ = C2()
+  _ = NonIsolatedInit()
+  _ = NonIsolatedInit(x: 10)
+}

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -20,16 +20,28 @@ func requiresMainActor() -> Int { 0 }
 @SomeGlobalActor
 func requiresSomeGlobalActor() -> Int { 0 }
 
+// expected-error@+1 {{main actor-isolated default argument in a nonisolated context}}
+func mainActorDefaultArgInvalid(value: Int = requiresMainActor()) {}
+
+func mainActorClosureInvalid(
+  closure: () -> Int = { // expected-error {{main actor-isolated default argument in a nonisolated context}}
+    requiresMainActor()
+  }
+) {}
+
+// expected-note@+2 {{calls to global function 'mainActorDefaultArg(value:)' from outside of its actor context are implicitly asynchronous}}
+@MainActor
 func mainActorDefaultArg(value: Int = requiresMainActor()) {}
 
-func mainActorClosure(
+// expected-note@+1 {{calls to global function 'mainActorClosure(closure:)' from outside of its actor context are implicitly asynchronous}}
+@MainActor func mainActorClosure(
   closure: () -> Int = {
     requiresMainActor()
   }
 ) {}
 
 func mainActorClosureCall(
-  closure: Int = {
+  closure: Int = { // expected-error {{main actor-isolated default argument in a nonisolated context}}
     requiresMainActor()
   }()
 ) {}
@@ -40,40 +52,29 @@ func mainActorClosureCall(
   mainActorClosureCall()
 }
 
+// expected-note@+1 2 {{add '@MainActor' to make global function 'nonisolatedCaller()' part of global actor 'MainActor'}}
 func nonisolatedCaller() {
-  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-error@+1 {{call to main actor-isolated global function 'mainActorDefaultArg(value:)' in a synchronous nonisolated context}}
   mainActorDefaultArg()
 
-  // FIXME: confusing error message.
-  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-error@+1 {{call to main actor-isolated global function 'mainActorClosure(closure:)' in a synchronous nonisolated context}}
   mainActorClosure()
-
-  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
-  mainActorClosureCall()
 }
 
 func nonisolatedAsyncCaller() async {
-  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@+1 {{calls to global function 'mainActorDefaultArg(value:)' from outside of its actor context are implicitly asynchronous}}
   mainActorDefaultArg()
 
-  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@+1 {{calls to global function 'mainActorClosure(closure:)' from outside of its actor context are implicitly asynchronous}}
   mainActorClosure()
-
-  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
-  mainActorClosureCall()
 
   await mainActorDefaultArg(value: requiresMainActor())
 
-  // 'await' doesn't help closures in default arguments; the calling context needs a matching
-  // actor isolation for that isolation to be inferred for the closure value.
-
-  // expected-error@+2 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
-  // expected-warning@+1 {{no 'async' operations occur within 'await' expression}}
   await mainActorClosure()
 
-  // expected-error@+2 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
-  // expected-warning@+1 {{no 'async' operations occur within 'await' expression}}
-  await mainActorClosureCall()
+  mainActorClosureCall()
 }
 
 func conflictingIsolationDefaultArg(
@@ -125,6 +126,7 @@ func closureWithIsolatedParam(
   }
 ) {}
 
+// expected-note@+2 3 {{calls to initializer 'init(required:x:y:)' from outside of its actor context are implicitly asynchronous}}
 @MainActor
 struct S1 {
   var required: Int
@@ -136,6 +138,7 @@ struct S1 {
   static var z: Int = requiresMainActor()
 }
 
+// expected-note@+2 3 {{calls to initializer 'init(required:x:y:)' from outside of its actor context are implicitly asynchronous}}
 @SomeGlobalActor
 struct S2 {
   var required: Int
@@ -156,32 +159,34 @@ struct S3 {
 func initializeFromMainActor() {
   _ = S1(required: 10)
 
-  // expected-error@+1 {{global actor 'SomeGlobalActor'-isolated default argument cannot be synchronously evaluated from a main actor-isolated context}}
+  // expected-error@+1 {{call to global actor 'SomeGlobalActor'-isolated initializer 'init(required:x:y:)' in a synchronous main actor-isolated context}}
   _ = S2(required: 10)
 }
 
 @SomeGlobalActor
 func initializeFromSomeGlobalActor() {
-  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a global actor 'SomeGlobalActor'-isolated context}}
+  // expected-error@+1 {{call to main actor-isolated initializer 'init(required:x:y:)' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
   _ = S1(required: 10)
 
   _ = S2(required: 10)
 }
 
+// expected-note@+2 {{add '@MainActor' to make global function 'initializeFromNonisolated()' part of global actor 'MainActor'}}
+// expected-note@+1 {{add '@SomeGlobalActor' to make global function 'initializeFromNonisolated()' part of global actor 'SomeGlobalActor'}}
 func initializeFromNonisolated() {
-  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-error@+1 {{call to main actor-isolated initializer 'init(required:x:y:)' in a synchronous nonisolated context}}
   _ = S1(required: 10)
 
-  // expected-error@+1 {{global actor 'SomeGlobalActor'-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
+  // expected-error@+1 {{call to global actor 'SomeGlobalActor'-isolated initializer 'init(required:x:y:)' in a synchronous nonisolated context}}
   _ = S2(required: 10)
 }
 
 extension A {
   func initializeFromActorInstance() {
-    // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a actor-isolated context}}
+    // expected-error@+1 {{call to main actor-isolated initializer 'init(required:x:y:)' in a synchronous actor-isolated context}}
     _ = S1(required: 10)
 
-    // expected-error@+1 {{global actor 'SomeGlobalActor'-isolated default argument cannot be synchronously evaluated from a actor-isolated context}}
+    // expected-error@+1 {{call to global actor 'SomeGlobalActor'-isolated initializer 'init(required:x:y:)' in a synchronous actor-isolated context}}
     _ = S2(required: 10)
   }
 }

--- a/test/Concurrency/isolated_default_arguments_serialized.swift
+++ b/test/Concurrency/isolated_default_arguments_serialized.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-experimental-feature IsolatedDefaultValues %S/Inputs/serialized_default_arguments.swift
+// RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedDefaultArguments.swiftmodule -module-name SerializedDefaultArguments -enable-upcoming-feature IsolatedDefaultValues %S/Inputs/serialized_default_arguments.swift
 
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable -enable-experimental-feature IsolatedDefaultValues
+// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature SendNonSendable -enable-upcoming-feature IsolatedDefaultValues
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_default_arguments_serialized.swift
+++ b/test/Concurrency/isolated_default_arguments_serialized.swift
@@ -16,7 +16,6 @@ func mainActorCaller() {
 }
 
 func nonisolatedCaller() async {
-  // expected-error@+1 {{main actor-isolated default argument cannot be synchronously evaluated from a nonisolated context}}
   await useMainActorDefault()
 
   await useMainActorDefault(mainActorDefaultArg())

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -19,11 +19,11 @@ func requiresMainActor() -> Int { 0 }
 @SomeGlobalActor
 func requiresSomeGlobalActor() -> Int { 0 }
 
-struct S1 {
+class C1 {
   // expected-note@+1 2 {{'self.x' not initialized}}
-  var x = requiresMainActor()
+  @MainActor var x = requiresMainActor()
   // expected-note@+1 2 {{'self.y' not initialized}}
-  var y = requiresSomeGlobalActor()
+  @SomeGlobalActor var y = requiresSomeGlobalActor()
   var z = 10
 
   // expected-error@+1 {{return from initializer without initializing all stored properties}}
@@ -36,9 +36,9 @@ struct S1 {
   @SomeGlobalActor init(c: Int) {}
 }
 
-struct S2 {
-  var x = requiresMainActor()
-  var y = requiresSomeGlobalActor()
+class C2 {
+  @MainActor var x = requiresMainActor()
+  @SomeGlobalActor var y = requiresSomeGlobalActor()
   var z = 10
 
   nonisolated init(x: Int, y: Int) {

--- a/test/Concurrency/isolated_default_property_inits.swift
+++ b/test/Concurrency/isolated_default_property_inits.swift
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-upcoming-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -81,7 +81,7 @@ func testElsewhere(x: X) {
 }
 
 func testCalls(x: X) {
-  // expected-complete-tns-note @-1 2{{add '@MainActor' to make global function 'testCalls(x:)' part of global actor 'MainActor'}}
+  // expected-complete-sns-note @-1 2{{add '@MainActor' to make global function 'testCalls(x:)' part of global actor 'MainActor'}}
 
   unsafelyMainActorClosure {
     onMainActor()
@@ -108,7 +108,7 @@ func testCalls(x: X) {
   let c = MyModelClass()
 
   // okay with minimal/targeted... an error with complete.
-  c.f() // expected-complete-tns-warning {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  c.f() // expected-complete-sns-error {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
 }
 
 func testCallsWithAsync() async {
@@ -117,10 +117,10 @@ func testCallsWithAsync() async {
 
   let _: () -> Void = onMainActorAlways // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
-  let c = MyModelClass() // expected-minimal-targeted-warning{{expression is 'async' but is not marked with 'await'}}
+  let c = MyModelClass() // expected-minimal-targeted-error{{expression is 'async' but is not marked with 'await'}}
   // expected-minimal-targeted-note@-1{{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
 
-  c.f() // expected-warning{{expression is 'async' but is not marked with 'await'}}
+  c.f() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 }
 

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -59,18 +59,18 @@ func testElsewhere(x: X) {
 // expected-note@-1{{are implicitly asynchronous}}
 
 @preconcurrency @MainActor class MyModelClass {
- // expected-note@-1{{are implicitly asynchronous}}
  func f() { }
   // expected-note@-1{{are implicitly asynchronous}}
 }
 
 func testCalls(x: X) {
-  // expected-note@-1 3{{add '@MainActor' to make global function 'testCalls(x:)' part of global actor 'MainActor'}}
+  // expected-note@-1 2{{add '@MainActor' to make global function 'testCalls(x:)' part of global actor 'MainActor'}}
   onMainActorAlways() // expected-error{{call to main actor-isolated global function 'onMainActorAlways()' in a synchronous nonisolated context}}
 
   let _: () -> Void = onMainActorAlways // expected-error{{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
-  let c = MyModelClass() // expected-error{{call to main actor-isolated initializer 'init()' in a synchronous nonisolated context}}
+  let c = MyModelClass() // okay, synthesized init() is 'nonisolated'
+
   c.f() // expected-error{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
 }
 
@@ -80,8 +80,8 @@ func testCallsWithAsync() async {
 
   let _: () -> Void = onMainActorAlways // expected-error{{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
-  let c = MyModelClass() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+  let c = MyModelClass() // okay, synthesized init() is 'nonisolated'
+
   c.f() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 }

--- a/test/Concurrency/sendable_cycle.swift
+++ b/test/Concurrency/sendable_cycle.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null
 // RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=targeted
-// RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=complete -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend %S/Inputs/sendable_cycle_other.swift  -disable-availability-checking %s -verify -emit-sil -o /dev/null -strict-concurrency=complete -verify-additional-prefix complete-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -emit-sil -verify -o /dev/null %s
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s -enable-experimental-feature SendNonSendable
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s -verify-additional-prefix complete-
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -emit-sil -verify -o /dev/null %s -enable-experimental-feature SendNonSendable -verify-additional-prefix complete-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -8,14 +8,18 @@
 @available(SwiftStdlib 5.1, *)
 struct TL {
   @TaskLocal
-  static var number: Int = 0
+  static var number: Int = 0 // expected-complete-warning {{static property 'number' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+  // expected-complete-note@-1 {{isolate 'number' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 
   @TaskLocal
-  static var someNil: Int?
+  static var someNil: Int? // expected-complete-warning {{static property 'someNil' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+  // expected-complete-note@-1 {{isolate 'someNil' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 
   @TaskLocal
   static var noValue: Int // expected-error{{'static var' declaration requires an initializer expression or an explicitly stated getter}}
   // expected-note@-1{{add an initializer to silence this error}}
+  // expected-complete-warning@-2 {{static property 'noValue' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+  // expected-complete-note@-3 {{isolate 'noValue' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 
   @TaskLocal
   var notStatic: String? // expected-error{{property 'notStatic', must be static because property wrapper 'TaskLocal<String?>' can only be applied to static properties}}


### PR DESCRIPTION
* **Explanation**: 

SE-0411: Isolated Default Values closed an important hole in Swift's static data-race safety model which prevents actor-isolated default stored property values from being synchronously evaluated from outside the actor. For example, the following code is currently valid, but it will crash at runtime at the call to `MainActor.assertIsolated()`:

```swift
@MainActor func requiresMainActor() -> Int {
  MainActor.assertIsolated()
  return 0
}

@MainActor struct S {
  var x = requiresMainActor()
  var y: Int
}

nonisolated func call() async {
  let s = await S(y: 10)
}

await call()
```

This happens because `requiresMainActor()` is used as a default argument to the member-wise initializer of `S`, but default arguments are always evaluated in the caller. In this case, the caller is on the generic executor, so the default argument evaluation crashes. Under `-enable-upcoming-feature IsolatedDefaultValues`, this code is still value, but callees that have isolated default arguments will hop to the isolation domain before evaluating the default arguments.

* **Scope**: Only impacts code that builds with `-strict-concurrency=complete`. Code can also opt into this feature using `-enable-upcoming-feature IsolatedDefaultValues`. More specifically, this change impacts structs and classes whose stored properties are global actor isolated and their initial values must run on that global actor.
* **Risk**:

Medium. This is technically a source breaking change for code that uses isolated stored property initial values in a `nonisolated` initializer: 

```swift
@MainActor func requiresMainActor() -> Int {
  MainActor.assertIsolated()
  return 0
}

class C {
  @MainActor var x = requiresMainActor()

  init() {}
}
```

In Swift 5.9, the above code is valid. With this change, it's invalid under `-strict-concurrency=complete`:

```
error: return from initializer without initializing all stored properties
  init() {}
          ^
note: 'self.x' not initialized
  @MainActor var x = requiresMainActor()
                 ^
```

However, I believe such code is rare in practice, and the common code pattern that currently exhibits data races is like the above example, which remains valid (but safe) under this proposal.
* **Testing**: Updated existing tests that use `-strict-concurrency=complete` and added new unit tests for `IsolatedDefaultValues`. The `main` PR for enabling `IsolatedDefaultValues` under `-strict-concurrency=complete` also passed the source compatibility suite.
* **Issue**: Resolves #58177.
* **Main branch PRs**:
  * https://github.com/apple/swift/pull/69391
  * https://github.com/apple/swift/pull/69974
  * https://github.com/apple/swift/pull/70257
  * https://github.com/apple/swift/pull/70222 