### PR TITLE
[CodeComplete] Emit `Copyable` declaration instead of keyword

### DIFF
--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -628,7 +628,7 @@ public:
 
   void getOptionalBindingCompletions(SourceLoc Loc);
 
-  void getWithoutConstraintTypes();
+  void addWithoutConstraintTypes();
 };
 
 } // end namespace ide

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1314,7 +1314,8 @@ void swift::ide::postProcessCompletionResults(
         Kind != CompletionKind::TypeSimpleWithoutDot &&
         Kind != CompletionKind::TypeSimpleWithDot &&
         Kind != CompletionKind::TypeDeclResultBeginning &&
-        Kind != CompletionKind::GenericRequirement) {
+        Kind != CompletionKind::GenericRequirement &&
+        Kind != CompletionKind::WithoutConstraintType) {
       flair |= CodeCompletionFlairBit::RareTypeAtCurrentPosition;
       modified = true;
     }
@@ -2007,7 +2008,7 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
   }
 
   case CompletionKind::WithoutConstraintType: {
-    Lookup.getWithoutConstraintTypes();
+    Lookup.addWithoutConstraintTypes();
     break;
   }
 

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3440,8 +3440,8 @@ void CompletionLookup::getOptionalBindingCompletions(SourceLoc Loc) {
                      /*IncludeTopLevel=*/false, Loc);
 }
 
-void CompletionLookup::getWithoutConstraintTypes() {
-  // FIXME: Once we have a typealias declaration for copyable, we should be
-  // returning that instead of a keyword (rdar://109107817).
-  addKeyword("Copyable");
+void CompletionLookup::addWithoutConstraintTypes() {
+  auto *CopyableDecl = Ctx.getProtocol(KnownProtocolKind::Copyable);
+  addNominalTypeRef(CopyableDecl, DeclVisibilityKind::VisibleAtTopLevel,
+                    DynamicLookupInfo());
 }

--- a/test/IDE/complete_without_constraint_type.swift
+++ b/test/IDE/complete_without_constraint_type.swift
@@ -1,5 +1,4 @@
 // RUN: %batch-code-completion
 
 struct FileDescriptor: ~#^COMPLETE^# {}
-// FIXME: This should be emitting a `Copyable` declaration instead of a keyword, once there is a declaration for `Copyable`
-// COMPLETE: Keyword/None:                       Copyable; name=Copyable
+// COMPLETE: Decl[Protocol]/OtherModule[Swift]/IsSystem: Copyable[#Copyable#]; name=Copyable


### PR DESCRIPTION
Now that there is an actual declaration for `Copyable` we should be emitting that as a code completion result instead of a keyword, like we currently do.

rdar://109107817
