### PR TITLE
[Macros] Track macro dependency separately in module trace

### DIFF
--- a/include/swift/AST/PluginLoader.h
+++ b/include/swift/AST/PluginLoader.h
@@ -88,8 +88,9 @@ public:
   llvm::Expected<LoadedExecutablePlugin *>
   loadExecutablePlugin(llvm::StringRef path);
 
-  /// Add the specified path to the dependency tracker if needed.
-  void recordDependency(StringRef path);
+  /// Add the specified plugin associated with the module name to the dependency
+  /// tracker if needed.
+  void recordDependency(const PluginEntry &plugin, Identifier moduleName);
 };
 
 } // namespace swift

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -115,6 +115,7 @@ FRONTEND_STATISTIC(AST, NumASTBytesAllocated)
 /// AST context's dependency collector.
 FRONTEND_STATISTIC(AST, NumDependencies)
 FRONTEND_STATISTIC(AST, NumIncrementalDependencies)
+FRONTEND_STATISTIC(AST, NumMacroPluginDependencies)
 
 /// Number of top-level, dynamic, and member names referenced in this frontend
 /// job's source file, as tracked by the AST context's referenced-name tracker.

--- a/lib/AST/FrontendSourceFileDepGraphFactory.cpp
+++ b/lib/AST/FrontendSourceFileDepGraphFactory.cpp
@@ -550,6 +550,9 @@ public:
     for (StringRef s : depTracker.getDependencies()) {
       enumerateUse<NodeKind::externalDepend>(enumerator, s, llvm::None);
     }
+    for (const auto &dep : depTracker.getMacroPluginDependencies()) {
+      enumerateUse<NodeKind::externalDepend>(enumerator, dep.path, llvm::None);
+    }
   }
 
 private:

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -59,6 +59,11 @@ void DependencyTracker::addIncrementalDependency(StringRef File,
   }
 }
 
+void DependencyTracker::addMacroPluginDependency(StringRef File,
+                                                 Identifier ModuleName) {
+  macroPluginDeps.insert({ModuleName, std::string(File)});
+}
+
 ArrayRef<std::string>
 DependencyTracker::getDependencies() const {
   return clangCollector->getDependencies();
@@ -67,6 +72,11 @@ DependencyTracker::getDependencies() const {
 ArrayRef<DependencyTracker::IncrementalDependency>
 DependencyTracker::getIncrementalDependencies() const {
   return incrementalDeps;
+}
+
+ArrayRef<DependencyTracker::MacroPluginDependency>
+DependencyTracker::getMacroPluginDependencies() const {
+  return macroPluginDeps.getArrayRef();
 }
 
 std::shared_ptr<clang::DependencyCollector>

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -110,6 +110,9 @@ bool ExplicitModuleInterfaceBuilder::collectDepsForSerialization(
   auto IncDeps =
       Instance.getDependencyTracker()->getIncrementalDependencyPaths();
   InitialDepNames.append(IncDeps.begin(), IncDeps.end());
+  auto MacroDeps =
+      Instance.getDependencyTracker()->getMacroPluginDependencyPaths();
+  InitialDepNames.append(MacroDeps.begin(), MacroDeps.end());
   InitialDepNames.push_back(interfacePath.str());
   for (const auto &extra : extraDependencies) {
     InitialDepNames.push_back(extra.str());

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -311,6 +311,7 @@ static void countASTStats(UnifiedStatsReporter &Stats,
   if (auto *D = Instance.getDependencyTracker()) {
     C.NumDependencies = D->getDependencies().size();
     C.NumIncrementalDependencies = D->getIncrementalDependencies().size();
+    C.NumMacroPluginDependencies = D->getMacroPluginDependencies().size();
   }
 
   for (auto SF : Instance.getPrimarySourceFiles()) {

--- a/lib/FrontendTool/MakeStyleDependencies.cpp
+++ b/lib/FrontendTool/MakeStyleDependencies.cpp
@@ -132,6 +132,12 @@ bool swift::emitMakeDependenciesIfNeeded(DiagnosticEngine &diags,
     dependencyString.push_back(' ');
     dependencyString.append(frontend::utils::escapeForMake(path, buffer).str());
   }
+  auto macroPluginDependencyPath =
+      reversePathSortedFilenames(depTracker->getMacroPluginDependencyPaths());
+  for (auto const &path : macroPluginDependencyPath) {
+    dependencyString.push_back(' ');
+    dependencyString.append(frontend::utils::escapeForMake(path, buffer).str());
+  }
 
   // FIXME: Xcode can't currently handle multiple targets in a single
   // dependency line.

--- a/lib/IDETool/DependencyChecking.cpp
+++ b/lib/IDETool/DependencyChecking.cpp
@@ -57,6 +57,10 @@ forEachDependencyUntilTrue(CompilerInstance &CI,
     if (callback(dep))
       return true;
   }
+  for (auto dep : CI.getDependencyTracker()->getMacroPluginDependencyPaths()) {
+    if (callback(dep))
+      return true;
+  }
 
   return false;
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -282,8 +282,6 @@ initializeExecutablePlugin(ASTContext &ctx,
       return llvm::createStringError(err, err.message());
     }
 
-    ctx.getPluginLoader().recordDependency(resolvedLibraryPath);
-
     std::string resolvedLibraryPathStr(resolvedLibraryPath);
     std::string moduleNameStr(moduleName.str());
 

--- a/test/Driver/loaded_module_trace.swift
+++ b/test/Driver/loaded_module_trace.swift
@@ -27,7 +27,9 @@
 // CHECK-DAG: {"name":"Swift","path":"{{[^"]*\\[/\\]}}Swift.swiftmodule{{(\\[/\\][^"]+[.]swiftmodule)?}}","isImportedDirectly":true,"supportsLibraryEvolution":true}
 // CHECK-DAG: {"name":"SwiftOnoneSupport","path":"{{[^"]*\\[/\\]}}SwiftOnoneSupport.swiftmodule{{(\\[/\\][^"]+[.]swiftmodule)?}}","isImportedDirectly":true,"supportsLibraryEvolution":true}
 // CHECK-DAG: {"name":"Module","path":"{{[^"]*\\[/\\]}}Module.swiftmodule","isImportedDirectly":false,"supportsLibraryEvolution":false}
-// CHECK-DAG: {"name":"Plugin","path":"{{[^"]*\\[/\\]}}{{libPlugin.dylib|libPlugin.so|Plugin.dll}}","isImportedDirectly":false,"supportsLibraryEvolution":false}
+// CHECK: ],
+// CHECK: "swiftmacros":[
+// CHECK-DAG: {"name":"Plugin","path":"{{[^"]*\\[/\\]}}{{libPlugin.dylib|libPlugin.so|Plugin.dll}}"}
 // CHECK: ]
 // CHECK: }
 


### PR DESCRIPTION
Macro plugins are not normal Swift modules, track them differently. Add "swiftmacros" field to the JSON file.

rdar://110927706