### PR TITLE
[cxx-interop] Split some modules in tests

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/module.modulemap
@@ -1,11 +1,18 @@
 module ConvertibleToBool {
   header "convertible-to-bool.h"
   requires cplusplus
+  export *
+}
+
+module CustomIterator {
+  header "custom-iterator.h"
+  requires cplusplus
+  export *
 }
 
 module CustomSequence {
-  header "custom-iterator.h" // TODO: extract into another module
   header "custom-sequence.h"
   header "custom-collection.h"
   requires cplusplus
+  export *
 }

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomIterator -source-filename=x -I %S/Inputs -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
 
 // CHECK: struct ConstIterator : UnsafeCxxInputIterator {
 // CHECK:   func successor() -> ConstIterator


### PR DESCRIPTION
This cleans up the C++ iteration tests and makes sure that we test the setup where a C++ iterator and a C++ collection are defined in different Clang modules.