### PR TITLE
Fix @retroactive for conditional conformances, and more

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -39,9 +39,6 @@ class AbstractClosureExpr;
 /// to avoid having to include Types.h.
 bool areTypesEqual(Type type1, Type type2);
 
-/// Determine whether the given type is suitable as a concurrent value type.
-bool isSendableType(ModuleDecl *module, Type type);
-
 /// Determines if the 'let' can be read from anywhere within the given module,
 /// regardless of the isolation or async-ness of the context in which
 /// the var is read.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2829,6 +2829,25 @@ public:
   void cacheResult(TypeWitnessAndDecl value) const;
 };
 
+class ReferencedAssociatedTypesRequest
+    : public SimpleRequest<ReferencedAssociatedTypesRequest,
+                           TinyPtrVector<AssociatedTypeDecl *>(ValueDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  TinyPtrVector<AssociatedTypeDecl *>
+  evaluate(Evaluator &evaluator, ValueDecl *req) const;
+
+public:
+  // Caching.
+  bool isCached() const { return true; }
+};
+
 class ValueWitnessRequest
     : public SimpleRequest<ValueWitnessRequest,
                            Witness(NormalProtocolConformance *, ValueDecl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -426,6 +426,9 @@ SWIFT_REQUEST(TypeChecker, AssociatedConformanceRequest,
               ProtocolConformanceRef(NormalProtocolConformance *,
                                      Type, ProtocolDecl *, unsigned),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ReferencedAssociatedTypesRequest,
+              TinyPtrVector<AssociatedTypeDecl *>(ValueDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ValueWitnessRequest,
               Witness(NormalProtocolConformance *, ValueDecl *),
               SeparatelyCached, NoLocationInfo)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -925,11 +925,9 @@ public:
   /// Determines whether this type is an any actor type.
   bool isAnyActorType();
 
-  /// Returns true if this type is a Sendable type.
-  bool isSendableType(DeclContext *declContext);
-
-  /// Returns true if this type is a Sendable type.
-  bool isSendableType(ModuleDecl *parentModule);
+  /// Returns true if this type conforms to Sendable, or if its a function type
+  /// that is @Sendable.
+  bool isSendableType();
 
   /// Determines whether this type conforms or inherits (if it's a protocol
   /// type) from `DistributedActor`.

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -891,9 +891,6 @@ public:
   /// Returns true if this function conforms to the Sendable protocol.
   bool isSendable(SILFunction *fn) const;
 
-  ProtocolConformanceRef conformsToProtocol(SILFunction *fn,
-                                            ProtocolDecl *protocol) const;
-
   /// False if SILValues of this type cannot be used outside the scope of their
   /// lifetime dependence.
   bool isEscapable() const;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -637,6 +637,8 @@ Type CompletionLookup::getTypeOfMember(const ValueDecl *VD,
     //     τ_1_0(U) => U }
     auto subs = keyPathInfo.baseType->getMemberSubstitutions(SD);
 
+    // FIXME: The below should use substitution map substitution.
+
     // If the keyPath result type has type parameters, that might affect the
     // subscript result type.
     auto keyPathResultTy =

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -800,21 +800,20 @@ void CompletionLookup::analyzeActorIsolation(
   // If the reference is 'async', all types must be 'Sendable'.
   if (Ctx.LangOpts.StrictConcurrencyLevel >= StrictConcurrency::Complete &&
       implicitlyAsync && T) {
-    auto *M = CurrDeclContext->getParentModule();
     if (isa<VarDecl>(VD)) {
-      if (!isSendableType(M, T)) {
+      if (!T->isSendableType()) {
         NotRecommended = ContextualNotRecommendedReason::CrossActorReference;
       }
     } else {
       assert(isa<FuncDecl>(VD) || isa<SubscriptDecl>(VD));
       // Check if the result and the param types are all 'Sendable'.
       auto *AFT = T->castTo<AnyFunctionType>();
-      if (!isSendableType(M, AFT->getResult())) {
+      if (!AFT->getResult()->isSendableType()) {
         NotRecommended = ContextualNotRecommendedReason::CrossActorReference;
       } else {
         for (auto &param : AFT->getParams()) {
           Type paramType = param.getPlainType();
-          if (!isSendableType(M, paramType)) {
+          if (!paramType->isSendableType()) {
             NotRecommended =
                 ContextualNotRecommendedReason::CrossActorReference;
             break;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -52,7 +52,9 @@ swift::getTopLevelDeclsForDisplay(ModuleDecl *M,
           !accessScope.isPublic() && !accessScope.isPackage())
         continue;
 
-      (void)swift::isSendableType(M, NTD->getDeclaredInterfaceType());
+      auto proto = M->getASTContext().getProtocol(KnownProtocolKind::Sendable);
+      if (proto)
+        (void) M->lookupConformance(NTD->getDeclaredInterfaceType(), proto);
     }
   }
 

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1250,11 +1250,6 @@ SILType SILType::removingMoveOnlyWrapperToBoxedType(const SILFunction *fn) {
   return SILType::getPrimitiveObjectType(newBoxType);
 }
 
-ProtocolConformanceRef
-SILType::conformsToProtocol(SILFunction *fn, ProtocolDecl *protocol) const {
-  return fn->getParentModule()->checkConformance(getASTType(), protocol);
-}
-
 bool SILType::isSendable(SILFunction *fn) const {
-  return getASTType()->isSendableType(fn->getParentModule());
+  return getASTType()->isSendableType();
 }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -361,7 +361,7 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
       auto type = var->getTypeInContext();
       auto isolation = getActorIsolation(var);
       if (isolation.isGlobalActor()) {
-        if (!isSendableType(decl->getModuleContext(), type) ||
+        if (!type->isSendableType() ||
             var->getInitializerIsolation().isGlobalActor()) {
           // If different isolated stored properties require different
           // global actors, it is impossible to initialize this type.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2806,8 +2806,7 @@ ConstraintSystem::getTypeOfMemberReference(
     FunctionType::ExtInfo info;
 
     if (Context.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
-      if (isPartialApplication(locator) &&
-          isSendableType(DC->getParentModule(), baseOpenedTy)) {
+      if (isPartialApplication(locator) && baseOpenedTy->isSendableType()) {
         // Add @Sendable to functions without conditional conformances
         functionType =
             functionType

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6825,9 +6825,6 @@ void AttributeChecker::visitKnownToBeLocalAttr(KnownToBeLocalAttr *attr) {
 }
 
 void AttributeChecker::visitSendableAttr(SendableAttr *attr) {
-
-  auto dc = D->getDeclContext();
-
   if ((isa<AbstractFunctionDecl>(D) || isa<AbstractStorageDecl>(D)) &&
       !isAsyncDecl(cast<ValueDecl>(D))) {
     auto value = cast<ValueDecl>(D);
@@ -6841,8 +6838,8 @@ void AttributeChecker::visitSendableAttr(SendableAttr *attr) {
   }
   // Prevent Sendable Attr from being added to methods of non-sendable types
   if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(D)) {
-    if (auto selfdecl = funcDecl->getImplicitSelfDecl()) {
-      if (!isSendableType(dc->getParentModule(), selfdecl->getTypeInContext())) {
+    if (auto selfDecl = funcDecl->getImplicitSelfDecl()) {
+      if (!selfDecl->getTypeInContext()->isSendableType()) {
         diagnose(attr->getLocation(), diag::nonsendable_instance_method)
         .warnUntilSwiftVersion(6);
       }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -683,31 +683,6 @@ static bool isSendableClosure(
   return false;
 }
 
-/// Determine whether the given type is suitable as a concurrent value type.
-bool swift::isSendableType(ModuleDecl *module, Type type) {
-  auto proto = module->getASTContext().getProtocol(KnownProtocolKind::Sendable);
-  if (!proto)
-    return true;
-
-  // First check if we have a function type. If we do, check if it is
-  // Sendable. We do this since functions cannot conform to protocols.
-  if (auto *fas = type->getAs<SILFunctionType>())
-    return fas->isSendable();
-  if (auto *fas = type->getAs<AnyFunctionType>())
-    return fas->isSendable();
-
-  auto conformance = module->checkConformance(type, proto);
-  if (conformance.isInvalid())
-    return false;
-
-  // Look for missing Sendable conformances.
-  return !conformance.forEachMissingConformance(
-      [](BuiltinProtocolConformance *missing) {
-        return missing->getProtocol()->isSpecificProtocol(
-            KnownProtocolKind::Sendable);
-      });
-}
-
 /// Add Fix-It text for the given nominal type to adopt Sendable.
 static void addSendableFixIt(
     const NominalTypeDecl *nominal, InFlightDiagnostic &diag, bool unchecked) {
@@ -4741,8 +4716,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
           diagVar = originalVar;
         }
         if (var->isLet()) {
-          if (!isSendableType(var->getModuleContext(),
-                              var->getInterfaceType())) {
+          if (!var->getInterfaceType()->isSendableType()) {
             diagVar->diagnose(diag::shared_immutable_state_decl, diagVar)
                 .warnUntilSwiftVersion(6);
           }
@@ -6356,7 +6330,7 @@ ActorReferenceResult ActorReferenceResult::forReference(
         (!actorInstance || actorInstance->isSelf())) {
       auto type =
           fromDC->mapTypeIntoContext(declRef.getDecl()->getInterfaceType());
-      if (!isSendableType(fromDC->getParentModule(), type)) {
+      if (!type->isSendableType()) {
         // Treat the decl isolation as 'preconcurrency' to downgrade violations
         // to warnings, because violating Sendable here is accepted by the
         // Swift 5.9 compiler.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1653,7 +1653,7 @@ static void diagnoseRetroactiveConformances(
     proto->walkInheritedProtocols([&](ProtocolDecl *decl) {
 
       // Get the original conformance of the extended type to this protocol.
-      auto conformanceRef = ext->getParentModule()->checkConformance(
+      auto conformanceRef = ext->getParentModule()->lookupConformance(
           extendedType, decl);
       if (!conformanceRef.isConcrete()) {
 

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/TypeMatcher.h"
 #include "swift/AST/Types.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Defer.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "llvm/ADT/Statistic.h"
@@ -374,7 +375,6 @@ static bool isExtensionUsableForInference(const ExtensionDecl *extension,
 
 InferredAssociatedTypesByWitnesses
 AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
-                    ConformanceChecker &checker,
                     const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
                     ValueDecl *req) {
   // Conformances constructed by the ClangImporter should have explicit type
@@ -392,7 +392,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
   InferredAssociatedTypesByWitnesses result;
 
   for (auto witness :
-       checker.lookupValueWitnesses(req, /*ignoringNames=*/nullptr)) {
+       lookupValueWitnesses(dc, req, /*ignoringNames=*/nullptr)) {
     LLVM_DEBUG(llvm::dbgs() << "Inferring associated types from decl:\n";
                witness->dump(llvm::dbgs()));
 
@@ -582,9 +582,7 @@ next_witness:;
 
 InferredAssociatedTypes
 AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
-  ConformanceChecker &checker,
-  const llvm::SetVector<AssociatedTypeDecl *> &assocTypes)
-{
+  const llvm::SetVector<AssociatedTypeDecl *> &assocTypes) {
   InferredAssociatedTypes result;
   for (auto member : proto->getMembers()) {
     auto req = dyn_cast<ValueDecl>(member);
@@ -598,8 +596,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
       if (assocTypes.count(assocType) == 0)
         continue;
 
-      auto reqInferred = inferTypeWitnessesViaAssociatedType(checker,
-                                                             assocTypes,
+      auto reqInferred = inferTypeWitnessesViaAssociatedType(assocTypes,
                                                              assocType);
       if (!reqInferred.empty())
         result.push_back({req, std::move(reqInferred)});
@@ -623,7 +620,9 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     // Check whether any of the associated types we care about are
     // referenced in this value requirement.
     {
-      const auto referenced = checker.getReferencedAssociatedTypes(req);
+      auto referenced = evaluateOrDefault(ctx.evaluator,
+                                          ReferencedAssociatedTypesRequest{req},
+                                          TinyPtrVector<AssociatedTypeDecl *>());
       if (llvm::find_if(referenced, [&](AssociatedTypeDecl *const assocType) {
                           return assocTypes.count(assocType);
                         }) == referenced.end())
@@ -633,7 +632,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
     // Infer associated types from the potential value witnesses for
     // this requirement.
     auto reqInferred =
-      inferTypeWitnessesViaValueWitnesses(checker, assocTypes, req);
+      inferTypeWitnessesViaValueWitnesses(assocTypes, req);
     if (reqInferred.empty())
       continue;
 
@@ -738,7 +737,6 @@ static Type removeSelfParam(ValueDecl *value, Type type) {
 
 InferredAssociatedTypesByWitnesses
 AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
-                   ConformanceChecker &checker,
                    const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
                    AssociatedTypeDecl *assocType) {
   // Form the default name _Default_Foo.
@@ -2513,13 +2511,13 @@ bool AssociatedTypeInference::diagnoseAmbiguousSolutions(
 }
 
 bool AssociatedTypeInference::canAttemptEagerTypeWitnessDerivation(
-    ConformanceChecker &checker,
-    AssociatedTypeDecl *assocType) {
+    DeclContext *DC, AssociatedTypeDecl *assocType) {
 
   /// Rather than locating the TypeID via the default implementation of
   /// Identifiable, we need to find the type based on the associated ActorSystem
-  if (checker.Adoptee->isDistributedActor() &&
-      assocType->getProtocol()->isSpecificProtocol(KnownProtocolKind::Identifiable)) {
+  if (auto *nominal = DC->getSelfNominalTypeDecl())
+    if (nominal->isDistributedActor() &&
+        assocType->getProtocol()->isSpecificProtocol(KnownProtocolKind::Identifiable)) {
     return true;
   }
 
@@ -2550,7 +2548,7 @@ auto AssociatedTypeInference::solve(ConformanceChecker &checker)
     if (conformance->hasTypeWitness(assocType))
       continue;
 
-    if (canAttemptEagerTypeWitnessDerivation(checker, assocType)) {
+    if (canAttemptEagerTypeWitnessDerivation(dc, assocType)) {
       auto derivedType = computeDerivedTypeWitness(assocType);
       if (derivedType.first) {
         checker.recordTypeWitness(assocType,
@@ -2602,8 +2600,7 @@ auto AssociatedTypeInference::solve(ConformanceChecker &checker)
     return result;
 
   // Infer potential type witnesses from value witnesses.
-  inferred = inferTypeWitnessesViaValueWitnesses(checker,
-                                                 unresolvedAssocTypes);
+  inferred = inferTypeWitnessesViaValueWitnesses(unresolvedAssocTypes);
   LLVM_DEBUG(llvm::dbgs() << "Candidates for inference:\n";
              dumpInferredAssociatedTypes(inferred));
 
@@ -3036,7 +3033,11 @@ void ConformanceChecker::resolveSingleWitness(ValueDecl *requirement) {
 
   // If any of the type witnesses was erroneous, don't bother to check
   // this value witness: it will fail.
-  for (auto assocType : getReferencedAssociatedTypes(requirement)) {
+  auto assocTypes = evaluateOrDefault(getASTContext().evaluator,
+                                      ReferencedAssociatedTypesRequest{requirement},
+                                      TinyPtrVector<AssociatedTypeDecl *>());
+
+  for (auto assocType : assocTypes) {
     if (Conformance->getTypeWitness(assocType)->hasError()) {
       Conformance->setInvalid();
       return;

--- a/test/IRGen/bitwise-copyable-derived-loadRaw.swift
+++ b/test/IRGen/bitwise-copyable-derived-loadRaw.swift
@@ -6,7 +6,7 @@
 
 public protocol MyBitwiseCopyable : _BitwiseCopyable {}
 
-extension SIMD16 : @retroactive MyBitwiseCopyable where Scalar.SIMD16Storage : MyBitwiseCopyable {}
+extension SIMD16 : MyBitwiseCopyable where Scalar.SIMD16Storage : MyBitwiseCopyable {}
 extension UInt8.SIMD16Storage : MyBitwiseCopyable {}
 
 func doit() {

--- a/test/Sema/extension_retroactive_conformances.swift
+++ b/test/Sema/extension_retroactive_conformances.swift
@@ -15,6 +15,9 @@ public struct Sample5 {}
 public struct Sample6 {}
 
 public struct SampleAlreadyConforms: SampleProtocol1 {}
+
+public struct GenericSample1<T> {}
+
 #else
 
 import Library
@@ -80,5 +83,10 @@ public struct OriginallyDefinedInLibrary {}
 extension OriginallyDefinedInLibrary: SampleProtocol1 {} // ok, @_originallyDefinedIn attribute makes this authoritative
 
 #endif
+
+// conditional conformances
+extension GenericSample1: SampleProtocol1 where T: SampleProtocol1 {}
+// expected-warning@-1 {{extension declares a conformance of imported type 'GenericSample1' to imported protocol 'SampleProtocol1'; this will not behave correctly if the owners of 'Library' introduce this conformance in the future}}
+// expected-note@-2 {{add '@retroactive' to silence this warning}}
 
 #endif

--- a/test/stdlib/SIMD_as_AdditiveArithmetic.swift
+++ b/test/stdlib/SIMD_as_AdditiveArithmetic.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-extension SIMD2: AdditiveArithmetic where Scalar: FloatingPoint { }
-extension SIMD3: AdditiveArithmetic where Scalar: FloatingPoint { }
-extension SIMD4: AdditiveArithmetic where Scalar: FloatingPoint { }
-extension SIMD8: AdditiveArithmetic where Scalar: FloatingPoint { }
+extension SIMD2: @retroactive AdditiveArithmetic where Scalar: FloatingPoint { }
+extension SIMD3: @retroactive AdditiveArithmetic where Scalar: FloatingPoint { }
+extension SIMD4: @retroactive AdditiveArithmetic where Scalar: FloatingPoint { }
+extension SIMD8: @retroactive AdditiveArithmetic where Scalar: FloatingPoint { }


### PR DESCRIPTION
- We weren't diagnosing `@retroactive` one way or the other with conditional conformances.
- Clean up and consolidate all the isSendableType() variants.
- A couple of other smaller cleanups.