### PR TITLE
[CodeComplete] Delete `.` in completion suggestions of call pattern

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1233,6 +1233,10 @@ void CompletionLookup::addFunctionCallPattern(
             : CodeCompletionResultKind::Pattern,
         SemanticContext ? *SemanticContext : getSemanticContextKind(AFD));
     Builder.addFlair(CodeCompletionFlairBit::ArgumentLabels);
+    if (DotLoc) {
+      Builder.setNumBytesToErase(Ctx.SourceMgr.getByteDistance(
+          DotLoc, Ctx.SourceMgr.getIDEInspectionTargetLoc()));
+    }
     if (AFD)
       Builder.setAssociatedDecl(AFD);
 

--- a/test/IDE/complete_call_pattern_after_dot.swift
+++ b/test/IDE/complete_call_pattern_after_dot.swift
@@ -1,0 +1,16 @@
+// RUN: %batch-code-completion
+
+struct Foo {
+  func bar(argLabel: Int) -> Int { 1 }
+}
+let x = Foo().bar
+x.#^AFTER_DOT^#
+// AFTER_DOT: Pattern/CurrModule/Flair[ArgLabels]/Erase[1]: ({#Int#})[#Int#]; name=() 
+
+x. #^AFTER_DOT_AND_SPACE^#
+// AFTER_DOT_AND_SPACE: Pattern/CurrModule/Flair[ArgLabels]/Erase[2]: ({#Int#})[#Int#]; name=() 
+
+x.#^AFTER_DOT_FOLLOWING_DOT?check=AFTER_DOT^#.
+
+Foo().bar.#^UNRESOLVED_MEMBER_REF^#
+// UNRESOLVED_MEMBER_REF: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]/Erase[1]: ({#argLabel: Int#})[#Int#]; name=(argLabel:)


### PR DESCRIPTION
Previously, were were suggesting to add `()` after eg. `x.` if `x` has a function type, resulting in `x.()`, which is incorrect. We need to remove the `.` in the completion suggestion.

rdar://121155241