### PR TITLE
For scripts, use DYLD_FRAMEWORK/LIBRARY_PATH to find frameworks / run…

### DIFF
--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -89,8 +89,10 @@ void *swift::immediate::loadSwiftRuntime(ArrayRef<std::string>
                                          runtimeLibPaths) {
 #if defined(_WIN32)
   return loadRuntimeLib("swiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
-#else
+#elif (defined(__linux__) || defined(_WIN64) || defined(__FreeBSD__))
   return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
+#else
+  return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, {"/usr/lib/swift"});
 #endif
 }
 


### PR DESCRIPTION
…times.

Add DYLD_FRAMEWORK_PATH=/System/Library/Frameworks to the environment when constructing swift-frontend invocations for the interpreter so that dlopen can find autolinked frameworks.

As a follow-up: don't expand runtime paths to find the path to the runtime in libImmediate, but instead hard-code "/usr/lib/swift/libswiftCore.dylib" and allow any overrides to be found via DYLD_LIBRARY_PATH (this ensures that dyld treats whichever libswiftCore.dylib is found as override for the one in the shared cache, which doesn't happen if dlopen is passed a non-standard path).

Resolves #68785.