### PR TITLE
Install swift-format into Linux toolchains

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -865,6 +865,7 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
+swiftformat
 swiftdocc
 lit-args=-v --time-tests
 


### PR DESCRIPTION
It looks like we were only installing swift-format into macOS toolchains. We should also build it on Linux toolchains so it can be installed there as well.
