### PR TITLE
Add REQUIRES: asserts to sendable_objc_attr_in_type_context.swift

### DIFF
--- a/test/Concurrency/sendable_objc_attr_in_type_context.swift
+++ b/test/Concurrency/sendable_objc_attr_in_type_context.swift
@@ -9,6 +9,7 @@
 // RUN:   -module-name main -I %t -verify
 
 // REQUIRES: objc_interop
+// REQUIRES: asserts
 
 //--- Test.h
 #define SWIFT_SENDABLE __attribute__((__swift_attr__("@Sendable")))


### PR DESCRIPTION
The test specifies `-enable-experimental-feature SendableCompletionHandlers`.