### PR TITLE
test: Exclude invalid target triple construction for IRGen/lto_autolink.swift

### DIFF
--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -46,3 +46,4 @@ import AutolinkModuleMapLink
 // UNSUPPORTED: OS=macosx && CPU=arm64
 // UNSUPPORTED: OS=watchos && CPU=arm64_32
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
+// UNSUPPORTED: CPU=wasm32


### PR DESCRIPTION
`%target-cpu-apple-macosx` in this test can result in invalid triples like `wasm32-apple-macosx` and it confuse LLVM. Exclude such triple combination.

See https://github.com/apple/swift/pull/71110#issuecomment-1912231788 for details