### PR TITLE
[build] Support cross-compilation of swift-format

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftformat.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftformat.py
@@ -27,6 +27,7 @@ from . import swiftpm
 from . import swiftsyntax
 from . import xctest
 from .. import shell
+from .. import targets
 
 
 class SwiftFormat(product.Product):
@@ -57,8 +58,6 @@ class SwiftFormat(product.Product):
         script_path = os.path.join(
             self.source_dir, 'build-script-helper.py')
 
-        install_destdir = self.host_install_destdir(host_target)
-
         helper_cmd = [
             script_path,
             action,
@@ -66,14 +65,34 @@ class SwiftFormat(product.Product):
             '--configuration', self.configuration(),
             '--build-path', self.build_dir,
             '--multiroot-data-file', MULTIROOT_DATA_FILE_PATH,
-            # There might have been a Package.resolved created by other builds
-            # or by the package being opened using Xcode. Discard that and
-            # reset the dependencies to be local.
-            '--update'
         ]
-        helper_cmd.extend([
-            '--prefix', install_destdir + self.args.install_prefix
-        ])
+
+        install_destdir = self.host_install_destdir(host_target)
+        toolchain_path = self.native_toolchain_path(host_target)
+
+        # Pass Cross compile host info unless we're testing.
+        # It doesn't make sense to run tests of the cross compile host.
+        if self.has_cross_compile_hosts() and action != 'test':
+            if self.is_darwin_host(host_target):
+                if len(self.args.cross_compile_hosts) != 1:
+                    raise RuntimeError("Cross-Compiling swift-format to multiple " +
+                                       "targets is not supported")
+                helper_cmd += ['--cross-compile-host', self.args.cross_compile_hosts[0]]
+            elif self.is_cross_compile_target(host_target):
+                helper_cmd.extend(['--cross-compile-host', host_target])
+                build_toolchain_path = install_destdir + self.args.install_prefix
+                resource_dir = f'{build_toolchain_path}/lib/swift'
+                cross_compile_config = targets.StdlibDeploymentTarget \
+                    .get_target_for_name(host_target) \
+                    .platform \
+                    .swiftpm_config(
+                        self.args,
+                        output_dir=build_toolchain_path,
+                        swift_toolchain=toolchain_path,
+                        resource_path=resource_dir
+                    )
+                helper_cmd += ['--cross-compile-config', cross_compile_config]
+
         if self.args.verbose_build:
             helper_cmd.append('--verbose')
         helper_cmd.extend(additional_params)
@@ -139,7 +158,12 @@ class SwiftFormat(product.Product):
         return self.args.install_swiftformat
 
     def install(self, host_target):
-        self.run_build_script_helper('install', host_target)
+        install_destdir = self.host_install_destdir(host_target)
+        self.run_build_script_helper(
+            'install',
+            host_target,
+            additional_params=['--prefix', install_destdir + self.args.install_prefix]
+        )
 
     @classmethod
     def get_dependencies(cls):


### PR DESCRIPTION
Companion of https://github.com/apple/swift-format/pull/679

---

This should build swift-format as a fat binary containing both an x86_64 and an arm64 slice in the open source toolchains.

The implementation is mostly stolen from the SourceKitLSP product.

rdar://121326143