### PR TITLE
Add `i686-unknown-windows-coff`/`x86_64-unknown-windows-coff` embedded triples

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -194,8 +194,10 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
       "i686    i686-unknown-none-elf       i686-unknown-none-elf"
       "x86_64  x86_64-unknown-none-elf     x86_64-unknown-none-elf"
-      "i686    i686-pc-windows-coff       i686-pc-windows-coff"
-      "x86_64  x86_64-pc-windows-coff     x86_64-pc-windows-coff"
+      # Without specifying the `windows` component LLVM refuses to
+      # generate valid COFF object files.
+      "i686    i686-unknown-windows-coff   i686-unknown-windows-coff"
+      "x86_64  x86_64-unknown-windows-coff x86_64-unknown-windows-coff"
     )
   endif()
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -194,6 +194,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
     list(APPEND EMBEDDED_STDLIB_TARGET_TRIPLES
       "i686    i686-unknown-none-elf       i686-unknown-none-elf"
       "x86_64  x86_64-unknown-none-elf     x86_64-unknown-none-elf"
+      "i686    i686-pc-windows-coff       i686-pc-windows-coff"
+      "x86_64  x86_64-pc-windows-coff     x86_64-pc-windows-coff"
     )
   endif()
 


### PR DESCRIPTION
These triples don't need additional adjustments in the standard library and complement existing embedded triples for i686 and x86_64 CPU architectures.

Ideally, this would allow compiling Embedded Swift code for Windows without MSVC more easily.
