### PR TITLE
[Concurrency] isolated fixes; ban Array<T> and handle Self in actor

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4481,14 +4481,17 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
 
   Type type = resolveType(repr->getBase(), options);
 
+  Type unwrappedType = type;
   if (auto ty = dyn_cast<DynamicSelfType>(type)) {
-    type = ty->getSelfType();
+    unwrappedType = ty->getSelfType();
   }
 
   // isolated parameters must be of actor type
-  if (!type->hasTypeParameter() && !type->isAnyActorType() && !type->hasError()) {
+  if (!unwrappedType->isTypeParameter() &&
+      !unwrappedType->isAnyActorType() &&
+      !unwrappedType->hasError()) {
     // Optional actor types are fine - `nil` represents `nonisolated`.
-    auto wrapped = type->getOptionalObjectType();
+    auto wrapped = unwrappedType->getOptionalObjectType();
     auto allowOptional = getASTContext().LangOpts
         .hasFeature(Feature::OptionalIsolatedParameters);
     if (allowOptional && wrapped && wrapped->isAnyActorType()) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4479,25 +4479,27 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
     return ErrorType::get(getASTContext());
   }
 
+  // Keep the `type` to be returned, while we unwrap and inspect the inner
+  // type for whether it can be isolated on.
   Type type = resolveType(repr->getBase(), options);
-
   Type unwrappedType = type;
-  if (auto ty = dyn_cast<DynamicSelfType>(type)) {
-    unwrappedType = ty->getSelfType();
+
+  // Optional actor types are fine - `nil` represents `nonisolated`.
+  auto allowOptional = getASTContext().LangOpts
+                           .hasFeature(Feature::OptionalIsolatedParameters);
+  if (allowOptional) {
+    if (auto wrappedOptionalType = unwrappedType->getOptionalObjectType()) {
+      unwrappedType = wrappedOptionalType;
+    }
+  }
+  if (auto dynamicSelfType = dyn_cast<DynamicSelfType>(unwrappedType)) {
+    unwrappedType = dynamicSelfType->getSelfType();
   }
 
   // isolated parameters must be of actor type
   if (!unwrappedType->isTypeParameter() &&
       !unwrappedType->isAnyActorType() &&
       !unwrappedType->hasError()) {
-    // Optional actor types are fine - `nil` represents `nonisolated`.
-    auto wrapped = unwrappedType->getOptionalObjectType();
-    auto allowOptional = getASTContext().LangOpts
-        .hasFeature(Feature::OptionalIsolatedParameters);
-    if (allowOptional && wrapped && wrapped->isAnyActorType()) {
-      return type;
-    }
-
     diagnoseInvalid(
         repr, repr->getSpecifierLoc(), diag::isolated_parameter_not_actor, type);
     return ErrorType::get(type);

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -356,7 +356,11 @@ func isolated_generic_bad_2<T: Equatable>(_ t: isolated T) {}
 func isolated_generic_bad_3<T: AnyActor>(_ t: isolated T) {}
 // expected-error@-1 {{'isolated' parameter 'T' must conform to 'Actor' or 'DistributedActor' protocol}}
 
+func isolated_generic_bad_4<T>(_ t: isolated Array<T>) {}
+// expected-error@-1 {{'isolated' parameter has non-actor type 'Array<T>'}}
+
 func isolated_generic_ok_1<T: Actor>(_ t: isolated T) {}
+
 
 class NotSendable {} // expected-complete-note 5 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
 
@@ -396,9 +400,16 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   // expected-complete-warning@-3 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
 }
 
-actor A2 {}
-extension A2 {
-  nonisolated func f() async {
+// TODO: Consider making an actor's Self behave like in a struct, removing this special casing.
+//       We could consider changing this, so that self is always Self because we don't allow inheritance of actors.
+//       See: https://github.com/apple/swift/issues/70954 and rdar://121091417
+actor A2 {
+  nonisolated func f1() async {
     await { (self: isolated Self) in }(self)
+    // expected-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self'}}
+  }
+  nonisolated func f2() async -> Self {
+    await { (self: isolated Self) in }(self)
+    return self
   }
 }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -407,9 +407,12 @@ actor A2 {
   nonisolated func f1() async {
     await { (self: isolated Self) in }(self)
     // expected-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self'}}
+    await { (self: isolated Self?) in }(self)
+    // expected-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self?'}}
   }
   nonisolated func f2() async -> Self {
     await { (self: isolated Self) in }(self)
+    await { (self: isolated Self?) in }(self)
     return self
   }
 }


### PR DESCRIPTION
This fixes two logic isolated issues:

Seems to have been present for a long time:

- Due to a typo in the logic "is" vs "has" TypeParameter we allowed Array<T> which doesn't make sense.

Recent, due to https://github.com/apple/swift/pull/70925 being too permissive in Self handling:

- Technically `self` in an actor is handled like self in classess... so @slavapestov explained that we need to handle the following differently:

```swift
// TODO: Consider making an actor's Self behave like in a struct, removing this special casing.
//       We could consider changing this, so that self is always Self because we don't allow inheritance of actors.
//       See: https://github.com/apple/swift/issues/70954 and rdar://121091417
actor A2 {
  nonisolated func f1() async {
    await { (self: isolated Self) in }(self)
    // expected-error@-1 {{cannot convert value of type 'A2' to expected argument type 'Self'}}
  }
  nonisolated func f2() async -> Self {
    await { (self: isolated Self) in }(self)
    return self
  }
}
```