### PR TITLE
[IRGen] Eagerly name anon globals before BitcodeWriter pass

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -89,6 +89,7 @@
 #include "llvm/Transforms/Instrumentation/ThreadSanitizer.h"
 #include "llvm/Transforms/ObjCARC.h"
 #include "llvm/Transforms/Scalar.h"
+#include "llvm/Transforms/Utils/NameAnonGlobals.h"
 
 #include <thread>
 
@@ -393,6 +394,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
         // lto summary.)
         Module->addModuleFlag(llvm::Module::Error, "EnableSplitLTOUnit",
                               uint32_t(1));
+        MPM.addPass(NameAnonGlobalPass());
       }
       MPM.addPass(BitcodeWriterPass(
           *out, /*ShouldPreserveUseListOrder*/ false, EmitRegularLTOSummary));


### PR DESCRIPTION
<!-- What's in this pull request? -->

For some reason, the way optimisation is done has perhaps changed a bit in 5.9. The upshot is that compiling our standard library crashes during the write bitcode phase for AVR without this patch to IRGen.cpp. Its possible that this problem would crash other non apple platforms such as CortexARM and Linux too without this patch.

It's a bit hard to know how to produce a concise test for this.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
