### PR TITLE
[SILOpt] Represent _TrivialStride pre-specializations with vector types

### DIFF
--- a/include/swift/AST/LayoutConstraint.h
+++ b/include/swift/AST/LayoutConstraint.h
@@ -157,6 +157,11 @@ class LayoutConstraintInfo
     return 8*8;
   }
 
+  unsigned getTrivialStride() const {
+    assert(isTrivialStride());
+    return (SizeInBits + 7) / 8;
+  }
+
   unsigned getTrivialStrideInBits() const {
     assert(isTrivialStride());
     return SizeInBits;

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -528,10 +528,12 @@ GenericSignature GenericSignature::typeErased(ArrayRef<Type> typeErasedParams) c
             Requirement(RequirementKind::SameType, req.getFirstType(),
                         CanType(BuiltinIntegerType::get(bitWidth, C))));
       } else if (layout->isTrivialStride()) {
-        unsigned bitWidth = layout->getTrivialStrideInBits();
         requirementsErased.push_back(
             Requirement(RequirementKind::SameType, req.getFirstType(),
-                        CanType(BuiltinIntegerType::get(bitWidth, C))));
+                        CanType(BuiltinVectorType::get(
+                            Ptr->getASTContext(),
+                            BuiltinIntegerType::get(8, Ptr->getASTContext()),
+                            layout->getTrivialStride()))));
       } else {
         requirementsErased.push_back(req);
       }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -3053,9 +3053,10 @@ bool usePrespecialized(
               stride = irgen::Size(1);
 
             if (stride.getValueInBits() == layout->getTrivialStrideInBits()) {
-              newSubs.push_back(CanType(
-                  BuiltinIntegerType::get(layout->getTrivialStrideInBits(),
-                                          genericParam->getASTContext())));
+              newSubs.push_back(CanType(BuiltinVectorType::get(
+                  genericParam->getASTContext(),
+                  BuiltinIntegerType::get(8, genericParam->getASTContext()),
+                  layout->getTrivialStride())));
             }
           }
         } else {

--- a/test/SILOptimizer/Inputs/pre_specialized_module_layouts.swift
+++ b/test/SILOptimizer/Inputs/pre_specialized_module_layouts.swift
@@ -12,7 +12,7 @@ public class SomeClass {
 @_specialize(exported: true, where @_noMetadata T : _Class)
 @_specialize(exported: true, where @_noMetadata T : _BridgeObject)
 @_specialize(exported: true, where @_noMetadata T : _Trivial(64))
-@_specialize(exported: true, where @_noMetadata T : _TrivialStride(128))
+@_specialize(exported: true, where @_noMetadata T : _TrivialStride(96))
 @_specialize(exported: true, availability: macOS 10.50, *; where T == SomeData)
 public func publicPrespecialized<T>(_ t: T) {
 }

--- a/test/SILOptimizer/pre_specialize_layouts.swift
+++ b/test/SILOptimizer/pre_specialize_layouts.swift
@@ -36,9 +36,10 @@ public struct TwoInt32 {
   let y: Int32 = 0
 }
 
-public struct Stride128 {
-  let x: Int64 = 0
-  let y: Bool = false
+public struct Stride96 {
+  let x: Int32 = 0
+  let y: Int32 = 0
+  let z: Bool = false
 }
 
 // Make sure we generate the public pre-specialized entry points.
@@ -83,8 +84,8 @@ internal func testEmitIntoClient<T>(t: T) {
   print(t)
 }
 
-// OPT: sil @$s22pre_specialize_layouts28usePrespecializedEntryPoints13wrapperStruct11overaligned5array9stride128yAA016ReferenceWrapperI0V_AA011OveralignedmnI0VSaySiGAA9Stride128VtF : $@convention(thin) (@guaranteed ReferenceWrapperStruct, @guaranteed OveralignedReferenceWrapperStruct, @guaranteed Array<Int>, Stride128) -> () {
-// OPT: bb0([[P1:%.*]] : $ReferenceWrapperStruct, [[P2:%.*]] : $OveralignedReferenceWrapperStruct, [[P3:%.*]] : $Array<Int>, [[P4:%.*]] : $Stride128):
+// OPT: sil @$s22pre_specialize_layouts28usePrespecializedEntryPoints13wrapperStruct11overaligned5array8stride96yAA016ReferenceWrapperI0V_AA011OveralignedmnI0VSaySiGAA8Stride96VtF : $@convention(thin) (@guaranteed ReferenceWrapperStruct, @guaranteed OveralignedReferenceWrapperStruct, @guaranteed Array<Int>, Stride96) -> () {
+// OPT: bb0([[P1:%.*]] : $ReferenceWrapperStruct, [[P2:%.*]] : $OveralignedReferenceWrapperStruct, [[P3:%.*]] : $Array<Int>, [[P4:%.*]] : $Stride96):
 // OPT:   [[F1:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFSi_Ts5 : $@convention(thin) (Int) -> ()
 // OPT:   apply [[F1]]
 // OPT:   [[F2:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFSd_Ts5 : $@convention(thin) (Double) -> ()
@@ -106,16 +107,16 @@ internal func testEmitIntoClient<T>(t: T) {
 // OPT-macosx: [[F8:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFBb_Ts5 : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
 // OPT-macosx: [[A4:%.*]] = unchecked_bitwise_cast [[P3]] : $Array<Int> to $Builtin.BridgeObject
 // OPT-macosx: apply [[F8]]([[A4]]) : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
-// OPT:   [[F10:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFBi128__Ts5 : $@convention(thin) (Builtin.Int128) -> ()
-// OPT:   [[A6:%.*]] = unchecked_trivial_bit_cast [[P4]] : $Stride128 to $Builtin.Int128
-// OPT:   apply [[F10]]([[A6]]) : $@convention(thin) (Builtin.Int128) -> ()
+// OPT:   [[F10:%.*]] = function_ref @$s30pre_specialized_module_layouts20publicPrespecializedyyxlFBi8_Bv12__Ts5 : $@convention(thin) (Builtin.Vec12xInt8) -> ()
+// OPT:   [[A6:%.*]] = unchecked_trivial_bit_cast [[P4]] : $Stride96 to $Builtin.Vec12xInt8
+// OPT:   apply [[F10]]([[A6]]) : $@convention(thin) (Builtin.Vec12xInt8) -> ()
 // OPT:   [[F3:%.*]] = function_ref @$s30pre_specialized_module_layouts36internalEmitIntoClientPrespecializedyyxlFSi_Ts5 : $@convention(thin) (Int) -> ()
 // OPT:   apply [[F3]]
 // OPT:   [[F4:%.*]] = function_ref @$s30pre_specialized_module_layouts36internalEmitIntoClientPrespecializedyyxlFSd_Ts5 : $@convention(thin) (Double) -> ()
 // OPT:   apply [[F4]]
 // OPT:   [[F5:%.*]] = function_ref @$s30pre_specialized_module_layouts16useInternalThingyyxlFSi_Tg5
 // OPT:   apply [[F5]]({{.*}}) : $@convention(thin) (Int) -> ()
-// OPT: } // end sil function '$s22pre_specialize_layouts28usePrespecializedEntryPoints13wrapperStruct11overaligned5array9stride128yAA016ReferenceWrapperI0V_AA011OveralignedmnI0VSaySiGAA9Stride128VtF'
+// OPT: } // end sil function '$s22pre_specialize_layouts28usePrespecializedEntryPoints13wrapperStruct11overaligned5array8stride96yAA016ReferenceWrapperI0V_AA011OveralignedmnI0VSaySiGAA8Stride96VtF'
 
 // OPT: sil {{.*}} @$s30pre_specialized_module_layouts16useInternalThingyyxlFSi_Tg5 : $@convention(thin) (Int) -> () {
 // OPT:   [[F1:%.*]] = function_ref @$s30pre_specialized_module_layouts14InternalThing2V7computexyFSi_Ts5 : $@convention(method) (InternalThing2<Int>) -> Int
@@ -160,7 +161,7 @@ internal func testEmitIntoClient<T>(t: T) {
 // OPT:   [[R10:%.*]] = unchecked_addr_cast [[R9]] : $*AnyObject to $*SomeClass
 // OPT: } // end sil function '$s30pre_specialized_module_layouts16useInternalThingyyxlFAA9SomeClassC_Tg5'
 
-public func usePrespecializedEntryPoints(wrapperStruct: ReferenceWrapperStruct, overaligned: OveralignedReferenceWrapperStruct, array: [Int], stride128: Stride128) {
+public func usePrespecializedEntryPoints(wrapperStruct: ReferenceWrapperStruct, overaligned: OveralignedReferenceWrapperStruct, array: [Int], stride96: Stride96) {
   publicPrespecialized(1)
   publicPrespecialized(1.0)
   publicPrespecialized(UInt64(1))
@@ -171,7 +172,7 @@ public func usePrespecializedEntryPoints(wrapperStruct: ReferenceWrapperStruct, 
   // should not apply _Class specialization for overaligned struct
   publicPrespecialized(overaligned)
   publicPrespecialized(array)
-  publicPrespecialized(stride128)
+  publicPrespecialized(stride96)
   useInternalEmitIntoClientPrespecialized(2)
   useInternalEmitIntoClientPrespecialized(2.0)
   useInternalThing(2)


### PR DESCRIPTION
rdar://121071710

Currently it uses builtin integers, which round up to the next power of 2, which is not what we want here. Instead it should use builtin vectors of uint8 and a number of elements equal to the stride in bytes.
