### PR TITLE
Sema: exempt some imports from the warning on implementation-only use from non-resilient modules

### DIFF
--- a/test/Sema/implementation-only-import-from-non-resilient.swift
+++ b/test/Sema/implementation-only-import-from-non-resilient.swift
@@ -12,6 +12,13 @@
 // RUN: %target-swift-frontend -typecheck %t/client-resilient.swift -I %t -verify \
 // RUN:   -enable-library-evolution -swift-version 5
 
+/// Some imports are exempt.
+// RUN: %target-swift-frontend -emit-module %t/empty.swift \
+// RUN:   -o %t/CCryptoBoringSSL.swiftmodule \
+// RUN:   -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -typecheck %t/Crypto.swift -I %t -verify \
+// RUN:   -module-name Crypto
+
 //--- empty.swift
 
 //--- client-non-resilient.swift
@@ -21,3 +28,8 @@ import B
 //--- client-resilient.swift
 @_implementationOnly import A
 import B
+
+//--- Crypto.swift
+@_implementationOnly import A // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'Crypto' may lead to instability during execution}}
+import B
+@_implementationOnly import CCryptoBoringSSL


### PR DESCRIPTION
The correct use `@_implementationOnly` from a non-resilient module is not enforced by the compiler at this time. Using that configuration can cause memory corruption at runtime if it affects the memory layout of types, and it can lead to compiler crashes at compilation in general.

Some modules rely on this configuration with a very limited use for it. We can grandfather them in its use and silence the warning on specific import edges.