### PR TITLE
[region-isolation] Values captured by an actor isolated closure are transferred into that closure

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -898,6 +898,9 @@ WARNING(regionbasedisolation_transfer_yields_race_no_isolation, none,
 WARNING(regionbasedisolation_transfer_yields_race_with_isolation, none,
         "transferring value of non-Sendable type %0 from %1 context to %2 context; later accesses could race",
         (Type, ActorIsolation, ActorIsolation))
+WARNING(regionbasedisolation_isolated_capture_yields_race, none,
+        "%1 closure captures value of non-Sendable type %0 from %2 context; later accesses to value could race",
+        (Type, ActorIsolation, ActorIsolation))
 WARNING(regionbasedisolation_transfer_yields_race_transferring_parameter, none,
         "transferring value of non-Sendable type %0 into transferring parameter; later accesses could race",
         (Type))

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -907,8 +907,14 @@ WARNING(regionbasedisolation_transfer_yields_race_transferring_parameter, none,
 WARNING(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, none,
         "binding of non-Sendable type %0 accessed after being transferred; later accesses could race",
         (Type))
+WARNING(regionbasedisolation_arg_transferred, none,
+        "task isolated value of type %0 transferred to %1 context; later accesses to value could race",
+        (Type, ActorIsolation))
 NOTE(regionbasedisolation_maybe_race, none,
      "access here could race", ())
+NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
+     "value is %0 since it is in the same region as %1",
+     (StringRef, DeclBaseName))
 ERROR(regionbasedisolation_unknown_pattern, none,
       "pattern that the region based isolation checker does not understand how to check. Please file a bug",
       ())

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3846,6 +3846,20 @@ public:
     Bits.AbstractClosureExpr.Discriminator = InvalidDiscriminator;
   }
 
+  /// If we find that a capture x of this AbstractClosureExpr belongs to a
+  /// different isolation domain than the closure, add an ApplyIsolationCrossing
+  /// to foundIsolationCrossing.
+  ///
+  /// \p foundIsolationCrossings an out parameter that contains the
+  /// ApplyIsolationCrossing if any of the captures are isolation crossing and
+  /// the index of the capture in the capture array. We return the index since
+  /// all captures may not cross isolation boundaries and we may need to be able
+  /// to look up the corresponding capture at the SIL level by index.
+  void getIsolationCrossing(
+      SmallVectorImpl<
+          std::tuple<CapturedValue, unsigned, ApplyIsolationCrossing>>
+          &foundIsolationCrossings);
+
   CaptureInfo getCaptureInfo() const { return Captures; }
   void setCaptureInfo(CaptureInfo captures) { Captures = captures; }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2927,3 +2927,55 @@ Type ThrownErrorDestination::getContextErrorType() const {
   auto conversion = storage.get<Conversion *>();
   return conversion->conversion->getType();
 }
+
+void AbstractClosureExpr::getIsolationCrossing(
+    SmallVectorImpl<std::tuple<CapturedValue, unsigned, ApplyIsolationCrossing>>
+        &foundIsolationCrossings) {
+  /// For each capture...
+  for (auto pair : llvm::enumerate(getCaptureInfo().getCaptures())) {
+    auto capture = pair.value();
+
+    // First check quickly if we have dynamic self metadata. This is Sendable
+    // data so we don't care about it.
+    if (capture.isDynamicSelfMetadata())
+      continue;
+
+    auto declIsolation = swift::getActorIsolation(capture.getDecl());
+
+    // Then see if we have an opaque value.
+    if (auto *opaqueValue = capture.getOpaqueValue()) {
+      continue;
+    }
+
+    // If our decl is actor isolated...
+    if (declIsolation.isActorIsolated()) {
+      // And our closure is also actor isolated, then add the apply isolation
+      // crossing if the actors are different.
+      if (actorIsolation.isActorIsolated()) {
+        if (declIsolation.getActor() == actorIsolation.getActor()) {
+          continue;
+        }
+
+        foundIsolationCrossings.emplace_back(
+            capture, pair.index(),
+            ApplyIsolationCrossing(declIsolation, actorIsolation));
+        continue;
+      }
+
+      // Otherwise, our closure is not actor isolated but our decl is actor
+      // isolated. Add it.
+      foundIsolationCrossings.emplace_back(
+          capture, pair.index(),
+          ApplyIsolationCrossing(declIsolation, actorIsolation));
+      continue;
+    }
+
+    if (!actorIsolation.isActorIsolated()) {
+      continue;
+    }
+
+    foundIsolationCrossings.emplace_back(
+        capture, pair.index(),
+        ApplyIsolationCrossing(declIsolation, actorIsolation));
+  }
+}

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2942,10 +2942,10 @@ void AbstractClosureExpr::getIsolationCrossing(
 
     auto declIsolation = swift::getActorIsolation(capture.getDecl());
 
-    // Then see if we have an opaque value.
-    if (auto *opaqueValue = capture.getOpaqueValue()) {
-      continue;
-    }
+    // Assert that we do not have an opaque value capture. These only appear in
+    // TypeLowering and should never appear in the AST itself.
+    assert(!capture.getOpaqueValue() &&
+           "This should only be created in TypeLowering");
 
     // If our decl is actor isolated...
     if (declIsolation.isActorIsolated()) {

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -251,11 +251,11 @@ final class NonSendable {
   func call() async {
     await update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-tns-warning @-2 {{task isolated value of type 'NonSendable' transferred to main actor-isolated context; later accesses to value could race}}
 
     await self.update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    // expected-tns-warning @-2 {{task isolated value of type 'NonSendable' transferred to main actor-isolated context; later accesses to value could race}}
 
     _ = await x
     // expected-warning@-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
@@ -287,18 +287,18 @@ func globalSendable(_ ns: NonSendable) async {}
 @available(SwiftStdlib 5.1, *)
 @MainActor
 func callNonisolatedAsyncClosure(
-  ns: NonSendable,
+  ns: NonSendable, // expected-tns-note {{value is task isolated since it is in the same region as 'ns'}}
   g: (NonSendable) async -> Void
 ) async {
   await g(ns)
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
-  // expected-tns-warning @-3 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-tns-warning @-2 {{task isolated value of type 'NonSendable' transferred to nonisolated context; later accesses to value could race}}
+  // expected-tns-warning @-3 {{task isolated value of type '@noescape @async @callee_guaranteed (@guaranteed NonSendable) -> ()' transferred to nonisolated context; later accesses to value could race}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-tns-warning @-2 {{task isolated value of type 'NonSendable' transferred to nonisolated context; later accesses to value could race}}
 
 }
 

--- a/test/Concurrency/transfernonsendable_globalactors.swift
+++ b/test/Concurrency/transfernonsendable_globalactors.swift
@@ -48,6 +48,7 @@ struct CustomActor {
 }
 
 @MainActor func testTransferGlobalActorGuardedValueWithlet(_ k: Klass) async {
+  // expected-note @-1 {{value is task isolated since it is in the same region as 'k'}}
   globalKlass = k
-  await transferToCustom(k) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToCustom(k) // expected-tns-warning {{task isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context; later accesses to value could race}}
 }

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -1,0 +1,77 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -disable-availability-checking -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// This test validates how we handle partial applies that are isolated to a
+// specific isolation domain (causing isolation crossings to occur).
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+actor Custom {
+  var x = NonSendableKlass()
+}
+
+@globalActor
+struct CustomActor {
+    static var shared: Custom {
+        return Custom()
+    }
+}
+
+func useValue<T>(_ t: T) {}
+@MainActor func transferToMain<T>(_ t: T) {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+actor ProtectsNonSendable {
+  var ns: NonSendableKlass = .init()
+
+  nonisolated func testParameter(_ ns: NonSendableKlass) async {
+    self.assumeIsolated { isolatedSelf in
+      // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+      isolatedSelf.ns = ns
+    }
+  }
+
+  nonisolated func testLocal() async {
+    let l = NonSendableKlass()
+
+    // This is safe since we do not reuse l.
+    self.assumeIsolated { isolatedSelf in
+      isolatedSelf.ns = l
+    }
+  }
+
+  nonisolated func testLocal2() async {
+    let l = NonSendableKlass()
+
+    // This is not safe since we use l later.
+    self.assumeIsolated { isolatedSelf in
+      isolatedSelf.ns = l // expected-warning {{actor-isolated closure captures value of non-Sendable type 'NonSendableKlass' from nonisolated context; later accesses to value could race}}
+    }
+
+    useValue(l) // expected-note {{access here could race}}
+  }
+}
+
+func normalFunc_testLocal_1() {
+  let x = NonSendableKlass()
+  let _ = { @MainActor in
+    print(x)
+  }
+}
+
+func normalFunc_testLocal_2() {
+  let x = NonSendableKlass()
+  let _ = { @MainActor in
+    useValue(x) // expected-warning {{main actor-isolated closure captures value of non-Sendable type 'NonSendableKlass' from nonisolated context; later accesses to value could race}}
+  }
+  useValue(x) // expected-note {{access here could race}}
+}

--- a/test/Concurrency/transfernonsendable_strong_transferring.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify -enable-experimental-feature RegionBasedIsolation %s
+// RUN: %target-swift-frontend -emit-sil -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify -enable-experimental-feature RegionBasedIsolation %s -o /dev/null
 
 // REQUIRES: asserts
 
@@ -84,8 +84,9 @@ func testNonStrongTransferDoesntMerge() async {
 //////////////////////////////////
 
 func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) async {
+  // expected-note @-1:71 {{value is task isolated since it is in the same region as 'y'}}
   await transferToMain(x)
-  await transferToMain(y) // expected-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToMain(y) // expected-warning {{task isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
@@ -102,8 +103,9 @@ actor MyActor {
   var field = Klass()
 
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
+    // expected-note @-1:72 {{value is task isolated since it is in the same region as 'y'}}
     await transferToMain(x)
-    await transferToMain(y) // expected-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(y) // expected-warning {{task isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {


### PR DESCRIPTION
This PR contains a few different pieces that fix the above mentioned issue:

1. The first commit ensures that we treat actor isolated closures as capturing things via transfer.
2. When I looked at how (1) changed some of the tests, I decided to use this as an opportunity to clean up a few instances of the "call site transfers arg or self" since it showed up in the tests I added in (1).
3. The rest of the commits involved cleaning that up a bit more.
4. The final commit removes dead code from Sema around OpaqueValueExpr and captures. Originally I thought I needed to handle this, but @xedin and I think that it is dead, so I removed it. Doing more thorough testing on CI will tell.

rdar://121345525