### PR TITLE
[5.10] Tests: Make some IRGen tests less deployment target dependent

### DIFF
--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -52,7 +52,7 @@ entry(%n : $Builtin.NativeObject):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @u_cast_to_class_existential(ptr %0)
 // CHECK:         call { ptr, ptr } @dynamic_cast_existential_1_unconditional(ptr {{%.*}}, ptr {{%.*}}, {{.*}} @"$s5casts2CPMp"
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden { ptr, ptr } @dynamic_cast_existential_1_unconditional(ptr %0, ptr %1, ptr %2) {{.*}} {
-// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %1, ptr %2)
+// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %1, ptr %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq ptr [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
 // CHECK:       cont:
@@ -78,11 +78,11 @@ entry(%a : $@thick Any.Type):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr, ptr } @u_cast_to_class_existential_2(ptr %0)
 // CHECK:         call { ptr, ptr, ptr } @dynamic_cast_existential_2_unconditional(ptr {{%.*}}, ptr {{%.*}}, {{.*}} @"$s5casts2CPMp"{{[^,]*}}, {{.*}} @"$s5casts3CP2Mp"
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden { ptr, ptr, ptr } @dynamic_cast_existential_2_unconditional(ptr %0, ptr %1, ptr %2, ptr %3)
-// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %1, ptr %2)
+// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %1, ptr %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq ptr [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
 // CHECK:       cont:
-// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %1, ptr %3)
+// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %1, ptr %3)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq ptr [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont1
 // CHECK:       cont1:
@@ -119,7 +119,7 @@ entry(%a : $@thick Any.Type):
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr } @c_cast_to_class_existential(ptr %0)
 // CHECK:         call { ptr, ptr } @dynamic_cast_existential_1_conditional(ptr {{.*}}, ptr %.Type, {{.*}} @"$s5casts2CPMp"
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden { ptr, ptr } @dynamic_cast_existential_1_conditional(ptr %0, ptr %1, ptr %2)
-// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %1, ptr %2)
+// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %1, ptr %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq ptr [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
 // CHECK:       cont:
@@ -149,11 +149,11 @@ nay:
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { ptr, ptr, ptr } @c_cast_to_class_existential_2(ptr %0)
 // CHECK:         call { ptr, ptr, ptr } @dynamic_cast_existential_2_conditional(ptr {{%.*}}, ptr {{%.*}}, {{.*}} @"$s5casts2CPMp"{{[^,]*}}, {{.*}} @"$s5casts3CP2Mp"
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden { ptr, ptr, ptr } @dynamic_cast_existential_2_conditional(ptr %0, ptr %1, ptr %2, ptr %3)
-// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %1, ptr %2)
+// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %1, ptr %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq ptr [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
 // CHECK:       cont:
-// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %1, ptr %3)
+// CHECK:         [[WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %1, ptr %3)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq ptr [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont1
 // CHECK:       cont1:

--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -1,21 +1,21 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.15 -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target x86_64-apple-macosx10.15 -lto=llvm-full -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-MACHO
-// RUN: %target-swift-emit-ir -target x86_64-apple-macosx10.15 -lto=llvm-thin -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-MACHO
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target %target-cpu-apple-macosx10.15 -lto=llvm-full -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-MACHO
+// RUN: %target-swift-emit-ir -target %target-cpu-apple-macosx10.15 -lto=llvm-thin -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-MACHO
 
 // CHECK-MACHO-DAG: !llvm.linker.options = !{
 // CHECK-MACHO-DAG: !{{[0-9]+}} = !{!"-lempty"}
 
-// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target x86_64-unknown-linux-gnu -lto=llvm-full -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-ELF
-// RUN: %target-swift-emit-ir -target x86_64-unknown-linux-gnu -lto=llvm-thin -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-ELF
+// RUN: %target-swift-frontend -target %target-cpu-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-linux-gnu -lto=llvm-full -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-ELF
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-linux-gnu -lto=llvm-thin -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-ELF
 
 // CHECK-ELF-DAG: !llvm.dependent-libraries = !{
 // CHECK-ELF-DAG: !{{[0-9]+}} = !{!"empty"}
 
-// RUN: %target-swift-frontend -target x86_64-unknown-windows-msvc -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target x86_64-unknown-windows-msvc -lto=llvm-full -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-COFF
-// RUN: %target-swift-emit-ir -target x86_64-unknown-windows-msvc -lto=llvm-thin -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-COFF
+// RUN: %target-swift-frontend -target %target-cpu-unknown-windows-msvc -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-windows-msvc -lto=llvm-full -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-COFF
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-windows-msvc -lto=llvm-thin -parse-stdlib -I %t %s | %FileCheck %s --check-prefix CHECK-COFF
 
 // CHECK-COFF-DAG: !llvm.linker.options = !{
 // CHECK-COFF-DAG: !{{[0-9]+}} = !{!"/DEFAULTLIB:empty.lib"}
@@ -26,18 +26,18 @@ import empty
 // Ensure the dependent libraries embedded by clang are merged.
 
 
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.15 -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target x86_64-apple-macosx10.15 -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-MACHO-MERGE
-// RUN: %target-swift-emit-ir -target x86_64-apple-macosx10.15 -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-MACHO-MERGE
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.15 -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target %target-cpu-apple-macosx10.15 -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-MACHO-MERGE
+// RUN: %target-swift-emit-ir -target %target-cpu-apple-macosx10.15 -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-MACHO-MERGE
 
 // CHECK-MACHO-MERGE-DAG: !llvm.linker.options = !{
 // CHECK-MACHO-MERGE-DAG: !{{[0-9]+}} = !{!"-lempty"}
 // CHECK-MACHO-MERGE-DAG: !{{[0-9]+}} = !{!"-lautolink-module-map-link"}
 
 
-// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
-// RUN: %target-swift-emit-ir -target x86_64-unknown-linux-gnu -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-ELF-MERGE
-// RUN: %target-swift-emit-ir -target x86_64-unknown-linux-gnu -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-ELF-MERGE
+// RUN: %target-swift-frontend -target %target-cpu-unknown-linux-gnu -emit-module -parse-stdlib -o %t -module-name empty -module-link-name empty %S/../Inputs/empty.swift
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-linux-gnu -lto=llvm-full -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-ELF-MERGE
+// RUN: %target-swift-emit-ir -target %target-cpu-unknown-linux-gnu -lto=llvm-thin -parse-stdlib -I %t -I %S/Inputs -DTEST_CLANG_OPTIONS_MERGE %s | %FileCheck %s --check-prefix CHECK-ELF-MERGE
 
 // CHECK-ELF-MERGE-DAG: !llvm.dependent-libraries = !{
 // CHECK-ELF-MERGE-DAG: !{{[0-9]+}} = !{!"empty"}

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -108,7 +108,7 @@ bb0(%0 : @owned $C, %1 : @owned $C & P):
 // CHECK-NEXT:  br i1 [[IS_SUBCLASS]], label %cont, label %fail
 
 // CHECK:     cont:
-// CHECK-NEXT:  [[WTABLE:%.*]] = call ptr @swift_conformsToProtocol(ptr %1, {{.*}} %3)
+// CHECK-NEXT:  [[WTABLE:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %1, {{.*}} %3)
 // CHECK-NEXT:  [[IS_NOT_CONFORMING:%.*]] = icmp eq ptr [[WTABLE]], null
 // CHECK-NEXT:  br i1 [[IS_NOT_CONFORMING]], label %fail, label %cont1
 
@@ -141,7 +141,7 @@ bb0(%0 : @owned $C):
 
 // CHECK-LABEL: define linkonce_odr hidden { ptr, ptr } @dynamic_cast_existential_1_unconditional(ptr %0, ptr
 // CHECK:     entry:
-// CHECK-NEXT:  [[WTABLE:%.*]] = call ptr @swift_conformsToProtocol(ptr %1, {{.*}} %2)
+// CHECK-NEXT:  [[WTABLE:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %1, {{.*}} %2)
 // CHECK-NEXT:  [[IS_NOT_CONFORMING:%.*]] = icmp eq ptr [[WTABLE]], null
 // CHECK-NEXT:  br i1 [[IS_NOT_CONFORMING]], label %fail, label %cont
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/71110.

Also, use `%target-cpu` lit substitution in `IRGen/lto_autolink.swift`.

Resolves rdar://121344608