### PR TITLE
[autolink-extract] Support (and ignore) LLVM IR files.

### DIFF
--- a/test/AutolinkExtract/llvm-ir.cpp
+++ b/test/AutolinkExtract/llvm-ir.cpp
@@ -1,0 +1,7 @@
+// REQUIRES: autolink-extract
+// RUN: %clang -flto=thin -c -o - %s | %target-swift-autolink-extract -o - - 2>&1 | %FileCheck --allow-empty %s
+// CHECK-NOT: The file was not recognized as a valid object file
+
+int test() {
+  return 1;
+}


### PR DESCRIPTION
In Linux, the current implementation of swift-autolink-extract does not support LLVM IR files resulting from using LTO.

If one tries to build LLVM using LTO and then try to link one of the targets that use `swiftc` to link, but link against LLVM object files (like `swift-plugin-server`), `swift-autolink-extract` will fail saying that some object files are not valid.

To deal with LLVM IR files correctly, create and pass a `llvm::LLVMContext` around, which allows the APIs in `llvm::object` to read LLVM IR files. Additionally, handle the case of `IRObjectFile` when extracting, but perform no action.