### PR TITLE
[cxx-interop] Emit function types as Swift closures in templated params

### DIFF
--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -56,7 +56,7 @@ struct TemplateInstantiationNamePrinter
     }
 
     if (swiftType) {
-      if (swiftType->is<NominalType>()) {
+      if (swiftType->is<NominalType>() || swiftType->isVoid()) {
         return swiftType->getStringAsComponent();
       }
     }
@@ -110,6 +110,22 @@ struct TemplateInstantiationNamePrinter
     buffer << pointeeResult;
     if (decorator != TagTypeDecorator::None)
       buffer << '>';
+
+    return buffer.str().str();
+  }
+
+  std::string VisitFunctionProtoType(const clang::FunctionProtoType *type) {
+    llvm::SmallString<128> storage;
+    llvm::raw_svector_ostream buffer(storage);
+
+    buffer << "((";
+    llvm::interleaveComma(type->getParamTypes(), buffer,
+                          [&](const clang::QualType &paramType) {
+                            buffer << Visit(paramType.getTypePtr());
+                          });
+    buffer << ") -> ";
+    buffer << Visit(type->getReturnType().getTypePtr());
+    buffer << ")";
 
     return buffer.str().str();
   }

--- a/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
+++ b/lib/ClangImporter/ClangClassTemplateNamePrinter.cpp
@@ -28,6 +28,11 @@ struct TemplateInstantiationNamePrinter
                                    ImportNameVersion version)
       : swiftCtx(swiftCtx), nameImporter(nameImporter), version(version) {}
 
+  std::string VisitType(const clang::Type *type) {
+    // Print "_" as a fallback if we couldn't emit a more meaningful type name.
+    return "_";
+  }
+
   std::string VisitBuiltinType(const clang::BuiltinType *type) {
     Type swiftType = nullptr;
     switch (type->getKind()) {

--- a/test/Interop/Cxx/templates/Inputs/class-template-with-function-parameter.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-with-function-parameter.h
@@ -1,0 +1,21 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_FUNCTION_ARGUMENT_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_FUNCTION_ARGUMENT_H
+
+template <typename Fn>
+class function_wrapper;
+
+template <typename Ret, typename... Params>
+class function_wrapper<Ret(Params...)> {
+  Ret (*fn)(Params... params) = nullptr;
+};
+
+typedef function_wrapper<bool(bool)> FuncBoolToBool;
+typedef function_wrapper<bool()> FuncVoidToBool;
+typedef function_wrapper<void(bool)> FuncBoolToVoid;
+typedef function_wrapper<void()> FuncVoidToVoid;
+typedef function_wrapper<int(int)> FuncIntToInt;
+typedef function_wrapper<int(int, int)> FuncIntIntToInt;
+typedef function_wrapper<void(int, int)> FuncIntIntToVoid;
+typedef function_wrapper<void(int, int, bool)> FuncIntIntBoolToVoid;
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_FUNCTION_ARGUMENT_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -8,6 +8,11 @@ module ClassTemplateWithPrimitiveArgument {
   requires cplusplus
 }
 
+module ClassTemplateWithFunctionParameter {
+  header "class-template-with-function-parameter.h"
+  requires cplusplus
+}
+
 module ClassTemplateWithOutOfLineMember {
   header "class-template-with-static-out-of-line-member.h"
   requires cplusplus

--- a/test/Interop/Cxx/templates/class-template-with-function-parameter-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-function-parameter-module-interface.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithFunctionParameter -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithFunctionParameter -I %S/Inputs -source-filename=x -cxx-interoperability-mode=upcoming-swift | %FileCheck %s
+
+// CHECK: @available(*, unavailable
+// CHECK: struct function_wrapper<Fn> {
+// CHECK: }
+
+// CHECK: typealias FuncBoolToBool = function_wrapper<((CBool) -> CBool)>
+// CHECK: typealias FuncVoidToBool = function_wrapper<(() -> CBool)>
+// CHECK: typealias FuncBoolToVoid = function_wrapper<((CBool) -> Void)>
+// CHECK: typealias FuncVoidToVoid = function_wrapper<(() -> Void)>
+// CHECK: typealias FuncIntToInt = function_wrapper<((CInt) -> CInt)>
+// CHECK: typealias FuncIntIntToInt = function_wrapper<((CInt, CInt) -> CInt)>
+// CHECK: typealias FuncIntIntToVoid = function_wrapper<((CInt, CInt) -> Void)>
+// CHECK: typealias FuncIntIntBoolToVoid = function_wrapper<((CInt, CInt, CBool) -> Void)>


### PR DESCRIPTION
This is required to make the compiler distinguish between instantiations of `std::function`.

Previously, when generating a Swift type name for a `std::function` instantiation, we would always emit `_` as the template parameter. If someone referenced two different instantiations of `std::function` in a Swift module, they would get mangled with the same name, triggering linker errors later.

rdar://103979602