### PR TITLE
[SILOptimizer] set the parent module context for _bridgeToObjectiveC …

### DIFF
--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -522,6 +522,12 @@ findBridgeToObjCFunc(SILOptFunctionBuilder &functionBuilder,
   // Implementation of _bridgeToObjectiveC could not be found.
   if (!bridgedFunc)
     return llvm::None;
+  // The bridging function must have the correct parent module set. This ensures
+  // that IRGen sets correct linkage when this function comes from the same
+  // module as being compiled.
+  if (!bridgedFunc->getDeclContext())
+    bridgedFunc->setParentModule(
+        resultDecl->getDeclContext()->getParentModule());
 
   if (dynamicCast.getFunction()->isSerialized() &&
       !bridgedFunc->hasValidLinkageForFragileRef())

--- a/test/SILOptimizer/Inputs/foundation_bridging.swift
+++ b/test/SILOptimizer/Inputs/foundation_bridging.swift
@@ -1,0 +1,11 @@
+// Input for bridged_casts_folding_same_module.swift test case.
+
+open class NSObject {
+    public init() {}
+}
+
+extension AnyHashable : _ObjectiveCBridgeable {
+    public func _bridgeToObjectiveC() -> NSObject {
+        return NSObject()
+    }
+}

--- a/test/SILOptimizer/bridged_casts_folding_same_module.swift
+++ b/test/SILOptimizer/bridged_casts_folding_same_module.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -O -emit-ir %S/Inputs/foundation_bridging.swift -primary-file %s -disable-autolink-framework CoreFoundation -parse-as-library -module-name Foundation | %FileCheck %s
+
+// REQUIRES: OS=windows-msvc
+
+open class NSSet {
+    public init(_ set: AnyHashable) {
+        if let item = set as? NSObject {
+            print("yay, has object!")    
+        }
+    }
+}
+
+// Ensure that the _bridgeToObjectiveC function (from the same module) is not annotated
+// with 'dllimport'.
+// CHECK: declare swiftcc ptr @"$ss11AnyHashableV10FoundationE19_bridgeToObjectiveCAC8NSObjectCyF"


### PR DESCRIPTION
…SILFunction

This fixes the Windows linker 4217 warning seen when building swift-corelibs-foundation for windows, when IRGen adds 'dllimport' to the _bridgeToObjectiveC IR reference within the same Swift module

The exact warning fixed: warning LNK4217: symbol 'sSS10FoundationE19_bridgeToObjectiveCAA8NSStringCyF' defined in 'Bridging.swift.obj' is imported by 'NSSet.swift.obj' in function 's10Foundation5NSSetC3set9copyItemsACShys11AnyHashableVG_SbtcfC'
