### PR TITLE
[Clang Importer] improve import of some macros as constants

### DIFF
--- a/test/ClangImporter/macros.swift
+++ b/test/ClangImporter/macros.swift
@@ -45,6 +45,14 @@ func subThree(_ x: CInt) -> CInt {
   return x + MINUS_THREE
 }
 
+func invertInput(_ x: UInt8) -> Int8 {
+  if x == FALLING_EDGE {
+    return HIGH_C
+  } else if x == RISING_EDGE {
+    return LOW_C
+  }
+}
+
 // true/false are keywords, so they shouldn't conflict with the true/false in
 // the C header.
 func testTrueFalse() {

--- a/test/Inputs/clang-importer-sdk/usr/include/macros.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/macros.h
@@ -156,6 +156,13 @@
 #define RECURSION_WITH_EXPR3 RECURSION_WITH_EXPR3_HELPER + 1
 #define RECURSION_WITH_EXPR3_HELPER RECURSION_WITH_EXPR3 + 1
 
+// casts
+#define HIGH_C (char)1
+#define LOW_C (char)0
+#define FALLING_EDGE (unsigned char)2
+#define RISING_EDGE (unsigned char)3
+#define D0 (unsigned char)0
+#define D1 (unsigned char)1
 
 // Casts with problematic types
 #define UNAVAILABLE_ONE ((unavailable_t)1)


### PR DESCRIPTION
<!-- What's in this pull request? -->

Allow import of #define constants that are cast to (unsigned XXX) as constants with the appropriate type in Swift.

Note: this will work best in conjunction with the apple/llvm-project PR https://github.com/apple/llvm-project/pull/7976. Otherwise macros with constants cast to (_Bool) may not work in this patch.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This work was not listed as a publicly trackable issue on this repository. We tracked it in our own bug fix tracker at the time. I'm happy to create an issue on GitHub if that's useful?

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
