### PR TITLE
Fix the deprecation of `String.init(validatingUTF8: [CChar])`.

### DIFF
--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -215,7 +215,7 @@ extension String {
 
   @inlinable
   @_alwaysEmitIntoClient
-  @available(*, deprecated, renamed: "String.init(validatingCString:)")
+  @available(swift, deprecated: 6, renamed: "String.init(validatingCString:)")
   public init?(validatingUTF8 cString: [CChar]) {
     self.init(validatingCString: cString)
   }


### PR DESCRIPTION
This PR changes the deprecation annotation of `String.init(validatingUTF8: [CChar])` to match that of `String.init(validatingUTF8: UnsafePointer<CChar>)`. Both have been given new, undeprecated, renamed replacements (`validatingCString:`).

This regressed with #68423.

Resolves rdar://121674502.