### PR TITLE
[Runtime][IRGen] Trap C++ exceptions on *throw*, not catch.

### DIFF
--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -59,6 +59,7 @@ FEATURE(SignedDescriptor,                               (5, 9))
 FEATURE(ObjCSymbolicReferences,                         (5, 11))
 FEATURE(TypedThrows,                                    (5, 11))
 FEATURE(StaticReadOnlyArrays,                           (5, 11))
+FEATURE(SwiftExceptionPersonality,                      (5, 11))
 
 FEATURE(TaskExecutor,                                   FUTURE)
 FEATURE(Differentiation,                                FUTURE)

--- a/include/swift/Runtime/Exception.h
+++ b/include/swift/Runtime/Exception.h
@@ -1,0 +1,42 @@
+//===--- Exception.h - Exception support ------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift doesn't support exception handlers, but might call code that uses
+// exceptions, and when they leak out into Swift code, we want to trap them.
+//
+// To that end, we have our own exception personality routine, which we use
+// to trap exceptions and terminate.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_EXCEPTION_H
+#define SWIFT_RUNTIME_EXCEPTION_H
+
+#include "swift/Runtime/Config.h"
+
+#if defined(__ELF__) || defined(__APPLE__)
+#include <unwind.h>
+
+namespace swift {
+
+SWIFT_RUNTIME_STDLIB_API _Unwind_Reason_Code
+swift_exceptionPersonality(int version,
+                           _Unwind_Action actions,
+                           uint64_t exceptionClass,
+                           struct _Unwind_Exception *exceptionObject,
+                           struct _Unwind_Context *context);
+
+} // end namespace swift
+
+#endif // defined(__ELF__) || defined(__APPLE__)
+
+#endif // SWIFT_RUNTIME_EXCEPTION_H

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2807,6 +2807,24 @@ FUNCTION(InitRawStructMetadata,
          EFFECT(MetaData),
          UNKNOWN_MEMEFFECTS)
 
+// _Unwind_Reason_Code swift_exceptionPersonality(int version,
+//                                                _Unwind_Action actions,
+//                                                uint64 exceptionClass,
+//                                                struct _Unwind_Exception *exceptionObject,
+//                                                struct _Unwind_Context *context);
+FUNCTION(ExceptionPersonality,
+         swift_exceptionPersonality,
+         C_CC, AlwaysAvailable,
+         RETURNS(Int32Ty),
+         ARGS(Int32Ty,
+              Int32Ty,
+              Int64Ty,
+              Int8PtrTy,
+              Int8PtrTy),
+         ATTRS(NoUnwind),
+         EFFECT(NoEffect),
+         UNKNOWN_MEMEFFECTS)
+
 #undef RETURNS
 #undef ARGS
 #undef ATTRS

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2807,13 +2807,13 @@ FUNCTION(InitRawStructMetadata,
          EFFECT(MetaData),
          UNKNOWN_MEMEFFECTS)
 
-// _Unwind_Reason_Code swift_exceptionPersonality(int version,
-//                                                _Unwind_Action actions,
-//                                                uint64 exceptionClass,
-//                                                struct _Unwind_Exception *exceptionObject,
-//                                                struct _Unwind_Context *context);
+// _Unwind_Reason_Code _swift_exceptionPersonality(int version,
+//                                                 _Unwind_Action actions,
+//                                                 uint64 exceptionClass,
+//                                                 struct _Unwind_Exception *exceptionObject,
+//                                                 struct _Unwind_Context *context);
 FUNCTION(ExceptionPersonality,
-         swift_exceptionPersonality,
+         _swift_exceptionPersonality,
          C_CC, AlwaysAvailable,
          RETURNS(Int32Ty),
          ARGS(Int32Ty,

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -4997,11 +4997,9 @@ void IRGenFunction::emitEpilogue() {
 
     auto deploymentAvailability =
       AvailabilityContext::forDeploymentTarget(IGM.Context);
-    bool canUseSwiftPersonality = deploymentAvailability.isContainedIn(
-      IGM.Context.getSwift511Availability());
     llvm::Constant *personality;
 
-    if (canUseSwiftPersonality) {
+    if (IGM.isSwiftExceptionPersonalityFeatureAvailable()) {
       // The function should use our personality routine
       auto swiftPersonality = IGM.getExceptionPersonalityFunctionPointer();
       personality = swiftPersonality.getDirectPointer();

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -47,6 +47,7 @@ set(swift_runtime_sources
     ErrorObjectNative.cpp
     Errors.cpp
     ErrorDefaultImpls.cpp
+    Exception.cpp
     Exclusivity.cpp
     ExistentialContainer.cpp
     Float16Support.cpp

--- a/stdlib/public/runtime/Exception.cpp
+++ b/stdlib/public/runtime/Exception.cpp
@@ -1,0 +1,51 @@
+//===--- Exception.cpp - Exception support --------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Swift doesn't support exception handlers, but might call code that uses
+// exceptions, and when they leak out into Swift code, we want to trap them.
+//
+// To that end, we have our own exception personality routine, which we use
+// to trap exceptions and terminate.
+//
+//===----------------------------------------------------------------------===//
+
+#if defined(__ELF__) || defined(__APPLE__)
+
+#include <exception>
+
+#include <cstdio>
+
+#include <unwind.h>
+
+#include "swift/Runtime/Exception.h"
+
+using namespace swift;
+
+extern "C" void __cxa_begin_catch(void *);
+
+SWIFT_RUNTIME_STDLIB_API _Unwind_Reason_Code
+swift_exceptionPersonality(int version,
+                           _Unwind_Action actions,
+                           uint64_t exceptionClass,
+                           struct _Unwind_Exception *exceptionObject,
+                           struct _Unwind_Context *context)
+{
+  // Handle exceptions by catching them and calling std::terminate().
+  // This, in turn, will trigger the unhandled exception routine in the
+  // C++ runtime.
+  __cxa_begin_catch(exceptionObject);
+  std::terminate();
+
+  return _URC_FATAL_PHASE1_ERROR;
+}
+
+#endif /* defined(__ELF__) || defined(__APPLE__) */

--- a/stdlib/public/runtime/Exception.cpp
+++ b/stdlib/public/runtime/Exception.cpp
@@ -33,11 +33,11 @@ using namespace swift;
 extern "C" void __cxa_begin_catch(void *);
 
 SWIFT_RUNTIME_STDLIB_API _Unwind_Reason_Code
-swift_exceptionPersonality(int version,
-                           _Unwind_Action actions,
-                           uint64_t exceptionClass,
-                           struct _Unwind_Exception *exceptionObject,
-                           struct _Unwind_Context *context)
+_swift_exceptionPersonality(int version,
+                            _Unwind_Action actions,
+                            uint64_t exceptionClass,
+                            struct _Unwind_Exception *exceptionObject,
+                            struct _Unwind_Context *context)
 {
   // Handle exceptions by catching them and calling std::terminate().
   // This, in turn, will trigger the unhandled exception routine in the

--- a/test/Interop/Cxx/exceptions/objc-trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/objc-trap-on-exception-irgen-itanium.swift
@@ -32,7 +32,7 @@ func testObjCMethodCall() {
 
 testObjCMethodCall()
 
-// CHECK: define {{.*}} @"$s4test0A14ObjCMethodCallyyF"() #[[#UWATTR:]] personality ptr @swift_exceptionPersonality
+// CHECK: define {{.*}} @"$s4test0A14ObjCMethodCallyyF"() #[[#UWATTR:]] personality ptr @_swift_exceptionPersonality
 // CHECK: invoke void {{.*}}@objc_msgSend
 // CHECK-NEXT: to label %[[CONT1:.*]] unwind label %[[UNWIND1:.*]]
 // CHECK-EMPTY:

--- a/test/Interop/Cxx/exceptions/objc-trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/objc-trap-on-exception-irgen-itanium.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-emit-ir %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir -target %target-future-triple -min-runtime-version 5.11 %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir -target %target-triple -min-runtime-version 5.9 %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop | %FileCheck %s --check-prefix=GXX
 
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=windows-msvc
@@ -45,3 +46,17 @@ testObjCMethodCall()
 // CHECK-NEXT: call void @llvm.trap()
 // CHECK-NEXT: unreachable
 // CHECK-NEXT: }
+
+// GXX: define {{.*}} @"$s4test0A14ObjCMethodCallyyF"() #[[#UWATTR:]] personality ptr @__gxx_personality_v0
+// GXX: invoke void {{.*}}@objc_msgSend
+// GXX-NEXT: to label %[[CONT1:.*]] unwind label %[[UNWIND1:.*]]
+// GXX-EMPTY:
+// GXX-NEXT: [[CONT1]]:
+// GXX:  ret
+// GXX-EMPTY:
+// GXX-NEXT: [[UNWIND1]]:
+// GXX-NEXT: landingpad { ptr, i32 }
+// GXX-NEXT:    catch ptr null
+// GXX-NEXT: call void @llvm.trap()
+// GXX-NEXT: unreachable
+// GXX-NEXT: }

--- a/test/Interop/Cxx/exceptions/objc-trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/objc-trap-on-exception-irgen-itanium.swift
@@ -32,7 +32,7 @@ func testObjCMethodCall() {
 
 testObjCMethodCall()
 
-// CHECK: define {{.*}} @"$s4test0A14ObjCMethodCallyyF"() #[[#UWATTR:]] personality
+// CHECK: define {{.*}} @"$s4test0A14ObjCMethodCallyyF"() #[[#UWATTR:]] personality ptr @swift_exceptionPersonality
 // CHECK: invoke void {{.*}}@objc_msgSend
 // CHECK-NEXT: to label %[[CONT1:.*]] unwind label %[[UNWIND1:.*]]
 // CHECK-EMPTY:

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -1,8 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-emit-ir %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop | %FileCheck %s
-// RUN: %target-swift-emit-ir %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop -g | %FileCheck --check-prefix=DEBUG %s
+// RUN: %target-swift-emit-ir -target %target-future-triple -min-runtime-version 5.11 %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir -target %target-future-triple -min-runtime-version 5.11 %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop -g | %FileCheck --check-prefix=DEBUG %s
+// RUN: %target-swift-emit-ir -target %target-triple -min-runtime-version 5.9 %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop | %FileCheck --check-prefix=GXX %s
+// RUN: %target-swift-emit-ir -target %target-triple -min-runtime-version 5.9 %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop -g | %FileCheck --check-prefix=GXX %s
 
 // UNSUPPORTED: OS=windows-msvc
 
@@ -335,7 +337,7 @@ public func test() {
 // CHECK-NEXT: unreachable
 // CHECK-NEXT: }
 
-// CHECK: i32 @_swift_exceptionPersonality(...)
+// CHECK: i32 @_swift_exceptionPersonality(i32, i32, i64, ptr, ptr)
 
 // CHECK: define {{.*}} @"$s4test0A11MethodCallss5Int32VyF"() #[[#SWIFTUWMETA]] personality
 // CHECK: call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
@@ -502,3 +504,6 @@ public func test() {
 // DEBUG: ![[#DEBUGLOC_TRAP1]] = !DILocation(line: 0, scope: ![[#TRAPSCOPE:]], inlinedAt: ![[#DEBUGLOC_FREEFUNCTIONTHROWS1]])
 // DEBUG: ![[#TRAPSCOPE]] = distinct !DISubprogram(name: "Swift runtime failure: unhandled C++{{ / Objective-C | }}exception"
 // DEBUG: ![[#DEBUGLOC_TRAP2]] = !DILocation(line: 0, scope: ![[#TRAPSCOPE]], inlinedAt: ![[#DEBUGLOC_FREEFUNCTIONTHROWS2]])
+
+// GXX: __gxx_personality_v0
+// GXX-NOT: _swift_exceptionPersonality

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -309,7 +309,7 @@ public func test() {
 // CHECK-NEXT:  ret i32
 // CHECK-NEXT: }
 
-// CHECK: define {{.*}} @"$s4test0A17FreeFunctionCallss5Int32VyF"() #[[#SWIFTUWMETA:]] personality ptr @swift_exceptionPersonality
+// CHECK: define {{.*}} @"$s4test0A17FreeFunctionCallss5Int32VyF"() #[[#SWIFTUWMETA:]] personality ptr @_swift_exceptionPersonality
 // CHECK:   invoke i32 @_Z18freeFunctionThrowsi(i32 0)
 // CHECK-NEXT:  to label %[[CONT1:.*]] unwind label %[[UNWIND1:.*]]
 // CHECK-EMPTY:
@@ -335,7 +335,7 @@ public func test() {
 // CHECK-NEXT: unreachable
 // CHECK-NEXT: }
 
-// CHECK: i32 @__gxx_personality_v0(...)
+// CHECK: i32 @_swift_exceptionPersonality(...)
 
 // CHECK: define {{.*}} @"$s4test0A11MethodCallss5Int32VyF"() #[[#SWIFTUWMETA]] personality
 // CHECK: call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -309,7 +309,7 @@ public func test() {
 // CHECK-NEXT:  ret i32
 // CHECK-NEXT: }
 
-// CHECK: define {{.*}} @"$s4test0A17FreeFunctionCallss5Int32VyF"() #[[#SWIFTUWMETA:]] personality ptr @__gxx_personality_v0
+// CHECK: define {{.*}} @"$s4test0A17FreeFunctionCallss5Int32VyF"() #[[#SWIFTUWMETA:]] personality ptr @swift_exceptionPersonality
 // CHECK:   invoke i32 @_Z18freeFunctionThrowsi(i32 0)
 // CHECK-NEXT:  to label %[[CONT1:.*]] unwind label %[[UNWIND1:.*]]
 // CHECK-EMPTY:

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -255,3 +255,4 @@ Added: __swift_pod_direct_initializeBufferWithCopyOfBuffer
 Added: __swift_pod_indirect_initializeBufferWithCopyOfBuffer
 Added: __swift_validatePrespecializedMetadata
 Added: _swift_willThrowTypedImpl
+Added: _swift_exceptionPersonality

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -254,5 +254,5 @@ Added: __swift_pod_destroy
 Added: __swift_pod_direct_initializeBufferWithCopyOfBuffer
 Added: __swift_pod_indirect_initializeBufferWithCopyOfBuffer
 Added: __swift_validatePrespecializedMetadata
+Added: __swift_exceptionPersonality
 Added: _swift_willThrowTypedImpl
-Added: _swift_exceptionPersonality

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -255,3 +255,4 @@ Added: __swift_pod_direct_initializeBufferWithCopyOfBuffer
 Added: __swift_pod_indirect_initializeBufferWithCopyOfBuffer
 Added: __swift_validatePrespecializedMetadata
 Added: _swift_willThrowTypedImpl
+Added: _swift_exceptionPersonality

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -254,5 +254,5 @@ Added: __swift_pod_destroy
 Added: __swift_pod_direct_initializeBufferWithCopyOfBuffer
 Added: __swift_pod_indirect_initializeBufferWithCopyOfBuffer
 Added: __swift_validatePrespecializedMetadata
+Added: __swift_exceptionPersonality
 Added: _swift_willThrowTypedImpl
-Added: _swift_exceptionPersonality


### PR DESCRIPTION
The previous approach was effectively to catch the exception and then run a trap instruction.  That has the unfortunate feature that we end up with a crash at the catch site, not at the throw site, which leaves us with very little information about which exception was thrown or where from.

(Strictly we do have the exception pointer and could obtain exception information, but it still won't tell us what threw it.)

Instead of that, set a personality function for Swift functions that call potentially throwing code, and have that personality function trap the exception during phase 1 (i.e. *before* the original stack has been unwound).

rdar://120952971
