### PR TITLE
[cxx-interop] Check for unsafe types of default arguments consistently

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2540,7 +2540,8 @@ bool ClangImporter::Implementation::isDefaultArgSafeToImport(
   // default expression, since we cannot guarantee the lifetime of the
   // pointee value.
   if (auto paramRecordDecl = param->getType()->getAsCXXRecordDecl()) {
-    if (isViewType(paramRecordDecl))
+    if (isViewType(paramRecordDecl) &&
+        !paramRecordDecl->hasUserDeclaredCopyConstructor())
       return false;
   }
   // If the parameter is a const reference, check if the expression

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -22,6 +22,12 @@ module StdSet {
   export *
 }
 
+module StdString {
+  header "std-string.h"
+  requires cplusplus
+  export *
+}
+
 module StdPair {
   header "std-pair.h"
   requires cplusplus

--- a/test/Interop/Cxx/stdlib/Inputs/std-string.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-string.h
@@ -1,0 +1,8 @@
+#include <string>
+
+struct HasMethodThatReturnsString {
+  int value = 111;
+  std::string getString() const { return std::to_string(value); }
+};
+
+inline std::string takesStringWithDefaultArg(std::string s = "abc") { return s; }

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -1,10 +1,14 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
-// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -D USE_CUSTOM_STRING_API)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D SUPPORTS_DEFAULT_ARGUMENTS -D USE_CUSTOM_STRING_API)
 //
 // REQUIRES: executable_test
 
 import StdlibUnittest
 import CxxStdlib
+#if USE_CUSTOM_STRING_API
+import StdString
+#endif
 
 var StdStringTestSuite = TestSuite("StdString")
 
@@ -391,5 +395,31 @@ StdStringTestSuite.test("std::string from C string") {
     }
     expectEqual(str, std.string("abc"))
 }
+
+#if USE_CUSTOM_STRING_API
+StdStringTestSuite.test("get from a method") {
+    let box = HasMethodThatReturnsString()
+    let str = box.getString()
+    expectEqual(str.size(), 3)
+    expectEqual(str, std.string("111"))
+}
+
+StdStringTestSuite.test("pass as an argument") {
+    let s = std.string("a")
+    let res = takesStringWithDefaultArg(s)
+    expectEqual(res.size(), 1)
+    expectEqual(res[0], 97)
+}
+
+#if SUPPORTS_DEFAULT_ARGUMENTS
+StdStringTestSuite.test("pass as a default argument") {
+    let res = takesStringWithDefaultArg()
+    expectEqual(res.size(), 3)
+    expectEqual(res[0], 97)
+    expectEqual(res[1], 98)
+    expectEqual(res[2], 99)
+}
+#endif
+#endif
 
 runAllTests()


### PR DESCRIPTION
If the C++ type of a function parameter defines a custom copy constructor, assume that it is safe to use from Swift. This matches the heuristic that we use to detect if a C++ method is safe based on the return type.

rdar://121391798