### PR TITLE
[Runtime] Do a proper hash table lookup in the prespecializations library.

### DIFF
--- a/include/swift/Runtime/PrebuiltStringMap.h
+++ b/include/swift/Runtime/PrebuiltStringMap.h
@@ -57,7 +57,7 @@ struct PrebuiltStringMap {
   PrebuiltStringMap(uint64_t arraySize) : arraySize(arraySize) {}
 
   // Based on MurmurHash2
-  uint64_t hash(const void *data, size_t len) {
+  uint64_t hash(const void *data, size_t len) const {
     uint64_t magic = 0xc6a4a7935bd1e995ULL;
     uint64_t salt = 47;
 
@@ -148,8 +148,12 @@ struct PrebuiltStringMap {
 
   /// Look up the given string in the table. Requires that StringTy be
   /// `const char *`.
-  ArrayElement *find(const char *toFind) {
+  const ArrayElement *find(const char *toFind) const {
     size_t len = strlen(toFind);
+    return find(toFind, len);
+  }
+
+  const ArrayElement *find(const char *toFind, size_t len) const {
     uint64_t hashValue = hash(toFind, len);
 
     size_t index = hashValue % arraySize;

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -94,6 +94,9 @@ VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED, bool, true,
 VARIABLE(SWIFT_DEBUG_LIB_PRESPECIALIZED_PATH, string, "",
          "A path to a prespecializations library to use at runtime.")
 
+VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_LOGGING, bool, false,
+         "Enable debug logging of prespecializations library use.")
+
 VARIABLE(SWIFT_ROOT, string, "",
          "Overrides the root directory of the Swift installation. "
          "This is used to locate auxiliary files relative to the runtime "

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -280,6 +280,13 @@ public:
   Demangle::NodePointer _swift_buildDemanglingForMetadata(const Metadata *type,
                                                           Demangle::Demangler &Dem);
 
+  /// Build the demangling for the generic type that's created by specializing
+  /// the given type context descriptor with the given arguments.
+  Demangle::NodePointer
+  _buildDemanglingForGenericType(const TypeContextDescriptor *description,
+                                 const void *const *arguments,
+                                 Demangle::Demangler &Dem);
+
   /// Callback used to provide the substitution of a generic parameter
   /// (described by depth/index) to its metadata.
   ///


### PR DESCRIPTION
We were doing a linear scan of the table contents as a stopgap. Stop doing that, and compute the proper key for the lookup, matching the one used in the builder.