### PR TITLE
[stdlib] Avoid materializing strong references in potential dangling unmanaged opaque functions

### DIFF
--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -56,8 +56,9 @@ public struct Unmanaged<Instance: AnyObject> {
   /// - Returns: An opaque pointer to the value of this unmanaged reference.
   @_transparent
   public func toOpaque() -> UnsafeMutableRawPointer {
-    // NOTE: This function does not attempt to unsafeBitCast '_value' because
-    // that will get a strong reference temporary value who the compiler will
+    // NOTE: `self` is allowed to be a dangling reference.
+    // Therefore, this function must not unsafeBitCast '_value' because
+    // that will get a strong reference temporary value that the compiler will
     // try to retain/release. Use 'self' to avoid this. 'Unmanaged<Instance>' is
     // layout compatible with 'UnsafeRawPointer' and casting from that will not
     // attempt to retain the reference held at '_value'.

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -34,7 +34,9 @@ public struct Unmanaged<Instance: AnyObject> {
   public static func fromOpaque(
     @_nonEphemeral _ value: UnsafeRawPointer
   ) -> Unmanaged {
-    // NOTE: This function does NOT go through the init(_private:) initializer
+    // NOTE: `value` is allowed to be a dangling pointer, so 
+    // this function must not ever try to dereference it. For
+    // example, it must NOT go through the init(_private:) initializer
     // because it requires us to materialize a strong reference to 'Instance'.
     // This materialization is enough to convince the compiler to add
     // retain/releases which we want to avoid for the opaque pointer functions.

--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -34,12 +34,12 @@ public struct Unmanaged<Instance: AnyObject> {
   public static func fromOpaque(
     @_nonEphemeral _ value: UnsafeRawPointer
   ) -> Unmanaged {
-    // NOTE: `value` is allowed to be a dangling pointer, so 
+    // NOTE: `value` is allowed to represent a dangling reference, so 
     // this function must not ever try to dereference it. For
-    // example, it must NOT go through the init(_private:) initializer
-    // because it requires us to materialize a strong reference to 'Instance'.
-    // This materialization is enough to convince the compiler to add
-    // retain/releases which we want to avoid for the opaque pointer functions.
+    // example, this function must NOT use the init(_private:) initializer
+    // because doing so requires materializing a strong reference to 'Instance'.
+    // This materialization would be enough to convince the compiler to add
+    // retain/releases which must be avoided for the opaque pointer functions.
     // 'Unmanaged<Instance>' is layout compatible with 'UnsafeRawPointer' and
     // casting to that will not attempt to retain the reference held at 'value'.
     unsafeBitCast(value, to: Unmanaged<Instance>.self)

--- a/test/stdlib/Unmanaged.swift
+++ b/test/stdlib/Unmanaged.swift
@@ -71,4 +71,22 @@ UnmanagedTests.test("Opaque") {
   _fixLifetime(ref)
 }
 
+UnmanagedTests.test("Opaque avoid retain/release") {
+  // The purpose of this test is to ensure that the fromOpaque/toOpaque calls do
+  // NOT attempt to retain/release the class instance at the passed pointer.
+  // Here we're simulating a dangling pointer referencing a class who has
+  // already been released (the allocated pointer points at nothing) and
+  // attempting to create an Unmanaged instance from it and get back the
+  // pointer. This test's expectEqual is kind of bogus, we're just checking that
+  // it doesn't crash.
+
+  let ref = UnsafeMutablePointer<Int>(capacity: 1)
+  let unmanaged = Unmanaged.fromOpaque(UnsafeRawPointer(ref))
+  let ref2 = unmanaged.toOpaque()
+
+  expectEqual(ref, ref2)
+
+  ref.deallocate()
+}
+
 runAllTests()

--- a/test/stdlib/Unmanaged.swift
+++ b/test/stdlib/Unmanaged.swift
@@ -80,13 +80,17 @@ UnmanagedTests.test("Opaque avoid retain/release") {
   // pointer. This test's expectEqual is kind of bogus, we're just checking that
   // it doesn't crash.
 
-  let ref = UnsafeMutablePointer<Int>(capacity: 1)
-  let unmanaged = Unmanaged.fromOpaque(UnsafeRawPointer(ref))
+  // Create a dangling pointer, usually to unmapped memory.
+  let ref = UnsafeRawPointer(bitPattern: 1)!
+  // Turn it into a dangling unmanaged reference.
+  // We expect this not to crash, as this operation isn't 
+  // supposed to dereference the pointer in any way.
+  let unmanaged = Unmanaged.fromOpaque(ref)
+  // Similarly, converting the unmanaged reference back to a 
+  // pointer should not ever try to dereference it either.
   let ref2 = unmanaged.toOpaque()
-
+  // ...and we must get back the same pointer.
   expectEqual(ref, ref2)
-
-  ref.deallocate()
 }
 
 runAllTests()

--- a/test/stdlib/Unmanaged.swift
+++ b/test/stdlib/Unmanaged.swift
@@ -85,7 +85,7 @@ UnmanagedTests.test("Opaque avoid retain/release") {
   // Turn it into a dangling unmanaged reference.
   // We expect this not to crash, as this operation isn't 
   // supposed to dereference the pointer in any way.
-  let unmanaged = Unmanaged.fromOpaque(ref)
+  let unmanaged = Unmanaged<Foobar>.fromOpaque(ref)
   // Similarly, converting the unmanaged reference back to a 
   // pointer should not ever try to dereference it either.
   let ref2 = unmanaged.toOpaque()


### PR DESCRIPTION
The current implementations of `toOpaque` and `fromOpaque` accidentally/incorrectly gets hold of temporary strong references to `Instance` which will emit retain/releases from the compiler in certain configurations. These functions should not induce any ARC traffic whatsoever. Bit cast `self` to and from the pointer value instead to avoid this.

Resolves: rdar://120849792