### PR TITLE
[Concurrency] Fix more missing builtin guards for DiscardingTaskGroup

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -85,6 +85,7 @@ LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroup, 0, "Task create in task group bu
 LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroupWithExecutor, 0, "Task create in task group builtin with extra flags")
 LANGUAGE_FEATURE(BuiltinCreateAsyncDiscardingTaskInGroup, 0, "Task create in discarding task group builtin, accounting for the Void return type")
 LANGUAGE_FEATURE(BuiltinCreateAsyncTaskWithExecutor, 0, "Task create builtin with extra executor preference")
+LANGUAGE_FEATURE(BuiltinCreateAsyncDiscardingTaskInGroupWithExecutor, 0, "Task create in discarding task group with extra executor preference")
 LANGUAGE_FEATURE(BuiltinCopy, 0, "Builtin.copy()")
 LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc")
 LANGUAGE_FEATURE(BuiltinUnprotectedStackAlloc, 0, "Builtin.unprotectedStackAlloc")

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3296,6 +3296,11 @@ static bool usesFeatureBuiltinCreateAsyncTaskWithExecutor(Decl *decl) {
   return false;
 }
 
+static bool
+usesFeatureBuiltinCreateAsyncDiscardingTaskInGroupWithExecutor(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureBuiltinCopy(Decl *decl) { return false; }
 
 static bool usesFeatureBuiltinTaskRunInline(Decl *) { return false; }

--- a/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
+++ b/stdlib/public/Concurrency/TaskGroup+TaskExecutor.swift
@@ -223,7 +223,7 @@ extension DiscardingTaskGroup {
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) {
-    #if $BuiltinCreateAsyncTaskInGroupWithExecutor
+    #if $BuiltinCreateAsyncDiscardingTaskInGroupWithExecutor
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
@@ -265,7 +265,7 @@ extension DiscardingTaskGroup {
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async -> Void
   ) -> Bool {
-    #if $BuiltinCreateAsyncTaskInGroupWithExecutor
+    #if $BuiltinCreateAsyncDiscardingTaskInGroupWithExecutor
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
 
     guard canAdd else {
@@ -317,7 +317,7 @@ extension ThrowingDiscardingTaskGroup {
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) {
-    #if $BuiltinCreateAsyncTaskInGroupWithExecutor
+    #if $BuiltinCreateAsyncDiscardingTaskInGroupWithExecutor
     let flags = taskCreateFlags(
       priority: priority, isChildTask: true, copyTaskLocals: false,
       inheritContext: false, enqueueJob: true,
@@ -359,7 +359,7 @@ extension ThrowingDiscardingTaskGroup {
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping () async throws -> Void
   ) -> Bool {
-    #if $BuiltinCreateAsyncTaskInGroupWithExecutor
+    #if $BuiltinCreateAsyncDiscardingTaskInGroupWithExecutor
     let canAdd = _taskGroupAddPendingTask(group: _group, unconditionally: false)
 
     guard canAdd else {


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/70837 to add guards for more built-ins that were recently introduced.

Further resolves rdar://120801949