### PR TITLE
[AST] Remove unused decl modifiers

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -547,12 +547,6 @@ SIMPLE_DECL_ATTR(_noExistentials, NoExistentials,
 SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
   OnAbstractFunction | OnSubscript | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   155)
-CONTEXTUAL_SIMPLE_DECL_ATTR(_resultDependsOn, ResultDependsOn,
-  OnParam | DeclModifier | UserInaccessible | ABIBreakingToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
-  156)
-CONTEXTUAL_SIMPLE_DECL_ATTR(transferring, Transferring,
-  OnParam | DeclModifier | UserInaccessible | NotSerialized | ABIBreakingToAdd | ABIBreakingToRemove | APIBreakingToAdd | APIStableToRemove,
-  157)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7531,8 +7531,6 @@ static ParserStatus parseAccessorIntroducer(Parser &P,
       P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Consuming);
     } else if (P.Tok.isContextualKeyword("borrowing")) {
       P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Borrowing);
-    } else if (P.Tok.isContextualKeyword("transferring")) {
-      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Transferring);
     }
   }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -165,7 +165,6 @@ public:
   IGNORED_ATTR(BackDeployed)
   IGNORED_ATTR(Documentation)
   IGNORED_ATTR(LexicalLifetimes)
-  IGNORED_ATTR(ResultDependsOn)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {
@@ -206,7 +205,6 @@ public:
   void visitNonMutatingAttr(NonMutatingAttr *attr) { visitMutationAttr(attr); }
   void visitBorrowingAttr(BorrowingAttr *attr) { visitMutationAttr(attr); }
   void visitConsumingAttr(ConsumingAttr *attr) { visitMutationAttr(attr); }
-  void visitTransferringAttr(TransferringAttr *attr) {}
   void visitLegacyConsumingAttr(LegacyConsumingAttr *attr) { visitMutationAttr(attr); }
   void visitResultDependsOnSelfAttr(ResultDependsOnSelfAttr *attr) {
     FuncDecl *FD = cast<FuncDecl>(D);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1535,7 +1535,6 @@ namespace  {
     UNINTERESTING_ATTR(Override)
     UNINTERESTING_ATTR(RawDocComment)
     UNINTERESTING_ATTR(RawLayout)
-    UNINTERESTING_ATTR(ResultDependsOn)
     UNINTERESTING_ATTR(ResultDependsOnSelf)
     UNINTERESTING_ATTR(Required)
     UNINTERESTING_ATTR(Convenience)
@@ -1559,7 +1558,6 @@ namespace  {
     UNINTERESTING_ATTR(PrivateImport)
     UNINTERESTING_ATTR(MainType)
     UNINTERESTING_ATTR(Preconcurrency)
-    UNINTERESTING_ATTR(Transferring)
 
     // Differentiation-related attributes.
     UNINTERESTING_ATTR(Differentiable)


### PR DESCRIPTION
`_resultDependsOn` and `transferring` are - at least at this point - only used as type specifiers, not decl modifiers. And if they are actually specified as a decl modifiers, they're just accepted and ignored, which is not ideal.
