### PR TITLE
[Runtime] Fix dyld call for Swift prespecialized data.

### DIFF
--- a/include/swift/Runtime/LibPrespecialized.h
+++ b/include/swift/Runtime/LibPrespecialized.h
@@ -45,7 +45,7 @@ struct LibPrespecializedData {
   }
 };
 
-LibPrespecializedData<InProcess> *getLibPrespecializedData();
+const LibPrespecializedData<InProcess> *getLibPrespecializedData();
 Metadata *getLibPrespecializedMetadata(const TypeContextDescriptor *description,
                                        const void *const *arguments);
 


### PR DESCRIPTION
Make our variables const to match the call signature, and do a weak check of the symbol before calling it.