### PR TITLE
Revert #68952 [Casting] Make more casts look inside __SwiftValue

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1171,25 +1171,6 @@ swift_dynamicCastObjCClassImpl(const void *object,
   if (object == nullptr)
     return nullptr;
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wreceiver-forward-class"
-  if ([id_const_cast(object) isKindOfClass:[__SwiftValue class]]) {
-#pragma clang diagnostic pop
-    // Source is a `__SwiftValue` container
-    // Unwrap, then use the most general casting machine to do the heavy lifting
-    auto typeValue = getValueFromSwiftValue(reinterpret_cast<__SwiftValue *>(object));
-    const void *result = nullptr;
-    if (swift_dynamicCast(reinterpret_cast<OpaqueValue *>(&result),
-			  const_cast<OpaqueValue *>(typeValue.second),
-			  typeValue.first,
-			  targetType,
-			  DynamicCastFlags::TakeOnSuccess)) {
-      return result;
-    } else {
-      return nullptr;
-    }
-  }
-
   if ([id_const_cast(object) isKindOfClass:class_const_cast(targetType)]) {
     return object;
   }

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1065,13 +1065,24 @@ CastsTests.test("Don't put AnyHashable inside AnyObject") {
 }
 
 #if _runtime(_ObjC)
-CastsTests.test("__SwiftValue should not be obvious to `is`") {
+// We currently (as of Jan 2024) bridge NSSet to Swift with `x as!
+// Set<NSObject>`, which in turn demands that __SwiftValue successfully cast to
+// NSObject.
+// So this nonsensical behavior can probably never be fixed.
+// (It's nonsense because it implies that every Swift object is derived
+// from NSObject.)  See PR #68952 for an early attempt to change it which
+// had to be reverted.
+CastsTests.test("__SwiftValue should not be obvious to `is`")
+.xfail(.always("Probably can never be fixed"))
+.code {
   struct S {}
   let s = S() as AnyObject
   expectFalse(s is NSObject)
 }
 #endif
 
+// See above for reasons why this might need to remain broken forever,
+// though I do have some hope for it.
 CastsTests.test("type(of:) should look through __SwiftValue")
 .xfail(.always("Known to be broken"))
 .code {


### PR DESCRIPTION
Turns out that our Obj-C bridging relies on this inconsistent behavior, so it can quite likely never be actually fixed.

I kept the tests and marked them as XFAIL with comments explaining why they should be left that way.