### PR TITLE
[Concurrency] More precise modeling of `ActorIsolation` for isolated arguments and captures.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -70,7 +70,7 @@ public:
 
 private:
   union {
-    llvm::PointerUnion<NominalTypeDecl *, VarDecl *> actorInstance;
+    llvm::PointerUnion<NominalTypeDecl *, VarDecl *, Expr *> actorInstance;
     Type globalActor;
     void *pointer;
   };
@@ -84,7 +84,9 @@ private:
 
   ActorIsolation(Kind kind, NominalTypeDecl *actor, unsigned parameterIndex);
 
-  ActorIsolation(Kind kind, VarDecl *capturedActor);
+  ActorIsolation(Kind kind, VarDecl *actor, unsigned parameterIndex);
+
+  ActorIsolation(Kind kind, Expr *actor, unsigned parameterIndex);
 
   ActorIsolation(Kind kind, Type globalActor)
       : globalActor(globalActor), kind(kind), isolatedByPreconcurrency(false),
@@ -113,8 +115,18 @@ public:
     return ActorIsolation(ActorInstance, actor, parameterIndex + 1);
   }
 
+  static ActorIsolation forActorInstanceParameter(VarDecl *actor,
+                                                  unsigned parameterIndex) {
+    return ActorIsolation(ActorInstance, actor, parameterIndex + 1);
+  }
+
+  static ActorIsolation forActorInstanceParameter(Expr *actor,
+                                                  unsigned parameterIndex) {
+    return ActorIsolation(ActorInstance, actor, parameterIndex + 1);
+  }
+
   static ActorIsolation forActorInstanceCapture(VarDecl *capturedActor) {
-    return ActorIsolation(ActorInstance, capturedActor);
+    return ActorIsolation(ActorInstance, capturedActor, 0);
   }
 
   static ActorIsolation forGlobalActor(Type globalActor) {
@@ -178,6 +190,8 @@ public:
   NominalTypeDecl *getActor() const;
 
   VarDecl *getActorInstance() const;
+
+  Expr *getActorInstanceExpr() const;
 
   bool isGlobalActor() const {
     return getKind() == GlobalActor;

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -106,9 +106,7 @@ public:
     return ActorIsolation(unsafe ? NonisolatedUnsafe : Nonisolated, nullptr);
   }
 
-  static ActorIsolation forActorInstanceSelf(NominalTypeDecl *actor) {
-    return ActorIsolation(ActorInstance, actor, 0);
-  }
+  static ActorIsolation forActorInstanceSelf(ValueDecl *decl);
 
   static ActorIsolation forActorInstanceParameter(NominalTypeDecl *actor,
                                                   unsigned parameterIndex) {
@@ -121,9 +119,7 @@ public:
   }
 
   static ActorIsolation forActorInstanceParameter(Expr *actor,
-                                                  unsigned parameterIndex) {
-    return ActorIsolation(ActorInstance, actor, parameterIndex + 1);
-  }
+                                                  unsigned parameterIndex);
 
   static ActorIsolation forActorInstanceCapture(VarDecl *capturedActor) {
     return ActorIsolation(ActorInstance, capturedActor, 0);
@@ -227,27 +223,12 @@ public:
   /// Substitute into types within the actor isolation.
   ActorIsolation subst(SubstitutionMap subs) const;
 
+  static bool isEqual(const ActorIsolation &lhs,
+               const ActorIsolation &rhs);
+
   friend bool operator==(const ActorIsolation &lhs,
                          const ActorIsolation &rhs) {
-    if (lhs.isGlobalActor() && rhs.isGlobalActor())
-      return areTypesEqual(lhs.globalActor, rhs.globalActor);
-
-    if (lhs.getKind() != rhs.getKind())
-      return false;
-
-    switch (lhs.getKind()) {
-    case Nonisolated:
-    case NonisolatedUnsafe:
-    case Unspecified:
-      return true;
-
-    case ActorInstance:
-      return (lhs.getActor() == rhs.getActor() &&
-              lhs.parameterIndex == rhs.parameterIndex);
-
-    case GlobalActor:
-      llvm_unreachable("Global actors handled above");
-    }
+    return ActorIsolation::isEqual(lhs, rhs);
   }
 
   friend bool operator!=(const ActorIsolation &lhs,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11238,9 +11238,6 @@ ActorIsolation::forActorInstanceParameter(Expr *actor,
                                           unsigned parameterIndex) {
   auto &ctx = actor->getType()->getASTContext();
 
-  if (auto *isolation = dyn_cast<CurrentContextIsolationExpr>(actor))
-    actor = isolation->getActor();
-
   // An isolated value of `nil` is statically nonisolated.
   // FIXME: Also allow 'Optional.none'
   if (dyn_cast<NilLiteralExpr>(actor))

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -549,6 +549,10 @@ NominalTypeDecl *TypeBase::getAnyActor() {
     return nullptr;
   }
 
+  if (auto self = getAs<DynamicSelfType>()) {
+    return self->getSelfType()->getAnyActor();
+  }
+
   // Existential types: check for Actor protocol.
   if (isExistentialType()) {
     auto layout = getExistentialLayout();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6833,7 +6833,14 @@ void AttributeChecker::visitDistributedActorAttr(DistributedActorAttr *attr) {
 }
 
 void AttributeChecker::visitKnownToBeLocalAttr(KnownToBeLocalAttr *attr) {
-  if (!D->isImplicit()) {
+  auto &ctx = D->getASTContext();
+  auto *module = D->getDeclContext()->getParentModule();
+  auto *distributed = ctx.getLoadedModule(ctx.Id_Distributed);
+
+  // FIXME: An explicit `_local` is used in the implementation of
+  // `DistributedActor.whenLocal`, which otherwise violates actor
+  // isolation checking.
+  if (!D->isImplicit() && (module != distributed)) {
     diagnoseAndRemoveAttr(attr, diag::distributed_local_cannot_be_used);
   }
 }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3281,6 +3281,17 @@ namespace {
           continue;
 
         auto *arg = args->getExpr(paramIdx);
+
+        // FIXME: CurrentContextIsolationExpr does not have its actor set
+        // at this point.
+        if (auto *macro = dyn_cast<MacroExpansionExpr>(arg)) {
+          auto *expansion = macro->getRewritten();
+          if (auto *isolation = dyn_cast<CurrentContextIsolationExpr>(expansion)) {
+            recordCurrentContextIsolation(isolation);
+            arg = isolation->getActor();
+          }
+        }
+
         argForIsolatedParam = arg;
         if (getIsolatedActor(arg))
           continue;

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -366,7 +366,8 @@ extension DistributedActor {
     _ body: @Sendable (isolated Self) async throws -> T
   ) async rethrows -> T? {
     if __isLocalActor(self) {
-       return try await body(self)
+       _local let localSelf = self
+       return try await body(localSelf)
     } else {
       return nil
     }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -442,18 +442,22 @@ func sync(isolatedTo actor: isolated (any Actor)?) {}
 func preciseIsolated(a: isolated MyActor) async {
   sync(isolatedTo: a)
   sync(isolatedTo: nil) // okay from anywhere
+  sync(isolatedTo: #isolation)
 
   Task { @MainActor in
     sync(isolatedTo: MainActor.shared)
     sync(isolatedTo: nil) // okay from anywhere
+    sync(isolatedTo: #isolation)
   }
 
   Task { @MyGlobal in
     sync(isolatedTo: MyGlobal.shared)
     sync(isolatedTo: nil) // okay from anywhere
+    sync(isolatedTo: #isolation)
   }
 
   Task.detached {
     sync(isolatedTo: nil) // okay from anywhere
+    sync(isolatedTo: #isolation)
   }
 }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -363,6 +363,7 @@ func isolated_generic_ok_1<T: Actor>(_ t: isolated T) {}
 
 
 class NotSendable {} // expected-complete-note 5 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+// expected-note@-1 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
 
 func optionalIsolated(_ ns: NotSendable, to actor: isolated (any Actor)?) async {}
 func optionalIsolatedSync(_ ns: NotSendable, to actor: isolated (any Actor)?) {}
@@ -392,7 +393,7 @@ nonisolated func callFromNonisolated(ns: NotSendable) async {
   let myActor = A()
 
   await optionalIsolated(ns, to: myActor)
-  // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' into actor-isolated context may introduce data races}}
+  // expected-complete-warning@-1 {{passing argument of non-sendable type 'NotSendable' outside of main actor-isolated context may introduce data races}}
 
   optionalIsolatedSync(ns, to: myActor)
   // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
@@ -414,5 +415,45 @@ actor A2 {
     await { (self: isolated Self) in }(self)
     await { (self: isolated Self?) in }(self)
     return self
+  }
+}
+
+func testNonSendableCaptures(ns: NotSendable, a: isolated MyActor) {
+  Task {
+    _ = a
+    _ = ns
+  }
+
+  // FIXME: The `a` in the capture list and `isolated a` are the same,
+  // but the actor isolation checker doesn't know that.
+  Task { [a] in
+    _ = a
+    _ = ns // expected-warning {{capture of 'ns' with non-sendable type 'NotSendable' in a `@Sendable` closure}}
+  }
+}
+
+
+@globalActor actor MyGlobal {
+  static let shared = MyGlobal()
+}
+
+func sync(isolatedTo actor: isolated (any Actor)?) {}
+
+func preciseIsolated(a: isolated MyActor) async {
+  sync(isolatedTo: a)
+  sync(isolatedTo: nil) // okay from anywhere
+
+  Task { @MainActor in
+    sync(isolatedTo: MainActor.shared)
+    sync(isolatedTo: nil) // okay from anywhere
+  }
+
+  Task { @MyGlobal in
+    sync(isolatedTo: MyGlobal.shared)
+    sync(isolatedTo: nil) // okay from anywhere
+  }
+
+  Task.detached {
+    sync(isolatedTo: nil) // okay from anywhere
   }
 }

--- a/test/Concurrency/optional_isolated_parameters.swift
+++ b/test/Concurrency/optional_isolated_parameters.swift
@@ -23,5 +23,5 @@ func optionalIsolated(to actor: isolated (any Actor)?) {
 // CHECK: isolated to Swift.MainActor
 // CHECK: isolated to MyActor
 optionalIsolated(to: nil)
-await optionalIsolated(to: MainActor.shared)
+optionalIsolated(to: MainActor.shared)
 await optionalIsolated(to: MyActor())


### PR DESCRIPTION
Teach `ActorIsolation` that a `nil` isolated argument is statically nonisolated, and a reference to `GlobalActor.shared` statically has global actor isolation:

```swift
func sync(isolatedTo actor: isolated (any Actor)?) {}

@MainActor func onMain() {
  sync(isolatedTo: MainActor.shared)

  sync(isolatedTo: nil) // okay to call synchronously from anywhere with `nil`
}
```

This change also models arbitrary actor instance isolation using `VarDecl`s when possible, which allows comparing two `ActorIsolation` values that may represent different actor instances. Previously, `ActorIsolation` was modeled only by storing the nominal actor type and the parameter index, so the actor isolation value for two different actors was considered to be equal. Now, the nominal actor type is only used for isolated `self` in cases where there is no implicit self parameter decl, such as for stored properties. This modeling change fixes an issue where `Task { ... }` would not properly inherit actor isolation when used in a function with an isolated parameter other than `self`:

```swift
class NotSendable {}
actor MyActor{}

func testNonSendableCaptures(ns: NotSendable, a: isolated MyActor) {
  Task {
    _ = a
    _ = ns
  }
}
```