### PR TITLE
[DependencyScanning] Fix clang submodule canImport check after #70974

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2382,10 +2382,12 @@ bool ASTContext::canImportModule(ImportPath::Module ModuleName,
   if (!canImportModuleImpl(ModuleName, version, underlyingVersion, true))
     return false;
 
-  // If inserted successfully, add that to success list as dependency.
-  SmallString<64> FullModuleName;
-  ModuleName.getString(FullModuleName);
-  SucceededModuleImportNames.insert(FullModuleName.str());
+  // If checked successfully, add the top level name to success list as
+  // dependency to handle clang submodule correctly. Swift does not have
+  // submodule so the name should be the same.
+  SmallString<64> TopModuleName;
+  ModuleName.getTopLevelPath().getString(TopModuleName);
+  SucceededModuleImportNames.insert(TopModuleName.str());
   return true;
 }
 

--- a/test/CAS/can-import.swift
+++ b/test/CAS/can-import.swift
@@ -69,14 +69,14 @@
 
 //--- main.swift
 #if canImport(A.Sub)
-import A.Sub
+func a() {}
 #endif
 
 #if canImport(A.Missing)
 import A.Missing
 #endif
 
-#if canImport(B) // never actually import B
+#if canImport(B)
 func b() {}
 #endif
 
@@ -99,7 +99,7 @@ module B {
 }
 
 //--- include/sub.h
-void a(void);
+void notused(void);
 
 //--- include/B.h
-void notused(void);
+void notused2(void);

--- a/test/ScanDependencies/module_deps_can_import.swift
+++ b/test/ScanDependencies/module_deps_can_import.swift
@@ -1,14 +1,18 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -module-name Test -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -swift-version 4
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/main.swift -module-name Test -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -I %t/include -swift-version 4
 
 // RUN: %{python} %S/../CAS/Inputs/SwiftDepsExtractor.py %t/deps.json Test directDependencies | %FileCheck %s
 
 // CHECK-DAG: "clang": "C"
+// CHECK-DAG: "clang": "ClangTest"
 // CHECK-DAG: "swift": "A"
 // CHECK-DAG: "swift": "F"
 // CHECK-NOT: "swift": "G"
 // CHECK-NOT: "swift": "B"
 // CHECK-NOT: "Missing"
+
+//--- main.swift
 
 #if canImport(Missing)
 import G
@@ -32,3 +36,18 @@ import Missing
 // B is short circuited
 #if canImport(C) || canImport(B)
 #endif
+
+// Check clang submodule, this should import ClangTest, not ClangTest.Sub
+#if canImport(ClangTest.Sub)
+#endif
+
+//--- include/module.modulemap
+module ClangTest {
+  module Sub {
+    header "sub.h"
+    export *
+  }
+}
+
+//--- include/sub.h
+void notused(void);


### PR DESCRIPTION
When clang submodule is used in `canImport` check, it should return the top level module as dependency, not the submodule. This fixes a regression after #70974 that causes dependency scanning to fail due to failed submodule lookup during dependency scanning.