### PR TITLE
NFC: Work around 'cycle detected while resolving' warning

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3072,8 +3072,10 @@ public:
       return *this;
     }
 
+#ifndef __swift__
     bool operator==(iterator x) const { return x.attr == attr; }
     bool operator!=(iterator x) const { return x.attr != attr; }
+#endif // __swift__
 
     CustomAttr *operator*() const { return attr; }
     CustomAttr &operator->() const { return *attr; }


### PR DESCRIPTION
When building the Swift sources of the compiler many instances of the following warning are emitted:

```
.../swift-project/swift/include/swift/AST/Attr.h:3075:10: warning: cycle detected while resolving 'iterator' in swift_name attribute for 'operator=='
    bool operator==(iterator x) const { return x.attr == attr; }
         ^
```

These warnings were implemented in https://github.com/apple/swift/pull/37940 and they indicate that Swift compiler is failing to import a clang decl because of circular references. Something about the structure of some operator declarations in C++ headers triggers this warning. I'm not sure what the correct long term fix for this is, but in the meantime the build log for the compiler is getting drowned in these warnings which makes it difficult to notice and find other diagnostics. Since these declarations are getting dropped instead of imported, we can simply hide them from the Swift compiler in the first place by guarding the declarations with `#ifdef __swift__`.
