### PR TITLE
[Sema] Group Actor Errors

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2128,11 +2128,15 @@ namespace {
 
         // Add Fix-it for missing @SomeActor annotation
         if (isolation.isGlobalActor()) {
-          if (missingGlobalActorOnContext(
+          if (errors.size() == 1) {
+            missingGlobalActorOnContext(
+                    const_cast<DeclContext *>(getDeclContext()),
+                                        isolation.getGlobalActor(), behavior);
+          } else if (missingGlobalActorOnContext(
                   const_cast<DeclContext *>(getDeclContext()),
                   isolation.getGlobalActor(), behavior) &&
               errors.size() > 1) {
-            behavior= DiagnosticBehavior::Note;
+            behavior = DiagnosticBehavior::Note;
           }
         }
 
@@ -2153,11 +2157,15 @@ namespace {
 
         // Add Fix-it for missing @SomeActor annotation
         if (isolation.isGlobalActor()) {
-          if (missingGlobalActorOnContext(
+          if (errors.size() == 1) {
+            missingGlobalActorOnContext(
+                    const_cast<DeclContext *>(getDeclContext()),
+                                        isolation.getGlobalActor(), behavior);
+          } else if (missingGlobalActorOnContext(
                   const_cast<DeclContext *>(getDeclContext()),
                   isolation.getGlobalActor(), behavior) &&
               errors.size() > 1) {
-            behavior= DiagnosticBehavior::Note;
+            behavior = DiagnosticBehavior::Note;
           }
         }
 


### PR DESCRIPTION
When there are multiple errors in a function, it can be difficult to identify and fix them individually. To simplify the process, we should group them into a single error, but only if there is more than one error present.