### PR TITLE
[Concurrency] clarify diagnostic for 'nonisolated' stored properties being due to mutability

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5655,8 +5655,12 @@ ERROR(nonisolated_let,none,
       "they are immutable",
       ())
 ERROR(nonisolated_mutable_storage,none,
-      "'nonisolated' can not be applied to stored properties",
+      "'nonisolated' cannot be applied to mutable stored properties",
       ())
+NOTE(nonisolated_mutable_storage_note,none,
+     "convert %0 to a 'let' constant or consider declaring it "
+     "'nonisolated(unsafe)' if manually managing concurrency safety",
+     (const VarDecl *))
 ERROR(nonisolated_local_var,none,
       "'nonisolated' can not be applied to local variables",
       ())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6861,7 +6861,9 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
       // 'nonisolated' can not be applied to mutable stored properties unless
       // qualified as 'unsafe'.
       if (var->supportsMutation() && !attr->isUnsafe()) {
-        diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage);
+        diagnoseAndRemoveAttr(attr, diag::nonisolated_mutable_storage)
+            .fixItInsertAfter(attr->getRange().End, "(unsafe)");
+        var->diagnose(diag::nonisolated_mutable_storage_note, var);
         return;
       }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -139,7 +139,8 @@ struct InferredFromContext {
     get { [] }
   }
 
-  nonisolated var status: Bool = true // expected-error {{'nonisolated' can not be applied to stored properties}}{{3-15=}}
+  nonisolated var status: Bool = true // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}{{3-15=}}{{3-15=}}{{14-14=(unsafe)}}
+  // expected-note@-1{{convert 'status' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
 
   nonisolated let flag: Bool = false // expected-warning {{'nonisolated' is redundant on struct's stored properties; this is an error in Swift 6}}{{3-15=}}
 


### PR DESCRIPTION
rdar://115607322 Misleading diagnostic wording: 'nonisolated' can not be applied to stored properties