### PR TITLE
[Concurrency] Always downgrade `concurrent_access_of_local_capture` to a warning until Swift 6.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3578,10 +3578,6 @@ namespace {
         }
 
         // Otherwise, we have concurrent access. Complain.
-        bool preconcurrencyContext =
-            getActorIsolationOfContext(
-              const_cast<DeclContext *>(getDeclContext())).preconcurrency();
-
         ctx.Diags.diagnose(
             loc, diag::concurrent_access_of_local_capture,
             parent.dyn_cast<LoadExpr *>(),

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3586,7 +3586,7 @@ namespace {
             loc, diag::concurrent_access_of_local_capture,
             parent.dyn_cast<LoadExpr *>(),
             var)
-          .warnUntilSwiftVersionIf(preconcurrencyContext, 6);
+          .warnUntilSwiftVersion(6);
         return true;
       }
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -325,8 +325,8 @@ extension MyActor {
       acceptInout(&self.mutable) // expected-error{{actor-isolated property 'mutable' can not be used 'inout' from a Sendable closure}}
       _ = self.immutable
       _ = self.synchronous() // expected-error{{call to actor-isolated instance method 'synchronous()' in a synchronous nonisolated context}}
-      _ = localVar // expected-error{{reference to captured var 'localVar' in concurrently-executing code}}
-      localVar = 25 // expected-error{{mutation of captured var 'localVar' in concurrently-executing code}}
+      _ = localVar // expected-warning{{reference to captured var 'localVar' in concurrently-executing code}}
+      localVar = 25 // expected-warning{{mutation of captured var 'localVar' in concurrently-executing code}}
       _ = localConstant
 
       _ = otherLocalVar
@@ -357,8 +357,8 @@ extension MyActor {
     @Sendable func localFn1() {
       _ = self.text[0] // expected-error{{actor-isolated property 'text' can not be referenced from a Sendable function}}
       _ = self.synchronous() // expected-error{{call to actor-isolated instance method 'synchronous()' in a synchronous nonisolated context}}
-      _ = localVar // expected-error{{reference to captured var 'localVar' in concurrently-executing code}}
-      localVar = 25 // expected-error{{mutation of captured var 'localVar' in concurrently-executing code}}
+      _ = localVar // expected-warning{{reference to captured var 'localVar' in concurrently-executing code}}
+      localVar = 25 // expected-warning{{mutation of captured var 'localVar' in concurrently-executing code}}
       _ = localConstant
     }
 
@@ -366,8 +366,8 @@ extension MyActor {
       acceptClosure {
         _ = text[0]  // expected-error{{actor-isolated property 'text' can not be referenced from a non-isolated context}}
         _ = self.synchronous() // expected-error{{call to actor-isolated instance method 'synchronous()' in a synchronous nonisolated context}}
-        _ = localVar // expected-error{{reference to captured var 'localVar' in concurrently-executing code}}
-        localVar = 25 // expected-error{{mutation of captured var 'localVar' in concurrently-executing code}}
+        _ = localVar // expected-warning{{reference to captured var 'localVar' in concurrently-executing code}}
+        localVar = 25 // expected-warning{{mutation of captured var 'localVar' in concurrently-executing code}}
         _ = localConstant
       }
     }
@@ -640,8 +640,8 @@ func testGlobalRestrictions(actor: MyActor) async {
   // code.
   var i = 17
   acceptConcurrentClosure {
-    _ = i // expected-error{{reference to captured var 'i' in concurrently-executing code}}
-    i = 42 // expected-error{{mutation of captured var 'i' in concurrently-executing code}}
+    _ = i // expected-warning{{reference to captured var 'i' in concurrently-executing code}}
+    i = 42 // expected-warning{{mutation of captured var 'i' in concurrently-executing code}}
   }
   print(i)
 
@@ -738,7 +738,7 @@ func checkLocalFunctions() async {
   }
 
   func local3() { // expected-warning{{concurrently-executed local function 'local3()' must be marked as '@Sendable'}}
-    k = 25 // expected-error{{mutation of captured var 'k' in concurrently-executing code}}
+    k = 25 // expected-warning{{mutation of captured var 'k' in concurrently-executing code}}
   }
 
   print(k)
@@ -1158,12 +1158,12 @@ extension MyActor {
       _ = synchronous() // expected-error{{expression is 'async' but is not marked with 'await'}}
       // expected-note@-1{{calls to instance method 'synchronous()' from outside of its actor context are implicitly asynchronous}}
 
-      counter += 1 // expected-error{{mutation of captured var 'counter' in concurrently-executing code}}
+      counter += 1 // expected-warning{{mutation of captured var 'counter' in concurrently-executing code}}
     }
 
     acceptAsyncSendableClosure {
       _ = await synchronous() // ok
-      counter += 1 // expected-error{{mutation of captured var 'counter' in concurrently-executing code}}
+      counter += 1 // expected-warning{{mutation of captured var 'counter' in concurrently-executing code}}
     }
 
     acceptAsyncSendableClosureInheriting {
@@ -1184,7 +1184,7 @@ func testGlobalActorInheritance() {
   var counter = 0
 
   acceptAsyncSendableClosure {
-    counter += 1 // expected-error{{mutation of captured var 'counter' in concurrently-executing code}}
+    counter += 1 // expected-warning{{mutation of captured var 'counter' in concurrently-executing code}}
   }
 
   acceptAsyncSendableClosure { @SomeGlobalActor in

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -21,7 +21,7 @@ actor MyActor {
     async let z = synchronous()
 
     var localText = text
-    async let w = localText.removeLast() // expected-error{{mutation of captured var 'localText' in concurrently-executing code}}
+    async let w = localText.removeLast() // expected-warning{{mutation of captured var 'localText' in concurrently-executing code}}
 
     _ = await x
     _ = await y

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -188,7 +188,7 @@ func testConcurrency() {
   acceptConcurrent {
     print(x) // expected-warning{{capture of 'x' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
     print(y) // expected-warning{{capture of 'y' with non-sendable type 'NotConcurrent' in a `@Sendable` closure}}
-    // expected-error@-1{{reference to captured var 'y' in concurrently-executing code}}
+    // expected-warning@-1{{reference to captured var 'y' in concurrently-executing code}}
   }
 }
 

--- a/test/attr/attr_concurrent.swift
+++ b/test/attr/attr_concurrent.swift
@@ -84,12 +84,12 @@ func mutationOfLocal() {
     }()
 
     // Mutations of captured variables executing concurrently are bad.
-    localInt = 17 // expected-error{{mutation of captured var 'localInt' in concurrently-executing code}}
-    localInt += 1 // expected-error{{mutation of captured var 'localInt' in concurrently-executing code}}
-    localInt.makeNegative() // expected-error{{mutation of captured var 'localInt' in concurrently-executing code}}
+    localInt = 17 // expected-warning{{mutation of captured var 'localInt' in concurrently-executing code}}
+    localInt += 1 // expected-warning{{mutation of captured var 'localInt' in concurrently-executing code}}
+    localInt.makeNegative() // expected-warning{{mutation of captured var 'localInt' in concurrently-executing code}}
 
     _ = {
-      localInt = localInt + 12 // expected-error{{mutation of captured var 'localInt' in concurrently-executing code}}
+      localInt = localInt + 12 // expected-warning{{mutation of captured var 'localInt' in concurrently-executing code}}
     }()
 
     return i + localInt
@@ -114,8 +114,8 @@ func testCaseNonTrivialValue() {
     print(i.optArray?[j] ?? 0)
     print(i.optArray![j])
 
-    i.int = 5 // expected-error{{mutation of captured var 'i' in concurrently-executing code}}
-    i.array[0] = 5 // expected-error{{mutation of captured var 'i' in concurrently-executing code}}
+    i.int = 5 // expected-warning{{mutation of captured var 'i' in concurrently-executing code}}
+    i.array[0] = 5 // expected-warning{{mutation of captured var 'i' in concurrently-executing code}}
 
     return value
   }


### PR DESCRIPTION
This error only happens if you mutate a var in a `@Sendable` closure, and all `Sendable` diagnostics should be warnings in Swift 5 mode.