### PR TITLE
Update some Distributed tests to be less deployment target sensitive

### DIFF
--- a/test/Distributed/Inputs/CustomSerialExecutorAvailability.swift
+++ b/test/Distributed/Inputs/CustomSerialExecutorAvailability.swift
@@ -1,0 +1,62 @@
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.7, *)
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+@available(SwiftStdlib 5.7, *)
+distributed actor FiveSevenActor_NothingExecutor {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+
+  @available(SwiftStdlib 5.9, *)
+  distributed func test(x: Int) throws {
+    print("executed: \(#function)")
+    defer {
+      print("done executed: \(#function)")
+    }
+    MainActor.assumeIsolated {
+      // ignore
+    }
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+distributed actor FiveNineActor_NothingExecutor {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+
+  distributed func test(x: Int) throws {
+    print("executed: \(#function)")
+    defer {
+      print("done executed: \(#function)")
+    }
+    MainActor.assumeIsolated {
+      // ignore
+    }
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+distributed actor FiveSevenActor_FiveNineExecutor {
+  @available(SwiftStdlib 5.9, *)
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+
+  @available(SwiftStdlib 5.9, *)
+  distributed func test(x: Int) throws {
+    print("executed: \(#function)")
+    defer {
+      print("done executed: \(#function)")
+    }
+    MainActor.assumeIsolated {
+      // ignore
+    }
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
@@ -1,8 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-build-swift -parse-as-library -target %target-swift-abi-5.7-triple -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift %S/../Inputs/CustomSerialExecutorAvailability.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
-// RUN:  %target-run %t/a.out
+// RUN: %target-run %t/a.out
+
+// These are the only platforms for which compiling a Swift 5.7 aligned deployment target is possible.
+// REQUIRES: OS=macosx || OS=ios || OS=watchos || OS=tvos
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency
@@ -16,67 +19,6 @@
 
 import StdlibUnittest
 import Distributed
-import FakeDistributedActorSystems
-
-@available(SwiftStdlib 5.7, *)
-typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
-
-@available(SwiftStdlib 5.7, *)
-distributed actor FiveSevenActor_NothingExecutor {
-  nonisolated var unownedExecutor: UnownedSerialExecutor {
-    print("get unowned executor")
-    return MainActor.sharedUnownedExecutor
-  }
-
-    @available(SwiftStdlib 5.9, *)
-    distributed func test(x: Int) throws {
-    print("executed: \(#function)")
-    defer {
-      print("done executed: \(#function)")
-    }
-    MainActor.assumeIsolated {
-      // ignore
-    }
-  }
-}
-
-@available(SwiftStdlib 5.9, *)
-distributed actor FiveNineActor_NothingExecutor {
-  nonisolated var unownedExecutor: UnownedSerialExecutor {
-    print("get unowned executor")
-    return MainActor.sharedUnownedExecutor
-  }
-
-  distributed func test(x: Int) throws {
-    print("executed: \(#function)")
-    defer {
-      print("done executed: \(#function)")
-    }
-    MainActor.assumeIsolated {
-      // ignore
-    }
-  }
-}
-
-@available(SwiftStdlib 5.7, *)
-distributed actor FiveSevenActor_FiveNineExecutor {
-  @available(SwiftStdlib 5.9, *)
-  nonisolated var unownedExecutor: UnownedSerialExecutor {
-    print("get unowned executor")
-    return MainActor.sharedUnownedExecutor
-  }
-
-  @available(SwiftStdlib 5.9, *)
-  distributed func test(x: Int) throws {
-    print("executed: \(#function)")
-    defer {
-      print("done executed: \(#function)")
-    }
-    MainActor.assumeIsolated {
-      // ignore
-    }
-  }
-}
 
 @available(SwiftStdlib 5.7, *)
 @main struct Main {
@@ -86,7 +28,6 @@ distributed actor FiveSevenActor_FiveNineExecutor {
 
       let system = LocalTestingDistributedActorSystem()
 
-      #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
       tests.test("5.7 actor, no availability executor property => no custom executor") {
         expectCrashLater(withMessage: "Fatal error: Incorrect actor executor assumption; Expected 'MainActor' executor.")
         try! await FiveSevenActor_NothingExecutor(actorSystem: system).test(x: 42)
@@ -100,22 +41,6 @@ distributed actor FiveSevenActor_FiveNineExecutor {
         expectCrashLater(withMessage: "Fatal error: Incorrect actor executor assumption; Expected 'MainActor' executor.")
         try! await FiveSevenActor_FiveNineExecutor(actorSystem: system).test(x: 42)
       }
-      #else
-      // On non-apple platforms the SDK comes with the toolchains,
-      // so the feature works because we're executing in a 5.9 context already,
-      // which otherwise could not have been compiled
-      tests.test("non apple platform: 5.7 actor, no availability executor property => no custom executor") {
-        try! await FiveSevenActor_NothingExecutor(actorSystem: system).test(x: 42)
-      }
-
-      tests.test("non apple platform: 5.9 actor, no availability executor property => custom executor") {
-        try! await FiveNineActor_NothingExecutor(actorSystem: system).test(x: 42)
-      }
-
-      tests.test("non apple platform: 5.7 actor, 5.9 executor property => no custom executor") {
-        try! await FiveSevenActor_FiveNineExecutor(actorSystem: system).test(x: 42)
-      }
-      #endif
 
       await runAllTestsAsync()
     }

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_availability_swift59.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_availability_swift59.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -parse-as-library -target %target-swift-abi-5.9-triple -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift %S/../Inputs/CustomSerialExecutorAvailability.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN:  %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+import StdlibUnittest
+import Distributed
+
+@main struct Main {
+  static func main() async {
+    if #available(SwiftStdlib 5.9, *) {
+      let tests = TestSuite("DistributedActorExecutorAvailabilitySwift59")
+
+      let system = LocalTestingDistributedActorSystem()
+
+      // On non-apple platforms the SDK comes with the toolchains,
+      // so the feature works because we're executing in a 5.9 context already,
+      // which otherwise could not have been compiled
+      tests.test("non apple platform: 5.7 actor, no availability executor property => no custom executor") {
+        try! await FiveSevenActor_NothingExecutor(actorSystem: system).test(x: 42)
+      }
+
+      tests.test("non apple platform: 5.9 actor, no availability executor property => custom executor") {
+        try! await FiveNineActor_NothingExecutor(actorSystem: system).test(x: 42)
+      }
+
+      tests.test("non apple platform: 5.7 actor, 5.9 executor property => no custom executor") {
+        try! await FiveSevenActor_FiveNineExecutor(actorSystem: system).test(x: 42)
+      }
+
+      await runAllTestsAsync()
+    }
+  }
+}

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -104,13 +104,13 @@ public distributed actor MyOtherActor {
 // CHECK: [[ARG_0_SIZE_ADJ:%.*]] = add i64 %size, 15
 // CHECK-NEXT: [[ARG_0_SIZE:%.*]] = and i64 [[ARG_0_SIZE_ADJ]], -16
 // CHECK-NEXT: [[ARG_0_VALUE_BUF:%.*]] = call swiftcc ptr @swift_task_alloc(i64 [[ARG_0_SIZE]])
-// CHECK-NEXT: [[ENCODABLE_WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %arg_type, ptr @"$sSeMp")
+// CHECK-NEXT: [[ENCODABLE_WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %arg_type, ptr @"$sSeMp")
 // CHECK-NEXT: [[IS_NULL:%.*]] = icmp eq ptr [[ENCODABLE_WITNESS]], null
 // CHECK-NEXT: br i1 [[IS_NULL]], label %missing-witness, label [[CONT:%.*]]
 // CHECK: missing-witness:
 // CHECK-NEXT: call void @llvm.trap()
 // CHECK-NEXT: unreachable
-// CHECK: [[DECODABLE_WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %arg_type, ptr @"$sSEMp")
+// CHECK: [[DECODABLE_WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %arg_type, ptr @"$sSEMp")
 // CHECK-NEXT: [[IS_NULL:%.*]] = icmp eq ptr [[DECODABLE_WITNESS]], null
 // CHECK-NEXT: br i1 [[IS_NULL]], label %missing-witness1, label [[CONT:%.*]]
 // CHECK: missing-witness1:


### PR DESCRIPTION
- Loosen `CHECK:` lines in distributed_actor_accessor_thunks_64bit.swift.
- Split `distributed_actor_custom_executor_availability.swift` into two tests, one that only runs on existing platforms that support back deployment to Swift 5.7 aligned runtimes, and another test that is not restricted by platform that tests behavior when deploying to a Swift 5.9 aligned runtime or later.

Resolves rdar://121344936