### PR TITLE
Clarify wording in ContinuousClock documentation.

### DIFF
--- a/stdlib/public/Concurrency/ContinuousClock.swift
+++ b/stdlib/public/Concurrency/ContinuousClock.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 import Swift
 
-/// A clock that measures time that always increments but does not stop 
+/// A clock that measures time that always increments and does not stop 
 /// incrementing while the system is asleep. 
 ///
 /// `ContinuousClock` can be considered as a stopwatch style time. The frame of


### PR DESCRIPTION
“And” is a continuation of a prior statement. “But” is a negation of a prior statement.

<!-- What's in this pull request? -->

The description of `SuspendingClock` currently reads, in part:

```swift
/// A clock that measures time that always increments but stops incrementing 
/// while the system is asleep.
```

The description of `ContinuousClock` currently reads, in part:

```swift
/// A clock that measures time that always increments but does not stop 
/// incrementing while the system is asleep.
```

I believe the use of “but” is appropriate for `SuspendingClock`, because it is introducing an exception to the statement that it “always increments.” But I believe its use in `ContinuousClock` is misleading, because the “but” does not negate the earlier statement that the clock measures time that “always increments.”

I first noticed this change in the Xcode documentation viewer. I don’t know whether changes made to this file will automatically make their way to that documentation, or if anything else needs to be updated, but I’m happy to make more changes if needed.