### PR TITLE
[BitwiseCopyable] Remove gating from protocol declaration.

### DIFF
--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -182,6 +182,4 @@ func _rethrowsViaClosure(_ fn: () throws -> ()) rethrows {
 @_marker public protocol Escapable {}
 #endif
 
-#if $BitwiseCopyable
 @_marker public protocol _BitwiseCopyable {}
-#endif

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -783,6 +783,4 @@ extension Optional: _ObjectiveCBridgeable {
 
 extension Optional: Sendable where Wrapped: Sendable { }
 
-#if $BitwiseCopyable
 extension Optional: _BitwiseCopyable where Wrapped: _BitwiseCopyable { }
-#endif


### PR DESCRIPTION
It's harmless to have the protocol defined in the swiftinterface for older compilers and removing the gating permits the gating to be omitted from conformances.
