### PR TITLE
For scripts, use DYLD_FRAMEWORK/LIBRARY_PATH to find frameworks / runtimes.

### DIFF
--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -84,7 +84,8 @@ toolchains::Darwin::constructInvocation(const InterpretJobAction &job,
                                      ":", options::OPT_L, context.Args,
                                      runtimeLibraryPaths);
   addPathEnvironmentVariableIfNeeded(II.ExtraEnvironment, "DYLD_FRAMEWORK_PATH",
-                                     ":", options::OPT_F, context.Args);
+                                     ":", options::OPT_F, context.Args,
+                                     {"/System/Library/Frameworks"});
   // FIXME: Add options::OPT_Fsystem paths to DYLD_FRAMEWORK_PATH as well.
   return II;
 }

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -86,8 +86,10 @@ void *swift::immediate::loadSwiftRuntime(ArrayRef<std::string>
                                          runtimeLibPaths) {
 #if defined(_WIN32)
   return loadRuntimeLib("swiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
-#else
+#elif (defined(__linux__) || defined(_WIN64) || defined(__FreeBSD__))
   return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, runtimeLibPaths);
+#else
+  return loadRuntimeLib("libswiftCore" LTDL_SHLIB_EXT, {"/usr/lib/swift"});
 #endif
 }
 

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -15,47 +15,43 @@
 
 
 // RUN: %swift_driver_plain -sdk "" -### -target x86_64-apple-macosx10.9 -resource-dir /RSRC/ %s | %FileCheck -check-prefix=CHECK-RESOURCE-DIR-ONLY %s
-// CHECK-RESOURCE-DIR-ONLY: # DYLD_LIBRARY_PATH=/RSRC/macosx{{$}}
+// CHECK-RESOURCE-DIR-ONLY: # DYLD_LIBRARY_PATH=/RSRC/macosx DYLD_FRAMEWORK_PATH=/System/Library/Frameworks{{$}}
 
 // RUN: %swift_driver_plain -sdk "" -### -target x86_64-unknown-linux-gnu -resource-dir /RSRC/ %s | %FileCheck -check-prefix=CHECK-RESOURCE-DIR-ONLY-LINUX${LD_LIBRARY_PATH+_LAX} %s
 // CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux{{$}}
 // CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux{{$|:}}
 
 // RUN: %swift_driver_plain -sdk "" -### -target x86_64-apple-macosx10.9 -L/foo/ %s | %FileCheck -check-prefix=CHECK-L %s
-// CHECK-L: # DYLD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/macosx$}}
+// CHECK-L: # DYLD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/macosx}} DYLD_FRAMEWORK_PATH=/System/Library/Frameworks
 
 // RUN: %swift_driver_plain -sdk "" -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-L2 %s
-// CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx$}}
+// CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx}}  DYLD_FRAMEWORK_PATH=/System/Library/Frameworks
 
 // RUN: env DYLD_LIBRARY_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s 2>&1 | %FileCheck -check-prefix=CHECK-L2-ENV %s 
-// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift:/abc/$}}
-
-// RUN: %swift_driver_plain -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
-// RUN: env DYLD_FRAMEWORK_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
-// CHECK-NO-FRAMEWORKS-NOT: DYLD_FRAMEWORK_PATH
+// CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift:/abc/}} DYLD_FRAMEWORK_PATH=/System/Library/Frameworks
 
 // RUN: %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ %s | %FileCheck -check-prefix=CHECK-F %s
 // CHECK-F: -F /foo/
 // CHECK-F: #
-// CHECK-F: DYLD_FRAMEWORK_PATH=/foo/{{$}}
+// CHECK-F: DYLD_FRAMEWORK_PATH=/foo/:/System/Library/Frameworks{{$}}
 
 // RUN: %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ %s | %FileCheck -check-prefix=CHECK-F2 %s
 // CHECK-F2: -F /foo/
 // CHECK-F2: -F /bar/
 // CHECK-F2: #
-// CHECK-F2: DYLD_FRAMEWORK_PATH=/foo/:/bar/{{$}}
+// CHECK-F2: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/System/Library/Frameworks{{$}}
 
 // RUN: env DYLD_FRAMEWORK_PATH=/abc/ %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ %s | %FileCheck -check-prefix=CHECK-F2-ENV %s
 // CHECK-F2-ENV: -F /foo/
 // CHECK-F2-ENV: -F /bar/
 // CHECK-F2-ENV: #
-// CHECK-F2-ENV: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$}}
+// CHECK-F2-ENV: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/System/Library/Frameworks:/abc/{{$}}
 
 // RUN: env DYLD_FRAMEWORK_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ -L/foo2/ -L/bar2/ %s 2>&1 | %FileCheck -check-prefix=CHECK-COMPLEX %s
 // CHECK-COMPLEX: -F /foo/
 // CHECK-COMPLEX: -F /bar/
 // CHECK-COMPLEX: #
-// CHECK-COMPLEX-DAG: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$| }}
+// CHECK-COMPLEX-DAG: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/System/Library/Frameworks:/abc/{{$| }}
 // CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift($| )}}
 
 // RUN: %swift_driver_plain -sdk /sdk -### -target aarch64-unknown-linux-gnu %s | %FileCheck -check-prefix=CHECK-RUNTIME-LIBRARY-PATH %s


### PR DESCRIPTION
For scripts, use DYLD_FRAMEWORK/LIBRARY_PATH to find frameworks / runtimes.

Adds DYLD_FRAMEWORK_PATH=/System/Library/Frameworks to the environment
when constructing swift-frontend invocations for the interpreter so that dlopen can
find autolinked frameworks. This is intended to fix
https://github.com/apple/swift/issues/68785.
    
Replaces expansion of runtime paths to find the path to the runtime in
libImmediate, instead hard-coding "/usr/lib/swift/libswiftCore.dylib" and
using DYLD_LIBRARY_PATH to find any built runtime (this ensures that dyld
treats whichever libswiftCore.dylib is found as override for the one in the
shared cache, which doesn't happen if dlopen is passed a non-standard path).

Resolves #68785, rdar://120964868.