### PR TITLE
Prevent crash with `-playground` when `-experimental-skip-non-inlinable-function-bodies-without-types` also passed

### DIFF
--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -925,7 +925,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, PlaygroundOptionSet Opts)
 
     PreWalkAction walkToDeclPre(Decl *D) override {
       if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
-        if (!FD->isImplicit()) {
+        if (!FD->isImplicit() && !FD->isBodySkipped()) {
           if (BraceStmt *Body = FD->getBody()) {
             const ParameterList *PL = FD->getParameters();
             Instrumenter I(ctx, FD, RNG, Options, TmpNameIndex);

--- a/test/PlaygroundTransform/skip_bodies_without_types.swift
+++ b/test/PlaygroundTransform/skip_bodies_without_types.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -emit-module -Xfrontend -experimental-skip-non-inlinable-function-bodies-without-types -Xfrontend -playground -I=%t %s
+// REQUIRES: executable_test
+
+import PlaygroundSupport
+
+struct Foo {
+    func Bar() {
+        print("hello")
+    }
+}
+
+// This test will cause the frontend to crash without the fix for skipping playground transformation of functions that have skipped type information. If it doesn't crash, it passes.


### PR DESCRIPTION
Skip playground transform for functions that have skipped bodies.

### Discussion

This can happen when passing `-emit-module` and `-experimental-skip-non-inlinable-function-bodies-without-types` and also enabling the playground transform.  This causes the type to be `nullptr`.  The fix is for the playground transform to check `AbstractFunctionDecl::isBodySkipped()`.

### Changes

- make the playground transform skip functions that return true for `isBodySkipped`
- add a test to check that we prevent this crash

rdar://119258854
