### PR TITLE
[build] Install swift-format in all jobs that test sourcekit-lsp

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -396,6 +396,7 @@ install-llbuild
 install-swiftpm
 install-swift-driver
 install-swiftsyntax
+install-swiftformat
 
 [preset: buildbot_incremental,tools=RA,stdlib=RA,apple_silicon]
 mixin-preset=buildbot_incremental,tools=RA,stdlib=RA
@@ -603,6 +604,7 @@ install-llbuild
 install-swiftpm
 install-swiftsyntax
 install-swift-driver
+install-swiftformat
 
 # We need to build the unittest extras so we can test
 build-swift-stdlib-unittest-extra
@@ -872,6 +874,7 @@ lldb-test-swift-only
 
 install-foundation
 install-libdispatch
+install-swiftformat
 reconfigure
 
 # gcc version on amazon linux 2 is too old to configure and build tablegen.
@@ -1039,6 +1042,7 @@ lit-args=-v
 
 install-foundation
 install-libdispatch
+install-swiftformat
 reconfigure
 test-optimized
 
@@ -1148,6 +1152,7 @@ install-swiftsyntax
 install-foundation
 install-libdispatch
 install-xctest
+install-swiftformat
 
 [preset: buildbot_incremental_linux,long_test]
 mixin-preset=buildbot_incremental_linux
@@ -1625,6 +1630,7 @@ install-swiftpm
 install-swift-driver
 install-swiftsyntax
 install-swiftdocc
+install-swiftformat
 
 # Build the stress tester
 skstresstester
@@ -1776,6 +1782,8 @@ assertions
 
 # Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
+swiftformat
+install-swiftformat
 
 toolchain-benchmarks
 skip-test-toolchain-benchmarks
@@ -1795,6 +1803,8 @@ assertions
 
 # Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
+swiftformat
+install-swiftformat
 
 toolchain-benchmarks
 skip-test-toolchain-benchmarks
@@ -1816,6 +1826,8 @@ assertions
 
 # Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
+swiftformat
+install-swiftformat
 
 #===------------------------------------------------------------------------===#
 # Test llbuild on Linux builder
@@ -1830,6 +1842,8 @@ assertions
 
 # Downstream projects that import llbuild+SwiftPM.
 sourcekit-lsp
+swiftformat
+install-swiftformat
 
 #===------------------------------------------------------------------------===#
 # Test Swift Driver (new)
@@ -1863,6 +1877,7 @@ swiftsyntax-lint
 swiftformat
 skstresstester
 sourcekit-lsp
+install-swiftformat
 skip-test-swift=false
 
 [preset: buildbot_swiftsyntax_linux]
@@ -1874,6 +1889,7 @@ swiftsyntax-enable-rawsyntax-validation
 swiftsyntax-enable-test-fuzzing
 sourcekit-lsp
 swiftformat
+install-swiftformat
 
 #===------------------------------------------------------------------------===#
 # Test Swift Format
@@ -1885,6 +1901,7 @@ release
 assertions
 swiftsyntax
 swiftformat
+install-swiftformat
 swiftsyntax-lint
 sourcekit-lsp-lint
 
@@ -1917,6 +1934,7 @@ release
 assertions
 sourcekit-lsp
 swiftformat
+install-swiftformat
 sourcekit-lsp-lint
 
 [preset: buildbot_sourcekitlsp_linux,no_sanitize]
@@ -1924,6 +1942,8 @@ mixin-preset=mixin_swiftpm_package_linux_platform
 release
 assertions
 sourcekit-lsp
+swiftformat
+install-swiftformat
 
 [preset: buildbot_sourcekitlsp_macos,sanitize]
 mixin-preset=buildbot_sourcekitlsp_macos,no_sanitize
@@ -1951,6 +1971,8 @@ release
 assertions
 indexstore-db
 sourcekit-lsp
+swiftformat
+install-swiftformat
 
 [preset: buildbot_indexstoredb_linux,no_sanitize]
 mixin-preset=mixin_swiftpm_package_linux_platform
@@ -1958,6 +1980,8 @@ release
 assertions
 indexstore-db
 sourcekit-lsp
+swiftformat
+install-swiftformat
 
 [preset: buildbot_indexstoredb_macos,sanitize]
 mixin-preset=buildbot_indexstoredb_macos,no_sanitize
@@ -1991,6 +2015,7 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
+swiftformat
 
 release
 validation-test
@@ -2007,6 +2032,7 @@ install-swiftpm
 install-swiftsyntax
 install-xctest
 install-sourcekit-lsp
+install-swiftformat
 
 skip-test-cmark
 skip-test-swift


### PR DESCRIPTION
With https://github.com/apple/sourcekit-lsp/pull/769, sourcekit-lsp supports formatting that invokes swift-format from the toolchain and tests that test this behavior. For those to pass, we need to install swift-format into the toolchain on all jobs that test sourcekit-lsp.
