### PR TITLE
[AddressLowering] Handle mark_unresolved... inst.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -947,6 +947,9 @@ static Operand *getProjectedDefOperand(SILValue value) {
 
     return nullptr;
 
+  case ValueKind::MarkUnresolvedNonCopyableValueInst:
+    return &cast<MarkUnresolvedNonCopyableValueInst>(value)->getOperandRef();
+
   case ValueKind::MoveValueInst:
     return &cast<MoveValueInst>(value)->getOperandRef();
 
@@ -3479,6 +3482,16 @@ protected:
   // the use-side because it may produce either loadable or address-only
   // types.
   void visitOpenExistentialValueInst(OpenExistentialValueInst *openExistential);
+
+  void visitMarkUnresolvedNonCopyableValueInst(
+      MarkUnresolvedNonCopyableValueInst *inst) {
+    assert(use == getProjectedDefOperand(inst));
+
+    auto address = pass.valueStorageMap.getStorage(use->get()).storageAddress;
+    auto *replacement = builder.createMarkUnresolvedNonCopyableValueInst(
+        inst->getLoc(), address, inst->getCheckKind());
+    markRewritten(inst, replacement);
+  }
 
   void visitMoveValueInst(MoveValueInst *mvi);
 

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -2526,6 +2526,32 @@ bb0:
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_mark_unresolved_non_copyable_value_1_consumable_and_assignable : {{.*}} {
+// CHECK:       bb0([[T:%[^,]+]] :
+// CHECK:         [[TP:%[^,]+]] = mark_unresolved_non_copyable_value [consumable_and_assignable] [[T]]
+// CHECK:         destroy_addr [[TP]]
+// CHECK-LABEL: } // end sil function 'test_mark_unresolved_non_copyable_value_1_consumable_and_assignable'
+sil [ossa] @test_mark_unresolved_non_copyable_value_1_consumable_and_assignable : $@convention(thin) <T> (@in @moveOnly T) -> () {
+entry(%t : @owned $@moveOnly T):
+  %tp = mark_unresolved_non_copyable_value [consumable_and_assignable] %t : $@moveOnly T
+  destroy_value %tp : $@moveOnly T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_mark_unresolved_non_copyable_value_2_no_consume_or_assign : {{.*}} {
+// CHECK:       bb0([[T:%[^,]+]] :
+// CHECK:         [[TP:%[^,]+]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[T]]
+// CHECK:         destroy_addr [[TP]]
+// CHECK-LABEL: } // end sil function 'test_mark_unresolved_non_copyable_value_2_no_consume_or_assign'
+sil [ossa] @test_mark_unresolved_non_copyable_value_2_no_consume_or_assign : $@convention(thin) <T> (@in @moveOnly T) -> () {
+entry(%t : @owned $@moveOnly T):
+  %tp = mark_unresolved_non_copyable_value [no_consume_or_assign] %t : $@moveOnly T
+  destroy_value %tp : $@moveOnly T
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil [ossa] @test_open_pack_element_dominance : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat each T}, Builtin.Word) -> () {
 // CHECK:       bb0([[PACK:%[^,]+]] : 
 // CHECK-SAME:      [[RAW_INDEX:%[^,]+]] :


### PR DESCRIPTION
In the fullness of time, AddressLowering should never see such instructions because they will be eliminated after diagnostics.  Until that time, though they need to be handled.
