### PR TITLE
[IRGen][WMO] type descriptors generated for an imported Clang types a…

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1597,6 +1597,9 @@ public:
            getKind() == Kind::DispatchThunkAllocator ||
            getKind() == Kind::DispatchThunkDerivative;
   }
+  bool isNominalTypeDescriptor() const {
+    return getKind() == Kind::NominalTypeDescriptor;
+  }
 
   /// Determine whether this entity will be weak-imported.
   bool isWeakImported(ModuleDecl *module) const;

--- a/test/IRGen/imported_clang_type_metadata_is_local.swift
+++ b/test/IRGen/imported_clang_type_metadata_is_local.swift
@@ -1,0 +1,53 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend  -c -num-threads 1 -emit-ir -wmo -O  %t/useA.swift %t/useB.swift -I %t/Inputs -o %t/useA.swift.ir -o %t/useB.swift.ir
+// RUN: cat %t/useB.swift.ir | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module ClangModule {
+    header "header.h"
+}
+
+//--- Inputs/header.h
+
+struct ImportedClangType {
+  int x;
+};
+
+//--- useA.swift
+
+import ClangModule
+
+func testA<T>(_ x: T) {
+  print(x)
+}
+
+public func testARun() {
+  testA(ImportedClangType(x: 0))
+}
+
+public struct TestUseFieldA {
+  let x: ImportedClangType = ImportedClangType()
+}
+
+//--- useB.swift
+
+import ClangModule
+
+func testB<T>(_ x: T) {
+  print(x)
+}
+
+public func testBRun() {
+  testB(ImportedClangType(x: 0))
+}
+
+public struct TestUseFieldB {
+  let x: ImportedClangType = ImportedClangType()
+}
+
+// The type metadata emitted for TU B, refers to the metadata from TU A,
+// but it doesn't need to dllimport it across the module boundary, as it's
+// emitted in the same module.
+// CHECK: @"$sSo17ImportedClangTypeVMn" = external global %swift.type_descriptor


### PR DESCRIPTION
…re always known local declarations

This fixes a LNK4217 linker warning when building code on Windows
