### PR TITLE
Implement support for #isolation for distributed actors

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3460,6 +3460,13 @@ namespace {
         actorExpr = new (ctx) DeclRefExpr(
             const_cast<VarDecl *>(var), DeclNameLoc(loc),
             /*Implicit=*/true);
+
+        // For a distributed actor, we need to retrieve the local
+        // actor.
+        if (isolation.isDistributedActor()) {
+          actorExpr = UnresolvedDotExpr::createImplicit(
+              ctx, actorExpr, ctx.getIdentifier("asLocalActor"));
+        }
         break;
       }
       case ActorIsolation::GlobalActor: {
@@ -3479,6 +3486,7 @@ namespace {
         actorExpr = new (ctx) NilLiteralExpr(loc, /*implicit=*/true);
         break;
       }
+
 
       // Convert the actor argument to the appropriate type.
       (void)TypeChecker::typeCheckExpression(

--- a/test/Distributed/isolation_macro.swift
+++ b/test/Distributed/isolation_macro.swift
@@ -1,0 +1,47 @@
+// RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature OptionalIsolatedParameters -verify
+
+// RUN: %target-swift-frontend -dump-ast %s -enable-experimental-feature OptionalIsolatedParameters | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+// REQUIRES: distributed
+
+import Distributed
+
+@available(SwiftStdlib 5.7, *)
+extension DistributedActor {
+  // CHECK-LABEL: actorIsolationToSelf()
+  func actorIsolationToSelf() {
+    // CHECK: macro_expansion_expr
+    // CHECK: rewritten=current_context_isolation_expr
+    // CHECK-NEXT: inject_into_optional
+    // CHECK: member_ref_expr{{.*}}asLocalActor
+    // CHECK: declref_expr implicit type="Self"
+    _ = #isolation
+  }
+}
+
+// CHECK-LABEL: actorIsolationToParam(_:)
+@available(SwiftStdlib 5.7, *)
+func actorIsolationToParam(_ isolatedParam: isolated any DistributedActor) {
+  // CHECK: macro_expansion_expr
+  // CHECK: rewritten=current_context_isolation_expr
+  // CHECK: member_ref_expr{{.*}}asLocalActor
+  _ = #isolation
+}
+
+func acceptClosure(_ body: () -> Void) { }
+
+// CHECK-LABEL: closureIsolatedToOuterParam(
+@available(SwiftStdlib 5.7, *)
+func closureIsolatedToOuterParam(_ isolatedParam: isolated any DistributedActor) {
+  // CHECK: closure_expr
+  // CHECK: macro_expansion_expr
+  // CHECK: rewritten=current_context_isolation_expr
+  // CHECK: inject_into_optional
+  // CHECK: member_ref_expr{{.*}}asLocalActor
+  acceptClosure {
+    _ = #isolation
+    print(isolatedParam)
+  }
+}


### PR DESCRIPTION
When using `#isolation` within a context that is isolated to a distributed actor, resolve to an `asLocalActor` access to retrieve the local actor corresponding to the distributed actor.
