### PR TITLE
[region-isolation] Make it so that we only propagate actor self if the callee takes self as isolated.

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1206,7 +1206,8 @@ enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind : size_t {
   BridgedTypeAttrKind_moveOnly,
   BridgedTypeAttrKind_thin,
   BridgedTypeAttrKind_thick,
-  BridgedTypeAttrKind_Count
+  BridgedTypeAttrKind_Count,
+  BridgedTypeAttrKind_isolated,
 };
 
 SWIFT_NAME("BridgedTypeAttrKind.init(from:)")

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -99,6 +99,7 @@ TYPE_ATTR(yield_many)
 TYPE_ATTR(captures_generics)
 // Used at the SIL level to mark a type as moveOnly.
 TYPE_ATTR(moveOnly)
+TYPE_ATTR(isolated)
 
 // SIL metatype attributes.
 TYPE_ATTR(thin)

--- a/include/swift/AST/TypeDifferenceVisitor.h
+++ b/include/swift/AST/TypeDifferenceVisitor.h
@@ -291,7 +291,7 @@ public:
   bool visitComponent(CanType type1, CanType type2,
                       SILParameterInfo param1, SILParameterInfo param2) {
     if (param1.getConvention() != param2.getConvention() ||
-        param1.getOptions().containsOnly(param2.getOptions()))
+        !param1.getOptions().containsOnly(param2.getOptions()))
       return asImpl().visitDifferentTypeStructure(type1, type2);
 
     return asImpl().visit(param1.getInterfaceType(),
@@ -410,6 +410,7 @@ private:
     return asImpl().visit(CanType(componentType1), CanType(componentType2));
   }
 
+protected:
   template <class T>
   bool visitComponentArray(CanType type1, CanType type2, T array1, T array2) {
     if (array1.size() != array2.size())

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4129,6 +4129,9 @@ public:
 
     /// Set if the given parameter is transferring.
     Transferring = 0x2,
+
+    /// Set if the given parameter is isolated.
+    Isolated = 0x4,
   };
 
   using Options = OptionSet<Flag>;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -8086,6 +8086,11 @@ void SILParameterInfo::print(ASTPrinter &Printer,
     Printer << "@transferring ";
   }
 
+  if (options.contains(SILParameterInfo::Isolated)) {
+    options -= SILParameterInfo::Isolated;
+    Printer << "@isolated ";
+  }
+
   // If we did not handle a case in Options, this code was not updated
   // appropriately.
   assert(!bool(options) && "Code not updated for introduced option");

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -236,6 +236,8 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
     Printer.printSimpleAttr("@Sendable") << " ";
   if (hasAttr(TAK_noDerivative))
     Printer.printSimpleAttr("@noDerivative") << " ";
+  if (hasAttr(TAK_isolated))
+    Printer.printSimpleAttr("@isolated") << " ";
 
   if (hasAttr(TAK_differentiable)) {
     Printer.callPrintStructurePre(PrintStructureKind::BuiltinAttribute);

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -415,7 +415,8 @@ extension ASTGenVisitor {
           .sil_weak, .sil_unowned, .inout, .block_storage, .box,
           .dynamic_self, .sil_unmanaged, .error, .error_indirect,
           .error_unowned, .direct, .inout_aliasable,
-          .in_guaranteed, .in_constant, .captures_generics, .moveOnly:
+          .in_guaranteed, .in_constant, .captures_generics, .moveOnly,
+          .isolated:
           fallthrough
 
         case .autoclosure, .escaping, .noescape, .noDerivative, .async,

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1737,6 +1737,8 @@ private:
       param = param.addingOption(SILParameterInfo::NotDifferentiable);
     if (origFlags.isTransferring())
       param = param.addingOption(SILParameterInfo::Transferring);
+    if (origFlags.isIsolated())
+      param = param.addingOption(SILParameterInfo::Isolated);
 
     Inputs.push_back(param);
     maybeAddForeignParameters();

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1619,10 +1619,14 @@ public:
 
   void translateNonIsolationCrossingSILApply(FullApplySite fas) {
     SILMultiAssignOptions options;
+
+    // If self is an actor and we are isolated to it, propagate actor self.
     if (fas.hasSelfArgument()) {
-      if (auto self = fas.getSelfArgument()) {
-        if (self->getType().isActor())
-          options |= SILMultiAssignFlags::PropagatesActorSelf;
+      auto &self = fas.getSelfArgumentOperand();
+      if (self.get()->getType().isActor() &&
+          fas.getArgumentParameterInfo(self).hasOption(
+              SILParameterInfo::Isolated)) {
+        options |= SILMultiAssignFlags::PropagatesActorSelf;
       }
     }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2998,13 +2998,10 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
   // Some function representation attributes are not supported at source level;
   // only SIL knows how to handle them.  Reject them unless this is a SIL input.
   if (!(options & TypeResolutionFlags::SILType)) {
-    for (auto silOnlyAttr : {TAK_pseudogeneric,
-                             TAK_unimplementable,
-                             TAK_callee_owned,
-                             TAK_callee_guaranteed,
-                             TAK_noescape,
-                             TAK_yield_once,
-                             TAK_yield_many}) {
+    for (auto silOnlyAttr :
+         {TAK_pseudogeneric, TAK_unimplementable, TAK_callee_owned,
+          TAK_callee_guaranteed, TAK_noescape, TAK_yield_once, TAK_yield_many,
+          TAK_isolated}) {
       checkUnsupportedAttr(silOnlyAttr);
     }
   }  
@@ -4102,6 +4099,10 @@ SILParameterInfo TypeResolver::resolveSILParameter(
     if (attrs.has(TAK_noDerivative)) {
       attrs.clearAttribute(TAK_noDerivative);
       parameterOptions |= SILParameterInfo::NotDifferentiable;
+    }
+    if (attrs.has(TAK_isolated)) {
+      attrs.clearAttribute(TAK_isolated);
+      parameterOptions |= SILParameterInfo::Isolated;
     }
 
     type = resolveAttributedType(attrs, attrRepr->getTypeRepr(), options);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6378,6 +6378,11 @@ getActualSILParameterOptions(uint8_t raw) {
     result |= SILParameterInfo::NotDifferentiable;
   }
 
+  if (options.contains(serialization::SILParameterInfoFlags::Isolated)) {
+    options -= serialization::SILParameterInfoFlags::Isolated;
+    result |= SILParameterInfo::Isolated;
+  }
+
   // Check if we have any remaining options and return none if we do. We found
   // some option that we did not understand.
   if (bool(options)) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 839; // @_implements
+const uint16_t SWIFTMODULE_VERSION_MINOR = 840; // isolated SIL param info
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -400,6 +400,7 @@ enum class SILParameterDifferentiability : uint8_t {
 /// module version.
 enum class SILParameterInfoFlags : uint8_t {
   NotDifferentiable = 0x1,
+  Isolated = 0x2,
 };
 
 using SILParameterInfoOptions = OptionSet<SILParameterInfoFlags>;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5078,6 +5078,11 @@ getRawSILParameterInfoOptions(swift::SILParameterInfo::Options options) {
     result |= SILParameterInfoFlags::NotDifferentiable;
   }
 
+  if (options.contains(SILParameterInfo::Isolated)) {
+    options -= SILParameterInfo::Isolated;
+    result |= SILParameterInfoFlags::Isolated;
+  }
+
   // If we still have options left, this code is out of sync... return none.
   if (bool(options))
     return {};

--- a/test/Concurrency/transfernonsendable_nonisolated.swift
+++ b/test/Concurrency/transfernonsendable_nonisolated.swift
@@ -1,0 +1,70 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -disable-availability-checking -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// This test validates behavior of transfernonsendable around nonisolated
+// functions and fields.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendable {}
+
+actor MyActor {
+  nonisolated func asyncNonisolated(_ x: NonSendable) async {}
+  nonisolated func syncNonisolated(_ x: NonSendable) {}
+  nonisolated func asyncNonisolatedGeneric<T>(_ t: T) async {}
+  nonisolated func syncNonisolatedGeneric<T>(_ t: T) {}
+}
+
+@MainActor func transferToMain<T>(_ t: T) async {}
+func useValueAsync<T>(_ t: T) async {}
+func useValueSync<T>(_ t: T) {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+func callNonIsolatedAsync_TransferAfter(_ a: MyActor) async {
+  let x = NonSendable()
+  await a.asyncNonisolated(x)
+  await a.asyncNonisolated(x)
+  await transferToMain(x)
+}
+
+func callNonIsolatedSync_TransferAfter(_ a: MyActor) async {
+  let x = NonSendable()
+  a.syncNonisolated(x)
+  a.syncNonisolated(x)
+  await transferToMain(x)
+}
+
+func callNonIsolatedAsync_AsyncUseAfter(_ a: MyActor) async {
+  let x = NonSendable()
+  await a.asyncNonisolated(x)
+  await a.asyncNonisolated(x)
+  await useValueAsync(x)
+}
+
+func callNonIsolatedSync_AsyncUseAfter(_ a: MyActor) async {
+  let x = NonSendable()
+  a.syncNonisolated(x)
+  a.syncNonisolated(x)
+  await useValueAsync(x)
+}
+
+func callNonIsolatedAsync_SyncUseAfter(_ a: MyActor) async {
+  let x = NonSendable()
+  await a.asyncNonisolated(x)
+  await a.asyncNonisolated(x)
+  useValueSync(x)
+}
+
+func callNonIsolatedSync_SyncUseAfter(_ a: MyActor) async {
+  let x = NonSendable()
+  a.syncNonisolated(x)
+  a.syncNonisolated(x)
+  useValueSync(x)
+}

--- a/test/Distributed/Runtime/distributed_actor_self_calls.swift
+++ b/test/Distributed/Runtime/distributed_actor_self_calls.swift
@@ -16,7 +16,7 @@ distributed actor Philosopher {
   distributed func think() {
   }
 
-  // CHECK: sil hidden [ossa] @$s28distributed_actor_self_calls11PhilosopherC10stopEatingyyF : $@convention(method) (@guaranteed Philosopher) -> () {
+  // CHECK: sil hidden [ossa] @$s28distributed_actor_self_calls11PhilosopherC10stopEatingyyF : $@convention(method) (@isolated @guaranteed Philosopher) -> () {
   func stopEating() { // NOTE: marking this async solves the issue; we find the async context then
     self.think()
 
@@ -25,7 +25,7 @@ distributed actor Philosopher {
     // trying to get the async context to call the async thunk would fail here.
     //
     // CHECK:        // function_ref Philosopher.think()
-    // CHECK-NEXT:   [[E:%[0-9]+]] = function_ref @$s28distributed_actor_self_calls11PhilosopherC5thinkyyF : $@convention(method) (@guaranteed Philosopher) -> ()
+    // CHECK-NEXT:   [[E:%[0-9]+]] = function_ref @$s28distributed_actor_self_calls11PhilosopherC5thinkyyF : $@convention(method) (@isolated @guaranteed Philosopher) -> ()
   }
 }
 

--- a/test/Distributed/SIL/distributed_actor_default_init_sil_3.swift
+++ b/test/Distributed/SIL/distributed_actor_default_init_sil_3.swift
@@ -29,7 +29,7 @@ distributed actor MyDistActor {
   }
 
   // CHECK-LABEL: // MyDistActor.init(system_async_fail:cond:)
-  // CHECK: sil hidden{{.*}} @$s14default_deinit11MyDistActorC17system_async_fail4condACSg015FakeDistributedE7Systems0jE6SystemV_SbtYacfc : $@convention(method) @async (@owned FakeActorSystem, Bool, @owned MyDistActor) -> @owned Optional<MyDistActor> {
+  // CHECK: sil hidden{{.*}} @$s14default_deinit11MyDistActorC17system_async_fail4condACSg015FakeDistributedE7Systems0jE6SystemV_SbtYacfc : $@convention(method) @async (@owned FakeActorSystem, Bool, @isolated @owned MyDistActor) -> @owned Optional<MyDistActor> {
   // CHECK: bb0([[SYSTEM:%[0-9]+]] : $FakeActorSystem, [[COND:%[0-9]+]] : $Bool, [[SELF:%[0-9]+]] : $MyDistActor):
   // CHECK:   cond_br {{%[0-9]+}}, [[SUCCESS_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
 

--- a/test/Distributed/SIL/distributed_actor_default_init_sil_4.swift
+++ b/test/Distributed/SIL/distributed_actor_default_init_sil_4.swift
@@ -31,7 +31,7 @@ distributed actor MyDistActor {
   }
 
   // CHECK-LABEL: // MyDistActor.init(system_async_fail_throws:cond:)
-  // CHECK: sil hidden @$s14default_deinit11MyDistActorC24system_async_fail_throws4condACSg015FakeDistributedE7Systems0kE6SystemV_SbtYaKcfc : $@convention(method) @async (@owned FakeActorSystem, Bool, @owned MyDistActor) -> (@owned Optional<MyDistActor>, @error any Error) {
+  // CHECK: sil hidden @$s14default_deinit11MyDistActorC24system_async_fail_throws4condACSg015FakeDistributedE7Systems0kE6SystemV_SbtYaKcfc : $@convention(method) @async (@owned FakeActorSystem, Bool, @isolated @owned MyDistActor) -> (@owned Optional<MyDistActor>, @error any Error) {
   // CHECK: bb0([[SYSTEM:%[0-9]+]] : $FakeActorSystem, [[COND:%[0-9]+]] : $Bool, [[SELF:%[0-9]+]] : $MyDistActor):
   // CHECK:   cond_br {{%[0-9]+}}, [[SUCCESS_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
 

--- a/test/Distributed/SIL/distributed_actor_default_init_sil_5.swift
+++ b/test/Distributed/SIL/distributed_actor_default_init_sil_5.swift
@@ -31,7 +31,7 @@ distributed actor MyDistActor {
     self.localOnlyField = SomeClass()
   }
 
-// CHECK: sil hidden @$s14default_deinit11MyDistActorC12system_async4condAC015FakeDistributedE7Systems0iE6SystemV_SbtYacfc : $@convention(method) @async (@owned FakeActorSystem, Bool, @owned MyDistActor) -> @owned MyDistActor {
+// CHECK: sil hidden @$s14default_deinit11MyDistActorC12system_async4condAC015FakeDistributedE7Systems0iE6SystemV_SbtYacfc : $@convention(method) @async (@owned FakeActorSystem, Bool, @isolated @owned MyDistActor) -> @owned MyDistActor {
 // CHECK: bb0([[SYSTEM:%[0-9]+]] : $FakeActorSystem, [[COND:%[0-9]+]] : $Bool, [[SELF:%[0-9]+]] : $MyDistActor):
 // CHECK:   builtin "initializeDefaultActor"([[SELF]] : $MyDistActor)
 // CHECK:   [[SYS_FIELD:%[0-9]+]] = ref_element_addr [[SELF]] : $MyDistActor, #MyDistActor.actorSystem

--- a/test/Distributed/SIL/distributed_thunk.swift
+++ b/test/Distributed/SIL/distributed_thunk.swift
@@ -13,7 +13,7 @@ extension DA {
   // CHECK: function_ref @swift_distributed_actor_is_remote
 
   // Call the actor function
-  // CHECK: function_ref @$s17distributed_thunk2DAC1fyyF : $@convention(method) (@guaranteed DA) -> ()
+  // CHECK: function_ref @$s17distributed_thunk2DAC1fyyF : $@convention(method) (@isolated @guaranteed DA) -> ()
 
   distributed func f() { }
 }

--- a/test/Distributed/SIL/distributed_thunk_skip_function_bodies.swift
+++ b/test/Distributed/SIL/distributed_thunk_skip_function_bodies.swift
@@ -36,7 +36,7 @@ extension DA {
 
   // CHECK-SKIP-ALL-NOT: s38distributed_thunk_skip_function_bodies2DAC13inlinableFuncyyF
 
-  // CHECK-SKIP-NONINLINE-LABEL: sil [serialized] [distributed] [ossa] @$s38distributed_thunk_skip_function_bodies2DAC13inlinableFuncyyF : $@convention(method) (@guaranteed DA) -> () {
+  // CHECK-SKIP-NONINLINE-LABEL: sil [serialized] [distributed] [ossa] @$s38distributed_thunk_skip_function_bodies2DAC13inlinableFuncyyF : $@convention(method) (@isolated @guaranteed DA) -> () {
   // CHECK-SKIP-NONINLINE:         function_ref @$s38distributed_thunk_skip_function_bodies9blackHoleyyxlF
   // CHECK-SKIP-NONINLINE:       } // end sil function '$s38distributed_thunk_skip_function_bodies2DAC13inlinableFuncyyF'
   @inlinable public distributed func inlinableFunc() {

--- a/test/Distributed/distributed_actor_to_actor.swift
+++ b/test/Distributed/distributed_actor_to_actor.swift
@@ -21,7 +21,7 @@ import Distributed
 // Make sure there is no runtime record of the protocol descriptor.
 // CHECK-IR-NOT: $sxScA11DistributedHc
 
-// CHECK-SIL-LABEL: sil hidden @$s021distributed_actor_to_B011getAnyActor0aF0ScA_pxYi_t11Distributed0gF0RzlF : $@convention(thin) <τ_0_0 where τ_0_0 : DistributedActor> (@guaranteed τ_0_0) -> @owned any Actor
+// CHECK-SIL-LABEL: sil hidden @$s021distributed_actor_to_B011getAnyActor0aF0ScA_pxYi_t11Distributed0gF0RzlF : $@convention(thin) <τ_0_0 where τ_0_0 : DistributedActor> (@isolated @guaranteed τ_0_0) -> @owned any Actor
 func getAnyActor(distributedActor: isolated some DistributedActor) -> any Actor {
   // CHECK-SIL: [[EXISTENTIAL:%.*]] = init_existential_ref %0 : $τ_0_0 : $τ_0_0, $any Actor
   // CHECK-SIL-NEXT: strong_retain [[EXISTENTIAL]] : $any Actor

--- a/test/IRGen/distributed_func_indirect_in_parameter.swift
+++ b/test/IRGen/distributed_func_indirect_in_parameter.swift
@@ -21,7 +21,7 @@ public struct LargeValue : Codable {
 distributed actor D {
   typealias ActorSystem = LocalTestingDistributedActorSystem
 
-  // CHECK: sil hidden [distributed] @takeLarge : $@convention(method) (@in_guaranteed LargeValue, @guaranteed D) -> () {
+  // CHECK: sil hidden [distributed] @takeLarge : $@convention(method) (@in_guaranteed LargeValue, @isolated @guaranteed D) -> () {
   @_silgen_name("takeLarge")
   distributed func takeLarge(_ l: LargeValue) {}
 }

--- a/test/SIL/Parser/isolated_parameters.sil
+++ b/test/SIL/Parser/isolated_parameters.sil
@@ -1,0 +1,15 @@
+// RUN: %target-sil-opt -enable-objc-interop -enable-sil-verify-all=true %s | %target-sil-opt -enable-objc-interop -enable-sil-verify-all=true | %FileCheck %s
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+
+sil_stage canonical
+
+import Swift
+
+public protocol AnyActor: AnyObject, Sendable {}
+public protocol Actor : AnyActor {}
+
+// CHECK-LABEL: sil @$sScAsE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKlFTwB : $@convention(method) <τ_0_0 where τ_0_0 : Actor><τ_1_0> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <τ_0_0, τ_1_0>, StaticString, UInt, @guaranteed τ_0_0) -> (@out τ_1_0, @error any Error)
+
+sil @$sScAsE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKlFTwB : $@convention(method) <τ_0_0 where τ_0_0 : Actor><τ_1_0> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 : AnyObject> (@isolated @guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <τ_0_0, τ_1_0>, StaticString, UInt, @guaranteed τ_0_0) -> (@out τ_1_0, @error any Error)

--- a/test/SIL/Serialization/isolated_parameters.sil
+++ b/test/SIL/Serialization/isolated_parameters.sil
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-sil-opt %s -emit-sib -o %t/tmp.sib -module-name borrow
+// RUN: %target-sil-opt %t/tmp.sib -o %t/tmp.2.sib -module-name borrow
+// RUN: %target-sil-opt %t/tmp.2.sib -module-name borrow -emit-sorted-sil | %FileCheck %s
+
+// REQUIRES: asserts
+// REQUIRES: concurrency
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// NOTE: In SIL we do not save/print out imports, so we cannot import _Concurrency here!
+public protocol AnyActor: AnyObject, Sendable {}
+public protocol Actor : AnyActor {}
+
+
+// CHECK-LABEL: sil [serialized] [ossa] @assumeIsolated : $@convention(method) <τ_0_0 where τ_0_0 : Actor> (@isolated @guaranteed τ_0_0) -> () {
+
+sil [serialized] [ossa] @assumeIsolated : $@convention(method) <τ_0_0 where τ_0_0 : Actor> (@isolated @guaranteed τ_0_0) -> () {
+bb0(%0 : @guaranteed $τ_0_0):
+  unreachable
+}

--- a/test/SILGen/async_conversion.swift
+++ b/test/SILGen/async_conversion.swift
@@ -65,7 +65,7 @@ actor A: P2 {
 actor AnActor {
   func isolatedMethod(_ i: Int) {}
 
-  // CHECK-LABEL: sil hidden [ossa] @$s4test7AnActorC6calleryyYaF : $@convention(method) @async (@guaranteed AnActor) -> () {
+  // CHECK-LABEL: sil hidden [ossa] @$s4test7AnActorC6calleryyYaF : $@convention(method) @async (@isolated @guaranteed AnActor) -> () {
   func caller() async {
     // CHECK: hop_to_executor {{..*}} : $AnActor
     //  [[F:%.*]] = function_ref @$s4test7AnActorC6calleryyYaFySicACYicfu_ : $@convention(thin) (@guaranteed AnActor) -> @owned @callee_guaranteed (Int) -> ()

--- a/test/SILGen/async_initializer.swift
+++ b/test/SILGen/async_initializer.swift
@@ -56,7 +56,7 @@ enum MyEnum {
 }
 
 actor MyActor {
-  // CHECK-DAG:   sil hidden [ossa] @$s12initializers7MyActorCACyYacfc : $@convention(method) @async (@owned MyActor) -> @owned MyActor
+  // CHECK-DAG:   sil hidden [ossa] @$s12initializers7MyActorCACyYacfc : $@convention(method) @async (@isolated @owned MyActor) -> @owned MyActor
   init() async {}
 }
 
@@ -166,7 +166,7 @@ actor SomeActor {
   // The implicit check-not covers that for us. The hops are inserted later.
   init() async {}
 
-  // CHECK-LABEL: sil hidden [ossa] @$s12initializers9SomeActorC10someMethodyyYaF : $@convention(method) @async (@guaranteed SomeActor) -> () {
+  // CHECK-LABEL: sil hidden [ossa] @$s12initializers9SomeActorC10someMethodyyYaF : $@convention(method) @async (@isolated @guaranteed SomeActor) -> () {
   // CHECK:           hop_to_executor {{%[0-9]+}} : $SomeActor
   // CHECK: } // end sil function '$s12initializers9SomeActorC10someMethodyyYaF'
   func someMethod() async {}

--- a/test/SILGen/effectful_properties.swift
+++ b/test/SILGen/effectful_properties.swift
@@ -34,12 +34,12 @@ enum E {
 }
 
 actor A {
- // CHECK-DAG: sil hidden [transparent] [ossa] @$s9accessors1AC10normalPropSivg : $@convention(method) (@guaranteed A) -> Int {
+ // CHECK-DAG: sil hidden [transparent] [ossa] @$s9accessors1AC10normalPropSivg : $@convention(method) (@isolated @guaranteed A) -> Int {
   var normalProp : Int = 0
-  // CHECK-DAG: sil hidden [ossa] @$s9accessors1AC12computedPropSivg : $@convention(method) (@guaranteed A) -> Int {
+  // CHECK-DAG: sil hidden [ossa] @$s9accessors1AC12computedPropSivg : $@convention(method) (@isolated @guaranteed A) -> Int {
   var computedProp : Int { get { 0 } }
 
-  // CHECK-LABEL: sil hidden [ossa] @$s9accessors1AC9asyncPropSivg : $@convention(method) @async (@guaranteed A) -> Int {
+  // CHECK-LABEL: sil hidden [ossa] @$s9accessors1AC9asyncPropSivg : $@convention(method) @async (@isolated @guaranteed A) -> Int {
   // CHECK:       bb0([[SELF:%[0-9]+]] : @guaranteed $A):
   // CHECK:         hop_to_executor [[SELF]] : $A
   // CHECK:       } // end sil function '$s9accessors1AC9asyncPropSivg'
@@ -51,7 +51,7 @@ actor A {
 
 // CHECK-LABEL: sil hidden [ossa] @$s9accessors19testImplicitlyAsync1aSiAA1AC_tYaF : $@convention(thin) @async (@guaranteed A) -> Int {
 // CHECK:         hop_to_executor
-// CHECK:         apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@guaranteed A) -> Int
+// CHECK:         apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@isolated @guaranteed A) -> Int
 // CHECK:         hop_to_executor
 // CHECK:       } // end sil function '$s9accessors19testImplicitlyAsync1aSiAA1AC_tYaF'
 func testImplicitlyAsync(a : A) async -> Int {
@@ -60,7 +60,7 @@ func testImplicitlyAsync(a : A) async -> Int {
 
 
 // CHECK-LABEL: sil hidden [ossa] @$s9accessors15testNormalAsync1aSiAA1AC_tYaF : $@convention(thin) @async (@guaranteed A) -> Int {
-// CHECK:          apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) @async (@guaranteed A) -> Int
+// CHECK:          apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) @async (@isolated @guaranteed A) -> Int
 // CHECK:       } // end sil function '$s9accessors15testNormalAsync1aSiAA1AC_tYaF'
 func testNormalAsync(a : A) async -> Int {
   return await a.asyncProp

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -28,7 +28,7 @@ actor MyActor {
     print(x)
   }
 
-  // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0A13AsyncFunctionyyYaKF : $@convention(method) @async (@guaranteed MyActor) -> @error any Error {
+  // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0A13AsyncFunctionyyYaKF : $@convention(method) @async (@isolated @guaranteed MyActor) -> @error any Error {
   // CHECK:        hop_to_executor %0 : $MyActor 
   // CHECK:        = apply {{.*}} : $@convention(method) @async (Int, @guaranteed MyActor) -> ()
   // CHECK-NEXT:   hop_to_executor %0 : $MyActor 
@@ -43,7 +43,7 @@ actor MyActor {
     try await throwingCallee(p)
   }
 
-  // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0A22ConsumingAsyncFunctionyyYaF : $@convention(method) @async (@owned MyActor) -> () {
+  // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0A22ConsumingAsyncFunctionyyYaF : $@convention(method) @async (@isolated @owned MyActor) -> () {
   // CHECK:        [[BORROWED_SELF:%[0-9]+]] = begin_borrow %0 : $MyActor
   // CHECK:        hop_to_executor [[BORROWED_SELF]] : $MyActor 
   // CHECK:        = apply {{.*}} : $@convention(method) @async (Int, @guaranteed MyActor) -> ()
@@ -54,7 +54,7 @@ actor MyActor {
   }
 
   ///// MyActor.testClosure()
-  // CHECK: sil hidden [ossa] @$s4test7MyActorC0A7ClosureSiyYaF : $@convention(method) @async (@guaranteed MyActor) -> Int {
+  // CHECK: sil hidden [ossa] @$s4test7MyActorC0A7ClosureSiyYaF : $@convention(method) @async (@isolated @guaranteed MyActor) -> Int {
   // CHECK:     hop_to_executor [[A:%[0-9]+]] : $MyActor
   // CHECK:     {{%[0-9]+}} = apply
   // CHECK:     hop_to_executor [[A]] : $MyActor
@@ -71,7 +71,7 @@ actor MyActor {
     return await { () async in p }()
   }
 
-  // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC13dontInsertHTESiyF : $@convention(method) (@guaranteed MyActor) -> Int {
+  // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC13dontInsertHTESiyF : $@convention(method) (@isolated @guaranteed MyActor) -> Int {
   // CHECK-NOT:   hop_to_executor
   // CHECK:     } // end sil function '$s4test7MyActorC13dontInsertHTESiyF'
   func dontInsertHTE() -> Int {
@@ -195,36 +195,36 @@ func testGenericGlobalActorWithGetter() async {
 }
 
 actor RedActorImpl {
-  // CHECK-LABEL: sil hidden [ossa] @$s4test12RedActorImplC5helloyySiF : $@convention(method) (Int, @guaranteed RedActorImpl) -> () {
+  // CHECK-LABEL: sil hidden [ossa] @$s4test12RedActorImplC5helloyySiF : $@convention(method) (Int, @isolated @guaranteed RedActorImpl) -> () {
   // CHECK-NOT: hop_to_executor
   // CHECK: } // end sil function '$s4test12RedActorImplC5helloyySiF'
   func hello(_ x : Int) {}
 }
 
 actor BlueActorImpl {
-// CHECK-LABEL: sil hidden [ossa] @$s4test13BlueActorImplC4poke6personyAA03RedcD0C_tYaF : $@convention(method) @async (@guaranteed RedActorImpl, @guaranteed BlueActorImpl) -> () {
+// CHECK-LABEL: sil hidden [ossa] @$s4test13BlueActorImplC4poke6personyAA03RedcD0C_tYaF : $@convention(method) @async (@guaranteed RedActorImpl, @isolated @guaranteed BlueActorImpl) -> () {
 // CHECK:       bb0([[RED:%[0-9]+]] : @guaranteed $RedActorImpl, [[BLUE:%[0-9]+]] : @guaranteed $BlueActorImpl):
 // CHECK:         hop_to_executor [[BLUE]] : $BlueActorImpl
 // CHECK:         [[INTARG:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
-// CHECK:         [[METH:%[0-9]+]] = class_method [[RED]] : $RedActorImpl, #RedActorImpl.hello : (isolated RedActorImpl) -> (Int) -> (), $@convention(method) (Int, @guaranteed RedActorImpl) -> ()
+// CHECK:         [[METH:%[0-9]+]] = class_method [[RED]] : $RedActorImpl, #RedActorImpl.hello : (isolated RedActorImpl) -> (Int) -> (), $@convention(method) (Int, @isolated @guaranteed RedActorImpl) -> ()
 // CHECK:         hop_to_executor [[RED]] : $RedActorImpl
-// CHECK-NEXT:    {{%[0-9]+}} = apply [[METH]]([[INTARG]], [[RED]]) : $@convention(method) (Int, @guaranteed RedActorImpl) -> ()
+// CHECK-NEXT:    {{%[0-9]+}} = apply [[METH]]([[INTARG]], [[RED]]) : $@convention(method) (Int, @isolated @guaranteed RedActorImpl) -> ()
 // CHECK-NEXT:    hop_to_executor [[BLUE]] : $BlueActorImpl
 // CHECK: } // end sil function '$s4test13BlueActorImplC4poke6personyAA03RedcD0C_tYaF'
   func poke(person red : RedActorImpl) async {
     await red.hello(42)
   }
 
-// CHECK-LABEL: sil hidden [ossa] @$s4test13BlueActorImplC14createAndGreetyyYaF : $@convention(method) @async (@guaranteed BlueActorImpl) -> () {
+// CHECK-LABEL: sil hidden [ossa] @$s4test13BlueActorImplC14createAndGreetyyYaF : $@convention(method) @async (@isolated @guaranteed BlueActorImpl) -> () {
 // CHECK:     bb0([[BLUE:%[0-9]+]] : @guaranteed $BlueActorImpl):
 // CHECK:       hop_to_executor [[BLUE]] : $BlueActorImpl
 // CHECK:       [[RED:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@thick RedActorImpl.Type) -> @owned RedActorImpl
 // CHECK:       [[REDMOVE:%[0-9]+]] = move_value [lexical] [var_decl] [[RED]] : $RedActorImpl
 // CHECK:       [[REDBORROW:%[0-9]+]] = begin_borrow [[REDMOVE]] : $RedActorImpl
 // CHECK:       [[INTARG:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
-// CHECK:       [[METH:%[0-9]+]] = class_method [[REDBORROW]] : $RedActorImpl, #RedActorImpl.hello : (isolated RedActorImpl) -> (Int) -> (), $@convention(method) (Int, @guaranteed RedActorImpl) -> ()
+// CHECK:       [[METH:%[0-9]+]] = class_method [[REDBORROW]] : $RedActorImpl, #RedActorImpl.hello : (isolated RedActorImpl) -> (Int) -> (), $@convention(method) (Int, @isolated @guaranteed RedActorImpl) -> ()
 // CHECK:       hop_to_executor [[REDBORROW]] : $RedActorImpl
-// CHECK-NEXT:  = apply [[METH]]([[INTARG]], [[REDBORROW]]) : $@convention(method) (Int, @guaranteed RedActorImpl) -> ()
+// CHECK-NEXT:  = apply [[METH]]([[INTARG]], [[REDBORROW]]) : $@convention(method) (Int, @isolated @guaranteed RedActorImpl) -> ()
 // CHECK-NEXT:  end_borrow [[REDBORROW]] : $RedActorImpl
 // CHECK-NEXT:  hop_to_executor [[BLUE]] : $BlueActorImpl
 // CHECK:       destroy_value [[REDMOVE]] : $RedActorImpl
@@ -301,9 +301,9 @@ func unspecifiedAsyncFunc() async {
 // CHECK:         [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK-NEXT:    hop_to_executor [[GENERIC_EXEC]] :
 // CHECK:         [[INTARG:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
-// CHECK:         [[METH:%[0-9]+]] = class_method [[RED]] : $RedActorImpl, #RedActorImpl.hello : (isolated RedActorImpl) -> (Int) -> (), $@convention(method) (Int, @guaranteed RedActorImpl) -> ()
+// CHECK:         [[METH:%[0-9]+]] = class_method [[RED]] : $RedActorImpl, #RedActorImpl.hello : (isolated RedActorImpl) -> (Int) -> (), $@convention(method) (Int, @isolated @guaranteed RedActorImpl) -> ()
 // CHECK-NEXT:    hop_to_executor [[RED]] : $RedActorImpl
-// CHECK-NEXT:    {{%[0-9]+}} = apply [[METH]]([[INTARG]], [[RED]]) : $@convention(method) (Int, @guaranteed RedActorImpl) -> ()
+// CHECK-NEXT:    {{%[0-9]+}} = apply [[METH]]([[INTARG]], [[RED]]) : $@convention(method) (Int, @isolated @guaranteed RedActorImpl) -> ()
 // CHECK-NEXT:    hop_to_executor [[GENERIC_EXEC]]
 // CHECK: } // end sil function '$s4test27anotherUnspecifiedAsyncFuncyyAA12RedActorImplCYaF'
 func anotherUnspecifiedAsyncFunc(_ red : RedActorImpl) async {
@@ -423,18 +423,18 @@ func testImplicitAsyncIsolatedParam(
   // CHECK-NEXT: hop_to_executor [[GENERIC_EXEC]] :
   // CHECK: [[FN1:%.*]] = function_ref @$s4test19acceptIsolatedParamyySi_AA7MyActorCYiSdtF
   // CHECK-NEXT: hop_to_executor [[ACTOR:%.*]] : $MyActor
-  // CHECK-NEXT: apply [[FN1]](%0, %2, %1) : $@convention(thin) (Int, @guaranteed MyActor, Double) -> ()
+  // CHECK-NEXT: apply [[FN1]](%0, %2, %1) : $@convention(thin) (Int, @isolated @guaranteed MyActor, Double) -> ()
   // CHECK-NEXT: hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
   await acceptIsolatedParam(i, actor, d)
 
-  // CHECK: [[FN2:%.*]] = function_ref @$s4test7MyActorC13otherIsolatedyySi_ACYiSdtF : $@convention(method) (Int, @guaranteed MyActor, Double, @guaranteed MyActor) -> ()
+  // CHECK: [[FN2:%.*]] = function_ref @$s4test7MyActorC13otherIsolatedyySi_ACYiSdtF : $@convention(method) (Int, @isolated @guaranteed MyActor, Double, @guaranteed MyActor) -> ()
   // CHECK-NEXT: hop_to_executor [[ACTOR:%.*]] : $MyActor
-  // CHECK-NEXT: apply [[FN2]](%0, %2, %1, %3) : $@convention(method) (Int, @guaranteed MyActor, Double, @guaranteed MyActor) -> ()
+  // CHECK-NEXT: apply [[FN2]](%0, %2, %1, %3) : $@convention(method) (Int, @isolated @guaranteed MyActor, Double, @guaranteed MyActor) -> ()
   // CHECK-NEXT: hop_to_executor [[GENERIC_EXEC]] : $Optional<Builtin.Executor>
   await otherActor.otherIsolated(i, actor, d)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s4test22asyncWithIsolatedParam1i5actor1dySi_AA7MyActorCYiSdtYaF : $@convention(thin) @async (Int, @guaranteed MyActor, Double) -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s4test22asyncWithIsolatedParam1i5actor1dySi_AA7MyActorCYiSdtYaF : $@convention(thin) @async (Int, @isolated @guaranteed MyActor, Double) -> ()
 func asyncWithIsolatedParam(i: Int, actor: isolated MyActor, d: Double) async {
   // CHECK: [[ACTOR:%.*]] = copy_value %1 : $MyActor
   // CHECK-NEXT: [[BORROWED:%.*]] = begin_borrow [[ACTOR]] : $MyActor

--- a/test/SILGen/hop_to_executor_async_prop.swift
+++ b/test/SILGen/hop_to_executor_async_prop.swift
@@ -83,9 +83,9 @@ struct GlobalCat {
 // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat):
 // CHECK:    [[GENERIC_EXEC:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none
 // CHECK:    hop_to_executor [[GENERIC_EXEC]] :
-// CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+// CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@isolated @guaranteed Cat) -> @owned Sweater
 // CHECK:    hop_to_executor [[CAT]] : $Cat
-// CHECK:    [[SWEATER1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
+// CHECK:    [[SWEATER1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Sweater
 // CHECK:    hop_to_executor [[GENERIC_EXEC]]
 // CHECK:    [[SWEATER1:%[0-9]+]] = begin_borrow [[SWEATER1_REF]] : $Sweater
 // CHECK:    [[SWEATER1_OWNER:%[0-9]+]] = struct_extract [[SWEATER1]] : $Sweater, #Sweater.owner
@@ -94,9 +94,9 @@ struct GlobalCat {
 // CHECK:    destroy_value [[SWEATER1_REF]] : $Sweater
 
 // CHECK:    [[CAT2_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
-// CHECK:    [[CAT2_GETTER:%[0-9]+]] = class_method [[CAT2_FOR_LOAD]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+// CHECK:    [[CAT2_GETTER:%[0-9]+]] = class_method [[CAT2_FOR_LOAD]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@isolated @guaranteed Cat) -> @owned Sweater
 // CHECK:    hop_to_executor [[CAT2_FOR_LOAD]] : $Cat
-// CHECK:    [[SWEATER2_OWNER:%[0-9]+]] = apply [[CAT2_GETTER]]([[CAT2_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
+// CHECK:    [[SWEATER2_OWNER:%[0-9]+]] = apply [[CAT2_GETTER]]([[CAT2_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Sweater
 // CHECK:    hop_to_executor [[GENERIC_EXEC]]
 // CHECK:    end_borrow [[CAT2_FOR_LOAD]] : $Cat
 
@@ -135,7 +135,7 @@ func accessGlobalIsolatedMember(cat : Cat) async -> String {
 
 actor Dog {
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC15accessGlobalVarSbyYaF : $@convention(method) @async (@guaranteed Dog) -> Bool {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC15accessGlobalVarSbyYaF : $@convention(method) @async (@isolated @guaranteed Dog) -> Bool {
     // CHECK:   [[GLOBAL_BOOL_ADDR:%[0-9]+]] = global_addr @$s4test10globalBoolSbvp : $*Bool
     // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
     // CHECK:   [[SHARED_REF_FN:%[0-9]+]] = function_ref @$s4test9GlobalCatV6sharedAA0C0Cvau : $@convention(thin) () -> Builtin.RawPointer
@@ -159,7 +159,7 @@ actor Dog {
     }
 
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC24accessGlobalComputedPropSiyYaF : $@convention(method) @async (@guaranteed Dog) -> Int {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC24accessGlobalComputedPropSiyYaF : $@convention(method) @async (@isolated @guaranteed Dog) -> Int {
     // CHECK:  bb0([[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:    hop_to_executor [[SELF]] : $Dog
 
@@ -176,9 +176,9 @@ actor Dog {
 
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    [[BORROWED_BIRB_FOR_LOAD:%[0-9]+]] = begin_borrow [[BIRB]] : $Birb
-    // CHECK:    [[FEATHER_GETTER:%[0-9]+]] = class_method [[BORROWED_BIRB_FOR_LOAD]] : $Birb, #Birb.feathers!getter : (isolated Birb) -> () -> Int, $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    [[FEATHER_GETTER:%[0-9]+]] = class_method [[BORROWED_BIRB_FOR_LOAD]] : $Birb, #Birb.feathers!getter : (isolated Birb) -> () -> Int, $@convention(method) (@isolated @guaranteed Birb) -> Int
     // CHECK:    hop_to_executor [[BORROWED_BIRB_FOR_LOAD]] : $Birb
-    // CHECK:    [[THE_INT:%[0-9]+]] = apply [[FEATHER_GETTER]]([[BORROWED_BIRB_FOR_LOAD]]) : $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    [[THE_INT:%[0-9]+]] = apply [[FEATHER_GETTER]]([[BORROWED_BIRB_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Birb) -> Int
 
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    return [[THE_INT]] : $Int
@@ -188,17 +188,17 @@ actor Dog {
     }
 
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC21accessWrappedProperty3catSiAA3CatC_tYaF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> Int {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC21accessWrappedProperty3catSiAA3CatC_tYaF : $@convention(method) @async (@guaranteed Cat, @isolated @guaranteed Dog) -> Int {
     // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:    hop_to_executor [[SELF]] : $Dog
-    // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.bestFriend!getter : (isolated Cat) -> () -> Birb, $@convention(method) (@guaranteed Cat) -> @owned Birb
+    // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.bestFriend!getter : (isolated Cat) -> () -> Birb, $@convention(method) (@isolated @guaranteed Cat) -> @owned Birb
     // CHECK:    hop_to_executor [[CAT]] : $Cat
-    // CHECK:    [[BIRB_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Birb
+    // CHECK:    [[BIRB_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Birb
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    [[BIRB_FOR_LOAD:%[0-9]+]] = begin_borrow [[BIRB_REF]] : $Birb
-    // CHECK:    [[BIRB_GETTER:%[0-9]+]] = class_method [[BIRB_FOR_LOAD]] : $Birb, #Birb.feathers!getter : (isolated Birb) -> () -> Int, $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    [[BIRB_GETTER:%[0-9]+]] = class_method [[BIRB_FOR_LOAD]] : $Birb, #Birb.feathers!getter : (isolated Birb) -> () -> Int, $@convention(method) (@isolated @guaranteed Birb) -> Int
     // CHECK:    hop_to_executor [[BIRB_FOR_LOAD]] : $Birb
-    // CHECK:    [[THE_INT:%[0-9]+]] = apply [[BIRB_GETTER]]([[BIRB_FOR_LOAD]]) : $@convention(method) (@guaranteed Birb) -> Int
+    // CHECK:    [[THE_INT:%[0-9]+]] = apply [[BIRB_GETTER]]([[BIRB_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Birb) -> Int
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    return [[THE_INT]] : $Int
     // CHECK: } // end sil function '$s4test3DogC21accessWrappedProperty3catSiAA3CatC_tYaF'
@@ -207,15 +207,15 @@ actor Dog {
     }
 
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC16accessFromRValueSbyYaF : $@convention(method) @async (@guaranteed Dog) -> Bool {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC16accessFromRValueSbyYaF : $@convention(method) @async (@isolated @guaranteed Dog) -> Bool {
     // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
     // CHECK:   [[INIT:%[0-9]+]] = function_ref @$s4test3CatCACycfC : $@convention(method) (@thick Cat.Type) -> @owned Cat
     // CHECK:   [[CAT_REF:%[0-9]+]] = apply [[INIT]]({{%[0-9]+}}) : $@convention(method) (@thick Cat.Type) -> @owned Cat
 
     // CHECK:   [[CAT_BORROW_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
-    // CHECK:   [[GETTER:%[0-9]+]] = class_method [[CAT_BORROW_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (isolated Cat) -> () -> Bool, $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   [[GETTER:%[0-9]+]] = class_method [[CAT_BORROW_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (isolated Cat) -> () -> Bool, $@convention(method) (@isolated @guaranteed Cat) -> Bool
     // CHECK:   hop_to_executor [[CAT_BORROW_FOR_LOAD]] : $Cat
-    // CHECK:   [[THE_BOOL:%[0-9]+]] = apply [[GETTER]]([[CAT_BORROW_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   [[THE_BOOL:%[0-9]+]] = apply [[GETTER]]([[CAT_BORROW_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Cat) -> Bool
 
     // CHECK:   hop_to_executor [[SELF]] : $Dog
     // CHECK:   return [[THE_BOOL]] : $Bool
@@ -225,24 +225,24 @@ actor Dog {
     }
 
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC23accessFromRValueChainedSbyYaF : $@convention(method) @async (@guaranteed Dog) -> Bool {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC23accessFromRValueChainedSbyYaF : $@convention(method) @async (@isolated @guaranteed Dog) -> Bool {
     // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
     // CHECK:   [[INIT:%[0-9]+]] = function_ref @$s4test3CatCACycfC : $@convention(method) (@thick Cat.Type) -> @owned Cat
     // CHECK:   [[CAT_REF:%[0-9]+]] = apply [[INIT]]({{%[0-9]+}}) : $@convention(method) (@thick Cat.Type) -> @owned Cat
 
     // CHECK:   [[CAT_BORROW_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT_REF]] : $Cat
-    // CHECK:   [[FRIEND_GETTER:%[0-9]+]] = class_method [[CAT_BORROW_FOR_LOAD]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:   [[FRIEND_GETTER:%[0-9]+]] = class_method [[CAT_BORROW_FOR_LOAD]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@isolated @guaranteed Cat) -> @owned Cat
     // CHECK:   hop_to_executor [[CAT_BORROW_FOR_LOAD]] : $Cat
-    // CHECK:   [[FRIEND_REF:%[0-9]+]] = apply [[FRIEND_GETTER]]([[CAT_BORROW_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:   [[FRIEND_REF:%[0-9]+]] = apply [[FRIEND_GETTER]]([[CAT_BORROW_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Cat
     // CHECK:   hop_to_executor [[SELF]] : $Dog
     // CHECK:   end_borrow [[CAT_BORROW_FOR_LOAD]] : $Cat
 
     // CHECK:   destroy_value [[CAT_REF]] : $Cat
 
     // CHECK:   [[FRIEND_BORROW_FOR_LOAD:%[0-9]+]] = begin_borrow [[FRIEND_REF]] : $Cat
-    // CHECK:   [[BOOL_GETTER:%[0-9]+]] = class_method [[FRIEND_BORROW_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (isolated Cat) -> () -> Bool, $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   [[BOOL_GETTER:%[0-9]+]] = class_method [[FRIEND_BORROW_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (isolated Cat) -> () -> Bool, $@convention(method) (@isolated @guaranteed Cat) -> Bool
     // CHECK:   hop_to_executor [[FRIEND_BORROW_FOR_LOAD]] : $Cat
-    // CHECK:   [[THE_BOOL:%[0-9]+]] = apply [[BOOL_GETTER]]([[FRIEND_BORROW_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:   [[THE_BOOL:%[0-9]+]] = apply [[BOOL_GETTER]]([[FRIEND_BORROW_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Cat) -> Bool
 
     // CHECK:   hop_to_executor [[SELF]] : $Dog
     // CHECK:   end_borrow [[FRIEND_BORROW_FOR_LOAD]] : $Cat
@@ -254,14 +254,14 @@ actor Dog {
     }
 
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC15accessSubscript3catAA3CatCAG_tYaF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Cat {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC15accessSubscript3catAA3CatCAG_tYaF : $@convention(method) @async (@guaranteed Cat, @isolated @guaranteed Dog) -> @owned Cat {
     // CHECK: bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[DOG:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:   hop_to_executor [[DOG]] : $Dog
     // CHECK:   [[INTEGER1:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}, {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 
-    // CHECK:   [[SUBSCRIPT_FN:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.subscript!getter : (isolated Cat) -> (Int) -> Cat, $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   [[SUBSCRIPT_FN:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.subscript!getter : (isolated Cat) -> (Int) -> Cat, $@convention(method) (Int, @isolated @guaranteed Cat) -> @owned Cat
     // CHECK:   hop_to_executor [[CAT]] : $Cat
-    // CHECK:   [[OTHER_CAT:%[0-9]+]] = apply [[SUBSCRIPT_FN]]([[INTEGER1]], [[CAT]]) : $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   [[OTHER_CAT:%[0-9]+]] = apply [[SUBSCRIPT_FN]]([[INTEGER1]], [[CAT]]) : $@convention(method) (Int, @isolated @guaranteed Cat) -> @owned Cat
 
     // CHECK:   hop_to_executor [[DOG]] : $Dog
     // CHECK:   return [[OTHER_CAT]] : $Cat
@@ -270,16 +270,16 @@ actor Dog {
         return await cat[1]
     }
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC27accessRValueNestedSubscriptAA3CatCyYaF : $@convention(method) @async (@guaranteed Dog) -> @owned Cat {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC27accessRValueNestedSubscriptAA3CatCyYaF : $@convention(method) @async (@isolated @guaranteed Dog) -> @owned Cat {
     // CHECK:   hop_to_executor [[SELF:%[0-9]+]] : $Dog
     // CHECK:   [[RVALUE_CAT_REF:%[0-9]+]] = apply {{%[0-9]+}}({{%[0-9]+}}) : $@convention(method) (@thick Cat.Type) -> @owned Cat
     // CHECK:   [[LIT_ONE:%[0-9]+]] = integer_literal $Builtin.IntLiteral, 1
     // CHECK:   [[INT_ONE:%[0-9]+]] = apply {{%[0-9]+}}([[LIT_ONE]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 
     // CHECK:   [[RVALUE_CAT_FOR_LOAD:%[0-9]+]] = begin_borrow [[RVALUE_CAT_REF]] : $Cat
-    // CHECK:   [[RVALUE_CAT_SUBSCRIPT:%[0-9]+]] = class_method [[RVALUE_CAT_FOR_LOAD]] : $Cat, #Cat.subscript!getter : (isolated Cat) -> (Int) -> Cat, $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   [[RVALUE_CAT_SUBSCRIPT:%[0-9]+]] = class_method [[RVALUE_CAT_FOR_LOAD]] : $Cat, #Cat.subscript!getter : (isolated Cat) -> (Int) -> Cat, $@convention(method) (Int, @isolated @guaranteed Cat) -> @owned Cat
     // CHECK:   hop_to_executor [[RVALUE_CAT_FOR_LOAD]] : $Cat
-    // CHECK:   [[FIRST_CAT_REF:%[0-9]+]] = apply [[RVALUE_CAT_SUBSCRIPT]]([[INT_ONE]], [[RVALUE_CAT_FOR_LOAD]]) : $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   [[FIRST_CAT_REF:%[0-9]+]] = apply [[RVALUE_CAT_SUBSCRIPT]]([[INT_ONE]], [[RVALUE_CAT_FOR_LOAD]]) : $@convention(method) (Int, @isolated @guaranteed Cat) -> @owned Cat
     // CHECK:   hop_to_executor [[SELF]] : $Dog
     // CHECK:   end_borrow [[RVALUE_CAT_FOR_LOAD]] : $Cat
 
@@ -288,9 +288,9 @@ actor Dog {
     // CHECK:   [[INT_TWO:%[0-9]+]] = apply {{%[0-9]+}}([[LIT_TWO]], {{%[0-9]+}}) : $@convention(method) (Builtin.IntLiteral, @thin Int.Type) -> Int
 
     // CHECK:   [[FIRST_CAT_FOR_LOAD:%[0-9]+]] = begin_borrow [[FIRST_CAT_REF]] : $Cat
-    // CHECK:   [[FIRST_CAT_SUBSCRIPT:%[0-9]+]] = class_method [[FIRST_CAT_FOR_LOAD]] : $Cat, #Cat.subscript!getter : (isolated Cat) -> (Int) -> Cat, $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   [[FIRST_CAT_SUBSCRIPT:%[0-9]+]] = class_method [[FIRST_CAT_FOR_LOAD]] : $Cat, #Cat.subscript!getter : (isolated Cat) -> (Int) -> Cat, $@convention(method) (Int, @isolated @guaranteed Cat) -> @owned Cat
     // CHECK:   hop_to_executor [[FIRST_CAT_FOR_LOAD]] : $Cat
-    // CHECK:   [[SECOND_CAT_REF:%[0-9]+]] = apply [[FIRST_CAT_SUBSCRIPT]]([[INT_TWO]], [[FIRST_CAT_FOR_LOAD]]) : $@convention(method) (Int, @guaranteed Cat) -> @owned Cat
+    // CHECK:   [[SECOND_CAT_REF:%[0-9]+]] = apply [[FIRST_CAT_SUBSCRIPT]]([[INT_TWO]], [[FIRST_CAT_FOR_LOAD]]) : $@convention(method) (Int, @isolated @guaranteed Cat) -> @owned Cat
     // CHECK:   hop_to_executor [[SELF]] : $Dog
     // CHECK:   end_borrow [[FIRST_CAT_FOR_LOAD]] : $Cat
 
@@ -302,16 +302,16 @@ actor Dog {
     }
 
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC33accessStoredPropFromRefProjection3boxSbAA6CatBoxC_tYaF : $@convention(method) @async (@guaranteed CatBox, @guaranteed Dog) -> Bool {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC33accessStoredPropFromRefProjection3boxSbAA6CatBoxC_tYaF : $@convention(method) @async (@guaranteed CatBox, @isolated @guaranteed Dog) -> Bool {
     // CHECK:   bb0([[BOX:%[0-9]+]] : @guaranteed $CatBox, [[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:     hop_to_executor [[SELF]] : $Dog
     // CHECK:     [[BOX_GETTER:%[0-9]+]] = class_method [[BOX]] : $CatBox, #CatBox.cat!getter : (CatBox) -> () -> Cat, $@convention(method) (@guaranteed CatBox) -> @owned Cat
     // CHECK:     [[CAT_REF:%[0-9]+]] = apply [[BOX_GETTER]]([[BOX]]) : $@convention(method) (@guaranteed CatBox) -> @owned Cat
 
     // CHECK:     [[CAT_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT_REF:%[0-9]+]] : $Cat
-    // CHECK:     [[GETTER:%[0-9]+]] = class_method [[CAT_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (isolated Cat) -> () -> Bool, $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:     [[GETTER:%[0-9]+]] = class_method [[CAT_FOR_LOAD]] : $Cat, #Cat.storedBool!getter : (isolated Cat) -> () -> Bool, $@convention(method) (@isolated @guaranteed Cat) -> Bool
     // CHECK:     hop_to_executor [[CAT_FOR_LOAD]] : $Cat
-    // CHECK:     [[THE_BOOL:%[0-9]+]] = apply [[GETTER]]([[CAT_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> Bool
+    // CHECK:     [[THE_BOOL:%[0-9]+]] = apply [[GETTER]]([[CAT_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Cat) -> Bool
     // CHECK:     hop_to_executor [[SELF]] : $Dog
     // CHECK:     end_borrow [[CAT_FOR_LOAD]] : $Cat
 
@@ -322,13 +322,13 @@ actor Dog {
         return await box.cat.storedBool
     }
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC015accessSweaterOfD03catAA0D0VAA3CatC_tYaF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Sweater {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC015accessSweaterOfD03catAA0D0VAA3CatC_tYaF : $@convention(method) @async (@guaranteed Cat, @isolated @guaranteed Dog) -> @owned Sweater {
     // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:    hop_to_executor [[SELF]] : $Dog
 
-    // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+    // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@isolated @guaranteed Cat) -> @owned Sweater
     // CHECK:    hop_to_executor [[CAT]] : $Cat
-    // CHECK:    [[SWEATER1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
+    // CHECK:    [[SWEATER1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Sweater
 
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    [[SWEATER1:%[0-9]+]] = begin_borrow [[SWEATER1_REF]] : $Sweater
@@ -338,9 +338,9 @@ actor Dog {
     // CHECK:    destroy_value [[SWEATER1_REF]] : $Sweater
 
     // CHECK:    [[CAT2_FOR_LOAD:%[0-9]+]] = begin_borrow [[CAT2_REF]] : $Cat
-    // CHECK:    [[CAT2_GETTER:%[0-9]+]] = class_method [[CAT2_FOR_LOAD]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@guaranteed Cat) -> @owned Sweater
+    // CHECK:    [[CAT2_GETTER:%[0-9]+]] = class_method [[CAT2_FOR_LOAD]] : $Cat, #Cat.computedSweater!getter : (isolated Cat) -> () -> Sweater, $@convention(method) (@isolated @guaranteed Cat) -> @owned Sweater
     // CHECK:    hop_to_executor [[CAT2_FOR_LOAD]] : $Cat
-    // CHECK:    [[SWEATER2_OWNER:%[0-9]+]] = apply [[CAT2_GETTER]]([[CAT2_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Sweater
+    // CHECK:    [[SWEATER2_OWNER:%[0-9]+]] = apply [[CAT2_GETTER]]([[CAT2_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Sweater
 
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    end_borrow [[CAT2_FOR_LOAD]] : $Cat
@@ -353,17 +353,17 @@ actor Dog {
     }
 
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC13accessCatList3catAA0D0CAG_tYaF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Cat {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC13accessCatList3catAA0D0CAG_tYaF : $@convention(method) @async (@guaranteed Cat, @isolated @guaranteed Dog) -> @owned Cat {
     // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:    hop_to_executor [[SELF]] : $Dog
-    // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    [[CAT_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@isolated @guaranteed Cat) -> @owned Cat
     // CHECK:    hop_to_executor [[CAT]] : $Cat
-    // CHECK:    [[FRIEND1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    [[FRIEND1_REF:%[0-9]+]] = apply [[CAT_GETTER]]([[CAT]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Cat
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    [[FRIEND1_FOR_LOAD:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
-    // CHECK:    [[FRIEND1_GETTER:%[0-9]+]] = class_method [[FRIEND1_FOR_LOAD]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    [[FRIEND1_GETTER:%[0-9]+]] = class_method [[FRIEND1_FOR_LOAD]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@isolated @guaranteed Cat) -> @owned Cat
     // CHECK:    hop_to_executor [[FRIEND1_FOR_LOAD]] : $Cat
-    // CHECK:    [[FRIEND2_REF:%[0-9]+]] = apply [[FRIEND1_GETTER]]([[FRIEND1_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    [[FRIEND2_REF:%[0-9]+]] = apply [[FRIEND1_GETTER]]([[FRIEND1_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Cat
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    end_borrow [[FRIEND1_FOR_LOAD]] : $Cat
     // CHECK:    destroy_value [[FRIEND1_REF]] : $Cat
@@ -374,14 +374,14 @@ actor Dog {
     }
 
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC21accessOptionalCatList3catAA0E0CSgAG_tYaF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Optional<Cat> {
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC21accessOptionalCatList3catAA0E0CSgAG_tYaF : $@convention(method) @async (@guaranteed Cat, @isolated @guaranteed Dog) -> @owned Optional<Cat> {
     // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    [[FRIEND1_STACK:%[0-9]+]] = alloc_stack $Optional<Cat>
 
-    // CHECK:    [[MAYBE_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.maybeFriend!getter : (isolated Cat) -> () -> Cat?, $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+    // CHECK:    [[MAYBE_GETTER:%[0-9]+]] = class_method [[CAT]] : $Cat, #Cat.maybeFriend!getter : (isolated Cat) -> () -> Cat?, $@convention(method) (@isolated @guaranteed Cat) -> @owned Optional<Cat>
     // CHECK:    hop_to_executor [[CAT]] : $Cat
-    // CHECK:    [[MAYBE_FRIEND:%[0-9]+]] = apply [[MAYBE_GETTER]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+    // CHECK:    [[MAYBE_FRIEND:%[0-9]+]] = apply [[MAYBE_GETTER]]([[CAT]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Optional<Cat>
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    store [[MAYBE_FRIEND]] to [init] [[FRIEND1_STACK]] : $*Optional<Cat>
 
@@ -393,9 +393,9 @@ actor Dog {
     // CHECK:    [[FRIEND1_REF:%[0-9]+]] = load [copy] [[FRIEND1_ADDR]] : $*Cat
     // CHECK:    destroy_addr [[FRIEND1_STACK]] : $*Optional<Cat>
     // CHECK:    [[FRIEND1_FOR_LOAD:%[0-9]+]] = begin_borrow [[FRIEND1_REF]] : $Cat
-    // CHECK:    [[FRIEND1_GETTER:%[0-9]+]] = class_method [[FRIEND1_FOR_LOAD]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    [[FRIEND1_GETTER:%[0-9]+]] = class_method [[FRIEND1_FOR_LOAD]] : $Cat, #Cat.friend!getter : (isolated Cat) -> () -> Cat, $@convention(method) (@isolated @guaranteed Cat) -> @owned Cat
     // CHECK:    hop_to_executor [[FRIEND1_FOR_LOAD]] : $Cat
-    // CHECK:    [[FRIEND2_REF:%[0-9]+]] = apply [[FRIEND1_GETTER]]([[FRIEND1_FOR_LOAD]]) : $@convention(method) (@guaranteed Cat) -> @owned Cat
+    // CHECK:    [[FRIEND2_REF:%[0-9]+]] = apply [[FRIEND1_GETTER]]([[FRIEND1_FOR_LOAD]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Cat
     // CHECK:    hop_to_executor [[SELF]] : $Dog
     // CHECK:    end_borrow [[FRIEND1_FOR_LOAD]] : $Cat
     // CHECK:    destroy_value [[FRIEND1_REF]] : $Cat
@@ -409,13 +409,13 @@ actor Dog {
         return await cat.maybeFriend?.friend
     }
 
-    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC22accessOptionalViaIfLet3catAA3CatCSgAG_tYaF : $@convention(method) @async (@guaranteed Cat, @guaranteed Dog) -> @owned Optional<Cat>
+    // CHECK-LABEL: sil hidden [ossa] @$s4test3DogC22accessOptionalViaIfLet3catAA3CatCSgAG_tYaF : $@convention(method) @async (@guaranteed Cat, @isolated @guaranteed Dog) -> @owned Optional<Cat>
     // CHECK:  bb0([[CAT:%[0-9]+]] : @guaranteed $Cat, [[SELF:%[0-9]+]] : @guaranteed $Dog):
     func accessOptionalViaIfLet(cat: Cat) async -> Cat? {
         // CHECK: hop_to_executor [[SELF]] : $Dog
-        // CHECK: [[METHOD:%.*]] = class_method [[CAT]] : $Cat, #Cat.maybeFriend!getter : (isolated Cat) -> () -> Cat?, $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+        // CHECK: [[METHOD:%.*]] = class_method [[CAT]] : $Cat, #Cat.maybeFriend!getter : (isolated Cat) -> () -> Cat?, $@convention(method) (@isolated @guaranteed Cat) -> @owned Optional<Cat>
         // CHECK: hop_to_executor [[CAT]] : $Cat                       // id: %6
-        // CHECK: [[RESULT:%.*]] = apply [[METHOD]]([[CAT]]) : $@convention(method) (@guaranteed Cat) -> @owned Optional<Cat>
+        // CHECK: [[RESULT:%.*]] = apply [[METHOD]]([[CAT]]) : $@convention(method) (@isolated @guaranteed Cat) -> @owned Optional<Cat>
         // CHECK: hop_to_executor [[SELF]] : $Dog
         // CHECK: switch_enum [[RESULT]]
         if let friend = await cat.maybeFriend {

--- a/test/SILGen/isolated_parameters.swift
+++ b/test/SILGen/isolated_parameters.swift
@@ -15,7 +15,7 @@ public func takesIsolated(_: isolated A) { }
 public func takeClosureWithIsolatedParam(body: (isolated A) async -> Void) { }
 
 // Emit the unnamed parameter when it's isolated, so that we can hop to it.
-// CHECK-LABEL: sil private [ossa] @$s4test0A24ClosureWithIsolatedParamyyFyAA1ACYiYaXEfU_ : $@convention(thin) @async (@guaranteed A)
+// CHECK-LABEL: sil private [ossa] @$s4test0A24ClosureWithIsolatedParamyyFyAA1ACYiYaXEfU_ : $@convention(thin) @async (@isolated @guaranteed A)
 // CHECK: bb0(%0 : @guaranteed $A):
 // CHECK: [[COPY:%.*]] = copy_value %0 : $A
 // CHECK-NEXT: [[BORROW:%.*]] = begin_borrow [[COPY]] : $A

--- a/test/SILGen/objc_async_from_swift.swift
+++ b/test/SILGen/objc_async_from_swift.swift
@@ -202,12 +202,12 @@ class ActorConstrained: NSObject {
 
 actor Dril: NSObject {
     // Dril.postTo(twitter:)
-    // CHECK-LABEL: sil hidden [ossa] @$s{{.*}}4DrilC6postTo7twitter{{.*}} : $@convention(method) @async (@guaranteed String, @guaranteed Dril) -> Bool {
+    // CHECK-LABEL: sil hidden [ossa] @$s{{.*}}4DrilC6postTo7twitter{{.*}} : $@convention(method) @async (@guaranteed String, @isolated @guaranteed Dril) -> Bool {
     // CHECK:           hop_to_executor {{%.*}} : $Dril
 
     // @objc Dril.postTo(twitter:)
-    // CHECK-LABEL: sil private [thunk] [ossa] @$s{{.*}}4DrilC6postTo7twitter{{.*}}To : $@convention(objc_method) (NSString, @convention(block) (Bool) -> (), Dril) -> () {
-    // CHECK:         [[ASYNC_CLOS:%[0-9]+]] = function_ref @$s{{.*}}4DrilC6postTo7twitter{{.*}}U_To : $@convention(thin) @Sendable @async (NSString, @convention(block) (Bool) -> (), Dril) -> ()
+    // CHECK-LABEL: sil private [thunk] [ossa] @$s{{.*}}4DrilC6postTo7twitter{{.*}}To : $@convention(objc_method) (NSString, @convention(block) (Bool) -> (), @isolated Dril) -> () {
+    // CHECK:         [[ASYNC_CLOS:%[0-9]+]] = function_ref @$s{{.*}}4DrilC6postTo7twitter{{.*}}U_To : $@convention(thin) @Sendable @async (NSString, @convention(block) (Bool) -> (), @isolated Dril) -> ()
     // CHECK:         [[PRIMED_CLOS:%[0-9]+]] = partial_apply [callee_guaranteed] [[ASYNC_CLOS]](
     // CHECK:         [[TASK_RUNNER:%[0-9]+]] = function_ref @$ss29_runTaskForBridgedAsyncMethodyyyyYaYbcnF
     // CHECK:         apply [[TASK_RUNNER]]([[PRIMED_CLOS]])

--- a/test/SILOptimizer/definite_init_actor.swift
+++ b/test/SILOptimizer/definite_init_actor.swift
@@ -13,7 +13,7 @@ func arbitraryAsync() async {}
 
 actor BoringActor {
 
-    // CHECK-LABEL: sil hidden @$s4test11BoringActorCACyYacfc : $@convention(method) @async (@owned BoringActor) -> @owned BoringActor {
+    // CHECK-LABEL: sil hidden @$s4test11BoringActorCACyYacfc : $@convention(method) @async (@isolated @owned BoringActor) -> @owned BoringActor {
     // CHECK:   bb0([[SELF:%[0-9]+]] : $BoringActor):
     // CHECK:       initializeDefaultActor
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
@@ -21,7 +21,7 @@ actor BoringActor {
     // CHECK: } // end sil function '$s4test11BoringActorCACyYacfc'
     init() async {}
 
-    // CHECK-LABEL: sil hidden @$s4test11BoringActorC4sizeACSi_tYacfc : $@convention(method) @async (Int, @owned BoringActor) -> @owned BoringActor {
+    // CHECK-LABEL: sil hidden @$s4test11BoringActorC4sizeACSi_tYacfc : $@convention(method) @async (Int, @isolated @owned BoringActor) -> @owned BoringActor {
     // CHECK:   bb0({{%[0-9]+}} : $Int, [[SELF:%[0-9]+]] : $BoringActor):
     // CHECK:       initializeDefaultActor
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
@@ -47,7 +47,7 @@ actor BoringActor {
       await arbitraryAsync()
     }
 
-    // CHECK-LABEL: sil hidden @$s4test11BoringActorC6crashyACSgyt_tYacfc : $@convention(method) @async (@owned BoringActor) -> @owned Optional<BoringActor> {
+    // CHECK-LABEL: sil hidden @$s4test11BoringActorC6crashyACSgyt_tYacfc : $@convention(method) @async (@isolated @owned BoringActor) -> @owned Optional<BoringActor> {
     // CHECK:   bb0([[SELF:%[0-9]+]] : $BoringActor):
     // CHECK:       initializeDefaultActor
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
@@ -55,7 +55,7 @@ actor BoringActor {
     // CHECK: } // end sil function '$s4test11BoringActorC6crashyACSgyt_tYacfc'
     init!(crashy: Void) async { return nil }
 
-    // CHECK-LABEL: sil hidden @$s4test11BoringActorC5nillyACSgSi_tYacfc : $@convention(method) @async (Int, @owned BoringActor) -> @owned Optional<BoringActor> {
+    // CHECK-LABEL: sil hidden @$s4test11BoringActorC5nillyACSgSi_tYacfc : $@convention(method) @async (Int, @isolated @owned BoringActor) -> @owned Optional<BoringActor> {
     // CHECK:   bb0({{%[0-9]+}} : $Int, [[SELF:%[0-9]+]] : $BoringActor):
     // CHECK:       initializeDefaultActor
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
@@ -73,7 +73,7 @@ actor BoringActor {
      myVar = 0
    }
 
-    // CHECK-LABEL: sil hidden @$s4test14SingleVarActorCACyYacfc : $@convention(method) @async (@owned SingleVarActor) -> @owned SingleVarActor {
+    // CHECK-LABEL: sil hidden @$s4test14SingleVarActorCACyYacfc : $@convention(method) @async (@isolated @owned SingleVarActor) -> @owned SingleVarActor {
     // CHECK:    bb0([[SELF:%[0-9]+]] : $SingleVarActor):
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
     // CHECK:       store {{%[0-9]+}} to [[ACCESS:%[0-9]+]]
@@ -86,7 +86,7 @@ actor BoringActor {
         myVar = 1
     }
 
-    // CHECK-LABEL: sil hidden @$s4test14SingleVarActorC10iterationsACSi_tYacfc : $@convention(method) @async (Int, @owned SingleVarActor) -> @owned SingleVarActor {
+    // CHECK-LABEL: sil hidden @$s4test14SingleVarActorC10iterationsACSi_tYacfc : $@convention(method) @async (Int, @isolated @owned SingleVarActor) -> @owned SingleVarActor {
     // CHECK:   bb0({{%[0-9]+}} : $Int, [[SELF:%[0-9]+]] : $SingleVarActor):
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
     // CHECK:       [[MYVAR_REF:%[0-9]+]] = ref_element_addr [[EI]] : $SingleVarActor, #SingleVarActor.myVar
@@ -103,7 +103,7 @@ actor BoringActor {
         } while iter > 0
     }
 
-    // CHECK-LABEL: sil hidden @$s4test14SingleVarActorC2b12b2ACSb_SbtYacfc : $@convention(method) @async (Bool, Bool, @owned SingleVarActor) -> @owned SingleVarActor {
+    // CHECK-LABEL: sil hidden @$s4test14SingleVarActorC2b12b2ACSb_SbtYacfc : $@convention(method) @async (Bool, Bool, @isolated @owned SingleVarActor) -> @owned SingleVarActor {
     // CHECK:   bb0({{%[0-9]+}} : $Bool, {{%[0-9]+}} : $Bool, [[SELF:%[0-9]+]] : $SingleVarActor):
 
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
@@ -130,7 +130,7 @@ actor BoringActor {
         myVar = 2
     }
 
-   // CHECK-LABEL: sil hidden @$s4test14SingleVarActorC14failable_asyncACSgSb_tYacfc : $@convention(method) @async (Bool, @owned SingleVarActor) -> @owned Optional<SingleVarActor> {
+   // CHECK-LABEL: sil hidden @$s4test14SingleVarActorC14failable_asyncACSgSb_tYacfc : $@convention(method) @async (Bool, @isolated @owned SingleVarActor) -> @owned Optional<SingleVarActor> {
    // CHECK: bb0({{%[0-9]+}} : $Bool, {{%[0-9]+}} : $SingleVarActor):
    // CHECK:   cond_br {{%[0-9]+}}, [[SUCCESS_BB:bb[0-9]+]], {{bb[0-9]+}}
    //
@@ -177,7 +177,7 @@ actor DefaultInit {
     var y: String = ""
     var z: ActingError<Int> = .smuggledValue(5)
 
-    // CHECK-LABEL: sil hidden @$s4test11DefaultInitCACyYacfc : $@convention(method) @async (@owned DefaultInit) -> @owned DefaultInit {
+    // CHECK-LABEL: sil hidden @$s4test11DefaultInitCACyYacfc : $@convention(method) @async (@isolated @owned DefaultInit) -> @owned DefaultInit {
     // CHECK:   bb0([[SELF:%[0-9]+]] : $DefaultInit):
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
     // CHECK:       store {{%[0-9]+}} to {{%[0-9]+}} : $*ActingError<Int>
@@ -185,7 +185,7 @@ actor DefaultInit {
     // CHECK: } // end sil function '$s4test11DefaultInitCACyYacfc'
     init() async {}
 
-    // CHECK-LABEL: sil hidden @$s4test11DefaultInitC5nillyACSgSb_tYacfc : $@convention(method) @async (Bool, @owned DefaultInit) -> @owned Optional<DefaultInit> {
+    // CHECK-LABEL: sil hidden @$s4test11DefaultInitC5nillyACSgSb_tYacfc : $@convention(method) @async (Bool, @isolated @owned DefaultInit) -> @owned Optional<DefaultInit> {
     // CHECK:   bb0({{%[0-9]+}} : $Bool, [[SELF:%[0-9]+]] : $DefaultInit):
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
     // CHECK:       store {{%[0-9]+}} to {{%[0-9]+}} : $*ActingError<Int>
@@ -203,7 +203,7 @@ actor MultiVarActor {
     var firstVar: Int
     var secondVar: Float
 
-    // CHECK-LABEL: sil hidden @$s4test13MultiVarActorC10doNotThrowACSb_tYaKcfc : $@convention(method) @async (Bool, @owned MultiVarActor) -> (@owned MultiVarActor, @error any Error) {
+    // CHECK-LABEL: sil hidden @$s4test13MultiVarActorC10doNotThrowACSb_tYaKcfc : $@convention(method) @async (Bool, @isolated @owned MultiVarActor) -> (@owned MultiVarActor, @error any Error) {
     // CHECK:   bb0({{%[0-9]+}} : $Bool, [[SELF:%[0-9]+]] : $MultiVarActor):
     // CHECK:       [[EI:%.*]] = end_init_let_ref [[SELF]]
     // CHECK:       [[REF:%[0-9]+]] = ref_element_addr [[EI]] : $MultiVarActor, #MultiVarActor.firstVar
@@ -218,7 +218,7 @@ actor MultiVarActor {
         firstVar = 1
     }
 
-    // CHECK-LABEL: sil hidden @$s4test13MultiVarActorC10noSuccCaseACSb_tYacfc : $@convention(method) @async (Bool, @owned MultiVarActor) -> @owned MultiVarActor {
+    // CHECK-LABEL: sil hidden @$s4test13MultiVarActorC10noSuccCaseACSb_tYacfc : $@convention(method) @async (Bool, @isolated @owned MultiVarActor) -> @owned MultiVarActor {
     // CHECK:       store {{%[0-9]+}} to [[A1:%[0-9]+]] : $*Int
     // CHECK-NEXT:  end_access [[A1]]
     // CHECK-NEXT:  hop_to_executor {{%[0-9]+}} : $MultiVarActor
@@ -235,7 +235,7 @@ actor MultiVarActor {
         firstVar = 2
     }
 
-    // CHECK-LABEL: sil hidden @$s4test13MultiVarActorC10noPredCaseACSb_tYacfc : $@convention(method) @async (Bool, @owned MultiVarActor) -> @owned MultiVarActor {
+    // CHECK-LABEL: sil hidden @$s4test13MultiVarActorC10noPredCaseACSb_tYacfc : $@convention(method) @async (Bool, @isolated @owned MultiVarActor) -> @owned MultiVarActor {
     // CHECK:       store {{%[0-9]+}} to [[ACCESS:%[0-9]+]] : $*Int
     // CHECK-NEXT:  end_access [[ACCESS]]
     // CHECK-NEXT:  hop_to_executor {{%[0-9]+}} : $MultiVarActor
@@ -282,7 +282,7 @@ actor TaskMaster {
     func sayHello() { print("hello") }
 
     ////// for the initializer
-    // CHECK-LABEL: @$s4test10TaskMasterCACyYacfc : $@convention(method) @async (@owned TaskMaster) -> @owned TaskMaster {
+    // CHECK-LABEL: @$s4test10TaskMasterCACyYacfc : $@convention(method) @async (@isolated @owned TaskMaster) -> @owned TaskMaster {
     // CHECK:           [[ELM:%[0-9]+]] = ref_element_addr [[SELF:%[0-9]+]] : $TaskMaster, #TaskMaster.task
     // CHECK:           [[NIL:%[0-9]+]] = enum $Optional<Task<(), Never>>, #Optional.none!enumelt
     // CHECK:           store [[NIL]] to [[ELM]] : $*Optional<Task<(), Never>>
@@ -301,7 +301,7 @@ actor TaskMaster {
 actor SomeActor {
     var x: Int = 0
 
-    // CHECK-LABEL: sil hidden @$s4test9SomeActorCACyYacfc : $@convention(method) @async (@owned SomeActor) -> @owned SomeActor {
+    // CHECK-LABEL: sil hidden @$s4test9SomeActorCACyYacfc : $@convention(method) @async (@isolated @owned SomeActor) -> @owned SomeActor {
     // CHECK-NOT:       begin_access
     // CHECK:           store {{%[0-9]+}} to {{%[0-9]+}} : $*Int
     // CHECK-NEXT:      hop_to_executor {{%[0-9]+}} : $SomeActor


### PR DESCRIPTION
This PR contains two changes:

1. The first change makes it so that we can represent isolated in SILFunctionType. As a knock on effect, I had to teach an assert that a distributed thunk that differs in isolation type in self is an ok thunk.
2. I taught the region isolation checker that if we see self that is passed to a function that is non-isolated, do not treat it as actor derived.

rdar://121387872