### PR TITLE
[Test] Temporarily disable genericMetadataBuilder.swift on ARM64e.

### DIFF
--- a/test/Runtime/genericMetadataBuilder.swift
+++ b/test/Runtime/genericMetadataBuilder.swift
@@ -10,6 +10,10 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// Validation gets confused by ARM64e, temporarily disable the test there until
+// we've fixed that. rdar://121029024
+// UNSUPPORTED: CPU=arm64e
+
 struct ConcreteEmpty {}
 
 struct ConcreteFields {


### PR DESCRIPTION
The validation is getting confused by ptrauth. Disable the test there while we fix it.

rdar://121029024