### PR TITLE
[5.10][Concurrency] Downgrade `isolated_default_argument_context` to a warning until Swift 6 for stored properties.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4856,7 +4856,8 @@ DefaultInitializerIsolation::evaluate(Evaluator &evaluator,
     if (enclosingIsolation != requiredIsolation) {
       var->diagnose(
           diag::isolated_default_argument_context,
-          requiredIsolation, enclosingIsolation);
+          requiredIsolation, enclosingIsolation)
+        .warnUntilSwiftVersionIf(!isa<ParamDecl>(var), 6);
       return ActorIsolation::forUnspecified();
     }
   }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -784,15 +784,15 @@ actor LazyActor {
     lazy var l25: Int = { [unowned self] in self.l }()
 
     nonisolated lazy var l31: Int = { v }()
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
     nonisolated lazy var l32: Int = v
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
     nonisolated lazy var l33: Int = { self.v }()
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
     nonisolated lazy var l34: Int = self.v
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
     nonisolated lazy var l35: Int = { [unowned self] in self.v }()
-    // expected-error@-1 {{actor-isolated default value in a nonisolated context}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
 
     nonisolated lazy var l41: Int = { l }()
     nonisolated lazy var l42: Int = l

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -444,7 +444,7 @@ actor ActorWithWrapper {
   @WrapperOnActor var synced: Int = 0
   // expected-note@-1 3{{property declared here}}
   @WrapperWithMainActorDefaultInit var property: Int // expected-minimal-targeted-error {{call to main actor-isolated initializer 'init()' in a synchronous actor-isolated context}}
-  // expected-complete-sns-error@-1 {{main actor-isolated default value in a actor-isolated context}}
+  // expected-complete-sns-warning@-1 {{main actor-isolated default value in a actor-isolated context; this is an error in Swift 6}}
   func f() {
     _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced on a different actor instance}}
     _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced on a different actor instance}}
@@ -560,7 +560,7 @@ struct WrapperOnUnsafeActor<Wrapped> {
 
 // HasWrapperOnUnsafeActor gets an inferred @MainActor attribute.
 struct HasWrapperOnUnsafeActor {
-  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-sns-error {{global actor 'OtherGlobalActor'-isolated default value in a main actor-isolated context}}
+  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-sns-warning {{global actor 'OtherGlobalActor'-isolated default value in a main actor-isolated context; this is an error in Swift 6}}
   // expected-note @-1 3{{property declared here}}
   // expected-complete-sns-note @-2 3{{property declared here}}
 
@@ -680,10 +680,10 @@ class Cutter {
 @SomeGlobalActor
 class Butter {
   var a = useFooInADefer() // expected-minimal-targeted-error {{call to main actor-isolated global function 'useFooInADefer()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
-  // expected-complete-sns-error@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context}}
+  // expected-complete-sns-warning@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context; this is an error in Swift 6}}
 
   nonisolated let b = statefulThingy // expected-minimal-targeted-error {{main actor-isolated var 'statefulThingy' can not be referenced from a non-isolated context}}
-  // expected-complete-sns-error@-1 {{main actor-isolated default value in a nonisolated context}}
+  // expected-complete-sns-warning@-1 {{main actor-isolated default value in a nonisolated context; this is an error in Swift 6}}}
 
   var c: Int = {
     return getGlobal7()

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -156,7 +156,7 @@ struct S3 {
 }
 
 struct S4 {
-  // expected-error@+1 {{main actor-isolated default value in a nonisolated context}}
+  // expected-warning@+1 {{main actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
   var x: Int = requiresMainActor()
 }
 


### PR DESCRIPTION
* **Explanation**: I forgot to downgrade a new error introduced in the implementation of SE-0411 to a warning in cases that were accepted in compiler versions <=5.9. This PR adds the missing `.warnUntilSwiftVersionIf` condition, which will diagnose warnings in the following code:
```swift
@MainActor func requiresMainActor() -> Int {}

struct S {
  var x = requiresMainActor() // warning here
}
```

This is still diagnosed as an error for parameters, because compiler versions <=5.9 do not allow writing an isolated expression in default argument context at all.
* **Scope**: Only impacts stored properties whose isolation does not match the isolation of its initializer expression.
* **Risk**: Low. The only impact of this change is downgrading an error to a warning for code that was accepted by compiler versions <=5.9.
* **Testing**: Updated expected diagnostics in existing tests.
* **Main branch PR**: https://github.com/apple/swift/pull/70934