### PR TITLE
[Concurrency] allow isolated on dynamic self types

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4483,6 +4483,10 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
 
   Type type = resolveType(repr->getBase(), options);
 
+  if (auto ty = dyn_cast<DynamicSelfType>(type)) {
+    type = ty->getSelfType();
+  }
+
   // isolated parameters must be of actor type
   if (!type->hasTypeParameter() && !type->isAnyActorType() && !type->hasError()) {
     // Optional actor types are fine - `nil` represents `nonisolated`.

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -395,3 +395,10 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   // expected-note@-2 {{calls to global function 'optionalIsolatedSync(_:to:)' from outside of its actor context are implicitly asynchronous}}
   // expected-complete-warning@-3 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
 }
+
+actor A2 {}
+extension A2 {
+  nonisolated func f() async {
+    await { (self: isolated Self) in }(self)
+  }
+}


### PR DESCRIPTION
`isolated` typechecking missed the handling of `DynamicSelfType` and wrongly prevented using `Self` with `isolated`.

This patch fixes the behavior and adds tests for the specific case.

Resolves #70924
Resolves rdar://121022467 