### PR TITLE
[interop][SwiftToCxx] Ignore delayedMembers in C++

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -247,7 +247,7 @@ private:
         continue;
       if (isa<AccessorDecl>(VD))
         continue;
-      if (!AllowDelayed && owningPrinter.delayedMembers.count(VD)) {
+      if (!AllowDelayed && owningPrinter.objcDelayedMembers.count(VD)) {
         os << "// '" << VD->getName()
            << ((outputLang == OutputLanguageMode::Cxx) ? "' cannot be printed\n"
                                                        : "' below\n");

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -248,7 +248,9 @@ private:
       if (isa<AccessorDecl>(VD))
         continue;
       if (!AllowDelayed && owningPrinter.delayedMembers.count(VD)) {
-        os << "// '" << VD->getName() << "' below\n";
+        os << "// '" << VD->getName()
+           << ((outputLang == OutputLanguageMode::Cxx) ? "' cannot be printed\n"
+                                                       : "' below\n");
         continue;
       }
       if (VD->getAttrs().hasAttribute<OptionalAttr>() !=

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -57,7 +57,7 @@ private:
   raw_ostream &os;
   raw_ostream &prologueOS;
   raw_ostream &outOfLineDefinitionsOS;
-  const DelayedMemberSet &delayedMembers;
+  const DelayedMemberSet &objcDelayedMembers;
   CxxDeclEmissionScope *cxxDeclEmissionScope;
   PrimitiveTypeMapping &typeMapping;
   SwiftToClangInteropContext &interopContext;
@@ -84,7 +84,7 @@ public:
                      llvm::StringSet<> &exposedModules,
                      OutputLanguageMode outputLang)
       : M(mod), os(out), prologueOS(prologueOS),
-        outOfLineDefinitionsOS(outOfLineDefinitionsOS), delayedMembers(delayed),
+        outOfLineDefinitionsOS(outOfLineDefinitionsOS), objcDelayedMembers(delayed),
         cxxDeclEmissionScope(&topLevelEmissionScope), typeMapping(typeMapping),
         interopContext(interopContext), minRequiredAccess(access),
         requiresExposedAttribute(requiresExposedAttribute),

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -84,7 +84,8 @@ public:
                      llvm::StringSet<> &exposedModules,
                      OutputLanguageMode outputLang)
       : M(mod), os(out), prologueOS(prologueOS),
-        outOfLineDefinitionsOS(outOfLineDefinitionsOS), objcDelayedMembers(delayed),
+        outOfLineDefinitionsOS(outOfLineDefinitionsOS),
+        objcDelayedMembers(delayed),
         cxxDeclEmissionScope(&topLevelEmissionScope), typeMapping(typeMapping),
         interopContext(interopContext), minRequiredAccess(access),
         requiresExposedAttribute(requiresExposedAttribute),

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -796,16 +796,18 @@ public:
       }
     }
 
-    if (!delayedMembers.empty()) {
-      auto groupBegin = delayedMembers.begin();
-      for (auto i = groupBegin, e = delayedMembers.end(); i != e; ++i) {
-        if ((*i)->getDeclContext() != (*groupBegin)->getDeclContext()) {
-          printer.printAdHocCategory(make_range(groupBegin, i));
-          groupBegin = i;
+    if (outputLangMode == OutputLanguageMode::ObjC)
+      if (!delayedMembers.empty()) {
+        auto groupBegin = delayedMembers.begin();
+        for (auto i = groupBegin, e = delayedMembers.end(); i != e; ++i) {
+          if ((*i)->getDeclContext() != (*groupBegin)->getDeclContext()) {
+            printer.printAdHocCategory(make_range(groupBegin, i));
+            groupBegin = i;
+          }
         }
+        printer.printAdHocCategory(
+            make_range(groupBegin, delayedMembers.end()));
       }
-      printer.printAdHocCategory(make_range(groupBegin, delayedMembers.end()));
-    }
 
     // Print any out of line definitions.
     os << outOfLineDefinitionsOS.str();

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-generics-in-cxx.swift
@@ -35,7 +35,24 @@ public enum unsupportedGenericEnum<T: Proto> {
     case B(T)
 }
 
+public struct Struct1<IntType: FixedWidthInteger> {
+  private var value: IntType
+
+  public init(rawValue: IntType) {
+    self.value = rawValue
+  }
+}
+
+public class Class1 {
+  public var index1: Struct1<UInt32> { .init(rawValue: 123) }
+}
+
 // CHECK: supported
+
+// CHECK: class SWIFT_SYMBOL("s:5Decls6Class1C") Class1 : public swift::_impl::RefCountedClass {
+// CHECK: 'index1' cannot be printed
+
+// CHECK: class Struct1 { } SWIFT_UNAVAILABLE_MSG("generic requirements for generic struct 'Struct1' can not yet be represented in C++");
 
 // CHECK: // Unavailable in C++: Swift global function 'unsupportedFunc(_:)'.
 


### PR DESCRIPTION
This fixes a bug where an ObjC @interface declaration is emitted for a class that has a member that isn't emitted.

Resolves rdar://119835836