### PR TITLE
[5.10 🍒][Dependency Scanning] Escape quoted strings in dependency command-line output

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -413,6 +413,8 @@ std::string quote(StringRef unquoted) {
   for (const auto ch : unquoted) {
     if (ch == '\\')
       os << '\\';
+    if (ch == '"')
+      os << '\\';
     os << ch;
   }
   return buffer.str().str();

--- a/test/ScanDependencies/placholder_overlay_deps.swift
+++ b/test/ScanDependencies/placholder_overlay_deps.swift
@@ -14,8 +14,8 @@
 // RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -placeholder-dependency-module-map-file %t/inputs/map.json -o %t/deps.json
 
 // Check the contents of the JSON output
-// RUN: %validate-json %t/deps.json &>/dev/null
-// RUN: %FileCheck %s < %t/deps.json
+// RUN: %validate-json %t/deps.json > %t/validated_deps.json
+// RUN: %FileCheck %s < %t/validated_deps.json
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -25,8 +25,7 @@ import Metal
 // Ensure the dependency on Darwin is captured even though it is a placeholder
 
 // CHECK:   "modulePath": "{{.*}}{{/|\\}}Metal-{{.*}}.swiftmodule",
-// CHECK-NEXT:   "sourceFiles": [
-// CHECK-NEXT:   ],
+// CHECK:   "directDependencies": [
 // CHECK:     {
 // CHECK:       "swiftPlaceholder": "Darwin"
 // CHECK:     },

--- a/test/ScanDependencies/test_quoted_arg.swift
+++ b/test/ScanDependencies/test_quoted_arg.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)	
+// RUN: %empty-directory(%t/module-cache)		
+// RUN: %empty-directory(%t/inputs)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %t/inputs -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+// RUN: %validate-json %t/deps.json > %t/validated_deps.json
+// RUN: %FileCheck %s < %t/validated_deps.json
+
+//--- inputs/Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foo
+// swift-module-flags-ignorable-private: -package-name "\"ManyFoos\""
+public func foo() {}
+
+//--- test.swift
+import Foo
+
+// CHECK:      "-package-name"
+// CHECK-NEXT: "\"ManyFoos\""


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/70892
---------------------------------------------------

Explanation: Dependency scanner textual JSON output includes command-line recipes to build module dependencies. For Swift modules we grab additional command-line flags from the module's `.swiftinterface` and include them in the recipe. If such added flags contain escaped quote characters `\"`, we do not properly escape them in our textual output, which leads to invalid JSON. This change fixes that by always escaping such characters in the scanner textual output. 
Scope: Only impacts consumers of textual output of `-scan-dependencies` JSON. 
Risk: Low. The only impact of this change is to correctly escape quote characters `"` in textual JSON output. Presence of such characters otherwise would lead to invalid JSON output.
Testing: Updated tests to exercise that we produce expected output for quoted input strings
Main branch PR: https://github.com/apple/swift/pull/70892