### PR TITLE
[Test] Make sure macros are enabled for the tests that use the new #isolation macro

### DIFF
--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -3,6 +3,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_swift_parser
 
 @available(SwiftStdlib 5.1, *)
 actor A {

--- a/test/Concurrency/isolation_macro.swift
+++ b/test/Concurrency/isolation_macro.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: swift_swift_parser
 
 // CHECK-LABEL: nonisolatedFunc()
 @available(SwiftStdlib 5.1, *)

--- a/test/Distributed/isolation_macro.swift
+++ b/test/Distributed/isolation_macro.swift
@@ -5,6 +5,7 @@
 // REQUIRES: concurrency
 // REQUIRES: asserts
 // REQUIRES: distributed
+// REQUIRES: swift_swift_parser
 
 import Distributed
 


### PR DESCRIPTION
This is a follow-on to #71011, which also checked that macros were enabled before including this new macro in the stdlib. These tests [currently fail on the community Android CI](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/6390/console), which doesn't have a prebuilt Swift compiler so macros are disabled.

@DougGregor, please review.