### PR TITLE
[Regex] Really build _RegexParser without resilience

### DIFF
--- a/stdlib/public/RegexParser/CMakeLists.txt
+++ b/stdlib/public/RegexParser/CMakeLists.txt
@@ -22,12 +22,10 @@ foreach(source ${_MATCHING_ENGINE_SOURCES})
 endforeach()
 message(STATUS "Using Experimental String Processing library for _RegexParser (${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}).")
 
-set(SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS_NO_RESILIENCE)
-string(REGEX REPLACE "-enable-library-evolution" ""
-  SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS_NO_RESILIENCE
-  "${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}")
-
-add_swift_target_library(swift_RegexParser ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
+# The parser module can be fragile (does not use library evolution) because its
+# only dependents are _StringProcessing and RegexBuilder and it's version-locked
+# with those modules.
+add_swift_target_library(swift_RegexParser ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_FRAGILE
   "${MATCHING_ENGINE_SOURCES}"
 
   SWIFT_MODULE_DEPENDS_LINUX Glibc
@@ -42,7 +40,6 @@ add_swift_target_library(swift_RegexParser ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
   C_COMPILE_FLAGS
     -Dswift_RegexParser_EXPORTS
   SWIFT_COMPILE_FLAGS
-    ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS_NO_RESILIENCE}
     # Workaround until `_RegexParser` is imported as implementation-only
     # by `_StringProcessing`.
     -Xfrontend -disable-implicit-string-processing-module-import

--- a/validation-test/ParseableInterface/verify_all_overlays.py
+++ b/validation-test/ParseableInterface/verify_all_overlays.py
@@ -50,9 +50,9 @@ for filename in os.listdir(sdk_overlay_dir):
     ]:
         continue
 
-    # Cxx and CxxStdlib are built without library evolution and don't have a
+    # These modules are built without library evolution and don't have a
     # .swiftinterface file
-    if module_name in ["Cxx", "CxxStdlib"]:
+    if module_name in ["Cxx", "CxxStdlib", "_RegexParser"]:
         if not os.path.exists(interface_file):
             continue
 


### PR DESCRIPTION
This was originally attempted with https://github.com/apple/swift/pull/58810 but `_RegexParser` still ended up being built with library evolution enabled because the `-enable-library-evolution` flag is added to the command line after calling `add_swift_target_library` and therefore stripping the flag out of `SWIFT_COMPILE_FLAGS` does nothing.

The `IS_FRAGILE` flag was introduced to support building C++ interop overlay modules without library evolution and it can now be used to prevent `_RegexParser` from being built with library evolution.

Resolves rdar://93067204