### PR TITLE
[Concurrency] suppress global variable static checking for @TaskLocal property wrapper declarations

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4445,6 +4445,15 @@ ActorIsolation ActorIsolationRequest::evaluate(
       if (var->isGlobalStorage() && !isActorType) {
         auto *diagVar = var;
         if (auto *originalVar = var->getOriginalWrappedProperty()) {
+          // temporary 5.10 checking bypass for @TaskLocal <rdar://120907014>
+          // TODO: @TaskLocal should be a macro <rdar://120914014>
+          if (auto *classDecl =
+                  var->getInterfaceType()->getClassOrBoundGenericClass()) {
+            auto &ctx = var->getASTContext();
+            if (classDecl == ctx.getTaskLocalDecl()) {
+              return isolation;
+            }
+          }
           diagVar = originalVar;
         }
         if (var->isLet()) {

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -8,18 +8,14 @@
 @available(SwiftStdlib 5.1, *)
 struct TL {
   @TaskLocal
-  static var number: Int = 0 // expected-complete-warning {{static property 'number' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
-  // expected-complete-note@-1 {{isolate 'number' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
+  static var number: Int = 0
 
   @TaskLocal
-  static var someNil: Int? // expected-complete-warning {{static property 'someNil' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
-  // expected-complete-note@-1 {{isolate 'someNil' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
+  static var someNil: Int?
 
   @TaskLocal
   static var noValue: Int // expected-error{{'static var' declaration requires an initializer expression or an explicitly stated getter}}
   // expected-note@-1{{add an initializer to silence this error}}
-  // expected-complete-warning@-2 {{static property 'noValue' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
-  // expected-complete-note@-3 {{isolate 'noValue' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 
   @TaskLocal
   var notStatic: String? // expected-error{{property 'notStatic', must be static because property wrapper 'TaskLocal<String?>' can only be applied to static properties}}


### PR DESCRIPTION
Explanation: This  change resolves a bug in the [SE-0412](https://github.com/apple/swift-evolution/blob/main/proposals/0412-strict-concurrency-for-global-variables.md) implementation that makes it impossible to use the `@TaskLocal` property wrapper with strict concurrency enabled. This is due to the fact that `@TaskLocal` property wrappers are required to be `static`, and their storage is always declared `var`, and so they appear to the type checker as mutable global state, however the implementation of `@TaskLocal` ensures isolation to a single task, thereby obviating data race concerns. This change suppresses strict concurrency diagnostics for `@TaskLocal` declarations. Note that this is a temporary solution for 5.10 to unblock developers from experimenting with strict concurrency. The more complete solution will be to move to a `TaskLocal` macro as described in <rdar://121054518> and will be developed on `main` branch.

Scope: minor change to skip past `@TaskLocal` declarations during type checking under strict concurrency and the changes are guarded behind an upcoming feature flag

Issue: rdar://120907014

Risk: low risk given that the change is in functionality that is guarded behind `-strict-concurrency=complete` feature flag and the fact that `@TaskLocal` property wrapper instances do not have concurrency concerns.

Testing: `lit` tests included

Reviewer: @ktoso @hborla