### PR TITLE
Mark the exit() function in _SwiftConcurrency.h as noreturn in both C++ and C modes

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/_SwiftConcurrency.h
+++ b/stdlib/public/SwiftShims/swift/shims/_SwiftConcurrency.h
@@ -31,9 +31,9 @@ typedef struct _SwiftContext {
 #endif
 
 #ifdef __cplusplus
-extern "C" [[noreturn]]
+extern "C"
 #endif
-void exit(int);
+[[noreturn]] void exit(int);
 
 #define EXIT_SUCCESS 0
 


### PR DESCRIPTION
Just a cleanup, NFC. The one case where this might matter is if swiftc is called with `-Xcc -fno-builtin` which would suppress Clang's knowledge that `exit` is noreturn. This PR fixes that.