### PR TITLE
[5.10] Fix alignment-checking preconditions in UnsafeMutableRawBufferPointer

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -781,7 +781,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     }  
 
     _debugPrecondition(
-      Int(bitPattern: base) % MemoryLayout<S.Element>.stride == 0,
+      Int(bitPattern: base) & MemoryLayout<S.Element>.alignment-1 == 0,
       "buffer base address must be properly aligned to access S.Element"
     )
 
@@ -841,7 +841,7 @@ extension Unsafe${Mutable}RawBufferPointer {
         return .init(start: nil, count: 0)
       }
       _debugPrecondition(
-        Int(bitPattern: baseAddress) % MemoryLayout<C.Element>.stride == 0,
+        Int(bitPattern: baseAddress) & MemoryLayout<C.Element>.alignment-1 == 0,
         "buffer base address must be properly aligned to access C.Element"
       )
       _precondition(
@@ -866,7 +866,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     }
     _internalInvariant(_end != nil)
     _debugPrecondition(
-      Int(bitPattern: baseAddress) % MemoryLayout<C.Element>.stride == 0,
+      Int(bitPattern: baseAddress) & MemoryLayout<C.Element>.alignment-1 == 0,
       "buffer base address must be properly aligned to access C.Element"
     )
     var iterator = source.makeIterator()
@@ -928,7 +928,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       return .init(start: nil, count: 0)
     }
     _debugPrecondition(
-      Int(bitPattern: baseAddress) % MemoryLayout<T>.stride == 0,
+      Int(bitPattern: baseAddress) & MemoryLayout<T>.alignment-1 == 0,
       "buffer base address must be properly aligned to access T"
     )
     _precondition(

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -781,7 +781,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     }  
 
     _debugPrecondition(
-      Int(bitPattern: base) & MemoryLayout<S.Element>.alignment-1 == 0,
+      Int(bitPattern: base) & (MemoryLayout<S.Element>.alignment-1) == 0,
       "buffer base address must be properly aligned to access S.Element"
     )
 
@@ -841,7 +841,7 @@ extension Unsafe${Mutable}RawBufferPointer {
         return .init(start: nil, count: 0)
       }
       _debugPrecondition(
-        Int(bitPattern: baseAddress) & MemoryLayout<C.Element>.alignment-1 == 0,
+        Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
         "buffer base address must be properly aligned to access C.Element"
       )
       _precondition(
@@ -866,7 +866,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     }
     _internalInvariant(_end != nil)
     _debugPrecondition(
-      Int(bitPattern: baseAddress) & MemoryLayout<C.Element>.alignment-1 == 0,
+      Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
       "buffer base address must be properly aligned to access C.Element"
     )
     var iterator = source.makeIterator()
@@ -928,7 +928,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       return .init(start: nil, count: 0)
     }
     _debugPrecondition(
-      Int(bitPattern: baseAddress) & MemoryLayout<T>.alignment-1 == 0,
+      Int(bitPattern: baseAddress) & (MemoryLayout<T>.alignment-1) == 0,
       "buffer base address must be properly aligned to access T"
     )
     _precondition(

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -83,7 +83,10 @@ UnsafeRawBufferPointerTestSuite.test("nonmutating_subscript_setter") {
   }
   expectEqual(value2, value1)
 
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 4,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
   buffer.copyBytes(from: [0, 1, 2, 3] as [UInt8])
   let leftBytes = buffer[0..<2]
@@ -131,7 +134,10 @@ UnsafeRawBufferPointerTestSuite.test("initFromArray") {
 #if !os(WASI)
 // Trap tests aren't available on WASI.
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 30, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 30,
+    alignment: MemoryLayout<UInt64>.alignment
+  )
   defer { buffer.deallocate() }
   let source = stride(from: 5 as Int64, to: 0, by: -1)
   if _isDebugAssertConfiguration() {
@@ -147,7 +153,10 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).underflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 30, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 30,
+    alignment: MemoryLayout<UInt64>.alignment
+  )
   defer { buffer.deallocate() }
   let source: [Int64] = [5, 4, 3, 2, 1]
   if _isDebugAssertConfiguration() {
@@ -216,7 +225,10 @@ UnsafeRawBufferPointerTestSuite.test("empty") {
   for _ in emptyBytes {
     expectUnreachable()
   }
-  let emptyMutableBytes = UnsafeMutableRawBufferPointer.allocate(byteCount: 0, alignment: MemoryLayout<UInt>.alignment)
+  let emptyMutableBytes = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 0,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   for _ in emptyMutableBytes {
     expectUnreachable()
   }
@@ -232,8 +244,10 @@ UnsafeRawBufferPointerTestSuite.test("reinterpret") {
   }
   let numPairs = 2
   let bytes = UnsafeMutableRawBufferPointer.allocate(
-    byteCount: MemoryLayout<Pair>.stride * numPairs, alignment: MemoryLayout<UInt>.alignment)
-  defer { bytes.deallocate() }  
+    byteCount: MemoryLayout<Pair>.stride * numPairs,
+    alignment: MemoryLayout<Pair>.alignment
+  )
+  defer { bytes.deallocate() }
 
   for i in 0..<(numPairs * 2) {
     bytes.storeBytes(of: Int32(i), toByteOffset: i * MemoryLayout<Int32>.stride,
@@ -262,7 +276,9 @@ UnsafeRawBufferPointerTestSuite.test("reinterpret") {
 UnsafeRawBufferPointerTestSuite.test("inBounds") {
   let numInts = 4
   let bytes = UnsafeMutableRawBufferPointer.allocate(
-    byteCount: MemoryLayout<Int>.stride * numInts, alignment: MemoryLayout<UInt>.alignment)
+    byteCount: MemoryLayout<Int>.stride * numInts,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { bytes.deallocate() }
 
   for i in 0..<numInts {
@@ -292,7 +308,10 @@ UnsafeRawBufferPointerTestSuite.test("inBounds") {
 #if !os(WASI)
 // Trap tests aren't available on WASI.
 UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 2,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   let bytes = UnsafeRawBufferPointer(rebasing: buffer[1..<2])
@@ -305,7 +324,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.underflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 2,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   let bytes = UnsafeRawBufferPointer(rebasing: buffer[0..<1])
@@ -318,7 +340,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.get.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 2,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<2])
@@ -331,7 +356,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.underflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 2, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 2,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<1])
@@ -344,7 +372,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.set.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 3,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   let bytes = UnsafeRawBufferPointer(rebasing: buffer[1..<3])
@@ -357,7 +388,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.underflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 3,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   let bytes = UnsafeRawBufferPointer(rebasing: buffer[0..<2])
@@ -370,7 +404,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.get.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 3,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[1..<3])
@@ -383,7 +420,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.underflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 3,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   let bytes = UnsafeMutableRawBufferPointer(rebasing: buffer[0..<2])
@@ -397,7 +437,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.set.overflow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 3,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   if _isDebugAssertConfiguration() {
@@ -408,7 +451,10 @@ UnsafeRawBufferPointerTestSuite.test("subscript.range.narrow") {
 }
 
 UnsafeRawBufferPointerTestSuite.test("subscript.range.wide") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 3,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   if _isDebugAssertConfiguration() {
@@ -434,7 +480,10 @@ UnsafeRawBufferPointerTestSuite.test("_copyContents") {
 #if !os(WASI)
 // Trap tests aren't available on WASI.
 UnsafeRawBufferPointerTestSuite.test("copyMemory.overflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 3,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
 
   let bytes = buffer[0..<2]
@@ -464,7 +513,10 @@ UnsafeRawBufferPointerTestSuite.test("copyBytes.withoutContiguousStorage") {
 #if !os(WASI)
 // Trap tests aren't available on WASI.
 UnsafeRawBufferPointerTestSuite.test("copyBytes.sequence.overflow") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 3, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 3,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { buffer.deallocate() }
   
   let bytes = buffer[0..<2]
@@ -653,7 +705,10 @@ UnsafeRawBufferPointerTestSuite.test("copy.sequence.overflow")
 #endif
 
 UnsafeRawBufferPointerTestSuite.test("copy.overlap") {
-  let bytes = UnsafeMutableRawBufferPointer.allocate(byteCount: 4, alignment: MemoryLayout<UInt>.alignment)
+  let bytes = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 4,
+    alignment: MemoryLayout<UInt>.alignment
+  )
   defer { bytes.deallocate() }
   // Right Overlap
   bytes[0] = 1

--- a/test/stdlib/UnsafeRawBufferPointer.swift
+++ b/test/stdlib/UnsafeRawBufferPointer.swift
@@ -164,7 +164,10 @@ UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).overflow") {
 #endif
 
 UnsafeRawBufferPointerTestSuite.test("initializeMemory(as:from:).exact") {
-  let buffer = UnsafeMutableRawBufferPointer.allocate(byteCount: 24, alignment: MemoryLayout<UInt>.alignment)
+  let buffer = UnsafeMutableRawBufferPointer.allocate(
+    byteCount: 3*MemoryLayout<Int64>.stride,
+    alignment: MemoryLayout<Int64>.alignment
+  )
   defer { buffer.deallocate() }
   let source: [Int64] = [5, 4, 3]
   var (it,bound) = buffer.initializeMemory(as: Int64.self, from: source)


### PR DESCRIPTION
This precondition was mistakenly checking the stride instead of the alignment.

Cherry-pick of https://github.com/apple/swift/pull/70911

Addresses rdar://121064131