### PR TITLE
NFC: [MemAccessUtils] Tweaked API.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1271,9 +1271,10 @@ struct AccessPathWithBase {
 //
 // The "product leaves" are the leaves obtained by only looking through type
 // products (structs and tuples) and NOT type sums (enums).
-void visitProductLeafAccessPathNodes(
-    AccessPath rootPath, SILValue address, TypeExpansionContext tec,
-    SILModule &module,
+//
+// Returns false if the access path couldn't be computed.
+bool visitProductLeafAccessPathNodes(
+    SILValue address, TypeExpansionContext tec, SILModule &module,
     std::function<void(AccessPath::PathNode, SILType)> visitor);
 
 inline AccessPath AccessPath::compute(SILValue address) {

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -1435,12 +1435,13 @@ AccessPathWithBase AccessPathWithBase::computeInScope(SILValue address) {
       .findAccessPath(address);
 }
 
-void swift::visitProductLeafAccessPathNodes(
-    AccessPath rootPath, SILValue address, TypeExpansionContext tec,
-    SILModule &module,
+bool swift::visitProductLeafAccessPathNodes(
+    SILValue address, TypeExpansionContext tec, SILModule &module,
     std::function<void(AccessPath::PathNode, SILType)> visitor) {
-  assert(rootPath.isValid());
-  assert(AccessPath::compute(address) == rootPath);
+  auto rootPath = AccessPath::compute(address);
+  if (!rootPath.isValid()) {
+    return false;
+  }
   SmallVector<std::pair<SILType, IndexTrieNode *>, 32> worklist;
   auto *node = rootPath.getPathNode().node;
   worklist.push_back({address->getType(), node});
@@ -1474,6 +1475,7 @@ void swift::visitProductLeafAccessPathNodes(
       visitor(AccessPath::PathNode(node), silType);
     }
   }
+  return true;
 }
 
 void AccessPath::Index::print(raw_ostream &os) const {


### PR DESCRIPTION
Previously, `visitProductLeafAccessPathNodes` required its caller to provide both an `AccessPath` `path` and an `SILValue` `address` which satisfied `path == AccessPath::compute(address)` to force the caller to handle the case of an invalid `AccessPath`.  Now, instead, it computes the value itself and returns false if it's invalid.

It could be tweaked to also return false if the provided lambda returned false but that would make the only currently extant callers less pleasant and also would not be sufficient in the case of caller who wanted to distinguish between an invalid `AccessPath` and a particular leaf visit returning false.
