### PR TITLE
[DestroyAddrHoisting] Don't fold for invalid paths.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1272,7 +1272,8 @@ struct AccessPathWithBase {
 // The "product leaves" are the leaves obtained by only looking through type
 // products (structs and tuples) and NOT type sums (enums).
 void visitProductLeafAccessPathNodes(
-    SILValue address, TypeExpansionContext tec, SILModule &module,
+    AccessPath rootPath, SILValue address, TypeExpansionContext tec,
+    SILModule &module,
     std::function<void(AccessPath::PathNode, SILType)> visitor);
 
 inline AccessPath AccessPath::compute(SILValue address) {

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1436,10 +1436,12 @@ AccessPathWithBase AccessPathWithBase::computeInScope(SILValue address) {
 }
 
 void swift::visitProductLeafAccessPathNodes(
-    SILValue address, TypeExpansionContext tec, SILModule &module,
+    AccessPath rootPath, SILValue address, TypeExpansionContext tec,
+    SILModule &module,
     std::function<void(AccessPath::PathNode, SILType)> visitor) {
+  assert(rootPath.isValid());
+  assert(AccessPath::compute(address) == rootPath);
   SmallVector<std::pair<SILType, IndexTrieNode *>, 32> worklist;
-  auto rootPath = AccessPath::compute(address);
   auto *node = rootPath.getPathNode().node;
   worklist.push_back({address->getType(), node});
   while (!worklist.empty()) {

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1179,3 +1179,23 @@ entry(%addr : $*MoE):
   %retval = tuple ()
   return %retval : $()
 }
+
+sil @getPointer : $@convention(thin) () -> Builtin.RawPointer
+
+struct Nontrivial {
+  var guts: Builtin.AnyObject
+}
+
+sil [ossa] @rdar121327964 : $@convention(method) (@owned Nontrivial) -> () {
+bb0(%0 : @owned $Nontrivial):
+  %6 = function_ref @getPointer : $@convention(thin) () -> Builtin.RawPointer
+  %7 = apply %6() : $@convention(thin) () -> Builtin.RawPointer
+  %8 = pointer_to_address %7 : $Builtin.RawPointer to [strict] $*Nontrivial
+  %9 = copy_value %0 : $Nontrivial
+  %10 = begin_access [modify] [dynamic] %8 : $*Nontrivial
+  store %9 to [assign] %10 : $*Nontrivial
+  end_access %10 : $*Nontrivial
+  destroy_value %0 : $Nontrivial
+  %14 = tuple ()
+  return %14 : $()
+}


### PR DESCRIPTION
If the address for which hoisting is being performed doesn't have an invalid access path don't attempt to fold its `destroy_addr`s.

rdar://121486203
