### PR TITLE
Change effectiveAccessLevel of `package` decls from `public` to `package`.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4157,17 +4157,7 @@ AccessLevel ValueDecl::getEffectiveAccess() const {
   // Handle @testable/@_private(sourceFile:)
   switch (effectiveAccess) {
   case AccessLevel::Open:
-    break;
   case AccessLevel::Package:
-    if (getModuleContext()->isTestingEnabled() ||
-        getModuleContext()->arePrivateImportsEnabled()) {
-        effectiveAccess = getMaximallyOpenAccessFor(this);
-    } else {
-        // Package declarations are effectively public within their
-        // package unit.
-        effectiveAccess = AccessLevel::Public;
-    }
-    break;
   case AccessLevel::Public:
   case AccessLevel::Internal:
     if (getModuleContext()->isTestingEnabled() ||
@@ -5900,9 +5890,9 @@ bool ClassDecl::hasResilientMetadata() const {
   if (!getModuleContext()->isResilient())
     return false;
 
-  // If the class is not public, we can't use it outside the module at all.
+  // If the class is not public or package, we can't use it outside the module at all.
   // Take enable testing into account.
-  if (getEffectiveAccess() < AccessLevel::Public)
+  if (getEffectiveAccess() < AccessLevel::Package)
     return false;
 
   // Otherwise we access metadata members, such as vtable entries, resiliently.

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -467,7 +467,7 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
       auto effectiveAccess =
           VD->getFormalAccessScope(/*useDC=*/nullptr,
                                    /*treatUsableFromInlineAsPublic=*/true);
-      if (effectiveAccess.isPublic() || effectiveAccess.isPackage()) {
+      if (effectiveAccess.isPublic()) {
         return {FragileFunctionKind::DefaultArgument};
       }
 

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -467,7 +467,7 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
       auto effectiveAccess =
           VD->getFormalAccessScope(/*useDC=*/nullptr,
                                    /*treatUsableFromInlineAsPublic=*/true);
-      if (effectiveAccess.isPublic()) {
+      if (effectiveAccess.isPublic() || effectiveAccess.isPackage()) {
         return {FragileFunctionKind::DefaultArgument};
       }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5955,7 +5955,7 @@ bool IRGenModule::hasResilientMetadata(ClassDecl *D,
 ResilienceExpansion
 IRGenModule::getResilienceExpansionForAccess(NominalTypeDecl *decl) {
   if (decl->getModuleContext() == getSwiftModule() &&
-      decl->getEffectiveAccess() < AccessLevel::Public)
+      decl->getEffectiveAccess() < AccessLevel::Package)
     return ResilienceExpansion::Maximal;
   return ResilienceExpansion::Minimal;
 }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1883,7 +1883,7 @@ namespace {
       // Emit method dispatch thunk if the class is resilient.
       auto *func = cast<AbstractFunctionDecl>(fn.getDecl());
 
-      if ((Resilient && func->getEffectiveAccess() >= AccessLevel::Public) ||
+      if ((Resilient && func->getEffectiveAccess() >= AccessLevel::Package) ||
           IGM.getOptions().VirtualFunctionElimination) {
         IGM.emitDispatchThunk(fn);
       }
@@ -6922,7 +6922,7 @@ bool irgen::methodRequiresReifiedVTableEntry(IRGenModule &IGM,
   auto originatingClass =
     cast<ClassDecl>(method.getOverriddenVTableEntry().getDecl()->getDeclContext());
 
-  if (originatingClass->getEffectiveAccess() >= AccessLevel::Public) {
+  if (originatingClass->getEffectiveAccess() >= AccessLevel::Package) {
     // If the class is public,
     // and it's either marked fragile or part of a non-resilient module, then
     // other modules will directly address vtable offsets and we can't remove
@@ -6932,7 +6932,7 @@ bool irgen::methodRequiresReifiedVTableEntry(IRGenModule &IGM,
                               << vtable->getClass()->getName()
                               << " for ";
                  method.print(llvm::dbgs());
-                 llvm::dbgs() << " originates from a public fragile class\n");
+                 llvm::dbgs() << " originates from a public/package fragile class\n");
       return true;
     }
   }

--- a/lib/IRGen/TypeLayoutDumper.cpp
+++ b/lib/IRGen/TypeLayoutDumper.cpp
@@ -83,7 +83,7 @@ static void addYAMLTypeInfoNode(NominalTypeDecl *NTD,
                                 IRGenModule &IGM,
                                 std::vector<YAMLTypeInfoNode> &Result) {
   // We only care about public and @usableFromInline declarations.
-  if (NTD->getEffectiveAccess() < AccessLevel::Public)
+  if (NTD->getEffectiveAccess() < AccessLevel::Package)
     return;
 
   // We don't care about protocols or classes.

--- a/lib/SIL/IR/SILWitnessTable.cpp
+++ b/lib/SIL/IR/SILWitnessTable.cpp
@@ -171,8 +171,7 @@ bool SILWitnessTable::conformanceIsSerialized(
   if (normalConformance && normalConformance->isResilient())
     return false;
 
-  if (conformance->getProtocol()->getEffectiveAccess() < AccessLevel::Public ||
-      conformance->getProtocol()->hasPackageAccess())
+  if (conformance->getProtocol()->getEffectiveAccess() < AccessLevel::Package)
     return false;
 
   auto *nominal = conformance->getDeclContext()->getSelfNominalTypeDecl();

--- a/lib/SIL/IR/SILWitnessTable.cpp
+++ b/lib/SIL/IR/SILWitnessTable.cpp
@@ -171,7 +171,7 @@ bool SILWitnessTable::conformanceIsSerialized(
   if (normalConformance && normalConformance->isResilient())
     return false;
 
-  if (conformance->getProtocol()->getEffectiveAccess() < AccessLevel::Package)
+  if (conformance->getProtocol()->getEffectiveAccess() < AccessLevel::Public)
     return false;
 
   auto *nominal = conformance->getDeclContext()->getSelfNominalTypeDecl();

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -251,7 +251,7 @@ void verifyKeyPathComponent(SILModule &M,
   case KeyPathPatternComponent::Kind::StoredProperty: {
     auto property = component.getStoredPropertyDecl();
     if (expansion == ResilienceExpansion::Minimal) {
-      require(property->getEffectiveAccess() >= AccessLevel::Public,
+      require(property->getEffectiveAccess() >= AccessLevel::Package,
               "Key path in serialized function cannot reference non-public "
               "property");
     }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -307,7 +307,7 @@ public:
     IsSerialized_t serialized = IsNotSerialized;
     auto classIsPublic = theClass->getEffectiveAccess() >= AccessLevel::Public;
     // Only public, fixed-layout classes should have serialized vtables.
-    if (classIsPublic && !theClass->hasPackageAccess() && !isResilient)
+    if (classIsPublic && !isResilient)
       serialized = IsSerialized;
 
     // Finally, create the vtable.
@@ -1093,7 +1093,7 @@ void SILGenModule::emitNonCopyableTypeDeinitTable(NominalTypeDecl *nom) {
   auto serialized = IsSerialized_t::IsNotSerialized;
   bool nomIsPublic = nom->getEffectiveAccess() >= AccessLevel::Public;
   // We only serialize the deinit if the type is public and not resilient.
-  if (nomIsPublic && !nom->hasPackageAccess() && !nom->isResilient())
+  if (nomIsPublic && !nom->isResilient())
     serialized = IsSerialized;
   SILMoveOnlyDeinit::create(f->getModule(), nom, serialized, f);
 }

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -328,7 +328,7 @@ bool CrossModuleOptimization::canSerializeInstruction(SILInstruction *inst,
     // properties, because that would require to make the field decl public -
     // which keeps more metadata alive.
     return !conservative ||
-           REAI->getField()->getEffectiveAccess() >= AccessLevel::Public;
+           REAI->getField()->getEffectiveAccess() >= AccessLevel::Package;
   }
   return true;
 }
@@ -365,7 +365,7 @@ bool CrossModuleOptimization::canSerializeType(SILType type) {
       CanType subType = rawSubType->getCanonicalType();
       if (NominalTypeDecl *subNT = subType->getNominalOrBoundGenericNominal()) {
       
-        if (conservative && subNT->getEffectiveAccess() < AccessLevel::Public) {
+        if (conservative && subNT->getEffectiveAccess() < AccessLevel::Package) {
           return true;
         }
       
@@ -596,7 +596,7 @@ void CrossModuleOptimization::makeFunctionUsableFromInline(SILFunction *function
 
 /// Make a nominal type, including it's context, usable from inline.
 void CrossModuleOptimization::makeDeclUsableFromInline(ValueDecl *decl) {
-  if (decl->getEffectiveAccess() >= AccessLevel::Public)
+  if (decl->getEffectiveAccess() >= AccessLevel::Package)
     return;
 
   // We must not modify decls which are defined in other modules.

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2880,7 +2880,7 @@ void SILSerializer::writeSILVTable(const SILVTable &vt) {
   // Do not emit vtables for non-public classes unless everything has to be
   // serialized.
   if (!ShouldSerializeAll &&
-      vt.getClass()->getEffectiveAccess() < swift::AccessLevel::Public)
+      vt.getClass()->getEffectiveAccess() < swift::AccessLevel::Package)
     return;
 
   if (vt.isSpecialized())
@@ -2924,7 +2924,7 @@ void SILSerializer::writeSILMoveOnlyDeinit(const SILMoveOnlyDeinit &deinit) {
   // Do not emit deinit for non-public nominal types unless everything has to be
   // serialized.
   if (!ShouldSerializeAll && deinit.getNominalDecl()->getEffectiveAccess() <
-                                 swift::AccessLevel::Public)
+                                 swift::AccessLevel::Package)
     return;
 
   SILFunction *impl = deinit.getImplementation();

--- a/test/SILGen/witness_tables_serialized.swift
+++ b/test/SILGen/witness_tables_serialized.swift
@@ -51,7 +51,7 @@ internal struct UsableFromInlineStruct : PublicProtocol, UsableFromInlineProtoco
 // CHECK-NONRESILIENT-DAG: sil_witness_table PublicResilientStruct: PackageProtocol
 // CHECK-NONRESILIENT-DAG: sil_witness_table hidden PublicResilientStruct: InternalProtocol
 
-// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PackageStruct: PublicProtocol
-// CHECK-NONRESILIENT-DAG: sil_witness_table [serialized] PackageStruct: UsableFromInlineProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table PackageStruct: PublicProtocol
+// CHECK-NONRESILIENT-DAG: sil_witness_table PackageStruct: UsableFromInlineProtocol
 // CHECK-NONRESILIENT-DAG: sil_witness_table PackageStruct: PackageProtocol
 // CHECK-NONRESILIENT-DAG: sil_witness_table hidden PackageStruct: InternalProtocol

--- a/test/Sema/package_resilience_access.swift
+++ b/test/Sema/package_resilience_access.swift
@@ -143,9 +143,8 @@ package class PkgKlass: PkgProto {
 // UTILS-COMMON-LABEL: // default argument 0 of PkgKlass.init(data:)
 // UTILS-COMMON-NEXT: sil [ossa] @$s5Utils8PkgKlassC4dataACSi_tcfcfA_ : $@convention(thin) () -> Int {
 
-// FIXME: __allocating_init for a `package` class should not be serialized in resilient Utils.
 // UTILS-COMMON-LABEL: // PkgKlass.__allocating_init(data:)
-// UTILS-COMMON-NEXT: sil [serialized] [exact_self_class] [ossa] @$s5Utils8PkgKlassC4dataACSi_tcfC : $@convention(method) (Int, @thick PkgKlass.Type) -> @owned PkgKlass {
+// UTILS-COMMON-NEXT: sil [exact_self_class] [ossa] @$s5Utils8PkgKlassC4dataACSi_tcfC : $@convention(method) (Int, @thick PkgKlass.Type) -> @owned PkgKlass {
 
 // UTILS-COMMON-LABEL: // PkgKlass.init(data:)
 // UTILS-COMMON-NEXT: sil [ossa] @$s5Utils8PkgKlassC4dataACSi_tcfc : $@convention(method) (Int, @owned PkgKlass) -> @owned PkgKlass {


### PR DESCRIPTION
Currently decls defined with `package` access level have a different access level for optimization: `public`. It requires an extra check for the actual access level that was declared when determining serialization since the behavior should be different.

This PR sets its effective access level to `package` as originally defined, updates call sites to make appropriate acces level comparisons, and removes `package` specific checks.

Resolves rdar://121470986