### PR TITLE
Resolve warnings in the Concurrency runtime

### DIFF
--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -401,11 +401,7 @@ where E: SerialExecutor {
 @_silgen_name("_swift_task_enqueueOnTaskExecutor")
 internal func _enqueueOnTaskExecutor<E>(job unownedJob: UnownedJob, executor: E) where E: _TaskExecutor {
   #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-  if #available(SwiftStdlib 9999, *) {
-    executor.enqueue(ExecutorJob(context: unownedJob._context))
-  } else {
-    executor.enqueue(unownedJob)
-  }
+  executor.enqueue(ExecutorJob(context: unownedJob._context))
   #else // SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
   executor.enqueue(unownedJob)
   #endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -135,18 +135,24 @@ void swift::swift_task_enqueueGlobalWithDeadline(
 // Implemented in Swift because we need to obtain the user-defined flags on the executor ref.
 //
 // We could inline this with effort, though.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C" SWIFT_CC(swift)
 SerialExecutorRef _task_serialExecutor_getExecutorRef(
         HeapObject *executor, const Metadata *selfType,
         const SerialExecutorWitnessTable *wtable);
+#pragma clang diagnostic pop
 
 // Implemented in Swift because we need to obtain the user-defined flags on the executor ref.
 //
 // We could inline this with effort, though.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
 extern "C" SWIFT_CC(swift)
 TaskExecutorRef _task_executor_getTaskExecutorRef(
     HeapObject *executor, const Metadata *selfType,
     const SerialExecutorWitnessTable *wtable);
+#pragma clang diagnostic pop
 
 SWIFT_CC(swift)
 static bool swift_task_isOnExecutorImpl(HeapObject *executor,

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1381,7 +1381,12 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
       _swift_taskGroup_detachChild(asAbstract(this), completedTask);
       return unlock();
     }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunreachable-code"
+    // This _should_ be statically unreachable, but we leave it in as a
+    // safeguard in case the control flow above changes.
     swift_unreachable("expected to early return from when handling offer of last task in group");
+#pragma clang diagnostic pop
   }
 
   assert(!hadErrorResult && "only successfully completed tasks can reach here");


### PR DESCRIPTION
Squashes a few warnings in files under `stdlib/public/Concurrency/`.