### PR TITLE
`@Observable` Macro supports properties with the `package` access modifier

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -118,6 +118,7 @@ extension DeclModifierListSyntax {
         case .fileprivate: fallthrough
         case .private: fallthrough
         case .internal: fallthrough
+        case .package: fallthrough
         case .public:
           return false
         default:

--- a/test/ModuleInterface/Observable.swift
+++ b/test/ModuleInterface/Observable.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -plugin-path %swift-plugin-dir -disable-availability-checking
-// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library -disable-availability-checking
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -package-name Library -module-name Library -plugin-path %swift-plugin-dir -disable-availability-checking
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -package-name Library -module-name Library -disable-availability-checking
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 
 // REQUIRES: swift_swift_parser
@@ -15,6 +15,7 @@ import Observation
 @Observable
 public class SomeClass {
   public var field = 3
+  package var test = 4
   @ObservationIgnored public var ignored = 4
 }
 


### PR DESCRIPTION
I want to change the `@Observable` Macro so that properties with the `package` access modifier do not cause build errors.

Resolves #71060.

(Thanks to @p-x9 via https://x.com/p_x9/status/1749374558732493102)