### PR TITLE
Use `any Error` for caught error type of an exhaustive, non-throwing do..catch

### DIFF
--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -347,10 +347,19 @@ struct One<Two> { // expected-note{{'Two' declared as parameter to type 'One'}}
     }
 }
 
+enum HomeworkError: Error {
+case dogAteIt
+case forgot
+}
+
 func testOne() {
   do {
   } catch let error { // expected-warning{{'catch' block is unreachable because no errors are thrown in 'do' block}}
     if case One.E.SomeError = error {} // expected-error{{generic parameter 'Two' could not be inferred}}
+  }
+  do {
+  } catch HomeworkError.forgot { // expected-warning{{'catch' block is unreachable because no errors are thrown in 'do' block}}
+  } catch {
   }
 }
 

--- a/test/IDE/complete_exception.swift
+++ b/test/IDE/complete_exception.swift
@@ -147,14 +147,14 @@ func test006() {
   } catch {
     #^INSIDE_CATCH1^#
   }
-// IMPLICIT_ERROR: Decl[LocalVar]/Local:  error[#Never#]; name=error
+// IMPLICIT_ERROR: Decl[LocalVar]/Local:  error[#any Error#]; name=error
 }
 func test007() {
   do {
   } catch let e {
     #^INSIDE_CATCH2^#
   }
-// EXPLICIT_ERROR_E: Decl[LocalVar]/Local: e[#Never#]; name=e
+// EXPLICIT_ERROR_E: Decl[LocalVar]/Local: e[#any Error#]; name=e
 }
 func test008() {
   do {
@@ -195,7 +195,7 @@ func test012() {
     error.#^INSIDE_CATCH_ERR_DOT1^#
   }
 }
-// ERROR_DOT: Keyword[self]/CurrNominal: self[#Never#]; name=self
+// ERROR_DOT: Keyword[self]/CurrNominal: self[#any Error#]; name=self
 func test013() {
   do {
   } catch let e {

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -19,14 +19,12 @@ func one() {
   do {
     
   } catch { // expected-warning {{'catch' block is unreachable because no errors are thrown in 'do' block}}
-    let error2 = error // expected-warning{{constant 'error2' inferred to have type 'Never', which is an enum with no cases}}
-    // expected-note@-1{{add an explicit type annotation to silence this warning}}
+    let error2 = error
   }
 
   do {
   } catch where true { // expected-warning {{'catch' block is unreachable because no errors are thrown in 'do' block}}
-    let error2 = error // expected-warning{{constant 'error2' inferred to have type 'Never', which is an enum with no cases}}
-    // expected-note@-1{{add an explicit type annotation to silence this warning}}
+    let error2 = error
   } catch {
   }
   

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -139,6 +139,17 @@ func testTryIncompatibleTyped(cond: Bool) throws(HomeworkError) {
   }
 }
 
+func doSomethingWithoutThrowing() { }
+
+func testDoCatchWithoutThrowing() {
+  do {
+    try doSomethingWithoutThrowing() // expected-warning{{no calls to throwing functions occur within 'try' expression}}
+  } catch HomeworkError.forgot { // expected-warning{{'catch' block is unreachable because no errors are thrown in 'do' block}}
+    // expected-error@-1{{pattern of type 'HomeworkError' cannot match 'Never'}}
+  } catch {
+  }
+}
+
 // "Rethrow-like" functions are only allowed to be called from rethrows
 // functions as a compatibility hack, which is removed under FullTypedThrows.
 func rethrowsLike<E>(_ body: () throws(E) -> Void) throws(E) { }


### PR DESCRIPTION
Prior to the introduction of typed throws, a `do..catch` always had a caught error type of `any Error`, even if there were no throwing sites within the `do` body. With typed throws, such a `do..catch` would have a caught error type of `Never`, because it never throws. Unfortunately, this causes code like the following to produce an error, because `Never` cannot be pattern-matched to `HomeworkError.forgot`:

    func test() {
      do {
        try nonthrowing()
      } catch HomeworkError.forgot {
      } catch {
      }
    }

For source-compatibility reasons, adjust the caught error type to `any Error` in this case, so we continue to accept the code above. Don't do this adjustment under `FullTypedThrows`, because it's only there for compatibility.

Fixes rdar://121526201.