### PR TITLE
[5.10][CodeCompletion] Fix issue in which parts of a result builder were incorrectly skipped

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -227,8 +227,8 @@ protected:
                                    buildBlockArguments);
     }
     if (builder.supports(ctx.Id_buildExpression)) {
-      expr = builder.buildCall(expr->getLoc(), ctx.Id_buildExpression, {expr},
-                               {Identifier()});
+      expr = builder.buildCall(expr->getStartLoc(), ctx.Id_buildExpression,
+                               {expr}, {Identifier()});
     }
 
     if (isa<CodeCompletionExpr>(expr)) {

--- a/validation-test/IDE/issues_fixed/rdar120798355.swift
+++ b/validation-test/IDE/issues_fixed/rdar120798355.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+func test() {
+  MyStack {
+    MyStack {
+    }
+    .pnTapGesture {
+      #^COMPLETE^#
+    }
+    .everlay() {
+    }
+  }
+}
+
+struct MyView {
+  func everlay(content: () -> Void) -> MyView { MyView() }
+}
+
+struct MyStack {
+  init(@WiewBuilder content: () -> MyView) {}
+  func pnTapGesture(perform action: () -> Void) -> MyView { MyView() }
+}
+
+@resultBuilder
+struct WiewBuilder {
+  static func buildExpression(_ content: MyView) -> MyView { content }
+  static func buildBlock(_ content: MyView) -> MyView { content }
+  static func buildBlock() -> MyView { MyView() }
+}
+
+// COMPLETE: Decl[FreeFunction]/CurrModule:      test()[#Void#] 


### PR DESCRIPTION
* **Explanation**: `getLoc` does not necessarily return the start location of the location (e.g. for `a.b().c()` it returns the location of `c` because that’s the location of the call). But we used the location from `getLoc` as the start location of the synthesized `buildExpression` call. In the added test case, this means that the `buildExpression` call only contained `everlay() {}` and not the code completion token. We thus inferred that we could skip it the entire `MyStack {}.pnTabGesture {}.everlay() {}` call for code completion, which isn’t correct.
* **Scope**: Source locations of expressions in result builders that support `buildExpression`
* **Risk**: Very low
* **Testing**: Added regression test 
* **Issue**: rdar://120798355
* **Reviewer**:  @xedin on https://github.com/apple/swift/pull/70898