### PR TITLE
[Dependency Scanning] Escape quoted strings in dependency command-line output

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -421,6 +421,8 @@ std::string quote(StringRef unquoted) {
   for (const auto ch : unquoted) {
     if (ch == '\\')
       os << '\\';
+    if (ch == '"')
+      os << '\\';
     os << ch;
   }
   return buffer.str().str();

--- a/test/ScanDependencies/placholder_overlay_deps.swift
+++ b/test/ScanDependencies/placholder_overlay_deps.swift
@@ -14,8 +14,8 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json
 
 // Check the contents of the JSON output
-// RUN: %validate-json %t/deps.json &>/dev/null
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json > %t/validated_deps.json
+// RUN: %FileCheck %s < %t/validated_deps.json
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -25,8 +25,7 @@ import Metal
 // Ensure the dependency on Darwin is captured even though it is a placeholder
 
 // CHECK:   "modulePath": "{{.*}}{{/|\\}}Metal-{{.*}}.swiftmodule",
-// CHECK-NEXT:   "sourceFiles": [
-// CHECK-NEXT:   ],
+// CHECK:   "directDependencies": [
 // CHECK:     {
 // CHECK:       "swiftPlaceholder": "Darwin"
 // CHECK:     },

--- a/test/ScanDependencies/test_quoted_arg.swift
+++ b/test/ScanDependencies/test_quoted_arg.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)	
+// RUN: %empty-directory(%t/module-cache)		
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %t/inputs -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+// RUN: %validate-json %t/deps.json > %t/validated_deps.json
+// RUN: %FileCheck %s < %t/validated_deps.json
+
+//--- inputs/Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foo
+// swift-module-flags-ignorable-private: -package-name "\"ManyFoos\""
+public func foo() {}
+
+//--- test.swift
+import Foo
+
+// CHECK:      "-package-name"
+// CHECK-NEXT: "\"ManyFoos\""


### PR DESCRIPTION
Resolves rdar://120872469
