### PR TITLE
[AliasAnalysis] Improve builtin's effects to depend on escapingness.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -159,7 +159,10 @@ private func getMemoryEffect(ofBuiltin builtin: BuiltinInst, for address: Value,
     let callee = builtin.operands[1].value
     return context.calleeAnalysis.getSideEffects(ofCallee: callee).memory
   default:
-    return builtin.memoryEffects
+    if address.at(path).isEscaping(using: EscapesToInstructionVisitor(target: builtin, isAddress: true), context) {
+      return builtin.memoryEffects
+    }
+    return SideEffects.Memory()
   }
 }
 

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1076,3 +1076,25 @@ bb0(%0 : $*C, %1 : $*C, %2 : @owned $C):
   return %r : $()
 }
 
+// CHECK-LABEL: @test_builtin_zeroInitializer
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %0 = alloc_stack
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %1 = alloc_stack
+// CHECK-NEXT:    r=0,w=1
+sil @test_builtin_zeroInitializer : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $C
+  %1 = alloc_stack $C
+  %2 = builtin "zeroInitializer"<C>(%1 : $*C) : $()
+  %3 = apply undef<C>(%1) : $@convention(thin) <C> () -> @out C
+  copy_addr [take] %1 to [init] %0 : $*C
+  dealloc_stack %1 : $*C
+  destroy_addr %0 : $*C
+  dealloc_stack %0 : $*C
+  %4 = tuple ()
+  return %4 : $()
+}

--- a/test/SILOptimizer/templvalueopt.sil
+++ b/test/SILOptimizer/templvalueopt.sil
@@ -3,6 +3,8 @@
 import Swift
 import Builtin
 
+// REQUIRES: swift_in_compiler
+
 // CHECK-LABEL: sil @test_enum_with_initialize :
 // CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
 // CHECK-NEXT:   [[E:%[0-9]+]] = init_enum_data_addr %0
@@ -247,5 +249,22 @@ bb0(%0 : $*T, %1 : $*T):
   dealloc_stack %2 : $*T
   %78 = tuple ()
   return %78 : $()
+}
+
+
+// CHECK-LABEL: sil @optimize_builtin_zeroInitialize : {{.*}} {
+// CHECK:       bb0([[RET_ADDR:%[^,]+]] :
+// CHECK:         builtin "zeroInitializer"<T>([[RET_ADDR]] : $*T) : $()
+// CHECK:         apply undef<T>([[RET_ADDR]])
+// CHECK-LABEL: } // end sil function 'optimize_builtin_zeroInitialize'
+sil @optimize_builtin_zeroInitialize : $@convention(thin) <T> () -> @out T {
+bb0(%ret_addr : $*T):
+  %temporary = alloc_stack [lexical] $T
+  builtin "zeroInitializer"<T>(%temporary : $*T) : $()
+  apply undef<T>(%temporary) : $@convention(thin) <T> () -> @out T
+  copy_addr [take] %temporary to [init] %ret_addr : $*T
+  dealloc_stack %temporary : $*T
+  %15 = tuple ()
+  return %15 : $()
 }
 


### PR DESCRIPTION
Mostly restore the behavior of getMemoryEffectsFn on builtins other than `once` and `onceWithContext` to before 8a8a895239980343ec6a6d16930889fec389e75d but keeping the improvement to return `Instruction.memoryEffects` in the face of escaping.
