### PR TITLE
NFC: Ignore deprecation warnings for typed pointers in IRGen

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -3208,6 +3208,8 @@ static llvm::AttributeList
 assertTypesInByValAndStructRetAttributes(llvm::FunctionType *fnType,
                                          llvm::AttributeList attrList) {
   auto &context = fnType->getContext();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (context.supportsTypedPointers()) {
     for (unsigned i = 0; i < fnType->getNumParams(); ++i) {
       auto paramTy = fnType->getParamType(i);
@@ -3221,6 +3223,7 @@ assertTypesInByValAndStructRetAttributes(llvm::FunctionType *fnType,
               attrList.getParamByValType(i)));
     }
   }
+#pragma clang diagnostic pop
   return attrList;
 }
 
@@ -3462,10 +3465,13 @@ void CallEmission::emitToExplosion(Explosion &out, bool isOutlined) {
         resultTy = func->getParamStructRetType(0);
       }
       auto temp = IGF.createAlloca(resultTy, Alignment(), "indirect.result");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       if (IGF.IGM.getLLVMContext().supportsTypedPointers()) {
         temp = IGF.Builder.CreateElementBitCast(
             temp, fnType->getParamType(0)->getNonOpaquePointerElementType());
       }
+#pragma clang diagnostic pop
       emitToMemory(temp, substResultTI, isOutlined);
       return;
     }
@@ -3492,10 +3498,13 @@ void CallEmission::emitToExplosion(Explosion &out, bool isOutlined) {
         auto resultTy = func->getParamStructRetType(1);
         auto temp = IGF.createAlloca(resultTy, Alignment(/*safe alignment*/ 16),
                                      "indirect.result");
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         if (IGF.IGM.getLLVMContext().supportsTypedPointers()) {
           temp = IGF.Builder.CreateElementBitCast(
               temp, fnType->getParamType(1)->getNonOpaquePointerElementType());
         }
+#pragma clang diagnostic pop
         emitToMemory(temp, substResultTI, isOutlined);
         return;
       }
@@ -5931,6 +5940,8 @@ void irgen::forwardAsyncCallResult(IRGenFunction &IGF,
   emitAsyncReturn(IGF, layout, fnType, nativeResults);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 llvm::FunctionType *FunctionPointer::getFunctionType() const {
   // Static async function pointers can read the type off the secondary value
   // (the function definition.
@@ -5971,3 +5982,4 @@ llvm::FunctionType *FunctionPointer::getFunctionType() const {
              ->isOpaqueOrPointeeTypeMatches(Sig.getType()));
   return Sig.getType();
 }
+#pragma clang diagnostic pop

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -712,12 +712,15 @@ void DistributedAccessor::emit() {
 
     // Generic arguments associated with the distributed thunk directly
     // e.g. `distributed func echo<T, U>(...)`
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     assert(
         !IGM.getLLVMContext().supportsTypedPointers() ||
         expandedSignature.numTypeMetadataPtrs ==
             llvm::count_if(targetGenericArguments, [&](const llvm::Type *type) {
               return type == IGM.TypeMetadataPtrTy;
             }));
+#pragma clang diagnostic pop
 
     for (unsigned index = 0; index < expandedSignature.numTypeMetadataPtrs; ++index) {
       auto offset =

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -228,9 +228,12 @@ namespace {
       // We might be presented with a value of the more precise pointer to
       // function type "void(*)*" rather than the generic "i8*". Downcast to the
       // more general expected type.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       if (fn->getContext().supportsTypedPointers() &&
           fn->getType()->getNonOpaquePointerElementType()->isFunctionTy())
         fn = IGF.Builder.CreateBitCast(fn, getStorageType());
+#pragma clang diagnostic pop
 
       Explosion tmp;
       tmp.add(fn);

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -459,7 +459,10 @@ getProtocolRefsList(llvm::Constant *protocol) {
     return std::make_pair(0, nullptr);
   }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (!protocol->getContext().supportsTypedPointers()) {
+#pragma clang diagnostic pop
     auto protocolRefsVar = cast<llvm::GlobalVariable>(objCProtocolList);
     auto sizeListPair =
         cast<llvm::ConstantStruct>(protocolRefsVar->getInitializer());

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -463,7 +463,10 @@ namespace {
               clang::QualType(clangDecl->getTypeForDecl(), 0));
       auto *dstValue = dst.getAddress();
       auto *srcValue = src.getAddress();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       if (IGF.IGM.getLLVMContext().supportsTypedPointers()) {
+#pragma clang diagnostic pop
         dstValue = IGF.coerceValue(
             dst.getAddress(), copyFunction->getFunctionType()->getParamType(0),
             IGF.IGM.DataLayout);
@@ -634,7 +637,10 @@ namespace {
       clangFnAddr = emitCXXConstructorThunkIfNeeded(
           IGF.IGM, signature, copyConstructor, name, clangFnAddr);
       callee = cast<llvm::Function>(clangFnAddr);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       if (IGF.IGM.getLLVMContext().supportsTypedPointers()) {
+#pragma clang diagnostic pop
         dest = IGF.coerceValue(dest, callee->getFunctionType()->getParamType(0),
                                IGF.IGM.DataLayout);
         src = IGF.coerceValue(src, callee->getFunctionType()->getParamType(1),
@@ -705,7 +711,10 @@ namespace {
 
       SmallVector<llvm::Value *, 2> args;
       auto *thisArg = address.getAddress();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
       if (IGF.IGM.getLLVMContext().supportsTypedPointers())
+#pragma clang diagnostic pop
         thisArg = IGF.coerceValue(address.getAddress(),
                                   destructorFnAddr->getArg(0)->getType(),
                                   IGF.IGM.DataLayout);

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -115,8 +115,11 @@ TypeInfo::~TypeInfo() {
 }
 
 Address TypeInfo::getAddressForPointer(llvm::Value *ptr) const {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   assert(cast<llvm::PointerType>(ptr->getType())
              ->isOpaqueOrPointeeTypeMatches(getStorageType()));
+#pragma clang diagnostic pop
   return Address(ptr, getStorageType(), getBestKnownAlignment());
 }
 

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -1265,6 +1265,8 @@ static llvm::AttributeList
 fixUpTypesInByValAndStructRetAttributes(llvm::FunctionType *fnType,
                                         llvm::AttributeList attrList) {
   auto &context = fnType->getContext();
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
   if (!context.supportsTypedPointers())
     return attrList;
 
@@ -1282,6 +1284,7 @@ fixUpTypesInByValAndStructRetAttributes(llvm::FunctionType *fnType,
           context, attrListIndex, llvm::Attribute::ByVal,
           paramTy->getNonOpaquePointerElementType());
   }
+#pragma clang diagnostic pop
   return attrList;
 }
 /// Replace direct callers of Old with New. Also add parameters to the call to


### PR DESCRIPTION
Suppress the deprecation warnings emitted about using various LLVM APIs related to typed pointers since we are not planning to immediately stop referencing these APIs and in the meantime the diagnostics are just spam.

Filed rdar://121083958 to track formally addressing these deprecations.
