### PR TITLE
[CSSimplify] Increase impact of requirement failures in special result builder methods

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6448,6 +6448,9 @@ bool containsPackExpansionType(TupleType *tuple);
 /// \returns null if \c type is not a single unlabeled pack expansion tuple.
 Type getPatternTypeOfSingleUnlabeledPackExpansionTuple(Type type);
 
+/// Check whether this is a reference to one of the special result builder
+/// methods prefixed with `build*` i.e. `buildBlock`, `buildExpression` etc.
+bool isResultBuilderMethodReference(ASTContext &, UnresolvedDotExpr *);
 } // end namespace constraints
 
 template<typename ...Args>

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2755,7 +2755,12 @@ assessRequirementFailureImpact(ConstraintSystem &cs, Type requirementType,
     if (!cs.findSelectedOverloadFor(calleeLoc))
       return 10;
   }
-  
+
+  if (auto *UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
+    if (isResultBuilderMethodReference(cs.getASTContext(), UDE))
+      return 12;
+  }
+
   auto resolvedTy = cs.simplifyType(requirementType);
 
   // Increase the impact of a conformance fix for generic parameters on

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7963,9 +7963,9 @@ bool constraints::isResultBuilderMethodReference(ASTContext &ctx,
   if (!(UDE && UDE->isImplicit()))
     return false;
 
-  SmallVector<Identifier, 4> builderMethods(
+  SmallVector<Identifier, 5> builderMethods(
       {ctx.Id_buildBlock, ctx.Id_buildExpression, ctx.Id_buildPartialBlock,
-       ctx.Id_buildFinalResult});
+       ctx.Id_buildFinalResult, ctx.Id_buildIf});
 
   return llvm::any_of(builderMethods, [&](const Identifier &methodId) {
     return UDE->getName().compare(DeclNameRef(methodId)) == 0;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5496,21 +5496,6 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   // Aggregate all requirement fixes that belong to the same callee
   // and attempt to diagnose possible ambiguities.
   {
-    auto isResultBuilderMethodRef = [&](ASTNode node) {
-      auto *UDE = getAsExpr<UnresolvedDotExpr>(node);
-      if (!(UDE && UDE->isImplicit()))
-        return false;
-
-      auto &ctx = getASTContext();
-      SmallVector<Identifier, 4> builderMethods(
-          {ctx.Id_buildBlock, ctx.Id_buildExpression, ctx.Id_buildPartialBlock,
-           ctx.Id_buildFinalResult});
-
-      return llvm::any_of(builderMethods, [&](const Identifier &methodId) {
-        return UDE->getName().compare(DeclNameRef(methodId)) == 0;
-      });
-    };
-
     // Aggregates fixes fixes attached to `buildExpression` and `buildBlock`
     // methods at the particular source location.
     llvm::MapVector<SourceLoc, SmallVector<FixInContext, 4>>
@@ -5526,7 +5511,8 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
 
       auto *calleeLoc = entry.first->getCalleeLocator(fix->getLocator());
 
-      if (isResultBuilderMethodRef(calleeLoc->getAnchor())) {
+      auto *UDE = getAsExpr<UnresolvedDotExpr>(calleeLoc->getAnchor());
+      if (UDE && isResultBuilderMethodReference(getASTContext(), UDE)) {
         auto *anchor = castToExpr<Expr>(calleeLoc->getAnchor());
         builderMethodRequirementFixes[anchor->getLoc()].push_back(entry);
       } else {
@@ -7970,4 +7956,18 @@ void constraints::dumpAnchor(ASTNode anchor, SourceManager *SM,
     }
   }
   // TODO(diagnostics): Implement the rest of the cases.
+}
+
+bool constraints::isResultBuilderMethodReference(ASTContext &ctx,
+                                                 UnresolvedDotExpr *UDE) {
+  if (!(UDE && UDE->isImplicit()))
+    return false;
+
+  SmallVector<Identifier, 4> builderMethods(
+      {ctx.Id_buildBlock, ctx.Id_buildExpression, ctx.Id_buildPartialBlock,
+       ctx.Id_buildFinalResult});
+
+  return llvm::any_of(builderMethods, [&](const Identifier &methodId) {
+    return UDE->getName().compare(DeclNameRef(methodId)) == 0;
+  });
 }

--- a/validation-test/Sema/SwiftUI/builder_requirement_errors_should_not_shadow_errors_in_code.swift
+++ b/validation-test/Sema/SwiftUI/builder_requirement_errors_should_not_shadow_errors_in_code.swift
@@ -1,0 +1,186 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+extension [UInt8] {
+  var toASCII : String? { nil }
+}
+
+// rdar://111120803
+do {
+  struct MissingOptionalUnwrap : View {
+    var data: [UInt8]
+
+    var body: some View {
+      Group {
+        Text("")
+        Text(data.toASCII)
+        // expected-error@-1 {{value of optional type 'String?' must be unwrapped to a value of type 'String'}}
+        // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
+        // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+      }
+    }
+  }
+}
+
+// rdar://112928810
+do {
+  struct DismissAction {
+    func callAsFunction() {
+    }
+  }
+
+  struct TestConcurrencyMismatch : View {
+    private var dismiss : DismissAction
+
+    var body: some View {
+      List {
+      }
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Dismiss") {
+            dismiss()
+          }
+        }
+        ToolbarItem(placement: .primaryAction) {
+          Button("Done") {
+            MainActor.run {
+              // expected-error@-1 {{cannot pass function of type '@Sendable () async -> ()' to parameter expecting synchronous function type}}
+              await dismiss()
+              // expected-note@-1 {{'async' inferred from asynchronous operation used here}}
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// rdar://115784749
+do {
+  struct InvalidArgumentPlacement : View {
+    var body: some View {
+      let base = RoundedRectangle(cornerRadius: 12)
+      Group {
+        base.strokeBorder(lineWidth: 2, LinearGradient(gradient: Gradient(colors: [.red, .blue]), startPoint: .top, endPoint: .bottom))
+        // expected-error@-1 {{unnamed argument #2 must precede argument 'lineWidth'}}
+        Text("test")
+          .font(.system(size: 200))
+          .minimumScaleFactor(0.01)
+          .aspectRatio(1, contentMode: .fit)
+      }
+    }
+  }
+}
+
+// rdar://118326796
+do {
+  class Model: ObservableObject {
+  }
+
+  struct InvalidRef: View {
+    @State private var isLoading = true
+
+    var body: some View {
+      Group {
+        if isLoading{
+          EmptyView().onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+              isLoading = false
+            }
+          }
+        } else {
+          NavigationView {
+          }
+          .environmentObject(Model)
+          // expected-error@-1 {{type 'Model.Type' cannot conform to 'ObservableObject'}}
+          // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+          // expected-note@-3 {{required by instance method 'environmentObject' where 'T' = 'Model.Type'}}
+        }
+      }
+    }
+  }
+}
+
+// rdar://106804509
+do {
+  struct Entry: Identifiable {
+    var id: String { name }
+    let name: String
+    let type: String = "string"
+  }
+
+  struct MissingLabelTest: View {
+    var entry: [Entry] = []
+
+    var body: some View {
+      VStack(alignment: .leading) {
+        ForEach(entry) { entry in
+          HStack {
+            Text(entry.name)
+            Text("(\(entry.type))").foregroundColor(.secondary)
+          }
+          ViewWithTitle("title")
+          // expected-error@-1 {{missing argument label 'title:' in call}}
+        }
+      }
+    }
+  }
+
+  struct ViewWithTitle: View {
+    let title: String
+
+    var body: some View {
+      Text(title)
+    }
+  }
+}
+
+// rdar://119008852
+do {
+  struct LazyPageView: View {
+    @State var currentOffset = 0
+    @State private var tabViewSelection = 0
+    let minIndex: Int?
+    let maxIndex: Int?
+    let contentGen: (Int) -> any View
+
+    var body: some View {
+      TabView(selection: $tabViewSelection) {
+        Group {
+          if minIndex == nil || currentOffset - 1 >= minIndex! {
+            // expected-error@-1 {{type 'any View' cannot conform to 'View'}}
+            // expected-note@-2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+            // expected-note@-3 {{required by static method 'buildIf' where 'Content' = 'any View'}}
+            contentGen(currentOffset - 1)
+          }
+        }
+        contentGen(currentOffset)
+      }
+    }
+  }
+}
+
+// rdar://118374670
+do {
+  struct MissingWrapperInnerView: View {
+    @State var cond = false
+
+    var body: some View {
+      Group {
+        Group {
+          EmptyView()
+        }
+        .disabled(true)
+        Toggle(isOn: cond) {
+          // expected-error@-1 {{cannot convert value 'cond' of type 'Bool' to expected type 'Binding<Bool>', use wrapper instead}} {{22-22=$}}
+          Text("")
+        }
+      }
+      .disabled(true)
+    }
+  }
+}


### PR DESCRIPTION
Handle requirement failures in result builder `build*` methods explicitly
and give them a high impact rating because issues if such positions
imply that the transform didn't work and it shouldn't shadow errors
in user code.

Resolves: rdar://111120803
Resolves: rdar://120342129

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
