### PR TITLE
[MoveChecker] Distinguished scope end diagnostics.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -806,6 +806,12 @@ ERROR(sil_movechecking_capture_consumed, none,
 ERROR(sil_movechecking_not_reinitialized_before_end_of_function, none,
       "missing reinitialization of %select{inout parameter|closure capture}1 '%0' "
       "after consume", (StringRef, bool))
+ERROR(sil_movechecking_not_reinitialized_before_end_of_coroutine, none,
+      "field '%0' was consumed but not reinitialized; "
+      "the field must be reinitialized during the access", (StringRef))
+ERROR(sil_movechecking_not_reinitialized_before_end_of_access, none,
+      "missing reinitialization of %select{inout parameter|closure capture}1 '%0' "
+      "after consume while accessing memory", (StringRef, bool))
 ERROR(sil_movechecking_value_consumed_in_a_loop, none,
       "'%0' consumed in a loop", (StringRef))
 ERROR(sil_movechecking_use_after_partial_consume, none,

--- a/include/swift/SIL/FieldSensitivePrunedLiveness.h
+++ b/include/swift/SIL/FieldSensitivePrunedLiveness.h
@@ -1294,20 +1294,16 @@ public:
         bits, [&](auto range) { initializeDef(def, range); });
   }
 
-  void initializeDef(SILValue def, TypeTreeLeafTypeRange span) {
+  void initializeDef(SILNode *node, TypeTreeLeafTypeRange span) {
     assert(Super::isInitialized());
-    defs.insert(def, span);
-    auto *block = def->getParentBlock();
+    defs.insert(node, span);
+    auto *block = node->getParentBlock();
     defBlocks.insert(block, span);
     initializeDefBlock(block, span);
   }
 
   void initializeDef(SILInstruction *def, TypeTreeLeafTypeRange span) {
-    assert(Super::isInitialized());
-    defs.insert(cast<SILNode>(def), span);
-    auto *block = def->getParent();
-    defBlocks.insert(block, span);
-    initializeDefBlock(block, span);
+    initializeDef(cast<SILNode>(def), span);
   }
 
   bool isInitialized() const { return Super::isInitialized() && !defs.empty(); }

--- a/include/swift/SIL/FieldSensitivePrunedLiveness.h
+++ b/include/swift/SIL/FieldSensitivePrunedLiveness.h
@@ -1221,17 +1221,24 @@ public:
     return inst == defInst.first && defInst.second->contains(bit);
   }
 
-  bool isDef(SILInstruction *inst, SmallBitVector const &bits) const {
+  void isDef(SILInstruction *inst, SmallBitVector const &bits,
+             SmallBitVector &bitsOut) const {
+    assert(bitsOut.none());
     if (inst != defInst.first)
-      return false;
-    SmallBitVector defBits(bits.size());
-    defInst.second->setBits(defBits);
-    return (defBits & bits) == bits;
+      return;
+    defInst.second->setBits(bitsOut);
+    bitsOut &= bits;
   }
 
-  bool isDef(SILInstruction *inst, TypeTreeLeafTypeRange span) const {
-    return inst == defInst.first &&
-           defInst.second->setIntersection(span).has_value();
+  void isDef(SILInstruction *inst, TypeTreeLeafTypeRange span,
+             SmallBitVector &bitsOut) const {
+    assert(bitsOut.none());
+    if (inst != defInst.first)
+      return;
+    auto intersection = defInst.second->setIntersection(span);
+    if (!intersection.has_value())
+      return;
+    intersection.value().setBits(bitsOut);
   }
 
   bool isDefBlock(SILBasicBlock *block, unsigned bit) const {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4648,9 +4648,9 @@ enum class SILAccessEnforcement : uint8_t {
   /// behavior.
   Unsafe,
 
-  /// Access to pointers that are signed via pointer authentication mechanishm.
+  /// Access to pointers that are signed via pointer authentication.
   /// Such pointers should be authenticated before read and signed before a
-  /// write. Optimizer should avoid promoting such accesses to values.
+  /// write. Optimizations should avoid promoting such accesses to values.
   Signed,
 
   // This enum is encoded.

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -986,7 +986,7 @@ void UseState::initializeLiveness(
                "init!\n");
         // We cheat here slightly and use our address's operand.
         recordInitUse(address, address, liveness.getTopLevelSpan());
-        liveness.initializeDef(address, liveness.getTopLevelSpan());
+        liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
         break;
       case swift::SILArgumentConvention::Indirect_Out:
         llvm_unreachable("Should never have out addresses here");
@@ -1018,7 +1018,7 @@ void UseState::initializeLiveness(
                    << "Found move only arg closure box use... "
                       "adding mark_unresolved_non_copyable_value as init!\n");
         recordInitUse(address, address, liveness.getTopLevelSpan());
-        liveness.initializeDef(address, liveness.getTopLevelSpan());
+        liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
       }
     } else if (auto *box = dyn_cast<AllocBoxInst>(
                    lookThroughOwnershipInsts(projectBox->getOperand()))) {
@@ -1026,7 +1026,7 @@ void UseState::initializeLiveness(
                  << "Found move only var allocbox use... "
                     "adding mark_unresolved_non_copyable_value as init!\n");
       recordInitUse(address, address, liveness.getTopLevelSpan());
-      liveness.initializeDef(address, liveness.getTopLevelSpan());
+      liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
     }
   }
 
@@ -1038,7 +1038,7 @@ void UseState::initializeLiveness(
                << "Found ref_element_addr use... "
                   "adding mark_unresolved_non_copyable_value as init!\n");
     recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(address, liveness.getTopLevelSpan());
+    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
   }
 
   // Check if our address is from a global_addr. In such a case, we treat the
@@ -1049,7 +1049,7 @@ void UseState::initializeLiveness(
                << "Found global_addr use... "
                   "adding mark_unresolved_non_copyable_value as init!\n");
     recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(address, liveness.getTopLevelSpan());
+    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
   }
 
   if (auto *ptai = dyn_cast<PointerToAddressInst>(
@@ -1059,13 +1059,13 @@ void UseState::initializeLiveness(
                << "Found pointer to address use... "
                   "adding mark_unresolved_non_copyable_value as init!\n");
     recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(address, liveness.getTopLevelSpan());
+    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
   }
   
   if (auto *bai = dyn_cast_or_null<BeginApplyInst>(
         stripAccessMarkers(address->getOperand())->getDefiningInstruction())) {
     recordInitUse(address, address, liveness.getTopLevelSpan());
-    liveness.initializeDef(address, liveness.getTopLevelSpan());
+    liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
   }
 
   // Now that we have finished initialization of defs, change our multi-maps

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2688,12 +2688,19 @@ bool GlobalLivenessChecker::testInstVectorLiveness(
           // This can happen for instance along an exit block of a loop where
           // the error use is within the loop.
           continue;
-        case IsLive::LiveOut:
+        case IsLive::LiveOut: {
           LLVM_DEBUG(llvm::dbgs() << "    Live out block!\n");
           // If we see a live out block that is also a def block, we need to fa
-          assert(!liveness.isDefBlock(block, errorSpan) &&
+#ifndef NDEBUG
+          SmallBitVector defBits(addressUseState.getNumSubelements());
+          liveness.isDefBlock(block, errorSpan, defBits);
+          SmallBitVector errorSpanBits(addressUseState.getNumSubelements());
+          errorSpan.setBits(errorSpanBits);
+          assert((defBits & errorSpanBits).none() &&
                  "If in def block... we are in liveness block");
+#endif
           [[clang::fallthrough]];
+        }
         case IsLive::LiveWithin:
           if (isLive == IsLive::LiveWithin)
             LLVM_DEBUG(llvm::dbgs() << "    Live within block!\n");

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -3436,8 +3436,11 @@ bool ExtendUnconsumedLiveness::hasDefAfter(SILInstruction *start,
 
 void ExtendUnconsumedLiveness::addPreviousInstructionToLiveness(
     SILInstruction *inst, unsigned element) {
-  auto range = TypeTreeLeafTypeRange(element, element + 1);
   inst->visitPriorInstructions([&](auto *prior) {
+    if (liveness.isDef(prior, element)) {
+      return true;
+    }
+    auto range = TypeTreeLeafTypeRange(element, element + 1);
     liveness.extendToNonUse(prior, range);
     return true;
   });

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -146,7 +146,7 @@
 /// * copyTransformableToTake - certain load [copy], certain copy_addr ![take]
 /// %src of a temporary %dest.
 /// * reinit - store [assign], copy_addr ![init] %dest
-/// * borrow - load_borror, a load [copy] without consuming uses.
+/// * borrow - load_borrow, a load [copy] without consuming uses.
 /// * livenessOnly - a read only use of the address.
 ///
 /// We classify these by adding them to several disjoint SetVectors which track

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -25,6 +25,7 @@
 #include "swift/SIL/SILArgument.h"
 #include "llvm/Support/Debug.h"
 
+#include "MoveOnlyTypeUtils.h"
 using namespace swift;
 using namespace swift::siloptimizer;
 
@@ -931,13 +932,25 @@ void DiagnosticEmitter::emitPromotedBoxArgumentError(
   }
 }
 
-void DiagnosticEmitter::emitCannotPartiallyConsumeError(
-    MarkUnresolvedNonCopyableValueInst *markedValue, StringRef pathString,
-    NominalTypeDecl *nominal, SILInstruction *consumingUser, bool isForDeinit) {
+void DiagnosticEmitter::emitCannotPartiallyMutateError(
+    MarkUnresolvedNonCopyableValueInst *address, PartialMutationError error,
+    SILInstruction *user, TypeTreeLeafTypeRange usedBits,
+    PartialMutation kind) {
+
+  TypeOffsetSizePair pair(usedBits);
+
+  SmallString<128> pathString;
+  auto rootType = address->getType();
+  if (error.type != rootType) {
+    llvm::raw_svector_ostream os(pathString);
+    auto *fn = address->getFunction();
+    pair.constructPathString(error.type, {rootType, fn}, rootType, fn, os);
+  }
+
   auto &astContext = fn->getASTContext();
 
   SmallString<64> varName;
-  getVariableNameForValue(markedValue, varName);
+  getVariableNameForValue(address, varName);
 
   if (!pathString.empty())
     varName.append(pathString);
@@ -946,68 +959,43 @@ void DiagnosticEmitter::emitCannotPartiallyConsumeError(
       astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption);
   (void)hasPartialConsumption;
 
-  if (isForDeinit) {
-    assert(hasPartialConsumption);
-    diagnose(astContext, consumingUser,
-             diag::sil_movechecking_cannot_destructure_has_deinit, varName);
-
-  } else {
+  switch (error) {
+  case PartialMutationError::Kind::FeatureDisabled:
     assert(!hasPartialConsumption);
-    diagnose(astContext, consumingUser,
-             diag::sil_movechecking_cannot_destructure, varName);
-  }
-
-  registerDiagnosticEmitted(markedValue);
-
-  if (!isForDeinit)
+    switch (kind) {
+    case PartialMutation::Kind::Consume:
+      diagnose(astContext, user, diag::sil_movechecking_cannot_destructure,
+               varName);
+      break;
+    case PartialMutation::Kind::Reinit:
+      diagnose(astContext, user, diag::sil_movechecking_cannot_partially_reinit,
+               varName);
+      diagnose(astContext, &kind.getEarlierConsumingUse(),
+               diag::sil_movechecking_consuming_use_here);
+      break;
+    }
+    registerDiagnosticEmitted(address);
     return;
-
-  // Point to the deinit if we know where it is.
-  assert(nominal);
-  if (auto deinitLoc =
-          nominal->getValueTypeDestructor()->getLoc(/*SerializedOK=*/false))
-    astContext.Diags.diagnose(deinitLoc, diag::sil_movechecking_deinit_here);
-}
-
-void DiagnosticEmitter::emitCannotPartiallyReinitError(
-    MarkUnresolvedNonCopyableValueInst *markedValue, StringRef pathString,
-    NominalTypeDecl *nominal, SILInstruction *initingUser,
-    SILInstruction *consumingUser, bool isForDeinit) {
-  auto &astContext = fn->getASTContext();
-
-  SmallString<64> varName;
-  getVariableNameForValue(markedValue, varName);
-
-  if (!pathString.empty())
-    varName.append(pathString);
-
-  bool hasPartialConsumption =
-      astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption);
-  (void)hasPartialConsumption;
-
-  if (isForDeinit) {
+  case PartialMutationError::Kind::HasDeinit: {
     assert(hasPartialConsumption);
-    diagnose(astContext, initingUser,
-             diag::sil_movechecking_cannot_partially_reinit_has_deinit,
-             varName);
-
-  } else {
-    assert(!hasPartialConsumption);
-    diagnose(astContext, initingUser,
-             diag::sil_movechecking_cannot_partially_reinit, varName);
-  }
-
-  diagnose(astContext, consumingUser,
-           diag::sil_movechecking_consuming_use_here);
-
-  registerDiagnosticEmitted(markedValue);
-
-  if (!isForDeinit)
-    return;
-
-  // Point to the deinit if we know where it is.
-  assert(nominal);
-  if (auto deinitLoc =
-          nominal->getValueTypeDestructor()->getLoc(/*SerializedOK=*/false))
+    switch (kind) {
+    case PartialMutation::Kind::Consume:
+      diagnose(astContext, user,
+               diag::sil_movechecking_cannot_destructure_has_deinit, varName);
+      break;
+    case PartialMutation::Kind::Reinit:
+      diagnose(astContext, user,
+               diag::sil_movechecking_cannot_partially_reinit_has_deinit,
+               varName);
+      break;
+    }
+    registerDiagnosticEmitted(address);
+    auto deinitLoc = error.getNominal().getValueTypeDestructor()->getLoc(
+        /*SerializedOK=*/false);
+    if (!deinitLoc)
+      return;
     astContext.Diags.diagnose(deinitLoc, diag::sil_movechecking_deinit_here);
+    return;
+  }
+  }
 }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -20,6 +20,7 @@
 #define SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYDIAGNOSTICS_H
 
 #include "MoveOnlyObjectCheckerUtils.h"
+#include "MoveOnlyTypeUtils.h"
 #include "swift/Basic/NullablePtr.h"
 #include "swift/SIL/FieldSensitivePrunedLiveness.h"
 #include "swift/SIL/SILInstruction.h"
@@ -187,15 +188,10 @@ public:
   emitPromotedBoxArgumentError(MarkUnresolvedNonCopyableValueInst *markedValue,
                                SILFunctionArgument *arg);
 
-  void emitCannotPartiallyConsumeError(
-      MarkUnresolvedNonCopyableValueInst *markedValue, StringRef pathString,
-      NominalTypeDecl *nominal, SILInstruction *consumingUser,
-      bool dueToDeinit);
-
-  void emitCannotPartiallyReinitError(
-      MarkUnresolvedNonCopyableValueInst *markedValue, StringRef pathString,
-      NominalTypeDecl *nominal, SILInstruction *initUser,
-      SILInstruction *consumingUser, bool dueToDeinit);
+  void emitCannotPartiallyMutateError(
+      MarkUnresolvedNonCopyableValueInst *markedValue,
+      PartialMutationError error, SILInstruction *user,
+      TypeTreeLeafTypeRange usedBits, PartialMutation kind);
 
 private:
   /// Emit diagnostics for the final consuming uses and consuming uses needing

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -144,10 +144,29 @@ public:
     return valuesWithDiagnostics.count(markedValue);
   }
 
-  void emitAddressDiagnostic(MarkUnresolvedNonCopyableValueInst *markedValue,
-                             SILInstruction *lastLiveUse,
-                             SILInstruction *violatingUse, bool isUseConsuming,
-                             bool isInOutEndOfFunction = false);
+  /// The kind of scope at the end of which an address must be initialized.
+  enum class ScopeRequiringFinalInit {
+    /// The scope for an inout argument.
+    ///
+    /// The whole function.
+    InoutArgument,
+    /// The scope for an address yielded by a coroutine.
+    ///
+    /// It begins at the begin_apply and ends at all corresponding
+    /// end_apply/abort_apply instructions.
+    Coroutine,
+    /// The scope for an address done through an access scope marker.
+    ///
+    /// It begins at the begin_access and ends at all corresponding end_access
+    /// instructions.
+    ModifyMemoryAccess,
+  };
+
+  void emitAddressDiagnostic(
+      MarkUnresolvedNonCopyableValueInst *markedValue,
+      SILInstruction *lastLiveUse, SILInstruction *violatingUse,
+      bool isUseConsuming,
+      llvm::Optional<ScopeRequiringFinalInit> scopeKind = llvm::None);
   void emitInOutEndOfFunctionDiagnostic(
       MarkUnresolvedNonCopyableValueInst *markedValue,
       SILInstruction *violatingUse);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.h
@@ -20,6 +20,7 @@
 #ifndef SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYTYPEUTILS_H
 #define SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYTYPEUTILS_H
 
+#include "swift/Basic/TaggedUnion.h"
 #include "swift/SIL/FieldSensitivePrunedLiveness.h"
 #include "swift/SIL/SILBuilder.h"
 
@@ -87,6 +88,105 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
             << ")";
 }
 
+/// How a portion of a move-only value/address was "mutated".
+///
+/// Emulates this enum with associated value:
+///
+/// enum PartialMutation {
+/// case consumed
+/// case reinitialized(Instruction)
+/// }
+class PartialMutation {
+  struct Consume {};
+  struct Reinit {
+    SILInstruction &earlierConsumingUse;
+  };
+  TaggedUnion<Consume, Reinit> storage;
+
+  PartialMutation(Consume c) : storage({c}) {}
+  PartialMutation(Reinit r) : storage({r}) {}
+
+public:
+  enum class Kind {
+    Consume,
+    Reinit,
+  };
+
+  operator Kind() {
+    if (storage.isa<Consume>())
+      return Kind::Consume;
+    return Kind::Reinit;
+  }
+
+  static PartialMutation consume() { return PartialMutation(Consume{}); }
+  static PartialMutation reinit(SILInstruction &earlierConsumingUse) {
+    return PartialMutation(Reinit{earlierConsumingUse});
+  }
+  SILInstruction &getEarlierConsumingUse() {
+    return storage.get<Reinit>().earlierConsumingUse;
+  }
+};
+
+/// How a partial mutation (consume/reinit) is illegal for diagnostic emission.
+///
+/// Emulates the following enum with associated value:
+///
+/// enum class PartialMutationError {
+/// case featureDisabled(SILType)
+/// case hasDeinit(SILType, NominalTypeDecl)
+/// }
+class PartialMutationError {
+  struct FeatureDisabled {};
+  struct HasDeinit {
+    NominalTypeDecl &nominal;
+  };
+  TaggedUnion<FeatureDisabled, HasDeinit> kind;
+
+  PartialMutationError(SILType type, FeatureDisabled fd)
+      : kind({fd}), type(type) {}
+  PartialMutationError(SILType type, HasDeinit r) : kind({r}), type(type) {}
+
+public:
+  /// The type within the aggregate responsible for the error.
+  ///
+  /// case featureDisabled:
+  ///   The type of the portion of the aggregate that would be mutated.
+  /// case hasDeinit:
+  ///   The type that has the deinit.
+  SILType type;
+  /// The reason it's illegal.
+  ///
+  /// See shouldEmitPartialMutationError, emitPartialMutationError.
+  enum class Kind : uint8_t {
+    /// The partial consumption feature is disabled.
+    ///
+    /// See -enable-experimental-feature MoveOnlyPartialConsumption.
+    FeatureDisabled,
+    /// A partially consumed/reinitialized aggregate has a deinit.
+    ///
+    /// The aggregate is somewhere in the type layout between the consumed
+    /// range and the full value.  It is the \p nominal field of
+    /// PartialMutationError.
+    HasDeinit,
+  };
+
+  operator Kind() {
+    if (kind.isa<FeatureDisabled>())
+      return Kind::FeatureDisabled;
+    return Kind::HasDeinit;
+  }
+
+  static PartialMutationError featureDisabled(SILType type) {
+    return PartialMutationError(type, FeatureDisabled{});
+  }
+
+  static PartialMutationError hasDeinit(SILType type,
+                                        NominalTypeDecl &nominal) {
+    return PartialMutationError(type, HasDeinit{nominal});
+  }
+
+  NominalTypeDecl &getNominal() { return kind.get<HasDeinit>().nominal; };
+};
 } // namespace siloptimizer
 } // namespace swift
 

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -859,3 +859,15 @@ bb0(%0 : @guaranteed $NonTrivialStruct):
   %9999 = tuple ()
   return %9999 : $()
 }
+
+sil [ossa] @f : $@convention(thin) (@inout NonTrivialStruct, @owned NonTrivialStruct) -> () {
+entry(%out : $*NonTrivialStruct, %s : @owned $NonTrivialStruct):
+  %munc = mark_unresolved_non_copyable_value [consumable_and_assignable] %out : $*NonTrivialStruct
+  br body
+body:
+  store %s to [assign] %munc : $*NonTrivialStruct
+  br exit
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_resilient.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_resilient.swift
@@ -1,0 +1,92 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Library.swift                                        \
+// RUN:     -emit-module                                            \
+// RUN:     -enable-library-evolution                               \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -module-name Library                                    \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Client.swift                                         \
+// RUN:     -emit-sil -verify                                       \
+// RUN:     -debug-diagnostic-names                                 \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -I %t
+
+
+//--- Library.swift
+
+public struct Ur : ~Copyable {
+  deinit {}
+}
+public func consume(_ ur: consuming Ur) {}
+public func borrow(_ ur: borrowing Ur) {}
+
+@frozen
+public struct AggFrozen : ~Copyable {
+  public var field1: Ur
+  public var field2: Ur
+}
+public func consume(_ a: consuming AggFrozen) {}
+public func borrow(_ ur: borrowing AggFrozen) {}
+
+@frozen
+public struct AggFrozenDeiniting : ~Copyable {
+  public var field1: Ur
+  public var field2: Ur
+  deinit {}
+}
+public func consume(_ a: consuming AggFrozenDeiniting) {}
+public func borrow(_ ur: borrowing AggFrozenDeiniting) {}
+
+public struct AggResilient : ~Copyable {
+  public var field1: Ur
+  public var field2: Ur
+}
+public func consume(_ a: consuming AggResilient) {}
+public func borrow(_ ur: borrowing AggResilient) {}
+
+public struct AggResilientDeiniting : ~Copyable {
+  public var field1: Ur
+  public var field2: Ur
+  deinit {}
+}
+public func consume(_ a: consuming AggResilientDeiniting) {}
+public func borrow(_ ur: borrowing AggResilientDeiniting) {}
+
+//--- Client.swift
+
+import Library
+
+struct AggLocalDeiniting : ~Copyable {
+  var field1: Ur
+  var field2: Ur
+  deinit {}
+}
+
+struct AggLocal : ~Copyable {
+  var field1: Ur
+  var field2: Ur
+}
+
+func consumeField1_AggFrozen(_ a: consuming AggFrozen) {
+  consume(a.field1)
+}
+
+func consumeField1_AggFrozenDeiniting(_ a: consuming AggFrozenDeiniting) {
+  consume(a.field1) // expected-error{{cannot partially consume 'a' when it has a deinitializer}}
+}
+
+func consumeField1_AggResilient(_ a: consuming AggResilient) {
+  consume(a.field1) // expected-error{{field 'a.field1' was consumed but not reinitialized; the field must be reinitialized during the access}}
+                    // expected-note@-1{{consumed here}}
+}
+
+func consumeField1_AggResilientDeiniting(_ a: consuming AggResilientDeiniting) {
+  consume(a.field1) // expected-error{{field 'a.field1' was consumed but not reinitialized; the field must be reinitialized during the access}}
+                    // expected-note@-1{{consumed here}}
+}

--- a/test/SILOptimizer/moveonly_modify_coroutine.swift
+++ b/test/SILOptimizer/moveonly_modify_coroutine.swift
@@ -56,7 +56,7 @@ func mod(_ nc: inout NC) {}
 func test(c: C) {
   borrow(c.data)
   // TODO: Not an inout parameter, should use a "cannot be consumed" error message
-  take(c.data) // expected-error{{missing reinitialization of inout parameter 'c.data' after consume}} expected-note{{consumed here}}
+  take(c.data) // expected-error{{field 'c.data' was consumed but not reinitialized; the field must be reinitialized during the access}} expected-note{{consumed here}}
   mod(&c.data)
 }
 func test(s: S) {
@@ -65,7 +65,7 @@ func test(s: S) {
 }
 func test(m_s s: inout S) {
   borrow(s.data)
-  take(s.data) // expected-error{{missing reinitialization of inout parameter 's.data' after consume}} expected-note{{consumed here}}
+  take(s.data) // expected-error{{field 's.data' was consumed but not reinitialized; the field must be reinitialized during the access}} expected-note{{consumed here}}
   mod(&s.data)
 }
 func test(snc: borrowing SNC) {
@@ -74,7 +74,7 @@ func test(snc: borrowing SNC) {
 }
 func test(m_snc snc: inout SNC) {
   borrow(snc.data)
-  take(snc.data) // expected-error{{missing reinitialization of inout parameter 'snc.data' after consume}} expected-note{{consumed here}}
+  take(snc.data) // expected-error{{field 'snc.data' was consumed but not reinitialized; the field must be reinitialized during the access}} expected-note{{consumed here}}
   mod(&snc.data)
 }
 
@@ -84,7 +84,7 @@ func test<T: P>(t: T) {
 }
 func test<T: P>(m_t t: inout T) {
   borrow(t.data)
-  take(t.data) // expected-error{{missing reinitialization of inout parameter 't.data' after consume}} expected-note{{consumed here}}
+  take(t.data) // expected-error{{field 't.data' was consumed but not reinitialized; the field must be reinitialized during the access}} expected-note{{consumed here}}
   mod(&t.data)
 }
 
@@ -94,7 +94,7 @@ func test(p: P) {
 }
 func test(m_p p: inout P) {
   borrow(p.data)
-  take(p.data) // expected-error{{missing reinitialization of inout parameter 'p.data' after consume}} expected-note{{consumed here}}
+  take(p.data) // expected-error{{field 'p.data' was consumed but not reinitialized; the field must be reinitialized during the access}} expected-note{{consumed here}}
   mod(&p.data)
 }
 


### PR DESCRIPTION
There are several kinds of scopes at which it is required that an address be initialized:
(1) the whole function -- for inout argument to the function
(2) the region a coroutine is active -- for an inout yielded by a coroutine into the function
(3) the region of a memory access -- for a `begin_access [modify]`.

The move checker enforces that they are initialized at that point by adding instructions at which the field must be live to liveness.

Previously, all such scopes used the end of the function as the point at which the memory had to have been reinitialized.  Here, the relevant end of scope markers are used instead.

More importantly, here the diagnostic is made to vary--the diagnostic, that is, that is issued in the face an address not being initialized at the end of these different kind of scopes.

