### PR TITLE
[5.10] Update some Distributed tests to be less deployment target sensitive

### DIFF
--- a/test/Distributed/Inputs/CustomSerialExecutorAvailability.swift
+++ b/test/Distributed/Inputs/CustomSerialExecutorAvailability.swift
@@ -1,0 +1,60 @@
+import Distributed
+import FakeDistributedActorSystems
+
+@available(SwiftStdlib 5.7, *)
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+@available(SwiftStdlib 5.7, *)
+distributed actor FiveSevenActor_NothingExecutor {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+
+  distributed func test(x: Int) async throws {
+    print("executed: \(#function)")
+    defer {
+      print("done executed: \(#function)")
+    }
+    MainActor.assumeIsolated {
+      // ignore
+    }
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+distributed actor FiveNineActor_NothingExecutor {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+
+  distributed func test(x: Int) async throws {
+    print("executed: \(#function)")
+    defer {
+      print("done executed: \(#function)")
+    }
+    MainActor.assumeIsolated {
+      // ignore
+    }
+  }
+}
+
+@available(SwiftStdlib 5.7, *)
+distributed actor FiveSevenActor_FiveNineExecutor {
+  @available(SwiftStdlib 5.9, *)
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+
+  distributed func test(x: Int) async throws {
+    print("executed: \(#function)")
+    defer {
+      print("done executed: \(#function)")
+    }
+    MainActor.assumeIsolated {
+      // ignore
+    }
+  }
+}

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -104,13 +104,13 @@ public distributed actor MyOtherActor {
 // CHECK: [[ARG_0_SIZE_ADJ:%.*]] = add i64 %size, 15
 // CHECK-NEXT: [[ARG_0_SIZE:%.*]] = and i64 [[ARG_0_SIZE_ADJ]], -16
 // CHECK-NEXT: [[ARG_0_VALUE_BUF:%.*]] = call swiftcc ptr @swift_task_alloc(i64 [[ARG_0_SIZE]])
-// CHECK-NEXT: [[ENCODABLE_WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %arg_type, ptr @"$sSeMp")
+// CHECK-NEXT: [[ENCODABLE_WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %arg_type, ptr @"$sSeMp")
 // CHECK-NEXT: [[IS_NULL:%.*]] = icmp eq ptr [[ENCODABLE_WITNESS]], null
 // CHECK-NEXT: br i1 [[IS_NULL]], label %missing-witness, label [[CONT:%.*]]
 // CHECK: missing-witness:
 // CHECK-NEXT: call void @llvm.trap()
 // CHECK-NEXT: unreachable
-// CHECK: [[DECODABLE_WITNESS:%.*]] = call ptr @swift_conformsToProtocol(ptr %arg_type, ptr @"$sSEMp")
+// CHECK: [[DECODABLE_WITNESS:%.*]] = call ptr @swift_conformsToProtocol{{(2)?}}(ptr %arg_type, ptr @"$sSEMp")
 // CHECK-NEXT: [[IS_NULL:%.*]] = icmp eq ptr [[DECODABLE_WITNESS]], null
 // CHECK-NEXT: br i1 [[IS_NULL]], label %missing-witness1, label [[CONT:%.*]]
 // CHECK: missing-witness1:


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/71132.

- Loosen `CHECK:` lines in `distributed_actor_accessor_thunks_64bit.swift`.
- Split `distributed_actor_custom_executor_availability.swift` into two tests, one that only runs on existing platforms that support back deployment to Swift 5.7 aligned runtimes, and another test that is not restricted by platform that tests behavior when deploying to a Swift 5.9 aligned runtime or later.

Resolves rdar://121344936