### PR TITLE
[Frontend][AST] Add min-runtime-version option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,9 +101,11 @@ include(FetchContent)
 check_language(Swift)
 if(CMAKE_Swift_COMPILER)
   enable_language(Swift)
+  set(DEFAULT_SWIFT_MIN_RUNTIME_VERSION "${CMAKE_Swift_COMPILER_VERSION}")
 else()
   message(STATUS "WARNING! Did not find a host compiler swift?! Can not build
                   any compiler host sources written in Swift")
+  set(DEFAULT_SWIFT_MIN_RUNTIME_VERSION)
 endif()
 
 # A convenience pattern to match Darwin platforms. Example:
@@ -460,6 +462,10 @@ set(SWIFT_DARWIN_MODULE_ARCHS "" CACHE STRING
 targets on Darwin platforms. These targets are in addition to the full \
 library targets.")
 
+set(SWIFT_MIN_RUNTIME_VERSION "${DEFAULT_SWIFT_MIN_RUNTIME_VERSION}" CACHE STRING
+  "Specify the minimum version of the runtime that we target when building \
+the compiler itself. This is used on non-Darwin platforms to ensure \
+that it's possible to build the compiler using host tools.")
 
 #
 # User-configurable Android specific options.

--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -106,7 +106,13 @@ function(add_swift_compiler_modules_library name)
       "-Xcc" "-std=c++17"
       "-Xcc" "-DCOMPILED_WITH_SWIFT" "-Xcc" "-DSWIFT_TARGET"
       "-Xcc" "-UIBOutlet" "-Xcc" "-UIBAction" "-Xcc" "-UIBInspectable")
+
   if (NOT BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+    if(SWIFT_MIN_RUNTIME_VERSION)
+      list(APPEND swift_compile_options
+        "-Xfrontend" "-min-runtime-version"
+        "-Xfrontend" "${SWIFT_MIN_RUNTIME_VERSION}")
+    endif()
     list(APPEND swift_compile_options "-Xfrontend" "-disable-implicit-string-processing-module-import")
   endif()
 

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1010,10 +1010,10 @@ public:
   /// compiler for the target platform.
   AvailabilityContext getSwift59Availability();
 
-  /// Get the runtime availability of features introduced in the Swift 5.9
+  /// Get the runtime availability of features introduced in the Swift 5.11
   /// compiler for the target platform.
   AvailabilityContext getSwift511Availability();
-  
+
   // Note: Update this function if you add a new getSwiftXYAvailability above.
   /// Get the runtime availability for a particular version of Swift (5.0+).
   AvailabilityContext
@@ -1021,7 +1021,9 @@ public:
 
   /// Get the runtime availability of features that have been introduced in the
   /// Swift compiler for future versions of the target platform.
-  AvailabilityContext getSwiftFutureAvailability();
+  AvailabilityContext getSwiftFutureAvailability(
+    llvm::VersionTuple swiftVersion = llvm::VersionTuple(99, 99, 0)
+  );
 
   /// Returns `true` if versioned availability annotations are supported for the
   /// target triple.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -174,6 +174,9 @@ namespace swift {
     /// User-overridable language version to compile for.
     version::Version EffectiveLanguageVersion = version::Version::getCurrentLanguageVersion();
 
+    /// Swift runtime version to compile for.
+    version::Version RuntimeVersion = version::Version::getCurrentLanguageVersion();
+
     /// PackageDescription version to compile for.
     version::Version PackageDescriptionVersion;
 
@@ -589,7 +592,7 @@ namespace swift {
     /// Returns the minimum platform version to which code will be deployed.
     ///
     /// This is only implemented on certain OSs. If no target has been
-    /// configured, returns v0.0.0.
+    /// configured, returns the minimum Swift runtime version.
     llvm::VersionTuple getMinPlatformVersion() const {
       if (Target.isMacOSX()) {
         llvm::VersionTuple OSVersion;
@@ -600,7 +603,7 @@ namespace swift {
       } else if (Target.isWatchOS()) {
         return Target.getOSVersion();
       }
-      return llvm::VersionTuple(/*Major=*/0, /*Minor=*/0, /*Subminor=*/0);
+      return RuntimeVersion;
     }
 
     /// Sets an implicit platform condition.

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -64,6 +64,9 @@ public:
   /// Create a literal version from a list of components.
   Version(std::initializer_list<unsigned> Values) : Components(Values) {}
 
+  /// Create a version from an llvm::VersionTuple.
+  Version(const llvm::VersionTuple &version);
+
   /// Return a string to be used as an internal preprocessor define.
   ///
   /// The components of the version are multiplied element-wise by

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1349,6 +1349,11 @@ def min_inlining_target_version : Separate<["-"], "target-min-inlining-version">
   HelpText<"Require inlinable code with no '@available' attribute to back-deploy "
            "to this version of the '-target' OS">;
 
+def min_runtime_version : Separate<["-"], "min-runtime-version">,
+  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
+  HelpText<"Specify the minimum runtime version to build force on non-Darwin "
+           "systems">;
+
 def profile_generate : Flag<["-"], "profile-generate">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Generate instrumented code to collect execution counts">;

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -771,16 +771,20 @@ AvailabilityContext ASTContext::getSwift59Availability() {
     return AvailabilityContext(
         VersionRange::allGTE(llvm::VersionTuple(10, 0, 0)));
   } else {
-    return AvailabilityContext::alwaysAvailable();
+    // Keyed off the Swift runtime version
+    return AvailabilityContext(
+        VersionRange::allGTE(llvm::VersionTuple(5, 9, 0)));
   }
 }
 
 AvailabilityContext ASTContext::getSwift511Availability() {
   // Placeholder
-  return getSwiftFutureAvailability();
+  return getSwiftFutureAvailability(llvm::VersionTuple(5, 11, 0));
 }
 
-AvailabilityContext ASTContext::getSwiftFutureAvailability() {
+AvailabilityContext ASTContext::getSwiftFutureAvailability(
+  llvm::VersionTuple swiftVersion
+) {
   auto target = LangOpts.Target;
 
   if (target.isMacOSX() ) {
@@ -793,7 +797,8 @@ AvailabilityContext ASTContext::getSwiftFutureAvailability() {
     return AvailabilityContext(
         VersionRange::allGTE(llvm::VersionTuple(99, 99, 0)));
   } else {
-    return AvailabilityContext::alwaysAvailable();
+    // For non-MacOS/iOS/WatchOS, this is keyed off the *Swift* version
+    return AvailabilityContext(VersionRange::allGTE(swiftVersion));
   }
 }
 

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -100,6 +100,23 @@ Version::preprocessorDefinition(StringRef macroName,
   return define;
 }
 
+Version::Version(const llvm::VersionTuple &version) {
+  if (version.empty())
+    return;
+
+  Components.emplace_back(version.getMajor());
+
+  if (auto minor = version.getMinor()) {
+    Components.emplace_back(*minor);
+    if (auto subminor = version.getSubminor()) {
+      Components.emplace_back(*subminor);
+      if (auto build = version.getBuild()) {
+        Components.emplace_back(*build);
+      }
+    }
+  }
+}
+
 Version::operator llvm::VersionTuple() const
 {
   switch (Components.size()) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1208,6 +1208,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     // FIXME: Should we diagnose if it's below the default?
     Opts.MinimumInliningTargetVersion = *vers;
 
+  if (auto vers = parseVersionArg(OPT_min_runtime_version))
+    Opts.RuntimeVersion = version::Version(*vers);
+
   if (auto vers = parseVersionArg(OPT_target_sdk_version))
     Opts.SDKVersion = *vers;
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -116,6 +116,9 @@ KNOWN_SETTINGS=(
     darwin-toolchain-require-use-os-runtime       "0"               "When setting up a plist for a toolchain, require the users of the toolchain to link against the OS instead of the packaged toolchain runtime. 0 for false, 1 for true"
     darwin-xcrun-toolchain                        "default"         "the name of the toolchain to use on Darwin"
 
+    ## Runtime options
+    min-runtime-version                ""                "Used to specify the minimum host runtime version when building the compiler on non-Darwin platforms"
+
     ## WebAssembly/WASI Options
     wasi-sysroot                                  ""                "An absolute path to the wasi-sysroot that will be used as a libc implementation for Wasm builds"
 
@@ -747,6 +750,12 @@ function set_build_options_for_host() {
                 swift_cmake_options+=(
                     -DLLVM_ENABLE_MODULE_DEBUGGING:BOOL=NO
                     "-DSWIFT_PARALLEL_LINK_JOBS=${SWIFT_TOOLS_NUM_PARALLEL_LTO_LINK_JOBS}"
+                )
+            fi
+
+            if [[ ! -z "${MIN_RUNTIME_VERSION}" ]]; then
+                swift_cmake_options+=(
+                    -DSWIFT_MIN_RUNTIME_VERSION="${MIN_RUNTIME_VERSION}"
                 )
             fi
 


### PR DESCRIPTION
**This is intended for use within the compiler build itself; it is not envisaged that third parties will use it.**

The goal here is to avoid a situation where a single PR that adds code to call a new runtime function makes the compiler hard to build on Linux and/or Windows, simply because you need a Swift build installed that has the new runtime function in order to perform a successful build.

On Darwin we already have a way around this, namely the OS version based availability mechanism.  This PR adds an equivalent for Linux and Windows based on the Swift version number itself; when building the Swift code within the compiler proper, this will be set to match the version of the compiler that's being used, and thereby provide a way to gate the use of newer runtime APIs by the compiler during the build.

rdar://121522431
