### PR TITLE
docs: add documentation for the `-sil-pass-count-config-file` option in DebuggingTheCompiler

### DIFF
--- a/docs/DebuggingTheCompiler.md
+++ b/docs/DebuggingTheCompiler.md
@@ -738,6 +738,11 @@ it's quite easy to do this manually:
    the sub-pass number. The option `-Xllvm -sil-opt-pass-count=<n>.<m>`
    can be used for that, where `m` is the sub-pass number.
 
+For bisecting pass counts in large projects, the pass counts can be read from
+a configuration file using the `-Xllvm -sil-pass-count-config-file=<file>`
+option. For details see the comment for `SILPassCountConfigFile` in the pass
+manager sources.
+
 ### Using git-bisect in the presence of branch forwarding/feature branches
 
 `git-bisect` is a useful tool for finding where a regression was

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -71,7 +71,7 @@ llvm::cl::opt<std::string> SILNumOptPassesToRun(
 
 // Read pass counts for each module from a config file.
 // Config file format:
-//   <module-name>:<pass-count>(.<sub-pass-count>)
+//   <module-name>:<pass-count>(.<sub-pass-count>)?
 //
 // This is useful for bisecting passes in large projects:
 //   1. create a config file from a full build log. E.g. with

--- a/utils/swift-autocomplete.bash
+++ b/utils/swift-autocomplete.bash
@@ -8,6 +8,10 @@ _swift_complete()
   local tool currentWord prevWord
 
   tool="${COMP_WORDS[0]}"
+  if alias "$tool" >/dev/null; then
+    tool=`alias "$tool" | sed "s/.*'\\(.*\\)'.*/\\1/"`
+  fi
+  
   currentWord="${COMP_WORDS[COMP_CWORD]}"
   prevWord="${COMP_WORDS[COMP_CWORD-1]}"
 
@@ -92,6 +96,7 @@ _swift_complete()
       -sil-lower-agg-instrs-expand-all \
       -sil-merge-stack-slots \
       -sil-opt-pass-count \
+      -sil-pass-count-config-file \
       -sil-opt-remark-ignore-always-infer \
       -sil-optimized-access-markers \
       -sil-ownership-verifier-enable-testing \


### PR DESCRIPTION
Also, add this option in swift-autocomplete.bash.
Unrelated: support aliased commands in swift-autocomplete.bash

This is a follow-up of https://github.com/apple/swift/pull/70786
