### PR TITLE
[Concurrency] [shims] Don't declare `exit` in  the concurrency shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@
   Having been [gated](https://github.com/apple/swift/pull/28171) behind a
   compiler warning since at least Swift 5.2, this syntax is now rejected.
 
+* [bugfix][]:
+
+  \_SwiftConcurrencyShims used to declare the `exit` function, even though it
+  might not be available. The declaration has been removed, and must be imported
+  from the appropriate C library module (e.g. Darwin or SwiftGlibc)
+
 ## Swift 5.10
 
 * Swift 5.10 closes all known static data-race safey holes in complete strict

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -11,7 +11,7 @@
 #===----------------------------------------------------------------------===#
 
 set(SWIFT_RUNTIME_CONCURRENCY_C_FLAGS)
-set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS)
+set(SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS -I${CMAKE_CURRENT_SOURCE_DIR}/InternalShims)
 
 set(swift_concurrency_private_link_libraries)
 if(CMAKE_SYSTEM_NAME STREQUAL "Windows")

--- a/stdlib/public/Concurrency/InternalShims/module.modulemap
+++ b/stdlib/public/Concurrency/InternalShims/module.modulemap
@@ -1,0 +1,6 @@
+module SwiftConcurrencyInternalShims {
+  module stdlib {
+    header "stdlib_shims.h"
+    export *
+  }
+}

--- a/stdlib/public/Concurrency/InternalShims/stdlib_shims.h
+++ b/stdlib/public/Concurrency/InternalShims/stdlib_shims.h
@@ -1,4 +1,4 @@
-//===--- _SwiftConcurrency.h - Swift Concurrency Support --------*- C++ -*-===//
+//===--- stdlib_shims.h - Swift Concurrency Support -----------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,24 +10,18 @@
 //
 //===----------------------------------------------------------------------===//
 //
-//  Defines types and support functions for the Swift concurrency model.
+//  Forward declarations of <stdlib.h> interfaces so that Swift Concurrency
+//  doesn't depend on the C library.
 //
 //===----------------------------------------------------------------------===//
-#ifndef SWIFT_CONCURRENCY_H
-#define SWIFT_CONCURRENCY_H
+#ifndef STDLIB_SHIMS_H
+#define STDLIB_SHIMS_H
 
 #ifdef __cplusplus
-namespace swift {
-extern "C" {
+extern "C" [[noreturn]]
 #endif
+void exit(int);
 
-typedef struct _SwiftContext {
-  struct _SwiftContext *parentContext;
-} _SwiftContext;
+#define EXIT_SUCCESS 0
 
-#ifdef __cplusplus
-} // extern "C"
-} // namespace swift
-#endif
-
-#endif // SWIFT_CONCURRENCY_H
+#endif // STDLIB_SHIMS_H

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -12,6 +12,7 @@
 
 import Swift
 @_implementationOnly import _SwiftConcurrencyShims
+@_implementationOnly import SwiftConcurrencyInternalShims
 
 // ==== Task -------------------------------------------------------------------
 

--- a/test/Backtracing/DwarfReader.swift
+++ b/test/Backtracing/DwarfReader.swift
@@ -7,6 +7,15 @@
 // REQUIRES: backtracing
 
 @_spi(DwarfTest) import _Backtracing
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(SwiftWASILibc)
+import SwiftWASILibc
+#elseif canImport(ucrt)
+import ucrt
+#elseif canImport(SwiftGlibc)
+import SwiftGlibc
+#endif
 
 @main
 struct DwarfReader {

--- a/test/Backtracing/ElfReader.swift
+++ b/test/Backtracing/ElfReader.swift
@@ -16,6 +16,15 @@
 // REQUIRES: backtracing
 
 @_spi(ElfTest) import _Backtracing
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(SwiftWASILibc)
+import SwiftWASILibc
+#elseif canImport(ucrt)
+import ucrt
+#elseif canImport(SwiftGlibc)
+import SwiftGlibc
+#endif
 
 @main
 struct ElfReader {

--- a/test/Backtracing/Inputs/Inlining.swift
+++ b/test/Backtracing/Inputs/Inlining.swift
@@ -1,3 +1,13 @@
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(SwiftWASILibc)
+import SwiftWASILibc
+#elseif canImport(ucrt)
+import ucrt
+#elseif canImport(SwiftGlibc)
+import SwiftGlibc
+#endif
+
 func square(_ x: Int) -> Int {
   return x * x
 }

--- a/validation-test/SIL/verify_all_overlays.py
+++ b/validation-test/SIL/verify_all_overlays.py
@@ -41,6 +41,10 @@ for module_file in os.listdir(sdk_overlay_dir):
         extra_args = ["-I", os.path.join(source_dir, "stdlib",
                                          "public", "Backtracing", "modules"),
                       "-I", os.path.join(source_dir, "include")]
+    # _Concurrency needs its own additional modules in the module path
+    if module_name == "_Concurrency":
+        extra_args = ["-I", os.path.join(source_dir, "stdlib",
+                                         "public", "Concurrency", "InternalShims")]
 
     print("# " + module_name)
 


### PR DESCRIPTION
Don't delete the OS declaration of `exit` because the concurrency shims aren't always imported, and so the shim declaration might not always be available. Don't override the OS declaration of `exit` in the concurrency shims since we can't just delete the OS one. Instead, set up internal shims just for building Concurrency that forward declares `exit`.

rdar://121946366