### PR TITLE
CMake: on Darwin be explicit about inclusion in the dyld shared cache

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -19,6 +19,19 @@ if(SWIFT_STDLIB_SIL_DEBUGGING)
   list(APPEND SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "-Xfrontend" "-sil-based-debuginfo")
 endif()
 
+option(SWIFT_RUNTIME_DYLD_SHARED_CACHE_COMPATIBLE
+       "On Darwin platforms, link the standard library in a way that
+       allows inclusion in the dyld shared cache"
+       FALSE)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND
+   LLVM_LINKER_IS_APPLE AND
+   NOT SWIFT_RUNTIME_DYLD_SHARED_CACHE_COMPATIBLE)
+  set(shared_cache_link_flags "LINKER:-not_for_dyld_shared_cache")
+  list(APPEND SWIFT_RUNTIME_LINK_FLAGS ${shared_cache_link_flags})
+  list(APPEND SWIFT_RUNTIME_SWIFT_LINK_FLAGS ${shared_cache_link_flags})
+endif()
+
 # Build the runtime with -Wall to catch, e.g., uninitialized variables
 # warnings.
 if(SWIFT_COMPILER_IS_MSVC_LIKE)

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -173,6 +173,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     -diagnostic-style swift
     ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
   ${swift_concurrency_options}
+  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
   INSTALL_IN_COMPONENT stdlib
   MACCATALYST_BUILD_FLAVOR zippered
 )

--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -29,6 +29,7 @@ add_swift_target_library(swiftObservation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
 
   C_COMPILE_FLAGS
     ${swift_runtime_library_compile_flags}
+  LINK_FLAGS "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
 
   SWIFT_MODULE_DEPENDS _Concurrency
   INSTALL_IN_COMPONENT stdlib

--- a/stdlib/public/Synchronization/CMakeLists.txt
+++ b/stdlib/public/Synchronization/CMakeLists.txt
@@ -32,6 +32,9 @@ add_swift_target_library(swiftSynchronization ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES
     "-enable-experimental-feature" "RawLayout"
     "-enable-experimental-feature" "StaticExclusiveOnly"
 
+  LINK_FLAGS
+    "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}"
+
   INSTALL_IN_COMPONENT
     stdlib
 


### PR DESCRIPTION
This entails passing a linker flags to Apple linkers when the standard library is not meant for inclusion in such cache.

For this to have effect on every library, propagate link flags when building _Concurrency and Observation.

This is needed for Apple internal configurations.

Addresses rdar://120653968