### PR TITLE
[Sema] Avoid forming nested `do` expressions in `if`/`switch` bindings

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2535,9 +2535,14 @@ SingleValueStmtExpr *SingleValueStmtExpr::createWithWrappedBranches(
           if (!IS->isSyntacticallyExhaustive())
             continue;
         } else if (auto *DCS = dyn_cast<DoCatchStmt>(S)) {
+          if (!ctx.LangOpts.hasFeature(Feature::DoExpressions))
+            continue;
           if (!DCS->isSyntacticallyExhaustive())
             continue;
-        } else if (!isa<SwitchStmt>(S) && !isa<DoStmt>(S)) {
+        } else if (isa<DoStmt>(S)) {
+          if (!ctx.LangOpts.hasFeature(Feature::DoExpressions))
+            continue;
+        } else if (!isa<SwitchStmt>(S)) {
           continue;
         }
       } else {

--- a/test/expr/unary/do_expr.swift
+++ b/test/expr/unary/do_expr.swift
@@ -76,6 +76,42 @@ func test14() -> Int {
   return fn()
 }
 
+func test15() -> Int {
+  let x = if .random() {
+    do { 0 }
+  } else {
+    1
+  }
+  return x
+}
+
+func test16() -> Int {
+  let x = if .random() {
+    1
+  } else {
+    do { 2 } catch { 3 }
+    // expected-warning@-1 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+  }
+  return x
+}
+
+func test17() -> Int {
+  if .random() {
+    do { 0 }
+  } else {
+    1
+  }
+}
+
+func test18() -> Int {
+  if .random() {
+    1
+  } else {
+    do { 2 } catch { 3 }
+    // expected-warning@-1 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+  }
+}
+
 func testEmpty1() {
   let _ = do {} // expected-error {{expected expression in branch of 'do' expression}}
 }

--- a/test/expr/unary/do_expr_disabled.swift
+++ b/test/expr/unary/do_expr_disabled.swift
@@ -92,3 +92,39 @@ func test12() -> Int {
 
   return fn() // expected-error {{cannot convert return expression of type '()' to return type 'Int'}}
 }
+
+func test13() -> Int {
+  let x = if .random() {
+    do { 0 } // expected-warning {{integer literal is unused}}
+  } else { // expected-error {{non-expression branch of 'if' expression may only end with a 'throw'}}
+    1
+  }
+  return x
+}
+
+func test14() -> Int {
+  let x = if .random() {
+    1
+  } else {
+    do { 2 } catch { 3 } // expected-warning 2{{integer literal is unused}}
+    // expected-warning@-1 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+  } // expected-error {{non-expression branch of 'if' expression may only end with a 'throw'}}
+  return x
+}
+
+func test15() -> Int {
+  if .random() {
+    do { 0 } // expected-warning {{integer literal is unused}}
+  } else {
+    1 // expected-warning {{integer literal is unused}}
+  }
+}
+
+func test16() -> Int {
+  if .random() {
+    1 // expected-warning {{integer literal is unused}}
+  } else {
+    do { 2 } catch { 3 } // expected-warning 2{{integer literal is unused}}
+    // expected-warning@-1 {{'catch' block is unreachable because no errors are thrown in 'do' block}}
+  }
+}


### PR DESCRIPTION
In asserts builds this hits an assert that the feature isn't enabled, and in no-asserts builds this incorrectly allows `do` expressions to be used with the feature disabled. Note this only affects their use when nested in an `if`/`switch` that is used in a binding, we correctly handled the other cases.

rdar://121193678