### PR TITLE
AST: Fix ReplaceOpaqueTypesWithUnderlyingTypes to consider the curren…

### DIFF
--- a/test/IRGen/Inputs/opaque_result_type_internal_inlinable.swift
+++ b/test/IRGen/Inputs/opaque_result_type_internal_inlinable.swift
@@ -1,0 +1,36 @@
+public protocol P {}
+
+public struct G<T, V> : P {
+
+  var t: T
+  var v: V
+
+  public init(_ t: T, _ v: V) {
+    self.t = t
+    self.v = v
+  }
+}
+
+struct I {
+  public init() {
+  }
+}
+
+public struct E : P {
+  public init() {}
+
+  @inlinable
+  public static var a : some P {
+    return G(E(), C().b())
+  }
+}
+
+public struct C {
+  public init() {}
+
+  @usableFromInline
+  internal func b() -> some P {
+    return G(self, I())
+  }
+}
+

--- a/test/IRGen/oapque_result_type_internal.swift
+++ b/test/IRGen/oapque_result_type_internal.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -O -disable-availability-checking -emit-module -emit-module-path=%t/R.swiftmodule -module-name=R %S/Inputs/opaque_result_type_internal_inlinable.swift
+// RUN: %target-swift-frontend -O -I %t -disable-availability-checking -c -primary-file %s
+
+import R
+
+// This used to crash because when we were importing E.a the serialized sil
+// contained underlying types that this module does not have access to (internal type `I`).
+
+public func testIt() {
+    var e = E.a
+    print(e)
+}


### PR DESCRIPTION
…t resilience expansion in non resilient mode

When we decide which access level we can allow for types we need to consider the resilience expansion context. 'internal' visibility cannot be allowed to be looked through in inlineable code as an external module does not have visiblity to such a symbol.

rdar://119725428

(Cherry picked from commit 8d649a252505d3132ffae47985d005cc2e1d070e)
