### PR TITLE
[Concurrency] Handle cases where a property initializer is subsumed by another property for `IsolatedDefaultValues`.

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1583,9 +1583,20 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
 
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:
-    case ActorIsolation::ActorInstance:
-      if (requiredIsolation != contextIsolation)
+    case ActorIsolation::ActorInstance: {
+      if (requiredIsolation != contextIsolation) {
+        // Implicit initializers diagnose actor isolation violations
+        // for property initializers in Sema. Still emit the invalid
+        // member initializer here to avoid duplicate diagnostics and
+        // to preserve warn-until-Swift-6 behavior.
+        auto *init =
+            dyn_cast_or_null<ConstructorDecl>(dc->getAsDecl());
+        if (init && init->isImplicit())
+          break;
+
         continue;
+      }
+    }
     }
 
     auto *varPattern = field->getPattern(i);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -351,34 +351,59 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
     // and actor initializers do not run on the actor, so initial values
     // cannot be actor-instance-isolated.
     bool shouldAddNonisolated = true;
-    llvm::Optional<ActorIsolation> existingIsolation = llvm::None;
+    ActorIsolation existingIsolation = getActorIsolation(decl);
     VarDecl *previousVar = nullptr;
 
-    // The memberwise init properties are also effectively what the
-    // default init uses, e.g. default initializers initialize via
-    // properties wrapped and init accessors.
-    for (auto var : decl->getMemberwiseInitProperties()) {
+    for (auto member : decl->getImplementationContext()->getAllMembers()) {
+      auto pbd = dyn_cast<PatternBindingDecl>(member);
+      if (!pbd || pbd->isStatic())
+        continue;
+
+      auto *var = pbd->getSingleVar();
+      if (!var) {
+        shouldAddNonisolated = false;
+        break;
+      }
+
+      auto i = pbd->getPatternEntryIndexForVarDecl(var);
+      if (pbd->isInitializerSubsumed(i))
+        continue;
+
+      ActorIsolation initIsolation;
+      if (var->hasInitAccessor()) {
+        // Init accessors share the actor isolation of the property;
+        // the accessor body can call anything in that isolation domain,
+        // and we don't attempt to infer when the isolation isn't
+        // necessary.
+        initIsolation = getActorIsolation(var);
+      } else {
+        initIsolation = var->getInitializerIsolation();
+      }
+
       auto type = var->getTypeInContext();
       auto isolation = getActorIsolation(var);
       if (isolation.isGlobalActor()) {
         if (!type->isSendableType() ||
-            var->getInitializerIsolation().isGlobalActor()) {
+            initIsolation.isGlobalActor()) {
           // If different isolated stored properties require different
           // global actors, it is impossible to initialize this type.
-          if (existingIsolation &&
-              *existingIsolation != isolation) {
+          if (existingIsolation != isolation) {
             ctx.Diags.diagnose(decl->getLoc(),
                 diag::conflicting_stored_property_isolation,
                 ICK == ImplicitConstructorKind::Memberwise,
-                decl->getDeclaredType(), *existingIsolation, isolation);
-            previousVar->diagnose(
-                diag::property_requires_actor,
-                previousVar->getDescriptiveKind(),
-                previousVar->getName(), *existingIsolation);
+                decl->getDeclaredType(), existingIsolation, isolation)
+              .warnUntilSwiftVersion(6);
+            if (previousVar) {
+              previousVar->diagnose(
+                  diag::property_requires_actor,
+                  previousVar->getDescriptiveKind(),
+                  previousVar->getName(), existingIsolation);
+            }
             var->diagnose(
                 diag::property_requires_actor,
                 var->getDescriptiveKind(),
                 var->getName(), isolation);
+            break;
           }
 
           existingIsolation = isolation;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -350,21 +350,31 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
     // initializers apply Sendable checking to arguments at the call-site,
     // and actor initializers do not run on the actor, so initial values
     // cannot be actor-instance-isolated.
-    bool shouldAddNonisolated = true;
     ActorIsolation existingIsolation = getActorIsolation(decl);
     VarDecl *previousVar = nullptr;
+    bool hasError = false;
 
-    for (auto member : decl->getImplementationContext()->getAllMembers()) {
-      bool hasError = false;
-      auto pbd = dyn_cast<PatternBindingDecl>(member);
-      if (!pbd || pbd->isStatic())
-        continue;
+    // FIXME: Calling `getAllMembers` here causes issues for conformance
+    // synthesis to RawRepresentable and friends. Instead, iterate over
+    // both the stored properties and the init accessor properties, as
+    // those can participate in implicit initializers.
 
-      for (auto i : range(pbd->getNumPatternEntries())) {
-        if (pbd->isInitializerSubsumed(i))
+    auto stored = decl->getStoredProperties();
+    auto initAccessor = decl->getInitAccessorProperties();
+
+    auto shouldAddNonisolated = [&](ArrayRef<VarDecl *> properties) {
+      if (hasError)
+        return false;
+
+      bool addNonisolated = true;
+      for (auto *var : properties) {
+        auto *pbd = var->getParentPatternBinding();
+        if (!pbd)
           continue;
 
-        auto *var = pbd->getAnchoringVarDecl(i);
+        auto i = pbd->getPatternEntryIndexForVarDecl(var);
+        if (pbd->isInitializerSubsumed(i))
+          continue;
 
         ActorIsolation initIsolation;
         if (var->hasInitAccessor()) {
@@ -401,21 +411,21 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
                   var->getDescriptiveKind(),
                   var->getName(), isolation);
               hasError = true;
-              break;
+              return false;
             }
 
             existingIsolation = isolation;
             previousVar = var;
-            shouldAddNonisolated = false;
+            addNonisolated = false;
           }
         }
       }
 
-      if (hasError)
-        break;
-    }
+      return addNonisolated;
+    };
 
-    if (shouldAddNonisolated) {
+    if (shouldAddNonisolated(stored) &&
+        shouldAddNonisolated(initAccessor)) {
       addNonIsolatedToSynthesized(decl, ctor);
     }
   }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -168,9 +168,12 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
 }
 
 // check for instance members that do not need global-actor protection
+
+// expected-warning@+2 {{memberwise initializer for 'NoGlobalActorValueType' cannot be both nonisolated and global actor 'SomeGlobalActor'-isolated; this is an error in Swift 6}}
 // expected-note@+1 2 {{consider making struct 'NoGlobalActorValueType' conform to the 'Sendable' protocol}}
 struct NoGlobalActorValueType {
   @SomeGlobalActor var point: Point // expected-warning {{stored property 'point' within struct cannot have a global actor; this is an error in Swift 6}}
+  // expected-note@-1 {{initializer for property 'point' is global actor 'SomeGlobalActor'-isolated}}
 
   @MainActor let counter: Int // expected-warning {{stored property 'counter' within struct cannot have a global actor; this is an error in Swift 6}}
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -559,9 +559,13 @@ struct WrapperOnUnsafeActor<Wrapped> {
   }
 }
 
-// HasWrapperOnUnsafeActor gets an inferred @MainActor attribute.
+// HasWrapperOnUnsafeActor does not have an inferred global actor attribute,
+// because synced and $synced have different global actors.
 struct HasWrapperOnUnsafeActor {
-  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-tns-warning {{global actor 'OtherGlobalActor'-isolated default value in a main actor-isolated context; this is an error in Swift 6}}
+// expected-complete-tns-warning@-1 {{memberwise initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in Swift 6}}
+// expected-complete-tns-warning@-2 {{default initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in Swift 6}}
+
+  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-tns-note 2 {{initializer for property '_synced' is global actor 'OtherGlobalActor'-isolated}}
   // expected-note @-1 3{{property declared here}}
   // expected-complete-tns-note @-2 3{{property declared here}}
 
@@ -584,6 +588,10 @@ struct HasWrapperOnUnsafeActor {
     _ = synced
     synced = 17
   }
+}
+
+nonisolated func createHasWrapperOnUnsafeActor() {
+  _ = HasWrapperOnUnsafeActor()
 }
 
 // ----------------------------------------------------------------------
@@ -670,7 +678,9 @@ func replacesDynamicOnMainActor() {
 // Global-actor isolation of stored property initializer expressions
 // ----------------------------------------------------------------------
 
+// expected-complete-tns-warning@+1 {{default initializer for 'Cutter' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
 class Cutter {
+  // expected-complete-tns-note@+1 {{initializer for property 'x' is main actor-isolated}}
   @MainActor var x = useFooInADefer()
   @MainActor var y = { () -> Bool in
       var z = statefulThingy

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -149,7 +149,7 @@ struct S2 {
 }
 
 struct S3 {
-  // expected-error@+1 {{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+  // expected-error@+1 3 {{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
   var (x, y, z) = (requiresMainActor(), requiresSomeGlobalActor(), 10)
 }
 
@@ -274,4 +274,11 @@ struct InitAccessors {
       _a
     }
   }
+}
+
+// Make sure isolation inference for implicit initializers
+// doesn't impact conformance synthesis.
+
+struct CError: Error, RawRepresentable {
+  var rawValue: CInt
 }

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -220,10 +220,21 @@ class C3 {
   var y = 0
 }
 
+@MainActor class MultipleVars {
+  var (x, y) = (0, 0)
+}
+
 func callDefaultInit() async {
   _ = C2()
   _ = NonIsolatedInit()
   _ = NonIsolatedInit(x: 10)
+  _ = MultipleVars()
+}
+
+// expected-warning@+1 {{default initializer for 'MultipleVarsInvalid' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
+class MultipleVarsInvalid {
+  // expected-note@+1 {{initializer for property 'x' is main actor-isolated}}
+  @MainActor var (x, y) = (requiresMainActor(), requiresMainActor())
 }
 
 @propertyWrapper 


### PR DESCRIPTION
When determining whether compiler synthesized initializers should have `nonisolated` applied, skip property initializers that are subsumed, e.g. by an init accessor or a backing property wrapper initializer, and always consider the subsuming initializer. This fixes an issue where the compiler would apply `nonisolated` to memberwise and default initializers of types that use property wrappers whose backing property wrapper initializer is global actor isolated, but the wrapped value initializer is not, e.g.

```swift
@MainActor
@propertyWrapper struct RequiresMain<Value>  {
  var wrappedValue: Value

  init(wrappedValue: Value) {
    self.wrappedValue = wrappedValue
  }
}

// `S.init()` should be isolated to `@MainActor` because 
// `RequiresMain.init(wrappedValue:)` is isolated to `@MainActor`
struct S {
  @RequiresMain private var x = 10
}
```

This change also lessens the source break of SE-0411 by still emitting member initializers in implicit constructors when the initializer violates actor isolation to preserve the behavior of existing code when concurrency diagnostics are downgraded to warnings in Swift 5 mode.

Resolves rdar://121282537