### PR TITLE
ASTDumper: Fix archetype address dumping

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -445,6 +445,7 @@ static unsigned getDumpString(unsigned value) {
 static size_t getDumpString(size_t value) {
   return value;
 }
+static void *getDumpString(void *value) { return value; }
 
 //===----------------------------------------------------------------------===//
 //  Decl printing.

--- a/unittests/AST/ASTDumperTests.cpp
+++ b/unittests/AST/ASTDumperTests.cpp
@@ -1,0 +1,56 @@
+//===--- ASTDumperTests.cpp - Tests for ASTDumper -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "TestContext.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/GenericSignature.h"
+#include "swift/AST/Types.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include "gtest/gtest.h"
+#include <string>
+
+using namespace swift;
+using namespace swift::unittest;
+
+TEST(ASTDumper, ArchetypeType) {
+  TestContext C;
+  auto &ctx = C.Ctx;
+
+  auto *genericParamTy = GenericTypeParamType::get(false, 0, 0, ctx);
+  auto sig = buildGenericSignature(ctx, nullptr, {genericParamTy}, {});
+
+  TypeBase *archetype = nullptr;
+  {
+    llvm::SmallVector<ProtocolDecl *> protocols;
+    archetype = PrimaryArchetypeType::getNew(ctx, sig.getGenericEnvironment(),
+                                             genericParamTy, protocols, Type(),
+                                             nullptr);
+  }
+
+  std::string fullStr;
+  {
+    llvm::raw_string_ostream os(fullStr);
+    archetype->dump(os);
+  }
+
+  llvm::StringRef str(fullStr);
+  EXPECT_TRUE(str.consume_front("(primary_archetype_type address=0x"));
+  {
+    intptr_t integer;
+    EXPECT_FALSE(str.consumeInteger(16, integer));
+  }
+
+  EXPECT_EQ(str,
+            " name=\"\\xCF\\x84_0_0\"\n"
+            "  (interface_type=generic_type_param_type depth=0 index=0))\n");
+}

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_swift_unittest(SwiftASTTests
   ArithmeticEvaluator.cpp
+  ASTDumperTests.cpp
   IndexSubsetTests.cpp
   DiagnosticConsumerTests.cpp
   SourceLocTests.cpp


### PR DESCRIPTION
The best `getDumpString` match we had for `void *` was the one that takes a `bool`.
