### PR TITLE
[Explicit Module Builds] Register Clang module dependencies' input `.h` files with the dependency tracker

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -433,7 +433,7 @@ ClangImporter::ClangImporter(ASTContext &ctx,
                              DependencyTracker *tracker,
                              DWARFImporterDelegate *dwarfImporterDelegate)
     : ClangModuleLoader(tracker),
-      Impl(*new Implementation(ctx, dwarfImporterDelegate)) {
+      Impl(*new Implementation(ctx, tracker, dwarfImporterDelegate)) {
 }
 
 ClangImporter::~ClangImporter() {
@@ -2228,6 +2228,22 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
     (void) namelookup::getAllImports(result);
   }
 
+  // Register '.h' inputs of each Clang module dependency with
+  // the dependency tracker. In implicit builds such dependencies are registered
+  // during the on-demand construction of Clang module. In Explicit Module
+  // Builds, since we load pre-built PCMs directly, we do not get to do so. So
+  // instead, manually register all `.h` inputs of Clang module dependnecies.
+  if (SwiftDependencyTracker &&
+      !Instance->getInvocation().getLangOpts().ImplicitModules) {
+    auto *moduleFile = Instance->getASTReader()->getModuleManager().lookup(
+        clangModule->getASTFile());
+    Instance->getASTReader()->visitInputFileInfos(
+        *moduleFile, /*IncludeSystem=*/true,
+        [&](const clang::serialization::InputFileInfo &IFI, bool isSystem) {
+          SwiftDependencyTracker->addDependency(IFI.Filename, isSystem);
+        });
+  }
+
   if (clangModule->isSubModule()) {
     finishLoadingClangModule(clangModule->getTopLevelModule(), importLoc);
   } else {
@@ -2428,7 +2444,8 @@ bool PlatformAvailability::treatDeprecatedAsUnavailable(
 }
 
 ClangImporter::Implementation::Implementation(
-    ASTContext &ctx, DWARFImporterDelegate *dwarfImporterDelegate)
+    ASTContext &ctx, DependencyTracker *dependencyTracker,
+    DWARFImporterDelegate *dwarfImporterDelegate)
     : SwiftContext(ctx), ImportForwardDeclarations(
                              ctx.ClangImporterOpts.ImportForwardDeclarations),
       DisableSwiftBridgeAttr(ctx.ClangImporterOpts.DisableSwiftBridgeAttr),
@@ -2444,6 +2461,7 @@ ClangImporter::Implementation::Implementation(
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
       platformAvailability(ctx.LangOpts), nameImporter(),
       DisableSourceImport(ctx.ClangImporterOpts.DisableSourceImport),
+      SwiftDependencyTracker(dependencyTracker),
       DWARFImporter(dwarfImporterDelegate) {}
 
 ClangImporter::Implementation::~Implementation() {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -416,7 +416,7 @@ class LLVM_LIBRARY_VISIBILITY ClangImporter::Implementation
   using Version = importer::ImportNameVersion;
 
 public:
-  Implementation(ASTContext &ctx,
+  Implementation(ASTContext &ctx, DependencyTracker *dependencyTracker,
                  DWARFImporterDelegate *dwarfImporterDelegate);
   ~Implementation();
 
@@ -826,6 +826,9 @@ private:
   /// DWARFImporter delegate.
   bool DisableSourceImport;
   
+  /// File dependency tracker, if installed.
+  DependencyTracker *SwiftDependencyTracker = nullptr;
+
   /// The DWARF importer delegate, if installed.
   DWARFImporterDelegate *DWARFImporter = nullptr;
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -417,7 +417,7 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
         Instance, Invocation.getClangModuleCachePath(),
         FEOpts.BackupModuleInterfaceDir, PrebuiltCachePath, ABIPath, InputPath,
         Invocation.getOutputFilename(),
-        FEOpts.SerializeModuleInterfaceDependencyHashes,
+        /* shouldSerializeDeps */ true,
         Invocation.getSearchPathOptions().CandidateCompiledModules);
   else
     return ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(

--- a/test/ScanDependencies/explicit-dependencies-headerdeps.swift
+++ b/test/ScanDependencies/explicit-dependencies-headerdeps.swift
@@ -1,0 +1,67 @@
+// UNSUPPORTED: OS=windows-msvc
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/inputs
+
+// RUN: split-file %s %t
+// RUN: sed -e "s|INPUTSDIR|%/t/inputs|g" %t/map.json.template > %t/map.json.template1
+// RUN: sed -e "s|STDLIBMOD|%/stdlib_module|g" %t/map.json.template1 > %t/map.json.template2
+// RUN: sed -e "s|ONONEMOD|%/ononesupport_module|g" %t/map.json.template2 > %t/map.json.template3
+// RUN: sed -e "s|CHEADERSDIR|%/S/Inputs/CHeaders|g" %t/map.json.template3 > %t/map.json.template4
+// RUN: sed -e "s|SWIFTLIBDIR|%swift-lib-dir|g" %t/map.json.template4 > %t/map.json
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/A.swiftmodule -emit-module-doc-path %t/inputs/A.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/A.swiftsourceinfo -import-underlying-module -I%S/Inputs/CHeaders -module-cache-path %t.module-cache %t/A.swift -module-name A -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+// RUN: %target-swift-emit-pcm -module-name A -o %t/inputs/A.pcm %S/Inputs/CHeaders/module.modulemap
+// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm
+
+// RUN: %target-swift-frontend -emit-module-path %t/Foo.swiftmodule -disable-implicit-swift-modules -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -module-cache-path %t.module-cache -explicit-swift-module-map-file %t/map.json -primary-file %t/test.swift -emit-dependencies-path %t/test.d -emit-reference-dependencies-path %t/test.swiftdeps -o %t/test.o
+
+// Verify that make-style dependencies contain header files of transitive clang module dependency
+// RUN: cat %t/test.d | %FileCheck %s -check-prefix=MAKEDEP-CHECK
+// MAKEDEP-CHECK: {{.*}}test{{/|\\}}ScanDependencies{{/|\\}}Inputs{{/|\\}}CHeaders{{/|\\}}A.h
+
+// Verify that Swift reference dependencies contain header files of transitive clang module dependency
+// RUN: llvm-bcanalyzer --dump %t/test.swiftdeps | %FileCheck %s -check-prefix=SWIFTDEPS-CHECK
+// SWIFTDEPS-CHECK: <IDENTIFIER_NODE abbrevid=8/> blob data = '{{.*}}test{{/|\\}}ScanDependencies{{/|\\}}Inputs{{/|\\}}CHeaders{{/|\\}}A.h'
+
+
+//--- A.swift
+public func anotherFuncA() {}
+
+//--- map.json.template
+[
+  {
+      "moduleName": "A",
+      "modulePath": "INPUTSDIR/A.swiftmodule",
+      "docPath": "INPUTSDIR/A.swiftdoc",
+      "sourceInfoPath": "INPUTSDIR/A.swiftsourceinfo",
+      "isFramework": false,
+  },
+  {
+      "moduleName": "A",
+      "clangModulePath": "INPUTSDIR/A.pcm",
+      "clangModuleMapPath": "CHEADERSDIR/module.modulemap"
+  },
+  {
+      "moduleName": "Swift",
+      "modulePath": "STDLIBMOD",
+      "isFramework": false
+  },
+  {
+      "moduleName": "SwiftOnoneSupport",
+      "modulePath": "ONONEMOD",
+      "isFramework": false
+  },
+  {
+      "moduleName": "SwiftShims",
+      "isFramework": false,
+      "clangModuleMapPath": "SWIFTLIBDIR/swift/shims/module.modulemap",
+      "clangModulePath": "INPUTSDIR/SwiftShims.pcm"
+}]
+
+//--- test.swift
+import A
+
+func callA() {
+  funcA()
+  anotherFuncA()
+}


### PR DESCRIPTION
Prior to emission of `.d` and `.swiftdeps` outputs. In implicit builds such dependencies are registered during the construction of the corresponding Clang module by the ClangImporter's built-in Compiler Instance. In explicit builds, since we load pre-built PCMs directly, we do not get to do so. So instead, manually register all `.h` inputs of Clang module dependencies.

Resolves rdar://121354886
