### PR TITLE
[Sema] Temporary disable l-value stripping while erasing opened exist…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2270,7 +2270,7 @@ static Type typeEraseExistentialSelfReferences(Type refTy, Type baseTy,
             return parameterized->getBaseType();
         }
       }
-
+      /*
       if (auto lvalue = dyn_cast<LValueType>(t)) {
         auto objTy = lvalue->getObjectType();
         auto erasedTy =
@@ -2284,6 +2284,7 @@ static Type typeEraseExistentialSelfReferences(Type refTy, Type baseTy,
 
         return erasedTy;
       }
+      */
 
       if (!predicateFn(t)) {
         // Recurse.

--- a/test/Constraints/rdar121214563.swift
+++ b/test/Constraints/rdar121214563.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P<A>: AnyObject {
+  associatedtype A: P2
+  var x: A.A2 { get set }
+}
+
+protocol P2 {
+  associatedtype A2
+  var x: A2 { get }
+}
+
+func test<T: P2>(x: T.A2, y: any P<T>, z: any P2) {
+  y.x = x // Ok
+  y.x = z.x // expected-error {{cannot assign value of type 'Any' to type 'T.A2'}}
+}

--- a/test/Sema/open_existential_lvalue.swift
+++ b/test/Sema/open_existential_lvalue.swift
@@ -1,5 +1,8 @@
 // RUN: %target-typecheck-verify-swift
 
+// rdar://121214563
+// REQUIRES: rdar121214563
+
 protocol Q {}
 
 protocol P {


### PR DESCRIPTION
…entials

Reverts part of https://github.com/apple/swift/pull/69950 because it causes failure in existing code.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
