### PR TITLE
[Runtime] Fix `AbsoluteFuncPtr` to allow template parameter inference

### DIFF
--- a/include/swift/ABI/CompactFunctionPointer.h
+++ b/include/swift/ABI/CompactFunctionPointer.h
@@ -26,7 +26,7 @@ namespace swift {
 /// integer.
 /// As a trade-off compared to relative pointers, this has load-time overhead in PIC
 /// and is only available on 32-bit targets.
-template <typename T>
+template <typename T, bool Nullable = false, typename Offset = int32_t>
 class AbsoluteFunctionPointer {
   T *Pointer;
   static_assert(sizeof(T *) == sizeof(int32_t),

--- a/include/swift/ABI/TargetLayout.h
+++ b/include/swift/ABI/TargetLayout.h
@@ -104,7 +104,7 @@ struct InProcess {
 
   template <typename T, bool Nullable = true, typename Offset = int32_t>
 #if SWIFT_COMPACT_ABSOLUTE_FUNCTION_POINTER
-  using CompactFunctionPointer = AbsoluteFunctionPointer<T>;
+  using CompactFunctionPointer = AbsoluteFunctionPointer<T, Nullable, Offset>;
 #else
   using CompactFunctionPointer =
       swift::RelativeDirectPointer<T, Nullable, Offset>;


### PR DESCRIPTION
`AbsoluteFunctionPointer` was not able to be passed to a function that takes a `TargetCompactFunctionPointer` because the template parameters `Nullable` and `Offset` were not parameterized by `AbsoluteFunctionPointer`.

29c350e8139625935d240a4ee7ad91ab39db4475 introduced the first such function `InProcessReaderWriter::resolveFunctionPointer` and it revealed this issue.

This only affects WebAssembly build ATM.