### PR TITLE
[DebugInfo] Fix getScopeOfFirstNonMetaInstruction

### DIFF
--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -441,7 +441,7 @@ bool SILBasicBlock::hasPhi() const {
 
 const SILDebugScope *SILBasicBlock::getScopeOfFirstNonMetaInstruction() {
   for (auto &Inst : *this)
-    if (Inst.isMetaInstruction())
+    if (!Inst.isMetaInstruction())
       return Inst.getDebugScope();
   return begin()->getDebugScope();
 }


### PR DESCRIPTION
This function is clearly returning the opposite of what its name says:

```
const SILDebugScope *SILBasicBlock::getScopeOfFirstNonMetaInstruction() {
  for (auto &Inst : *this)
    if (Inst.isMetaInstruction())
      return Inst.getDebugScope();
  return begin()->getDebugScope();
}
```

Looking at the PR history (sadly GH doesn't preserve old versions of the patch...) https://github.com/apple/swift/pull/15575

There was this snippet of code:

```
// Find the correct debug scope for alloc stack. We want to give to the
// expanded sequence the correct debug scope so we skip over instructions
// that aren't lowered to anything real (e.g. debug_value).
static const SILDebugScope *findAllocStackDebugScope(SILBasicBlock &BB) {
  auto It = BB.begin();
  while (It != BB.end()) {
    if (!isMaintenanceInst(&*It))
```

We don't know what used to be after that line but, based on the comments, it must have been a `return It->getDebugScope()`.

Adrian then asked the author to make this a different helper function `getScopeOfFirstNonMetaInstruction`, and the subsequence force-push had the code we see today. So maybe it was in this conversion that the author made the mistake?

Fixing the implementation doesn't cause any tests to fail (sadly the original PR did not add any SIL->SIL tests, which would have been ideal).
