### PR TITLE
[Tests] NFC: Few more tests for objc thunks dynamic actor isolation e…

### DIFF
--- a/test/ClangImporter/preconcurrency_conformances.swift
+++ b/test/ClangImporter/preconcurrency_conformances.swift
@@ -74,3 +74,59 @@ final class K : @preconcurrency P {
 // CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MY_ACTOR_REF]] : $MyActor
 // CHECK: [[PRECONDITION:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
 // CHECK-NEXT: {{.*}} = apply [[PRECONDITION]]({{.*}}, [[EXEC]]) : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+
+@MainActor
+class TestObjCMethod {
+  @objc func testImplicit() -> Int { 42 }
+
+  @GlobalActor
+  @objc func testExplicit() {}
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s27preconcurrency_conformances14TestObjCMethodC12testImplicitSiyFTo : $@convention(objc_method) (TestObjCMethod) -> Int
+// CHECK: [[MAIN_ACTOR_METATYPE:%.*]] = metatype $@thick MainActor.Type
+// CHECK: [[SHARED_FIELD:%.*]] = function_ref @$sScM6sharedScMvgZ : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK-NEXT: [[SHARED_ACTOR:%.*]] = apply [[SHARED_FIELD]]([[MAIN_ACTOR_METATYPE]]) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK-NEXT: [[MAIN_ACTOR:%.*]] = begin_borrow [[SHARED_ACTOR]] : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[PRECONDITION:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+// CHECK-NEXT: {{.*}} = apply [[PRECONDITION]]({{.*}}, [[EXEC]]) : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s27preconcurrency_conformances14TestObjCMethodC12testExplicityyFTo : $@convention(objc_method) (TestObjCMethod) -> ()
+// CHECK: [[GLOBAL_ACTOR_METATYPE:%.*]] = metatype $@thin GlobalActor.Type
+// CHECK: [[SHARED_ACTOR_GETTER:%.*]] = function_ref @$s27preconcurrency_conformances11GlobalActorV6sharedAA02MyD0Cvau : $@convention(thin) () -> Builtin.RawPointer
+// CHECK-NEXT: [[ACTOR_PTR:%.*]] = apply [[SHARED_ACTOR_GETTER]]() : $@convention(thin) () -> Builtin.RawPointer
+// CHECK-NEXT: [[MY_ACTOR_ADDR:%.*]] = pointer_to_address [[ACTOR_PTR]] : $Builtin.RawPointer to [strict] $*MyActor
+// CHECK-NEXT: [[MY_ACTOR_ACCESS:%.*]] = begin_access [read] [dynamic] [[MY_ACTOR_ADDR]] : $*MyActor
+// CHECK-NEXT: [[MY_ACTOR:%.*]] = load [copy] [[MY_ACTOR_ACCESS]] : $*MyActor
+// CHECK: [[MY_ACTOR_REF:%.*]] = begin_borrow [[MY_ACTOR]] : $MyActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MY_ACTOR_REF]] : $MyActor
+// CHECK: [[PRECONDITION:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+// CHECK-NEXT: {{.*}} = apply [[PRECONDITION]]({{.*}}, [[EXEC]]) : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+
+@objcMembers
+class Super {
+  @MainActor func test() {}
+}
+
+class Sub : Super {
+  override func test() {}
+}
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s27preconcurrency_conformances5SuperC4testyyFTo : $@convention(objc_method) (Super) -> ()
+// CHECK: [[MAIN_ACTOR_METATYPE:%.*]] = metatype $@thick MainActor.Type
+// CHECK: [[SHARED_FIELD:%.*]] = function_ref @$sScM6sharedScMvgZ : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK-NEXT: [[SHARED_ACTOR:%.*]] = apply [[SHARED_FIELD]]([[MAIN_ACTOR_METATYPE]]) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK-NEXT: [[MAIN_ACTOR:%.*]] = begin_borrow [[SHARED_ACTOR]] : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[PRECONDITION:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+// CHECK-NEXT: {{.*}} = apply [[PRECONDITION]]({{.*}}, [[EXEC]]) : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+
+// CHECK-LABEL: sil private [thunk] [ossa] @$s27preconcurrency_conformances3SubC4testyyFTo : $@convention(objc_method) (Sub) -> ()
+// CHECK: [[MAIN_ACTOR_METATYPE:%.*]] = metatype $@thick MainActor.Type
+// CHECK: [[SHARED_FIELD:%.*]] = function_ref @$sScM6sharedScMvgZ : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK-NEXT: [[SHARED_ACTOR:%.*]] = apply [[SHARED_FIELD]]([[MAIN_ACTOR_METATYPE]]) : $@convention(method) (@thick MainActor.Type) -> @owned MainActor
+// CHECK-NEXT: [[MAIN_ACTOR:%.*]] = begin_borrow [[SHARED_ACTOR]] : $MainActor
+// CHECK-NEXT: [[EXEC:%.*]] = extract_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[PRECONDITION:%.*]] = function_ref @$ss22_checkExpectedExecutor14_filenameStart01_D6Length01_D7IsASCII5_line9_executoryBp_BwBi1_BwBetF : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()
+// CHECK-NEXT: {{.*}} = apply [[PRECONDITION]]({{.*}}, [[EXEC]]) : $@convention(thin) (Builtin.RawPointer, Builtin.Word, Builtin.Int1, Builtin.Word, Builtin.Executor) -> ()


### PR DESCRIPTION
…nforcement

Makes sure that overriden, explicit and inferred `@objc` members get dynamic actor isolation checks emitted into their `@objc` thunks.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
