### PR TITLE
[5.10][Concurrency] Handle cases where a property initializer is subsumed by another property for `IsolatedDefaultValues`.

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1544,9 +1544,20 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
 
     case ActorIsolation::GlobalActor:
     case ActorIsolation::GlobalActorUnsafe:
-    case ActorIsolation::ActorInstance:
-      if (requiredIsolation != contextIsolation)
+    case ActorIsolation::ActorInstance: {
+      if (requiredIsolation != contextIsolation) {
+        // Implicit initializers diagnose actor isolation violations
+        // for property initializers in Sema. Still emit the invalid
+        // member initializer here to avoid duplicate diagnostics and
+        // to preserve warn-until-Swift-6 behavior.
+        auto *init =
+            dyn_cast_or_null<ConstructorDecl>(dc->getAsDecl());
+        if (init && init->isImplicit())
+          break;
+
         continue;
+      }
+    }
     }
 
     auto *varPattern = field->getPattern(i);

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -354,62 +354,64 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
     VarDecl *previousVar = nullptr;
 
     for (auto member : decl->getImplementationContext()->getAllMembers()) {
+      bool hasError = false;
       auto pbd = dyn_cast<PatternBindingDecl>(member);
       if (!pbd || pbd->isStatic())
         continue;
 
-      auto *var = pbd->getSingleVar();
-      if (!var) {
-        shouldAddNonisolated = false;
-        break;
-      }
+      for (auto i : range(pbd->getNumPatternEntries())) {
+        if (pbd->isInitializerSubsumed(i))
+          continue;
 
-      auto i = pbd->getPatternEntryIndexForVarDecl(var);
-      if (pbd->isInitializerSubsumed(i))
-        continue;
+        auto *var = pbd->getAnchoringVarDecl(i);
 
-      ActorIsolation initIsolation;
-      if (var->hasInitAccessor()) {
-        // Init accessors share the actor isolation of the property;
-        // the accessor body can call anything in that isolation domain,
-        // and we don't attempt to infer when the isolation isn't
-        // necessary.
-        initIsolation = getActorIsolation(var);
-      } else {
-        initIsolation = var->getInitializerIsolation();
-      }
+        ActorIsolation initIsolation;
+        if (var->hasInitAccessor()) {
+          // Init accessors share the actor isolation of the property;
+          // the accessor body can call anything in that isolation domain,
+          // and we don't attempt to infer when the isolation isn't
+          // necessary.
+          initIsolation = getActorIsolation(var);
+        } else {
+          initIsolation = var->getInitializerIsolation();
+        }
 
-      auto type = var->getTypeInContext();
-      auto isolation = getActorIsolation(var);
-      if (isolation.isGlobalActor()) {
-        if (!isSendableType(decl->getModuleContext(), type) ||
-            initIsolation.isGlobalActor()) {
-          // If different isolated stored properties require different
-          // global actors, it is impossible to initialize this type.
-          if (existingIsolation != isolation) {
-            ctx.Diags.diagnose(decl->getLoc(),
-                diag::conflicting_stored_property_isolation,
-                ICK == ImplicitConstructorKind::Memberwise,
-                decl->getDeclaredType(), existingIsolation, isolation)
-              .warnUntilSwiftVersion(6);
-            if (previousVar) {
-              previousVar->diagnose(
+        auto type = var->getTypeInContext();
+        auto isolation = getActorIsolation(var);
+        if (isolation.isGlobalActor()) {
+          if (!isSendableType(decl->getModuleContext(), type) ||
+              initIsolation.isGlobalActor()) {
+            // If different isolated stored properties require different
+            // global actors, it is impossible to initialize this type.
+            if (existingIsolation != isolation) {
+              ctx.Diags.diagnose(decl->getLoc(),
+                  diag::conflicting_stored_property_isolation,
+                  ICK == ImplicitConstructorKind::Memberwise,
+                  decl->getDeclaredType(), existingIsolation, isolation)
+                .warnUntilSwiftVersion(6);
+              if (previousVar) {
+                previousVar->diagnose(
+                    diag::property_requires_actor,
+                    previousVar->getDescriptiveKind(),
+                    previousVar->getName(), existingIsolation);
+              }
+              var->diagnose(
                   diag::property_requires_actor,
-                  previousVar->getDescriptiveKind(),
-                  previousVar->getName(), existingIsolation);
+                  var->getDescriptiveKind(),
+                  var->getName(), isolation);
+              hasError = true;
+              break;
             }
-            var->diagnose(
-                diag::property_requires_actor,
-                var->getDescriptiveKind(),
-                var->getName(), isolation);
-            break;
-          }
 
-          existingIsolation = isolation;
-          previousVar = var;
-          shouldAddNonisolated = false;
+            existingIsolation = isolation;
+            previousVar = var;
+            shouldAddNonisolated = false;
+          }
         }
       }
+
+      if (hasError)
+        break;
     }
 
     if (shouldAddNonisolated) {

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -168,9 +168,12 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
 }
 
 // check for instance members that do not need global-actor protection
+
+// expected-warning@+2 {{memberwise initializer for 'NoGlobalActorValueType' cannot be both nonisolated and global actor 'SomeGlobalActor'-isolated; this is an error in Swift 6}}
 // expected-note@+1 2 {{consider making struct 'NoGlobalActorValueType' conform to the 'Sendable' protocol}}
 struct NoGlobalActorValueType {
   @SomeGlobalActor var point: Point // expected-warning {{stored property 'point' within struct cannot have a global actor; this is an error in Swift 6}}
+  // expected-note@-1 {{initializer for property 'point' is global actor 'SomeGlobalActor'-isolated}}
 
   @MainActor let counter: Int // expected-warning {{stored property 'counter' within struct cannot have a global actor; this is an error in Swift 6}}
 

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -558,9 +558,13 @@ struct WrapperOnUnsafeActor<Wrapped> {
   }
 }
 
-// HasWrapperOnUnsafeActor gets an inferred @MainActor attribute.
+// HasWrapperOnUnsafeActor does not have an inferred global actor attribute,
+// because synced and $synced have different global actors.
 struct HasWrapperOnUnsafeActor {
-  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-sns-warning {{global actor 'OtherGlobalActor'-isolated default value in a main actor-isolated context; this is an error in Swift 6}}
+// expected-complete-sns-warning@-1 {{memberwise initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in Swift 6}}
+// expected-complete-sns-warning@-2 {{default initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in Swift 6}}
+
+  @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-sns-note 2 {{initializer for property '_synced' is global actor 'OtherGlobalActor'-isolated}}
   // expected-note @-1 3{{property declared here}}
   // expected-complete-sns-note @-2 3{{property declared here}}
 
@@ -583,6 +587,10 @@ struct HasWrapperOnUnsafeActor {
     _ = synced
     synced = 17
   }
+}
+
+nonisolated func createHasWrapperOnUnsafeActor() {
+  _ = HasWrapperOnUnsafeActor()
 }
 
 // ----------------------------------------------------------------------
@@ -669,7 +677,9 @@ func replacesDynamicOnMainActor() {
 // Global-actor isolation of stored property initializer expressions
 // ----------------------------------------------------------------------
 
+// expected-complete-sns-warning@+1 {{default initializer for 'Cutter' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
 class Cutter {
+  // expected-complete-sns-note@+1 {{initializer for property 'x' is main actor-isolated}}
   @MainActor var x = useFooInADefer()
   @MainActor var y = { () -> Bool in
       var z = statefulThingy

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -149,7 +149,7 @@ struct S2 {
 }
 
 struct S3 {
-  // expected-error@+1 {{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+  // expected-error@+1 3 {{default argument cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
   var (x, y, z) = (requiresMainActor(), requiresSomeGlobalActor(), 10)
 }
 
@@ -274,4 +274,11 @@ struct InitAccessors {
       _a
     }
   }
+}
+
+// Make sure isolation inference for implicit initializers
+// doesn't impact conformance synthesis.
+
+struct CError: Error, RawRepresentable {
+  var rawValue: CInt
 }

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -220,10 +220,21 @@ class C3 {
   var y = 0
 }
 
+@MainActor class MultipleVars {
+  var (x, y) = (0, 0)
+}
+
 func callDefaultInit() async {
   _ = C2()
   _ = NonIsolatedInit()
   _ = NonIsolatedInit(x: 10)
+  _ = MultipleVars()
+}
+
+// expected-warning@+1 {{default initializer for 'MultipleVarsInvalid' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
+class MultipleVarsInvalid {
+  // expected-note@+1 {{initializer for property 'x' is main actor-isolated}}
+  @MainActor var (x, y) = (requiresMainActor(), requiresMainActor())
 }
 
 @propertyWrapper 

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -1,7 +1,5 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
-
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -enable-upcoming-feature IsolatedDefaultValues -parse-as-library -emit-sil -o /dev/null -verify %s
 // RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature IsolatedDefaultValues -enable-experimental-feature SendNonSendable %s
 
@@ -196,21 +194,19 @@ extension A {
   }
 }
 
-// expected-error@+1 {{default initializer for 'C1' cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+// expected-warning@+1 {{default initializer for 'C1' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
 class C1 {
   // expected-note@+1 {{initializer for property 'x' is main actor-isolated}}
   @MainActor var x = requiresMainActor()
-  // expected-note@+1 {{initializer for property 'y' is global actor 'SomeGlobalActor'-isolated}}
   @SomeGlobalActor var y = requiresSomeGlobalActor()
 }
 
 class NonSendable {}
 
-// expected-error@+1 {{default initializer for 'C2' cannot be both main actor-isolated and global actor 'SomeGlobalActor'-isolated}}
+// expected-warning@+1 {{default initializer for 'C2' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
 class C2 {
   // expected-note@+1 {{initializer for property 'x' is main actor-isolated}}
   @MainActor var x = NonSendable()
-  // expected-note@+1 {{initializer for property 'y' is global actor 'SomeGlobalActor'-isolated}}
   @SomeGlobalActor var y = NonSendable()
 }
 
@@ -228,4 +224,43 @@ func callDefaultInit() async {
   _ = C2()
   _ = NonIsolatedInit()
   _ = NonIsolatedInit(x: 10)
+}
+
+@propertyWrapper 
+@preconcurrency @MainActor
+struct RequiresMain<Value>  {
+  var wrappedValue: Value
+
+  init(wrappedValue: Value) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+// This is okay; UseRequiresMain has an inferred 'MainActor'
+// attribute.
+struct UseRequiresMain {
+  @RequiresMain private var x = 10
+}
+
+nonisolated func test() async {
+  // expected-error@+2 {{expression is 'async' but is not marked with 'await'}}
+  // expected-note@+1 {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
+  _ = UseRequiresMain()
+}
+
+// expected-warning@+2 {{memberwise initializer for 'InitAccessors' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
+// expected-warning@+1 {{default initializer for 'InitAccessors' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
+struct InitAccessors {
+  private var _a: Int
+
+  // expected-note@+1 2 {{initializer for property 'a' is main actor-isolated}}
+  @MainActor var a: Int = 5 {
+    @storageRestrictions(initializes: _a)
+    init {
+      _a = requiresMainActor()
+    }
+    get {
+      _a
+    }
+  }
 }


### PR DESCRIPTION
* **Explanation**: SE-0411 applies `nonisolated` to implicit initializers when the initializer does not require actor isolation because all property types are `Sendable` with `nonisolated` initializer expressions. This was done by looking at the properties and initial values from the memberwise initializer. However, property wrappers and init accessors can have an actor isolation that's different from the initializer expression that it subsumes. If the backing property wrapper initializer is global actor isolation but the wrapped value initializer is not, the compiler incorrectly applied `nonisolated` to implicit initializers, and SILGen later errored because the property wrapper backing initializer was skipped due to mismatching isolation, e.g.

```swift
@MainActor
@propertyWrapper struct RequiresMain<Value>  {
  var wrappedValue: Value

  init(wrappedValue: Value) {
    self.wrappedValue = wrappedValue
  }
}

struct S { // error: return from initializer without initializing all stored properties
  @RequiresMain private var x = 10
}
```
 
To fix this, skip property initializers that are subsumed, e.g. by an init accessor or a backing property wrapper initializer, and always consider the subsuming initializer to determine whether an implicit initializer can be `nonisolated`.

This change also lessens the source break of SE-0411 by still emitting member initializers in implicit constructors when the initializer violates actor isolation to preserve the behavior of existing code when concurrency diagnostics are downgraded to warnings in Swift 5 mode.

* **Scope**: Only impacts code built with `-strict-concurrency=complete` or `-enable-upcoming-feature IsolatedDefaultValues` that uses global-actor-isolated property wrappers with `Sendable`, `nonisolated` wrapped value expressions and implicit initializers.
* **Risk**: Low risk; this change is relatively narrow in scope, and I've also downgraded the relevant compiler errors to warnings until Swift 6 to prevent any other implicit initializer bugs from causing source breakage. Note that the source break mentioned in https://github.com/apple/swift/pull/70839 still applies for explicit initializers; the bug here was only with actor isolation inference for implicit initializers.
* **Testing**: Added new tests. Passed source compatibility testing on the `main` PR.
* **Reviewer**: @DougGregor
* **Main branch PR**: https://github.com/apple/swift/pull/71033