### PR TITLE
[c-interop] Make Extern a suppressible language feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -112,6 +112,7 @@ LANGUAGE_FEATURE(FreestandingMacros, 397, "freestanding declaration macros")
 SUPPRESSIBLE_LANGUAGE_FEATURE(RetroactiveAttribute, 364, "@retroactive")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)")
 LANGUAGE_FEATURE(TypedThrows, 413, "Typed throws")
+SUPPRESSIBLE_LANGUAGE_FEATURE(Extern, 0, "@_extern")
 
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
 UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
@@ -245,9 +246,6 @@ EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 /// Enable non-escapable type attributes and function attributes that support
 /// lifetime-dependent results.
 EXPERIMENTAL_FEATURE(NonescapableTypes, false)
-
-/// Enable the `@_extern` attribute.
-EXPERIMENTAL_FEATURE(Extern, true)
 
 // Infer Sendability of unapplied and partial applied methods,
 // global functions and key paths.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3885,6 +3885,14 @@ static bool usesFeatureExtern(Decl *decl) {
   return decl->getAttrs().hasAttribute<ExternAttr>();
 }
 
+static void suppressingFeatureExtern(PrintOptions &options,
+                                     llvm::function_ref<void()> action) {
+  unsigned originalExcludeAttrCount = options.ExcludeAttrList.size();
+  options.ExcludeAttrList.push_back(DAK_Extern);
+  action();
+  options.ExcludeAttrList.resize(originalExcludeAttrCount);
+}
+
 static bool usesFeatureStaticExclusiveOnly(Decl *decl) {
   return decl->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>();
 }

--- a/test/ModuleInterface/extern_attr.swift
+++ b/test/ModuleInterface/extern_attr.swift
@@ -6,15 +6,21 @@
 
 // CHECK:      #if compiler(>=5.3) && $Extern
 // CHECK-NEXT:   @_extern(c) public func externalCFunc()
+// CHECK-NEXT: #else
+// CHECK-NEXT:   public func externalCFunc()
 // CHECK-NEXT: #endif
 @_extern(c) public func externalCFunc()
 
 // CHECK:      #if compiler(>=5.3) && $Extern
 // CHECK-NEXT:   @_extern(c, "renamedCFunc") public func externalRenamedCFunc()
+// CHECK-NEXT: #else
+// CHECK-NEXT:   public func externalRenamedCFunc()
 // CHECK-NEXT: #endif
 @_extern(c, "renamedCFunc") public func externalRenamedCFunc()
 
 // CHECK:      #if compiler(>=5.3) && $Extern
 // CHECK-NEXT:   @_extern(wasm, module: "m", name: "f") public func wasmImportedFunc()
+// CHECK-NEXT: #else
+// CHECK-NEXT:  public func wasmImportedFunc()
 // CHECK-NEXT: #endif
 @_extern(wasm, module: "m", name: "f") public func wasmImportedFunc()


### PR DESCRIPTION
Fixes building the standard library's .swiftinterface with older Swift compilers.