### PR TITLE
IRGen: Remove supportsTypedPointers, getNonOpaquePointerElementType, isOpaqueOrPointeeTypeMatches

### DIFF
--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -712,12 +712,6 @@ void DistributedAccessor::emit() {
 
     // Generic arguments associated with the distributed thunk directly
     // e.g. `distributed func echo<T, U>(...)`
-    assert(
-        !IGM.getLLVMContext().supportsTypedPointers() ||
-        expandedSignature.numTypeMetadataPtrs ==
-            llvm::count_if(targetGenericArguments, [&](const llvm::Type *type) {
-              return type == IGM.TypeMetadataPtrTy;
-            }));
 
     for (unsigned index = 0; index < expandedSignature.numTypeMetadataPtrs; ++index) {
       auto offset =

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -225,13 +225,6 @@ namespace {
                     bool isOutlined) const override {
       auto *fn = src.claimNext();
 
-      // We might be presented with a value of the more precise pointer to
-      // function type "void(*)*" rather than the generic "i8*". Downcast to the
-      // more general expected type.
-      if (fn->getContext().supportsTypedPointers() &&
-          fn->getType()->getNonOpaquePointerElementType()->isFunctionTy())
-        fn = IGF.Builder.CreateBitCast(fn, getStorageType());
-
       Explosion tmp;
       tmp.add(fn);
       PODSingleScalarTypeInfo<ThinFuncTypeInfo,LoadableTypeInfo>::initialize(IGF, tmp, addr, isOutlined);

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -459,20 +459,7 @@ getProtocolRefsList(llvm::Constant *protocol) {
     return std::make_pair(0, nullptr);
   }
 
-  if (!protocol->getContext().supportsTypedPointers()) {
-    auto protocolRefsVar = cast<llvm::GlobalVariable>(objCProtocolList);
-    auto sizeListPair =
-        cast<llvm::ConstantStruct>(protocolRefsVar->getInitializer());
-    auto size =
-        cast<llvm::ConstantInt>(sizeListPair->getOperand(0))->getZExtValue();
-    auto protocolRefsList =
-        cast<llvm::ConstantArray>(sizeListPair->getOperand(1));
-    return std::make_pair(size, protocolRefsList);
-  }
-
-  auto bitcast = cast<llvm::ConstantExpr>(objCProtocolList);
-  assert(bitcast->getOpcode() == llvm::Instruction::BitCast);
-  auto protocolRefsVar = cast<llvm::GlobalVariable>(bitcast->getOperand(0));
+  auto protocolRefsVar = cast<llvm::GlobalVariable>(objCProtocolList);
   auto sizeListPair =
       cast<llvm::ConstantStruct>(protocolRefsVar->getInitializer());
   auto size =

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -463,14 +463,6 @@ namespace {
               clang::QualType(clangDecl->getTypeForDecl(), 0));
       auto *dstValue = dst.getAddress();
       auto *srcValue = src.getAddress();
-      if (IGF.IGM.getLLVMContext().supportsTypedPointers()) {
-        dstValue = IGF.coerceValue(
-            dst.getAddress(), copyFunction->getFunctionType()->getParamType(0),
-            IGF.IGM.DataLayout);
-        srcValue = IGF.coerceValue(
-            src.getAddress(), copyFunction->getFunctionType()->getParamType(1),
-            IGF.IGM.DataLayout);
-      }
       IGF.Builder.CreateCall(copyFunction->getFunctionType(), copyFunction,
                              {dstValue, srcValue});
     }
@@ -634,12 +626,6 @@ namespace {
       clangFnAddr = emitCXXConstructorThunkIfNeeded(
           IGF.IGM, signature, copyConstructor, name, clangFnAddr);
       callee = cast<llvm::Function>(clangFnAddr);
-      if (IGF.IGM.getLLVMContext().supportsTypedPointers()) {
-        dest = IGF.coerceValue(dest, callee->getFunctionType()->getParamType(0),
-                               IGF.IGM.DataLayout);
-        src = IGF.coerceValue(src, callee->getFunctionType()->getParamType(1),
-                              IGF.IGM.DataLayout);
-      }
       llvm::Value *args[] = {dest, src};
       if (clangFnAddr == origClangFnAddr) {
         // Ensure we can use 'invoke' to trap on uncaught exceptions when
@@ -705,10 +691,6 @@ namespace {
 
       SmallVector<llvm::Value *, 2> args;
       auto *thisArg = address.getAddress();
-      if (IGF.IGM.getLLVMContext().supportsTypedPointers())
-        thisArg = IGF.coerceValue(address.getAddress(),
-                                  destructorFnAddr->getArg(0)->getType(),
-                                  IGF.IGM.DataLayout);
       args.push_back(thisArg);
       llvm::Value *implicitParam =
           clang::CodeGen::getCXXDestructorImplicitParam(

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -115,8 +115,6 @@ TypeInfo::~TypeInfo() {
 }
 
 Address TypeInfo::getAddressForPointer(llvm::Value *ptr) const {
-  assert(cast<llvm::PointerType>(ptr->getType())
-             ->isOpaqueOrPointeeTypeMatches(getStorageType()));
   return Address(ptr, getStorageType(), getBestKnownAlignment());
 }
 


### PR DESCRIPTION
Typed pointers are no longer supported by llvm.

rdar://121083958