### PR TITLE
SILGen: Always match noncopyable values by borrowing.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -273,6 +273,9 @@ EXPERIMENTAL_FEATURE(TransferringArgsAndResults, true)
 // Enable `@preconcurrency` attribute on protocol conformances.
 EXPERIMENTAL_FEATURE(PreconcurrencyConformances, false)
 
+// Allow for `switch` of noncopyable values to be borrowing or consuming.
+EXPERIMENTAL_FEATURE(BorrowingSwitch, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3940,6 +3940,8 @@ static bool usesFeaturePreconcurrencyConformances(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBorrowingSwitch(Decl *decl) { return false; }
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -689,9 +689,7 @@ struct ImmutableAddressUseVerifier {
         }
         break;
       case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
-        auto type =
-            cast<UncheckedTakeEnumDataAddrInst>(inst)->getOperand()->getType();
-        if (type.getOptionalObjectType()) {
+        if (!cast<UncheckedTakeEnumDataAddrInst>(inst)->isDestructive()) {
           for (auto result : inst->getResults()) {
             llvm::copy(result->getUses(), std::back_inserter(worklist));
           }

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -469,9 +469,6 @@ public:
   /*implicit*/ ConsumableManagedValue(ManagedValue value,
                                       CastConsumptionKind finalConsumption)
       : Value(value), FinalConsumption(finalConsumption) {
-    assert((value.getType().isObject() ||
-            finalConsumption != CastConsumptionKind::BorrowAlways) &&
-           "Can not borrow always a value");
     assert((value.getType().isAddress() ||
             finalConsumption != CastConsumptionKind::CopyOnSuccess) &&
            "Can not copy on success a value.");

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4112,7 +4112,8 @@ diagnoseMoveOnlyPatternMatchSubject(ASTContext &C,
   if (auto load = dyn_cast<LoadExpr>(subjectExpr)) {
     subjectExpr = load->getSubExpr()->getSemanticsProvidingExpr();
   }
-  if (isa<DeclRefExpr>(subjectExpr)) {
+  if (!C.LangOpts.hasFeature(Feature::BorrowingSwitch)
+      && isa<DeclRefExpr>(subjectExpr)) {
     C.Diags.diagnose(subjectExpr->getLoc(),
                            diag::move_only_pattern_match_not_consumed)
       .fixItInsert(subjectExpr->getStartLoc(), "consume ");


### PR DESCRIPTION
Even if the final pattern ends up consuming the value, the match itself must be nondestructive, because any match condition could fail and cause us to have to go back to the original aggregate. For copyable values, we can always copy our way out of consuming operations, but we don't have that luxury for noncopyable types, so the entire match operation has to be done as a borrow.

For address-only enums, this requires codifying part of our tag layout algorithm in SIL, namely that an address-only enum will never use spare bits or other overlapping storage for the enum tag. This allows us to assume that `unchecked_take_enum_data_addr` is safely non-side- effecting and match an address-only noncopyable enum as a borrow. I put TODOs to remove defensive copies from various parts of our copyable enum codegen, as well as to have the instruction report its memory behavior as `None` when the projection is nondestructive, but this disturbs SILGen for existing code in ways SIL passes aren't yet ready for, so I'll leave those as is for now.

This patch is enough to get simple examples of noncopyable enum switches to SILGen correctly. Additional work is necessary to stage in the binding step of the pattern match; for a consuming switch, we'll need to end the borrow(s) and then reproject the matched components so we can consume them moving them into the owned bindings. The move-only checker also needs to be updated because it currently always tries to convert a switch into a consuming operation.