### PR TITLE
Fix the SIL type equality assert failures due to opaque return types.

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -947,6 +947,10 @@ public:
     return value.getOpaqueValue() != rhs.value.getOpaqueValue();
   }
 
+  // Returns true if the SILTypes are equal with the opaque return
+  // types being considered to be equal to their underlying types.
+  bool isEqualWithOpaqueReturnTypes(SILType rhs) const;
+
   /// Return the mangled name of this type, ignoring its prefix. Meant for
   /// diagnostic purposes.
   std::string getMangledName() const;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -949,7 +949,8 @@ public:
 
   /// Assert that two types are equal.
   void requireSameType(SILType type1, SILType type2, const Twine &complaint) {
-    _require(type1 == type2, complaint,
+    _require(type1 == type2 || type1.isEqualWithOpaqueReturnTypes(type2),
+             complaint,
              [&] { llvm::dbgs() << "  " << type1 << "\n  " << type2 << '\n'; });
   }
 
@@ -6106,7 +6107,8 @@ public:
       ++argI;
       if (bbarg->getType() != mappedTy &&
           bbarg->getType() != F.getLoweredType(mappedTy.getASTType())
-                                  .getCategoryType(mappedTy.getCategory())) {
+                                  .getCategoryType(mappedTy.getCategory()) &&
+          !bbarg->getType().isEqualWithOpaqueReturnTypes(mappedTy)) {
         llvm::errs() << what << " type mismatch!\n";
         llvm::errs() << "  argument: "; bbarg->dump();
         llvm::errs() << "  expected: "; mappedTy.dump();

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -314,7 +314,9 @@ SILValue SILDeserializer::getLocalValue(ValueID Id,
     Entry = ::new PlaceholderValue(Type);
   }
   // If this value was already defined, check it to make sure types match.
-  assert(Entry->getType() == Type && "Value Type mismatch?");
+  assert((Entry->getType() == Type ||
+          Entry->getType().isEqualWithOpaqueReturnTypes(Type)) &&
+         "Value Type mismatch?");
   return Entry;
 }
 

--- a/test/SIL/Serialization/Inputs/opaque_return_type_equality_input.swift
+++ b/test/SIL/Serialization/Inputs/opaque_return_type_equality_input.swift
@@ -1,0 +1,26 @@
+public protocol Reducer<State> {
+  associatedtype State
+}
+
+public class WindowData {}
+
+public struct CR<State, R: Reducer>: Reducer
+where State == R.State {
+}
+
+internal struct SidebarContextMenu<WindowState: WindowData>: Reducer {
+  typealias State = WindowState
+}
+
+public protocol Factory {
+  associatedtype X: Reducer<WindowData>
+  func build() -> X
+}
+
+public struct MyFactory<WindowState: WindowData>: Factory {
+  public typealias State = WindowData
+  public init() {}
+  public func build() -> some Reducer<WindowData> {
+    CR<WindowData, SidebarContextMenu<WindowData>>()
+  }
+}

--- a/test/SIL/Serialization/opaque_return_type_equality.swift
+++ b/test/SIL/Serialization/opaque_return_type_equality.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -c %S/Inputs/opaque_return_type_equality_input.swift -emit-module-path %t/opaque_return_type_equality_input.swiftmodule -I %t -O -module-name opaque_return_type_equality_input -o %t/opaque_return_type_equality_input.o
+// RUN: %target-swift-frontend -c %S/opaque_return_type_equality.swift -emit-module-path %t/opaque_return_type_equality.swiftmodule -I %t -O -module-name opaque_return_type_equality -o %t/opaque_return_type_equality.o
+
+// Check that the SIL type equality check asserts don't fail between the opaque return types and their underlying types.
+
+import opaque_return_type_equality_input
+
+public func build<F: Factory>(f: F) -> any Reducer<WindowData> {
+  return f.build()
+}
+
+build(f: MyFactory())


### PR DESCRIPTION
We encountered several SIL type equality assert failures in our internal app and reduced them into the included test.

The issue seemed to be that some places have the opaque return type and other places have the opaque types' underlying types and the type equality asserts fail. This change adds some logic to replace the opaque types with their underlying types, absorb the differences and avoid the assert failures.
