### PR TITLE
[Distributed] Allow `isolated any DistributedActor`

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -922,6 +922,9 @@ public:
   /// Determines whether this type is an actor type.
   bool isActorType();
 
+  /// Determines whether this type is an any actor type.
+  bool isAnyActorType();
+
   /// Returns true if this type is a Sendable type.
   bool isSendableType(DeclContext *declContext);
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -574,6 +574,12 @@ bool TypeBase::isActorType() {
   return false;
 }
 
+bool TypeBase::isAnyActorType() {
+  if (auto actor = getAnyActor())
+    return actor->isAnyActor();
+  return false;
+}
+
 bool TypeBase::isSendableType(DeclContext *ctx) {
   return isSendableType(ctx->getParentModule());
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4484,12 +4484,12 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
   Type type = resolveType(repr->getBase(), options);
 
   // isolated parameters must be of actor type
-  if (!type->hasTypeParameter() && !type->isActorType() && !type->hasError()) {
+  if (!type->hasTypeParameter() && !type->isAnyActorType() && !type->hasError()) {
     // Optional actor types are fine - `nil` represents `nonisolated`.
     auto wrapped = type->getOptionalObjectType();
     auto allowOptional = getASTContext().LangOpts
         .hasFeature(Feature::OptionalIsolatedParameters);
-    if (allowOptional && wrapped && wrapped->isActorType()) {
+    if (allowOptional && wrapped && wrapped->isAnyActorType()) {
       return type;
     }
 

--- a/test/Distributed/Runtime/distributed_actor_isolated_existential.swift
+++ b/test/Distributed/Runtime/distributed_actor_isolated_existential.swift
@@ -1,0 +1,64 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: freestanding
+
+// FIXME(distributed): Distributed actors currently have some issues on windows rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+import StdlibUnittest
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.9, *)
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+@available(SwiftStdlib 5.9, *)
+func globalFunc(isolatedTo actor: isolated any DistributedActor) async {
+  MainActor.preconditionIsolated() // we forced the `actor` onto the main actor's executor
+}
+
+@available(SwiftStdlib 5.9, *) // because conforming to the protocol requirement introduced in 5.9
+distributed actor NormalWorker {
+
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    return MainActor.sharedUnownedExecutor
+  }
+
+  distributed func offerSelf() async {
+    print("executed: \(#function)")
+    MainActor.preconditionIsolated() // we forced the `actor` onto the main actor's executor
+
+    await globalFunc(isolatedTo: self)
+    MainActor.preconditionIsolated() // we forced the `actor` onto the main actor's executor
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+@main struct Main {
+  @available(SwiftStdlib 5.1, *)
+  static func main() async {
+    if #available(SwiftStdlib 5.9, *) {
+      let tests = TestSuite("DistributedIsolatedTests")
+      let system = DefaultDistributedActorSystem()
+      let normalLocalWorker = NormalWorker(actorSystem: system)
+      precondition(__isLocalActor(normalLocalWorker), "must be local")
+
+      tests.test("remote actor reference should have crash-on-enqueue executor") {
+        try! await normalLocalWorker.offerSelf()
+      }
+
+      await runAllTestsAsync()
+    }
+  }
+}

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -260,3 +260,5 @@ extension Greeting where SerializationRequirement == Codable {
 }
 
 func isolated_generic_ok<T: DistributedActor>(_ t: isolated T) {}
+
+func isolated_existential_ok(_ t: isolated any DistributedActor) {}


### PR DESCRIPTION
This was mistakenly not allowed; the logic for hopping actors will just work, however we guarded the isolated being allowed only on "is actor" but it should have been checking for "is any actor"


resolves rdar://120938773