### PR TITLE
[RemoteInspection] Pass through null returns from TypeRefVisitor.

### DIFF
--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -531,6 +531,8 @@ public:
   Demangle::NodePointer visit(const TypeRef *typeRef) {
     auto node = TypeRefVisitor<DemanglingForTypeRef,
                                 Demangle::NodePointer>::visit(typeRef);
+    if (!node)
+      return nullptr;
 
     // Wrap all nodes in a Type node, as consumers generally expect.
     auto typeNode = Dem.createNode(Node::Kind::Type);


### PR DESCRIPTION
If `TypeRefVisitor<DemanglingForTypeRef, Demangle,NodePointer>::visit` returns `nullptr`, we should pass it through.  The callers of `TypeRef::getDemangling()` are already prepared to cope with `nullptr` returns, so this should be fine and avoids hitting an assertion failure in that case.

rdar://120941628
