### PR TITLE
[AddressLowering] Handle instructions that wrap and unwrap in @moveOnly.

### DIFF
--- a/lib/SIL/Utils/InstWrappers.cpp
+++ b/lib/SIL/Utils/InstWrappers.cpp
@@ -51,6 +51,7 @@ bool ForwardingOperation::hasSameRepresentation() const {
   case SILInstructionKind::OpenExistentialRefInst:
   case SILInstructionKind::OpenExistentialValueInst:
   case SILInstructionKind::MarkUnresolvedNonCopyableValueInst:
+  case SILInstructionKind::MoveOnlyWrapperToCopyableValueInst:
   case SILInstructionKind::MarkUninitializedInst:
   case SILInstructionKind::StructExtractInst:
   case SILInstructionKind::TupleExtractInst:

--- a/lib/SIL/Utils/InstWrappers.cpp
+++ b/lib/SIL/Utils/InstWrappers.cpp
@@ -43,6 +43,7 @@ bool ForwardingOperation::hasSameRepresentation() const {
     return false;
 
   case SILInstructionKind::ConvertFunctionInst:
+  case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:
   case SILInstructionKind::DestructureTupleInst:
   case SILInstructionKind::DestructureStructInst:
   case SILInstructionKind::InitExistentialRefInst:

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -2552,6 +2552,34 @@ entry(%t : @owned $@moveOnly T):
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_moveonlywrapper_to_copyable_1_owned : {{.*}} {
+// CHECK:       bb0([[TMO:%[^,]+]] :
+// CHECK:         [[T:%[^,]+]] = moveonlywrapper_to_copyable_addr [[TMO]]
+// CHECK:         destroy_addr [[T]]
+// CHECK-LABEL: } // end sil function 'test_moveonlywrapper_to_copyable_1_owned'
+sil [ossa] @test_moveonlywrapper_to_copyable_1_owned : $@convention(thin) <T> (@in @moveOnly T) -> () {
+entry(%tmo : @owned $@moveOnly T):
+  %t = moveonlywrapper_to_copyable [owned] %tmo : $@moveOnly T
+  destroy_value %t : $T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_moveonlywrapper_to_copyable_2_guaranteed : {{.*}} {
+// CHECK:       bb0([[TMO:%[^,]+]] :
+// CHECK:         [[T:%[^,]+]] = moveonlywrapper_to_copyable_addr [[TMO]]
+// CHECK:         [[BORROW_T:%[^,]+]] = function_ref @borrowT
+// CHECK:         apply [[BORROW_T]]<T>([[T]])
+// CHECK-LABEL: } // end sil function 'test_moveonlywrapper_to_copyable_2_guaranteed'
+sil [ossa] @test_moveonlywrapper_to_copyable_2_guaranteed : $@convention(thin) <T> (@in_guaranteed @moveOnly T) -> () {
+entry(%tmo : @guaranteed $@moveOnly T):
+  %t = moveonlywrapper_to_copyable [guaranteed] %tmo : $@moveOnly T
+  %borrowT = function_ref @borrowT : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  apply %borrowT<T>(%t) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil [ossa] @test_open_pack_element_dominance : $@convention(thin) <each T> (@pack_guaranteed Pack{repeat each T}, Builtin.Word) -> () {
 // CHECK:       bb0([[PACK:%[^,]+]] : 
 // CHECK-SAME:      [[RAW_INDEX:%[^,]+]] :

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -100,6 +100,7 @@ sil [ossa] @getT : $@convention(thin) <T> () -> @out T
 sil [ossa] @getKlass : $@convention(thin) () -> (@owned Klass)
 sil [ossa] @borrowKlass : $(@in_guaranteed Klass) -> ()
 sil [ossa] @borrowT : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil [ossa] @borrowMoveOnlyT : $@convention(thin) <T> (@in_guaranteed @moveOnly T) -> ()
 sil [ossa] @getPair : $@convention(thin) <T> () -> @out Pair<T>
 sil [ossa] @getOwned : $@convention(thin) <T : AnyObject> () -> (@owned T)
 sil [ossa] @takeGuaranteedObject : $@convention(thin) (@guaranteed AnyObject) -> ()
@@ -2341,6 +2342,34 @@ failure(%original : @owned $T):
   destroy_value %original : $T
   br exit
 exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_copyable_to_moveonlywrapper_1_owned : {{.*}} {
+// CHECK:       bb0([[TMO:%[^,]+]] :
+// CHECK:         [[T:%[^,]+]] = copyable_to_moveonlywrapper_addr [[TMO]]
+// CHECK:         destroy_addr [[T]]
+// CHECK-LABEL: } // end sil function 'test_copyable_to_moveonlywrapper_1_owned'
+sil [ossa] @test_copyable_to_moveonlywrapper_1_owned : $@convention(thin) <T> (@in T) -> () {
+entry(%t : @owned $T):
+  %tmo = copyable_to_moveonlywrapper [owned] %t : $T
+  destroy_value %tmo : $@moveOnly T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_copyable_to_moveonlywrapper_2_guaranteed : {{.*}} {
+// CHECK:       bb0([[TMO:%[^,]+]] :
+// CHECK:         [[T:%[^,]+]] = copyable_to_moveonlywrapper_addr [[TMO]]
+// CHECK:         [[BORROW_T:%[^,]+]] = function_ref @borrowMoveOnlyT
+// CHECK:         apply [[BORROW_T]]<T>([[T]])
+// CHECK-LABEL: } // end sil function 'test_copyable_to_moveonlywrapper_2_guaranteed'
+sil [ossa] @test_copyable_to_moveonlywrapper_2_guaranteed : $@convention(thin) <T> (@in_guaranteed T) -> () {
+entry(%t : @guaranteed $T):
+  %tmo = copyable_to_moveonlywrapper [guaranteed] %t : $T
+  %borrowT = function_ref @borrowMoveOnlyT : $@convention(thin) <T> (@in_guaranteed @moveOnly T) -> ()
+  apply %borrowT<T>(%tmo) : $@convention(thin) <T> (@in_guaranteed @moveOnly T) -> ()
   %retval = tuple ()
   return %retval : $()
 }


### PR DESCRIPTION
The `_value` version of the instructions lowers to the `_address` version.
