### PR TITLE
[Sema] Update hash function for maps using ActorIsolation class

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -631,7 +631,7 @@ struct DenseMapInfo<swift::ReferencedActor::Kind> {
     }
 
     static unsigned getHashValue(RefActor Val) {
-     return static_cast<unsigned>(Val.getKind());
+     return hash_value(Val);
     }
 
     static bool isEqual(const RefActor &LHS, const RefActor &RHS) {


### PR DESCRIPTION
Maps using ActorIsolation should use the `friend hash_value` function declared in the ActorIsolation class.