### PR TITLE
Create a uniform representation for function type isolation

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -143,7 +143,7 @@ public:
 
   Type createFunctionType(
       ArrayRef<Demangle::FunctionParam<Type>> params,
-      Type output, FunctionTypeFlags flags,
+      Type output, FunctionTypeFlags flags, ExtendedFunctionTypeFlags extFlags,
       FunctionMetadataDifferentiabilityKind diffKind, Type globalActor,
       Type thrownError);
 

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -812,6 +812,7 @@ protected:
                                     Node->getNumChildren());
 
       FunctionTypeFlags flags;
+      ExtendedFunctionTypeFlags extFlags;
       if (Node->getKind() == NodeKind::ObjCBlock ||
           Node->getKind() == NodeKind::EscapingObjCBlock) {
         flags = flags.withConvention(FunctionMetadataConvention::Block);
@@ -846,6 +847,8 @@ protected:
         globalActorType = globalActorResult.getType();
         ++firstChildIdx;
       }
+
+      // FIXME: other kinds of isolation
 
       FunctionMetadataDifferentiabilityKind diffKind;
       if (Node->getChild(firstChildIdx)->getKind() ==
@@ -895,6 +898,8 @@ protected:
 
         thrownErrorType = thrownErrorResult.getType();
         ++firstChildIdx;
+
+        extFlags = extFlags.withTypedThrows(true);
       }
 
       bool isSendable = false;
@@ -941,8 +946,11 @@ protected:
       if (result.isError())
         return result;
 
+      if (extFlags != ExtendedFunctionTypeFlags())
+        flags = flags.withExtendedFlags(true);
+
       return Builder.createFunctionType(
-          parameters, result.getType(), flags, diffKind, globalActorType,
+          parameters, result.getType(), flags, extFlags, diffKind, globalActorType,
           thrownErrorType);
     }
     case NodeKind::ImplFunctionType: {

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -1122,6 +1122,7 @@ public:
   const FunctionTypeRef *createFunctionType(
       llvm::ArrayRef<remote::FunctionParam<const TypeRef *>> params,
       const TypeRef *result, FunctionTypeFlags flags,
+      ExtendedFunctionTypeFlags extFlags,
       FunctionMetadataDifferentiabilityKind diffKind,
       const TypeRef *globalActor, const TypeRef *thrownError) {
     return FunctionTypeRef::create(*this, params, result, flags, diffKind,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10661,12 +10661,14 @@ Type ConstructorDecl::getInitializerInterfaceType() {
   auto initSelfParam = computeSelfParam(this, /*isInitializingCtor=*/true);
 
   // FIXME: Verify ExtInfo state is correct, not working by accident.
+  AnyFunctionType::ExtInfo info;
+  if (initSelfParam.isIsolated())
+    info = info.withIsolation(FunctionTypeIsolation::forParameter());
+
   Type initFuncTy;
   if (auto sig = getGenericSignature()) {
-    GenericFunctionType::ExtInfo info;
     initFuncTy = GenericFunctionType::get(sig, {initSelfParam}, funcTy, info);
   } else {
-    FunctionType::ExtInfo info;
     initFuncTy = FunctionType::get({initSelfParam}, funcTy, info);
   }
   InitializerInterfaceType = initFuncTy;

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -4660,6 +4660,10 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
     extInfo = extInfo.withAsync(true).withThrows(true, Type());
   }
 
+  // The uncurried function is parameter-isolated if the inner type is.
+  if (innerExtInfo.getIsolation().isParameter())
+    extInfo = extInfo.withIsolation(innerExtInfo.getIsolation());
+
   // If this is a C++ constructor, don't add the metatype "self" parameter
   // because we'll never use it and it will cause problems in IRGen.
   if (isa_and_nonnull<clang::CXXConstructorDecl>(

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3681,6 +3681,7 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
                                       funcType->getThrownError())
           .withConcurrent(funcType->isSendable())
           .withAsync(funcType->isAsync())
+          .withIsolation(funcType->getIsolation())
           .build();
 
   return CanAnyFunctionType::get(

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2539,10 +2539,22 @@ namespace {
                 : 0));
       }();
 
-      // For a non-async function type, add the global actor if present.
-      if (!extInfo.isAsync()) {
-        extInfo = extInfo.withGlobalActor(getExplicitGlobalActor(closure));
-      }
+      // Determine the isolation of the closure.
+      auto isolation = [&] {
+        // Priority goes to an explicit isolated parameter.
+        if (hasIsolatedParameter(closureParams))
+          return FunctionTypeIsolation::forParameter();
+
+        // Honor an explicit global actor.  This is suppressed if the
+        // closure is async (but should it be?).
+        if (!extInfo.isAsync()) {
+          if (auto actorType = getExplicitGlobalActor(closure))
+            return FunctionTypeIsolation::forGlobalActor(actorType);
+        }
+
+        return FunctionTypeIsolation::forNonIsolated();
+      }();
+      extInfo = extInfo.withIsolation(isolation);
 
       auto *fnTy = FunctionType::get(closureParams, resultTy, extInfo);
       return CS.replaceInferableTypesWithTypeVars(

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2817,6 +2817,11 @@ ConstraintSystem::getTypeOfMemberReference(
       info = info.withConcurrent();
     }
 
+    // We'll do other adjustment later, but we need to handle parameter
+    // isolation to avoid assertions.
+    if (fullFunctionType->getIsolation().isParameter())
+      info = info.withIsolation(FunctionTypeIsolation::forParameter());
+
     openedType =
         FunctionType::get(fullFunctionType->getParams(), functionType, info);
   }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2778,22 +2778,20 @@ SynthesizeMainFunctionRequest::evaluate(Evaluator &evaluator,
 
     Type mainActor = context.getMainActorType();
     if (mainActor) {
+      auto extInfo = ASTExtInfoBuilder().withIsolation(
+          FunctionTypeIsolation::forGlobalActor(mainActor));
       mainTypes.push_back(FunctionType::get(
           /*params*/ {}, context.TheEmptyTupleType,
-          ASTExtInfoBuilder().withGlobalActor(mainActor).build()));
+          extInfo.build()));
       mainTypes.push_back(FunctionType::get(
           /*params*/ {}, context.TheEmptyTupleType,
-          ASTExtInfoBuilder().withAsync().withGlobalActor(mainActor).build()));
+          extInfo.withAsync().build()));
       mainTypes.push_back(FunctionType::get(
           /*params*/ {}, context.TheEmptyTupleType,
-          ASTExtInfoBuilder().withThrows().withGlobalActor(mainActor).build()));
-      mainTypes.push_back(FunctionType::get(/*params*/ {},
-                                            context.TheEmptyTupleType,
-                                            ASTExtInfoBuilder()
-                                                .withAsync()
-                                                .withThrows()
-                                                .withGlobalActor(mainActor)
-                                                .build()));
+          extInfo.withThrows().build()));
+      mainTypes.push_back(FunctionType::get(
+          /*params*/ {}, context.TheEmptyTupleType,
+          extInfo.withAsync().withThrows().build()));
     }
     TypeVariableType *mainType =
         CS.createTypeVariable(locator, /*options=*/0);

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 841; // NoncopyableGenerics versioning
+const uint16_t SWIFTMODULE_VERSION_MINOR = 842; // function isolation kinds
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -684,6 +684,14 @@ enum class PluginSearchOptionKind : uint8_t {
 };
 using PluginSearchOptionKindField = BCFixed<3>;
 
+enum class FunctionTypeIsolation : uint8_t {
+  NonIsolated,
+  Parameter,
+  Dynamic,
+  GlobalActorOffset, // Add this to the global actor type ID
+};
+using FunctionTypeIsolationField = TypeIDField;
+
 // Encodes a VersionTuple:
 //
 //  Major
@@ -1219,7 +1227,7 @@ namespace decls_block {
     BCFixed<1>,                      // throws?
     TypeIDField,                     // thrown error
     DifferentiabilityKindField,      // differentiability kind
-    TypeIDField                      // global actor
+    FunctionTypeIsolationField       // isolation
     // trailed by parameters
   );
 
@@ -1317,7 +1325,7 @@ namespace decls_block {
     BCFixed<1>,                      // throws?
     TypeIDField,                     // thrown error
     DifferentiabilityKindField,      // differentiability kind
-    TypeIDField,                     // global actor
+    FunctionTypeIsolationField,      // isolation
     GenericSignatureIDField          // generic signature
 
     // trailed by parameters

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1957,6 +1957,7 @@ public:
   createFunctionType(
       llvm::ArrayRef<Demangle::FunctionParam<BuiltType>> params,
       BuiltType result, FunctionTypeFlags flags,
+      ExtendedFunctionTypeFlags extFlags,
       FunctionMetadataDifferentiabilityKind diffKind,
       BuiltType globalActorType, BuiltType thrownError) const {
     assert(
@@ -1991,12 +1992,6 @@ public:
                                      "the global actor type is a pack");
       }
       flags = flags.withGlobalActor(true);
-    }
-
-    ExtendedFunctionTypeFlags extFlags;
-    if (thrownError) {
-      flags = flags.withExtendedFlags(true);
-      extFlags = extFlags.withTypedThrows(true);
     }
 
     return BuiltType(

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -14,7 +14,7 @@ extension Actor {
   func g() { }
 }
 
-@MainActor func mainActorFn() {}
+@MainActor func mainActorFn() {} // expected-note {{calls to global function 'mainActorFn()' from outside of its actor context are implicitly asynchronous}}
 
 @available(SwiftStdlib 5.1, *)
 func testA<T: Actor>(
@@ -232,7 +232,7 @@ func checkIsolatedAndGlobalClosures(_ a: A) {
   let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}
       = {
     $0.f()
-    mainActorFn()
+    mainActorFn() // expected-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous actor-isolated context}}
   }
 
   let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -134,13 +134,13 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
                               ArrayRef<StringRef>());
 
   auto F1 = Builder.createFunctionType(
-      Parameters1, Result, FunctionTypeFlags(),
+      Parameters1, Result, FunctionTypeFlags(), ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F2 = Builder.createFunctionType(
-      Parameters1, Result, FunctionTypeFlags(),
+      Parameters1, Result, FunctionTypeFlags(), ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F3 = Builder.createFunctionType(
-      Parameters2, Result, FunctionTypeFlags(),
+      Parameters2, Result, FunctionTypeFlags(), ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
 
   EXPECT_EQ(F1, F2);
@@ -148,9 +148,11 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 
   auto F4 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withThrows(true),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F5 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withThrows(true),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
 
   EXPECT_EQ(F4, F5);
@@ -165,41 +167,51 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 
   auto F6 = Builder.createFunctionType(
       {Param1.withFlags(inoutFlags)}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F6_1 = Builder.createFunctionType(
       {Param1.withFlags(inoutFlags)}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   EXPECT_EQ(F6, F6_1);
 
   auto F7 = Builder.createFunctionType(
       {Param1.withFlags(variadicFlags)}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F7_1 = Builder.createFunctionType(
       {Param1.withFlags(variadicFlags)}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   EXPECT_EQ(F7, F7_1);
 
   auto F8 = Builder.createFunctionType(
       {Param1.withFlags(sharedFlags)}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F8_1 = Builder.createFunctionType(
       {Param1.withFlags(sharedFlags)}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   EXPECT_EQ(F8, F8_1);
 
   auto F9 = Builder.createFunctionType(
       {Param1.withFlags(ownedFlags)}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F9_1 = Builder.createFunctionType(
       {Param1.withFlags(ownedFlags)}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   EXPECT_EQ(F9, F9_1);
 
   auto F10 = Builder.createFunctionType(
       {Param1}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F10_1 = Builder.createFunctionType(
       {Param1.withLabel("foo")}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   EXPECT_NE(F10, F10_1);
 
@@ -216,9 +228,11 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 
   auto VoidVoid1 =
       Builder.createFunctionType(VoidParams, VoidResult, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto VoidVoid2 =
       Builder.createFunctionType(VoidParams, VoidResult, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
 
   EXPECT_EQ(VoidVoid1, VoidVoid2);
@@ -227,12 +241,15 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
   // Test escaping.
   auto F11 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withEscaping(true),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F12 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withEscaping(true),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F13 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withEscaping(false),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   EXPECT_EQ(F11, F12);
   EXPECT_NE(F11, F13);
@@ -240,12 +257,15 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
   // Test sendable.
   auto F14 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withConcurrent(true),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F15 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withConcurrent(true),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F16 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withConcurrent(false),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   EXPECT_EQ(F14, F15);
   EXPECT_NE(F14, F16);
@@ -253,12 +273,15 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
   // Test differentiable.
   auto F17 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withDifferentiable(true),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::Reverse, nullptr, nullptr);
   auto F18 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withDifferentiable(true),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::Reverse, nullptr, nullptr);
   auto F19 = Builder.createFunctionType(
       Parameters1, Result, FunctionTypeFlags().withDifferentiable(false),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::Reverse, nullptr, nullptr);
   EXPECT_EQ(F17, F18);
   EXPECT_NE(F17, F19);
@@ -269,12 +292,15 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
     parameters[1].setNoDerivative();
     auto f1 = Builder.createFunctionType(
         parameters, Result, FunctionTypeFlags().withDifferentiable(true),
+        ExtendedFunctionTypeFlags(),
         FunctionMetadataDifferentiabilityKind::Reverse, nullptr, nullptr);
     auto f2 = Builder.createFunctionType(
         parameters, Result, FunctionTypeFlags().withDifferentiable(true),
+        ExtendedFunctionTypeFlags(),
         FunctionMetadataDifferentiabilityKind::Reverse, nullptr, nullptr);
     auto f3 = Builder.createFunctionType(
         Parameters1, Result, FunctionTypeFlags().withDifferentiable(true),
+        ExtendedFunctionTypeFlags(),
         FunctionMetadataDifferentiabilityKind::Reverse, nullptr, nullptr);
     EXPECT_EQ(f1, f2);
     EXPECT_NE(f1, f3);
@@ -522,6 +548,7 @@ TEST(TypeRefTest, DeriveSubstitutions) {
                                         ArrayRef<StringRef>());
   auto Func = Builder.createFunctionType(
       {Nominal}, Result, FunctionTypeFlags(),
+      ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
 
   TypeRefDecl SubstOneName("subst1");


### PR DESCRIPTION
Not quite NFC because apparently the representation bleeds into what's accepted in some situations where we're supposed to be warning about conflicts and then making an arbitrary choice.  But what we're doing is nonsense, so we definitely need to break behavior here.

This is setting up for isolated(any) and isolated(caller).  I tried to keep that out of the patch as much as reasonably possible, though.