### PR TITLE
[Test] Fix genericMetadataBuilder.swift requirements.

### DIFF
--- a/test/Runtime/genericMetadataBuilder.swift
+++ b/test/Runtime/genericMetadataBuilder.swift
@@ -6,6 +6,10 @@
 // The builder doesn't yet know how to look up symbols on Windows.
 // UNSUPPORTED: OS=windows-msvc
 
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 struct ConcreteEmpty {}
 
 struct ConcreteFields {


### PR DESCRIPTION
It requires executable_test and a just-built stdlib.

rdar://120908563