### PR TITLE
[5.10] [Concurrency] Don't infer MainActor on top level globals in the task to thread concurrency model

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3718,7 +3718,13 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
 
   if (nominal->isMainActor() && Ctx.LangOpts.isConcurrencyModelTaskToThread() &&
       !AvailableAttr::isUnavailable(D)) {
-    Ctx.Diags.diagnose(attr->getLocation(),
+    SourceLoc loc;
+    if (attr->isImplicit()) {
+      loc = D->getStartLoc();
+    } else {
+      loc = attr->getLocation();
+    }
+    Ctx.Diags.diagnose(loc,
                        diag::concurrency_task_to_thread_model_main_actor,
                        "task-to-thread concurrency model");
     return;

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4631,8 +4631,10 @@ ActorIsolation ActorIsolationRequest::evaluate(
   }
 
   if (auto var = dyn_cast<VarDecl>(value)) {
-    if (var->isTopLevelGlobal() &&
-        (var->getASTContext().LangOpts.StrictConcurrencyLevel >=
+    auto &ctx = var->getASTContext();
+    if (!ctx.LangOpts.isConcurrencyModelTaskToThread() &&
+        var->isTopLevelGlobal() &&
+        (ctx.LangOpts.StrictConcurrencyLevel >=
              StrictConcurrency::Complete ||
          var->getDeclContext()->isAsyncContext())) {
       if (Type mainActor = var->getASTContext().getMainActorType())

--- a/test/Concurrency/freestanding_top_level.swift
+++ b/test/Concurrency/freestanding_top_level.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -concurrency-model=task-to-thread -typecheck  -verify %s
+// RUN: %target-swift-frontend -concurrency-model=task-to-thread -typecheck  -verify -verify-additional-prefix complete- -strict-concurrency=complete %s
+
+// expected-complete-warning@+3 {{var 'global' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+// expected-complete-note@+2 {{isolate 'global' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
+// expected-complete-note@+1 {{var declared here}}
+var global = 10
+
+// expected-complete-warning@+1 {{reference to var 'global' is not concurrency-safe because it involves shared mutable state; this is an error in Swift 6}}
+print(global)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/71039

Explanation: Global actors aren't permitted in the task-to-thread concurrency model, so don't infer them.
Scope: Narrow; suppresses inference of global actors in the task-to-thread model.
Issue: rdar://121329164
Risk: Very low; only affects task-to-thread model
Testing: Added tests, and already tested on `main`
Reviewer: Holly Borla (author) / Doug Gregor (reviewer)