### PR TITLE
One more round of associated type inference fixes

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -12,6 +12,23 @@
 //
 // This file implements type witness lookup and associated type inference.
 //
+// There are three entry points into the code here, all via request evaluation:
+//
+// - TypeWitnessRequest resolves a type witness in a normal conformance.
+//   - First, we perform a qualified lookup into the conforming type to find a
+//     member type with the same name as the associated type.
+//   - If the lookup succeeds, we record the type witness.
+//   - If the lookup fails, we attempt to resolve all type witnesses.
+//
+// - ResolveTypeWitnessesRequest resolves all type witnesses of a normal
+//   conformance.
+//   - First, we attempt to resolve each associated type via lookup.
+//   - For any witnesses still unresolved, we perform associated type inference.
+//
+// - AssociatedConformanceRequest resolves an associated conformance of a
+//   normal conformance. This computes the substituted subject type and performs
+//   a global conformance lookup.
+//
 //===----------------------------------------------------------------------===//
 #include "TypeCheckProtocol.h"
 #include "DerivedConformances.h"
@@ -3941,6 +3958,10 @@ TypeWitnessSystem::compareResolvedTypes(Type ty1, Type ty2) {
   // concrete type).
   return ResolvedTypeComparisonResult::EquivalentOrWorse;
 }
+
+//
+// Request evaluator entry points
+//
 
 evaluator::SideEffect
 ResolveTypeWitnessesRequest::evaluate(Evaluator &evaluator,

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t 2>&1 %s
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift -enable-experimental-associated-type-inference
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -I %t -enable-experimental-associated-type-inference 2>&1 %s
 // REQUIRES: concurrency
 // REQUIRES: distributed
 
@@ -48,6 +48,8 @@ actor A2: DistributedActor {
 // FIXME(distributed): error reporting is a bit whacky here; needs cleanup
 // expected-error@-2{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
 // expected-error@-3{{actor type 'A2' cannot conform to the 'DistributedActor' protocol. Isolation rules of these actor types are not interchangeable.}}
+// expected-error@-4{{'DistributedActor' requires the types 'ObjectIdentifier' and 'FakeActorSystem.ActorID' (aka 'ActorAddress') be equivalent}}
+// expected-note@-5{{requirement specified as 'Self.ID' == 'Self.ActorSystem.ActorID' [with Self = A2]}}
   nonisolated var id: ID {
     fatalError()
   }
@@ -67,6 +69,8 @@ actor A2: DistributedActor {
 final class DA2: DistributedActor {
 // expected-error@-1{{non-actor type 'DA2' cannot conform to the 'AnyActor' protocol}}
 // expected-error@-2{{non-distributed actor type 'DA2' cannot conform to the 'DistributedActor' protocol}}
+// expected-error@-3{{'DistributedActor' requires the types 'ObjectIdentifier' and 'FakeActorSystem.ActorID' (aka 'ActorAddress') be equivalent}}
+// expected-note@-4{{requirement specified as 'Self.ID' == 'Self.ActorSystem.ActorID' [with Self = DA2]}}
   nonisolated var id: ID {
     fatalError()
   }

--- a/test/Generics/specialized_conformance_type_witness.swift
+++ b/test/Generics/specialized_conformance_type_witness.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 struct Row {}
 

--- a/test/decl/protocol/req/associated_type_inference_more_specific.swift
+++ b/test/decl/protocol/req/associated_type_inference_more_specific.swift
@@ -1,0 +1,32 @@
+// RUN: not %target-swift-frontend -typecheck %s -disable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+
+protocol P {
+  associatedtype A
+}
+
+protocol Q: P {
+  associatedtype A
+  func f() -> A
+}
+
+protocol R: Q {}
+
+// We don't have enough information to infer 'A' just from the 'S1: P' and
+// 'S2: P' conformances. Make sure that if we force one of those conformances
+// first, we jump up to the conformance to Q, which has a requirement 'f()'
+// that gives us a way to infer 'A'.
+
+func forceP<T: P>(_: T) -> T.A {}
+
+let x: Int = forceP(S1())
+
+struct S1: Q {
+  func f() -> Int {}
+}
+
+let y: String = forceP(S2())
+
+struct S2: R {
+  func f() -> String {}
+}

--- a/test/decl/protocol/req/associated_type_inference_proto_ext.swift
+++ b/test/decl/protocol/req/associated_type_inference_proto_ext.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 func assertEqualTypes<T>(_: T.Type, _: T.Type) {}
 

--- a/test/decl/protocol/req/associated_type_inference_tautology.swift
+++ b/test/decl/protocol/req/associated_type_inference_tautology.swift
@@ -1,0 +1,50 @@
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+
+protocol P1 {
+  associatedtype A
+  associatedtype B
+
+  func f(_: A, _: B)
+  func g(_: A, _: B)
+}
+
+struct G<T> {}
+
+extension P1 {
+  // These two are not candidate witnesses at all!
+  func f(_: G<A>, _: Int) {}
+  func g(_: Float, _: G<B>) {}
+
+  // We can infer A and B from these two:
+  func f(_: A, _: String) {}
+  func g(_: String, _: B) {}
+}
+
+struct S1: P1 {}
+
+let x1: String.Type = S1.A.self
+let y1: String.Type = S1.B.self
+
+protocol P2 {
+  associatedtype A
+  associatedtype B
+
+  func f(_: A, _: B)
+  func g(_: A, _: B)
+}
+
+extension P2 {
+  // These two are not candidate witnesses at all!
+  func f<T>(_: G<T>, _: Int) {}
+  func g<T>(_: Float, _: G<T>) {}
+
+  // We can infer A and B from these two:
+  func f<T>(_: T, _: String) {}
+  func g<T>(_: String, _: T) {}
+}
+
+struct S2: P2 {}
+
+let x2: String.Type = S2.A.self
+let y2: String.Type = S2.B.self

--- a/validation-test/compiler_crashers_fixed/28871-nested-second-nested-second-isequal-result-nested-second-haserror-result-haserro.swift
+++ b/validation-test/compiler_crashers_fixed/28871-nested-second-nested-second-isequal-result-nested-second-haserror-result-haserro.swift
@@ -6,6 +6,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-// RUN: not %target-swift-frontend %s -emit-ir
+// FIXME: Figure this out before removing -disable-experimental-associated-type-inference
+// RUN: not %target-swift-frontend %s -emit-ir -disable-experimental-associated-type-inference
 class a:A
 protocol A:a{typealias a:=a


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/71131. Hopefully the last before we enable the new flag.