### PR TITLE
Fix compiler Test Registry to use a StringMap.

### DIFF
--- a/include/swift/SIL/Test.h
+++ b/include/swift/SIL/Test.h
@@ -120,6 +120,9 @@ class TestRunner;
 /// Tests are instantiated once at program launch.  At that time, they are
 /// stored in a registry name -> test.  When an specify_test instruction
 /// naming a particular test is processed, that test is run.
+///
+/// This is a value type because we have no persistent location in which to
+/// store SwiftCompilerSources tests.
 class FunctionTest final {
 public:
   /// Wraps a test lambda.
@@ -190,7 +193,7 @@ private:
            SILFunctionTransform &pass, Dependencies &dependencies);
 
   /// Retrieve the test with named \p name from the global registry.
-  static FunctionTest *get(StringRef name);
+  static FunctionTest get(StringRef name);
 
   /// The instance of the TestRunner pass currently running this test.  Only
   /// non-null when FunctionTest::run is executing.

--- a/lib/SIL/Utils/Test.cpp
+++ b/lib/SIL/Utils/Test.cpp
@@ -25,7 +25,7 @@ using namespace swift::test;
 namespace {
 
 class Registry {
-  DenseMap<StringRef, FunctionTest *> registeredTests;
+  StringMap<FunctionTest *> registeredTests;
   SwiftNativeFunctionTestThunk thunk;
 
 public:
@@ -47,7 +47,8 @@ public:
   SwiftNativeFunctionTestThunk getFunctionTestThunk() { return thunk; }
 
   FunctionTest *getFunctionTest(StringRef name) {
-    auto *res = registeredTests[name];
+    // Avoid creating a new entry here.
+    auto *res = registeredTests.lookup(name);
     if (!res) {
       llvm::errs() << "Found no test named " << name << "!\n";
       print(llvm::errs());
@@ -58,8 +59,9 @@ public:
   void print(raw_ostream &OS) const {
     OS << "test::Registry(" << this << ") with " << registeredTests.size()
        << " entries: {{\n";
-    for (auto pair : registeredTests) {
-      OS << "\t" << pair.getFirst() << " -> " << pair.getSecond() << "\n";
+    for (auto &stringMapEntry : registeredTests) {
+      OS << "\t" << stringMapEntry.getKey() << " -> "
+         << stringMapEntry.getValue() << "\n";
     }
     OS << "}} test::Registry(" << this << ")\n";
   }

--- a/lib/SILOptimizer/UtilityPasses/TestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/TestRunner.cpp
@@ -98,14 +98,10 @@ void TestRunner::printTestLifetime(bool begin, unsigned testIndex,
 }
 
 void TestRunner::runTest(StringRef name, Arguments &arguments) {
-  auto *test = FunctionTest::get(name);
-  if (!test) {
-    llvm::outs() << "No test named: " << name << "\n";
-    assert(false && "Invalid test name");
-  }
+  FunctionTest test = FunctionTest::get(name);
   auto *function = getFunction();
   FunctionTestDependenciesImpl dependencies(this, function);
-  test->run(*function, arguments, *this, dependencies);
+  test.run(*function, arguments, *this, dependencies);
 }
 
 void TestRunner::run() {


### PR DESCRIPTION
We have no guarantee that the StringRef passed to the registry lives in the static data segment.

This resulted in memory corruption during compiler bootstrapping, which is particularly difficult to diagnose and reproduce.
