### PR TITLE
[CMake] Propagate header changes to pure Swift modules

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -264,40 +264,6 @@ else()
 
   add_subdirectory(Sources)
 
-  # TODO: generate this dynamically through the modulemap; this cannot use `sed`
-  # as that is not available on all platforms (e.g. Windows).
-  #
-  # step 1: generate a dummy source file, which just includes all headers
-  # defined in include/swift/module.modulemap
-  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp.tmp"
-       "
-#define COMPILED_WITH_SWIFT
-
-#include \"swift/Basic/BasicBridging.h\"
-#include \"swift/SIL/SILBridging.h\"
-#include \"swift/SILOptimizer/OptimizerBridging.h\"
-")
-  add_custom_command(
-    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp"
-    DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp.tmp"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp.tmp"
-      "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp"
-  )
-
-  # step 2: build a library containing that source file. This library depends on all the included header files.
-  #         The swift modules can now depend on that target.
-  #         Note that this library is unused, i.e. not linked to anything.
-  add_library(importedHeaderDependencies "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp")
-
-  # When building unified, we need to make sure all the Clang headers are
-  # generated before we try to use them.
-  # When building Swift against an already compiled LLVM/Clang, like
-  # build-script does, this target does not exist, but the headers
-  # are already completely generated at that point.
-  if(TARGET clang-tablegen-targets)
-    add_dependencies(importedHeaderDependencies clang-tablegen-targets)
-  endif()
 
   if(BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|CROSSCOMPILE")
 

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,1 +1,30 @@
 add_subdirectory(swift)
+
+
+# Create a library that depends on all headers defined in include/swift/module.modulemap
+#
+# TODO: generate this dynamically through the modulemap; this cannot use `sed`
+# as that is not available on all platforms (e.g. Windows).
+file(GENERATE
+  OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp"
+  CONTENT "
+#define COMPILED_WITH_SWIFT
+#define SWIFT_TARGET
+
+#include \"swift/Basic/BasicBridging.h\"
+#include \"swift/AST/ASTBridging.h\"
+#include \"swift/IDE/IDEBridging.h\"
+#include \"swift/Parse/ParseBridging.h\"
+#include \"swift/SIL/SILBridging.h\"
+#include \"swift/SILOptimizer/OptimizerBridging.h\"
+")
+add_library(importedHeaderDependencies "${CMAKE_CURRENT_BINARY_DIR}/HeaderDependencies.cpp")
+
+# When building unified, we need to make sure all the Clang headers are
+# generated before we try to use them.
+# When building Swift against an already compiled LLVM/Clang, like
+# build-script does, this target does not exist, but the headers
+# are already completely generated at that point.
+if(TARGET clang-tablegen-targets)
+  add_dependencies(importedHeaderDependencies clang-tablegen-targets)
+endif()


### PR DESCRIPTION
Changes to the headers imported by Swift files aren't not correctly propagated in CMake/Ninja. So Modifying C/C++ headers didn't rebuild ASTGen modules. Move the similar hack from SwiftCompilerSources and use it in ASTGen as well.

rdar://120863405
