### PR TITLE
[Concurrency] Deprecate `@GlobalActor(unsafe)` in favor of `@preconcurrency @GlobalActor`

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -121,9 +121,8 @@ public:
     return ActorIsolation(ActorInstance, capturedActor);
   }
 
-  static ActorIsolation forGlobalActor(Type globalActor, bool unsafe) {
-    return ActorIsolation(
-        unsafe ? GlobalActorUnsafe : GlobalActor, globalActor);
+  static ActorIsolation forGlobalActor(Type globalActor) {
+    return ActorIsolation(GlobalActor, globalActor);
   }
 
   static std::optional<ActorIsolation> forSILString(StringRef string) {

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -66,10 +66,6 @@ public:
     /// The declaration is isolated to a global actor. It can refer to other
     /// entities with the same global actor.
     GlobalActor,
-    /// The declaration is isolated to a global actor but with the "unsafe"
-    /// annotation, which means that we only enforce the isolation if we're
-    /// coming from something with specific isolation.
-    GlobalActorUnsafe,
   };
 
 private:
@@ -139,7 +135,7 @@ public:
             .Case("global_actor",
                   std::optional<ActorIsolation>(ActorIsolation::GlobalActor))
             .Case("global_actor_unsafe", std::optional<ActorIsolation>(
-                                             ActorIsolation::GlobalActorUnsafe))
+                                             ActorIsolation::GlobalActor))
             .Default(std::nullopt);
     if (kind == std::nullopt)
       return std::nullopt;
@@ -170,7 +166,6 @@ public:
     switch (getKind()) {
     case ActorInstance:
     case GlobalActor:
-    case GlobalActorUnsafe:
       return true;
 
     case Unspecified:
@@ -185,7 +180,7 @@ public:
   VarDecl *getActorInstance() const;
 
   bool isGlobalActor() const {
-    return getKind() == GlobalActor || getKind() == GlobalActorUnsafe;
+    return getKind() == GlobalActor;
   }
 
   bool isMainActor() const;
@@ -237,7 +232,6 @@ public:
               lhs.parameterIndex == rhs.parameterIndex);
 
     case GlobalActor:
-    case GlobalActorUnsafe:
       llvm_unreachable("Global actors handled above");
     }
   }
@@ -269,9 +263,6 @@ public:
       return;
     case GlobalActor:
       os << "global_actor";
-      return;
-    case GlobalActorUnsafe:
-      os << "global_actor_unsafe";
       return;
     }
     llvm_unreachable("Covered switch isn't covered?!");

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5743,8 +5743,13 @@ ERROR(global_actor_on_local_variable,none,
 ERROR(global_actor_on_storage_of_value_type,none,
       "stored property %0 within struct cannot have a global actor",
       (DeclName))
-ERROR(global_actor_non_unsafe_init,none,
-      "global actor attribute %0 argument can only be '(unsafe)'", (Type))
+ERROR(unsafe_global_actor,none,
+      "'(unsafe)' global actors are deprecated; "
+      "use '@preconcurrency' instead",
+      ())
+ERROR(global_actor_arg,none,
+      "global actor attribute %0 cannot have arguments",
+      (Type))
 ERROR(global_actor_non_final_class,none,
       "non-final class %0 cannot be a global actor", (DeclName))
 ERROR(global_actor_top_level_var,none,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2789,7 +2789,6 @@ public:
       break;
 
     case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
       printFieldQuoted(isolation.getGlobalActor().getString(),
                        "global_actor_isolated", CapturesColor);
       break;

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1329,8 +1329,6 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
       type.print(Printer, Options);
     else
       attr->getTypeRepr()->print(Printer, Options);
-    if (attr->isArgUnsafe() && Options.IsForSwiftInterface)
-      Printer << "(unsafe)";
     Printer.printNamePost(PrintNameContext::Attribute);
     break;
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10965,9 +10965,9 @@ ActorIsolation swift::getActorIsolationOfContext(
         dcToUse->getASTContext().LangOpts.StrictConcurrencyLevel >=
             StrictConcurrency::Complete) {
       if (Type mainActor = dcToUse->getASTContext().getMainActorType())
-        return ActorIsolation::forGlobalActor(
-            mainActor,
-            /*unsafe=*/!dcToUse->getASTContext().isSwiftVersionAtLeast(6));
+        return ActorIsolation::forGlobalActor(mainActor)
+            .withPreconcurrency(
+                !dcToUse->getASTContext().isSwiftVersionAtLeast(6));
     }
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2512,15 +2512,21 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
         if (type->isAnyActor())
           return true;
 
-        switch (getActorIsolation(type)) {
+        auto isolation = getActorIsolation(type);
+        switch (isolation) {
           case ActorIsolation::Unspecified:
           case ActorIsolation::NonisolatedUnsafe:
-          case ActorIsolation::GlobalActorUnsafe:
             break;
+
+          case ActorIsolation::GlobalActorUnsafe:
+          case ActorIsolation::GlobalActor:
+            if (isolation.preconcurrency())
+              break;
+
+            return true;
 
           case ActorIsolation::ActorInstance:
           case ActorIsolation::Nonisolated:
-          case ActorIsolation::GlobalActor:
             return true;
         }
       }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2518,7 +2518,6 @@ static bool deferMatchesEnclosingAccess(const FuncDecl *defer) {
           case ActorIsolation::NonisolatedUnsafe:
             break;
 
-          case ActorIsolation::GlobalActorUnsafe:
           case ActorIsolation::GlobalActor:
             if (isolation.preconcurrency())
               break;
@@ -10903,7 +10902,6 @@ bool VarDecl::isSelfParamCaptureIsolated() const {
       case ActorIsolation::Nonisolated:
       case ActorIsolation::NonisolatedUnsafe:
       case ActorIsolation::GlobalActor:
-      case ActorIsolation::GlobalActorUnsafe:
         return false;
 
       case ActorIsolation::ActorInstance:

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -910,8 +910,7 @@ static void formatDiagnosticArgument(StringRef Modifier,
       Out << "actor-isolated";
       break;
 
-    case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe: {
+    case ActorIsolation::GlobalActor: {
       if (isolation.isMainActor()) {
         Out << "main actor-isolated";
       } else {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1687,6 +1687,9 @@ ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
 
 void swift::simple_display(
     llvm::raw_ostream &out, const ActorIsolation &state) {
+  if (state.preconcurrency())
+    out << "preconcurrency ";
+
   switch (state) {
     case ActorIsolation::ActorInstance:
       out << "actor-isolated to instance of ";
@@ -1721,9 +1724,6 @@ void swift::simple_display(
       } else {
         out << state.getGlobalActor().getString();
       }
-
-      if (state == ActorIsolation::GlobalActorUnsafe)
-        out << "(unsafe)";
       break;
   }
 }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1663,7 +1663,6 @@ bool ActorIsolation::requiresSubstitution() const {
     return false;
 
   case GlobalActor:
-  case GlobalActorUnsafe:
     return getGlobalActor()->hasTypeParameter();
   }
   llvm_unreachable("unhandled actor isolation kind!");
@@ -1678,7 +1677,6 @@ ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
     return *this;
 
   case GlobalActor:
-  case GlobalActorUnsafe:
     return forGlobalActor(getGlobalActor().subst(subs))
         .withPreconcurrency(preconcurrency());
   }
@@ -1717,7 +1715,6 @@ void swift::simple_display(
       break;
 
     case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
       out << "actor-isolated to global actor ";
       if (state.isSILParsed()) {
         out << "SILPARSED";

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1679,9 +1679,8 @@ ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
 
   case GlobalActor:
   case GlobalActorUnsafe:
-    return forGlobalActor(
-        getGlobalActor().subst(subs), kind == GlobalActorUnsafe)
-              .withPreconcurrency(preconcurrency());
+    return forGlobalActor(getGlobalActor().subst(subs))
+        .withPreconcurrency(preconcurrency());
   }
   llvm_unreachable("unhandled actor isolation kind!");
 }

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -767,7 +767,6 @@ void CompletionLookup::analyzeActorIsolation(
     }
     break;
   }
-  case ActorIsolation::GlobalActorUnsafe:
   case ActorIsolation::GlobalActor: {
     // For "preconcurrency" global actor isolation, automatic 'async' only happens
     // if the context has adopted concurrency.

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -768,14 +768,15 @@ void CompletionLookup::analyzeActorIsolation(
     break;
   }
   case ActorIsolation::GlobalActorUnsafe:
-    // For "unsafe" global actor isolation, automatic 'async' only happens
+  case ActorIsolation::GlobalActor: {
+    // For "preconcurrency" global actor isolation, automatic 'async' only happens
     // if the context has adopted concurrency.
-    if (!CanCurrDeclContextHandleAsync &&
+    if (isolation.preconcurrency() &&
+        !CanCurrDeclContextHandleAsync &&
         !completionContextUsesConcurrencyFeatures(CurrDeclContext)) {
       return;
     }
-    LLVM_FALLTHROUGH;
-  case ActorIsolation::GlobalActor: {
+
     auto getClosureActorIsolation = [this](AbstractClosureExpr *CE) {
       // Prefer solution-specific actor-isolations and fall back to the one
       // recorded in the AST.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3051,7 +3051,6 @@ done:
     SILValue executor;
     switch (*defaultArgIsolation) {
     case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
       executor = SGF.emitLoadGlobalActorExecutor(
           defaultArgIsolation->getGlobalActor());
       break;
@@ -5630,7 +5629,6 @@ RValue SILGenFunction::emitApply(
       break;
 
     case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
       executor = emitLoadGlobalActorExecutor(
           implicitActorHopTarget->getGlobalActor());
       break;

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -611,7 +611,6 @@ static bool ctorHopsInjectedByDefiniteInit(ConstructorDecl *ctor,
     case ActorIsolation::Nonisolated:
     case ActorIsolation::NonisolatedUnsafe:
     case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
       return false;
   }
 }
@@ -1582,7 +1581,6 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
       break;
 
     case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
     case ActorIsolation::ActorInstance: {
       if (requiredIsolation != contextIsolation) {
         // Implicit initializers diagnose actor isolation violations

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1274,7 +1274,6 @@ void SILGenFunction::emitProlog(
           return true;
 
         case ActorIsolation::GlobalActor:
-        case ActorIsolation::GlobalActorUnsafe:
           // Global-actor-isolated types should likely have deinits that
           // are not themselves actor-isolated, yet still have access to
           // the instance properties of the class.
@@ -1373,7 +1372,6 @@ void SILGenFunction::emitProlog(
     }
 
     case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
       if (F.isAsync() || wantDataRaceChecks) {
         ExpectedExecutor =
           emitLoadGlobalActorExecutor(actorIsolation.getGlobalActor());
@@ -1397,7 +1395,6 @@ void SILGenFunction::emitProlog(
     }
 
     case ActorIsolation::GlobalActor:
-    case ActorIsolation::GlobalActorUnsafe:
       if (wantExecutor) {
         ExpectedExecutor =
           emitLoadGlobalActorExecutor(actorIsolation.getGlobalActor());
@@ -1553,7 +1550,6 @@ SILGenFunction::emitExecutor(SILLocation loc, ActorIsolation isolation,
   }
 
   case ActorIsolation::GlobalActor:
-  case ActorIsolation::GlobalActorUnsafe:
     return emitLoadGlobalActorExecutor(isolation.getGlobalActor());
   }
   llvm_unreachable("covered switch");

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1047,7 +1047,6 @@ void LifetimeChecker::injectActorHops() {
   case ActorIsolation::Unspecified:
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedUnsafe:
-  case ActorIsolation::GlobalActorUnsafe:
   case ActorIsolation::GlobalActor:
     return;
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7727,7 +7727,6 @@ ConstraintSystem::inferKeyPathLiteralCapability(KeyPathExpr *keyPath) {
       // A reference to an actor isolated state make key path non-Sendable.
       case ActorIsolation::ActorInstance:
       case ActorIsolation::GlobalActor:
-      case ActorIsolation::GlobalActorUnsafe:
         isSendable = false;
         break;
       }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4863,8 +4863,6 @@ ActorIsolation ActorIsolationRequest::evaluate(
             TypeExpr::createImplicit(inferred.getGlobalActor(), ctx);
         auto attr =
             CustomAttr::create(ctx, SourceLoc(), typeExpr, /*implicit=*/true);
-        if (inferred == ActorIsolation::GlobalActorUnsafe)
-          attr->setArgIsUnsafe(true);
         value->getAttrs().add(attr);
 
         if (inferred.preconcurrency()) {

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -483,7 +483,6 @@ static bool checkObjCActorIsolation(const ValueDecl *VD, ObjCReason Reason) {
     return false;
 
   case ActorIsolation::GlobalActor:
-  case ActorIsolation::GlobalActorUnsafe:
     // FIXME: Consider whether to limit @objc on global-actor-qualified
     // declarations. Perhaps only allow main actor, which we can reflect
     // in the generated header.

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -96,7 +96,6 @@ static VarDecl *findValueProperty(ASTContext &ctx, NominalTypeDecl *nominal,
     return nullptr;
 
   case ActorIsolation::GlobalActor:
-  case ActorIsolation::GlobalActorUnsafe:
   case ActorIsolation::Nonisolated:
   case ActorIsolation::NonisolatedUnsafe:
   case ActorIsolation::Unspecified:

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3863,8 +3863,8 @@ public:
 
       case ActorIsolation::GlobalActor:
       case ActorIsolation::GlobalActorUnsafe:
-        isolation = ActorIsolation::forGlobalActor(
-            globalActor, isoKind == ActorIsolation::GlobalActorUnsafe);
+        isolation = ActorIsolation::forGlobalActor(globalActor)
+            .withPreconcurrency(isoKind == ActorIsolation::GlobalActorUnsafe);
         break;
 
       case ActorIsolation::ActorInstance:

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -468,8 +468,9 @@ getActualActorIsolationKind(uint8_t raw) {
   CASE(Nonisolated)
   CASE(NonisolatedUnsafe)
   CASE(GlobalActor)
-  CASE(GlobalActorUnsafe)
 #undef CASE
+  case serialization::ActorIsolation::GlobalActorUnsafe:
+    return swift::ActorIsolation::GlobalActor;
   }
   return llvm::None;
 }
@@ -3862,7 +3863,6 @@ public:
         break;
 
       case ActorIsolation::GlobalActor:
-      case ActorIsolation::GlobalActorUnsafe:
         // 'unsafe' or 'preconcurrency' doesn't mean anything for isolated
         // default arguments.
         isolation = ActorIsolation::forGlobalActor(globalActor);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3863,8 +3863,9 @@ public:
 
       case ActorIsolation::GlobalActor:
       case ActorIsolation::GlobalActorUnsafe:
-        isolation = ActorIsolation::forGlobalActor(globalActor)
-            .withPreconcurrency(isoKind == ActorIsolation::GlobalActorUnsafe);
+        // 'unsafe' or 'preconcurrency' doesn't mean anything for isolated
+        // default arguments.
+        isolation = ActorIsolation::forGlobalActor(globalActor);
         break;
 
       case ActorIsolation::ActorInstance:

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1427,7 +1427,6 @@ getRawStableActorIsolationKind(swift::ActorIsolation::Kind kind) {
   CASE(Nonisolated)
   CASE(NonisolatedUnsafe)
   CASE(GlobalActor)
-  CASE(GlobalActorUnsafe)
 #undef CASE
   }
   llvm_unreachable("bad actor isolation");

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -11,8 +11,10 @@ actor SomeGlobalActor {
   static let shared = SomeGlobalActor()
 }
 
+// expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
 @MainActor(unsafe) func globalMain() { } // expected-note {{calls to global function 'globalMain()' from outside of its actor context are implicitly asynchronous}}
 
+// expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
 @SomeGlobalActor(unsafe) func globalSome() { } // expected-note 2{{calls to global function 'globalSome()' from outside of its actor context are implicitly asynchronous}}
 // expected-complete-tns-note @-1 {{calls to global function 'globalSome()' from outside of its actor context are implicitly asynchronous}}
 
@@ -20,6 +22,7 @@ actor SomeGlobalActor {
 // Witnessing and unsafe global actor
 // ----------------------------------------------------------------------
 protocol P1 {
+  // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
   @MainActor(unsafe) func onMainActor() // expected-note 2{{mark the protocol requirement 'onMainActor()' 'async' to allow actor-isolated conformances}}
 }
 
@@ -45,7 +48,7 @@ struct S4_P1: P1 {
   @SomeGlobalActor func onMainActor() { } // expected-warning{{global actor 'SomeGlobalActor'-isolated instance method 'onMainActor()' cannot be used to satisfy main actor-isolated protocol requirement}}
 }
 
-
+// expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
 @MainActor(unsafe)
 protocol P2 {
   func f() // expected-note{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
@@ -80,6 +83,7 @@ func testP2_noconcurrency(x: S5_P2, p2: P2) {
 // Overriding and unsafe global actor
 // ----------------------------------------------------------------------
 class C1 {
+  // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
   @MainActor(unsafe) func method() { } // expected-note{{overridden declaration is here}}
 }
 
@@ -114,12 +118,14 @@ class C6: C2 {
 }
 
 class C7: C2 {
+  // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
   @SomeGlobalActor(unsafe) override func method() { // expected-error{{global actor 'SomeGlobalActor'-isolated instance method 'method()' has different actor isolation from main actor-isolated overridden declaration}}
     globalMain() // expected-warning{{call to main actor-isolated global function 'globalMain()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
     globalSome() // okay
   }
 }
 
+// expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
 @MainActor(unsafe) // expected-note {{'GloballyIsolatedProto' is isolated to global actor 'MainActor' here}}
 protocol GloballyIsolatedProto {
 }

--- a/test/Concurrency/actor_isolation_unsafe.swift
+++ b/test/Concurrency/actor_isolation_unsafe.swift
@@ -62,7 +62,7 @@ struct S5_P2: P2 {
 nonisolated func testP2(x: S5_P2, p2: P2) {
   p2.f() // expected-warning{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p2.g() // OKAY
-  x.f() // expected-error{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  x.f() // expected-warning{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   x.g() // OKAY
 }
 
@@ -72,7 +72,7 @@ func testP2_noconcurrency(x: S5_P2, p2: P2) {
   // expected-complete-tns-warning @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p2.g() // okay
   x.f() // okay without complete. with targeted/minimal not concurrency-related code
-  // expected-complete-tns-error @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
+  // expected-complete-tns-warning @-1 {{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   x.g() // OKAY
 }
 

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -26,8 +26,8 @@ actor Door {
     @MainActor var globActor_mutable : Int = 0
     @MainActor let globActor_immutable : Int = 0
 
-    @MainActor(unsafe) var unsafeGlobActor_mutable : Int = 0
-    @MainActor(unsafe) let unsafeGlobActor_immutable : Int = 0
+    @preconcurrency @MainActor var unsafeGlobActor_mutable : Int = 0
+    @preconcurrency @MainActor let unsafeGlobActor_immutable : Int = 0
 
     subscript(byIndex: Int) -> Int { 0 }
 

--- a/test/Concurrency/actor_keypath_isolation_swift6.swift
+++ b/test/Concurrency/actor_keypath_isolation_swift6.swift
@@ -25,8 +25,8 @@ actor Door {
     @MainActor var globActor_mutable : Int = 0
     @MainActor let globActor_immutable : Int = 0
 
-    @MainActor(unsafe) var unsafeGlobActor_mutable : Int = 0
-    @MainActor(unsafe) let unsafeGlobActor_immutable : Int = 0
+    @preconcurrency @MainActor var unsafeGlobActor_mutable : Int = 0
+    @preconcurrency @MainActor let unsafeGlobActor_immutable : Int = 0
 
     subscript(byIndex: Int) -> Int { 0 }
 

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -112,8 +112,13 @@ enum E {
 struct SomeStruct {
   @MainActor init(asyncMainActor: Int) async {}
   @MainActor init(mainActor: Int) {} // expected-note {{calls to initializer 'init(mainActor:)' from outside of its actor context are implicitly asynchronous}}
+
+  // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
   @MainActor(unsafe) init(asyncMainActorUnsafe: Int) async {}
-  @MainActor(unsafe) init(mainActorUnsafe: Int) {} // expected-complete-and-tns-note {{calls to initializer 'init(mainActorUnsafe:)' from outside of its actor context are implicitly asynchronous}}
+
+  // expected-warning@+2 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
+  // expected-complete-and-tns-note@+1 {{calls to initializer 'init(mainActorUnsafe:)' from outside of its actor context are implicitly asynchronous}}
+  @MainActor(unsafe) init(mainActorUnsafe: Int) {}
 }
 
 // expected-complete-and-tns-note @+3 {{add '@MainActor' to make global function 'globActorTest1()' part of global actor 'MainActor'}}

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -28,10 +28,10 @@ func testConversions(f: @escaping @SomeGlobalActor (Int) -> Void, g: @escaping (
 }
 
 @SomeGlobalActor func onSomeGlobalActor() -> Int { 5 }
-@SomeGlobalActor(unsafe) func onSomeGlobalActorUnsafe() -> Int { 5 }
+@preconcurrency @SomeGlobalActor func onSomeGlobalActorUnsafe() -> Int { 5 }
 
 @OtherGlobalActor func onOtherGlobalActor() -> Int { 5 } // expected-note{{calls to global function 'onOtherGlobalActor()' from outside of its actor context are implicitly asynchronous}}
-@OtherGlobalActor(unsafe) func onOtherGlobalActorUnsafe() -> Int { 5 }  // expected-note 2{{calls to global function 'onOtherGlobalActorUnsafe()' from outside of its actor context are implicitly asynchronous}}
+@preconcurrency @OtherGlobalActor func onOtherGlobalActorUnsafe() -> Int { 5 }  // expected-note 2{{calls to global function 'onOtherGlobalActorUnsafe()' from outside of its actor context are implicitly asynchronous}}
 // expected-complete-tns-note @-1 {{calls to global function 'onOtherGlobalActorUnsafe()' from outside of its actor context are implicitly asynchronous}}
 
 func someSlowOperation() async -> Int { 5 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -49,7 +49,7 @@ struct Carbon {
 // ----------------------------------------------------------------------
 // Check that @MainActor(blah) doesn't work
 // ----------------------------------------------------------------------
-// expected-error@+1{{global actor attribute 'MainActor' argument can only be '(unsafe)'}}
+// expected-error@+1{{global actor attribute 'MainActor' cannot have arguments}}
 @MainActor(blah) func brokenMainActorAttr() { }
 
 // ----------------------------------------------------------------------
@@ -504,7 +504,7 @@ class WrappedContainsNonisolatedAttr {
 // Unsafe global actors
 // ----------------------------------------------------------------------
 protocol UGA {
-  @SomeGlobalActor(unsafe) func req() // expected-note{{calls to instance method 'req()' from outside of its actor context are implicitly asynchronous}}
+  @preconcurrency @SomeGlobalActor func req() // expected-note{{calls to instance method 'req()' from outside of its actor context are implicitly asynchronous}}
 }
 
 struct StructUGA1: UGA {
@@ -528,7 +528,7 @@ func testUGA<T: UGA>(_ value: T) {
 }
 
 class UGAClass {
-  @SomeGlobalActor(unsafe) func method() { }
+  @preconcurrency @SomeGlobalActor func method() { }
 }
 
 class UGASubclass1: UGAClass {
@@ -540,7 +540,7 @@ class UGASubclass2: UGAClass {
 }
 
 @propertyWrapper
-@OtherGlobalActor(unsafe)
+@preconcurrency @OtherGlobalActor
 struct WrapperOnUnsafeActor<Wrapped> {
   private var stored: Wrapped
 
@@ -548,12 +548,12 @@ struct WrapperOnUnsafeActor<Wrapped> {
     stored = wrappedValue
   }
 
-  @MainActor(unsafe) var wrappedValue: Wrapped {
+  @preconcurrency @MainActor var wrappedValue: Wrapped {
     get { }
     set { }
   }
 
-  @SomeGlobalActor(unsafe) var projectedValue: Wrapped {
+  @preconcurrency @SomeGlobalActor var projectedValue: Wrapped {
     get { }
     set { }
   }

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -112,7 +112,7 @@ open class TestThing {}
 open class TestSubThing : TestThing {}
 
 @available(SwiftStdlib 5.1, *)
-@MainActor(unsafe)
+@MainActor(unsafe) // expected-warning {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
 open class TestThing2 {}
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/toplevel/async-5-top-level.swift
+++ b/test/Concurrency/toplevel/async-5-top-level.swift
@@ -22,7 +22,7 @@ func isolatedSync() {
 func nonIsolatedAsync() async {
     await print(a)
     a = a + 10
-    // expected-error@-1:5 {{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
+    // expected-warning@-1:5 {{main actor-isolated var 'a' can not be mutated from a non-isolated context}}
     // expected-warning@-2:9 {{expression is 'async' but is not marked with 'await'}}{{9-9=await }}
     // expected-note@-3:9 {{property access is 'async'}}
 }

--- a/test/Sema/availability_main_actor.swift
+++ b/test/Sema/availability_main_actor.swift
@@ -8,7 +8,7 @@
 @MainActor
 struct AlwaysAvailable {}
 
-@MainActor(unsafe)
+@preconcurrency @MainActor
 struct AlwaysAvailableUnsafe {}
 
 @available(SwiftStdlib 5.1, *)
@@ -16,5 +16,5 @@ struct AlwaysAvailableUnsafe {}
 struct AvailableSwift5_1 {}
 
 @available(SwiftStdlib 5.1, *)
-@MainActor(unsafe)
+@preconcurrency @MainActor
 struct AvailableSwift5_1Unsafe {}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -1878,7 +1878,7 @@ class HasIBOutlet {
 // CHECK-LABEL: {{^}}class HasIBAction {
 class HasIBAction {
   @IBAction func goodAction(_ sender: AnyObject?) { }
-  // CHECK: {{^}}  @objc @IBAction @MainActor func goodAction(_ sender: AnyObject?) {
+  // CHECK: {{^}}  @objc @IBAction @MainActor @preconcurrency func goodAction(_ sender: AnyObject?) {
 
   @IBAction func badAction(_ sender: PlainStruct?) { }
   // expected-error@-1{{method cannot be marked @IBAction because the type of the parameter cannot be represented in Objective-C}}

--- a/test/decl/class/actor/global_actor_conformance.swift
+++ b/test/decl/class/actor/global_actor_conformance.swift
@@ -58,7 +58,7 @@ extension OnMain: NonIsolatedRequirement {
 }
 
 // expected-note@+1 {{calls to global function 'downgrade()' from outside of its actor context are implicitly asynchronous}}
-@MainActor(unsafe) func downgrade() {}
+@preconcurrency @MainActor func downgrade() {}
 
 extension OnMain {
   struct Nested {

--- a/validation-test/ParseableInterface/unsafe-mainactor.swift
+++ b/validation-test/ParseableInterface/unsafe-mainactor.swift
@@ -7,8 +7,8 @@
 
 import AppKit
 
-// CHECK: @objc @_inheritsConvenienceInitializers @_Concurrency.MainActor(unsafe) public class Subclass : AppKit.NSView {
+// CHECK: @objc @_inheritsConvenienceInitializers @_Concurrency.MainActor @preconcurrency public class Subclass : AppKit.NSView {
 public class Subclass: NSView {
-  // CHECK: @_Concurrency.MainActor(unsafe) @objc override dynamic public init(frame frameRect: Foundation.NSRect)
-  // CHECK: @_Concurrency.MainActor(unsafe) @objc required dynamic public init?(coder: Foundation.NSCoder)
+  // CHECK: @_Concurrency.MainActor @preconcurrency @objc override dynamic public init(frame frameRect: Foundation.NSRect)
+  // CHECK: @_Concurrency.MainActor @preconcurrency @objc required dynamic public init?(coder: Foundation.NSCoder)
 }

--- a/validation-test/Sema/SwiftUI/rdar76252310.swift
+++ b/validation-test/Sema/SwiftUI/rdar76252310.swift
@@ -42,13 +42,13 @@ func fromConcurrencyAware() async {
   // expected-warning@+4 {{non-sendable type 'CoffeeTrackerView' passed in implicitly asynchronous call to main actor-isolated property 'body' cannot cross actor boundary}}
   // expected-note@+3 {{property access is 'async'}}
   // expected-warning@+2 {{non-sendable type 'some View' in implicitly asynchronous access to main actor-isolated property 'body' cannot cross actor boundary}}
-  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@+1 {{expression is 'async' but is not marked with 'await'}}
   _ = view.body
 
   // expected-warning@+4 {{non-sendable type 'CoffeeTrackerView' passed in implicitly asynchronous call to main actor-isolated property 'showDrinkList' cannot cross actor boundary}}
   // expected-note@+3 {{property access is 'async'}}
   // expected-warning@+2 {{non-sendable type 'Visibility' in implicitly asynchronous access to main actor-isolated property 'showDrinkList' cannot cross actor boundary}}
-  // expected-error@+1 {{expression is 'async' but is not marked with 'await'}}
+  // expected-warning@+1 {{expression is 'async' but is not marked with 'await'}}
   _ = view.showDrinkList
 
   // expected-warning@+2 {{non-sendable type 'CoffeeTrackerView' passed in implicitly asynchronous call to main actor-isolated property 'storage' cannot cross actor boundary}}


### PR DESCRIPTION
For a global actor type `GlobalActor`, `@GlobalActor(unsafe)` was a pre-Swift Evolution spelling for `@preconcurrency @GlobalActor`. These two spellings mean the same thing, but there were two different representations in the actor isolation checker. Standardize on the preconcurrency representation.

A diagnostic is now emitted if the `(unsafe)` spelling is written in source, staged in as a warning until Swift 6 and ignored in Swift interfaces. Swift interfaces will now stop printing `(unsafe)`, even if it was written in source, in favor of `@preconcurrency`.