### PR TITLE
[libSwiftScan] Support response file as input arguments

### DIFF
--- a/test/CAS/Inputs/PrintResponseFile.py
+++ b/test/CAS/Inputs/PrintResponseFile.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+#
+# Usage: PrintResponseFile.py [SwiftCommandLine]
+
+import sys
+
+# Grab swift-frontend arguments. argv[0] is python script, argv[1] is
+# swift-frontend path, the remaining args are what needs to be used.
+cmd = sys.argv[2:]
+
+# Print quoted command-line as response file.
+for c in cmd:
+    print('"{}"'.format(c))

--- a/test/CAS/swift-scan-response-file.swift
+++ b/test/CAS/swift-scan-response-file.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %S/Inputs/PrintResponseFile.py  %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
+// RUN:   -allow-unstable-cache-key-for-testing > %t/cmd.resp
+
+// RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %swift_frontend_plain @%t/cmd.resp > %t/key.casid
+
+// RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- %swift_frontend_plain @%t/cmd.resp > %t/key1.casid
+
+// RUN: diff %t/key.casid %t/key1.casid
+
+// RUN: not %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=CHECK-QUERY-NOT-FOUND
+
+// RUN: %swift_frontend_plain @%t/cmd.resp
+
+// RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
+
+// RUN: %{python} %S/Inputs/PrintResponseFile.py  %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
+// RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
+// RUN:   -allow-unstable-cache-key-for-testing > %t/cmd2.resp
+// RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %swift_frontend_plain @%t/cmd2.resp
+
+// RUN: diff %t/Test.swiftmodule %t/Test2.swiftmodule
+// RUN: diff %t/test.o %t/test.o
+
+// CHECK-QUERY-NOT-FOUND: cached output not found
+// CHECK-QUERY: Cached Compilation for key "llvmcas://{{.*}}" has 4 outputs:
+// CHECK-QUERY-NEXT: object: llvmcas://
+// CHECK-QUERY-NEXT: dependencies: llvmcas://
+// CHECK-QUERY-NEXT: swiftmodule: llvmcas://
+// CHECK-QUERY-NEXT: cached-diagnostics: llvmcas://
+
+func testFunc() {}
+

--- a/tools/swift-scan-test/swift-scan-test.cpp
+++ b/tools/swift-scan-test/swift-scan-test.cpp
@@ -133,7 +133,7 @@ static int action_cache_query(swiftscan_cas_t cas, const char *key) {
     return printError(err_msg);
 
   if (!comp) {
-    llvm::errs() << "cached output not found for \"" << key << "\n";
+    llvm::errs() << "cached output not found for \"" << key << "\"\n";
     return EXIT_FAILURE;
   }
 


### PR DESCRIPTION
Build system can pass response file to libSwiftScan as the command-line arguments. libSwiftScan needs to expand the response file before  performing tasks.

rdar://121291342