### PR TITLE
Switch #isolation from AnyActor to Actor 

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3916,7 +3916,7 @@ namespace {
 
     Type visitCurrentContextIsolationExpr(CurrentContextIsolationExpr *E) {
       auto actorProto = CS.getASTContext().getProtocol(
-          KnownProtocolKind::AnyActor);
+          KnownProtocolKind::Actor);
       return OptionalType::get(actorProto->getDeclaredExistentialType());
     }
 

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -77,4 +77,4 @@ internal func _enqueueOnMain(_ job: UnownedJob)
 /// isolated, or `nil` if the code is nonisolated.
 @available(SwiftStdlib 5.1, *)
 @freestanding(expression)
-public macro isolation() -> (any AnyActor)? = Builtin.IsolationMacro
+public macro isolation() -> (any Actor)? = Builtin.IsolationMacro

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -73,8 +73,11 @@ public func _defaultActorDestroy(_ actor: AnyObject)
 @usableFromInline
 internal func _enqueueOnMain(_ job: UnownedJob)
 
+#if $Macros
 /// Produce a reference to the actor to which the enclosing code is
 /// isolated, or `nil` if the code is nonisolated.
 @available(SwiftStdlib 5.1, *)
 @freestanding(expression)
 public macro isolation() -> (any Actor)? = Builtin.IsolationMacro
+#endif
+


### PR DESCRIPTION
We are currently lacking the ability to describe "normal or distributed
actor" with a single protocol in a manner that allows hopping to it,
because `AnyActor` is a marker protocol. Use `Actor` while we sort
this out.