### PR TITLE
[5.10] Tests: Update stdlib/RuntimeObjC.swift to always link libswiftCoreGraphics

### DIFF
--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -171,6 +171,11 @@ func withSwiftObjectCanary<T>(
   expectEqual(0, swiftObjectCanaryCount, stackTrace: stackTrace)
 }
 
+// Hack to ensure the CustomReflectable conformance is used directly by the test
+// in case it comes from a library that would otherwise not be autolinked.
+@inline(never)
+func assertCustomReflectable<T: CustomReflectable>(_ t: T) {}
+
 var Runtime = TestSuite("Runtime")
 
 func _isClassOrObjCExistential_Opaque<T>(_ x: T.Type) -> Bool {
@@ -614,7 +619,9 @@ Reflection.test("MetatypeMirror") {
 
 Reflection.test("CGPoint") {
   var output = ""
-  dump(CGPoint(x: 1.25, y: 2.75), to: &output)
+  let point = CGPoint(x: 1.25, y: 2.75)
+  assertCustomReflectable(point)
+  dump(point, to: &output)
 
   let expected =
     "▿ (1.25, 2.75)\n" +
@@ -626,7 +633,9 @@ Reflection.test("CGPoint") {
 
 Reflection.test("CGSize") {
   var output = ""
-  dump(CGSize(width: 1.25, height: 2.75), to: &output)
+  let size = CGSize(width: 1.25, height: 2.75)
+  assertCustomReflectable(size)
+  dump(size, to: &output)
 
   let expected =
     "▿ (1.25, 2.75)\n" +
@@ -638,11 +647,11 @@ Reflection.test("CGSize") {
 
 Reflection.test("CGRect") {
   var output = ""
-  dump(
-    CGRect(
-      origin: CGPoint(x: 1.25, y: 2.25),
-      size: CGSize(width: 10.25, height: 11.75)),
-    to: &output)
+  let rect = CGRect(
+    origin: CGPoint(x: 1.25, y: 2.25),
+    size: CGSize(width: 10.25, height: 11.75))
+  assertCustomReflectable(rect)
+  dump(rect, to: &output)
 
   let expected =
     "▿ (1.25, 2.25, 10.25, 11.75)\n" +


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/71101.

The core definitions of `CGPoint` and other types were pushed down from CoreGraphics to CoreFoundation. This test indirectly depends on the conformance of those types to CustomReflectable, but nothing in the test was using those conformances explicitly and so libswiftCoreGraphics would not be auto-linked when the test is compiled at a high enough deployment target. Use the conformances directly to force linkage.

Resolves rdar://121343931
