### PR TITLE
[region-isolation] Fix support for GlobalActor guarded variables and wordsmith some diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -893,16 +893,16 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 WARNING(regionbasedisolation_selforargtransferred, none,
         "call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller", ())
 WARNING(regionbasedisolation_transfer_yields_race_no_isolation, none,
-        "transferred value of non-Sendable type %0 that could race with later accesses",
+        "transferring value of non-Sendable type %0; later accesses could race",
         (Type))
 WARNING(regionbasedisolation_transfer_yields_race_with_isolation, none,
-        "passing argument of non-sendable type %0 from %1 context to %2 context at this call site could yield a race with accesses later in this function",
+        "transferring value of non-Sendable type %0 from %1 context to %2 context; later accesses could race",
         (Type, ActorIsolation, ActorIsolation))
 WARNING(regionbasedisolation_transfer_yields_race_transferring_parameter, none,
-        "transferred value of non-Sendable type %0 into transferring parameter; later accesses could result in races",
+        "transferring value of non-Sendable type %0 into transferring parameter; later accesses could race",
         (Type))
 WARNING(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, none,
-        "binding of non-Sendable type %0 accessed after being transferred; later accesses could result in races",
+        "binding of non-Sendable type %0 accessed after being transferred; later accesses could race",
         (Type))
 NOTE(regionbasedisolation_maybe_race, none,
      "access here could race", ())

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2924,6 +2924,17 @@ TrackableValue RegionAnalysisValueMap::getTrackableValue(
           iter.first->getSecond().addFlag(TrackableValueFlag::isActorDerived);
         }
       }
+
+      // See if the memory base is a global_addr from a global actor protected global.
+      if (auto *ga = dyn_cast<GlobalAddrInst>(storage.base)) {
+        if (auto *global = ga->getReferencedGlobal()) {
+          if (auto *globalDecl = global->getDecl()) {
+            if (getActorIsolation(globalDecl).isGlobalActor()) {
+              iter.first->getSecond().addFlag(TrackableValueFlag::isActorDerived);
+            }
+          }
+        }
+      }
     }
   }
 

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -31,13 +31,13 @@ func iterate(stream: AsyncStream<Int>) async {
   // FIXME: Region isolation should consider a value from a 'nonisolated(unsafe)'
   // declaration to be in a disconnected region
 
-  // expected-region-isolation-warning@+2 {{passing argument of non-sendable type 'AsyncStream<Int>.Iterator' from main actor-isolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  // expected-region-isolation-warning@+2 {{transferring value of non-Sendable type 'AsyncStream<Int>.Iterator' from main actor-isolated context to nonisolated context; later accesses could race}}
   // expected-region-isolation-note@+1 {{access here could race}}
   while let element = await it.next() {
     print(element)
   }
 
-  // expected-region-isolation-warning@+2 {{passing argument of non-sendable type 'AsyncStream<Int>.Iterator' from main actor-isolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  // expected-region-isolation-warning@+2 {{transferring value of non-Sendable type 'AsyncStream<Int>.Iterator' from main actor-isolated context to nonisolated context; later accesses could race}}
   // expected-region-isolation-note@+1 {{access here could race}}
   for await x in stream {
     print(x)

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -273,7 +273,7 @@ func testNonSendableBaseArg() async {
   let t = NonSendable()
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-  // expected-tns-warning@-2 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning@-2 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to main actor-isolated context; later accesses could race}}
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -117,7 +117,7 @@ func closureInOut(_ a: Actor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-2 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context; later accesses could race}}
 
   // We only emit a warning on the first use we see, so make sure we do both
   // klass and the closure.
@@ -139,12 +139,12 @@ func closureInOut2(_ a: Actor) async {
 
   var closure = {}
 
-  await a.useKlass(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await a.useKlass(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure = { useInOut(&contents) } // expected-tns-note {{access here could race}}
 
-  await a.useKlass(ns1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{access here could race}}
@@ -165,7 +165,7 @@ func closureNonInOut(_ a: Actor) async {
 
   closure = { useValue(contents) }
 
-  await a.useKlass(ns1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{access here could race}}
@@ -278,7 +278,7 @@ extension Actor {
     var closure: () -> () = {}
 
     // We get a transfer after use error.
-    await transferToMain(closure) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from actor-isolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(closure) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from actor-isolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -486,7 +486,7 @@ extension Actor {
 
     // This re-assignment shouldn't error.
     closure = {}
-    await transferToMain(closure) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from actor-isolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(closure) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from actor-isolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -541,7 +541,7 @@ func singleFieldVarMergeTest() async {
   useValue(box)
   useValue(box.k)
 
-  await transferToMain(box) // expected-tns-warning {{passing argument of non-sendable type 'SingleFieldKlassBox' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(box) // expected-tns-warning {{transferring value of non-Sendable type 'SingleFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
   
 
@@ -555,7 +555,7 @@ func multipleFieldVarMergeTest1() async {
   box = TwoFieldKlassBox()
 
   // This transfers the entire region.
-  await transferToMain(box.k1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(box.k1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   
 
@@ -595,7 +595,7 @@ func multipleFieldTupleMergeTest1() async {
   box = (NonSendableKlass(), NonSendableKlass())
 
   // This transfers the entire region.
-  await transferToMain(box.0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(box.0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // So even if we reassign over k1, since we did a merge, this should error.
@@ -647,7 +647,7 @@ class ClassFieldTests { // expected-complete-note 6{{}}
 
 func letSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -655,7 +655,7 @@ func letSendableTrivialClassFieldTest() async {
 
 func letSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
 
   _ = test.letSendableNonTrivial
@@ -664,7 +664,7 @@ func letSendableNonTrivialClassFieldTest() async {
 
 func letNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
   useValue(test)
@@ -672,7 +672,7 @@ func letNonSendableNonTrivialClassFieldTest() async {
 
 func varSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{access here could race}}
   useValue(test)
@@ -680,7 +680,7 @@ func varSendableTrivialClassFieldTest() async {
 
 func varSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{access here could race}}
   useValue(test)
@@ -688,7 +688,7 @@ func varSendableNonTrivialClassFieldTest() async {
 
 func varNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   useValue(test)
@@ -709,7 +709,7 @@ final class FinalClassFieldTests { // expected-complete-note 6 {{}}
 
 func letSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -717,7 +717,7 @@ func letSendableTrivialFinalClassFieldTest() async {
 
 func letSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -725,7 +725,7 @@ func letSendableNonTrivialFinalClassFieldTest() async {
 
 func letNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
   useValue(test)
@@ -733,7 +733,7 @@ func letNonSendableNonTrivialFinalClassFieldTest() async {
 
 func varSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{access here could race}}
   useValue(test)
@@ -741,7 +741,7 @@ func varSendableTrivialFinalClassFieldTest() async {
 
 func varSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{access here could race}}
   useValue(test)
@@ -749,7 +749,7 @@ func varSendableNonTrivialFinalClassFieldTest() async {
 
 func varNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   useValue(test)
@@ -770,7 +770,7 @@ struct StructFieldTests { // expected-complete-note 31 {{}}
 
 func letSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -778,7 +778,7 @@ func letSendableTrivialLetStructFieldTest() async {
 
 func letSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -786,7 +786,7 @@ func letSendableNonTrivialLetStructFieldTest() async {
 
 func letNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
@@ -796,7 +796,7 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
 func letSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests() 
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -805,7 +805,7 @@ func letSendableTrivialVarStructFieldTest() async {
 func letSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() 
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -814,7 +814,7 @@ func letSendableNonTrivialVarStructFieldTest() async {
 func letNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() 
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
@@ -833,7 +833,7 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
     print(test)
   }
   _ = cls2
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial
   _ = z
@@ -844,7 +844,7 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
 
 func varSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -852,7 +852,7 @@ func varSendableTrivialLetStructFieldTest() async {
 
 func varSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -860,7 +860,7 @@ func varSendableNonTrivialLetStructFieldTest() async {
 
 func varNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
@@ -870,7 +870,7 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
 func varSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests() 
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -879,7 +879,7 @@ func varSendableTrivialVarStructFieldTest() async {
 func varSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() 
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -888,7 +888,7 @@ func varSendableNonTrivialVarStructFieldTest() async {
 func varNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() 
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
@@ -903,7 +903,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
@@ -917,7 +917,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
@@ -931,7 +931,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
@@ -946,7 +946,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
@@ -961,7 +961,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
@@ -976,7 +976,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
@@ -990,7 +990,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
     test.varSendableNonTrivial = SendableKlass()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
@@ -1004,7 +1004,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
     useInOut(&test)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
@@ -1018,7 +1018,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
     useInOut(&test.varSendableNonTrivial)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
@@ -1035,7 +1035,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
     test.varSendableNonTrivial = SendableKlass()
@@ -1055,7 +1055,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
     }
     _ = cls
 
-    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1076,7 +1076,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1090,7 +1090,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
   var cls = {}
 
   for _ in 0..<1024 {
-    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests() // expected-tns-note {{access here could race}}
     cls = {
@@ -1115,7 +1115,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   // this. This is a case where we are going to need to be able to have the
   // compiler explain the regions well.
   for _ in 0..<1024 {
-    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-tns-note @-1 {{access here could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests()
@@ -1138,10 +1138,10 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1157,14 +1157,14 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
   var cls = {}
 
   if await booleanFlag {
-    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
     cls = {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
@@ -1178,7 +1178,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
 
 func varSendableTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.0
   useValue(z)
@@ -1187,7 +1187,7 @@ func varSendableTrivialLetTupleFieldTest() async {
 
 func varSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.1
   useValue(z)
@@ -1196,7 +1196,7 @@ func varSendableNonTrivialLetTupleFieldTest() async {
 
 func varNonSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2
   // The SIL emitted for the assignment of the tuple is just a jumble of
@@ -1209,7 +1209,7 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
 func varSendableTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.0
   useValue(test) // expected-tns-note {{access here could race}}
@@ -1218,7 +1218,7 @@ func varSendableTrivialVarTupleFieldTest() async {
 func varSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.1
   useValue(test) // expected-tns-note {{access here could race}}
@@ -1227,7 +1227,7 @@ func varSendableNonTrivialVarTupleFieldTest() async {
 func varNonSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2 // expected-tns-note {{access here could race}}
   useValue(z)
@@ -1242,10 +1242,10 @@ func controlFlowTest1() async {
   let x = NonSendableKlass()
 
   if await booleanFlag {
-    await transferToMain(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -1264,7 +1264,7 @@ func controlFlowTest2() async {
   var x = NonSendableKlass()
 
   for _ in 0..<1024 {
-    await transferToMain(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await transferToMain(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
     // expected-tns-note @-1 {{access here could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -63,7 +63,7 @@ struct TwoFieldKlassBox { // expected-complete-note 24{{}}
 
 func asyncLet_Let_ActorIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{access here could race}}
@@ -72,7 +72,7 @@ func asyncLet_Let_ActorIsolated_Simple1() async {
 
 func asyncLet_Let_ActorIsolated_Simple2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   let _ = await y
@@ -81,7 +81,7 @@ func asyncLet_Let_ActorIsolated_Simple2() async {
 
 func asyncLet_Let_ActorIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
@@ -100,7 +100,7 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
 
 func asyncLet_Let_ActorIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
@@ -113,7 +113,7 @@ func asyncLet_Let_ActorIsolated_Simple4() async {
 
 func asyncLet_Let_ActorIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
@@ -128,7 +128,7 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{access here could race}}
@@ -137,7 +137,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field) // expected-tns-note {{access here could race}}
@@ -146,7 +146,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field2) // expected-tns-note {{access here could race}}
@@ -157,7 +157,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{passing argument of non-sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{access here could race}}
@@ -166,7 +166,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{passing argument of non-sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k1) // expected-tns-note {{access here could race}}
@@ -175,7 +175,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{passing argument of non-sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k2) // expected-tns-note {{access here could race}}
@@ -184,7 +184,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{passing argument of non-sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.k1.field) // expected-tns-note {{access here could race}}
@@ -195,7 +195,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{passing argument of non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -205,7 +205,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{passing argument of non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -215,7 +215,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{passing argument of non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -225,7 +225,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{passing argument of non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -237,8 +237,8 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
-  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -252,8 +252,8 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
-  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -268,8 +268,8 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
-  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -288,7 +288,7 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
 func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-tns-note @-1:67 {{access here could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -303,7 +303,7 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-tns-note @-1:53 {{access here could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -335,7 +335,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1:53 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-1:53 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -352,8 +352,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
-  // expected-tns-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-2 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -370,8 +370,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
-  // expected-tns-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-2 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -388,8 +388,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
-  // expected-tns-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-2 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -408,7 +408,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
 
 func asyncLet_Let_NonIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x) // expected-tns-note {{access here could race}}
@@ -426,7 +426,7 @@ func asyncLet_Let_NonIsolated_Simple2() async {
 
 func asyncLet_Let_NonIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   // TODO: We shouldn't emit the 2nd error here given the current implementation
@@ -444,7 +444,7 @@ func asyncLet_Let_NonIsolated_Simple3() async {
 
 func asyncLet_Let_NonIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   if await booleanFlag {
@@ -457,7 +457,7 @@ func asyncLet_Let_NonIsolated_Simple4() async {
 
 func asyncLet_Let_NonIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   if await booleanFlag {
@@ -472,7 +472,7 @@ func asyncLet_Let_NonIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x) // expected-tns-note {{access here could race}}
@@ -481,7 +481,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x.field) // expected-tns-note {{access here could race}}
@@ -490,7 +490,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   useValue(x.field2) // expected-tns-note {{access here could race}}
@@ -501,7 +501,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferred value of non-Sendable type 'TwoFieldKlassBox' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x) // expected-tns-note {{access here could race}}
@@ -510,7 +510,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferred value of non-Sendable type 'TwoFieldKlassBox' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x.k1) // expected-tns-note {{access here could race}}
@@ -519,7 +519,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferred value of non-Sendable type 'TwoFieldKlassBox' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x.k2) // expected-tns-note {{access here could race}}
@@ -528,7 +528,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{transferred value of non-Sendable type 'TwoFieldKlassBox' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
   useValue(x.k1.field) // expected-tns-note {{access here could race}}
@@ -539,7 +539,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferred value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
@@ -549,7 +549,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferred value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x.1) // expected-tns-note {{access here could race}}
@@ -558,7 +558,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferred value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
@@ -568,7 +568,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
 
 func asyncLet_Let_NonIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{transferred value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' that could race with later accesses}}
+  async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x.0.k2.field) // expected-tns-note {{access here could race}}
@@ -579,7 +579,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   useValue(x) // expected-tns-note {{access here could race}}
@@ -591,7 +591,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   useValue(x2) // expected-tns-note {{access here could race}}
@@ -604,8 +604,8 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
-  // expected-tns-warning @-1 {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -633,7 +633,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_NonIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-tns-note @-1:60 {{access here could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -661,7 +661,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
-  // expected-tns-warning @-1:60 {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-tns-warning @-1:60 {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -704,7 +704,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x2))
-  // expected-tns-warning @-1 {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -721,7 +721,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
 
 func asyncLet_Let_NormalUse_Simple1() async {
   let x = NonSendableKlass()
-  async let y = x // expected-tns-warning {{transferred value of non-Sendable type 'NonSendableKlass' that could race with later accesses}}
+  async let y = x // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   useValue(x) // expected-tns-note {{access here could race}}
   let _ = await y

--- a/test/Concurrency/transfernonsendable_cfg.sil
+++ b/test/Concurrency/transfernonsendable_cfg.sil
@@ -44,7 +44,7 @@ bb2:
 bb3:
   %transferKlass = function_ref @transferKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferKlass(%klass) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %useKlass = function_ref @useKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %useKlass(%klass) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   // expected-note @-1 {{access here could race}}

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -89,7 +89,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 @GlobalActor func useGlobalActor5() async {
   let x = NonSendableLinkedListNode<Int>()
 
-  await transferToNonIsolated(x) // expected-tns-warning {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' from global actor 'GlobalActor'-isolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableLinkedListNode<Int>' from global actor 'GlobalActor'-isolated context to nonisolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
   useValue(x) // expected-tns-note {{access here could race}}
@@ -104,7 +104,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = StructContainingValue()
   x = StructContainingValue()
 
-  await transferToNonIsolated(x) // expected-tns-warning {{passing argument of non-sendable type 'StructContainingValue' from global actor 'GlobalActor'-isolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring value of non-Sendable type 'StructContainingValue' from global actor 'GlobalActor'-isolated context to nonisolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
   useValue(x) // expected-tns-note {{access here could race}}
@@ -124,7 +124,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = (NonSendableLinkedList<Int>(), NonSendableLinkedList<Int>())
   x = (NonSendableLinkedList<Int>(), NonSendableLinkedList<Int>())
 
-  await transferToNonIsolated(x) // expected-tns-warning {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' from global actor 'GlobalActor'-isolated context to nonisolated context at this call site could yield a race with accesses later in this function}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' from global actor 'GlobalActor'-isolated context to nonisolated context; later accesses could race}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_globalactors.swift
+++ b/test/Concurrency/transfernonsendable_globalactors.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -parse-as-library
+
+// Tests specific to global actors.
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class Klass {}
+
+struct NonSendableStruct {
+  var first = Klass()
+  var second = Klass()
+}
+
+func useValue<T>(_ t: T) {}
+func getAny() -> Any { fatalError() }
+
+actor Custom {
+}
+
+@globalActor
+struct CustomActor {
+    static var shared: Custom {
+        return Custom()
+    }
+}
+
+@MainActor func transferToMain<T>(_ t: T) {}
+@CustomActor func transferToCustom<T>(_ t: T) {}
+
+@MainActor var globalKlass = Klass()
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+@MainActor func testTransferGlobalActorGuardedValue() async {
+  await transferToCustom(globalKlass) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+}
+
+@MainActor func testTransferGlobalActorGuardedValueWithlet() async {
+  let x = globalKlass
+  await transferToCustom(x) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+}
+
+@MainActor func testTransferGlobalActorGuardedValueWithlet(_ k: Klass) async {
+  globalKlass = k
+  await transferToCustom(k) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+}

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -66,7 +66,7 @@ bb0:
   %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
   %2 = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   // expected-note @-1 {{access here could race}}
@@ -83,7 +83,7 @@ bb0:
   %3 = store_borrow %1 to %2 : $*NonSendableKlass
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   yield %3 : $*NonSendableKlass, resume bb1, unwind bb2
   // expected-note @-1 {{access here could race}}
 
@@ -110,7 +110,7 @@ bb0:
   store %1a to [init] %2 : $*FakeOptional<NonSendableKlass>
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<FakeOptional<NonSendableKlass>>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'FakeOptional<NonSendableKlass>' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'FakeOptional<NonSendableKlass>' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   switch_enum_addr %2 : $*FakeOptional<NonSendableKlass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
   // expected-note @-1 {{access here could race}}
 
@@ -136,7 +136,7 @@ bb0:
   %2 = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   %1a = explicit_copy_value %1 : $NonSendableKlass
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1a) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   // expected-note @-1 {{access here could race}}
@@ -153,7 +153,7 @@ bb0:
   %2 = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   %1a = move_value %1 : $NonSendableKlass
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1a) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1a) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   // expected-note @-1 {{access here could race}}
@@ -173,7 +173,7 @@ bb0:
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableMoveOnlyStruct>(%unresolved) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableMoveOnlyStruct' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableMoveOnlyStruct' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableMoveOnlyStruct>(%unresolved) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-note @-1 {{access here could race}}
@@ -193,7 +193,7 @@ bb0:
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%project) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%project) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-note @-1 {{access here could race}}
@@ -212,7 +212,7 @@ bb0:
   %0b = begin_borrow %0a : $@moveOnly NonSendableKlass
   %0c = moveonlywrapper_to_copyable [guaranteed] %0b : $@moveOnly NonSendableKlass
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%0c) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   end_borrow %0b : $@moveOnly NonSendableKlass
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   %0bb = begin_borrow %0a : $@moveOnly NonSendableKlass
@@ -237,7 +237,7 @@ bb0:
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%unwrappedProject) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%unwrappedProject) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -270,7 +270,7 @@ bb0:
   %pa = partial_apply %f2(%copiedUnwrappedBox) : $@convention(thin) (@guaranteed { var NonSendableKlass }) -> ()
   %4 = function_ref @transfer_partial_apply : $@convention(thin) @async (@guaranteed @callee_owned () -> ()) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4(%pa) : $@convention(thin) @async (@guaranteed @callee_owned () -> ()) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type '@callee_owned () -> ()' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type '@callee_owned () -> ()' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %bb2 = begin_borrow %unwrappedBox : ${ var NonSendableKlass }
   %p2 = project_box %bb2 : ${ var NonSendableKlass }, 0
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -341,7 +341,7 @@ bb0:
   %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
   %2 = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   fix_lifetime %1 : $NonSendableKlass
   // expected-note @-1 {{access here could race}}
   destroy_value %1 : $NonSendableKlass
@@ -359,7 +359,7 @@ bb0:
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -396,7 +396,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%2) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   // No error here since just a requires on the first.
   %useNonSendableKlass = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
@@ -423,7 +423,7 @@ sil [ossa] @mark_dependence_test_base_has_a_require : $@convention(thin) @async 
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%2) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   // No error here since just a requires on the first.
   %useNonSendableKlass = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
@@ -447,7 +447,7 @@ sil [ossa] @mark_dependence_test_base_is_a_require : $@convention(thin) @async (
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%0) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %1a = begin_borrow %1 : $NonSendableKlass
   %2 = mark_dependence %1a : $NonSendableKlass on %0 : $NonSendableKlass
@@ -551,9 +551,9 @@ bb0(%0 : $Builtin.RawPointer):
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%2) : $@convention(thin) @async (Builtin.RawPointer) -> ()
   // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}  
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%3a) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%5a) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %useRawPointer = function_ref @useRawPointer : $@convention(thin) (Builtin.RawPointer) -> ()
   apply %useRawPointer(%3a) : $@convention(thin) (Builtin.RawPointer) -> ()
@@ -579,7 +579,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   // Test that this is viewed as a use of %construct
   %3 = raw_pointer_to_ref %3a : $Builtin.RawPointer to $SendableKlass
@@ -599,7 +599,7 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
   // expected-note @-1 {{access here could race}}
@@ -618,12 +618,12 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $SendableKlass
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   // expected-note @-2 {{access here could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
@@ -641,7 +641,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %word = unchecked_trivial_bit_cast %value : $NonSendableKlass to $Builtin.Word
   // expected-note @-1 {{access here could race}}
@@ -675,7 +675,7 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
   // expected-note @-1 {{access here could race}}
@@ -694,12 +694,12 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $SendableKlass
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   // expected-note @-2 {{access here could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
@@ -717,7 +717,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %word = unchecked_bitwise_cast %value : $NonSendableKlass to $Builtin.Word
   // expected-note @-1 {{access here could race}}
@@ -752,7 +752,7 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
   // expected-note @-1 {{access here could race}}
@@ -773,12 +773,12 @@ bb0:
 
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $SendableKlass
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   // expected-note @-2 {{access here could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
@@ -797,7 +797,7 @@ bb0:
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %valueB = begin_borrow %value : $NonSendableKlass
   %word = unchecked_value_cast %valueB : $NonSendableKlass to $Builtin.Word
@@ -868,7 +868,7 @@ bb0:
   %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %value2 = unchecked_ref_cast %value : $NonSendableKlass to $Builtin.BridgeObject
   %1 = classify_bridge_object %value2 : $Builtin.BridgeObject // expected-note {{access here could race}}
@@ -884,7 +884,7 @@ bb0:
   %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %value2 = unchecked_ref_cast %value : $NonSendableKlass to $Builtin.BridgeObject
   %1 = bridge_object_to_word %value2 : $Builtin.BridgeObject to $Builtin.Word // expected-note {{access here could race}}
@@ -911,7 +911,7 @@ bb0:
   store %valueCopy to [init] %a : $*NonSendableKlass
 
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   destroy_value %value : $NonSendableKlass
   %1 = is_unique %a : $*NonSendableKlass // expected-note {{access here could race}}
@@ -932,7 +932,7 @@ bb0:
   store %1_copy to [init] %a : $*NonSendableStruct
 
   %f = function_ref @transferStruct : $@convention(thin) @async (@guaranteed NonSendableStruct) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableStruct) -> () // expected-warning {{passing argument of non-sendable type 'NonSendableStruct' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableStruct) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableStruct' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %s = struct_element_addr %a : $*NonSendableStruct, #NonSendableStruct.ns
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -958,7 +958,7 @@ bb0:
   store %tup to [init] %a : $*(NonSendableKlass, NonSendableKlass)
 
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{passing argument of non-sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context at this call site could yield a race with accesses later in this function}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %s = tuple_element_addr %a : $*(NonSendableKlass, NonSendableKlass), 0
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -58,7 +58,7 @@ func test_isolation_crossing_sensitivity(a : A) async {
     foo_noniso(ns0);
 
     //this call consumes ns1
-    await a.foo(ns1); // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await a.foo(ns1); // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     print(ns0);
@@ -101,7 +101,7 @@ func test_closure_capture(a : A) async {
     print(ns3)
 
     // this should consume ns0
-    await a.run_closure(captures0) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await a.run_closure(captures0) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -111,7 +111,7 @@ func test_closure_capture(a : A) async {
     print(ns3)
 
     // this should consume ns1 and ns2
-    await a.run_closure(captures12) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await a.run_closure(captures12) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -122,7 +122,7 @@ func test_closure_capture(a : A) async {
     print(ns3)
 
     // this should consume ns3
-    await a.run_closure(captures3indirect) // expected-tns-warning {{passing argument of non-sendable type '() -> ()' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await a.run_closure(captures3indirect) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
@@ -153,7 +153,7 @@ func test_regions(a : A, b : Bool) async {
     // check for each of the above pairs that consuming half of it consumes the other half
 
     if (b) {
-        await a.foo(ns0_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns0_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if (b) {
@@ -162,7 +162,7 @@ func test_regions(a : A, b : Bool) async {
           print(ns0_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns0_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns0_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -173,7 +173,7 @@ func test_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns1_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns1_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -182,7 +182,7 @@ func test_regions(a : A, b : Bool) async {
           print(ns1_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns1_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns1_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
       // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -193,7 +193,7 @@ func test_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns2_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns2_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -202,7 +202,7 @@ func test_regions(a : A, b : Bool) async {
           print(ns2_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns2_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns2_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -252,7 +252,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     // now check for each pair that consuming half of it consumed the other half
 
     if (b) {
-        await a.foo(ns0_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns0_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -261,7 +261,7 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns0_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns0_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns0_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -272,7 +272,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns1_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns1_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -281,7 +281,7 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns1_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns1_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns1_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -292,7 +292,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns2_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns2_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -301,7 +301,7 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns2_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns2_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns2_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -312,7 +312,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns3_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns3_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -321,7 +321,7 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns3_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns3_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns3_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -332,7 +332,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns4_0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns4_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -341,7 +341,7 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns4_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns4_1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns4_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
@@ -352,7 +352,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns5_0) // expected-tns-warning {{passing argument of non-sendable type 'Any' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns5_0) // expected-tns-warning {{transferring value of non-Sendable type 'Any' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
         if b {
@@ -361,7 +361,7 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns5_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns5_1) // expected-tns-warning {{passing argument of non-sendable type 'Any' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns5_1) // expected-tns-warning {{transferring value of non-Sendable type 'Any' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
         if b {
@@ -431,7 +431,7 @@ func basic_loopiness(a : A, b : Bool) async {
 
     while (b) {
         await a.foo(ns)
-        // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-tns-note @-2 {{access here could race}}
         // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     }
@@ -448,7 +448,7 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
         (ns0, ns1, ns2, ns3) = (ns1, ns2, ns3, ns0)
     }
 
-    await a.foo(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo(ns3) // expected-tns-note {{access here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -512,7 +512,7 @@ func test_class_assign_merges(a : A, b : Bool) async {
     box.contents = ns0
     box.contents = ns1
 
-    await a.foo(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo(ns1) // expected-tns-note {{access here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -548,7 +548,7 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
     contents = ns0
     contents = ns1
 
-    await a.foo(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo(ns1) // expected-tns-note {{access here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -565,7 +565,7 @@ func test_tuple_formation(a : A, i : Int) async {
 
     switch (i) {
     case 0:
-        await a.foo(ns0) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if bool {
@@ -584,7 +584,7 @@ func test_tuple_formation(a : A, i : Int) async {
           foo_noniso(ns13); // expected-tns-note {{access here could race}}
         }
     case 1:
-        await a.foo(ns1) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if bool {
@@ -603,7 +603,7 @@ func test_tuple_formation(a : A, i : Int) async {
           foo_noniso(ns13); // expected-tns-note {{access here could race}}
         }
     case 2:
-        await a.foo(ns2) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns2) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if bool {
@@ -622,7 +622,7 @@ func test_tuple_formation(a : A, i : Int) async {
           foo_noniso(ns13); // expected-tns-note {{access here could race}}
         }
     case 3:
-        await a.foo(ns4) // expected-tns-warning {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns4) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         foo_noniso(ns0);
@@ -632,7 +632,7 @@ func test_tuple_formation(a : A, i : Int) async {
         foo_noniso(ns012);
         foo_noniso(ns13);
     case 4:
-        await a.foo(ns012) // expected-tns-warning {{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns012) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendable, NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
         // TODO: Interestingly with complete, we emit this error 3 times?!
         // expected-complete-warning @-2 3{{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
@@ -652,7 +652,7 @@ func test_tuple_formation(a : A, i : Int) async {
           foo_noniso(ns13); // expected-tns-note {{access here could race}}
         }
     default:
-        await a.foo(ns13) // expected-tns-warning {{passing argument of non-sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+        await a.foo(ns13) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 2{{passing argument of non-sendable type '(NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
         if bool {
@@ -693,7 +693,7 @@ func one_consume_many_require(a : A) async {
     let ns4 = NonSendable();
 
     await a.foo_multi(ns0, ns1, ns2);
-    // expected-tns-warning @-1 3{{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 3{{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{access here could race}}
@@ -707,7 +707,7 @@ func one_consume_one_require(a : A) async {
     let ns2 = NonSendable();
 
     await a.foo_multi(ns0, ns1, ns2);
-    // expected-tns-warning @-1 3{{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 3{{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{access here could race}}
@@ -722,13 +722,13 @@ func many_consume_one_require(a : A) async {
     let ns5 = NonSendable();
 
     await a.foo_multi(ns0, ns3, ns3)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo_multi(ns4, ns1, ns4)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo_multi(ns5, ns5, ns2)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{access here could race}}
 }
@@ -744,13 +744,13 @@ func many_consume_many_require(a : A) async {
     let ns7 = NonSendable();
 
     await a.foo_multi(ns0, ns3, ns3)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo_multi(ns4, ns1, ns4)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     await a.foo_multi(ns5, ns5, ns2)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'NonSendable' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{access here could race}}
@@ -780,7 +780,7 @@ func one_consume_many_require_varag(a : A) async {
 
     //TODO: find a way to make the type used in the diagnostic more specific than the signature type
     await a.foo_vararg(ns0, ns1, ns2);
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -798,7 +798,7 @@ func one_consume_one_require_vararg(a : A) async {
     let ns2 = NonSendable();
 
     await a.foo_vararg(ns0, ns1, ns2);
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
     foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 1{{access here could race}}
@@ -813,13 +813,13 @@ func many_consume_one_require_vararg(a : A) async {
     let ns5 = NonSendable();
 
     await a.foo_vararg(ns0, ns3, ns3)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
     await a.foo_vararg(ns4, ns1, ns4)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
     await a.foo_vararg(ns5, ns5, ns2)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
     foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{access here could race}}
@@ -836,13 +836,13 @@ func many_consume_many_require_vararg(a : A) async {
     let ns7 = NonSendable();
 
     await a.foo_vararg(ns0, ns3, ns3)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
     await a.foo_vararg(ns4, ns1, ns4)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
     await a.foo_vararg(ns5, ns5, ns2)
-    // expected-tns-warning @-1 {{passing argument of non-sendable type 'Any...' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
     if bool {
@@ -880,7 +880,7 @@ func enum_test(a : A) async {
     case .E2:
         switch (e3) {
         case let .E3(ns3):
-            await a.foo(ns3.x); // expected-tns-warning {{passing argument of non-sendable type 'Any' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+            await a.foo(ns3.x); // expected-tns-warning {{transferring value of non-Sendable type 'Any' from nonisolated context to actor-isolated context; later accesses could race}}
             // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
         default: ()
         }
@@ -890,7 +890,7 @@ func enum_test(a : A) async {
         foo_noniso(e4);
     }
 
-    await a.foo(e1); // expected-tns-warning {{passing argument of non-sendable type 'E' from nonisolated context to actor-isolated context at this call site could yield a race with accesses later in this function}}
+    await a.foo(e1); // expected-tns-warning {{transferring value of non-Sendable type 'E' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
     foo_noniso(e2); // expected-tns-note {{access here could race}}
     foo_noniso(e3); // expected-tns-note {{access here could race}}


### PR DESCRIPTION
1. The first commit in this PR fixes support for GlobalActor guarded variables. Previously we were not setting the "actor derived" variable on values derived from global_addr. This means at the Source Level one could transfer a GlobalActor guarded global. That hole is closed.
2. I am doing a small bit of work on diagnostics this evening. This is the first part and the most noisy (hence why I am pushing it in sooner since I want to reduce rebasing possibilities). Specifically, this changes:

```
 WARNING(regionbasedisolation_transfer_yields_race_no_isolation, none,
-        "transferred value of non-Sendable type %0 that could race with later accesses",
+        "transferring value of non-Sendable type %0; later accesses could race",
         (Type))
 WARNING(regionbasedisolation_transfer_yields_race_with_isolation, none,
-        "passing argument of non-sendable type %0 from %1 context to %2 context at this call site could yield a race with accesses later in this function",
+        "transferring value of non-Sendable type %0 from %1 context to %2 context; later accesses could race",
         (Type, ActorIsolation, ActorIsolation))
 WARNING(regionbasedisolation_transfer_yields_race_transferring_parameter, none,
-        "transferred value of non-Sendable type %0 into transferring parameter; later accesses could result in races",
+        "transferring value of non-Sendable type %0 into transferring parameter; later accesses could race",
         (Type))
 WARNING(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, none,
-        "binding of non-Sendable type %0 accessed after being transferred; later accesses could result in races",
+        "binding of non-Sendable type %0 accessed after being transferred; later accesses could race",
         (Type))
```

I standardized on later accesses could race as the signal to the user of the type of problem.