### PR TITLE
[CSStep] Add a nullptr check to `IsDeclRefinementOfRequest::evaluate`

### DIFF
--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -650,6 +650,9 @@ bool IsDeclRefinementOfRequest::evaluate(Evaluator &evaluator,
     auto interfaceTy =
         origType->getInterfaceType()->getCanonicalType()->getAs<SubstitutableType>();
 
+    if (!interfaceTy)
+      return CanType();
+
     // Make sure any duplicate bindings are equal to the one already recorded.
     // Otherwise, the substitution has conflicting generic arguments.
     auto bound = substMap.find(interfaceTy);

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -163,3 +163,29 @@ do {
 
   f2(f1) // expected-error {{no 'f1' candidates produce the expected type '(String) -> Void' for parameter #0}}
 }
+
+// https://forums.swift.org/t/1-x-type-inference/69417/15
+protocol N { associatedtype D }
+
+infix operator ++ : AdditionPrecedence
+infix operator -- : AdditionPrecedence
+
+func ++ <T: N> (lhs: T, rhs: T) -> T.D { fatalError() } // expected-note {{found this candidate}}
+func ++ <T: N> (lhs: T, rhs: T) -> T { fatalError() } // expected-note {{found this candidate}}
+
+func -- <T: N> (lhs: T, rhs: T) -> T { fatalError() } // expected-note {{found this candidate}}
+func -- <T: N> (lhs: T, rhs: T) -> T.D { fatalError() } // expected-note {{found this candidate}}
+
+do {
+  struct MyInt16: N { typealias D = MyInt32 }
+  struct MyInt32: N { typealias D = MyInt64 }
+  struct MyInt64 {}
+
+  var i16 = MyInt16()
+
+  let _ = i16 ++ i16
+  // expected-error@-1 {{ambiguous use of operator '++'}}
+
+  let _ = i16 -- i16
+  // expected-error@-1 {{ambiguous use of operator '--'}}
+}


### PR DESCRIPTION
Interface type of an archetype is not always represented by a
`SubstitutableType`, it could be a `DependentMemberType` as well.

The code in `IsDeclRefinementOfRequest::evaluate` already partially
accounts for that by using `getAs` but the nullptr check is missing
which means that the resulting substitution map is incorrect.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
