### PR TITLE
[AST] Remove SerializedLocalDeclContext

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2488,16 +2488,13 @@ public:
 /// SerializedTopLevelCodeDeclContext - This represents what was originally a
 /// TopLevelCodeDecl during serialization. It is preserved only to maintain the
 /// correct AST structure and remangling after deserialization.
-class SerializedTopLevelCodeDeclContext : public SerializedLocalDeclContext {
+class SerializedTopLevelCodeDeclContext : public DeclContext {
 public:
   SerializedTopLevelCodeDeclContext(DeclContext *Parent)
-    : SerializedLocalDeclContext(LocalDeclContextKind::TopLevelCodeDecl,
-                                 Parent) {}
+    : DeclContext(DeclContextKind::SerializedTopLevelCodeDecl, Parent) {}
+
   static bool classof(const DeclContext *DC) {
-    if (auto LDC = dyn_cast<SerializedLocalDeclContext>(DC))
-      return LDC->getLocalDeclContextKind() ==
-        LocalDeclContextKind::TopLevelCodeDecl;
-    return false;
+    return DC->getContextKind() == DeclContextKind::SerializedTopLevelCodeDecl;
   }
 };
 

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -97,7 +97,8 @@ enum class DeclContextKind : unsigned {
   SubscriptDecl,
   EnumElementDecl,
   AbstractFunctionDecl,
-  SerializedLocal,
+  SerializedAbstractClosure,
+  SerializedTopLevelCodeDecl,
   MacroDecl,
   Last_LocalDeclContextKind = MacroDecl,
   Package,
@@ -106,14 +107,6 @@ enum class DeclContextKind : unsigned {
   GenericTypeDecl,
   ExtensionDecl,
   Last_DeclContextKind = ExtensionDecl
-};
-
-/// Kinds of DeclContexts after deserialization.
-///
-/// \see SerializedLocalDeclContext.
-enum class LocalDeclContextKind : uint8_t {
-  AbstractClosure,
-  TopLevelCodeDecl
 };
 
 /// Describes the kind of a particular conformance.
@@ -249,10 +242,11 @@ class alignas(1 << DeclContextAlignInBits) DeclContext
     FileUnit,
     Package,
     Initializer,
-    SerializedLocal,
+    SerializedAbstractClosure,
+    SerializedTopLevelCodeDecl,
     // If you add a new AST hierarchies, then update the static_assert() below.
   };
-  static_assert(unsigned(ASTHierarchy::SerializedLocal) <
+  static_assert(unsigned(ASTHierarchy::SerializedTopLevelCodeDecl) <
                 (1 << DeclContextAlignInBits),
                 "ASTHierarchy exceeds bits available");
 
@@ -281,8 +275,10 @@ class alignas(1 << DeclContextAlignInBits) DeclContext
       return ASTHierarchy::Expr;
     case DeclContextKind::Initializer:
       return ASTHierarchy::Initializer;
-    case DeclContextKind::SerializedLocal:
-      return ASTHierarchy::SerializedLocal;
+    case DeclContextKind::SerializedAbstractClosure:
+      return ASTHierarchy::SerializedAbstractClosure;
+    case DeclContextKind::SerializedTopLevelCodeDecl:
+      return ASTHierarchy::SerializedTopLevelCodeDecl;
     case DeclContextKind::FileUnit:
       return ASTHierarchy::FileUnit;
     case DeclContextKind::Package:
@@ -702,31 +698,6 @@ public:
   
   // Some Decls are DeclContexts, but not all. See swift/AST/Decl.h
   static bool classof(const Decl *D);
-};
-
-/// SerializedLocalDeclContext - the base class for DeclContexts that were
-/// serialized to preserve AST structure and accurate mangling after
-/// deserialization.
-class SerializedLocalDeclContext : public DeclContext {
-private:
-  unsigned LocalKind : 3;
-
-protected:
-  unsigned SpareBits : 29;
-
-public:
-  SerializedLocalDeclContext(LocalDeclContextKind LocalKind,
-                             DeclContext *Parent)
-    : DeclContext(DeclContextKind::SerializedLocal, Parent),
-      LocalKind(static_cast<unsigned>(LocalKind)) {}
-
-  LocalDeclContextKind getLocalDeclContextKind() const {
-    return static_cast<LocalDeclContextKind>(LocalKind);
-  }
-
-  static bool classof(const DeclContext *DC) {
-    return DC->getContextKind() == DeclContextKind::SerializedLocal;
-  }
 };
 
 /// An iterator that walks through a list of declarations stored

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3947,7 +3947,7 @@ public:
 /// SerializedAbstractClosureExpr - This represents what was originally an
 /// AbstractClosureExpr during serialization. It is preserved only to maintain
 /// the correct AST structure and remangling after deserialization.
-class SerializedAbstractClosureExpr : public SerializedLocalDeclContext {
+class SerializedAbstractClosureExpr : public DeclContext {
   const Type Ty;
   llvm::PointerIntPair<Type, 1> TypeAndImplicit;
   const unsigned Discriminator;
@@ -3955,8 +3955,7 @@ class SerializedAbstractClosureExpr : public SerializedLocalDeclContext {
 public:
   SerializedAbstractClosureExpr(Type Ty, bool Implicit, unsigned Discriminator,
                                 DeclContext *Parent)
-    : SerializedLocalDeclContext(LocalDeclContextKind::AbstractClosure,
-                                 Parent),
+    : DeclContext(DeclContextKind::SerializedAbstractClosure, Parent),
       TypeAndImplicit(llvm::PointerIntPair<Type, 1>(Ty, Implicit)),
       Discriminator(Discriminator) {}
 
@@ -3973,10 +3972,7 @@ public:
   }
 
   static bool classof(const DeclContext *DC) {
-    if (auto LDC = dyn_cast<SerializedLocalDeclContext>(DC))
-      return LDC->getLocalDeclContextKind() ==
-        LocalDeclContextKind::AbstractClosure;
-    return false;
+    return DC->getContextKind() == DeclContextKind::SerializedAbstractClosure;
   }
 };
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1732,8 +1732,8 @@ void swift::printContext(raw_ostream &os, DeclContext *dc) {
     os << "(file)";
     break;
 
-  case DeclContextKind::SerializedLocal:
-    os << "local context";
+  case DeclContextKind::SerializedAbstractClosure:
+    os << "serialized abstract closure";
     break;
 
   case DeclContextKind::AbstractClosureExpr: {
@@ -1782,6 +1782,7 @@ void swift::printContext(raw_ostream &os, DeclContext *dc) {
     break;
 
   case DeclContextKind::TopLevelCodeDecl:
+  case DeclContextKind::SerializedTopLevelCodeDecl:
     os << "top-level code";
     break;
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2317,17 +2317,6 @@ void ASTMangler::appendContext(const DeclContext *ctx, StringRef useModuleName) 
     appendContext(ctx->getParent(), useModuleName);
     return;
 
-  case DeclContextKind::SerializedLocal: {
-    auto local = cast<SerializedLocalDeclContext>(ctx);
-    switch (local->getLocalDeclContextKind()) {
-    case LocalDeclContextKind::AbstractClosure:
-      appendClosureEntity(cast<SerializedAbstractClosureExpr>(local));
-      return;
-    case LocalDeclContextKind::TopLevelCodeDecl:
-      return appendContext(local->getParent(), useModuleName);
-    }
-  }
-
   case DeclContextKind::GenericTypeDecl:
     appendAnyGenericType(cast<GenericTypeDecl>(ctx));
     return;
@@ -2367,6 +2356,9 @@ void ASTMangler::appendContext(const DeclContext *ctx, StringRef useModuleName) 
 
   case DeclContextKind::AbstractClosureExpr:
     return appendClosureEntity(cast<AbstractClosureExpr>(ctx));
+
+  case DeclContextKind::SerializedAbstractClosure:
+    return appendClosureEntity(cast<SerializedAbstractClosureExpr>(ctx));
 
   case DeclContextKind::AbstractFunctionDecl: {
     auto fn = cast<AbstractFunctionDecl>(ctx);
@@ -2428,6 +2420,7 @@ void ASTMangler::appendContext(const DeclContext *ctx, StringRef useModuleName) 
     llvm_unreachable("bad initializer kind");
 
   case DeclContextKind::TopLevelCodeDecl:
+  case DeclContextKind::SerializedTopLevelCodeDecl:
     // Mangle the containing module context.
     return appendContext(ctx->getParent(), useModuleName);
 

--- a/lib/AST/AccessRequests.cpp
+++ b/lib/AST/AccessRequests.cpp
@@ -110,10 +110,12 @@ AccessLevelRequest::evaluate(Evaluator &evaluator, ValueDecl *D) const {
 
   switch (DC->getContextKind()) {
   case DeclContextKind::TopLevelCodeDecl:
+  case DeclContextKind::SerializedTopLevelCodeDecl:
     // Variables declared in a top-level 'guard' statement can be accessed in
     // later top-level code.
     return AccessLevel::FilePrivate;
   case DeclContextKind::AbstractClosureExpr:
+  case DeclContextKind::SerializedAbstractClosure:
     if (isa<ParamDecl>(D)) {
       // Closure parameters may need to be accessible to the enclosing
       // context, for single-expression closures.
@@ -121,7 +123,6 @@ AccessLevelRequest::evaluate(Evaluator &evaluator, ValueDecl *D) const {
     } else {
       return AccessLevel::Private;
     }
-  case DeclContextKind::SerializedLocal:
   case DeclContextKind::Initializer:
   case DeclContextKind::AbstractFunctionDecl:
   case DeclContextKind::SubscriptDecl:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11764,7 +11764,8 @@ MacroDiscriminatorContext::getInnermostMacroContext(DeclContext *dc) {
 
   case DeclContextKind::EnumElementDecl:
   case DeclContextKind::AbstractFunctionDecl:
-  case DeclContextKind::SerializedLocal:
+  case DeclContextKind::SerializedAbstractClosure:
+  case DeclContextKind::SerializedTopLevelCodeDecl:
   case DeclContextKind::Package:
   case DeclContextKind::Module:
   case DeclContextKind::FileUnit:

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1247,6 +1247,7 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
 
             case DeclContextKind::FileUnit:
             case DeclContextKind::TopLevelCodeDecl:
+            case DeclContextKind::SerializedTopLevelCodeDecl:
               break;
 
             case DeclContextKind::ExtensionDecl:
@@ -1257,9 +1258,9 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
               ppDecl = cast<GenericTypeDecl>(dc);
               break;
 
-            case DeclContextKind::SerializedLocal:
             case DeclContextKind::Initializer:
             case DeclContextKind::AbstractClosureExpr:
+            case DeclContextKind::SerializedAbstractClosure:
             case DeclContextKind::AbstractFunctionDecl:
             case DeclContextKind::SubscriptDecl:
             case DeclContextKind::EnumElementDecl:

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -886,12 +886,13 @@ IRGenModule::getAddrOfContextDescriptorForParent(DeclContext *parent,
                                                  bool fromAnonymousContext) {
   switch (parent->getContextKind()) {
   case DeclContextKind::AbstractClosureExpr:
+  case DeclContextKind::SerializedAbstractClosure:
   case DeclContextKind::AbstractFunctionDecl:
   case DeclContextKind::SubscriptDecl:
   case DeclContextKind::EnumElementDecl:
   case DeclContextKind::TopLevelCodeDecl:
+  case DeclContextKind::SerializedTopLevelCodeDecl:
   case DeclContextKind::Initializer:
-  case DeclContextKind::SerializedLocal:
     return {getAddrOfAnonymousContextDescriptor(
               fromAnonymousContext ? parent : ofChild),
             ConstantReference::Direct};

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -654,14 +654,15 @@ private:
     // The interesting cases are already handled above.
     case DeclContextKind::AbstractFunctionDecl:
     case DeclContextKind::AbstractClosureExpr:
+    case DeclContextKind::SerializedAbstractClosure:
 
     // We don't model these in DWARF.
-    case DeclContextKind::SerializedLocal:
     case DeclContextKind::Initializer:
     case DeclContextKind::ExtensionDecl:
     case DeclContextKind::SubscriptDecl:
     case DeclContextKind::EnumElementDecl:
     case DeclContextKind::TopLevelCodeDecl:
+    case DeclContextKind::SerializedTopLevelCodeDecl:
       return getOrCreateContext(DC->getParent());
 
     case DeclContextKind::Package: {

--- a/lib/Refactoring/ExtractExprBase.cpp
+++ b/lib/Refactoring/ExtractExprBase.cpp
@@ -186,7 +186,8 @@ swift::refactoring::checkExtractConditions(const ResolvedRangeInfo &RangeInfo,
   case swift::DeclContextKind::TopLevelCodeDecl:
     break;
 
-  case swift::DeclContextKind::SerializedLocal:
+  case swift::DeclContextKind::SerializedAbstractClosure:
+  case swift::DeclContextKind::SerializedTopLevelCodeDecl:
   case swift::DeclContextKind::Package:
   case swift::DeclContextKind::Module:
   case swift::DeclContextKind::FileUnit:

--- a/lib/Refactoring/LocalRename.cpp
+++ b/lib/Refactoring/LocalRename.cpp
@@ -297,8 +297,9 @@ DeclContext *getRenameScope(const ValueDecl *VD) {
     Scope = Scope->getParent();
     break;
   case DeclContextKind::AbstractClosureExpr:
+  case DeclContextKind::SerializedAbstractClosure:
+  case DeclContextKind::SerializedTopLevelCodeDecl:
   case DeclContextKind::Initializer:
-  case DeclContextKind::SerializedLocal:
   case DeclContextKind::Package:
   case DeclContextKind::Module:
   case DeclContextKind::FileUnit:

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -221,12 +221,9 @@ static void printFullContext(const DeclContext *Context, raw_ostream &Buffer) {
     return;
 
   case DeclContextKind::AbstractClosureExpr:
+  case DeclContextKind::SerializedAbstractClosure:
     // FIXME
     Buffer << "<anonymous function>";
-    return;
-
-  case DeclContextKind::SerializedLocal:
-    Buffer << "<serialized local context>";
     return;
 
   case DeclContextKind::GenericTypeDecl: {
@@ -245,6 +242,7 @@ static void printFullContext(const DeclContext *Context, raw_ostream &Buffer) {
   }
   
   case DeclContextKind::TopLevelCodeDecl:
+  case DeclContextKind::SerializedTopLevelCodeDecl:
     // FIXME
     Buffer << "<top level code>";
     return;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8254,8 +8254,8 @@ bool ExprRewriter::isDistributedThunk(ConcreteDeclRef ref, Expr *context) {
   while (true) {
     switch (referenceDC->getContextKind()) {
     case DeclContextKind::AbstractClosureExpr:
+    case DeclContextKind::SerializedAbstractClosure:
     case DeclContextKind::Initializer:
-    case DeclContextKind::SerializedLocal:
       referenceDC = referenceDC->getParent();
       continue;
 
@@ -8276,6 +8276,7 @@ bool ExprRewriter::isDistributedThunk(ConcreteDeclRef ref, Expr *context) {
       case DeclContextKind::Package:
       case DeclContextKind::Module:
       case DeclContextKind::TopLevelCodeDecl:
+      case DeclContextKind::SerializedTopLevelCodeDecl:
       case DeclContextKind::MacroDecl:
         break;
     }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -139,8 +139,9 @@ static void forEachOuterDecl(DeclContext *DC, Fn fn) {
   for (; !DC->isModuleScopeContext(); DC = DC->getParent()) {
     switch (DC->getContextKind()) {
     case DeclContextKind::AbstractClosureExpr:
+    case DeclContextKind::SerializedAbstractClosure:
     case DeclContextKind::TopLevelCodeDecl:
-    case DeclContextKind::SerializedLocal:
+    case DeclContextKind::SerializedTopLevelCodeDecl:
     case DeclContextKind::Package:
     case DeclContextKind::Module:
     case DeclContextKind::FileUnit:

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -261,11 +261,12 @@ void SymbolGraph::recordMemberRelationship(Symbol S) {
                         Symbol(this, DC->getSelfNominalTypeDecl(), nullptr),
                         RelationshipKind::MemberOf());
     case swift::DeclContextKind::AbstractClosureExpr:
+    case swift::DeclContextKind::SerializedAbstractClosure:
     case swift::DeclContextKind::Initializer:
     case swift::DeclContextKind::TopLevelCodeDecl:
+    case swift::DeclContextKind::SerializedTopLevelCodeDecl:
     case swift::DeclContextKind::SubscriptDecl:
     case swift::DeclContextKind::AbstractFunctionDecl:
-    case swift::DeclContextKind::SerializedLocal:
     case swift::DeclContextKind::Package:
     case swift::DeclContextKind::Module:
     case swift::DeclContextKind::FileUnit:

--- a/test/TypeDecoder/generic_local_types.swift
+++ b/test/TypeDecoder/generic_local_types.swift
@@ -175,7 +175,7 @@ class Generic<T> {
 // DEMANGLE-DECL: $s19generic_local_types7GenericCfd7Alias15L_a
 // DEMANGLE-DECL: $s19generic_local_types7GenericC6methodyySiF6nestedL_yylF5AliasL_a
 
-// CHECK-DECL: generic_local_types.(file).Generic.pattern binding initializer.local context.Alias1
+// CHECK-DECL: generic_local_types.(file).Generic.pattern binding initializer.serialized abstract closure.Alias1
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias2
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias3
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias4
@@ -186,7 +186,7 @@ class Generic<T> {
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias9
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias10
 // CHECK-DECL: generic_local_types.(file).Generic.<anonymous>.Alias11
-// CHECK-DECL: generic_local_types.(file).Generic.method(_:).default argument initializer.local context.Alias12
+// CHECK-DECL: generic_local_types.(file).Generic.method(_:).default argument initializer.serialized abstract closure.Alias12
 // CHECK-DECL: generic_local_types.(file).Generic.method(_:).Alias13
 // CHECK-DECL: generic_local_types.(file).Generic.init().Alias14
 // CHECK-DECL: generic_local_types.(file).Generic.deinit.Alias15

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -503,12 +503,13 @@ static bool initDocEntityInfo(const Decl *D,
 
   switch(D->getDeclContext()->getContextKind()) {
     case DeclContextKind::AbstractClosureExpr:
+    case DeclContextKind::SerializedAbstractClosure:
     case DeclContextKind::TopLevelCodeDecl:
+    case DeclContextKind::SerializedTopLevelCodeDecl:
     case DeclContextKind::AbstractFunctionDecl:
     case DeclContextKind::SubscriptDecl:
     case DeclContextKind::EnumElementDecl:
     case DeclContextKind::Initializer:
-    case DeclContextKind::SerializedLocal:
     case DeclContextKind::ExtensionDecl:
     case DeclContextKind::GenericTypeDecl:
     case DeclContextKind::MacroDecl:

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1247,9 +1247,10 @@ inferAccessSyntactically(const ValueDecl *D) {
 
   switch (DC->getContextKind()) {
   case DeclContextKind::TopLevelCodeDecl:
+  case DeclContextKind::SerializedTopLevelCodeDecl:
     return AccessLevel::FilePrivate;
-  case DeclContextKind::SerializedLocal:
   case DeclContextKind::AbstractClosureExpr:
+  case DeclContextKind::SerializedAbstractClosure:
   case DeclContextKind::EnumElementDecl:
   case DeclContextKind::Initializer:
   case DeclContextKind::AbstractFunctionDecl:


### PR DESCRIPTION
It's not clear that its worth keeping this as a base class for SerializedAbstractClosure and SerializedTopLevelCodeDecl, most clients are interested in the concrete kinds, not only whether the context is serialized.