### PR TITLE
[Observation] Add generation for `_modify` to fields such that we avoid extra CoW

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -326,8 +326,18 @@ public struct ObservationTrackedMacro: AccessorMacro {
       }
       }
       """
+      
+    let modifyAccessor: AccessorDeclSyntax =
+      """
+      _modify {
+      access(keyPath: \\.\(identifier))
+      \(raw: ObservableMacro.registrarVariableName).willSet(self, keyPath: \\.\(identifier))
+      defer { \(raw: ObservableMacro.registrarVariableName).didSet(self, keyPath: \\.\(identifier)) } 
+      yield &_\(identifier)
+      }
+      """
 
-    return [initAccessor, getAccessor, setAccessor]
+    return [initAccessor, getAccessor, setAccessor, modifyAccessor]
   }
 }
 

--- a/stdlib/public/Observation/Sources/Observation/Observable.swift
+++ b/stdlib/public/Observation/Sources/Observation/Observable.swift
@@ -50,7 +50,7 @@ public macro Observable() =
 /// The ``Observation`` module uses this macro. Its use outside of the
 /// framework isn't necessary.
 @available(SwiftStdlib 5.9, *)
-@attached(accessor, names: named(init), named(get), named(set))
+@attached(accessor, names: named(init), named(get), named(set), named(_modify))
 @attached(peer, names: prefixed(_))
 public macro ObservationTracked() =
   #externalMacro(module: "ObservationMacros", type: "ObservationTrackedMacro")

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -225,6 +225,28 @@ class GuardedAvailability {
   }()
 }
 
+struct CowContainer {
+  final class Contents { }
+  
+  var contents = Contents()
+  
+  mutating func mutate() {
+    if !isKnownUniquelyReferenced(&contents) {
+      contents = Contents()
+    }
+  }
+  
+  var id: ObjectIdentifier {
+    ObjectIdentifier(contents)
+  }
+}
+
+
+@Observable
+final class CowTest {
+  var container = CowContainer()
+}
+
 @main
 struct Validator {
   @MainActor
@@ -439,6 +461,14 @@ struct Validator {
       obj.inner.value = "test"
       expectEqual(obj.innerEventCount, 2)
       expectEqual(obj.outerEventCount, 2)
+    }
+    
+    suite.test("validate copy on write semantics") {
+      let subject = CowTest()
+      let startId = subject.container.id
+      expectEqual(subject.container.id, startId)
+      subject.container.mutate()
+      expectEqual(subject.container.id, startId)
     }
 
     runAllTests()


### PR DESCRIPTION
This changes the emission of the `@Observable` macro such that the field generation has an additional `_modify` accessor. Doing this avoids the potentially quadratic access for collection types and does in-place mutation. Provisionally this seems to have no adverse behavioral impact with interoperation of existing observation systems.

Resolves the following issues:
rdar://121161889
FB13547947
