### PR TITLE
[Concurrency] Downgrade `isolated_default_argument_context` to a warning until Swift 6 for stored properties.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5055,7 +5055,8 @@ DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
     if (enclosingIsolation != requiredIsolation) {
       var->diagnose(
           diag::isolated_default_argument_context,
-          requiredIsolation, enclosingIsolation);
+          requiredIsolation, enclosingIsolation)
+        .warnUntilSwiftVersionIf(!isa<ParamDecl>(var), 6);
       return ActorIsolation::forUnspecified();
     }
   }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -784,15 +784,15 @@ actor LazyActor {
     lazy var l25: Int = { [unowned self] in self.l }()
 
     nonisolated lazy var l31: Int = { v }()
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
     nonisolated lazy var l32: Int = v
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
     nonisolated lazy var l33: Int = { self.v }()
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
     nonisolated lazy var l34: Int = self.v
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
     nonisolated lazy var l35: Int = { [unowned self] in self.v }()
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
 
     nonisolated lazy var l41: Int = { l }()
     nonisolated lazy var l42: Int = l

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -445,7 +445,7 @@ actor ActorWithWrapper {
   @WrapperOnActor var synced: Int = 0
   // expected-note@-1 3{{property declared here}}
   @WrapperWithMainActorDefaultInit var property: Int // expected-minimal-targeted-error {{call to main actor-isolated initializer 'init()' in a synchronous actor-isolated context}}
-  // expected-complete-tns-error@-1 {{main actor-isolated default value in a actor-isolated context}}
+  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a actor-isolated context; this is an error in Swift 6}}
   func f() {
     _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced on a different actor instance}}
     _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced on a different actor instance}}
@@ -561,7 +561,7 @@ struct WrapperOnUnsafeActor<Wrapped> {
 
 // HasWrapperOnUnsafeActor gets an inferred @MainActor attribute.
 struct HasWrapperOnUnsafeActor {
-  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-tns-error {{global actor 'OtherGlobalActor'-isolated default value in a main actor-isolated context}}
+  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-tns-warning {{global actor 'OtherGlobalActor'-isolated default value in a main actor-isolated context; this is an error in Swift 6}}
   // expected-note @-1 3{{property declared here}}
   // expected-complete-tns-note @-2 3{{property declared here}}
 
@@ -681,10 +681,10 @@ class Cutter {
 @SomeGlobalActor
 class Butter {
   var a = useFooInADefer() // expected-minimal-targeted-error {{call to main actor-isolated global function 'useFooInADefer()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
-  // expected-complete-tns-error@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context}}
+  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context; this is an error in Swift 6}}
 
   nonisolated let b = statefulThingy // expected-minimal-targeted-error {{main actor-isolated var 'statefulThingy' can not be referenced from a non-isolated context}}
-  // expected-complete-tns-error@-1 {{main actor-isolated default value in a nonisolated context}}
+  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
 
   var c: Int = {
     return getGlobal7()

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -156,7 +156,7 @@ struct S3 {
 }
 
 struct S4 {
-  // expected-error@+1 {{main actor-isolated default value in a nonisolated context}}
+  // expected-warning@+1 {{main actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
   var x: Int = requiresMainActor()
 }
 


### PR DESCRIPTION
This code was accepted in compiler versions <=5.9:

```swift
@MainActor func requiresMainActor() -> Int {}

struct S {
  var x = requiresMainActor() // warning here
}
```

This code was made invalid by SE-0411. This change downgrades the error to a warning unless the var in question is a `ParamDecl`.

Resolves rdar://121060811