### PR TITLE
[test][IRGen] Fix static-vtable-stubs.swift on wasm32

### DIFF
--- a/test/IRGen/static-vtable-stubs.swift
+++ b/test/IRGen/static-vtable-stubs.swift
@@ -34,7 +34,7 @@ final class D: C {
 
 // CHECK: declare swiftcc ptr @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvg"(ptr swiftself) #0
 // CHECK: declare swiftcc void @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvs"(ptr, ptr swiftself) #0
-// CHECK: declare swiftcc { ptr, ptr } @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM"(ptr noalias dereferenceable(32), ptr swiftself) #0
+// CHECK: declare swiftcc { ptr, ptr } @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM"(ptr {{.*}}, ptr swiftself) #0
 
 @main
 struct Main {


### PR DESCRIPTION
The test was failing on 32-bit targets because of the different size of `dereferenceable` attribute.

```
B.swift:37:11: error: CHECK: expected string not found in input
// CHECK: declare swiftcc { ptr, ptr } @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM"(ptr noalias dereferenceable(32), ptr swiftself) #0
          ^
<stdin>:125:1: note: possible intended match here
declare swiftcc { ptr, ptr } @"$s1M1CC1i33_807E3D81CC6CDD898084F3279464DDF9LLSDySOypGvM"(ptr noalias dereferenceable(16), ptr swiftself) #0
```

The size of coroutine buffer passed as the first argument to the "modify" coroutine function is dependent on the target pointer size. (it's calculated as `NumWords_YieldOnceBuffer` * sizeof(void*)`).

The size is out of the scope of the test, so just accept any size.
