### PR TITLE
[embedded] Add Unicode.Scalar to embedded stdlib

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -107,7 +107,7 @@ split_embedded_sources(
   EMBEDDED ManagedBuffer.swift
     NORMAL Map.swift
   EMBEDDED MemoryLayout.swift
-    NORMAL UnicodeScalar.swift # ORDER DEPENDENCY: Must precede Mirrors.swift
+  EMBEDDED UnicodeScalar.swift # ORDER DEPENDENCY: Must precede Mirrors.swift
     NORMAL Mirrors.swift
   EMBEDDED Misc.swift
   EMBEDDED MutableCollection.swift

--- a/stdlib/public/core/EmbeddedStubs.swift
+++ b/stdlib/public/core/EmbeddedStubs.swift
@@ -149,76 +149,31 @@ extension String {
   public init<T: BinaryInteger>(_ value: T, radix: Int = 10, uppercase: Bool = false) { fatalError() }
 }
 
-/// Unicode.Scalar
+/// Unicode
 
 public enum Unicode {}
 
-extension Unicode {
-  public struct Scalar: Sendable {
-    internal var _value: UInt32
-    internal init(_value: UInt32) {
-      self._value = _value
-    }
-  }
-}
-
-extension Unicode.Scalar : _ExpressibleByBuiltinUnicodeScalarLiteral, ExpressibleByUnicodeScalarLiteral {
-  public var value: UInt32 { return _value }
-  public init(_builtinUnicodeScalarLiteral value: Builtin.Int32) {
-    self._value = UInt32(value)
-  }
-  public init(unicodeScalarLiteral value: Unicode.Scalar) {
-    self = value
-  }
-  public init?(_ v: UInt32) {
-    if (v < 0xD800 || v > 0xDFFF) && v <= 0x10FFFF {
-      self._value = v
-      return
-    }
-    return nil
-  }
-  public init?(_ v: UInt16) {
-    self.init(UInt32(v))
-  }
-  public init(_ v: UInt8) {
-    self._value = UInt32(v)
-  }
-  public init(_ v: Unicode.Scalar) {
-    self = v
-  }
-  @_unavailableInEmbedded
-  public func escaped(asASCII forceASCII: Bool) -> String { fatalError() }
-  @_unavailableInEmbedded
-  internal func _escaped(asASCII forceASCII: Bool) -> String? { fatalError() }
-  public var isASCII: Bool {
-    return value <= 127
-  }
-  internal var _isPrintableASCII: Bool {
-    return (self >= Unicode.Scalar(0o040) && self <= Unicode.Scalar(0o176))
-  }
-}
-
-extension Unicode.Scalar: Equatable {
-  public static func == (lhs: Unicode.Scalar, rhs: Unicode.Scalar) -> Bool {
-    return lhs.value == rhs.value
-  }
-}
-
-extension Unicode.Scalar: Comparable {
-  public static func < (lhs: Unicode.Scalar, rhs: Unicode.Scalar) -> Bool {
-    return lhs.value < rhs.value
-  }
-}
-
 public typealias UTF8 = Unicode.UTF8
+public typealias UTF16 = Unicode.UTF16
 
 extension Unicode {
   public enum UTF8 {
+  }
+  public enum UTF16 {
   }
 }
 
 extension Unicode.UTF8 {
   public typealias CodeUnit = UInt8
+}
+
+extension Unicode.UTF16 {
+  public typealias CodeUnit = UInt16
+}
+
+@_unavailableInEmbedded
+extension String {
+  public init(_ value: Unicode.Scalar) { fatalError() }
 }
 
 /// Codable

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -295,7 +295,7 @@ extension Unicode.Scalar: CustomStringConvertible, CustomDebugStringConvertible 
   }
 }
 
-@_unavailableInEmbedded
+#if !$Embedded
 extension Unicode.Scalar: LosslessStringConvertible {
   @inlinable
   public init?(_ description: String) {
@@ -306,6 +306,7 @@ extension Unicode.Scalar: LosslessStringConvertible {
     self = v
   }
 }
+#endif
 
 extension Unicode.Scalar: Hashable {
   /// Hashes the essential components of this value by feeding them into the
@@ -410,6 +411,8 @@ extension Unicode.Scalar {
     return UTF16View(value: self)
   }
 }
+
+#if !$Embedded
 
 extension Unicode.Scalar.UTF16View: RandomAccessCollection {
 
@@ -540,3 +543,4 @@ extension Unicode.Scalar {
   }
 }
 
+#endif

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -24,6 +24,11 @@ public func staticstring() -> StaticString {
   return "hello"
 }
 
+public func unicodescalars() {
+  let a = UInt8(ascii: "-")
+  let b = Unicode.Scalar("-").value
+}
+
 public func checks(n: Int) {
   precondition(n > 0)
   precondition(n > 0, "message")


### PR DESCRIPTION
Not adding any actual String or Unicode support, just the primitive Unicode.Scalar and it's basic integer APIs.

rdar://119587015