### PR TITLE
Revert "Obj-C class metatypes should never satisfy Obj-C existentials"

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1353,15 +1353,6 @@ id swift_dynamicCastObjCProtocolUnconditional(id object,
                                               Protocol * const *protocols,
                                               const char *filename,
                                               unsigned line, unsigned column) {
-  if (numProtocols == 0) {
-    return object;
-  }
-  if (object_isClass(object)) {
-    // ObjC classes never conform to protocols
-    Class sourceType = object_getClass(object);
-    swift_dynamicCastFailure(sourceType, class_getName(sourceType),
-	                     protocols[0], protocol_getName(protocols[0]));
-  }
   for (size_t i = 0; i < numProtocols; ++i) {
     if (![object conformsToProtocol:protocols[i]]) {
       Class sourceType = object_getClass(object);
@@ -1382,10 +1373,6 @@ id swift_dynamicCastObjCProtocolConditional(id object,
       // SwiftValue wrapper never holds a class object
       return nil;
     }
-  }
-  if (object_isClass(object)) {
-    // ObjC classes never conform to protocols
-    return nil;
   }
   for (size_t i = 0; i < numProtocols; ++i) {
     if (![object conformsToProtocol:protocols[i]]) {

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1081,23 +1081,4 @@ CastsTests.test("type(of:) should look through __SwiftValue")
   expectEqual(t, "S")  // Fails: currently says `__SwiftValue`
 }
 
-#if _runtime(_ObjC)
-@objc protocol P106973771 {
-  func sayHello()
-}
-CastsTests.test("Class metatype values should not cast to Obj-C existentials") {
-  class C106973771: NSObject, P106973771 {
-    func sayHello() { print("Hello") }
-  }
-  // A class instance clearly conforms to the protocol
-  expectTrue(C106973771() is any P106973771)
-  // But the metatype definitely does not
-  expectFalse(C106973771.self is any P106973771)
-  // The cast should not succeed
-  expectNil(C106973771.self as? any P106973771)
-  // The following will crash if the cast succeeds
-  (C106973771.self as? any P106973771)?.sayHello()
-}
-#endif
-
 runAllTests()


### PR DESCRIPTION
This reverts commit aed05b9a36ab593deb995127e2b0e2b2fc054a2b.

This needs some additional work.  Reverting out until it can be fixed.