### PR TITLE
[cxx-interop] Emit default expressions in symbolic interfaces

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3580,6 +3580,10 @@ namespace {
                   bodyName, Impl.ImportedHeaderUnit);
               paramInfo->setSpecifier(ParamSpecifier::Default);
               paramInfo->setInterfaceType(Impl.SwiftContext.TheAnyType);
+              if (param->hasDefaultArg()) {
+                paramInfo->setDefaultArgumentKind(DefaultArgumentKind::Normal);
+                paramInfo->setDefaultValueStringRepresentation("cxxDefaultArg");
+              }
               params.push_back(paramInfo);
             }
             bodyParams = ParameterList::create(Impl.SwiftContext, params);

--- a/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
@@ -37,6 +37,7 @@ namespace ns {
         template<class T2>
         struct InnerTemplate {
             void innerTemplateMethod();
+            void innerTemplateMethodWithDefaultArg(T2 x = 123);
         };
 
         InnerTemplate<int> returnsTemplateMethod();
@@ -78,6 +79,7 @@ public:
 // CHECK-NEXT:      @available(*, deprecated, message:
 // CHECK-NEXT:      init()
 // CHECK-NEXT:      mutating func innerTemplateMethod()
+// CHECK-NEXT:      mutating func innerTemplateMethodWithDefaultArg(_ x: Any = cxxDefaultArg)
 // CHECK-NEXT:    }
 // CHECK-NEXT:    mutating func returnsTemplateMethod()
 // CHECK-NEXT:  }


### PR DESCRIPTION
This makes sure we print `= cxxDefaultArg` for parameters that have a default expression on the C++ side.

Note that we can't run the safety heuristic that we use during normal compilation, since we don't know all of the types involved.

rdar://121440191