### PR TITLE
Fix SemanticARCOpts LoadCopyToBorrowOpt for ObjC closure thunk

### DIFF
--- a/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
+++ b/lib/SILOptimizer/SemanticARC/LoadCopyToLoadBorrowOpt.cpp
@@ -124,7 +124,7 @@ public:
     // If we have an inout parameter that isn't ever actually written to, return
     // false.
     if (!arg->isIndirectResult() &&
-        arg->getKnownParameterInfo().isIndirectMutating()) {
+        arg->getArgumentConvention().isExclusiveIndirectParameter()) {
       auto wellBehavedWrites = ctx.addressToExhaustiveWriteListCache.get(arg);
       if (!wellBehavedWrites.has_value()) {
         return answer(true);


### PR DESCRIPTION
Fix SemanticARCOpts LoadCopyToBorrowOpt for ObjC closure thunk

This fixes a use-after-free miscompile.

LoadCopyToBorrowOpt alias analysis was wrong in
visitArgumentAccess. inout_aliasable does not give you exclusive
access to an address.

This resulted in removal of a retain before calling an ObjC block
after converting it from a Swift closure.

    @_silgen_name("foreign")
    func foreign(block: @escaping @convention(block) () -> Void)

    public func doit(closure: @escaping () -> ()) {
      foreign { [closure] in closure() }
    }

 Fixes rdar://121268094