### PR TITLE
[5.10] [Sema] Avoid mentioning `then` in a diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1238,8 +1238,7 @@ ERROR(single_value_stmt_branch_empty,none,
       "expected expression in branch of '%0' expression",
       (StmtKind))
 ERROR(single_value_stmt_branch_must_end_in_result,none,
-      "non-expression branch of '%0' expression may only end with a 'throw' "
-      "or 'then'",
+      "non-expression branch of '%0' expression may only end with a 'throw'",
       (StmtKind))
 ERROR(cannot_jump_in_single_value_stmt,none,
       "cannot '%0' in '%1' when used as expression",

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3937,6 +3937,8 @@ private:
               continue;
             }
           }
+          // TODO: If 'then' statements are enabled by default, the wording of
+          // this diagnostic should be tweaked.
           Diags.diagnose(branch->getEndLoc(),
                          diag::single_value_stmt_branch_must_end_in_result,
                          S->getKind());


### PR DESCRIPTION
*5.10 cherry-pick of https://github.com/apple/swift/pull/70984*

- Explanation: Avoids mentioning a still-experimental feature in a diagnostic
- Scope: Affects a single diagnostic that we emit if an `if`/`switch` expression doesn't have a single expression branch
- Issue: rdar://121191225
- Risk: Basically none, only affects the wording of a diagnostic
- Testing: Verified the change locally
- Reviewer: Holly Borla