### PR TITLE
[IRGen] fix crashes emitting calls to get metadata from mangled name (16 bit architectures)

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1017,7 +1017,11 @@ llvm::Type *LinkEntity::getDefaultDeclarationType(IRGenModule &IGM) const {
   case Kind::NoncanonicalSpecializedGenericTypeMetadataCacheVariable:
     return IGM.TypeMetadataPtrTy;
   case Kind::TypeMetadataDemanglingCacheVariable:
-    return llvm::StructType::get(IGM.Int32Ty, IGM.Int32Ty);
+    if (IGM.getModule()->getDataLayout().isBigEndian()) {
+      return llvm::StructType::get(IGM.Int32Ty, IGM.RelativeAddressTy);
+    } else {
+      return llvm::StructType::get(IGM.RelativeAddressTy, IGM.Int32Ty);
+    }
   case Kind::TypeMetadataSingletonInitializationCache:
     // TODO: put a cache variable on IGM
     return llvm::StructType::get(IGM.getLLVMContext(),

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -3209,8 +3209,8 @@ emitMetadataAccessByMangledName(IRGenFunction &IGF, CanType type,
 
     auto stringAddrOffset = subIGF.Builder.CreateTrunc(load,
                                                        IGM.Int32Ty);
-    stringAddrOffset = subIGF.Builder.CreateSExtOrBitCast(stringAddrOffset,
-                                                          IGM.SizeTy);
+    stringAddrOffset = subIGF.Builder.CreateSExtOrTrunc(stringAddrOffset,
+                                                        IGM.SizeTy);
     auto stringAddrBase = subIGF.Builder.CreatePtrToInt(cache, IGM.SizeTy);
     if (IGM.getModule()->getDataLayout().isBigEndian()) {
       stringAddrBase = subIGF.Builder.CreateAdd(stringAddrBase,


### PR DESCRIPTION
<!-- What's in this pull request? -->
This tries to generalise the TypeMetadataDemanglingCacheVariable. In all other architectures this will emit an (i32, i32). For 16 bit architectures, the relative address should be an i16 to get the right relocations/fixups.

Also adjusts the generated `__swift_instantiateConcreteTypeFromMangledName` code emission to allow for the fact that SizeTy on 16 bit architectures is smaller than i32.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
