### PR TITLE
[5.10][cxx-interop] NFC: Temporarily disable tests failing because of a libc++ m…

### DIFF
--- a/test/Interop/Cxx/stdlib/import-string-view-from-std.swift
+++ b/test/Interop/Cxx/stdlib/import-string-view-from-std.swift
@@ -4,6 +4,7 @@
 // RUN: find %t/cache | %FileCheck %s
 
 // REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: rdar119869070
 
 //--- Inputs/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
@@ -5,6 +5,7 @@
 
 // This test is specific to libc++ and therefore only runs on Darwin platforms.
 // REQUIRES: OS=macosx || OS=ios
+// REQUIRES: rdar119869070
 
 // CHECK-STD: import CxxStdlib.iosfwd
 // CHECK-STD: import CxxStdlib.string

--- a/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
@@ -6,6 +6,7 @@
 
 // REQUIRES: asserts
 // REQUIRES: OS=macosx
+// REQUIRES: rdar119869070
 
 // CHECK: enum std {
 // CHECK: enum __1 {

--- a/test/SourceKit/InterfaceGen/gen_clang_libcxx_sdk_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_libcxx_sdk_module.swift
@@ -1,6 +1,7 @@
 // RUN: %sourcekitd-test -req=interface-gen -module CxxStdlib -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -cxx-interoperability-mode=default -target %target-triple -sdk %sdk | %FileCheck %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: rdar119869070
 
 // CHECK: import CxxStdlib.vector
 // CHECK: extension std.basic_string<CChar, char_traits<CChar>, allocator<CChar>> {


### PR DESCRIPTION
…odulemap change

Cherry-pick of https://github.com/apple/swift/pull/71124

rdar://119869070
(cherry picked from commit 63a71c9599a553b378f0ea7491212a510c8d1111)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
