### PR TITLE
[ClangImporter] Remove out-of-date clang argument

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -866,9 +866,6 @@ importer::addCommonInvocationArguments(
 
   invocationArgStrs.push_back("-fansi-escape-codes");
 
-  invocationArgStrs.push_back("-Xclang");
-  invocationArgStrs.push_back("-opaque-pointers");
-
   if (importerOpts.ValidateModulesOnce) {
     invocationArgStrs.push_back("-fmodules-validate-once-per-build-session");
     invocationArgStrs.push_back("-fbuild-session-file=" + importerOpts.BuildSessionFilePath);


### PR DESCRIPTION
"-opaque-pointer" has not been a valid clang cc1 argument for a long time since it is the default. What is even worst is that clang is treating that out of date option as "-o paque-pointer" and return no error. Fortunately, ClangImport doesn't write anything to output file, otherwise it is going directly to this "paque-pointer" file.
