### PR TITLE
[Threading] Add the correct scope for lazy_mutex_handle.

### DIFF
--- a/include/swift/Threading/Impl/C11.h
+++ b/include/swift/Threading/Impl/C11.h
@@ -95,7 +95,7 @@ struct lazy_mutex_handle {
   std::int32_t once; // -1 = initialized, 0 = uninitialized, 1 = initializing
 };
 
-#define SWIFT_LAZY_MUTEX_INITIALIZER ((lazy_mutex_handle){})
+#define SWIFT_LAZY_MUTEX_INITIALIZER ((threading_impl::lazy_mutex_handle){})
 
 inline void lazy_mutex_init(lazy_mutex_handle &handle) {
   // Sadly, we can't use call_once() for this as it doesn't have a context


### PR DESCRIPTION
Because we're mentioning the type in a macro and it gets used elsewhere, we need to be explicit that the type is inside threading_impl.

rdar://121122202
