### PR TITLE
[SourceKit] Don't realpath the primary file path

### DIFF
--- a/test/SourceKit/CursorInfo/solver_based_info_of_memory_only_file.swift
+++ b/test/SourceKit/CursorInfo/solver_based_info_of_memory_only_file.swift
@@ -1,0 +1,16 @@
+// RUN: split-file --leading-lines %s %t
+
+//--- input.swift
+
+func foo() -> Int { 1 }
+func foo() -> String { "" }
+func test() {
+// RUN: %sourcekitd-test \
+// RUN:   -req=open %t/memory-only.swift -text-input %t/input.swift -print-raw-response -- %t/memory-only.swift == \
+// RUN:   -req=cursor -pos=%(line + 1):7 %t/memory-only.swift -text-input %t/input.swift -- %t/memory-only.swift | %FileCheck %s
+  _ = foo()
+}
+
+// CHECK: () -> Int
+// CHECK-LABEL: SECONDARY SYMBOLS BEGIN
+// CHECK: () -> String

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2119,11 +2119,9 @@ void SwiftLangSupport::getCursorInfo(
   std::shared_ptr<llvm::MemoryBuffer> InputBuffer;
   if (InputBufferName.empty() && Length == 0) {
     std::string InputFileError;
-    llvm::SmallString<128> RealInputFilePath;
-    fileSystem->getRealPath(PrimaryFilePath, RealInputFilePath);
     InputBuffer =
         std::shared_ptr<llvm::MemoryBuffer>(getASTManager()->getMemoryBuffer(
-            RealInputFilePath, fileSystem, InputFileError));
+            PrimaryFilePath, fileSystem, InputFileError));
   }
 
   // Receiver is async, so be careful about captured values. This is all


### PR DESCRIPTION
If the file didn’t exist on disk, `fileSystem->getRealPath` returns an empty string, which means we can’t find the `InputBuffer` and thsu won’t run solver-based cursor info. There’s no reason to realpath `PrimaryInputPath`, `getMemoryBuffer` already does that.

rdar://120737244