### PR TITLE
[cxx-interop] Treat `std::string` as an owned type after libc++ change

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -7217,6 +7217,12 @@ static bool hasSwiftAttribute(const clang::Decl *decl, StringRef attr) {
 }
 
 static bool hasOwnedValueAttr(const clang::RecordDecl *decl) {
+  // HACK: this logic belongs in std.apinotes, but it got broken by a libc++
+  // modulemap change
+  if (decl->getNameAsString() == "basic_string" ||
+      decl->getNameAsString() == "vector")
+    return true;
+
   return hasSwiftAttribute(decl, "import_owned");
 }
 

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -22,6 +22,12 @@ module StdSet {
   export *
 }
 
+module StdString {
+  header "std-string.h"
+  requires cplusplus
+  export *
+}
+
 module StdPair {
   header "std-pair.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-string.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-string.h
@@ -1,0 +1,9 @@
+#include <string>
+
+struct HasMethodThatReturnsString {
+  int value = 111;
+  std::string getString() const { return std::to_string(value); }
+};
+
+inline std::string takesStringWithDefaultArg(std::string s = "abc") { return s; }
+inline std::string takesStringConstRefWithDefaultArg(const std::string& s = "def") { return s; }

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -1,10 +1,14 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -D USE_CUSTOM_STRING_API)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D SUPPORTS_DEFAULT_ARGUMENTS -D USE_CUSTOM_STRING_API)
 //
 // REQUIRES: executable_test
 
 import StdlibUnittest
 import CxxStdlib
+#if USE_CUSTOM_STRING_API
+import StdString
+#endif
 
 var StdStringTestSuite = TestSuite("StdString")
 
@@ -21,5 +25,39 @@ StdStringTestSuite.test("push back") {
     expectFalse(s.empty())
     expectEqual(s[0], 42)
 }
+
+#if USE_CUSTOM_STRING_API
+StdStringTestSuite.test("get from a method") {
+    let box = HasMethodThatReturnsString()
+    let str = box.getString()
+    expectEqual(str.size(), 3)
+    expectEqual(str, std.string("111"))
+}
+
+StdStringTestSuite.test("pass as an argument") {
+    let s = std.string("a")
+    let res = takesStringWithDefaultArg(s)
+    expectEqual(res.size(), 1)
+    expectEqual(res[0], 97)
+}
+
+#if SUPPORTS_DEFAULT_ARGUMENTS
+StdStringTestSuite.test("pass as a default argument") {
+    let res = takesStringWithDefaultArg()
+    expectEqual(res.size(), 3)
+    expectEqual(res[0], 97)
+    expectEqual(res[1], 98)
+    expectEqual(res[2], 99)
+}
+
+StdStringTestSuite.test("pass as a const ref default argument") {
+    let res = takesStringConstRefWithDefaultArg()
+    expectEqual(res.size(), 3)
+    expectEqual(res[0], 100)
+    expectEqual(res[1], 101)
+    expectEqual(res[2], 102)
+}
+#endif
+#endif
 
 runAllTests()


### PR DESCRIPTION
After the libc++ modulemap was split into multiple top-level modules, the owning module of `class basic_string` changed: it is now `std_string` instead of `std`. That means `std.apinotes` is no longer picked up by clang, and `SwiftImportAs: owned` has no effect.

This makes sure we continue treating `std::string` as an owned type, and import default expressions of `std::string` parameters properly.

rdar://121391798
