### PR TITLE
[builds] Build swift-format as part of `mixin_linux_installation `

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -810,6 +810,7 @@ swift-driver
 xctest
 libicu
 swiftdocc
+swiftformat
 
 build-ninja
 install-llvm
@@ -865,7 +866,6 @@ foundation
 libdispatch
 indexstore-db
 sourcekit-lsp
-swiftformat
 swiftdocc
 lit-args=-v --time-tests
 


### PR DESCRIPTION
We need swift-format to be installed in the toolchain in order to run SourceKit-LSP tests that invoke the swift-format executable.

rdar://121548636