### PR TITLE
[CMake] Replicate what ClangConfig does for unified builds

### DIFF
--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -272,9 +272,11 @@ macro(swift_common_unified_build_config product)
   set(${product}_NATIVE_CLANG_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
   set(LLVM_PACKAGE_VERSION ${PACKAGE_VERSION})
   set(LLVM_CMAKE_DIR "${CMAKE_SOURCE_DIR}/cmake/modules")
+  set(CLANG_INCLUDE_DIRS
+    "${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include"
+    "${CMAKE_BINARY_DIR}/tools/clang/include")
 
-  include_directories(${LLVM_EXTERNAL_CLANG_SOURCE_DIR}/include
-    ${CMAKE_BINARY_DIR}/tools/clang/include)
+  include_directories(${CLANG_INCLUDE_DIRS})
 
   # If cmark was checked out into tools/cmark, expect to build it as
   # part of the unified build.


### PR DESCRIPTION
ClangConfig sets `CLANG_INCLUDE_DIRS` and Swift build system uses that variable in a couple of places. Without this, several of the include directories for Clang might not be added to different parts of the compiler, like when using SwiftSourceSupport files. Before these changes, headers like `clang/CAS/CASOptions.h` were not being found.
