### PR TITLE
Refactor conformance checker diagnostics

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1313,9 +1313,8 @@ public:
   /// conformance itself, along with a bit indicating whether this diagnostic
   /// produces an error.
   struct DelayedConformanceDiag {
-    const ValueDecl *Requirement;
-    std::function<void()> Callback;
     bool IsError;
+    std::function<void(NormalProtocolConformance *)> Callback;
   };
 
   /// Check whether current context has any errors associated with
@@ -1330,8 +1329,9 @@ public:
 
   /// Add a delayed diagnostic produced while type-checking a
   /// particular protocol conformance.
-  void addDelayedConformanceDiag(NormalProtocolConformance *conformance,
-                                 DelayedConformanceDiag fn);
+  void addDelayedConformanceDiag(
+      NormalProtocolConformance *conformance, bool isError,
+      std::function<void(NormalProtocolConformance *)> callback);
 
   /// Retrieve the delayed-conformance diagnostic callbacks for the
   /// given normal protocol conformance.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5342,7 +5342,7 @@ ERROR(actor_protocol_illegal_inheritance,none,
       "non-actor type %0 cannot conform to the %1 protocol",
       (DeclName, DeclName))
 ERROR(distributed_actor_conformance_missing_system_type,none,
-      "distributed actor %0 does not declare ActorSystem it can be used with.",
+      "distributed actor %0 does not declare ActorSystem it can be used with",
       (DeclName))
 NOTE(note_distributed_actor_system_can_be_defined_using_defaultdistributedactorsystem,none,
      "you can provide a module-wide default actor system by declaring:\n"

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -229,6 +229,11 @@ public:
   /// diagnostics through the given diagnostics engine.
   Evaluator(DiagnosticEngine &diags, const LangOptions &opts);
 
+  /// For last-ditch diagnostics, get a good approximate source location for
+  /// the thing we're currently type checking by searching for a request whose
+  /// source location matches the predicate.
+  SourceLoc getInnermostSourceLoc(llvm::function_ref<bool(SourceLoc)> fn);
+
   /// Emit GraphViz output visualizing the request graph.
   void emitRequestEvaluatorGraphViz(llvm::StringRef graphVizPath);
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6403,6 +6403,8 @@ void simple_display(llvm::raw_ostream &out, const DefaultArgumentExpr *expr);
 void simple_display(llvm::raw_ostream &out, const Expr *expr);
 
 SourceLoc extractNearestSourceLoc(const DefaultArgumentExpr *expr);
+SourceLoc extractNearestSourceLoc(const MacroExpansionExpr *expr);
+SourceLoc extractNearestSourceLoc(const ClosureExpr *expr);
 
 } // end namespace swift
 

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -214,11 +214,6 @@ public:
   ProtocolConformanceRef getCanonicalConformanceRef() const;
 
   /// Get any additional requirements that are required for this conformance to
-  /// be satisfied, if they're possible to compute.
-  llvm::Optional<ArrayRef<Requirement>>
-  getConditionalRequirementsIfAvailable() const;
-
-  /// Get any additional requirements that are required for this conformance to
   /// be satisfied.
   ArrayRef<Requirement> getConditionalRequirements() const;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -192,6 +192,28 @@ template <> struct DenseMapInfo<OverrideSignatureKey> {
 };
 } // namespace llvm
 
+namespace {
+
+/// If the conformance is in a primary file, we might diagnose some failures
+/// early via request evaluation, with all remaining failures diagnosed when
+/// we completely force the conformance from typeCheckDecl(). To emit the
+/// diagnostics together, we batch them up in the Diags vector.
+///
+/// If the conformance is in a secondary file, we instead just diagnose a
+/// generic "T does not conform to P" error the first time we hit an error
+/// via request evaluation. The detailed delayed conformance diagnostics
+/// are discarded, since we'll emit them again when we compile the file as
+/// a primary file.
+struct DelayedConformanceDiags {
+  /// We set this if we've ever seen an error diagnostic here.
+  bool HadError = false;
+
+  /// The delayed conformance diagnostics that have not been emitted yet.
+  /// Never actually emitted for a secondary file.
+  std::vector<ASTContext::DelayedConformanceDiag> Diags;
+};
+
+}
 struct ASTContext::Implementation {
   Implementation();
   ~Implementation();
@@ -354,8 +376,7 @@ struct ASTContext::Implementation {
 
   /// Map from normal protocol conformances to diagnostics that have
   /// been delayed until the conformance is fully checked.
-  llvm::DenseMap<NormalProtocolConformance *,
-                 std::vector<ASTContext::DelayedConformanceDiag>>
+  llvm::DenseMap<NormalProtocolConformance *, ::DelayedConformanceDiags>
     DelayedConformanceDiags;
 
   /// Map from normal protocol conformances to missing witnesses that have
@@ -2733,17 +2754,10 @@ LazyIterableDeclContextData *ASTContext::getOrCreateLazyIterableContextData(
 bool ASTContext::hasDelayedConformanceErrors(
                           NormalProtocolConformance const* conformance) const {
 
-  auto hasDelayedErrors = [](std::vector<DelayedConformanceDiag> const& diags) {
-    return std::any_of(diags.begin(), diags.end(),
-                    [](ASTContext::DelayedConformanceDiag const& diag) {
-                      return diag.IsError;
-                    });
-  };
-
   if (conformance) {
     auto entry = getImpl().DelayedConformanceDiags.find(conformance);
     if (entry != getImpl().DelayedConformanceDiags.end())
-      return hasDelayedErrors(entry->second);
+      return entry->second.HadError;
 
     return false; // unknown conformance, so no delayed diags either.
   }
@@ -2751,7 +2765,7 @@ bool ASTContext::hasDelayedConformanceErrors(
   // check all conformances for any delayed errors
   for (const auto &entry : getImpl().DelayedConformanceDiags) {
     auto const& diagnostics = entry.getSecond();
-    if (hasDelayedErrors(diagnostics))
+    if (diagnostics.HadError)
       return true;
   }
 
@@ -2763,7 +2777,44 @@ MissingWitnessesBase::~MissingWitnessesBase() { }
 void ASTContext::addDelayedConformanceDiag(
        NormalProtocolConformance *conformance,
        DelayedConformanceDiag fn) {
-  getImpl().DelayedConformanceDiags[conformance].push_back(std::move(fn));
+  auto &diagnostics = getImpl().DelayedConformanceDiags[conformance];
+
+  if (fn.IsError && !diagnostics.HadError) {
+    diagnostics.HadError = true;
+
+    auto *proto = conformance->getProtocol();
+    auto *dc = conformance->getDeclContext();
+    auto *sf = dc->getParentSourceFile();
+    auto *mod = sf->getParentModule();
+    assert(mod->isMainModule());
+
+    // If we have at least one primary file and the conformance is declared in a
+    // non-primary file, emit a fallback diagnostic.
+    if ((!sf->isPrimary() && !mod->getPrimarySourceFiles().empty()) ||
+        TypeCheckerOpts.EnableLazyTypecheck) {
+      auto complainLoc = evaluator.getInnermostSourceLoc([&](SourceLoc loc) {
+        if (loc.isInvalid())
+          return false;
+
+        auto *otherSF = mod->getSourceFileContainingLocation(loc);
+        if (otherSF == nullptr)
+          return false;
+
+        return otherSF->isPrimary();
+      });
+
+      if (complainLoc.isInvalid()) {
+        complainLoc = conformance->getLoc();
+      }
+
+      Diags.diagnose(complainLoc,
+                     diag::type_does_not_conform,
+                     dc->getSelfInterfaceType(),
+                     proto->getDeclaredInterfaceType());
+    }
+  }
+
+  diagnostics.Diags.push_back(std::move(fn));
 }
 
 void ASTContext::addDelayedMissingWitnesses(
@@ -2789,8 +2840,7 @@ ASTContext::takeDelayedConformanceDiags(NormalProtocolConformance const* cnfrm){
   std::vector<ASTContext::DelayedConformanceDiag> result;
   auto known = getImpl().DelayedConformanceDiags.find(cnfrm);
   if (known != getImpl().DelayedConformanceDiags.end()) {
-    result = std::move(known->second);
-    getImpl().DelayedConformanceDiags.erase(known);
+    std::swap(result, known->second.Diags);
   }
   return result;
 }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1865,7 +1865,7 @@ void ASTContext::addCleanup(std::function<void(void)> cleanup) {
 }
 
 bool ASTContext::hadError() const {
-  return Diags.hadAnyError();
+  return Diags.hadAnyError() || hasDelayedConformanceErrors();
 }
 
 /// Retrieve the arena from which we should allocate storage for a type.

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -60,6 +60,17 @@ Evaluator::Evaluator(DiagnosticEngine &diags, const LangOptions &opts)
       debugDumpCycles(opts.DebugDumpCycles),
       recorder(opts.RecordRequestReferences) {}
 
+SourceLoc Evaluator::getInnermostSourceLoc(
+    llvm::function_ref<bool(SourceLoc)> fn) {
+  for (auto request : llvm::reverse(activeRequests)) {
+    SourceLoc loc = request.getNearestLoc();
+    if (fn(loc))
+      return loc;
+  }
+
+  return SourceLoc();
+}
+
 bool Evaluator::checkDependency(const ActiveRequest &request) {
   // Record this as an active request.
   if (activeRequests.insert(request)) {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2835,7 +2835,15 @@ void swift::simple_display(llvm::raw_ostream &out,
   out << "expression";
 }
 
+SourceLoc swift::extractNearestSourceLoc(const ClosureExpr *expr) {
+  return expr->getLoc();
+}
+
 SourceLoc swift::extractNearestSourceLoc(const DefaultArgumentExpr *expr) {
+  return expr->getLoc();
+}
+
+SourceLoc swift::extractNearestSourceLoc(const MacroExpansionExpr *expr) {
   return expr->getLoc();
 }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -483,12 +483,6 @@ NormalProtocolConformance::getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
     return { Type(), nullptr };
   }
 
-  // If the conditional requirements aren't known, we can't properly run
-  // inference.
-  if (!getConditionalRequirementsIfAvailable()) {
-    return TypeWitnessAndDecl();
-  }
-
   return evaluateOrDefault(
       assocType->getASTContext().evaluator,
       TypeWitnessRequest{const_cast<NormalProtocolConformance *>(this),

--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -189,17 +189,6 @@ ProtocolConformanceRef::getWitnessByName(Type type, DeclName name) const {
   return getConcrete()->getWitnessDeclRef(requirement);
 }
 
-llvm::Optional<ArrayRef<Requirement>>
-ProtocolConformanceRef::getConditionalRequirementsIfAvailable() const {
-  if (isConcrete())
-    return getConcrete()->getConditionalRequirementsIfAvailable();
-  else
-    // An abstract conformance is never conditional: any conditionality in the
-    // concrete types that will eventually pass through this at runtime is
-    // completely pre-checked and packaged up.
-    return ArrayRef<Requirement>();
-}
-
 ArrayRef<Requirement>
 ProtocolConformanceRef::getConditionalRequirements() const {
   if (isConcrete())

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7235,7 +7235,7 @@ void ConstraintSystem::maybeProduceFallbackDiagnostic(
   // diagnostics already emitted or waiting to be emitted. Because they are
   // a better indication of the problem.
   ASTContext &ctx = getASTContext();
-  if (ctx.Diags.hadAnyError() || ctx.hasDelayedConformanceErrors())
+  if (ctx.hadError())
     return;
 
   ctx.Diags.diagnose(target.getLoc(), diag::failed_to_produce_diagnostic);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2916,12 +2916,7 @@ ConformanceChecker::ConformanceChecker(
       LocalMissingWitnessesStartIndex(GlobalMissingWitnesses.size()),
       SuppressDiagnostics(suppressDiagnostics) {}
 
-ConformanceChecker::~ConformanceChecker() {
-  // its not OK to forget about error diagnostics, unless if we have already
-  // complained or are suppose to suppress diagnostics.
-  assert(AlreadyComplained || SuppressDiagnostics ||
-            !getASTContext().hasDelayedConformanceErrors(Conformance));
-}
+ConformanceChecker::~ConformanceChecker() {}
 
 
 TinyPtrVector<AssociatedTypeDecl *>

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2232,8 +2232,8 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
   }
 
   // Not every protocol/type is compatible with conditional conformances.
-  auto conditionalReqs = conformance->getConditionalRequirementsIfAvailable();
-  if (conditionalReqs && !conditionalReqs->empty()) {
+  auto conditionalReqs = conformance->getConditionalRequirements();
+  if (!conditionalReqs.empty()) {
     auto nestedType = DC->getSelfNominalTypeDecl()->getDeclaredInterfaceType();
     // Obj-C generics cannot be looked up at runtime, so we don't support
     // conditional conformances involving them. Check the full stack of nested
@@ -2256,7 +2256,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     // protocol, the conditional requirements must not involve conformance to a
     // marker protocol. We cannot evaluate such a conformance at runtime.
     if (!Proto->isMarkerProtocol()) {
-      for (const auto &req : *conditionalReqs) {
+      for (const auto &req : conditionalReqs) {
         if (req.getKind() == RequirementKind::Conformance &&
             req.getProtocolDecl()->isMarkerProtocol()) {
           C.Diags.diagnose(
@@ -2318,9 +2318,8 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
       implyingConf = implyingConf->getImplyingConformance();
     }
 
-    auto implyingCondReqs =
-      implyingConf->getConditionalRequirementsIfAvailable();
-    if (implyingCondReqs && !implyingCondReqs->empty()) {
+    auto implyingCondReqs = implyingConf->getConditionalRequirements();
+    if (!implyingCondReqs.empty()) {
       // We shouldn't suggest including witnesses for the conformance, because
       // those suggestions will go in the current DeclContext, but really they
       // should go into the new extension we (might) suggest here.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5110,20 +5110,19 @@ void ConformanceChecker::ensureRequirementsAreSatisfied() {
     // Diagnose the failure generically.
     // FIXME: Would be nice to give some more context here!
     if (!Conformance->isInvalid()) {
-      diags.diagnose(Loc, diag::type_does_not_conform,
-                     Adoptee,
-                     Proto->getDeclaredInterfaceType());
-
       if (result.getKind() == CheckRequirementsResult::RequirementFailure) {
-        TypeChecker::diagnoseRequirementFailure(
-            result.getRequirementFailureInfo(), Loc, Loc,
-            proto->getDeclaredInterfaceType(),
-            {proto->getSelfInterfaceType()->castTo<GenericTypeParamType>()},
-            QuerySubstitutionMap{substitutions}, module);
+        auto Loc = this->Loc;
+        diagnoseOrDefer(nullptr, /*isError=*/true,
+          [Loc, result, proto, substitutions, module](NormalProtocolConformance *conformance) {
+            TypeChecker::diagnoseRequirementFailure(
+              result.getRequirementFailureInfo(), Loc, Loc,
+              proto->getDeclaredInterfaceType(),
+              {proto->getSelfInterfaceType()->castTo<GenericTypeParamType>()},
+              QuerySubstitutionMap{substitutions}, module);
+          });
       }
 
       Conformance->setInvalid();
-      AlreadyComplained = true;
     }
     return;
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5752,10 +5752,13 @@ void ConformanceChecker::emitDelayedDiags() {
 
   assert(!SuppressDiagnostics && "Should not be suppressing diagnostics now");
   for (const auto &diag: diags) {
-    diagnoseOrDefer(diag.Requirement, diag.IsError,
-      [&](NormalProtocolConformance *conformance) {
-        return diag.Callback();
-    });
+    // Complain that the type does not conform, once.
+    if (diag.IsError && !AlreadyComplained) {
+      diagnoseConformanceFailure(Adoptee, Proto, DC, Loc);
+      AlreadyComplained = true;
+    }
+
+    diag.Callback();
   }
 }
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -889,7 +889,8 @@ public:
   /// Call this to diagnose currently known missing witnesses.
   ///
   /// \returns true if any witnesses were diagnosed.
-  bool diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind);
+  bool diagnoseMissingWitnesses(MissingWitnessDiagnosisKind Kind,
+                                bool Delayed);
 
   /// Emit any diagnostics that have been delayed.
   void emitDelayedDiags();

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -787,11 +787,6 @@ private:
   /// this protocol under checking.
   unsigned LocalMissingWitnessesStartIndex;
 
-  /// True if we shouldn't complain about problems with this conformance
-  /// right now, i.e. if methods are being called outside
-  /// checkConformance().
-  bool SuppressDiagnostics;
-
   /// Whether we've already complained about problems with this conformance.
   bool AlreadyComplained = false;
 
@@ -896,8 +891,7 @@ public:
   void emitDelayedDiags();
 
   ConformanceChecker(ASTContext &ctx, NormalProtocolConformance *conformance,
-                     llvm::SetVector<MissingWitness> &GlobalMissingWitnesses,
-                     bool suppressDiagnostics = true);
+                     llvm::SetVector<MissingWitness> &GlobalMissingWitnesses);
 
   ~ConformanceChecker();
 

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -857,18 +857,6 @@ private:
   /// the chosen type witnesses.
   void ensureRequirementsAreSatisfied();
 
-  /// Diagnose or defer a diagnostic, as appropriate.
-  ///
-  /// \param requirement The requirement with which this diagnostic is
-  /// associated, if any.
-  ///
-  /// \param isError Whether this diagnostic is an error.
-  ///
-  /// \param fn A function to call to emit the actual diagnostic. If
-  /// diagnostics are being deferred,
-  void diagnoseOrDefer(const ValueDecl *requirement, bool isError,
-                       std::function<void(NormalProtocolConformance *)> fn);
-
   ArrayRef<MissingWitness> getLocalMissingWitness() {
     return GlobalMissingWitnesses.getArrayRef().
       slice(LocalMissingWitnessesStartIndex,
@@ -1220,15 +1208,13 @@ private:
   ///
   /// \returns true if a diagnostic was emitted, false otherwise.
   bool diagnoseNoSolutions(
-                     ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
-                     ConformanceChecker &checker);
+                     ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes);
 
   /// Emit a diagnostic when there are multiple solutions.
   ///
   /// \returns true if a diagnostic was emitted, false otherwise.
   bool diagnoseAmbiguousSolutions(
                 ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
-                ConformanceChecker &checker,
                 SmallVectorImpl<InferredTypeWitnessesSolution> &solutions);
 
   /// We may need to determine a type witness, regardless of the existence of a

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -2993,10 +2993,6 @@ void ConformanceChecker::resolveTypeWitnesses() {
 
 void ConformanceChecker::resolveSingleTypeWitness(
        AssociatedTypeDecl *assocType) {
-  // Ensure we diagnose if the witness is missing.
-  SWIFT_DEFER {
-    diagnoseMissingWitnesses(MissingWitnessDiagnosisKind::ErrorFixIt);
-  };
   switch (resolveTypeWitnessViaLookup(assocType)) {
   case ResolveWitnessResult::Success:
   case ResolveWitnessResult::ExplicitFailed:

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -2227,15 +2227,14 @@ namespace {
 } // end anonymous namespace
 
 bool AssociatedTypeInference::diagnoseNoSolutions(
-                         ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
-                         ConformanceChecker &checker) {
+                         ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes) {
   // If a defaulted type witness failed, diagnose it.
   if (failedDefaultedAssocType) {
     auto failedDefaultedAssocType = this->failedDefaultedAssocType;
     auto failedDefaultedWitness = this->failedDefaultedWitness;
     auto failedDefaultedResult = this->failedDefaultedResult;
 
-    checker.diagnoseOrDefer(failedDefaultedAssocType, true,
+    ctx.addDelayedConformanceDiag(conformance, true,
       [failedDefaultedAssocType, failedDefaultedWitness,
        failedDefaultedResult](NormalProtocolConformance *conformance) {
         auto proto = conformance->getProtocol();
@@ -2304,7 +2303,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
       return false;
 
     auto failedSet = std::move(known->second);
-    checker.diagnoseOrDefer(assocType, true,
+    ctx.addDelayedConformanceDiag(conformance, true,
       [assocType, failedSet](NormalProtocolConformance *conformance) {
         auto proto = conformance->getProtocol();
         auto &diags = proto->getASTContext().Diags;
@@ -2411,7 +2410,7 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
   if (typeWitnessConflict) {
     auto typeWitnessConflict = this->typeWitnessConflict;
 
-    checker.diagnoseOrDefer(typeWitnessConflict->AssocType, true,
+    ctx.addDelayedConformanceDiag(conformance, true,
       [typeWitnessConflict](NormalProtocolConformance *conformance) {
         auto &diags = conformance->getDeclContext()->getASTContext().Diags;
         diags.diagnose(typeWitnessConflict->AssocType,
@@ -2438,7 +2437,6 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
 
 bool AssociatedTypeInference::diagnoseAmbiguousSolutions(
                   ArrayRef<AssociatedTypeDecl *> unresolvedAssocTypes,
-                  ConformanceChecker &checker,
                   SmallVectorImpl<InferredTypeWitnessesSolution> &solutions) {
   for (auto assocType : unresolvedAssocTypes) {
     // Find two types that conflict.
@@ -2474,7 +2472,7 @@ bool AssociatedTypeInference::diagnoseAmbiguousSolutions(
       continue;
 
     // We found an ambiguity. diagnose it.
-    checker.diagnoseOrDefer(assocType, true,
+    ctx.addDelayedConformanceDiag(conformance, true,
       [assocType, firstType, firstMatch, secondType, secondMatch](
         NormalProtocolConformance *conformance) {
         auto &diags = assocType->getASTContext().Diags;
@@ -2660,12 +2658,12 @@ auto AssociatedTypeInference::solve(ConformanceChecker &checker)
 
   // Diagnose the complete lack of solutions.
   if (solutions.empty() &&
-      diagnoseNoSolutions(unresolvedAssocTypes.getArrayRef(), checker))
+      diagnoseNoSolutions(unresolvedAssocTypes.getArrayRef()))
     return llvm::None;
 
   // Diagnose ambiguous solutions.
   if (!solutions.empty() &&
-      diagnoseAmbiguousSolutions(unresolvedAssocTypes.getArrayRef(), checker,
+      diagnoseAmbiguousSolutions(unresolvedAssocTypes.getArrayRef(),
                                  solutions))
     return llvm::None;
 

--- a/test/Distributed/distributed_actor_system_missing.swift
+++ b/test/Distributed/distributed_actor_system_missing.swift
@@ -7,7 +7,7 @@
 import Distributed
 
 distributed actor DA {
-  // expected-error@-1{{distributed actor 'DA' does not declare ActorSystem it can be used with.}}
+  // expected-error@-1{{distributed actor 'DA' does not declare ActorSystem it can be used with}}
 
   // Since synthesis would have failed due to the missing ActorSystem:
   // expected-error@-4{{type 'DA' does not conform to protocol 'Encodable'}}
@@ -23,7 +23,7 @@ distributed actor DA {
 // we need to fail gracefully, rather than crash trying to use the non-existing type.
 //
 // Test case for: https://github.com/apple/swift/issues/58663
-distributed actor Server { // expected-error 2 {{distributed actor 'Server' does not declare ActorSystem it can be used with.}}
+distributed actor Server { // expected-error 2 {{distributed actor 'Server' does not declare ActorSystem it can be used with}}
   // expected-note@-1{{you can provide a module-wide default actor system by declaring:}}
   typealias ActorSystem = DoesNotExistDataSystem
   // expected-error@-1{{cannot find type 'DoesNotExistDataSystem' in scope}}

--- a/test/Distributed/distributed_actor_system_missing_type_dontCrash.swift
+++ b/test/Distributed/distributed_actor_system_missing_type_dontCrash.swift
@@ -8,8 +8,8 @@ import Distributed
 
 // rdar://90886302 This test would crash if not typealias ActorSystem was declared for an actor
 distributed actor Fish {
-  // expected-error@-1{{distributed actor 'Fish' does not declare ActorSystem it can be used with.}}
-  // expected-error@-2{{distributed actor 'Fish' does not declare ActorSystem it can be used with.}}
+  // expected-error@-1{{distributed actor 'Fish' does not declare ActorSystem it can be used with}}
+  // expected-error@-2{{distributed actor 'Fish' does not declare ActorSystem it can be used with}}
   // expected-note@-3{{you can provide a module-wide default actor system by declaring:\ntypealias DefaultDistributedActorSystem = <#ConcreteActorSystem#>}}
 
   distributed func tell(_ text: String, by: Fish) {

--- a/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
+++ b/test/Distributed/distributed_protocols_distributed_func_serialization_requirements.swift
@@ -47,11 +47,10 @@ protocol ProtocolWithChecksSeqReq: DistributedActor
   distributed func testAT() async throws -> NotCodable
 }
 distributed actor ProtocolWithChecksSeqReqDA_MissingSystem: ProtocolWithChecksSeqReq {
-  // expected-error@-1{{distributed actor 'ProtocolWithChecksSeqReqDA_MissingSystem' does not declare ActorSystem it can be used with.}}
+  // expected-error@-1{{distributed actor 'ProtocolWithChecksSeqReqDA_MissingSystem' does not declare ActorSystem it can be used with}}
   // expected-note@-2{{you can provide a module-wide default actor system by declaring:}}
-  // expected-error@-3{{type 'ProtocolWithChecksSeqReqDA_MissingSystem' does not conform to protocol 'ProtocolWithChecksSeqReq'}}
   //
-  // expected-error@-5{{distributed actor 'ProtocolWithChecksSeqReqDA_MissingSystem' does not declare ActorSystem it can be used with.}}
+  // expected-error@-4{{distributed actor 'ProtocolWithChecksSeqReqDA_MissingSystem' does not declare ActorSystem it can be used with}}
 
   // Entire conformance is doomed, so we didn't proceed to checking the functions; that's fine
   distributed func testAT() async throws -> NotCodable { .init() }

--- a/test/SILGen/Inputs/dynamic_other.swift
+++ b/test/SILGen/Inputs/dynamic_other.swift
@@ -15,8 +15,8 @@ class FromOtherFile: Proto {
   @objc init(objc: Int) {}
   @objc func objcMethod() {}
   @objc var objcProp: Int = 0
-  @objc subscript(objc objc: Int) -> Int {
-    get { return objc }
+  @objc subscript(objc objc: AnyObject) -> Int {
+    get { return 0 }
     set {}
   }
 
@@ -26,6 +26,11 @@ class FromOtherFile: Proto {
   @objc dynamic var dynamicProp: Int = 0
   @objc dynamic subscript(dynamic dynamic: Int) -> Int {
     get { return dynamic }
+    set {}
+  }
+
+  static subscript(nativeType nativeType: Int) -> Int {
+    get { return nativeType }
     set {}
   }
 

--- a/test/SILGen/dynamic.swift
+++ b/test/SILGen/dynamic.swift
@@ -409,9 +409,9 @@ func objcMethodDispatchFromOtherFile() {
   // CHECK: class_method {{%.*}} : $FromOtherFile, #FromOtherFile.objcProp!setter :
   c.objcProp = x
   // CHECK: class_method {{%.*}} : $FromOtherFile, #FromOtherFile.subscript!getter :
-  let y = c[objc: 0]
+  let y = c[objc: 0 as AnyObject]
   // CHECK: class_method {{%.*}} : $FromOtherFile, #FromOtherFile.subscript!setter :
-  c[objc: 0] = y
+  c[objc: 0 as AnyObject] = y
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s7dynamic0A27MethodDispatchFromOtherFileyyF : $@convention(thin) () -> ()

--- a/test/TBD/lazy-typecheck-bad-conformance.swift
+++ b/test/TBD/lazy-typecheck-bad-conformance.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -typecheck -experimental-lazy-typecheck -emit-tbd -emit-tbd-path %t/lazy.tbd %s -enable-library-evolution -parse-as-library -tbd-install_name lazy
+// RUN: %target-swift-frontend -typecheck -verify -experimental-lazy-typecheck -emit-tbd -emit-tbd-path %t/lazy.tbd %s -enable-library-evolution -parse-as-library -tbd-install_name lazy
 
 public protocol P {
   func req()
 }
 
-// FIXME: This malformed conformance should probably be diagnosed.
+// expected-error@+1 {{type 'S' does not conform to protocol 'P'}}
 public struct S: P {
 }

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -572,8 +572,7 @@ protocol P35a {
   associatedtype B // expected-note {{protocol requires nested type 'B'}}
 }
 protocol P35b: P35a where B == A {}
-// expected-error@+2 {{type 'S35' does not conform to protocol 'P35a'}}
-// expected-error@+1 {{type 'S35' does not conform to protocol 'P35b'}}
+// expected-error@+1 {{type 'S35' does not conform to protocol 'P35a'}}
 struct S35: P35b {}
 
 // Circular reference through a value witness.
@@ -634,7 +633,6 @@ protocol P40b: P40a {
 protocol P40c: P40b where D == S40<Never> {}
 struct S40<E: Equatable>: P40c {
   // expected-error@-1 {{type 'S40<E>' does not conform to protocol 'P40b'}}
-  // expected-error@-2 {{type 'S40<E>' does not conform to protocol 'P40c'}}
   func foo(arg: Never) {}
 
   typealias B = Self
@@ -712,6 +710,5 @@ protocol FIXME_P1a {
   associatedtype B: FIXME_P1a // expected-note {{protocol requires nested type 'B'}}
 }
 protocol FIXME_P1b: FIXME_P1a where B == FIXME_S1<A> {}
-// expected-error@+2 {{type 'FIXME_S1<T>' does not conform to protocol 'FIXME_P1a'}}
-// expected-error@+1 {{type 'FIXME_S1<T>' does not conform to protocol 'FIXME_P1b'}}
+// expected-error@+1 {{type 'FIXME_S1<T>' does not conform to protocol 'FIXME_P1a'}}
 struct FIXME_S1<T: Equatable>: FIXME_P1b {}

--- a/test/decl/protocol/req/associated_type_inference_fixed_type.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type.swift
@@ -108,9 +108,8 @@ protocol Q11 {
 }
 do {
   struct Conformer: Q11, P11b {}
-  // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P11b'}}
-  // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P11a'}}
-  // expected-error@-3 {{type 'Conformer' does not conform to protocol 'Q11'}}
+  // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P11a'}}
+  // expected-error@-2 {{type 'Conformer' does not conform to protocol 'Q11'}}
 }
 
 protocol P12 where A == B {
@@ -151,7 +150,6 @@ protocol P15b: P15a where A == B {}
 do {
   struct Conformer: P15b {}
   // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P15a'}}
-  // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P15b'}}
 }
 
 protocol P16a where A == B {

--- a/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
@@ -885,5 +885,4 @@ do {
   struct Conformer: P48c {}
   // expected-error@-1 {{type 'Conformer' does not conform to protocol 'P48a'}}
   // expected-error@-2 {{type 'Conformer' does not conform to protocol 'P48b'}}
-  // expected-error@-3 {{type 'Conformer' does not conform to protocol 'P48c'}}
 }

--- a/test/multifile/protocol-conformance-broken-2.swift
+++ b/test/multifile/protocol-conformance-broken-2.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/Usage.swift %t/Conformance.swift
+
+//--- Conformance.swift
+protocol P {
+  associatedtype A: Equatable
+  func f() -> A
+}
+
+extension P {
+  func f() -> A { fatalError() }
+}
+
+struct S: P {}
+
+//--- Usage.swift
+func callee(_: some Equatable) {}
+
+// FIXME: This source location will become more accurate once TypeCheckExpr
+// is a request! For now, pointing at the function is still better than crashing.
+
+func caller() { // expected-error {{type 'S' does not conform to protocol 'P'}}
+  callee(S().f())
+}

--- a/test/multifile/protocol-conformance-issue-53408.swift
+++ b/test/multifile/protocol-conformance-issue-53408.swift
@@ -5,3 +5,4 @@
 
 func reproducer() -> Float { return Struct().func1(1.0) }
 // expected-error@-1 {{cannot convert value of type 'Double' to expected argument type 'Struct.Input'}}
+// expected-error@-2 {{type 'Struct' does not conform to protocol 'Proto1'}}

--- a/validation-test/compiler_crashers_2_fixed/0127-issue-48118.swift
+++ b/validation-test/compiler_crashers_2_fixed/0127-issue-48118.swift
@@ -1,5 +1,4 @@
-// RUN: not %target-swift-frontend %s -typecheck
-// REQUIRES: asserts
+// RUN: %target-typecheck-verify-swift
 
 // https://github.com/apple/swift/issues/48118
 
@@ -18,7 +17,7 @@ public protocol P {
     func f4(_ x: Context)
 }
 
-public extension P {
+extension P {
     public func f1(_ x: Context, _ y: PA) {
     }
     public func f2(_ x: Context, _ y: PB) {
@@ -35,6 +34,6 @@ public struct S: P {
 
     public func f1(_ x: Context, _ y: PA) {
     }
-    public func f2(_ x: Context, _ y: PB) {
+    public func f2(_ x: Context, _ y: PB) { // expected-error {{reference to invalid type alias 'Context' of type 'S'}}
     }
 }


### PR DESCRIPTION
This PR moves delayed diagnostics state entirely out of ConformanceChecker. The goal is to decouple type witness inference from ConformanceChecker, leaving it in charge of value witness inference only. This will in turn lead to better request evaluator usage in type witness inference.

This also fixes a case where we accepted invalid AST because a protocol conformance check failed in a secondary source file. We now emit a fallback diagnostic `type T does not conform to protocol P` in this case. The source location is chosen to be that of the innermost active request that refers to a primary file; if no active requests have such a location, we use the location of the conformance instead.

With a few more cleanups this will allow removing the older `reference to invalid associated type` fallback diagnostic, which is inaccurate because it misses cases where the invalid type witness ends up in a substitution map, or if the type witness is valid but does not satisfy an associated conformance requirement.