### PR TITLE
[BitwiseCopyable] Add targeted diagnostics for Copyable and Escapable.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7611,6 +7611,10 @@ ERROR(escapable_requires_feature_flag,none,
       ())
 ERROR(non_bitwise_copyable_type_class,none,
       "class cannot conform to 'BitwiseCopyable'", ())
+ERROR(non_bitwise_copyable_type_noncopyable,none,
+      "noncopyable type cannot conform to 'BitwiseCopyable'", ())
+ERROR(non_bitwise_copyable_type_nonescapable,none,
+      "nonescapable type cannot conform to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_type_member,none,
       "%select{stored property %2|associated value %2}1 of "
       "'BitwiseCopyable'-conforming %kind3 has non-bitwise-copyable type %0",

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -219,10 +219,8 @@ void BitwiseCopyableStorageVisitor::emitNonconformingMemberTypeDiagnostic(
 static bool checkBitwiseCopyableInstanceStorage(NominalTypeDecl *nominal,
                                                 DeclContext *dc,
                                                 BitwiseCopyableCheck check) {
-  // If the BitwiseCopyable protocol doesn't exist, there's nothing to do.
-  if (!dc->getParentModule()->getASTContext().getProtocol(
-          KnownProtocolKind::BitwiseCopyable))
-    return false;
+  assert(dc->getParentModule()->getASTContext().getProtocol(
+      KnownProtocolKind::BitwiseCopyable));
 
   if (isa<ClassDecl>(nominal)) {
     if (!isImplicit(check)) {

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -222,6 +222,16 @@ static bool checkBitwiseCopyableInstanceStorage(NominalTypeDecl *nominal,
   assert(dc->getParentModule()->getASTContext().getProtocol(
       KnownProtocolKind::BitwiseCopyable));
 
+  if (dc->mapTypeIntoContext(nominal->getDeclaredInterfaceType())->isNoncopyable()) {
+    nominal->diagnose(diag::non_bitwise_copyable_type_noncopyable);
+    return true;
+  }
+
+  if (!dc->mapTypeIntoContext(nominal->getDeclaredInterfaceType())->isEscapable()) {
+    nominal->diagnose(diag::non_bitwise_copyable_type_nonescapable);
+    return true;
+  }
+
   if (isa<ClassDecl>(nominal)) {
     if (!isImplicit(check)) {
       nominal->diagnose(diag::non_bitwise_copyable_type_class);

--- a/test/SILGen/bitwise_copyable.swift
+++ b/test/SILGen/bitwise_copyable.swift
@@ -22,3 +22,20 @@ struct B<T> {
 func doit() -> B<Int> {
   return .init(t: 0)
 }
+
+struct Conditional<T> {
+  var t: T
+}
+extension Conditional : _BitwiseCopyable where T : _BitwiseCopyable {}
+
+func doit() -> B<Conditional<Int>> { 
+  .init(t: .init(t: 0)) 
+}
+
+enum Context<T> {
+  struct Here {
+    var t: T
+  }
+}
+
+func doit() -> Context<Int>.Here { .init(t: 0) }

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -1,7 +1,9 @@
-// RUN: %target-typecheck-verify-swift                   \
-// RUN:     -disable-availability-checking               \
-// RUN:     -enable-experimental-feature BitwiseCopyable \
-// RUN:     -enable-builtin-module                       \
+// RUN: %target-typecheck-verify-swift                       \
+// RUN:     -disable-availability-checking                   \
+// RUN:     -enable-experimental-feature NonescapableTypes   \
+// RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature BitwiseCopyable     \
+// RUN:     -enable-builtin-module                           \
 // RUN:     -debug-diagnostic-names
 
 //==============================================================================
@@ -154,8 +156,8 @@ func passAnyAny(_ a: any Any) { take3(a) } // expected-error {{type_does_not_con
 func passString(_ s: String) { take3(s) } // expected-error    {{type_does_not_conform_decl_owner}}
                                           // expected-note@-17 {{where_requirement_failure_one_subst}}
 
-extension Optional {
-  struct Some : _BitwiseCopyable {
+extension Optional where Wrapped : Copyable & Escapable {
+  struct Some : _BitwiseCopyable & Copyable & Escapable {
     var wrapped: Wrapped // expected-error {{non_bitwise_copyable_type_member}}
   }
 }
@@ -183,6 +185,10 @@ struct S_Explicit_With_2_BitwiseCopyable_Generic_Optional<T : _BitwiseCopyable> 
   var o: Optional<T>
   var o2: T?
 }
+
+struct S_Explicit_Nonescapable : ~Escapable, _BitwiseCopyable {} // expected-error{{non_bitwise_copyable_type_nonescapable}}
+
+struct S_Explicit_Noncopyable : ~Copyable, _BitwiseCopyable {} // expected-error{{non_bitwise_copyable_type_noncopyable}}
 
 //==============================================================================
 //==========================STDLIB-DEPENDENCY TESTS=(BEGIN)==================={{

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -191,7 +191,7 @@ struct S_Explicit_Nonescapable : ~Escapable, _BitwiseCopyable {} // expected-err
 struct S_Explicit_Noncopyable : ~Copyable, _BitwiseCopyable {} // expected-error{{non_bitwise_copyable_type_noncopyable}}
 
 //==============================================================================
-//==========================STDLIB-DEPENDENCY TESTS=(BEGIN)==================={{
+//==========================STDLIB-DEPENDENCY TESTS=(END)=====================}}
 //==============================================================================
 
 //==============================================================================


### PR DESCRIPTION
Emit targeted diagnostics to prevent a type from conforming to `_BitwiseCopyable` while being noncopyable/nonescapable for now.
