### PR TITLE
Expose Split-DWARF support in Frontend and Driver

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -239,6 +239,9 @@ public:
   /// The DWARF version of debug info.
   uint8_t DWARFVersion = 4;
 
+  /// Enables Split DWARF and sets the file path for .dwo output.
+  std::string DWOPath;
+
   /// The command line string that is to be stored in the debug info.
   std::string DebugFlags;
 

--- a/include/swift/Basic/FileTypes.def
+++ b/include/swift/Basic/FileTypes.def
@@ -98,6 +98,8 @@ TYPE("pcm",                 ClangModuleFile,           "pcm",             "")
 TYPE("pch",                 PCH,                       "pch",             "")
 TYPE("none",                Nothing,                   "",                "")
 
+TYPE("dwo",                 SplitDwarfObjectFile,      "dwo",             "")
+
 TYPE("abi-baseline-json",   SwiftABIDescriptor,        "abi.json",        "")
 TYPE("api-descriptor-json", SwiftAPIDescriptor,        "",                "")
 TYPE("fixit",               SwiftFixIt,                "",                "")

--- a/include/swift/Basic/SupplementaryOutputPaths.def
+++ b/include/swift/Basic/SupplementaryOutputPaths.def
@@ -148,6 +148,9 @@ OUTPUT(PackageModuleInterfaceOutputPath,
 /// The path to which we should emit module summary file.
 OUTPUT(ModuleSummaryOutputPath, TY_SwiftModuleSummaryFile)
 
+/// The path of the Split DWARF file.
+OUTPUT(SplitDwarfObjectPath, TY_SplitDwarfObjectFile)
+
 /// The output path to generate ABI baseline.
 OUTPUT(ABIDescriptorOutputPath, TY_SwiftABIDescriptor)
 

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -128,6 +128,9 @@ public:
   /// DWARF output format version number.
   std::optional<uint8_t> DWARFVersion;
 
+  /// Emit debug info as split-DWARF in separate .dwo files.
+  bool SplitDWARF = false;
+
   /// Whether or not the driver should generate a module.
   bool ShouldGenerateModule = false;
 
@@ -393,6 +396,11 @@ private:
                                       const TypeToPathMap *OutputMap,
                                       StringRef workingDirectory,
                                       CommandOutput *Output) const;
+
+  void chooseModuleSplitDWARFOutputPath(Compilation &C,
+                                        const TypeToPathMap *OutputMap,
+                                        StringRef workingDirectory,
+                                        CommandOutput *Output) const;
 
   void chooseSwiftSourceInfoOutputPath(Compilation &C,
                                        const TypeToPathMap *OutputMap,

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -234,6 +234,8 @@ public:
   /// output files. If multiple are specified, the last one is returned.
   std::string getSingleIndexUnitOutputFilename() const;
 
+  std::string getSingleSplitDwarfObjectPath() const;
+
   bool isOutputFilenameStdout() const;
   bool isOutputFileDirectory() const;
   bool hasNamedOutputFile() const;
@@ -277,6 +279,7 @@ public:
   bool hasTBDPath() const;
   bool hasYAMLOptRecordPath() const;
   bool hasBitstreamOptRecordPath() const;
+  bool hasSplitDwarfObjectPath() const;
 
   bool hasDependencyTrackerPath() const;
 };

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -140,6 +140,9 @@ public:
   StringRef getFixItsOutputPath() const {
     return getPrimarySpecificPaths().SupplementaryOutputs.FixItsOutputPath;
   }
+  StringRef getSplitDwarfObjectPath() const {
+    return getPrimarySpecificPaths().SupplementaryOutputs.SplitDwarfObjectPath;
+  }
 };
 } // namespace swift
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1037,6 +1037,13 @@ def dwarf_version : Joined<["-"], "dwarf-version=">,
   Flags<[FrontendOption]>,
   HelpText<"DWARF debug info version to produce if requested">,
   MetaVarName<"<version>">;
+def split_dwarf : Flag<["-"], "split-dwarf">,
+  Flags<[FrontendOption]>,
+  HelpText<"Emit debug info as split-DWARF in a separate .dwo file">;
+def split_dwarf_path : Separate<["-"], "split-dwarf-path">,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath,
+         SupplementaryOutput]>,
+  HelpText<"Output debug info as split-DWARF .dwo file to <path>">;
 
 def prefix_serialized_debugging_options : Flag<["-"], "prefix-serialized-debugging-options">,
   Flags<[FrontendOption]>,

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -277,7 +277,8 @@ namespace swift {
                            UnifiedStatsReporter *stats, DiagnosticEngine &diags,
                            llvm::raw_pwrite_stream &out,
                            llvm::sys::Mutex *diagMutex = nullptr,
-                           llvm::raw_pwrite_stream *casid = nullptr);
+                           llvm::raw_pwrite_stream *casid = nullptr,
+                           llvm::raw_pwrite_stream *dwoOut = nullptr);
 
   /// Wrap a serialized module inside a swift AST section in an object file.
   void createSwiftModuleObjectFile(SILModule &SILMod, StringRef Buffer,

--- a/lib/Basic/FileTypes.cpp
+++ b/lib/Basic/FileTypes.cpp
@@ -137,6 +137,7 @@ bool file_types::isTextual(ID Id) {
   case file_types::TY_SwiftFixIt:
   case file_types::TY_ModuleSemanticInfo:
   case file_types::TY_CachedDiagnostics:
+  case file_types::TY_SplitDwarfObjectFile:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -152,6 +153,7 @@ bool file_types::isAfterLLVM(ID Id) {
   case file_types::TY_LLVM_IR:
   case file_types::TY_LLVM_BC:
   case file_types::TY_Object:
+  case file_types::TY_SplitDwarfObjectFile:
     return true;
   case file_types::TY_Swift:
   case file_types::TY_PCH:
@@ -253,6 +255,7 @@ bool file_types::isPartOfSwiftCompilation(ID Id) {
   case file_types::TY_SwiftFixIt:
   case file_types::TY_ModuleSemanticInfo:
   case file_types::TY_CachedDiagnostics:
+  case file_types::TY_SplitDwarfObjectFile:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");
@@ -311,6 +314,7 @@ bool file_types::isProducedFromDiagnostics(ID Id) {
   case file_types::TY_SwiftAPIDescriptor:
   case file_types::TY_ConstValues:
   case file_types::TY_ModuleSemanticInfo:
+  case file_types::TY_SplitDwarfObjectFile:
     return false;
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID.");

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -767,6 +767,7 @@ const char *ToolChain::JobContext::computeFrontendModeForCompile() const {
   case file_types::TY_SwiftFixIt:
   case file_types::TY_ModuleSemanticInfo:
   case file_types::TY_CachedDiagnostics:
+  case file_types::TY_SplitDwarfObjectFile:
     llvm_unreachable("Output type can never be primary output.");
   case file_types::TY_INVALID:
     llvm_unreachable("Invalid type ID");
@@ -912,6 +913,9 @@ void ToolChain::JobContext::addFrontendSupplementaryOutputArguments(
   addOutputsOfType(arguments, Output, Args,
                    file_types::TY_SwiftModuleSummaryFile,
                    "-emit-module-summary-path");
+  addOutputsOfType(arguments, Output, Args,
+                   file_types::TY_SplitDwarfObjectFile,
+                   "-split-dwarf-path");
 }
 
 ToolChain::InvocationInfo
@@ -1037,6 +1041,7 @@ ToolChain::constructInvocation(const BackendJobAction &job,
     case file_types::TY_SwiftFixIt:
     case file_types::TY_ModuleSemanticInfo:
     case file_types::TY_CachedDiagnostics:
+    case file_types::TY_SplitDwarfObjectFile:
       llvm_unreachable("Output type can never be primary output.");
     case file_types::TY_INVALID:
       llvm_unreachable("Invalid type ID");

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -340,12 +340,14 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       options::OPT_emit_module_semantic_info_path);
   auto optRecordOutput = getSupplementaryFilenamesFromArguments(
       options::OPT_save_optimization_record_path);
+  auto optSplitDwarfPath = getSupplementaryFilenamesFromArguments(
+      options::OPT_split_dwarf_path);
   if (!clangHeaderOutput || !moduleOutput || !moduleDocOutput ||
       !dependenciesFile || !referenceDependenciesFile ||
       !serializedDiagnostics || !fixItsOutput || !loadedModuleTrace || !TBD ||
       !moduleInterfaceOutput || !privateModuleInterfaceOutput || !packageModuleInterfaceOutput ||
       !moduleSourceInfoOutput || !moduleSummaryOutput || !abiDescriptorOutput ||
-      !moduleSemanticInfoOutput || !optRecordOutput) {
+      !moduleSemanticInfoOutput || !optRecordOutput || !optSplitDwarfPath) {
     return llvm::None;
   }
   std::vector<SupplementaryOutputPaths> result;
@@ -374,6 +376,7 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
     sop.ModuleSemanticInfoOutputPath = (*moduleSemanticInfoOutput)[i];
     sop.YAMLOptRecordPath = (*optRecordOutput)[i];
     sop.BitstreamOptRecordPath = (*optRecordOutput)[i];
+    sop.SplitDwarfObjectPath = (*optSplitDwarfPath)[i];
     result.push_back(sop);
   }
   return result;
@@ -443,6 +446,9 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
 
   // There is no non-path form of -emit-fixits-path
   auto fixItsOutputPath = pathsFromArguments.FixItsOutputPath;
+
+  // There is no non-path form of -split-dwarf-path
+  auto splitDwarfObjectPath = pathsFromArguments.SplitDwarfObjectPath;
 
   auto clangHeaderOutputPath = determineSupplementaryOutputFilename(
       OPT_emit_objc_header, pathsFromArguments.ClangHeaderOutputPath,
@@ -531,6 +537,7 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   sop.ModuleSemanticInfoOutputPath = ModuleSemanticInfoOutputPath;
   sop.YAMLOptRecordPath = YAMLOptRecordPath;
   sop.BitstreamOptRecordPath = bitstreamOptRecordPath;
+  sop.SplitDwarfObjectPath = splitDwarfObjectPath;
   return sop;
 }
 
@@ -624,6 +631,7 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
                                options::OPT_emit_private_module_interface_path,
                                options::OPT_emit_package_module_interface_path,
                                options::OPT_emit_module_source_info_path,
+                               options::OPT_split_dwarf_path,
                                options::OPT_emit_tbd_path)) {
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_have_supplementary_outputs,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2571,6 +2571,11 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
                      : "-gdwarf_types");
   }
 
+  if (FrontendOpts.InputsAndOutputs.hasSplitDwarfObjectPath()) {
+    Opts.DWOPath =
+        FrontendOpts.InputsAndOutputs.getSingleSplitDwarfObjectPath();
+  }
+
   if (auto A = Args.getLastArg(OPT_dwarf_version)) {
     unsigned vers;
     if (!StringRef(A->getValue()).getAsInteger(10, vers) && vers >= 2 &&

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -428,6 +428,13 @@ std::string FrontendInputsAndOutputs::getSingleIndexUnitOutputFilename() const {
                      : std::string();
 }
 
+std::string FrontendInputsAndOutputs::getSingleSplitDwarfObjectPath() const {
+  assertMustNotBeMoreThanOnePrimaryInputUnlessBatchModeChecksHaveBeenBypassed();
+  return hasInputs()
+             ? lastInputProducingOutput().getSplitDwarfObjectPath().str()
+             : std::string();
+}
+
 bool FrontendInputsAndOutputs::isOutputFilenameStdout() const {
   return getSingleOutputFilename() == "-";
 }
@@ -570,6 +577,12 @@ bool FrontendInputsAndOutputs::hasBitstreamOptRecordPath() const {
   return hasSupplementaryOutputPath(
       [](const SupplementaryOutputPaths &outs) -> const std::string & {
         return outs.BitstreamOptRecordPath;
+      });
+}
+bool FrontendInputsAndOutputs::hasSplitDwarfObjectPath() const {
+  return hasSupplementaryOutputPath(
+      [](const SupplementaryOutputPaths &outs) -> const std::string & {
+        return outs.SplitDwarfObjectPath;
       });
 }
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -270,11 +270,14 @@ void FrontendOptions::forAllOutputPaths(
   }
   const SupplementaryOutputPaths &outs =
       input.getPrimarySpecificPaths().SupplementaryOutputs;
-  const std::string *outputs[] = {
-      &outs.ModuleOutputPath,          &outs.ModuleDocOutputPath,
-      &outs.ModuleInterfaceOutputPath, &outs.PrivateModuleInterfaceOutputPath,
-      &outs.PackageModuleInterfaceOutputPath, &outs.ClangHeaderOutputPath,
-      &outs.ModuleSourceInfoOutputPath};
+  const std::string *outputs[] = {&outs.ModuleOutputPath,
+                                  &outs.ModuleDocOutputPath,
+                                  &outs.ModuleInterfaceOutputPath,
+                                  &outs.PrivateModuleInterfaceOutputPath,
+                                  &outs.PackageModuleInterfaceOutputPath,
+                                  &outs.ClangHeaderOutputPath,
+                                  &outs.ModuleSourceInfoOutputPath,
+                                  &outs.SplitDwarfObjectPath};
   for (const std::string *next : outputs) {
     if (!next->empty())
       fn(*next);

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -76,6 +76,7 @@
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Mutex.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Support/VirtualOutputBackend.h"
 #include "llvm/Support/VirtualOutputConfig.h"
 #include "llvm/Target/TargetMachine.h"
@@ -133,6 +134,9 @@ swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx) {
 
   // Set option to select the CASBackendMode.
   TargetOpts.MCOptions.CASObjMode = Opts.CASObjMode;
+
+  // Set option to split debug-info into a separate .dwo file.
+  TargetOpts.MCOptions.SplitDwarfFile = Opts.DWOPath;
 
   auto *Clang = static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
 
@@ -620,16 +624,40 @@ bool swift::performLLVM(const IRGenOptions &Opts,
     }
   }
 
+  llvm::Optional<llvm::vfs::OutputFile> DWOFile;
+  SWIFT_DEFER {
+    if (!DWOFile)
+      return;
+    if (auto E = DWOFile->keep()) {
+      diagnoseSync(Diags, DiagMutex, SourceLoc(), diag::error_closing_output,
+                   Opts.DWOPath, toString(std::move(E)));
+    }
+  };
+  if (Opts.OutputKind == IRGenOutputKind::ObjectFile &&
+      !Opts.DWOPath.empty()) {
+    // Try to open the output file.  Clobbering an existing file is fine.
+    // Open in binary mode if we're doing binary output.
+    llvm::vfs::OutputConfig Config;
+    if (auto Err = Backend.createFile(Opts.DWOPath, Config)
+                       .moveInto(DWOFile)) {
+      diagnoseSync(Diags, DiagMutex, SourceLoc(), diag::error_opening_output,
+                   Opts.DWOPath, toString(std::move(Err)));
+      return true;
+    }
+  }
+
   return compileAndWriteLLVM(Module, TargetMachine, Opts, Stats, Diags,
                              *OutputFile, DiagMutex,
-                             CASIDFile ? CASIDFile.get() : nullptr);
+                             CASIDFile ? CASIDFile.get() : nullptr,
+                             DWOFile ? &DWOFile->getOS() : nullptr);
 }
 
 bool swift::compileAndWriteLLVM(
     llvm::Module *module, llvm::TargetMachine *targetMachine,
     const IRGenOptions &opts, UnifiedStatsReporter *stats,
     DiagnosticEngine &diags, llvm::raw_pwrite_stream &out,
-    llvm::sys::Mutex *diagMutex, llvm::raw_pwrite_stream *casid) {
+    llvm::sys::Mutex *diagMutex, llvm::raw_pwrite_stream *casid,
+    llvm::raw_pwrite_stream *dwoOut) {
 
   // Set up the final code emission pass. Bitcode/LLVM IR is emitted as part of
   // the optimization pass pipeline.
@@ -650,11 +678,12 @@ bool swift::compileAndWriteLLVM(
     FileType =
         (opts.OutputKind == IRGenOutputKind::NativeAssembly ? CGFT_AssemblyFile
                                                             : CGFT_ObjectFile);
+
     EmitPasses.add(createTargetTransformInfoWrapperPass(
         targetMachine->getTargetIRAnalysis()));
 
     bool fail = targetMachine->addPassesToEmitFile(
-        EmitPasses, out, nullptr, FileType, !opts.Verify, nullptr, casid);
+        EmitPasses, out, dwoOut, FileType, !opts.Verify, nullptr, casid);
     if (fail) {
       diagnoseSync(diags, diagMutex, SourceLoc(),
                    diag::error_codegen_init_fail);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -121,6 +121,8 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
   case IRGenDebugInfoFormat::DWARF:
     CGO.DebugCompilationDir = Opts.DebugCompilationDir;
     CGO.DwarfVersion = Opts.DWARFVersion;
+    if (!Opts.DWOPath.empty())
+      CGO.SplitDwarfOutput = Opts.DWOPath;
     CGO.DwarfDebugFlags =
         Opts.getDebugFlags(PD, Context.LangOpts.EnableCXXInterop);
     break;

--- a/test/DebugInfo/Inputs/secondary.swift
+++ b/test/DebugInfo/Inputs/secondary.swift
@@ -1,0 +1,3 @@
+// Used as secondary input for swift-frontend by splitdwarf.swift
+
+func bar() {}

--- a/test/DebugInfo/splitdwarf.swift
+++ b/test/DebugInfo/splitdwarf.swift
@@ -1,0 +1,37 @@
+// Verify basic support for Split-DWARF (1-to-1 in/out)
+//
+// RUN: %target-swift-frontend -c %/s -o %t_single.o -g -debug-info-format=dwarf -split-dwarf-path %t_single.dwo
+// RUN: %llvm-dwarfdump -a %t_single.o | %FileCheck --check-prefix=OBJ -DDWO_PATH=%t_single.dwo %s
+// RUN: %llvm-dwarfdump -a %t_single.dwo | %FileCheck --check-prefixes=DWO,DIE-FOO %s
+//
+// Check object file:
+// * skeleton .debug_info and .debug_abbrev sections
+//   OBJ: .debug_abbrev
+//   OBJ: .debug_info
+// * single unit with attributes for DWARF-object's file name and 64-bit ID
+//   OBJ: DW_TAG_compile_unit
+//   OBJ-NOT: DW_TAG_compile_unit
+//   OBJ: DW_AT_GNU_dwo_name
+//   COM: DW_AT_GNU_dwo_name ([[DWO_PATH]])   <-- Fails on Windows due to escaping for backslash path separators
+//   OBJ: DW_AT_GNU_dwo_id (0x{{[0-9a-f]+}})
+//
+// Check DWARF-object file:
+// * section names have a .dwo suffix
+//   DWO: .debug_abbrev.dwo
+//   DWO: .debug_info.dwo
+// * there is a DIE for our function
+//   DIE-FOO: DW_TAG_subprogram
+//   DIE-FOO: DW_AT_name ("foo")
+
+// Verify it works with a secondary input (N-to-1 in/out)
+//
+// RUN: %target-swift-frontend -c %/s %/S/Inputs/secondary.swift -o /dev/null -g -debug-info-format=dwarf -split-dwarf-path %t_multi.dwo
+// RUN: %llvm-dwarfdump %t_multi.dwo | %FileCheck --check-prefixes=DIE-FOO,DIE-BAR %s
+//
+// Check the extra entry for the secondary input
+// DIE-BAR: DW_TAG_subprogram
+// DIE-BAR: DW_AT_name ("bar")
+
+public func foo(_ a: Int64, _ b: Int64) -> Int64 {
+    return a*b
+}

--- a/test/Driver/Inputs/splitdwarf-ofm.json
+++ b/test/Driver/Inputs/splitdwarf-ofm.json
@@ -1,0 +1,8 @@
+{
+  "Inputs/main.swift": {
+    "object": "main.o"
+  },
+  "Inputs/lib.swift": {
+    "object": "lib.o"
+  }
+}

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -135,6 +135,13 @@
 // RUN: %swift_driver -### -g -target arm64_32-apple-watchos10.0 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_4 %s
 // RUN: %swiftc_driver -### -g -target arm64_32-apple-watchos10.0 %s 2>&1 | %FileCheck -check-prefix DWARF_VERSION_4 %s
 
+// RUN: %swiftc_driver -### -g -split-dwarf -o split-dwarf.o %s 2>&1 | %FileCheck -check-prefix SPLIT_DWARF %s
+// SPLIT_DWARF: -split-dwarf-path {{.*}}options{{.*}}.dwo
+
+// RUN: %swiftc_driver -### -g -split-dwarf -emit-object -module-name test -output-file-map %S/Inputs/splitdwarf-ofm.json %S/Inputs/main.swift %S/Inputs/lib.swift %s 2>&1 | %FileCheck -check-prefix SPLIT_DWARF_MULTI %s
+// SPLIT_DWARF_MULTI: -primary-file {{.*}}main.swift {{.*}} -split-dwarf-path {{.*}}main{{.*}}.dwo {{.*}}
+// SPLIT_DWARF_MULTI: -primary-file {{.*}}lib.swift {{.*}} -split-dwarf-path {{.*}}lib{{.*}}.dwo {{.*}}
+
 // RUN: not %swift_driver -gline-tables-only -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s
 // RUN: not %swift_driver -gdwarf-types -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s
 // RUN: not %swiftc_driver -gline-tables-only -debug-info-format=codeview %s 2>&1 | %FileCheck -check-prefix BAD_DEBUG_LEVEL_ERROR %s


### PR DESCRIPTION
This patch wires up flags in Driver and Frontend that expose support for GNU debug fission / DWARF5 standardized Split-DWARF as implemented in LLVM. It splits the majority of debug information from .o outputs into separate .dwo files.

This is based on https://github.com/apple/swift/pull/70296 authored by weliveindetail and adds a rebase and fix for the macos test failure.
