### PR TITLE
AST: Rework UnavailableDeclOptimizationMode language option

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -184,8 +184,7 @@ namespace swift {
     bool DisableAvailabilityChecking = false;
 
     /// Optimization mode for unavailable declarations.
-    UnavailableDeclOptimization UnavailableDeclOptimizationMode =
-        UnavailableDeclOptimization::Stub;
+    llvm::Optional<UnavailableDeclOptimization> UnavailableDeclOptimizationMode;
 
     /// Causes the compiler to use weak linkage for symbols belonging to
     /// declarations introduced at the deployment target.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -323,10 +323,18 @@ static bool isUnconditionallyUnavailable(const Decl *D) {
   return false;
 }
 
+static UnavailableDeclOptimization
+getEffectiveUnavailableDeclOptimization(ASTContext &ctx) {
+  if (ctx.LangOpts.UnavailableDeclOptimizationMode.has_value())
+    return *ctx.LangOpts.UnavailableDeclOptimizationMode;
+
+  return UnavailableDeclOptimization::Stub;
+}
+
 bool Decl::isAvailableDuringLowering() const {
   // Unconditionally unavailable declarations should be skipped during lowering
   // when -unavailable-decl-optimization=complete is specified.
-  if (getASTContext().LangOpts.UnavailableDeclOptimizationMode !=
+  if (getEffectiveUnavailableDeclOptimization(getASTContext()) !=
       UnavailableDeclOptimization::Complete)
     return true;
 
@@ -339,7 +347,7 @@ bool Decl::isAvailableDuringLowering() const {
 bool Decl::requiresUnavailableDeclABICompatibilityStubs() const {
   // Code associated with unavailable declarations should trap at runtime if
   // -unavailable-decl-optimization=stub is specified.
-  if (getASTContext().LangOpts.UnavailableDeclOptimizationMode !=
+  if (getEffectiveUnavailableDeclOptimization(getASTContext()) !=
       UnavailableDeclOptimization::Stub)
     return false;
 


### PR DESCRIPTION
Instead of providing a default value for `UnavailableDeclOptimizationMode`, track it with an optional that defaults to `None`. This way the default behavior can vary contextually while still honoring an explicit option passed in on the command line.

Partially resolves rdar://121344690
