### PR TITLE
[build] Skip lldb tests on WebAssembly CI node

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -888,6 +888,9 @@ mixin-preset=buildbot_linux
 
 llvm-targets-to-build=X86;ARM;AArch64;WebAssembly
 build-wasm-stdlib
+# FIXME(katei): Test fails on a specific CI node.
+# https://github.com/apple/swift/issues/70980
+skip-test-lldb
 
 # A preset for Linux builders that uses a NoncopyableGenerics-enabled stdlib
 [preset: buildbot_linux_ncg]


### PR DESCRIPTION
The test somehow fails on a specific CI node. I couldn't find the root cause yet, so skip it for now to avoid more silent breakages.
The issue is tracked by https://github.com/apple/swift/issues/70980
