### PR TITLE
[region-isolation] Change warnings -> errors limited to warnings until swift 6 + a few other changes

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -910,6 +910,9 @@ ERROR(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, non
 ERROR(regionbasedisolation_arg_transferred, none,
       "task isolated value of type %0 transferred to %1 context; later accesses to value could race",
       (Type, ActorIsolation))
+ERROR(regionbasedisolation_arg_passed_to_strongly_transferred_param, none,
+      "task isolated value of type %0 passed as a strongly transferred parameter; later accesses could race",
+      (Type))
 NOTE(regionbasedisolation_maybe_race, none,
      "access here could race", ())
 NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -890,26 +890,26 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 
 // Warnings arising from the flow-sensitive checking of Sendability of
 // non-Sendable values
-WARNING(regionbasedisolation_selforargtransferred, none,
-        "call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller", ())
-WARNING(regionbasedisolation_transfer_yields_race_no_isolation, none,
-        "transferring value of non-Sendable type %0; later accesses could race",
-        (Type))
-WARNING(regionbasedisolation_transfer_yields_race_with_isolation, none,
-        "transferring value of non-Sendable type %0 from %1 context to %2 context; later accesses could race",
-        (Type, ActorIsolation, ActorIsolation))
-WARNING(regionbasedisolation_isolated_capture_yields_race, none,
-        "%1 closure captures value of non-Sendable type %0 from %2 context; later accesses to value could race",
-        (Type, ActorIsolation, ActorIsolation))
-WARNING(regionbasedisolation_transfer_yields_race_transferring_parameter, none,
-        "transferring value of non-Sendable type %0 into transferring parameter; later accesses could race",
-        (Type))
-WARNING(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, none,
-        "binding of non-Sendable type %0 accessed after being transferred; later accesses could race",
-        (Type))
-WARNING(regionbasedisolation_arg_transferred, none,
-        "task isolated value of type %0 transferred to %1 context; later accesses to value could race",
-        (Type, ActorIsolation))
+ERROR(regionbasedisolation_selforargtransferred, none,
+      "call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller", ())
+ERROR(regionbasedisolation_transfer_yields_race_no_isolation, none,
+      "transferring value of non-Sendable type %0; later accesses could race",
+      (Type))
+ERROR(regionbasedisolation_transfer_yields_race_with_isolation, none,
+      "transferring value of non-Sendable type %0 from %1 context to %2 context; later accesses could race",
+      (Type, ActorIsolation, ActorIsolation))
+ERROR(regionbasedisolation_isolated_capture_yields_race, none,
+      "%1 closure captures value of non-Sendable type %0 from %2 context; later accesses to value could race",
+      (Type, ActorIsolation, ActorIsolation))
+ERROR(regionbasedisolation_transfer_yields_race_transferring_parameter, none,
+      "transferring value of non-Sendable type %0 into transferring parameter; later accesses could race",
+      (Type))
+ERROR(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, none,
+      "binding of non-Sendable type %0 accessed after being transferred; later accesses could race",
+      (Type))
+ERROR(regionbasedisolation_arg_transferred, none,
+      "task isolated value of type %0 transferred to %1 context; later accesses to value could race",
+      (Type, ActorIsolation))
 NOTE(regionbasedisolation_maybe_race, none,
      "access here could race", ())
 NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -disable-availability-checking -verify %s -o /dev/null -swift-version 6 -enable-experimental-feature TransferringArgsAndResults
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// This test makes sure that all of our warnings are errors in swift6 mode.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableType {}
+
+@MainActor func transferToMain<T>(_ t: T) async {}
+func useValue<T>(_ t: T) {}
+func transferValue<T>(_ t: transferring T) {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+func testIsolationError() async {
+  let x = NonSendableType()
+  await transferToMain(x) // expected-error {{transferring value of non-Sendable type 'NonSendableType' from nonisolated context to main actor-isolated context; later accesses could race}}
+  useValue(x) // expected-note {{access here could race}}
+}
+
+func testArgumentError(_ x: NonSendableType) async { // expected-note {{value is task isolated since it is in the same region as 'x'}}
+  await transferToMain(x) // expected-error {{task isolated value of type 'NonSendableType' transferred to main actor-isolated context; later accesses to value could race}}
+}

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -28,3 +28,7 @@ func testIsolationError() async {
 func testArgumentError(_ x: NonSendableType) async { // expected-note {{value is task isolated since it is in the same region as 'x'}}
   await transferToMain(x) // expected-error {{task isolated value of type 'NonSendableType' transferred to main actor-isolated context; later accesses to value could race}}
 }
+
+func testTransferringArgument(_ x: NonSendableType) async {
+  transferValue(x) // expected-error {{task isolated value of type 'NonSendableType' passed as a strongly transferred parameter; later accesses could race}}
+}


### PR DESCRIPTION
The main part of this PR is that I made it so that warnings are now errors that are limited to warnings until Swift 6. While doing this I discovered:

1. We were not properly handling cases where we were assigning a parameter into a different transferring parameter. I fixed that in this PR.
2. I also discovered that when we were failing, we were crashing when we really should have been emitting a "We don't understand what is happening, file a bug" error since those are more discoverable than a crash for a user.

rdar://121755281