### PR TITLE
EXPERIMENT - DONT REVIEW [Concurrency] [shims] Don't declare `exit` in  the concurrency shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@
   Having been [gated](https://github.com/apple/swift/pull/28171) behind a
   compiler warning since at least Swift 5.2, this syntax is now rejected.
 
+* [bugfix][]:
+
+  \_SwiftConcurrencyShims used to declare the `exit` function, even though it
+  might not be available. The declaration has been removed, and must be imported
+  from the appropriate C library module (e.g. Darwin or SwiftGlibc)
+
 ## Swift 5.10
 
 * [SE-0412][]:

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3401,13 +3401,6 @@ namespace {
             return nullptr;
           }
         }
-        // Use the exit function from _SwiftConcurrency.h as it is platform
-        // agnostic.
-        if ((topLevelModuleEq(decl, "Darwin") ||
-             topLevelModuleEq(decl, "SwiftGlibc")) &&
-            decl->getDeclName().isIdentifier() && decl->getName() == "exit") {
-          return nullptr;
-        }
       }
 
       auto dc =

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -11,7 +11,7 @@
 #===----------------------------------------------------------------------===#
 
 set(SWIFT_RUNTIME_CONCURRENCY_C_FLAGS)
-set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS)
+set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS -I${CMAKE_CURRENT_SOURCE_DIR}/InternalShims)
 
 set(swift_concurrency_private_link_libraries)
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/stdlib/public/Concurrency/InternalShims/module.modulemap
+++ b/stdlib/public/Concurrency/InternalShims/module.modulemap
@@ -1,0 +1,6 @@
+module SwiftConcurrencyInternalShims {
+  module stdlib {
+    header "stdlib_shims.h"
+    export *
+  }
+}

--- a/stdlib/public/Concurrency/InternalShims/stdlib_shims.h
+++ b/stdlib/public/Concurrency/InternalShims/stdlib_shims.h
@@ -1,4 +1,4 @@
-//===--- _SwiftConcurrency.h - Swift Concurrency Support --------*- C++ -*-===//
+//===--- stdlib_shims.h - Swift Concurrency Support -----------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,24 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 //
-//  Defines types and support functions for the Swift concurrency model.
+//  Forward declarations of <stdlib.h> interfaces so that Swift Concurrency
+//  doesn't depend on the C library.
 //
 //===----------------------------------------------------------------------===//
-#ifndef SWIFT_CONCURRENCY_H
-#define SWIFT_CONCURRENCY_H
+#ifndef STDLIB_SHIMS_H
+#define STDLIB_SHIMS_H
 
 #ifdef __cplusplus
-namespace swift {
-extern "C" {
+extern "C" [[noreturn]]
 #endif
+void exit(int);
 
-typedef struct _SwiftContext {
-  struct _SwiftContext *parentContext;
-} _SwiftContext;
+#define EXIT_SUCCESS 0
 
-#ifdef __cplusplus
-} // extern "C"
-} // namespace swift
-#endif
-
-#endif // SWIFT_CONCURRENCY_H
+#endif // STDLIB_SHIMS_H

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -12,6 +12,7 @@
 
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
+@_implementationOnly import SwiftConcurrencyInternalShims
 
 // ==== Task -------------------------------------------------------------------
 

--- a/test/Backtracing/Inputs/Inlining.swift
+++ b/test/Backtracing/Inputs/Inlining.swift
@@ -1,3 +1,7 @@
+#if os(Linux)
+import SwiftGlibc
+#endif
+
 func square(_ x: Int) -> Int {
   return x * x
 }


### PR DESCRIPTION
Don't delete the OS declaration of `exit` because the concurrency shimes aren't always imported, and so the shim declaration might not always be available. Don't override the OS declaration of `exit` in the concurrency shims since we can't just delete the OS one. Instead, set up internal shims just for building Concurrency that forward declares `exit`.