### PR TITLE
Improve swift caching tests

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1273,9 +1273,6 @@ def always_compile_output_files :
   HelpText<"Always compile output files even it might not change the results">;
 
 // CAS/Caching related options.
-def allow_unstable_cache_key_for_testing: Flag<["-"], "allow-unstable-cache-key-for-testing">,
-  HelpText<"Allow compilation caching with unstable inputs for testing purpose">;
-
 def input_file_key : Separate<["-"], "input-file-key">,
   HelpText<"Cache Key for input file">;
 def bridging_header_pch_key : Separate<["-"], "bridging-header-pch-key">,

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -275,10 +275,8 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (Opts.EnableCaching && Opts.CASFSRootIDs.empty() &&
       Opts.ClangIncludeTrees.empty() &&
       FrontendOptions::supportCompilationCaching(Opts.RequestedAction)) {
-    if (!Args.hasArg(OPT_allow_unstable_cache_key_for_testing)) {
-        Diags.diagnose(SourceLoc(), diag::error_caching_no_cas_fs);
-        return true;
-    }
+    Diags.diagnose(SourceLoc(), diag::error_caching_no_cas_fs);
+    return true;
   }
 
   if (FrontendOptions::doesActionGenerateIR(Opts.RequestedAction)) {

--- a/test/CAS/Inputs/BuildCommandExtractor.py
+++ b/test/CAS/Inputs/BuildCommandExtractor.py
@@ -17,15 +17,22 @@ elif module_name.startswith('swiftPrebuiltExternal:'):
     mode = 'swiftPrebuiltExternal'
     module_name = module_name[22:]
 
+
+def printCmd(cmd):
+    for c in cmd:
+        print('"{}"'.format(c))
+
+
 with open(input_json, 'r') as file:
     deps = json.load(file)
-    module_names = deps['modules'][::2]
-    module_details = deps['modules'][1::2]
-    for name, detail in zip(module_names, module_details):
-        if name.get(mode, '') != module_name:
-            continue
+    if module_name == 'bridgingHeader':
+        cmd = deps['modules'][1]['details']['swift']['bridgingHeader']['commandLine']
+        printCmd(cmd)
+    else:
+        module_names = deps['modules'][::2]
+        module_details = deps['modules'][1::2]
+        for name, detail in zip(module_names, module_details):
+            if name.get(mode, '') != module_name:
+                continue
 
-        cmd = detail['details'][mode]['commandLine']
-        for c in cmd:
-            print('"{}"'.format(c))
-        break
+            printCmd(detail['details'][mode]['commandLine'])

--- a/test/CAS/Inputs/ExtractOutputKey.py
+++ b/test/CAS/Inputs/ExtractOutputKey.py
@@ -1,18 +1,17 @@
 #!/usr/bin/env python3
 #
-# Usage: ExtractOutputKey.py file.json OutputPath
+# Usage: ExtractOutputKey.py file.json InputPath
 
 import json
 import sys
 
 input_json = sys.argv[1]
-output_path = sys.argv[2]
+input_path = sys.argv[2]
 
 
 with open(input_json, 'r') as file:
     entries = json.load(file)
     for entry in entries:
-        for output in entry["Outputs"]:
-            if output['Path'] != output_path:
-                continue
-            print(entry['CacheKey'])
+        if entry['Input'] != input_path:
+            continue
+        print(entry['CacheKey'])

--- a/test/CAS/Inputs/GenerateExplicitModuleMap.py
+++ b/test/CAS/Inputs/GenerateExplicitModuleMap.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+#
+# Usage: GenerateExplicitModuleMap.py file.json
+
+import json
+import sys
+
+input_json = sys.argv[1]
+
+modules = []
+
+with open(input_json, 'r') as file:
+    deps = json.load(file)
+    main_module_name = deps['mainModuleName']
+    module_names = deps['modules'][::2]
+    module_details = deps['modules'][1::2]
+    # add all modules other than the main module into the module map.
+    for name, detail in zip(module_names, module_details):
+        kind, name = list(name.items())[0]
+        if name == main_module_name:
+            continue
+
+        module = {}
+        module["moduleName"] = name
+        module["isFramework"] = False
+        if kind == "clang":
+            module["clangModulePath"] = name + ".pcm"
+            module["clangModuleCacheKey"] = detail['details'][kind]["moduleCacheKey"]
+        else:
+            module["modulePath"] = name + ".swiftmdoule"
+            module["moduleCacheKey"] = detail['details'][kind]["moduleCacheKey"]
+
+        modules.append(module)
+
+
+json.dump(modules, sys.stdout, indent=2)

--- a/test/CAS/cache_key_compute.swift
+++ b/test/CAS/cache_key_compute.swift
@@ -1,56 +1,77 @@
 // RUN: %empty-directory(%t)
-// RUN: mkdir -p %t/cas
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/a.swift %t/b.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 
 /// Doesn't run because the command doesn't have CAS enabled.
 // RUN: not %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend %s -c -allow-unstable-cache-key-for-testing 2>&1 | \
+// RUN:   %target-swift-frontend %t/a.swift -c @%t/MyApp.cmd 2>&1 | \
 // RUN:   %FileCheck %s --check-prefix=NO-CAS
 
 // NO-CAS: Requested command-line arguments do not enable CAS
 
 /// Check few working cases.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %s -c -allow-unstable-cache-key-for-testing > %t1.casid
+// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd > %t1.casid
 /// A different CAS doesn't affect base key.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %s -c -allow-unstable-cache-key-for-testing -cas-path %t > %t2.casid
+// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -cas-path %t > %t2.casid
 /// Output path doesn't affect base key.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %s -c -allow-unstable-cache-key-for-testing -o %t/test.o > %t3.casid
+// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -o %t/test.o > %t3.casid
 /// Add -D will change.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job %s -c -allow-unstable-cache-key-for-testing -DTEST > %t4.casid
+// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -c @%t/MyApp.cmd -DTEST > %t4.casid
 
 // RUN: diff %t1.casid %t2.casid
 // RUN: diff %t1.casid %t3.casid
 // RUN: not diff %t1.casid %t4.casid
 
 /// Check filelist option.
-// RUN: echo "%s" > %t/filelist-1
-// RUN: echo "%s" > %t/filelist-2
-// RUN: cp %s %t/temp.swift
-// RUN: echo "%t/temp.swift" > %t/filelist-3
+// RUN: echo "%t/a.swift" > %t/filelist-1
+// RUN: echo "%t/a.swift" > %t/filelist-2
+// RUN: echo "%t/b.swift" > %t/filelist-3
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job -filelist %t/filelist-1 -c -allow-unstable-cache-key-for-testing > %t5.casid
+// RUN:   %target-swift-frontend -cache-compile-job -filelist %t/filelist-1 -c @%t/MyApp.cmd > %t5.casid
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job -filelist %t/filelist-2 -c -allow-unstable-cache-key-for-testing > %t6.casid
+// RUN:   %target-swift-frontend -cache-compile-job -filelist %t/filelist-2 -c @%t/MyApp.cmd > %t6.casid
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-base-key -- \
-// RUN:   %target-swift-frontend -cache-compile-job -filelist %t/filelist-3 -c -allow-unstable-cache-key-for-testing > %t7.casid
+// RUN:   %target-swift-frontend -cache-compile-job -filelist %t/filelist-3 -c @%t/MyApp.cmd > %t7.casid
 // RUN: diff %t5.casid %t6.casid
 // RUN: not diff %t5.casid %t7.casid
 
 /// Test output keys.
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend -cache-compile-job %s -emit-module -c -emit-dependencies \
-// RUN:   -emit-tbd -emit-tbd-path %t/test.tbd -o %t/test.o -allow-unstable-cache-key-for-testing | %FileCheck %s
+// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -emit-module -c -emit-dependencies \
+// RUN:   -emit-tbd -emit-tbd-path %t/test.tbd -o %t/test.o @%t/MyApp.cmd | %FileCheck %s
 
 /// Test plugin CAS.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/a.swift -o %t/plugin_deps.json -cache-compile-job -cas-path %t/cas -cas-plugin-path %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext \
+// RUN:   -cas-plugin-option first-prefix=myfirst-
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/plugin_deps.json > %t/plugin_map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/plugin_map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/plugin_deps.json Test > %t/plugin_MyApp.cmd
 // RUN: %cache-tool -cas-path %t/cas -cas-plugin-path %llvm_libs_dir/libCASPluginTest%llvm_plugin_ext \
 // RUN:   -cas-plugin-option first-prefix=myfirst- -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend -cache-compile-job %s -emit-module -c -emit-dependencies \
-// RUN:   -emit-tbd -emit-tbd-path %t/test.tbd -o %t/test.o -allow-unstable-cache-key-for-testing | %FileCheck %s --check-prefix=CHECK --check-prefix=PLUGIN
+// RUN:   %target-swift-frontend -cache-compile-job %t/a.swift -emit-module -c -emit-dependencies \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -emit-tbd -emit-tbd-path %t/test.tbd -o %t/test.o @%t/plugin_MyApp.cmd | %FileCheck %s --check-prefix=CHECK --check-prefix=PLUGIN
 
-// CHECK: "Input": "{{.*}}{{/|\\}}cache_key_compute.swift"
+// CHECK: "Input": "{{.*}}{{/|\\}}a.swift"
 // CHECK-NEXT: "CacheKey"
 // PLUGIN-SAME: myfirst-llvmcas://
 
@@ -81,3 +102,8 @@
 // CHECK-NEXT: }
 // CHECK-NEXT: ]
 
+//--- a.swift
+func a() {}
+
+//--- b.swift
+func b() {}

--- a/test/CAS/cache_replay.swift
+++ b/test/CAS/cache_replay.swift
@@ -1,42 +1,56 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-/// Run the command first time, expect cache miss.
-/// FIXME: This command doesn't use `-cas-fs` so it is not a good cache entry. It is currently allowed so it is easier to write tests.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
-// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
-
-/// Expect cache hit for second time.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
-// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
-
-/// Expect cache miss a subset of outputs.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c \
-// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
-
-/// Cache hit for retry.
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c \
-// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
-
-/// Skip cache
-// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -cache-disable-replay %t/test.swift -emit-module -emit-module-path %t/Test.swiftmodule -c \
-// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --allow-empty --check-prefix=SKIP-CACHE %s
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O -module-cache-path %t/clang-module-cache \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/test.swift -I %t -o %t/deps.json -cache-compile-job -cas-path %t/cas
 
 /// Check clang module
-// RUN: %target-swift-frontend -emit-pcm -module-name Dummy %t/module.modulemap -cache-compile-job -Rcache-compile-job -cas-path %t/cas \
-// RUN:   -allow-unstable-cache-key-for-testing -o %t/dummy.pcm 2>&1 | %FileCheck --allow-empty --check-prefix=CACHE-MISS %s
-// RUN: %target-swift-frontend -emit-pcm -module-name Dummy %t/module.modulemap -cache-compile-job -Rcache-compile-job -cas-path %t/cas \
-// RUN:   -allow-unstable-cache-key-for-testing -o %t/dummy.pcm 2>&1 | %FileCheck --allow-empty --check-prefix=CACHE-HIT-CLANG %s
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:Dummy > %t/dummy.cmd
+// RUN: %swift_frontend_plain @%t/dummy.cmd -Rcache-compile-job 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+// RUN: %swift_frontend_plain @%t/dummy.cmd -Rcache-compile-job 2>&1 | %FileCheck --check-prefix=CACHE-HIT-CLANG %s
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
+
+/// Run the command first time, expect cache miss.
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+
+/// Expect cache hit for second time.
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+
+/// Expect cache miss a subset of outputs.
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+
+/// Cache hit for retry.
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+
+/// Skip cache
+// RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -cache-disable-replay %t/test.swift -O -emit-module -emit-module-path %t/Test.swiftmodule -c \
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --allow-empty --check-prefix=SKIP-CACHE %s
 
 // CACHE-MISS: remark: cache miss for input
 // CACHE-HIT: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
 // CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}test.o': key 'llvmcas://{{.*}}'
 // CACHE-HIT: remark: replay output file '{{.*}}{{/|\\}}Test.swiftmodule': key 'llvmcas://{{.*}}'
 // CACHE-HIT-CLANG: remark: replay output file '<cached-diagnostics>': key 'llvmcas://{{.*}}'
-// CACHE-HIT-CLANG: remark: replay output file '{{.*}}{{/|\\}}dummy.pcm': key 'llvmcas://{{.*}}'
+// CACHE-HIT-CLANG: remark: replay output file '{{.*}}{{/|\\}}Dummy-{{.*}}.pcm': key 'llvmcas://{{.*}}'
 // SKIP-CACHE-NOT: remark:
 
 //--- test.swift
+import Dummy
 func testFunc() {}
 
 //--- module.modulemap

--- a/test/CAS/cache_replay_multiple_files.swift
+++ b/test/CAS/cache_replay_multiple_files.swift
@@ -1,21 +1,33 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/test.swift %t/foo.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
 /// Test compile multiple inputs with batch mode.
 // RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift %t/foo.swift -emit-module -o %t/Test.swiftmodule \
-// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+// RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
 // RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -primary-file %t/test.swift %t/foo.swift -c -o %t/test.o  \
-// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+// RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
 // RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -primary-file %t/foo.swift -c -o %t/foo.o  \
-// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
+// RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-MISS %s
 
 /// Expect cache hit second time
 // RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift %t/foo.swift -emit-module -o %t/Test.swiftmodule \
-// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+// RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
 // RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job -primary-file %t/test.swift %t/foo.swift -c -o %t/test.o  \
-// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+// RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
 // RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %t/test.swift -primary-file %t/foo.swift -c -o %t/foo.o  \
-// RUN:  -module-name Test -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
+// RUN:  -module-name Test -cas-path %t/cas @%t/MyApp.cmd 2>&1 | %FileCheck --check-prefix=CACHE-HIT %s
 
 //--- test.swift
 func testFunc() {}

--- a/test/CAS/cached_diagnostics.swift
+++ b/test/CAS/cached_diagnostics.swift
@@ -1,28 +1,41 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing %s \
-// RUN:   -import-objc-header %S/Inputs/objc.h -emit-module -emit-module-path %t/test.swiftmodule 2>&1 | %FileCheck %s
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing %s \
-// RUN:   -import-objc-header %S/Inputs/objc.h -emit-module -emit-module-path %t/test.swiftmodule > %t/cache_key.json
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing %s \
-// RUN:   -import-objc-header %S/Inputs/objc.h -emit-module -emit-module-path %t/test.swiftmodule 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O -import-objc-header %S/Inputs/objc.h \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %s -o %t/deps.json -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader | tail -n +2  > %t/header.cmd
+// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules %S/Inputs/objc.h -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix CHECK-BRIDGE
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules %S/Inputs/objc.h -O -o %t/objc.pch > %t/keys.json
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json %S/Inputs/objc.h > %t/key
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+// RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
+// RUN: echo "\"%t/objc.pch\"" >> %t/MyApp.cmd
+// RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
+
+// RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN:   -emit-module -o %t/test.swiftmodule 2>&1 | %FileCheck %s
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- %target-swift-frontend -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN:   -emit-module -o %t/test.swiftmodule > %t/cache_key.json
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- %target-swift-frontend -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
+// RUN:   -emit-module -o %t/test.swiftmodule 2>&1 | %FileCheck %s
 
 #warning("this is a warning")  // expected-warning {{this is a warning}}
 
-// CHECK: warning: warning in bridging header
+// CHECK-BRIDGE: warning: warning in bridging header
 // CHECK: warning: this is a warning
 
 /// Check other DiagnosticConsumers.
-// RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing %s \
+// RUN: %target-swift-frontend -c -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
 // RUN:   -typecheck -serialize-diagnostics -serialize-diagnostics-path %t/test.diag -verify
 // RUN: %FileCheck %s -check-prefix CHECK-SERIALIZED <%t/test.diag
 
-// Verify the serialized diags have the right magic at the top.
+/// Verify the serialized diags have the right magic at the top.
 // CHECK-SERIALIZED: DIA
-
-/// Check path remapping.
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- %target-swift-frontend -c -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing %s \
-// RUN:   -import-objc-header %S/Inputs/objc.h -emit-module -emit-module-path %t/test.swiftmodule -cache-replay-prefix-map %S=/^test  2>&1 | %FileCheck %s --check-prefix REMAP
-
-// REMAP: /^test/Inputs/objc.h:3:2: warning: warning in bridging header
-// REMAP: /^test/cached_diagnostics.swift:10:10: warning: this is a warning

--- a/test/CAS/cached_diagnostics_remap.swift
+++ b/test/CAS/cached_diagnostics_remap.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Check path remapping.
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O -import-objc-header %t/objc.h \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/test.swift -o %t/deps.json -cache-compile-job -cas-path %t/cas -scanner-prefix-map %t=/^test
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader | tail -n +2  > %t/header.cmd
+// RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix BRIDGE
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
+// RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch > %t/keys.json
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/keys.json -- \
+// RUN:    %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules /^test/objc.h -O -o %t/objc.pch -cache-replay-prefix-map /^test=%t 2>&1 \
+// RUN:    | %FileCheck %s -check-prefix BRIDGE -check-prefix BRIDGE-REMAP
+
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json /^test/objc.h > %t/key
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+// RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
+// RUN: echo "\"%t/objc.pch\"" >> %t/MyApp.cmd
+// RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
+
+// RUN: %target-swift-frontend -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd \
+// RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift 2>&1 | %FileCheck %s
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- %target-swift-frontend -cache-compile-job -module-name Test \
+// RUN:   -O -cas-path %t/cas @%t/MyApp.cmd \
+// RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift > %t/cache_key.json
+// RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json -- %target-swift-frontend -cache-compile-job -module-name Test \
+// RUN:   -O -cas-path %t/cas @%t/MyApp.cmd \
+// RUN:   -emit-module -o %t/test.swiftmodule /^test/test.swift -cache-replay-prefix-map /^test=%t 2>&1 | %FileCheck %s --check-prefix REMAP 
+
+// BRIDGE: /^test/objc.h:3:2: warning: warning in bridging header
+// BRIDGE-REMAP: BUILD_DIR{{.*}}{{/|\\}}objc.h:3:2: warning: warning in bridging header
+// CHECK: /^test/test.swift:1:10: warning: this is a warning
+// REMAP: BUILD_DIR{{.*}}{{/|\\}}test.swift:1:10: warning: this is a warning
+
+//--- test.swift
+#warning("this is a warning")
+
+//--- objc.h
+int test(int);
+
+#warning warning in bridging header

--- a/test/CAS/can-import.swift
+++ b/test/CAS/can-import.swift
@@ -5,7 +5,7 @@
 // RUN: split-file %s %t
 
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
-// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   %t/main.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas -I %t/include
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
@@ -14,57 +14,15 @@
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:B > %t/B.cmd
 // RUN: %swift_frontend_plain @%t/B.cmd
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd
-// RUN: %swift_frontend_plain @%t/SwiftShims.cmd
-
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Swift > %t/Swift.cmd
-// RUN: %swift_frontend_plain @%t/Swift.cmd
-
-// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json Swift moduleCacheKey | tr -d '\n' > %t/Swift.key
-// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:SwiftShims moduleCacheKey | tr -d '\n' > %t/Shims.key
-// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:A moduleCacheKey | tr -d '\n' > %t/A.key
-// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json clang:B moduleCacheKey | tr -d '\n' > %t/B.key
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json MyApp > %t/MyApp.cmd
-
-// RUN: echo "[{" > %/t/map.json
-// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/map.json
-// RUN: echo "\"modulePath\": \"Swift.swiftmodule\"," >> %/t/map.json
-// RUN: echo -n "\"moduleCacheKey\": " >> %/t/map.json
-// RUN: cat %t/Swift.key >> %/t/map.json
-// RUN: echo "," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"SwiftShims\"," >> %/t/map.json
-// RUN: echo "\"clangModulePath\": \"SwiftShims.pcm\"," >> %/t/map.json
-// RUN: echo -n "\"clangModuleCacheKey\": " >> %/t/map.json
-// RUN: cat %t/Shims.key >> %/t/map.json
-// RUN: echo "," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"A\"," >> %/t/map.json
-// RUN: echo "\"clangModulePath\": \"A.pcm\"," >> %/t/map.json
-// RUN: echo -n "\"clangModuleCacheKey\": " >> %/t/map.json
-// RUN: cat %t/A.key >> %/t/map.json
-// RUN: echo "," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"B\"," >> %/t/map.json
-// RUN: echo "\"clangModulePath\": \"B.pcm\"," >> %/t/map.json
-// RUN: echo -n "\"clangModuleCacheKey\": " >> %/t/map.json
-// RUN: cat %t/B.key >> %/t/map.json
-// RUN: echo "," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}]" >> %/t/map.json
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: %target-swift-frontend \
 // RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
 // RUN:   -swift-version 5 -disable-implicit-swift-modules \
-// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
-// RUN:   -module-name MyApp -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
 // RUN:   %t/main.swift @%t/MyApp.cmd
 
 //--- main.swift

--- a/test/CAS/cas-explicit-module-map.swift
+++ b/test/CAS/cas-explicit-module-map.swift
@@ -1,140 +1,51 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/cas
 // RUN: split-file %s %t
-// RUN: %target-swift-emit-pcm -Xfrontend -cache-compile-job -Xfrontend -allow-unstable-cache-key-for-testing -Xfrontend -cas-path -Xfrontend %t/cas -module-cache-path %t/clang-module-cache -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/SwiftShims.pcm
-// RUN: %target-swift-emit-pcm -Xfrontend -cache-compile-job -Xfrontend -allow-unstable-cache-key-for-testing -Xfrontend -cas-path -Xfrontend %t/cas -module-cache-path %t/clang-module-cache -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/SwiftShims.pcm -### > %t/Shims.cmd
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- @%t/Shims.cmd > %t/Shims.key.json
-// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/Shims.key.json %t/SwiftShims.pcm | tr -d '\n' > %t/Shims.key
 
-// RUN: %target-swift-emit-pcm -Xfrontend -cache-compile-job -Xfrontend -allow-unstable-cache-key-for-testing -module-cache-path %t/clang-module-cache -Xfrontend -cas-path -Xfrontend %t/cas -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/_SwiftConcurrencyShims.pcm
-// RUN: %target-swift-emit-pcm -Xfrontend -cache-compile-job -Xfrontend -allow-unstable-cache-key-for-testing -module-cache-path %t/clang-module-cache -Xfrontend -cas-path -Xfrontend %t/cas -module-name _SwiftConcurrencyShims %swift-lib-dir/swift/shims/module.modulemap -o %t/_SwiftConcurrencyShims.pcm -### > %t/ConcurrencyShims.cmd
-// RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- @%t/ConcurrencyShims.cmd > %t/ConcurrencyShims.key.json
-// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/ConcurrencyShims.key.json %t/_SwiftConcurrencyShims.pcm | tr -d '\n' > %t/ConcurrencyShims.key
+// RUN: %target-swift-frontend -emit-module -module-cache-path %t/clang-module-cache %t/A.swift -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -o %t/A.swiftmodule -swift-version 5
+// RUN: %target-swift-frontend -emit-module -module-cache-path %t/clang-module-cache %t/B.swift -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib -o %t/B.swiftmodule -I %t -swift-version 5
 
-// RUN: %target-swift-frontend -emit-module -module-cache-path %t/clang-module-cache %t/A.swift -o %t/A.swiftmodule -swift-version 5
-// RUN: %target-swift-frontend -emit-module -module-cache-path %t/clang-module-cache %t/B.swift -o %t/B.swiftmodule -I %t -swift-version 5
-// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/Test.swift -o %t/deps.json -I %t -swift-version 5 -cache-compile-job -cas-path %t/cas
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %t/Test.swift -o %t/deps.json -I %t -module-name Test \
+// RUN:    -swift-version 5 -cache-compile-job -cas-path %t/cas -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib
 // RUN: %validate-json %t/deps.json &>/dev/null
 
-// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json swiftPrebuiltExternal:A moduleCacheKey | tr -d '\n' > %t/A.key
-// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json swiftPrebuiltExternal:B moduleCacheKey | tr -d '\n' > %t/B.key
-
-/// Prepare the cas objects that can be used to construct CompileJobResultSchema object.
-// RUN: llvm-cas --cas %t/cas --get-cache-result @%t/A.key > %t/A.result
-// RUN: llvm-cas --cas %t/cas --ls-node-refs @%t/A.result | tail -n 1 > %t/schema.casid
-// RUN: llvm-cas --cas %t/cas --cat-blob @%t/A.result > %t/kind.blob
-
-/// Make keys for module loads. The result casid construction is tied with the actual structure of CompilerJobResultSchema.
-// RUN: llvm-cas --cas %t/cas --make-blob --data %stdlib_module | tr -d '\n' > %t/Swift.key
-// RUN: llvm-cas --cas %t/cas --make-node --data %t/kind.blob @%t/Swift.key @%t/schema.casid  > %t/Swift.casid
-// RUN: llvm-cas --cas %t/cas --put-cache-key @%t/Swift.key @%t/Swift.casid
-
-// RUN: llvm-cas --cas %t/cas --make-blob --data %ononesupport_module | tr -d '\n' > %t/ONone.key
-// RUN: llvm-cas --cas %t/cas --make-node --data %t/kind.blob @%t/ONone.key @%t/schema.casid > %t/ONone.casid
-// RUN: llvm-cas --cas %t/cas --put-cache-key @%t/ONone.key @%t/ONone.casid
-
-// RUN: llvm-cas --cas %t/cas --make-blob --data %concurrency_module | tr -d '\n' > %t/Concurrency.key
-// RUN: llvm-cas --cas %t/cas --make-node --data %t/kind.blob @%t/Concurrency.key @%t/schema.casid > %t/Concurrency.casid
-// RUN: llvm-cas --cas %t/cas --put-cache-key @%t/Concurrency.key @%t/Concurrency.casid
-
-// RUN: llvm-cas --cas %t/cas --make-blob --data %string_processing_module | tr -d '\n' > %t/String.key
-// RUN: llvm-cas --cas %t/cas --make-node --data %t/kind.blob @%t/String.key @%t/schema.casid > %t/String.casid
-// RUN: llvm-cas --cas %t/cas --put-cache-key @%t/String.key @%t/String.casid
-
-// RUN: echo "[{" > %/t/map.json
-// RUN: echo "\"moduleName\": \"A\"," >> %/t/map.json
-// RUN: echo "\"modulePath\": \"A.swiftmodule\"," >> %/t/map.json
-// RUN: echo -n "\"moduleCacheKey\": " >> %/t/map.json
-// RUN: cat %t/A.key >> %/t/map.json
-// RUN: echo "," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"B\"," >> %/t/map.json
-// RUN: echo "\"modulePath\": \"B.swiftmodule\"," >> %/t/map.json
-// RUN: echo -n "\"moduleCacheKey\": " >> %/t/map.json
-// RUN: cat %t/B.key >> %/t/map.json
-// RUN: echo "," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/map.json
-// RUN: echo "\"modulePath\": \"Swift.swiftmodule\"," >> %/t/map.json
-// RUN: echo -n "\"moduleCacheKey\": \"" >> %/t/map.json
-// RUN: cat %t/Swift.key >> %/t/map.json
-// RUN: echo "\"," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/map.json
-// RUN: echo "\"modulePath\": \"SwiftOnoneSupport.swiftmodule\"," >> %/t/map.json
-// RUN: echo -n "\"moduleCacheKey\": \"" >> %/t/map.json
-// RUN: cat %t/ONone.key >> %/t/map.json
-// RUN: echo "\"," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"_Concurrency\"," >> %/t/map.json
-// RUN: echo "\"modulePath\": \"_Concurrency.swiftmodule\"," >> %/t/map.json
-// RUN: echo -n "\"moduleCacheKey\": \"" >> %/t/map.json
-// RUN: cat %t/Concurrency.key >> %/t/map.json
-// RUN: echo "\"," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"_StringProcessing\"," >> %/t/map.json
-// RUN: echo "\"modulePath\": \"_StringProcessing.swiftmodule\"," >> %/t/map.json
-// RUN: echo -n "\"moduleCacheKey\": \"" >> %/t/map.json
-// RUN: cat %t/String.key >> %/t/map.json
-// RUN: echo "\"," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"SwiftShims\"," >> %/t/map.json
-// RUN: echo "\"clangModulePath\": \"SwiftShims.pcm\"," >> %/t/map.json
-// RUN: echo -n "\"clangModuleCacheKey\": \"" >> %/t/map.json
-// RUN: cat %t/Shims.key >> %/t/map.json
-// RUN: echo "\"," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}," >> %/t/map.json
-// RUN: echo "{" >> %/t/map.json
-// RUN: echo "\"moduleName\": \"_SwiftConcurrencyShims\"," >> %/t/map.json
-// RUN: echo "\"clangModulePath\": \"_SwiftConcurrency.pcm\"," >> %/t/map.json
-// RUN: echo -n "\"clangModuleCacheKey\": \"" >> %/t/map.json
-// RUN: cat %t/ConcurrencyShims.key >> %/t/map.json
-// RUN: echo "\"," >> %/t/map.json
-// RUN: echo "\"isFramework\": false" >> %/t/map.json
-// RUN: echo "}]" >> %/t/map.json
-
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
 // RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid -Rmodule-loading -Xcc -Rmodule-import %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing 2>&1 | %FileCheck %s
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/Test.swift @%t/MyApp.cmd
 
-// RUN: %target-swift-frontend -typecheck -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %s -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution -o %t/Foo.swiftmodule
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \
+// RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %t/Test.swift -cache-compile-job \
+// RUN:   -cas-path %t/cas -swift-version 5 -enable-library-evolution -o %t/Foo.swiftmodule \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib @%t/MyApp.cmd
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend -typecheck -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \
-// RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %s -cache-compile-job \
-// RUN:   -cas-path %t/cas -allow-unstable-cache-key-for-testing  -swift-version 5 -enable-library-evolution > %t/keys.json
+// RUN:   %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -emit-module-interface-path %t/Foo.swiftinterface -disable-implicit-swift-modules \
+// RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid %t/Test.swift -cache-compile-job \
+// RUN:   -cas-path %t/cas -swift-version 5 -enable-library-evolution -o %t/Foo.swiftmodule \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib @%t/MyApp.cmd > %t/keys.json
+// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json %t/Test.swift > %t/key
 
-// RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json %t/Foo.swiftinterface > %t/interface.casid
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
-// RUN:   -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution \
-// RUN:   -explicit-interface-module-build -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-MISS
+// RUN:   -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-library-evolution \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -explicit-interface-module-build -Rcache-compile-job @%t/MyApp.cmd -input-file-key @%t/key 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-MISS
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
-// RUN:   -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing -swift-version 5 -enable-library-evolution \
-// RUN:   -explicit-interface-module-build -Rcache-compile-job 2>&1 | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-HIT
-
-// CHECK-DAG: loaded module 'A'
-// CHECK-DAG: loaded module 'B'
-// CHECK-DAG: loaded module 'Swift'
-// CHECK-DAG: loaded module '_StringProcessing'
-// CHECK-DAG: loaded module '_Concurrency'
-// CHECK-DAG: loaded module 'SwiftOnoneSupport'
+// RUN:   -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-library-evolution \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -explicit-interface-module-build -Rcache-compile-job @%t/MyApp.cmd -input-file-key @%t/key 2>&1 \
+// RUN:   | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-HIT
 
 // CACHE-MISS: remark: cache miss for input
-// VERIFY-OUTPUT: warning: module 'A' was not compiled with library evolution support
+// VERIFY-OUTPUT: warning: module 'B' was not compiled with library evolution support
 // CACHE-HIT: remark: replay output file
 
 //--- A.swift

--- a/test/CAS/cas_output_backend.swift
+++ b/test/CAS/cas_output_backend.swift
@@ -4,9 +4,18 @@
 // RUN: not %target-swift-frontend -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o 2>&1 | %FileCheck %s --check-prefix=NO-CASFS
 // NO-CASFS: caching is enabled without -cas-fs option
 
-// RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o -allow-unstable-cache-key-for-testing
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
+// RUN: %target-swift-frontend -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
-// RUN:   %target-swift-frontend -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o -allow-unstable-cache-key-for-testing > %t/cache_key.json
+// RUN:   %target-swift-frontend -c -cache-compile-job -cas-path %t/cas %s -o %t/test.o @%t/MyApp.cmd > %t/cache_key.json
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action validate-outputs %t/cache_key.json
 
 /// make sure validate fails if the cas is cleared.

--- a/test/CAS/educational-notes.swift
+++ b/test/CAS/educational-notes.swift
@@ -1,8 +1,18 @@
 // RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
 // RUN: not %target-swift-frontend -color-diagnostics -diagnostic-style=llvm -print-educational-notes -diagnostic-documentation-path %S/../diagnostics/test-docs/ \
-// RUN:   -emit-module -emit-module-path %t/test.module -allow-unstable-cache-key-for-testing %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace
+// RUN:   -emit-module -emit-module-path %t/test.module @%t/MyApp.cmd %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace
 // RUN: not %target-swift-frontend -no-color-diagnostics -print-educational-notes -diagnostic-documentation-path %S/../diagnostics/test-docs/ \
-// RUN:   -emit-module -emit-module-path %t/test.module -allow-unstable-cache-key-for-testing %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace --check-prefix=NO-COLOR
+// RUN:   -emit-module -emit-module-path %t/test.module @%t/MyApp.cmd %s 2>&1 | %FileCheck %s --match-full-lines --strict-whitespace --check-prefix=NO-COLOR
 
 // A diagnostic with no educational notes
 let x = 1 +

--- a/test/CAS/include-tree.swift
+++ b/test/CAS/include-tree.swift
@@ -4,18 +4,30 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache %t/main.swift -o %t/deps.json -I %t/include -swift-version 4 -cache-compile-job -cas-path %t/cas
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache %t/main.swift \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -o %t/deps.json -I %t/include -swift-version 4 -cache-compile-job -cas-path %t/cas 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:DotDot > %t/DotDot.cmd
 // RUN: %swift_frontend_plain @%t/DotDot.cmd
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/SwiftShims.cmd
-// RUN: %swift_frontend_plain @%t/SwiftShims.cmd
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
 
-// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Swift > %t/Swift.cmd
-// RUN: %swift_frontend_plain @%t/Swift.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/main.swift @%t/MyApp.cmd
 
 /// Test that if there are non-existing module-map file passed through -Xcc, this still compiles.
-// RUN: %swift_frontend_plain @%t/Swift.cmd  -Xcc -fmodule-map-file=%t/do-not-exist.modulemap
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/main.swift @%t/MyApp.cmd -Xcc -fmodule-map-file=%t/do-not-exist.modulemap
 
 //--- main.swift
 import DotDot

--- a/test/CAS/loc-directive-diagnostics.swift
+++ b/test/CAS/loc-directive-diagnostics.swift
@@ -1,12 +1,22 @@
 // RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/test.module \
-// RUN:   -cache-compile-job -cas-path %t/cas -allow-unstable-cache-key-for-testing %s 2>&1 | %FileCheck %s
+// RUN:   -cache-compile-job -cas-path %t/cas @%t/MyApp.cmd %s 2>&1 | %FileCheck %s
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action print-output-keys -- \
 // RUN:   %target-swift-frontend -emit-module -emit-module-path %t/test.module -cache-compile-job -cas-path %t/cas \
-// RUN:   -allow-unstable-cache-key-for-testing %s > %t/cache_key.json
+// RUN:   @%t/MyApp.cmd %s > %t/cache_key.json
 // RUN: %cache-tool -cas-path %t/cas -cache-tool-action render-diags %t/cache_key.json --  \
 // RUN:   %target-swift-frontend -emit-module -emit-module-path %t/test.module -cache-compile-job -cas-path %t/cas \
-// RUN:   -allow-unstable-cache-key-for-testing %s 2>&1 | %FileCheck %s
+// RUN:   @%t/MyApp.cmd %s 2>&1 | %FileCheck %s
 
 #sourceLocation(file: "anything.swift", line: 1)
 #warning("this is a warning")

--- a/test/CAS/swift-scan-test-llvm-args.swift
+++ b/test/CAS/swift-scan-test-llvm-args.swift
@@ -1,19 +1,28 @@
 // RUN: %empty-directory(%t)
 
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
 // RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
-// RUN:   -allow-unstable-cache-key-for-testing -Xllvm -aarch64-use-tbi > %t/key.casid
+// RUN:   @%t/MyApp.cmd -Xllvm -aarch64-use-tbi > %t/key.casid
 
 // RUN: not %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=CHECK-QUERY-NOT-FOUND
 
 // RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
-// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing -Xllvm -aarch64-use-tbi
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd -Xllvm -aarch64-use-tbi
 
 // RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
 
 // RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -threads 10 -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
-// RUN:   -allow-unstable-cache-key-for-testing -Xllvm -aarch64-use-tbi
+// RUN:   @%t/MyApp.cmd -Xllvm -aarch64-use-tbi
 
 // CHECK-QUERY-NOT-FOUND: cached output not found
 // CHECK-QUERY: Cached Compilation for key "llvmcas://{{.*}}" has 4 outputs:

--- a/test/CAS/swift-scan-test.swift
+++ b/test/CAS/swift-scan-test.swift
@@ -1,25 +1,34 @@
 // RUN: %empty-directory(%t)
 
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %s -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
+// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
+
 // RUN: %swift-scan-test -action compute_cache_key -cas-path %t/cas -input %s -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
-// RUN:   -allow-unstable-cache-key-for-testing > %t/key.casid
+// RUN:   @%t/MyApp.cmd > %t/key.casid
 
 // RUN: %swift-scan-test -action compute_cache_key_from_index -cas-path %t/cas -input 0 -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies -module-name Test -o %t/test.o -cas-path %t/cas \
-// RUN:   -allow-unstable-cache-key-for-testing > %t/key1.casid
+// RUN:   @%t/MyApp.cmd > %t/key1.casid
 
 // RUN: diff %t/key.casid %t/key1.casid
 
 // RUN: not %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas 2>&1 | %FileCheck %s --check-prefix=CHECK-QUERY-NOT-FOUND
 
 // RUN: %target-swift-frontend -cache-compile-job -Rcache-compile-job %s -emit-module -emit-module-path %t/Test.swiftmodule -c -emit-dependencies \
-// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas -allow-unstable-cache-key-for-testing
+// RUN:  -module-name Test -o %t/test.o -cas-path %t/cas @%t/MyApp.cmd
 
 // RUN: %swift-scan-test -action cache_query -id @%t/key.casid -cas-path %t/cas | %FileCheck %s --check-prefix=CHECK-QUERY
 
 // RUN: %swift-scan-test -action replay_result -cas-path %t/cas -id @%t/key.casid -- %target-swift-frontend -cache-compile-job -Rcache-compile-job %s \
 // RUN:   -emit-module -emit-module-path %t/Test2.swiftmodule -c -emit-dependencies -module-name Test -o %t/test2.o -cas-path %t/cas \
-// RUN:   -allow-unstable-cache-key-for-testing
+// RUN:   @%t/MyApp.cmd
 
 // RUN: diff %t/Test.swiftmodule %t/Test2.swiftmodule
 // RUN: diff %t/test.o %t/test.o


### PR DESCRIPTION
Improve caching related tests to make them faster and test the situation
closer to what actually happens during explicit module build. Most
noticable changes are:
    * Avoid swift stdlib dependency during the tests to save time
    * Use dependency scanner output to construct test cases
    * Update old test cases that try to simulate caching from file system
      inputs to using only CAS inputs.
