### PR TITLE
Sema: Suppress unavoidable deprecation diagnostics in _Concurrency

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2646,6 +2646,9 @@ void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
     }
   }
 
+  if (shouldIgnoreDeprecationOfConcurrencyDecl(DeprecatedDecl, ReferenceDC))
+    return;
+
   StringRef Platform = Attr->prettyPlatformString();
   llvm::VersionTuple DeprecatedVersion;
   if (Attr->Deprecated)

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -324,6 +324,14 @@ void diagnoseMissingExplicitSendable(NominalTypeDecl *nominal);
 /// Warn about deprecated `Executor.enqueue` implementations.
 void tryDiagnoseExecutorConformance(ASTContext &C, const NominalTypeDecl *nominal, ProtocolDecl *proto);
 
+/// Whether to suppress deprecation diagnostics for \p decl in \p declContext
+/// because \p decl is a deprecated decl from the `_Concurrency` module and is
+/// being referenced from the implementation of the `_Concurrency` module. This
+/// prevents unaddressable warnings in the standard library build. Ideally, a
+/// language feature would obviate the need for this.
+bool shouldIgnoreDeprecationOfConcurrencyDecl(const Decl *decl,
+                                              DeclContext *declContext);
+
 // Get a concrete reference to a declaration
 ConcreteDeclRef getDeclRefInContext(ValueDecl *value);
 

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -151,7 +151,7 @@ extension GlobalActor {
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
   ) {
-    try Self.shared.preconditionIsolated(message(), file: file, line: line)
+    Self.shared.preconditionIsolated(message(), file: file, line: line)
   }
 }
 
@@ -292,7 +292,7 @@ extension GlobalActor {
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
   ) {
-    try Self.shared.assertIsolated(message(), file: file, line: line)
+    Self.shared.assertIsolated(message(), file: file, line: line)
   }
 }
 


### PR DESCRIPTION
The _Concurrency module must use some deprecated declarations in its implementation in order to maintain backward compatibility. Since these references are unavoidable, the deprecation diagnostics emitted about them are an unhelpful nuisance. This change introduces targetted logic for suppressing these specific deprecation diagnostics as a workaround until there is a language feature for suppressing deprecation diagnostics.

Also, remove a couple of superfluous `try`s.