### PR TITLE
[Sema] Classes with actor-isolated mutable properties should conform to Sendable

### DIFF
--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -343,17 +343,22 @@ class C9: Sendable { } // expected-warning{{non-final class 'C9' cannot conform 
 
 @globalActor
 struct SomeActor {
-  static var shared = A1()
+  static let shared = A1()
 }
+
+class NotSendable {}
+
 // actor-isolated mutable properties are valid
 final class C10: Sendable {
   @MainActor var x = 0
-  @SomeActor var y = 1
+  @MainActor var ns1 : NotSendable?
+  @MainActor let ns : NotSendable? = nil
 }
 
-// 'nonisolated (unsafe)' mutable properties are valid
-final class C13: Sendable {
-  nonisolated (unsafe) var z = 2
+final class C14: Sendable {
+  @SomeActor var y = 1
+  @SomeActor var nc = NotConcurrent()
+  @SomeActor let nc1 = NotConcurrent()
 }
 
 extension NotConcurrent {

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -341,6 +341,21 @@ final class C7<T>: Sendable { }
 
 class C9: Sendable { } // expected-warning{{non-final class 'C9' cannot conform to 'Sendable'; use '@unchecked Sendable'}}
 
+@globalActor
+struct SomeActor {
+  static var shared = A1()
+}
+// actor-isolated mutable properties are valid
+final class C10: Sendable {
+  @MainActor var x = 0
+  @SomeActor var y = 1
+}
+
+// 'nonisolated (unsafe)' mutable properties are valid
+final class C13: Sendable {
+  nonisolated (unsafe) var z = 2
+}
+
 extension NotConcurrent {
   func f() { }
 


### PR DESCRIPTION
Allow classes with mutable properties to conform to Sendable if properties are actor-isolated.

Fixes rdar://98735434