### PR TITLE
Rework the representation and handling of type attributes

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1213,8 +1213,8 @@ enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind : size_t {
 SWIFT_NAME("BridgedTypeAttrKind.init(from:)")
 BridgedTypeAttrKind BridgedTypeAttrKind_fromString(BridgedStringRef cStr);
 
-SWIFT_NAME("BridgedTypeAttributes.init()")
-BridgedTypeAttributes BridgedTypeAttributes_create(void);
+SWIFT_NAME("BridgedTypeAttributes.init(context:)")
+BridgedTypeAttributes BridgedTypeAttributes_create(BridgedASTContext cContext);
 
 SWIFT_NAME("BridgedTypeAttributes.addSimpleAttr(self:kind:atLoc:attrLoc:)")
 void BridgedTypeAttributes_addSimpleAttr(BridgedTypeAttributes cAttributes,
@@ -1259,10 +1259,9 @@ BridgedArrayTypeRepr BridgedArrayTypeRepr_createParsed(
     BridgedSourceLoc cLSquareLoc, BridgedSourceLoc cRSquareLoc);
 
 SWIFT_NAME(
-    "BridgedAttributedTypeRepr.createParsed(_:base:consumingAttributes:)")
+    "BridgedAttributedTypeRepr.createParsed(base:consumingAttributes:)")
 BridgedAttributedTypeRepr
-BridgedAttributedTypeRepr_createParsed(BridgedASTContext cContext,
-                                       BridgedTypeRepr base,
+BridgedAttributedTypeRepr_createParsed(BridgedTypeRepr base,
                                        BridgedTypeAttributes cAttributes);
 
 SWIFT_NAME("BridgedCompositionTypeRepr.createEmpty(_:anyKeywordLoc:)")

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -42,68 +42,97 @@
                    DECL_ATTR_ALIAS(SPELLING, CLASS)
 #endif
 
-#ifndef TYPE_ATTR
-#define TYPE_ATTR(X)
+// A type attribute that is both a simple type attribute and a
+// SIL type attribute (see below).  Delegates to SIL_TYPE_ATTR if that
+// is set and SIMPLE_TYPE_ATTR is not; otherwise delegates to SIMPLE_TYPE_ATTR.
+#ifndef SIMPLE_SIL_TYPE_ATTR
+#ifdef SIL_TYPE_ATTR
+#ifdef SIMPLE_TYPE_ATTR
+#error ambiguous delegation, must set SIMPLE_SIL_TYPE_ATTR explicitly
+#else
+#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) SIL_TYPE_ATTR(SPELLING, CLASS)
+#endif
+#else
+#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) SIMPLE_TYPE_ATTR(SPELLING, CLASS)
+#endif
 #endif
 
+// Any kind of type attribute.
+#ifndef TYPE_ATTR
+#define TYPE_ATTR(SPELLING, CLASS)
+#endif
+
+// A type attribute that is only valid in SIL mode.  Usually this means
+// that it's only valid in lowered types, but sometimes SIL files
+// also allow things in formal types that aren't normally expressible.
+#ifndef SIL_TYPE_ATTR
+#define SIL_TYPE_ATTR(SPELLING, CLASS) TYPE_ATTR(SPELLING, CLASS)
+#endif
+
+// A type attribute that's always just spelled `@identifier` in source.
+#ifndef SIMPLE_TYPE_ATTR
+#define SIMPLE_TYPE_ATTR(SPELLING, CLASS) TYPE_ATTR(SPELLING, CLASS)
+#endif
+
+
 // Type attributes
-TYPE_ATTR(autoclosure)
-TYPE_ATTR(convention)
-TYPE_ATTR(noescape)
-TYPE_ATTR(escaping)
-TYPE_ATTR(differentiable)
-TYPE_ATTR(noDerivative)
-TYPE_ATTR(async)
-TYPE_ATTR(Sendable)
-TYPE_ATTR(retroactive)
-TYPE_ATTR(unchecked)
-TYPE_ATTR(preconcurrency)
-TYPE_ATTR(_local)
-TYPE_ATTR(_noMetadata)
-TYPE_ATTR(_opaqueReturnTypeOf)
+SIMPLE_TYPE_ATTR(autoclosure, Autoclosure)
+TYPE_ATTR(convention, Convention)
+SIMPLE_TYPE_ATTR(noescape, NoEscape)
+SIMPLE_TYPE_ATTR(escaping, Escaping)
+TYPE_ATTR(differentiable, Differentiable)
+SIMPLE_TYPE_ATTR(noDerivative, NoDerivative)
+SIMPLE_TYPE_ATTR(async, Async)
+SIMPLE_TYPE_ATTR(Sendable, Sendable)
+SIMPLE_TYPE_ATTR(retroactive, Retroactive)
+SIMPLE_TYPE_ATTR(unchecked, Unchecked)
+SIMPLE_TYPE_ATTR(preconcurrency, Preconcurrency)
+SIMPLE_TYPE_ATTR(_local, Local)
+SIMPLE_TYPE_ATTR(_noMetadata, NoMetadata)
+TYPE_ATTR(_opaqueReturnTypeOf, OpaqueReturnTypeOf)
 
 // SIL-specific attributes
-TYPE_ATTR(block_storage)
-TYPE_ATTR(box)
-TYPE_ATTR(dynamic_self)
-#define REF_STORAGE(Name, name, ...) TYPE_ATTR(sil_##name)
+SIMPLE_SIL_TYPE_ATTR(block_storage, BlockStorage)
+SIMPLE_SIL_TYPE_ATTR(box, Box)
+SIMPLE_SIL_TYPE_ATTR(dynamic_self, DynamicSelf)
+#define REF_STORAGE(Name, name, ...) SIMPLE_TYPE_ATTR(sil_##name, SIL##Name)
 #include "swift/AST/ReferenceStorage.def"
-TYPE_ATTR(error)
-TYPE_ATTR(error_indirect)
-TYPE_ATTR(error_unowned)
-TYPE_ATTR(out)
-TYPE_ATTR(direct)
-TYPE_ATTR(in)
-TYPE_ATTR(inout)
-TYPE_ATTR(inout_aliasable)
-TYPE_ATTR(in_guaranteed)
-TYPE_ATTR(in_constant)
-TYPE_ATTR(pack_owned)
-TYPE_ATTR(pack_guaranteed)
-TYPE_ATTR(pack_inout)
-TYPE_ATTR(pack_out)
-TYPE_ATTR(owned)
-TYPE_ATTR(unowned_inner_pointer)
-TYPE_ATTR(guaranteed)
-TYPE_ATTR(autoreleased)
-TYPE_ATTR(callee_owned)
-TYPE_ATTR(callee_guaranteed)
-TYPE_ATTR(objc_metatype)
-TYPE_ATTR(opened)
-TYPE_ATTR(pack_element)
-TYPE_ATTR(pseudogeneric)
-TYPE_ATTR(unimplementable)
-TYPE_ATTR(yields)
-TYPE_ATTR(yield_once)
-TYPE_ATTR(yield_many)
-TYPE_ATTR(captures_generics)
+SIMPLE_SIL_TYPE_ATTR(error, Error)
+SIMPLE_SIL_TYPE_ATTR(error_indirect, ErrorIndirect)
+SIMPLE_SIL_TYPE_ATTR(error_unowned, ErrorUnowned)
+SIMPLE_SIL_TYPE_ATTR(out, Out)
+SIMPLE_SIL_TYPE_ATTR(direct, Direct)
+SIMPLE_SIL_TYPE_ATTR(in, In)
+SIMPLE_SIL_TYPE_ATTR(inout, Inout)
+SIMPLE_SIL_TYPE_ATTR(inout_aliasable, InoutAliasable)
+SIMPLE_SIL_TYPE_ATTR(in_guaranteed, InGuaranteed)
+SIMPLE_SIL_TYPE_ATTR(in_constant, InConstant)
+SIMPLE_SIL_TYPE_ATTR(pack_owned, PackOwned)
+SIMPLE_SIL_TYPE_ATTR(pack_guaranteed, PackGuaranteed)
+SIMPLE_SIL_TYPE_ATTR(pack_inout, PackInout)
+SIMPLE_SIL_TYPE_ATTR(pack_out, PackOut)
+SIMPLE_SIL_TYPE_ATTR(owned, Owned)
+SIMPLE_SIL_TYPE_ATTR(unowned_inner_pointer, UnownedInnerPointer)
+SIMPLE_SIL_TYPE_ATTR(guaranteed, Guaranteed)
+SIMPLE_SIL_TYPE_ATTR(autoreleased, Autoreleased)
+SIMPLE_SIL_TYPE_ATTR(callee_owned, CalleeOwned)
+SIMPLE_SIL_TYPE_ATTR(callee_guaranteed, CalleeGuaranteed)
+SIMPLE_SIL_TYPE_ATTR(objc_metatype, ObjCMetatype)
+SIL_TYPE_ATTR(opened, Opened)
+SIL_TYPE_ATTR(pack_element, PackElement)
+SIMPLE_SIL_TYPE_ATTR(pseudogeneric, Pseudogeneric)
+SIMPLE_SIL_TYPE_ATTR(unimplementable, Unimplementable)
+SIMPLE_SIL_TYPE_ATTR(yields, Yields)
+SIMPLE_SIL_TYPE_ATTR(yield_once, YieldOnce)
+SIMPLE_SIL_TYPE_ATTR(yield_many, YieldMany)
+SIMPLE_SIL_TYPE_ATTR(captures_generics, CapturesGenerics)
 // Used at the SIL level to mark a type as moveOnly.
-TYPE_ATTR(moveOnly)
-TYPE_ATTR(isolated)
+SIMPLE_SIL_TYPE_ATTR(moveOnly, MoveOnly)
+SIMPLE_SIL_TYPE_ATTR(isolated, Isolated)
 
 // SIL metatype attributes.
-TYPE_ATTR(thin)
-TYPE_ATTR(thick)
+SIMPLE_SIL_TYPE_ATTR(thin, Thin)
+SIMPLE_SIL_TYPE_ATTR(thick, Thick)
 
 // Declaration Attributes and Modifers
 DECL_ATTR(_silgen_name, SILGenName,
@@ -548,6 +577,9 @@ SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
   OnAbstractFunction | OnSubscript | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   155)
 
+#undef SIMPLE_SIL_TYPE_ATTR
+#undef SIMPLE_TYPE_ATTR
+#undef SIL_TYPE_ATTR
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -141,9 +141,16 @@ enum : unsigned { NumDeclAttrKindBits =
 
 // Define enumerators for each type attribute, e.g. TAK_weak.
 enum TypeAttrKind {
-#define TYPE_ATTR(X) TAK_##X,
+#define TYPE_ATTR(X, C) TAK_##X,
 #include "swift/AST/Attr.def"
-  TAK_Count
+};
+
+enum : unsigned {
+#define TYPE_ATTR(X, C) _counting_TAK_##X,
+#include "swift/AST/Attr.def"
+  NumTypeAttrKinds,
+
+  NumTypeAttrKindBits = countBitsUsed(NumTypeAttrKinds - 1)
 };
 
 } // end namespace swift

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6078,8 +6078,8 @@ ERROR(sil_function_input_label,PointsToFirstBadToken,
       "SIL function types cannot have labeled inputs", ())
 ERROR(sil_non_coro_yields,PointsToFirstBadToken,
       "non-coroutine SIL function types cannot have @yield results", ())
-ERROR(sil_function_repeat_convention,PointsToFirstBadToken,
-      "repeated %select{parameter|result|callee}0 convention attribute",
+ERROR(sil_function_invalid_convention,PointsToFirstBadToken,
+      "convention attribute isn't valid on a %select{parameter|result|callee}0",
       (unsigned))
 ERROR(ast_subst_function_type,none,
       "substitutions cannot be provided on a formal function type", ())
@@ -6100,6 +6100,9 @@ ERROR(sil_metatype_without_repr,none,
       ())
 ERROR(sil_metatype_multiple_reprs,none,
       "metatypes in SIL can only be one of @thin, @thick, or @objc_metatype",
+      ())
+ERROR(sil_metatype_not_metatype,none,
+      "@thin, @thick, or @objc_metatype can only apply to metatype types in SIL",
       ())
 
 //------------------------------------------------------------------------------

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -90,16 +90,17 @@ class AnyAttrKind {
 
 public:
   AnyAttrKind(TypeAttrKind K) : kind(static_cast<unsigned>(K)), isType(1) {
-    static_assert(TAK_Count < UINT_MAX, "TypeAttrKind is > 31 bits");
+    static_assert(NumTypeAttrKinds < UINT_MAX, "TypeAttrKind is > 31 bits");
   }
   AnyAttrKind(DeclAttrKind K) : kind(static_cast<unsigned>(K)), isType(0) {
     static_assert(DAK_Count < UINT_MAX, "DeclAttrKind is > 31 bits");
   }
-  AnyAttrKind() : kind(TAK_Count), isType(1) {}
+  AnyAttrKind() : kind(NumTypeAttrKinds), isType(1) {}
 
-  /// Returns the TypeAttrKind, or TAK_Count if this is not a type attribute.
-  TypeAttrKind type() const {
-    return isType ? static_cast<TypeAttrKind>(kind) : TAK_Count;
+  /// Returns the TypeAttrKind.
+  llvm::Optional<TypeAttrKind> type() const {
+    if (!isType || kind == NumTypeAttrKinds) return {};
+    return static_cast<TypeAttrKind>(kind);
   }
   /// Returns the DeclAttrKind, or DAK_Count if this is not a decl attribute.
   DeclAttrKind decl() const {

--- a/include/swift/Basic/EnumMap.h
+++ b/include/swift/Basic/EnumMap.h
@@ -1,0 +1,203 @@
+//===--- EnumMap.h - A map optimized for having enum keys -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file defines the EnumMap class template, which is a map data
+///  structure optimized for working with enumerated keys.  It is built on
+///  top of SmallMap, but it replaces the default large map with a flat
+///  heap-allocated array of indexes into the elements, which is reasonable
+///  for small-ish enums.
+///
+///  Currently the map requires the key type to be an enum type.
+///  The expectation is that the enum has a small number of enumerators
+///  which are all in the range 0..<NumValues.  NumValues must be provided
+///  by specializing the EnumTraits class.
+///
+///  The elements of the map remain insertion-ordered for the lifetime of
+///  the map.  There are currently no operations to remove elements.
+///  Iterators are invalidated by insertion.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_ENUMMAP_H
+#define SWIFT_BASIC_ENUMMAP_H
+
+#include "swift/Basic/EnumTraits.h"
+#include "swift/Basic/SmallMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include <type_traits>
+
+namespace swift {
+
+/// The maximum number of elements that the map can have before
+/// it flips from brute-force searching the keys to using a sparse
+/// array.
+static constexpr size_t DefaultEnumMapDirectSearchLimit =
+  DefaultSmallMapDirectSearchLimit;
+
+/// The primary customization point for an EnumMap.
+///
+/// template <>
+/// struct EnumMapTraits<MyKey> {
+///   using IndexType = <some integer type>;
+///   struct LargeMapStorage {
+///     std::optional<IndexType> find(IndexType) const;
+///     std::pair<IndexType, bool> insert(IndexType key, IndexType value);
+///   };
+/// };
+template <class Key, class KeyTraits = EnumTraits<Key>>
+struct EnumMapTraits;
+
+template <class Key, class Value,
+          size_t DirectSearchLimit = DefaultEnumMapDirectSearchLimit,
+          class MapTraits = EnumMapTraits<Key>,
+          class ElementStorage = llvm::SmallVector<Value>>
+class EnumMap {
+  using IndexType = typename MapTraits::IndexType;
+
+  // EnumMapTraits is currently designed to be usable directly as a
+  // SmallMapTraits.
+  using MapType =
+    SmallMap<IndexType, Value, DirectSearchLimit, MapTraits, ElementStorage>;
+  MapType map;
+
+public:
+  bool empty() const { return map.empty(); }
+  size_t size() const { return map.size(); }
+
+  using iterator = typename MapType::iterator;
+  iterator begin() { return map.begin(); }
+  iterator end() { return map.end(); }
+
+  using const_iterator = typename MapType::const_iterator;
+  const_iterator begin() const { return map.begin(); }
+  const_iterator end() const { return map.end(); }
+
+  /// Look up a key in the map.  Returns end() if the entry is not found.
+  const_iterator find(Key key) const {
+    return map.find(IndexType(key));
+  }
+
+  /// Try to insert the given key/value pair.  If there's already an element
+  /// with this key, return false and an iterator for the existing element.
+  /// Otherwise, return true and an iterator for the new element.
+  ///
+  /// The value in the set will be constructed by emplacing it with the
+  /// given arguments.
+  template <class... Args>
+  std::pair<iterator, bool> insert(Key key, Args &&...valueArgs) {
+    return map.insert(IndexType(key), std::forward<Args>(valueArgs)...);
+  }
+};
+
+namespace EnumMapImpl {
+
+template <size_t N,
+          bool SmallEnoughForUInt8 = (N < (1U << 8)),
+          bool SmallEnoughForUInt16 = (N < (1U << 16))>
+struct SufficientIntFor;
+
+template <size_t N>
+struct SufficientIntFor<N, true, true> {
+  using type = uint8_t;
+};
+
+template <size_t N>
+struct SufficientIntFor<N, false, true> {
+  using type = uint16_t;
+};
+
+template <size_t N>
+struct SufficientIntFor<N, false, false> {
+  static_assert(N < (1ULL << 32), "just how large is this \"enum\" exactly");
+  using type = uint32_t;
+};
+
+/// A map from integers in 0..<N to integers in 0..<N, implemented as a
+/// flat array of integers in 0...N, with zero meaning a missing entry.
+///
+/// This is a great implementation for N <= 255, where the
+/// entire flat array is <= 256 bytes.  It gets increasingly marginal
+/// for N up to ~1K or so (unless we really expect to have entries
+/// for a large proportion of the enum).  Past that, we should probably
+/// be falling back on something like a hashtable, because needing tens
+/// of kilobytes to hold as few as 17 entries is objectively unreasonable.
+template <size_t N>
+class FlatMap {
+public:
+  using IndexType = typename SufficientIntFor<N>::type;
+  using StoredIndexType = typename SufficientIntFor<N + 1>::type;
+
+private:
+  StoredIndexType *ptr;
+
+public:
+  FlatMap() : ptr(new StoredIndexType[N]) {
+    memset(ptr, 0, N * sizeof(StoredIndexType));
+  }
+  FlatMap(FlatMap &&other)
+      : ptr(other.ptr) {
+    other.ptr = nullptr;
+  }
+  FlatMap &operator=(FlatMap &&other) {
+    delete ptr;
+    ptr = other.ptr;
+    other.ptr = nullptr;
+  }
+  FlatMap(const FlatMap &other)
+      : ptr(new StoredIndexType[N]) {
+    memcpy(ptr, other.ptr, N * sizeof(StoredIndexType));
+  }
+  FlatMap &operator=(const FlatMap &other) {
+    memcpy(ptr, other.ptr, N * sizeof(StoredIndexType));
+  }
+
+  ~FlatMap() {
+    delete ptr;
+  }
+
+  std::pair<IndexType, bool> insert(IndexType key, IndexType value) {
+    assert(key < N);
+    StoredIndexType &entry = ptr[key];
+    if (entry == 0) {
+      entry = StoredIndexType(value) + 1;
+      return std::make_pair(value, true);
+    } else {
+      return std::make_pair(IndexType(entry - 1), false);
+    }
+  }
+
+  std::optional<IndexType> find(IndexType key) const {
+    assert(key < N);
+    StoredIndexType entry = ptr[key];
+    if (entry == 0) {
+      return std::nullopt;
+    } else {
+      return IndexType(entry - 1);
+    }
+  };
+};
+
+} // end namespace EnumMapImpl
+
+/// The default implementation of EnumMapTraits.
+template <class Key_, class KeyTraits_>
+struct EnumMapTraits {
+  using Key = Key_;
+  using KeyTraits = KeyTraits_;
+
+  using LargeMapStorage = EnumMapImpl::FlatMap<KeyTraits::NumValues>;
+  using IndexType = typename LargeMapStorage::IndexType;
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/Basic/EnumTraits.h
+++ b/include/swift/Basic/EnumTraits.h
@@ -1,0 +1,34 @@
+//===--- EnumTraits.h - Traits for densely-packed enums ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file defines the EnumTraits concept, which can be used to
+///  communicate information about an enum type's enumerators that currently
+///  can't be recovered from the compiler.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_ENUMTRAITS_H
+#define SWIFT_BASIC_ENUMTRAITS_H
+
+namespace swift {
+
+/// A simple traits concept for recording the number of cases in an enum.
+///
+///  template <> class EnumTraits<WdigetKind> {
+///    static constexpr size_t NumValues = NumWidgetKinds;
+///  };
+template <class E>
+struct EnumTraits;
+
+} // end namespace swift
+
+#endif

--- a/include/swift/Basic/SmallMap.h
+++ b/include/swift/Basic/SmallMap.h
@@ -1,0 +1,352 @@
+//===--- SmallMap.h - A map optimized for having few entries ----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file defines the SmallMap data structure, which is optimized for
+///  a small number of keys.  The values of the map are stored in a dynamic
+///  array (such a SmallVector).  Iterating the map iterates these values
+///  in insertion order.  If the number of entries is small (not more than
+///  the "direct search limit"), the keys are stored in an inline array
+///  that is parallel to the elements array, and lookups brute-force search
+///  this array for the key and then use the element with the same index.  If
+///  the number of entries grows beyond that limit, the map fall back to a
+///  "large" map of keys to indexes, which defaults to a DenseMap<Key, size_t>.
+///
+///  There are currently no operations to remove elements.
+///  Iterators are invalidated by insertion.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_SMALLMAP_H
+#define SWIFT_BASIC_SMALLMAP_H
+
+#include "swift/Basic/Range.h"
+#include "swift/Basic/UninitializedArray.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+namespace swift {
+
+/// The maximum number of elements that the map can have before
+/// it flips from brute-force searching the keys to using the
+/// large map structure.
+static constexpr size_t DefaultSmallMapDirectSearchLimit = 16;
+
+/// The primary customization point for a SmallMap.
+///
+/// template <>
+/// struct SmallMapTraits<MyKey> {
+///   using IndexType = <some integer type>;
+///   struct LargeMapStorage {
+///     std::optional<IndexType> find(const MyKey &key) const;
+///     std::pair<IndexType, bool> insert(MyKey &&key, IndexType value);
+///   };
+/// };
+template <class Key>
+struct SmallMapTraits;
+
+template <class Key, class Value,
+          size_t DirectSearchLimit = DefaultSmallMapDirectSearchLimit,
+          class MapTraits = SmallMapTraits<Key>,
+          class ElementStorage = llvm::SmallVector<Value>>
+class SmallMap {
+  using IndexType = typename MapTraits::IndexType;
+  using LargeMapStorage = typename MapTraits::LargeMapStorage;
+  using SmallMapStorage = UninitializedArray<Key, DirectSearchLimit>;
+
+  static_assert(std::is_integral_v<IndexType>,
+                "index type must be an integer type");
+
+  ElementStorage elements;
+
+  union {
+    LargeMapStorage largeMap;
+    SmallMapStorage smallMap;
+  };
+
+  bool isLarge() const {
+    // This only works because there are no operations to remove entries.
+    return elements.size() > DirectSearchLimit;
+  }
+
+  template <class... Args>
+  void initializeLargeMap(Args &&...args) {
+    ::new ((void*) &largeMap) LargeMapStorage(std::forward<Args>(args)...);
+  }
+  void destroyLargeMap() {
+    largeMap.~LargeMapStorage();
+  }
+
+  void initializeSmallMap() {
+    ::new ((void*) &smallMap) SmallMapStorage();
+  }
+  void destroySmallMap(size_t numElements) {
+    smallMap.destroy(numElements);
+    smallMap.~SmallMapStorage();
+  }
+
+public:
+  SmallMap() {
+    initializeSmallMap();
+  }
+
+  SmallMap(SmallMap &&other)
+      : elements(std::move(other.elements)) {
+
+    // Make sure that the other object has an element count of zero.
+    other.elements.clear();
+    assert(!other.isLarge());
+
+    auto newSize = size();
+    bool newIsLarge = isLarge();
+
+    // Destructively move the other object's map storage to this object.
+    // Postcondition: the other object's map storage is in the small
+    // map state with zero initialized objects.
+    if (newIsLarge) {
+      initializeLargeMap(std::move(other.largeMap));
+      other.destroyLargeMap();
+      other.initializeSmallMap();
+    } else {
+      initializeSmallMap();
+      smallMap.destructiveMoveInitialize(std::move(other.smallMap), newSize);
+    }
+  }
+
+  SmallMap(const SmallMap &other)
+      : elements(other.elements) {
+    auto newSize = size();
+    bool newIsLarge = isLarge();
+    if (newIsLarge) {
+      initializeLargeMap(other.largeMap);
+    } else {
+      initializeSmallMap();
+      smallMap.copyInitialize(other.smallMap, newSize);
+    }
+  }
+
+  SmallMap &operator=(SmallMap &&other) {
+    size_t oldSize = size();
+    bool oldIsLarge = isLarge();
+    elements = std::move(other.elements);
+    size_t newSize = size();
+    bool newIsLarge = isLarge();
+
+    // Make sure that the other object has an element count of zero.
+    other.elements.clear();
+    assert(!other.isLarge());
+
+    // Move the other object's map storage to this object.
+    // Postcondition: the other object's map storage is in the small
+    // map state with zero initialized objects.
+
+    // large -> large
+    if (oldIsLarge && newIsLarge) {
+      largeMap = std::move(other.largeMap);
+      other.destroyLargeMap();
+      other.initializeSmallMap();
+
+    // large -> small
+    } else if (oldIsLarge) {
+      destroyLargeMap();
+      initializeSmallMap();
+      smallMap.destructiveMoveInitialize(std::move(other.smallMap), newSize);
+
+    // small -> large
+    } else if (newIsLarge) {
+      destroySmallMap(oldSize);
+      initializeLargeMap(std::move(other.largeMap));
+      other.destroyLargeMap();
+      other.initializeSmallMap();
+
+    // small -> small
+    } else {
+      smallMap.destructiveMoveAssign(std::move(other.smallMap), oldSize, newSize);
+    }
+
+    return *this;
+  }
+
+  SmallMap &operator=(const SmallMap &other) {
+    size_t oldSize = size();
+    bool oldIsLarge = isLarge();
+
+    // Copy the other object's elements to this object.
+    elements = other.elements;
+
+    size_t newSize = size();
+    bool newIsLarge = isLarge();
+
+    // Copy the other object's map storage to this object:
+
+    // large -> large
+    if (oldIsLarge && newIsLarge) {
+      largeMap = other.largeMap;
+
+    // large -> small
+    } else if (oldIsLarge) {
+      destroyLargeMap();
+      initializeSmallMap();
+      smallMap.copyInitialize(other.smallMap, newSize);
+
+    // small -> large
+    } else if (newIsLarge) {
+      destroySmallMap(oldSize);
+      initializeLargeMap(other.largeMap);
+
+    // small -> small
+    } else {
+      smallMap.copyAssign(other.smallMap, oldSize, newSize);
+    }
+
+    return *this;
+  }
+
+  ~SmallMap() {
+    if (isLarge()) {
+      destroyLargeMap();
+    } else {
+      destroySmallMap(size());
+    }
+  }
+
+  bool empty() const { return elements.empty(); }
+  size_t size() const { return elements.size(); }
+
+  using iterator = typename ElementStorage::iterator;
+  iterator begin() { return elements.begin(); }
+  iterator end() { return elements.end(); }
+
+  using const_iterator = typename ElementStorage::const_iterator;
+  const_iterator begin() const { return elements.begin(); }
+  const_iterator end() const { return elements.end(); }
+
+  /// Look up a key in the map.  Returns end() if the entry is not found.
+  const_iterator find(const Key &key) const {
+    if (isLarge()) {
+      std::optional<IndexType> result = largeMap.find(key);
+      if (result)
+        return elements.begin() + *result;
+      return elements.end();
+    }
+
+    size_t n = elements.size();
+    for (size_t i : range(n))
+      if (smallMap[i] == key)
+        return elements.begin() + i;
+
+    return elements.end();
+  }
+
+  /// Try to insert the given key/value pair.  If there's already an element
+  /// with this key, return false and an iterator for the existing element.
+  /// Otherwise, return true and an iterator for the new element.
+  ///
+  /// The value in the set will be constructed by emplacing it with the
+  /// given arguments.
+  template <class KeyT, class... Args>
+  std::pair<iterator, bool> insert(KeyT &&key, Args &&...valueArgs) {
+    // The current number of elements, and therefore also the index of
+    // the new element if we create one.
+    auto n = elements.size();
+
+    if (isLarge()) {
+      // Try to insert a map entry pointing to the potential new element.
+      auto result = largeMap.insert(std::forward<KeyT>(key), n);
+
+      // If we successfully inserted, emplace the new element.
+      if (result.second) {
+        assert(result.first == n);
+        elements.emplace_back(std::forward<Args>(valueArgs)...);
+        return {elements.begin() + n, true};
+      }
+
+      // Otherwise, return the existing value.
+      return {elements.begin() + result.first, false};
+    }
+
+    // Search the small map for the key.
+    for (size_t i : range(n))
+      if (smallMap[i] == key)
+        return {elements.begin() + i, false};
+
+    // If that didn't match, we have to insert.  Emplace the new element.
+    elements.emplace_back(std::forward<Args>(valueArgs)...);
+
+    // If we aren't crossing the large-map threshold, just emplace the
+    // new key.
+    if (n < DirectSearchLimit) {
+      smallMap.emplace(n, std::forward<KeyT>(key));
+      return {elements.begin() + n, true};
+    }
+
+    // Otherwise, we need to transition the map from small to large.
+
+    // Move the small map aside.
+    assert(isLarge());
+    SmallMapStorage smallMapCopy;
+    smallMapCopy.destructiveMoveInitialize(std::move(smallMap), n);
+    destroySmallMap(0); // formally end lifetime
+
+    // Initialize the large map with the existing mappings taken from
+    // the moved-aside small map.
+    initializeLargeMap();
+    for (size_t i : range(n)) {
+      auto result = largeMap.insert(std::move(smallMapCopy[i]), i);
+      assert(result.second && result.first == i); (void) result;
+    }
+
+    // Add the new mapping.
+    auto result = largeMap.insert(std::forward<KeyT>(key), n);
+    assert(result.second && result.first == n); (void) result;
+
+    // Destroy the elements of the copied small map, which we moved
+    // into the large map but didn't *destructively* move.
+    smallMapCopy.destroy(n);
+
+    return {elements.begin() + n, true};
+  }
+};
+
+namespace SmallMapImpl {
+
+template <class Key>
+struct DefaultSmallMapTraits {
+  using IndexType = size_t;
+
+  struct LargeMapStorage {
+    llvm::DenseMap<Key, IndexType> map;
+
+    std::optional<IndexType> find(const Key &key) const {
+      auto it = map.find(key);
+      if (it == map.end()) return std::nullopt;
+      return it->second;
+    }
+
+    template <class KeyArg>
+    std::pair<IndexType, bool> insert(KeyArg &&key, IndexType value) {
+      auto result = map.insert(std::make_pair(std::forward<KeyArg>(key), value));
+      return std::make_pair(result.first->second, result.second);
+    }
+  };
+};
+
+} // end namespace SmallMapImpl
+
+template <class Key>
+struct SmallMapTraits : SmallMapImpl::DefaultSmallMapTraits<Key> {};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/Basic/UninitializedArray.h
+++ b/include/swift/Basic/UninitializedArray.h
@@ -1,0 +1,156 @@
+//===--- UninitializedArray.h - Array of uninitialized objects --*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+///  This file defines the UninitializedArray "data structure", which
+///  can hold an uninitialized array of values and provides explicit
+///  operations to copy, move, and destroy them.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_UNINITIALIZEDARRAY_H
+#define SWIFT_BASIC_UNINITIALIZEDARRAY_H
+
+#include <assert.h>
+#include <memory>
+
+namespace swift {
+
+/// An array of uninitialized elements.  The user is responsible for
+/// ensuring that it's used properly.
+template <class T, size_t N>
+class UninitializedArray {
+  union {
+    T elements[N];
+  };
+
+public:
+  UninitializedArray() {}
+  UninitializedArray(const UninitializedArray &other) = delete;
+  UninitializedArray &operator=(const UninitializedArray &other) = delete;
+  UninitializedArray(UninitializedArray &&other) = delete;
+  UninitializedArray &operator=(UninitializedArray &&other) = delete;
+  ~UninitializedArray() {}
+
+  using iterator = T *;
+  using const_iterator = const T *;
+  iterator begin() { return elements; }
+  const_iterator begin() const { return elements; }
+  // We intentionally don't provide end() because it's too easy to use it
+  // accidentally when there's no guarantee that those elements exist.
+
+  template <class... Args>
+  T &emplace(size_t i, Args &&...args) {
+    assert(i < N);
+    return *::new ((void*) &elements[i]) T(std::forward<Args>(args)...);
+  }
+
+  T &operator[](size_t i) {
+    assert(i < N);
+    return elements[i];
+  }
+
+  const T &operator[](size_t i) const {
+    assert(i < N);
+    return elements[i];
+  }
+
+  /// Given that this array contains no initialized elements and the other
+  /// array contains at least newSize initialized elements, fill this array
+  /// with newSize initialized elements copied from the other array.
+  void copyInitialize(const UninitializedArray &other, size_t newSize) {
+    assert(newSize <= N);
+    std::uninitialized_copy(other.begin(), other.begin() + newSize, begin());
+  }
+
+  /// Given that this array contains oldSize initialized elements and the other
+  /// array contains at least newSize initialized elements, fill this array
+  /// with newSize initialized elements copied from the other array.
+  void copyAssign(const UninitializedArray &other,
+                  size_t oldSize, size_t newSize) {
+    assert(oldSize <= N);
+    assert(newSize <= N);
+
+    auto commonSize = std::min(oldSize, newSize);
+    auto thisBegin = begin();
+    auto otherBegin = other.begin();
+
+    // Copy-assign the common prefix.
+    std::copy(otherBegin, otherBegin + commonSize, thisBegin);
+
+    // If there are more elements in the other array, copy-initialize those
+    // elements into this array starting after the common prefix.
+    if (oldSize < newSize) {
+      std::uninitialized_copy(otherBegin + commonSize, otherBegin + newSize,
+                              thisBegin + commonSize);
+
+    // Otherwise, if there were more elements in this array, destroy the
+    // excess elements.
+    } else if (oldSize > newSize) {
+      std::destroy(thisBegin + commonSize, thisBegin + oldSize);
+    }
+  }
+
+  /// Given that this array contains no initialized elements and the other
+  /// array contains exactly newSize initialized elements, fill this array
+  /// with newSize initialized elements destructively moved from the other
+  /// array.  The other array is left with no initialized elements.
+  void destructiveMoveInitialize(UninitializedArray &&other, size_t newSize) {
+    assert(newSize <= N);
+    auto it = std::move_iterator(other.begin());
+    std::uninitialized_copy(it, it + newSize, begin());
+    std::destroy(other.begin(), other.begin() + newSize);
+  }
+
+  /// Given that this array contains oldSize initialized elements and the other
+  /// array contains exactly newSize initialized elements, fill this array with
+  /// newSize initialized elements destructively moved from the other array.
+  /// The other array is left with no initialized elements.
+  void destructiveMoveAssign(UninitializedArray &&other,
+                             size_t oldSize, size_t newSize) {
+    assert(oldSize <= N);
+    assert(newSize <= N);
+
+    auto commonSize = std::min(oldSize, newSize);
+    auto thisBegin = begin();
+    auto otherBegin = std::move_iterator(other.begin());
+
+    // Move-assign the common prefix.  Note that we use a move_iterator to
+    // cause all these "copies" to be moves.
+    std::copy(otherBegin, otherBegin + commonSize, thisBegin);
+
+    // If there are more elements in the new array, move-initialize those
+    // elements starting after the common prefix.
+    if (oldSize < newSize) {
+      std::uninitialized_copy(otherBegin + commonSize, otherBegin + newSize,
+                              thisBegin + commonSize);
+
+    // Otherwise, if there were more elements in this array, destroy the
+    // excess elements.
+    } else if (oldSize > newSize) {
+      std::destroy(thisBegin + commonSize, thisBegin + oldSize);
+    }
+
+    // Destroy all of the elements in the other array.
+    std::destroy(other.begin(), other.begin() + oldSize);
+  }
+
+  /// Given thait this array contains exactly oldSize initialized elements,
+  /// destroy those elements, leaving it with no initialized elements.
+  void destroy(size_t oldSize) {
+    assert(oldSize <= N);
+    std::destroy(begin(), begin() + oldSize);
+  }
+};
+
+} // end namespace swift
+
+#endif

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2310,7 +2310,9 @@ static bool isDefaultInitializable(const TypeRepr *typeRepr, ASTContext &ctx) {
   // Look through most attributes.
   if (const auto attributed = dyn_cast<AttributedTypeRepr>(typeRepr)) {
     // Ownership kinds have optionalness requirements.
-    if (optionalityOf(attributed->getAttrs().getOwnership()) ==
+    // FIXME: this is checking for *SIL* ownership; normal weak/unowned/etc.
+    // are decl attributes.  Is this actually an important check to do?
+    if (optionalityOf(attributed->getSILOwnership()) ==
         ReferenceOwnershipOptionality::Required)
       return true;
 

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -389,7 +389,7 @@ extension ASTGenVisitor {
 
     // Handle type attributes.
     if !node.attributes.isEmpty {
-      let typeAttributes = BridgedTypeAttributes()
+      let typeAttributes = BridgedTypeAttributes(context: self.ctx)
       for attributeElt in node.attributes {
         // FIXME: Ignoring #ifs entirely. We want to provide a filtered view,
         // but we don't have that ability right now.
@@ -436,7 +436,6 @@ extension ASTGenVisitor {
       if (!typeAttributes.isEmpty) {
         type =
           BridgedAttributedTypeRepr.createParsed(
-            self.ctx,
             base: type,
             consumingAttributes: typeAttributes
           ).asTypeRepr

--- a/lib/Refactoring/MemberwiseInitLocalRefactoring.cpp
+++ b/lib/Refactoring/MemberwiseInitLocalRefactoring.cpp
@@ -38,7 +38,7 @@ static void generateMemberwiseInit(SourceEditConsumer &EditConsumer,
       // Unconditionally print '@escaping' if we print out a function type -
       // the assignments we generate below will escape this parameter.
       if (isa<AnyFunctionType>(memberData.MemberType->getCanonicalType())) {
-        OS << "@" << TypeAttributes::getAttrName(TAK_escaping) << " ";
+        OS << "@" << TypeAttribute::getAttrName(TAK_escaping) << " ";
       }
       OS << memberData.MemberType.getString();
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3100,7 +3100,7 @@ SerializeAttrGenericSignatureRequest::evaluate(Evaluator &evaluator,
          attr->getTrailingWhereClause()->getRequirements()) {
       if (reqRepr.getKind() == RequirementReprKind::LayoutConstraint) {
         if (auto *attributedTy = dyn_cast<AttributedTypeRepr>(reqRepr.getSubjectRepr())) {
-          if (attributedTy->getAttrs().has(TAK__noMetadata)) {
+          if (attributedTy->has(TAK__noMetadata)) {
             const auto resolution = TypeResolution::forInterface(
                 FD->getDeclContext(), genericSig, llvm::None,
                 /*unboundTyOpener*/ nullptr,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -41,6 +41,7 @@
 #include "swift/AST/TypeLoc.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/AST/TypeResolutionStage.h"
+#include "swift/Basic/EnumMap.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/StringExtras.h"
@@ -1928,12 +1929,16 @@ static Type resolveQualifiedIdentTypeRepr(TypeResolution resolution,
   return maybeDiagnoseBadMemberType(member, memberType, inferredAssocType);
 }
 
+static bool isDefaultNoEscapeContext(TypeResolutionOptions options) {
+  return options.is(TypeResolverContext::FunctionInput) &&
+         !options.contains(TypeResolutionFlags::DirectEscaping) &&
+         !options.hasBase(TypeResolverContext::EnumElementDecl);
+}
+
 // Hack to apply context-specific @escaping to an AST function type.
 static Type applyNonEscapingIfNecessary(Type ty,
                                         TypeResolutionOptions options) {
-  // Remember whether this is a function parameter.
-  bool defaultNoEscape = options.is(TypeResolverContext::FunctionInput) &&
-                         !options.hasBase(TypeResolverContext::EnumElementDecl);
+  bool defaultNoEscape = isDefaultNoEscapeContext(options);
 
   // Desugar here
   auto *funcTy = ty->castTo<FunctionType>();
@@ -1984,7 +1989,7 @@ static bool validateAutoClosureAttributeUse(DiagnosticEngine &Diags,
   // If is a parameter declaration marked as @autoclosure.
   if (options.is(TypeResolverContext::FunctionInput)) {
     if (auto *ATR = dyn_cast<AttributedTypeRepr>(TR)) {
-      const auto attrLoc = ATR->getAttrs().getLoc(TAK_autoclosure);
+      const auto attrLoc = ATR->getAttrLoc(TAK_autoclosure);
       if (attrLoc.isValid())
         return validateAutoClosureAttr(Diags, attrLoc, type);
     }
@@ -2044,6 +2049,11 @@ namespace {
     Type WrappedTy;
   };
 
+  using ContextualTypeAttrResolver =
+    llvm::function_ref<bool(TypeAttribute *attr)>;
+
+  class TypeAttrSet;
+
   class TypeResolver {
     const TypeResolution &resolution;
 
@@ -2062,6 +2072,11 @@ namespace {
     DeclContext *getDeclContext() { return resolution.getDeclContext(); }
     const DeclContext *getDeclContext() const {
       return resolution.getDeclContext();
+    }
+
+    bool isSILSourceFile() const {
+      auto SF = getDeclContext()->getParentSourceFile();
+      return (SF && SF->Kind == SourceFileKind::SIL);
     }
 
     /// Short-hand to query the current stage of type resolution.
@@ -2091,30 +2106,29 @@ namespace {
     
     bool diagnoseInvalidPlaceHolder(OpaqueReturnTypeRepr *repr);
 
+    Type resolveGlobalActor(SourceLoc loc, TypeResolutionOptions options,
+                            CustomAttr *&attr, TypeAttrSet &attrs);
+
+    const clang::Type *tryParseClangType(ConventionTypeAttr *conv,
+                                         bool hasConventionCOrBlock);
+
+    NeverNullType resolveAttributedTypeRepr(AttributedTypeRepr *repr,
+                                            TypeResolutionOptions options);
+
+    NeverNullType resolveAttributedType(TypeRepr *underlyingRepr,
+                                        TypeResolutionOptions options,
+                                        TypeAttrSet &attrs);
+
     NeverNullType resolveOpenedExistentialArchetype(
-        TypeAttributes &attrs, TypeRepr *repr,
-        TypeResolutionOptions options);
+        TypeRepr *repr, TypeResolutionOptions options, OpenedTypeAttr *attr);
 
     NeverNullType resolvePackElementArchetype(
-        TypeAttributes &attrs, TypeRepr *repr,
-        TypeResolutionOptions options);
+        TypeRepr *repr, TypeResolutionOptions options, PackElementTypeAttr *attr);
 
-    NeverNullType resolveAttributedType(AttributedTypeRepr *repr,
-                                        TypeResolutionOptions options);
-    NeverNullType resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
-                                        TypeResolutionOptions options);
     NeverNullType
     resolveASTFunctionType(FunctionTypeRepr *repr,
                            TypeResolutionOptions options,
-                           AnyFunctionType::Representation representation =
-                               AnyFunctionType::Representation::Swift,
-                           bool noescape = false,
-                           bool concurrent = false,
-                           const clang::Type *parsedClangFunctionType = nullptr,
-                           DifferentiabilityKind diffKind =
-                               DifferentiabilityKind::NonDifferentiable,
-                           FunctionTypeIsolation isolation =
-                               FunctionTypeIsolation::forNonIsolated());
+                           TypeAttrSet *attrs);
     SmallVector<AnyFunctionType::Param, 8>
     resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
                                  TypeResolutionOptions options,
@@ -2122,15 +2136,12 @@ namespace {
 
     NeverNullType resolveSILFunctionType(
         FunctionTypeRepr *repr, TypeResolutionOptions options,
-        SILCoroutineKind coroutineKind = SILCoroutineKind::None,
-        SILFunctionType::ExtInfoBuilder extInfoBuilder =
-            SILFunctionType::ExtInfoBuilder(),
-        ParameterConvention calleeConvention = DefaultParameterConvention,
-        TypeRepr *witnessmethodProtocol = nullptr);
+        TypeAttrSet *attrs);
     SILParameterInfo resolveSILParameter(TypeRepr *repr,
-                                         TypeResolutionOptions options);
-    SILYieldInfo resolveSILYield(TypeAttributes &remainingAttrs,
-                                 TypeRepr *repr, TypeResolutionOptions options);
+                                         TypeResolutionOptions options,
+                                         TypeAttrSet *yieldAttrs = nullptr);
+    SILYieldInfo resolveSILYield(TypeRepr *repr, TypeResolutionOptions options,
+                                 TypeAttrSet &remainingAttrs);
     bool resolveSILResults(TypeRepr *repr, TypeResolutionOptions options,
                            SmallVectorImpl<SILYieldInfo> &yields,
                            SmallVectorImpl<SILResultInfo> &results,
@@ -2164,7 +2175,7 @@ namespace {
                                     TypeResolutionOptions options);
     NeverNullType resolvePackType(PackTypeRepr *repr,
                                   TypeResolutionOptions options,
-                                  bool direct = false);
+                                  TypeAttrSet *attrs = nullptr);
     NeverNullType resolvePackExpansionType(PackExpansionTypeRepr *repr,
                                            TypeResolutionOptions options);
     NeverNullType resolvePackElement(PackElementTypeRepr *repr,
@@ -2182,9 +2193,14 @@ namespace {
     NeverNullType resolveProtocolType(ProtocolTypeRepr *repr,
                                       TypeResolutionOptions options);
     NeverNullType resolveSILBoxType(SILBoxTypeRepr *repr,
-                                    bool capturesGenerics,
-                                    TypeResolutionOptions options);
+                                    TypeResolutionOptions options,
+                                    TypeAttrSet *attrs);
+    NeverNullType resolveSILReferenceStorage(TypeAttribute *attr,
+                                             NeverNullType ty);
 
+    NeverNullType resolveSILMetatype(TypeRepr *repr,
+                                     TypeResolutionOptions options,
+                                     TypeAttribute *thicknessAttr);
     NeverNullType
     buildMetatypeType(MetatypeTypeRepr *repr, Type instanceType,
                       llvm::Optional<MetatypeRepresentation> storedRepr);
@@ -2218,6 +2234,142 @@ namespace {
       silContext->GenericParams = savedParams;
     }
   };
+
+  class TypeAttrSet {
+    const ASTContext &ctx;
+
+    llvm::TinyPtrVector<CustomAttr*> customAttrs;
+    EnumMap<TypeAttrKind, TypeAttribute *> typeAttrs;
+
+    llvm::SmallBitVector claimedCustomAttrs;
+    FixedBitSet<NumTypeAttrKinds> claimedTypeAttrs;
+
+#ifndef NDEBUG
+    bool diagnosedUnclaimed = false;
+#endif
+
+  public:
+    TypeAttrSet(const ASTContext &ctx) : ctx(ctx) {}
+
+    TypeAttrSet(const TypeAttrSet &) = delete;
+    TypeAttrSet &operator=(const TypeAttrSet &) = delete;
+
+    ~TypeAttrSet() {
+      assert(diagnosedUnclaimed);
+    }
+
+    static TypeAttrKind getRepresentative(TypeAttrKind attrKind);
+
+    /// Accumulate attributes from a chain of attributed type reprs,
+    /// and return the first non-attribute type repr.
+    TypeRepr *accumulate(AttributedTypeRepr *typeRepr);
+
+    /// Accumulate attributes from the given array.  Duplicate attributes
+    /// will be diagnosed.
+    void accumulate(ArrayRef<TypeOrCustomAttr> attrs);
+
+    /// Return all of the custom attributes.
+    ArrayRef<CustomAttr*> getCustomAttrs() const {
+      return customAttrs;
+    }
+
+    /// Claim a custom attribute.  It will not be diagnosed as unused.
+    void claim(CustomAttr *attr) {
+      auto it = std::find(customAttrs.begin(), customAttrs.end(), attr);
+      assert(it != customAttrs.end() && "attribute not in set");
+      claimedCustomAttrs.set(it - customAttrs.begin());
+    }
+
+    TypeAttribute *getWithoutClaiming(TypeAttrKind attrKind) {
+      auto it = typeAttrs.find(attrKind);
+      if (it != typeAttrs.end()) {
+        return *it;
+      } else {
+        return nullptr;
+      }
+    }
+
+    /// Claim the attribute matching the given representative kind.
+    /// It will not be diagnosed as unused.
+    TypeAttribute *claim(TypeAttrKind attrKind) {
+      assert(getRepresentative(attrKind) == attrKind);
+      auto it = typeAttrs.find(attrKind);
+      if (it != typeAttrs.end()) {
+        claimedTypeAttrs.insert(it - typeAttrs.begin());
+        return *it;
+      } else {
+        return nullptr;
+      }
+    }
+
+    /// Claim all attributes for which the given function returns true.
+    void claimAllWhere(ContextualTypeAttrResolver resolver) {
+      size_t i = 0;
+      for (TypeAttribute *attr : typeAttrs) {
+        if (resolver(attr))
+          claimedTypeAttrs.insert(i);
+        i++;
+      }
+    }
+
+    /// Claim all attributes for which the given function returns true,
+    /// but process them in reverse source order.
+    void reversedClaimAllWhere(ContextualTypeAttrResolver resolver) {
+      for (size_t i = typeAttrs.size(); i > 0; --i) {
+        TypeAttribute *attr = typeAttrs.begin()[i - 1];
+        if (resolver(attr))
+          claimedTypeAttrs.insert(i - 1);
+      }
+    }
+
+    /// Diagnose any unclaimed attributes left in the set.
+    void diagnoseUnclaimed(const TypeResolution &resolution,
+                           TypeResolutionOptions options,
+                           NeverNullType resolvedType);
+
+  private:
+    void diagnoseConflict(TypeAttrKind representativeKind,
+                          TypeAttribute *firstAttr,
+                          TypeAttribute *secondAttr);
+
+    void diagnoseUnclaimed(CustomAttr *attr,
+                           const TypeResolution &resolution,
+                           TypeResolutionOptions options,
+                           NeverNullType resolvedType);
+
+    void diagnoseUnclaimed(TypeAttribute *attr,
+                           const TypeResolution &resolution,
+                           TypeResolutionOptions options,
+                           NeverNullType resolvedType);
+
+    template<typename ...ArgTypes>
+    InFlightDiagnostic diagnose(ArgTypes &&...Args) const {
+      auto &diags = ctx.Diags;
+      return diags.diagnose(std::forward<ArgTypes>(Args)...);
+    }
+  };
+
+  template <class AttrClass>
+  AttrClass *claim(TypeAttrSet &attrs) {
+    auto attr = attrs.claim(AttrClass::StaticKind);
+    return cast_or_null<AttrClass>(attr);
+  }
+
+  template <class AttrClass>
+  AttrClass *claim(TypeAttrSet *attrs) {
+    return (attrs ? claim<AttrClass>(*attrs) : nullptr);
+  }
+
+  template <class AttrClass>
+  AttrClass *getWithoutClaiming(TypeAttrSet &attrs) {
+    auto attr = attrs.getWithoutClaiming(AttrClass::StaticKind);
+    return cast_or_null<AttrClass>(attr);
+  }
+
+  template <class AttrClass>
+  AttrClass *getWithoutClaiming(TypeAttrSet *attrs) {
+    return (attrs ? getWithoutClaiming<AttrClass>(*attrs) : nullptr);
+  }
 } // end anonymous namespace
 
 Type TypeResolution::resolveContextualType(
@@ -2440,7 +2592,7 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
     return ErrorType::get(getASTContext());
 
   case TypeReprKind::Attributed:
-    return resolveAttributedType(cast<AttributedTypeRepr>(repr), options);
+    return resolveAttributedTypeRepr(cast<AttributedTypeRepr>(repr), options);
   case TypeReprKind::Ownership:
     return resolveOwnershipTypeRepr(cast<OwnershipTypeRepr>(repr), options);
   case TypeReprKind::Isolated:
@@ -2458,18 +2610,14 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
     if (!(options & TypeResolutionFlags::SILType)) {
       // Default non-escaping for closure parameters
       auto result =
-          resolveASTFunctionType(cast<FunctionTypeRepr>(repr), options);
-      if (result->is<FunctionType>())
-        return applyNonEscapingIfNecessary(result, options);
+          resolveASTFunctionType(cast<FunctionTypeRepr>(repr), options, nullptr);
       return result;
     }
-    return resolveSILFunctionType(cast<FunctionTypeRepr>(repr), options);
+    return resolveSILFunctionType(cast<FunctionTypeRepr>(repr), options, nullptr);
   }
   case TypeReprKind::SILBox:
     assert((options & TypeResolutionFlags::SILType) && "SILBox repr in non-SIL type context?!");
-    return resolveSILBoxType(cast<SILBoxTypeRepr>(repr),
-                             /*captures generics*/ false,
-                             options);
+    return resolveSILBoxType(cast<SILBoxTypeRepr>(repr), options, nullptr);
 
   case TypeReprKind::Array:
     return resolveArrayType(cast<ArrayTypeRepr>(repr), options);
@@ -2660,22 +2808,11 @@ static Type rebuildWithDynamicSelf(ASTContext &Context, Type ty) {
   }
 }
 
-NeverNullType
-TypeResolver::resolveAttributedType(AttributedTypeRepr *repr,
-                                    TypeResolutionOptions options) {
-  // Copy the attributes, since we're about to start hacking on them.
-  TypeAttributes attrs = repr->getAttrs();
-  assert(!attrs.empty());
-
-  return resolveAttributedType(attrs, repr->getTypeRepr(), options);
-}
-
 /// In SIL, handle '@opened(UUID, constraintType) interfaceType',
 /// which creates an opened archetype.
 NeverNullType
 TypeResolver::resolveOpenedExistentialArchetype(
-    TypeAttributes &attrs, TypeRepr *repr,
-    TypeResolutionOptions options) {
+    TypeRepr *repr, TypeResolutionOptions options, OpenedTypeAttr *openedAttr) {
   assert(silContext);
 
   options.setContext(llvm::None);
@@ -2703,17 +2840,17 @@ TypeResolver::resolveOpenedExistentialArchetype(
 
   // The constraint type is stored inside the attribute. It is resolved
   // normally, as if it were written in the current context.
-  auto constraintType = resolveType(attrs.getConstraintType(), options);
+  auto constraintType = resolveType(openedAttr->getConstraintType(), options);
 
   Type archetypeType;
   if (!constraintType->isExistentialType()) {
-    diagnoseInvalid(repr, attrs.getLoc(TAK_opened),
+    diagnoseInvalid(repr, openedAttr->getAtLoc(),
                     diag::opened_bad_constraint_type,
                     constraintType);
 
     archetypeType = ErrorType::get(constraintType->getASTContext());
   } else if (!interfaceType->isTypeParameter()) {
-    diagnoseInvalid(repr, attrs.getLoc(TAK_opened),
+    diagnoseInvalid(repr, openedAttr->getAtLoc(),
                     diag::opened_bad_interface_type,
                     interfaceType);
 
@@ -2730,10 +2867,8 @@ TypeResolver::resolveOpenedExistentialArchetype(
     archetypeType = OpenedArchetypeType::get(constraintType->getCanonicalType(),
                                              interfaceType,
                                              GenericSignature(),
-                                             attrs.getOpenedID());
+                                             openedAttr->getUUID());
   }
-
-  attrs.clearAttribute(TAK_opened);
 
   return archetypeType;
 }
@@ -2742,26 +2877,22 @@ TypeResolver::resolveOpenedExistentialArchetype(
 /// which creates an opened archetype.
 NeverNullType
 TypeResolver::resolvePackElementArchetype(
-    TypeAttributes &attrs, TypeRepr *repr,
-    TypeResolutionOptions options) {
+    TypeRepr *repr, TypeResolutionOptions options,
+    PackElementTypeAttr *attr) {
   assert(silContext);
-  assert(attrs.has(TAK_pack_element));
-  assert(attrs.OpenedID.has_value());
-
-  attrs.clearAttribute(TAK_pack_element);
 
   auto dc = getDeclContext();
   auto &ctx = dc->getASTContext();
 
   const SILTypeResolutionContext::OpenedPackElement *entry = nullptr;
   if (const auto *openedPacksMap = silContext->OpenedPackElements) {
-    auto it = openedPacksMap->find(*attrs.OpenedID);
+    auto it = openedPacksMap->find(attr->getUUID());
     if (it != openedPacksMap->end()) {
       entry = &it->second;
     }
   }
   if (!entry) {
-    diagnoseInvalid(repr, attrs.getLoc(TAK_pack_element),
+    diagnoseInvalid(repr, attr->getAttrLoc(),
                     diag::sil_pack_element_uuid_not_found);
     return ErrorType::get(ctx);
   }
@@ -2785,7 +2916,7 @@ TypeResolver::resolvePackElementArchetype(
   }();
 
   if (!interfaceType->isTypeParameter()) {
-    diagnoseInvalid(repr, attrs.getLoc(TAK_pack_element),
+    diagnoseInvalid(repr, attr->getAttrLoc(),
                     diag::opened_bad_interface_type,
                     interfaceType);
 
@@ -2796,7 +2927,7 @@ TypeResolver::resolvePackElementArchetype(
   auto archetypeType =
     entry->Environment->mapPackTypeIntoElementContext(interfaceType);
   if (archetypeType->hasError()) {
-    diagnoseInvalid(repr, attrs.getLoc(TAK_pack_element),
+    diagnoseInvalid(repr, attr->getAttrLoc(),
                     diag::opened_bad_interface_type,
                     interfaceType);
   }
@@ -2816,510 +2947,441 @@ static unsigned countIsolatedParamsUpTo(FunctionTypeRepr* fnTy,
   return count;
 }
 
-/// \returns true iff the # of isolated params is > \c lowerBound
-static bool hasMoreIsolatedParamsThan(FunctionTypeRepr* fnTy,
-                                      unsigned lowerBound) {
-  return countIsolatedParamsUpTo(fnTy, lowerBound + 1) > lowerBound;
+// We trick the general infrastructure into diagnosing conflicts between
+// different attributes in the same category by using an arbitrary
+// representative from the category as the key when adding the attribute
+// to the TypeAttrSet.  We then just recognize this case and emit a
+// different diagnostic when diagnosing the conflict.
+//
+// The only basic requirement for categorization this way is that we'll
+// never want to allow two attributes from the same set.  So it's okay
+// that we lump the parameter, result, and error convention attributes
+// into a single category, because it's still invalid to apply e.g.
+// indirect_in and pack_out to the same value, even though one of them
+// is likely also structurally invalid on the value.  (This is useful
+// for that specific case because some of the attributes are used for
+// multiple roles, like `owned`.)
+static constexpr TypeAttrKind TAR_SILValueConvention = TAK_owned;
+static constexpr TypeAttrKind TAR_SILMetatype = TAK_thin;
+static constexpr TypeAttrKind TAR_TypeTransformer = TAK_opened;
+static constexpr TypeAttrKind TAR_SILCoroutine = TAK_yield_once;
+static constexpr TypeAttrKind TAR_SILCalleeConvention = TAK_callee_owned;
+static constexpr TypeAttrKind TAR_SILReferenceStorage = TAK_sil_weak;
+
+TypeAttrKind TypeAttrSet::getRepresentative(TypeAttrKind kind) {
+  switch (kind) {
+  // Most attributes are singleton for the purposes of this analysis.
+  default: return kind;
+
+  case TAK_autoreleased:
+  case TAK_in_guaranteed: 
+  case TAK_in:
+  case TAK_in_constant:
+  case TAK_inout:
+  case TAK_inout_aliasable:
+  case TAK_owned:
+  case TAK_guaranteed:
+  case TAK_pack_owned:
+  case TAK_pack_guaranteed:
+  case TAK_pack_inout:
+  case TAK_out:
+  case TAK_pack_out:
+  case TAK_unowned_inner_pointer:
+  case TAK_error:
+  case TAK_error_indirect:
+  case TAK_error_unowned:
+    return TAR_SILValueConvention;
+
+  case TAK_thin:
+  case TAK_thick:
+  case TAK_objc_metatype:
+    return TAR_SILMetatype;
+
+  case TAK_yield_many:
+  case TAK_yield_once:
+    return TAR_SILCoroutine;
+
+  case TAK_callee_owned:
+  case TAK_callee_guaranteed:
+    return TAR_SILCalleeConvention;
+
+#define REF_STORAGE(Name, name, ...) \
+  case TAK_sil_##name:
+#include "swift/AST/ReferenceStorage.def"
+    return TAR_SILReferenceStorage;
+
+  // These are total transforms on the type, and one of them can apply
+  // at once.
+  case TAK_opened:
+  case TAK_pack_element:
+  case TAK__opaqueReturnTypeOf:
+    return TAR_TypeTransformer;
+  };
 }
 
-NeverNullType
-TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
-                                    TypeResolutionOptions options) {
-  // Convenience to grab the source range of a type attribute.
-  auto getTypeAttrRangeWithAt = [](ASTContext &ctx, SourceLoc attrLoc) {
-    return SourceRange(attrLoc, attrLoc.getAdvancedLoc(1));
-
-  };
-
-  // Remember whether this is a function parameter.
-  bool isParam = options.is(TypeResolverContext::FunctionInput);
-
-  // Remember whether this is a function result.
-  bool isResult = options.is(TypeResolverContext::FunctionResult);
-
-  // Remember whether this is a variadic function parameter.
-  bool isVariadicFunctionParam =
-      options.is(TypeResolverContext::VariadicFunctionInput) &&
-      !options.hasBase(TypeResolverContext::EnumElementDecl);
-
-  // SIL box types have an attribute to indicate when the box contains
-  // the captured generic environment.
-  if (auto box = dyn_cast<SILBoxTypeRepr>(repr)) {
-    return resolveSILBoxType(box, attrs.has(TAK_captures_generics), options);
+TypeRepr *TypeAttrSet::accumulate(AttributedTypeRepr *attrRepr) {
+  while (true) {
+    accumulate(attrRepr->getAttrs());
+    auto underlyingRepr = attrRepr->getTypeRepr();
+    attrRepr = dyn_cast<AttributedTypeRepr>(underlyingRepr);
+    if (!attrRepr) return underlyingRepr;
   }
-  
-  // Resolve global actor.
-  CustomAttr *globalActorAttr = nullptr;
-  auto isolation = FunctionTypeIsolation::forNonIsolated();
-  if (auto fnTy = dyn_cast<FunctionTypeRepr>(repr)) {
-    auto foundGlobalActor = checkGlobalActorAttributes(
-        repr->getLoc(), getDeclContext(),
-        std::vector<CustomAttr *>(
-          attrs.getCustomAttrs().begin(), attrs.getCustomAttrs().end()));
-    if (foundGlobalActor) {
-      globalActorAttr = foundGlobalActor->first;
-      auto globalActor = resolveType(globalActorAttr->getTypeRepr(), options);
-      if (!globalActor->hasError()) {
-        isolation = FunctionTypeIsolation::forGlobalActor(globalActor);
-      }
+}
 
-      // make sure there is no `isolated` parameter in the type
-      if (globalActorAttr->isValid()) {
-        if (isolation.isGlobalActor() && hasMoreIsolatedParamsThan(fnTy, 0)) {
-          diagnose(repr->getLoc(), diag::isolated_parameter_global_actor_type)
-              .warnUntilSwiftVersion(6);
-          globalActorAttr->setInvalid();
-        }
-      }
-    }
-  }
-
-  // Diagnose custom attributes that haven't been processed yet.
-  for (auto customAttr : attrs.getCustomAttrs()) {
-    // If this was the global actor we matched, ignore it.
-    if (globalActorAttr == customAttr) {
-      Decl *decl = nullptr;
-      if (getASTContext().LangOpts.isConcurrencyModelTaskToThread() &&
-          (decl = getDeclContext()->getAsDecl()) &&
-          !AvailableAttr::isUnavailable(decl))
-        diagnose(customAttr->getLocation(),
-                 diag::concurrency_task_to_thread_model_global_actor_annotation,
-                 customAttr->getTypeRepr(), "task-to-thread concurrency model");
+void TypeAttrSet::accumulate(ArrayRef<TypeOrCustomAttr> attrs) {
+  for (auto attr : attrs) {
+    // Just put custom attributes into a separate list.
+    if (auto customAttr = attr.dyn_cast<CustomAttr*>()) {
+      customAttrs.push_back(customAttr);
       continue;
     }
 
-    // If this attribute was marked invalid, ignore it.
-    if (customAttr->isInvalid())
-      continue;
+    auto typeAttr = attr.get<TypeAttribute*>();
+    auto representativeKind = getRepresentative(typeAttr->getKind());
 
-    // Diagnose the attribute, because we don't yet handle custom type
-    // attributes.
-    std::string typeName;
-    if (auto typeRepr = customAttr->getTypeRepr()) {
-      llvm::raw_string_ostream out(typeName);
-      typeRepr->print(out);
-    } else {
-      typeName = customAttr->getType().getString();
-    }
+    // Try to insert the attribute in the set under its representative
+    // kind.  If this succeeds, we don't have a conflict.
+    auto insertResult = typeAttrs.insert(representativeKind, typeAttr);
+    if (insertResult.second) continue;
 
-    diagnose(customAttr->getLocation(), diag::unknown_attribute, typeName);
-    customAttr->setInvalid();
+    // Dignose the conflict.
+    TypeAttribute *previousAttr = *insertResult.first;
+
+    diagnoseConflict(representativeKind, previousAttr, typeAttr);
   }
 
-  // The type we're working with, in case we want to build it differently
-  // based on the attributes we see.
-  Type ty;
-  
-  // If this is a reference to an opaque return type, resolve it.
-  if (auto &opaque = attrs.OpaqueReturnTypeOf) {
-    return resolveOpaqueReturnType(repr, opaque->mangledName, opaque->index,
-                                   options);
-  }
-  
-  // In SIL *only*, allow @thin, @thick, or @objc_metatype to apply to
-  // a metatype.
-  if (attrs.has(TAK_thin) || attrs.has(TAK_thick) || 
-      attrs.has(TAK_objc_metatype)) {
-    if (auto SF = getDeclContext()->getParentSourceFile()) {
-      if (SF->Kind == SourceFileKind::SIL) {
-        if (auto existential = dyn_cast<ExistentialTypeRepr>(repr))
-          repr = existential->getConstraint();
+  claimedCustomAttrs.resize(customAttrs.size());
+}
 
-        TypeRepr *base;
-        if (auto metatypeRepr = dyn_cast<MetatypeTypeRepr>(repr)) {
-          base = metatypeRepr->getBase();
-        } else if (auto protocolRepr = dyn_cast<ProtocolTypeRepr>(repr)) {
-          base = protocolRepr->getBase();
-        } else {
-          base = nullptr;
-        }
+void TypeAttrSet::diagnoseConflict(TypeAttrKind representativeKind,
+                                   TypeAttribute *firstAttr,
+                                   TypeAttribute *secondAttr) {
+  secondAttr->setInvalid();
 
-        if (base) {
-          llvm::Optional<MetatypeRepresentation> storedRepr;
-          // The instance type is not a SIL type.
-          auto instanceOptions = options;
-          TypeResolverContext context = TypeResolverContext::None;
-          if (isa<MetatypeTypeRepr>(repr)) {
-            context = TypeResolverContext::MetatypeBase;
-          } else if (isa<ProtocolTypeRepr>(repr)) {
-            context = TypeResolverContext::ProtocolMetatypeBase;
-          }
-          instanceOptions.setContext(context);
-          instanceOptions -= TypeResolutionFlags::SILType;
-
-          auto instanceTy = resolveType(base, instanceOptions);
-          if (instanceTy->hasError())
-            return instanceTy;
-
-          // Check for @thin.
-          if (attrs.has(TAK_thin)) {
-            storedRepr = MetatypeRepresentation::Thin;
-            attrs.clearAttribute(TAK_thin);
-          }
-
-          // Check for @thick.
-          if (attrs.has(TAK_thick)) {
-            if (storedRepr) {
-              diagnoseInvalid(repr, repr->getStartLoc(),
-                              diag::sil_metatype_multiple_reprs);
-            }
-
-            storedRepr = MetatypeRepresentation::Thick;
-            attrs.clearAttribute(TAK_thick);
-          }
-
-          // Check for @objc_metatype.
-          if (attrs.has(TAK_objc_metatype)) {
-            if (storedRepr) {
-              diagnoseInvalid(repr, repr->getStartLoc(),
-                              diag::sil_metatype_multiple_reprs);
-            }
-            storedRepr = MetatypeRepresentation::ObjC;
-            attrs.clearAttribute(TAK_objc_metatype);
-          }
-
-          if (instanceTy->hasError()) {
-            ty = instanceTy;
-          } else if (auto metatype = dyn_cast<MetatypeTypeRepr>(repr)) {
-            ty = buildMetatypeType(metatype, instanceTy, storedRepr);
-          } else {
-            ty = buildProtocolType(cast<ProtocolTypeRepr>(repr),
-                                   instanceTy, storedRepr);
-          }
-        }
-      }
-    }
+  // Special diagnostic for an exact repeat
+  if (firstAttr->getKind() == secondAttr->getKind()) {
+    diagnose(secondAttr->getStartLoc(), diag::duplicate_attribute,
+             /*modifier*/false)
+      .fixItRemove(secondAttr->getSourceRange());
+    return;
   }
 
-  // Pass down the variable function type attributes to the
-  // function-type creator.
+  // Special diagnostic for SIL metatypes
+  if (representativeKind == TAR_SILMetatype) {
+    diagnose(secondAttr->getStartLoc(), diag::sil_metatype_multiple_reprs);
+    return;
+  }
+
+  // Generic conflict diagnostic
+  diagnose(secondAttr->getStartLoc(), diag::mutually_exclusive_attrs,
+           secondAttr->getAttrName(), firstAttr->getAttrName(),
+           /*modifier*/false);
+}
+
+void TypeAttrSet::diagnoseUnclaimed(const TypeResolution &resolution,
+                                    TypeResolutionOptions options,
+                                    NeverNullType resolvedType) {
+#ifndef NDEBUG
+  assert(!diagnosedUnclaimed && "diagnosing unclaimed attributes twice");
+  diagnosedUnclaimed = true;
+#endif
+
+  // Don't diagnose unclaimed attributes in this stage if we weren't able
+  // to resolve the type.
+  if (resolvedType->is<DependentMemberType>() &&
+      resolution.getStage() == TypeResolutionStage::Structural) {
+    return;
+  }
+
+  // Custom attributes
+  for (size_t i : range(customAttrs.size())) {
+    if (claimedCustomAttrs[i]) continue;
+
+    auto customAttr = customAttrs[i];
+    diagnoseUnclaimed(customAttr, resolution, options, resolvedType);
+  }
+
+  // Type attributes
+  size_t i = 0;
+  for (auto attr : typeAttrs) {
+    if (claimedTypeAttrs.contains(i)) continue;
+    i++;
+
+    diagnoseUnclaimed(attr, resolution, options, resolvedType);
+  }
+}
+
+void TypeAttrSet::diagnoseUnclaimed(CustomAttr *attr,
+                                    const TypeResolution &resolution,
+                                    TypeResolutionOptions options,
+                                    NeverNullType resolvedType) {
+  // Ignore attributes that have already been marked invalid.
+  if (attr->isInvalid()) return;
+
+  attr->setInvalid();
+
+  // Diagnose the attribute, because we don't yet handle custom type
+  // attributes.
+  std::string typeName;
+  if (auto typeRepr = attr->getTypeRepr()) {
+    llvm::raw_string_ostream out(typeName);
+    typeRepr->print(out);
+  } else {
+    typeName = attr->getType().getString();
+  }
+
+  diagnose(attr->getLocation(), diag::unknown_attribute, typeName);
+}
+
+static bool isSILAttribute(TypeAttrKind attrKind) {
+  switch (attrKind) {
+#define SIL_TYPE_ATTR(SPELLING, CLASS) \
+  case TAK_##SPELLING:
+#include "swift/AST/Attr.def"
+  case TAK_noescape: // noescape is only used in SIL now
+    return true;
+
+  default:
+    return false;
+  }
+}
+
+static bool isFunctionAttribute(TypeAttrKind attrKind) {
   static const TypeAttrKind FunctionAttrs[] = {
     TAK_convention, TAK_pseudogeneric, TAK_unimplementable,
     TAK_callee_owned, TAK_callee_guaranteed, TAK_noescape, TAK_autoclosure,
     TAK_differentiable, TAK_escaping, TAK_Sendable,
     TAK_yield_once, TAK_yield_many, TAK_async
   };
+  return llvm::any_of(FunctionAttrs, [attrKind](TypeAttrKind functionAttr) {
+                        return functionAttr == attrKind;
+                      });
+}
 
-  auto checkUnsupportedAttr = [&](TypeAttrKind attr) {
-    if (attrs.has(attr)) {
-      diagnoseInvalid(repr, attrs.getLoc(attr), diag::unknown_attribute,
-                      TypeAttributes::getAttrName(attr));
-      attrs.clearAttribute(attr);
-    }
-  };
-  
-  // Some function representation attributes are not supported at source level;
-  // only SIL knows how to handle them.  Reject them unless this is a SIL input.
-  if (!(options & TypeResolutionFlags::SILType)) {
-    for (auto silOnlyAttr :
-         {TAK_pseudogeneric, TAK_unimplementable, TAK_callee_owned,
-          TAK_callee_guaranteed, TAK_noescape, TAK_yield_once, TAK_yield_many,
-          TAK_isolated}) {
-      checkUnsupportedAttr(silOnlyAttr);
-    }
-  }  
+void TypeAttrSet::diagnoseUnclaimed(TypeAttribute *attr,
+                                    const TypeResolution &resolution,
+                                    TypeResolutionOptions options,
+                                    NeverNullType resolvedType) {
+  if (attr->isInvalid()) return;
 
-  // Other function representation attributes are not normally supported at
-  // source level, but we want to support them there in SIL files.
-  auto SF = getDeclContext()->getParentSourceFile();
-  if (!SF || SF->Kind != SourceFileKind::SIL) {
-    for (auto silOnlyAttr : {TAK_thin, TAK_thick}) {
-      checkUnsupportedAttr(silOnlyAttr);
+  attr->setInvalid();
+
+  // Use a special diagnostic for SIL attributes.
+  if (!(options & TypeResolutionFlags::SILType) &&
+      isSILAttribute(attr->getKind())) {
+    diagnose(attr->getStartLoc(), diag::unknown_attribute, attr->getAttrName());
+    return;
+  }
+
+  // Recognize function attributes being applied to non-functions.
+  if (isFunctionAttribute(attr->getKind()) &&
+      !resolvedType->is<AnyFunctionType>()) {
+    auto escapingAttr = dyn_cast<EscapingTypeAttr>(attr);
+
+    // Try to recognize `@escaping` placed on optional types.
+    if (escapingAttr) {
+      Type optionalObjectType = resolvedType->getOptionalObjectType();
+      if (optionalObjectType && optionalObjectType->is<AnyFunctionType>()) {
+        diagnose(escapingAttr->getAttrLoc(),
+                 diag::escaping_optional_type_argument)
+          .fixItRemove(attr->getSourceRange());
+        return;
+      }
+    }
+
+    auto diagnostic = diagnose(attr->getStartLoc(),
+                               diag::attribute_requires_function_type,
+                               attr->getAttrName());
+    if (isa<EscapingTypeAttr>(attr))
+      diagnostic.fixItRemove(attr->getSourceRange());
+    return;
+  }
+
+  ctx.Diags.diagnose(attr->getStartLoc(), diag::attribute_does_not_apply_to_type);
+}
+
+Type TypeResolver::resolveGlobalActor(SourceLoc loc, TypeResolutionOptions options,
+                                      CustomAttr *&attr, TypeAttrSet &attrs) {
+  auto foundGlobalActor = checkGlobalActorAttributes(
+      loc, getDeclContext(), attrs.getCustomAttrs());
+  if (!foundGlobalActor)
+    return Type();
+
+  attr = foundGlobalActor->first;
+  attrs.claim(attr);
+
+  Type result = resolveType(attr->getTypeRepr(), options);
+
+  // Diagnose use of global actor attributes under the task-to-thread model.
+  if (!result->hasError() && !attr->isInvalid() &&
+      getASTContext().LangOpts.isConcurrencyModelTaskToThread()) {
+    if (Decl *decl = getDeclContext()->getAsDecl()) {
+      if (!AvailableAttr::isUnavailable(decl))
+        diagnose(attr->getLocation(),
+                 diag::concurrency_task_to_thread_model_global_actor_annotation,
+                 attr->getTypeRepr(), "task-to-thread concurrency model");
     }
   }
 
-  // In SIL mode, allow certain attributes to apply to packs.
-  if (options & TypeResolutionFlags::SILType) {
-    if (auto packRepr = dyn_cast<PackTypeRepr>(repr)) {
-      bool direct = attrs.has(TAK_direct);
-      if (direct) attrs.clearAttribute(TAK_direct);
+  return result;
+}
 
-      ty = resolvePackType(packRepr, options, direct);
-    }
+const clang::Type *TypeResolver::tryParseClangType(ConventionTypeAttr *conv,
+                                                   bool hasConventionCOrBlock) {
+  auto clangTypeString = conv->getClangType();
+  auto clangTypeLoc = conv->getClangTypeLoc();
+  if (!clangTypeString || clangTypeString->empty())
+    return nullptr;
+  if (!hasConventionCOrBlock) {
+    diagnose(clangTypeLoc, diag::unexpected_ctype_for_non_c_convention,
+             conv->getConventionName(), *clangTypeString);
+    return nullptr;
   }
 
-  bool hasFunctionAttr = !isolation.isNonIsolated() ||
-      llvm::any_of(FunctionAttrs, [&attrs](const TypeAttrKind &attr) {
-        return attrs.has(attr);
-      });
+  const clang::Type *type =
+      getASTContext().getClangModuleLoader()->parseClangFunctionType(
+          *clangTypeString, clangTypeLoc);
+  if (!type)
+    diagnose(clangTypeLoc, diag::unable_to_parse_c_function_type,
+             *clangTypeString);
+  return type;
+}
 
-  // Function attributes require a syntactic function type.
-  auto *fnRepr = dyn_cast<FunctionTypeRepr>(repr);
+NeverNullType
+TypeResolver::resolveAttributedTypeRepr(AttributedTypeRepr *attrRepr,
+                                        TypeResolutionOptions options) {
+  TypeAttrSet attrs(getASTContext());
+  TypeRepr *underlyingRepr = attrs.accumulate(attrRepr);
 
-  auto tryParseClangType = [this](TypeAttributes::Convention &conv,
-                                  bool hasConventionCOrBlock)
-                           -> const clang::Type * {
-    if (conv.ClangType.Item.empty())
-      return nullptr;
-    if (!hasConventionCOrBlock) {
-      diagnose(conv.ClangType.Loc,
-               diag::unexpected_ctype_for_non_c_convention,
-               conv.Name, conv.ClangType.Item);
-      return nullptr;
-    }
+  auto result = resolveAttributedType(underlyingRepr, options, attrs);
 
-    const clang::Type *type =
-        getASTContext().getClangModuleLoader()->parseClangFunctionType(
-            conv.ClangType.Item, conv.ClangType.Loc);
-    if (!type)
-      diagnose(conv.ClangType.Loc, diag::unable_to_parse_c_function_type,
-               conv.ClangType.Item);
-    return type;
-  };
+  attrs.diagnoseUnclaimed(resolution, options, result);
 
-  if (fnRepr && hasFunctionAttr) {
-    const clang::Type *parsedClangFunctionType = nullptr;
-    if (options & TypeResolutionFlags::SILType) {
-      SILFunctionType::Representation rep;
-      TypeRepr *witnessMethodProtocol = nullptr;
+  return result;
+}
 
-      auto coroutineKind = SILCoroutineKind::None;
-      if (attrs.has(TAK_yield_once)) {
-        coroutineKind = SILCoroutineKind::YieldOnce;
-      } else if (attrs.has(TAK_yield_many)) {
-        coroutineKind = SILCoroutineKind::YieldMany;
-      }
+NeverNullType
+TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions options,
+                                    TypeAttrSet &attrs) {
+  // Adjust the context for the @escaping attribute.  We don't claim here
+  // because we want to diagnose it later if we didn't build a function type.
+  if (getWithoutClaiming<EscapingTypeAttr>(attrs))
+    options |= TypeResolutionFlags::DirectEscaping;
 
-      auto calleeConvention = ParameterConvention::Direct_Unowned;
-      if (attrs.has(TAK_callee_owned)) {
-        if (attrs.has(TAK_callee_guaranteed)) {
-          diagnoseInvalid(repr, attrs.getLoc(TAK_callee_owned),
-                          diag::sil_function_repeat_convention, /*callee*/ 2);
-        }
-        calleeConvention = ParameterConvention::Direct_Owned;
-      } else if (attrs.has(TAK_callee_guaranteed)) {
-        calleeConvention = ParameterConvention::Direct_Guaranteed;
-      }
+  // There are basically three kinds of type attributes:
+  //
+  // - Some attributes are basically totally new type structure, like
+  //   `@opened`, and their presence completely changes how the underlying
+  //   type is interpreted and built.  We have to check for these first.
+  //
+  // - Some attributes are adjustments to specific syntactic forms.
+  //   Generally we just make the attributes available to the resolution
+  //   function for the underlying type.
+  //
+  // - Some attributes apply uniformly to all types, or at least they
+  //   potentially do.  Once we've built the underlying type, we need
+  //   to check for them.
 
-      if (!attrs.hasConvention()) {
-        rep = SILFunctionType::Representation::Thick;
-      } else {
-        auto convention = attrs.getConventionName();
-        // SIL exposes a greater number of conventions than Swift source.
-        auto parsedRep =
-            llvm::StringSwitch<llvm::Optional<SILFunctionType::Representation>>(
-                convention)
-                .Case("thick", SILFunctionType::Representation::Thick)
-                .Case("block", SILFunctionType::Representation::Block)
-                .Case("thin", SILFunctionType::Representation::Thin)
-                .Case("c", SILFunctionType::Representation::CFunctionPointer)
-                .Case("method", SILFunctionType::Representation::Method)
-                .Case("objc_method",
-                      SILFunctionType::Representation::ObjCMethod)
-                .Case("witness_method",
-                      SILFunctionType::Representation::WitnessMethod)
-                .Case("keypath_accessor_getter",
-                      SILFunctionType::Representation::KeyPathAccessorGetter)
-                .Case("keypath_accessor_setter",
-                      SILFunctionType::Representation::KeyPathAccessorSetter)
-                .Case("keypath_accessor_equals",
-                      SILFunctionType::Representation::KeyPathAccessorEquals)
-                .Case("keypath_accessor_hash",
-                      SILFunctionType::Representation::KeyPathAccessorHash)
-                .Default(llvm::None);
-        if (!parsedRep) {
-          diagnoseInvalid(repr, attrs.getLoc(TAK_convention),
-                          diag::unsupported_sil_convention,
-                          attrs.getConventionName());
-          rep = SILFunctionType::Representation::Thin;
-        } else {
-          rep = *parsedRep;
-          parsedClangFunctionType = tryParseClangType(
-              attrs.ConventionArguments.value(), shouldStoreClangType(rep));
-        }
-
-        if (rep == SILFunctionType::Representation::WitnessMethod) {
-          auto protocolName =
-            attrs.ConventionArguments.value().WitnessMethodProtocol;
-          witnessMethodProtocol = new (getASTContext())
-              SimpleIdentTypeRepr(DeclNameLoc(), protocolName);
-        }
-      }
-
-      DifferentiabilityKind diffKind = DifferentiabilityKind::NonDifferentiable;
-      if (attrs.has(TAK_differentiable)) {
-        auto *SF = getDeclContext()->getParentSourceFile();
-        if (SF && isDifferentiableProgrammingEnabled(*SF)) {
-          diffKind = attrs.differentiabilityKind;
-        } else {
-          diagnoseInvalid(
-              repr, attrs.getLoc(TAK_differentiable),
-              diag::
-                  differentiable_programming_attr_used_without_required_module,
-              TypeAttributes::getAttrName(TAK_differentiable),
-              getASTContext().Id_Differentiation);
-        }
-      }
-
-      auto extInfoBuilder = SILFunctionType::ExtInfoBuilder(
-          rep, attrs.has(TAK_pseudogeneric), attrs.has(TAK_noescape),
-          attrs.has(TAK_Sendable), attrs.has(TAK_async),
-          attrs.has(TAK_unimplementable), diffKind,
-          parsedClangFunctionType);
-
-      ty =
-          resolveSILFunctionType(fnRepr, options, coroutineKind, extInfoBuilder,
-                                 calleeConvention, witnessMethodProtocol);
-      if (!ty || ty->hasError())
-        return ty;
+  // These are the total type transforms.
+  Type ty;
+  if (auto attr = attrs.claim(TAR_TypeTransformer)) {
+    if (auto opaqueAttr = dyn_cast<OpaqueReturnTypeOfTypeAttr>(attr)) {
+      ty = resolveOpaqueReturnType(repr, opaqueAttr->getMangledName(),
+                                   opaqueAttr->getIndex(),
+                                   options);
+    } else if (auto openedAttr = dyn_cast<OpenedTypeAttr>(attr)) {
+      ty = resolveOpenedExistentialArchetype(repr, options, openedAttr);
     } else {
-      FunctionType::Representation rep = FunctionType::Representation::Swift;
-      if (attrs.hasConvention()) {
-        auto parsedRep =
-            llvm::StringSwitch<llvm::Optional<FunctionType::Representation>>(
-                attrs.getConventionName())
-                .Case("swift", FunctionType::Representation::Swift)
-                .Case("block", FunctionType::Representation::Block)
-                .Case("thin", FunctionType::Representation::Thin)
-                .Case("c", FunctionType::Representation::CFunctionPointer)
-                .Default(llvm::None);
-        if (!parsedRep) {
-          diagnoseInvalid(repr, attrs.getLoc(TAK_convention),
-                          diag::unsupported_convention,
-                          attrs.getConventionName());
-          rep = FunctionType::Representation::Swift;
-        } else {
-          rep = *parsedRep;
-
-          parsedClangFunctionType = tryParseClangType(
-              attrs.ConventionArguments.value(), shouldStoreClangType(rep));
-        }
-      }
-
-      DifferentiabilityKind diffKind = DifferentiabilityKind::NonDifferentiable;
-      if (attrs.has(TAK_differentiable)) {
-        auto *SF = getDeclContext()->getParentSourceFile();
-        if (SF && isDifferentiableProgrammingEnabled(*SF)) {
-          diffKind = attrs.differentiabilityKind;
-        } else {
-          diagnoseInvalid(
-              repr, attrs.getLoc(TAK_differentiable),
-              diag::
-                  differentiable_programming_attr_used_without_required_module,
-              TypeAttributes::getAttrName(TAK_differentiable),
-              getASTContext().Id_Differentiation);
-        }
-      }
-
-      bool concurrent = attrs.has(TAK_Sendable);
-
-      ty = resolveASTFunctionType(fnRepr, options, rep, /*noescape=*/false,
-                                  concurrent, parsedClangFunctionType,
-                                  diffKind, isolation);
-      if (!ty || ty->hasError())
-        return ty;
-    }
-  }
-
-  // Validate use of @autoclosure
-  if (attrs.has(TAK_autoclosure)) {
-    bool didDiagnose = false;
-    if (attrs.hasConvention()) {
-      if (attrs.getConventionName() == "c" ||
-          attrs.getConventionName() == "block") {
-        diagnoseInvalid(repr, attrs.getLoc(TAK_convention),
-                        diag::invalid_autoclosure_and_convention_attributes,
-                        attrs.getConventionName());
-        attrs.clearAttribute(TAK_convention);
-        didDiagnose = true;
-      }
-    } else if (options.is(TypeResolverContext::VariadicFunctionInput) &&
-               !options.hasBase(TypeResolverContext::EnumElementDecl)) {
-      diagnoseInvalid(repr, attrs.getLoc(TAK_autoclosure),
-                      diag::attr_not_on_variadic_parameters, "@autoclosure");
-      attrs.clearAttribute(TAK_autoclosure);
-      didDiagnose = true;
-    } else if (!options.is(TypeResolverContext::FunctionInput)) {
-      diagnoseInvalid(repr, attrs.getLoc(TAK_autoclosure),
-                      diag::attr_only_on_parameters, "@autoclosure");
-      attrs.clearAttribute(TAK_autoclosure);
-      didDiagnose = true;
+      auto packElementAttr = cast<PackElementTypeAttr>(attr);
+      ty = resolvePackElementArchetype(repr, options, packElementAttr);
     }
 
-    if (didDiagnose) {
-      ty = ErrorType::get(getASTContext());
-    }
-  }
+  // The SIL metatype attributes are basically total type transforms, too.
+  // TODO: this should really be restricted to lowered types
+  } else if (auto attr = isSILSourceFile()
+                            ? attrs.claim(TAR_SILMetatype) : nullptr) {
+    ty = resolveSILMetatype(repr, options, attr);
 
-  if (attrs.has(TAK_unchecked)) {
+  // Okay, propagate attributes down to specific resolvers.
+
+  // Functions
+  } else if (auto fnRepr = dyn_cast<FunctionTypeRepr>(repr)) {
+    if (options & TypeResolutionFlags::SILType)
+      ty = resolveSILFunctionType(fnRepr, options, &attrs);
+    else
+      ty = resolveASTFunctionType(fnRepr, options, &attrs);
+
+  // Boxes 
+  } else if (auto boxRepr = dyn_cast<SILBoxTypeRepr>(repr)) {
+    ty = resolveSILBoxType(boxRepr, options, &attrs);
+
+  // Packs
+  } else if (auto packRepr = dyn_cast<PackTypeRepr>(repr)) {
+    ty = resolvePackType(packRepr, options, &attrs);
+
+  // Otherwise, just resolve normally.
+  } else {
     ty = resolveType(repr, options);
-    if (!ty || ty->hasError()) return ty;
+  }
+
+  // TODO: It would be better to write all of these attribute checks
+  // using claimAllWhere so that the work doen is proportional to the
+  // number of attributes that were actually written.
+
+  if (auto uncheckedAttr = claim<UncheckedTypeAttr>(attrs)) {
+    if (ty->hasError()) return ty;
 
     if (!options.is(TypeResolverContext::Inherited) ||
         getDeclContext()->getSelfProtocolDecl()) {
-      diagnoseInvalid(repr, attrs.getLoc(TAK_unchecked),
+      diagnoseInvalid(repr, uncheckedAttr->getAtLoc(),
                       diag::unchecked_not_inheritance_clause);
       ty = ErrorType::get(getASTContext());
     } else if (!ty->isConstraintType()) {
-      diagnoseInvalid(repr, attrs.getLoc(TAK_unchecked),
+      diagnoseInvalid(repr, uncheckedAttr->getAtLoc(),
                       diag::unchecked_not_existential, ty);
       ty = ErrorType::get(getASTContext());
     }
 
-    // Nothing to record in the type. Just clear the attribute.
-    attrs.clearAttribute(TAK_unchecked);
+    // Nothing to record in the type.
   }
 
-  if (attrs.has(TAK_preconcurrency)) {
+  if (auto preconcurrencyAttr = claim<PreconcurrencyTypeAttr>(attrs)) {
     auto &ctx = getASTContext();
     if (ctx.LangOpts.hasFeature(Feature::PreconcurrencyConformances)) {
-      ty = resolveType(repr, options);
-      if (!ty || ty->hasError())
+      if (ty->hasError())
         return ty;
 
       if (!options.is(TypeResolverContext::Inherited) ||
           getDeclContext()->getSelfProtocolDecl()) {
-        diagnoseInvalid(repr, attrs.getLoc(TAK_preconcurrency),
+        diagnoseInvalid(repr, preconcurrencyAttr->getAtLoc(),
                         diag::preconcurrency_not_inheritance_clause);
         ty = ErrorType::get(getASTContext());
       } else if (!ty->isConstraintType()) {
-        diagnoseInvalid(repr, attrs.getLoc(TAK_preconcurrency),
+        diagnoseInvalid(repr, preconcurrencyAttr->getAtLoc(),
                         diag::preconcurrency_not_existential, ty);
         ty = ErrorType::get(getASTContext());
       }
 
-      // Nothing to record in the type. Just clear the attribute.
-      attrs.clearAttribute(TAK_preconcurrency);
+      // Nothing to record in the type.
     } else {
-      diagnoseInvalid(repr, attrs.getLoc(TAK_preconcurrency),
+      diagnoseInvalid(repr, preconcurrencyAttr->getAtLoc(),
                       diag::preconcurrency_attr_disabled);
       ty = ErrorType::get(getASTContext());
     }
   }
 
-  if (attrs.has(TAK_retroactive)) {
-    ty = resolveType(repr, options);
-    if (!ty || ty->hasError()) return ty;
-
-    SourceLoc loc = attrs.getLoc(TAK_retroactive);
+  if (auto retroactiveAttr = claim<RetroactiveTypeAttr>(attrs)) {
+    if (ty->hasError()) return ty;
 
     auto extension = dyn_cast_or_null<ExtensionDecl>(getDeclContext());
     bool isInInheritanceClause = options.is(TypeResolverContext::Inherited);
     if (!isInInheritanceClause || !extension) {
-      diagnoseInvalid(repr, loc,
+      diagnoseInvalid(repr, retroactiveAttr->getAtLoc(),
                       diag::retroactive_not_in_extension_inheritance_clause)
-          .fixItRemove(getTypeAttrRangeWithAt(getASTContext(), loc));
+          .fixItRemove(retroactiveAttr->getSourceRange());
       ty = ErrorType::get(getASTContext());
     }
-    
-    attrs.clearAttribute(TAK_retroactive);
   }
-
-  if (attrs.has(TAK_opened)) {
-    ty = resolveOpenedExistentialArchetype(attrs, repr, options);
-  } else if (attrs.has(TAK_pack_element)) {
-    ty = resolvePackElementArchetype(attrs, repr, options);
-  }
-
-  auto instanceOptions = options;
-  instanceOptions.setContext(llvm::None);
-
-  // If we didn't build the type differently above, we might have
-  // a typealias pointing at a function type with the @escaping
-  // attribute. Resolve the type as if it were in non-parameter
-  // context, and then set isNoEscape if @escaping is not present.
-  if (!ty) ty = resolveType(repr, instanceOptions);
-  if (!ty || ty->hasError()) return ty;
 
   // Type aliases inside protocols are not yet resolved in the structural
   // stage of type resolution
@@ -3328,13 +3390,23 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
     return ty;
   }
 
-  // Handle @escaping
-  if (ty->is<FunctionType>()) {
-    if (attrs.has(TAK_escaping)) {
+  // Consume @escaping if we did ultimately produce a function type.
+  //
+  // A better way to handle this might be to thread attributes to both of the
+  // places that can produce function types (name resolution and
+  // FunctionTypeRepr) and have them check and claim it themselves.
+  // Then this "meaningless" diagnostic can just be special case
+  // in diagnoseUnclaimed.
+  if ((options & TypeResolutionFlags::DirectEscaping) &&
+      ty->is<FunctionType>()) {
+    // We might not actually have an @escaping attribute here if we saw
+    // something like `@escaping (@moreAttributes FnType)`.
+    if (auto escapingAttr = claim<EscapingTypeAttr>(attrs)) {
       // The attribute is meaningless except on non-variadic parameter types.
-      if (!isParam || options.getBaseContext() == TypeResolverContext::EnumElementDecl) {
-        auto loc = attrs.getLoc(TAK_escaping);
-        auto attrRange = getTypeAttrRangeWithAt(getASTContext(), loc);
+      if (!options.is(TypeResolverContext::FunctionInput) ||
+          options.getBaseContext() == TypeResolverContext::EnumElementDecl) {
+        auto loc = escapingAttr->getAtLoc();
+        auto attrRange = escapingAttr->getSourceRange();
 
         // Try to find a better diagnostic based on how the type is being used
         if (options.is(TypeResolverContext::ImmediateOptionalTypeArgument)) {
@@ -3348,15 +3420,10 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
 
         ty = ErrorType::get(getASTContext());
       }
-
-      attrs.clearAttribute(TAK_escaping);
-    } else {
-      // No attribute; set the isNoEscape bit if we're in parameter context.
-      ty = applyNonEscapingIfNecessary(ty, options);
     }
   }
 
-  if (attrs.has(TAK_autoclosure)) {
+  if (auto autoclosureAttr = claim<AutoclosureTypeAttr>(attrs)) {
     // If this is a situation where function type is wrapped
     // into a number of parens, let's try to look through them,
     // because parens are insignificant here e.g.:
@@ -3369,129 +3436,202 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
       repr->setInvalid();
     }
 
-    attrs.clearAttribute(TAK_autoclosure);
-  }
-
-  if (hasFunctionAttr && !fnRepr) {
-    const auto diagnoseInvalidAttr = [&](TypeAttrKind kind) {
-      if (kind == TAK_escaping) {
-        Type optionalObjectType = ty->getOptionalObjectType();
-        if (optionalObjectType && optionalObjectType->is<AnyFunctionType>()) {
-          return diagnoseInvalid(repr, attrs.getLoc(kind),
-                                 diag::escaping_optional_type_argument);
-        }
-      }
-      return diagnoseInvalid(repr, attrs.getLoc(kind),
-                             diag::attribute_requires_function_type,
-                             TypeAttributes::getAttrName(kind));
-    };
-
-    for (auto i : FunctionAttrs) {
-      if (!attrs.has(i))
-        continue;
-
-      auto diag = diagnoseInvalidAttr(i);
-      // If we see @escaping among the attributes on this type, because it
-      // isn't a function type, we'll remove it.
-      if (i == TAK_escaping) {
-        diag.fixItRemove(getTypeAttrRangeWithAt(getASTContext(),
-                                                attrs.getLoc(TAK_escaping)));
-      }
-      attrs.clearAttribute(i);
+    bool didDiagnose = false;
+    if (options.is(TypeResolverContext::VariadicFunctionInput) &&
+        !options.hasBase(TypeResolverContext::EnumElementDecl)) {
+      diagnoseInvalid(repr, autoclosureAttr->getAtLoc(),
+                      diag::attr_not_on_variadic_parameters, "@autoclosure");
+      didDiagnose = true;
+    } else if (!options.is(TypeResolverContext::FunctionInput)) {
+      diagnoseInvalid(repr, autoclosureAttr->getAtLoc(),
+                      diag::attr_only_on_parameters, "@autoclosure");
+      didDiagnose = true;
     }
-  } else if (hasFunctionAttr && fnRepr) {
-    // Remove the function attributes from the set so that we don't diagnose.
-    for (auto i : FunctionAttrs)
-      attrs.clearAttribute(i);
-    attrs.ConventionArguments = llvm::None;
+
+    if (didDiagnose) {
+      ty = ErrorType::get(getASTContext());
+    }
   }
 
-  if (attrs.has(TAK_noDerivative)) {
-    // @noDerivative is valid on function parameters (AST and SIL) or on
-    // function results (SIL-only).
+  // @noDerivative is valid on function parameters (AST and SIL) or on
+  // function results (SIL-only).  We just unconditionally claim this here,
+  // which is a little unnecessary.
+  if (auto noDerivativeAttr = claim<NoDerivativeTypeAttr>(attrs)) {
     bool isNoDerivativeAllowed =
-        isParam ||
+        options.is(TypeResolverContext::FunctionInput) ||
         options.is(TypeResolverContext::InoutFunctionInput) ||
-        (isResult && (options & TypeResolutionFlags::SILType));
+        (options.is(TypeResolverContext::FunctionResult) &&
+          (options & TypeResolutionFlags::SILType));
     auto *SF = getDeclContext()->getParentSourceFile();
     if (SF && !isDifferentiableProgrammingEnabled(*SF)) {
       diagnose(
-          attrs.getLoc(TAK_noDerivative),
+          noDerivativeAttr->getAtLoc(),
           diag::differentiable_programming_attr_used_without_required_module,
-          TypeAttributes::getAttrName(TAK_noDerivative),
+          TypeAttribute::getAttrName(TAK_noDerivative),
           getASTContext().Id_Differentiation);
     } else if (!isNoDerivativeAllowed) {
-      diagnose(attrs.getLoc(TAK_noDerivative),
+      bool isVariadicFunctionParam =
+          options.is(TypeResolverContext::VariadicFunctionInput) &&
+          !options.hasBase(TypeResolverContext::EnumElementDecl);
+      diagnose(noDerivativeAttr->getAtLoc(),
                (isVariadicFunctionParam
                     ? diag::attr_not_on_variadic_parameters
                     : diag::attr_only_on_parameters_of_differentiable),
                "@noDerivative");
     }
-    attrs.clearAttribute(TAK_noDerivative);
   }
 
   if (getASTContext().LangOpts.hasFeature(Feature::LayoutPrespecialization)) {
-    if (attrs.has(TAK__noMetadata)) {
-      // TODO: add proper validation
-      attrs.clearAttribute(TAK__noMetadata);
-    }
+    (void) claim<NoMetadataTypeAttr>(attrs);
+    // TODO: add proper validation
   }
 
-  // In SIL files *only*, permit @weak and @unowned to apply directly to types.
-  if (attrs.hasOwnership()) {
-    if (auto SF = getDeclContext()->getParentSourceFile()) {
-      if (SF->Kind == SourceFileKind::SIL) {
-        if (((attrs.has(TAK_sil_weak) || attrs.has(TAK_sil_unmanaged)) &&
-             ty->getOptionalObjectType()) ||
-            (!attrs.has(TAK_sil_weak) &&
-             GenericEnvironment::mapTypeIntoContext(
-                 resolution.getGenericSignature().getGenericEnvironment(), ty)
-                 ->hasReferenceSemantics())) {
-          ty = ReferenceStorageType::get(ty, attrs.getOwnership(),
-                                         getASTContext());
-          attrs.clearOwnership();
+  // There are a bunch of attributes in SIL that are essentially new
+  // type constructors.  Some of these are allowed even in AST positions;
+  // other are only allowed in lowered types.
+  if (isSILSourceFile()) {
+    // Process the attributes in reverse source order in order to follow the
+    // "recursive structure" of the type constructors.
+    attrs.reversedClaimAllWhere([&](TypeAttribute *attr) {
+      switch (attrs.getRepresentative(attr->getKind())) {
+      case TAK_dynamic_self:
+        ty = rebuildWithDynamicSelf(getASTContext(), ty);
+        return true;
+
+      case TAR_SILReferenceStorage:
+        ty = resolveSILReferenceStorage(attr, ty);
+        return true;
+
+      case TAK_block_storage:
+        if (options & TypeResolutionFlags::SILType) {
+          ty = SILBlockStorageType::get(ty->getCanonicalType());;
+          return true;
         }
+        return false;
+
+      case TAK_box:
+        if (options & TypeResolutionFlags::SILType) {
+          ty = SILBoxType::get(ty->getCanonicalType());
+          return true;
+        }
+        return false;
+
+      case TAK_moveOnly:
+        if (options & TypeResolutionFlags::SILType) {
+          ty = SILMoveOnlyWrappedType::get(ty->getCanonicalType());
+          return true;
+        }
+        return false;
+
+      default:
+        return false;
       }
+    });
+  }
+
+  return ty;
+}
+
+NeverNullType
+TypeResolver::resolveSILReferenceStorage(TypeAttribute *attr, NeverNullType ty) {
+  if (ty->hasError()) return ty;
+
+  auto ownership = [&] {
+#define REF_STORAGE(Name, name, ...) \
+    if (isa<SIL##Name##TypeAttr>(attr)) return ReferenceOwnership::Name;
+#include "swift/AST/ReferenceStorage.def"
+    llvm_unreachable("bad reference storage kind");
+  }();
+
+  bool isOptional = false;
+  auto objType = ty;
+  if (auto obj = ty->getOptionalObjectType()) {
+    isOptional = true;
+    objType = obj;
+  }
+
+  switch (optionalityOf(ownership)) {
+  case ReferenceOwnershipOptionality::Disallowed:
+    if (isOptional) {
+      diagnose(attr->getStartLoc(), diag::invalid_ownership_with_optional,
+               ownership);
+      attr->setInvalid();
+      return ty;
     }
-  }
-  
-  // In SIL *only*, allow @block_storage to specify a block storage type.
-  if ((options & TypeResolutionFlags::SILType) && attrs.has(TAK_block_storage)) {
-    ty = SILBlockStorageType::get(ty->getCanonicalType());
-    attrs.clearAttribute(TAK_block_storage);
-  }
-  
-  // In SIL *only*, allow @box to specify a box type.
-  if ((options & TypeResolutionFlags::SILType) && attrs.has(TAK_box)) {
-    ty = SILBoxType::get(ty->getCanonicalType());
-    attrs.clearAttribute(TAK_box);
-  }
+    break;
+  case ReferenceOwnershipOptionality::Allowed:
+    break;
+  case ReferenceOwnershipOptionality::Required:
+    if (!isOptional) {
+      diagnose(attr->getStartLoc(), diag::invalid_ownership_not_optional,
+               ownership, OptionalType::get(ty));
+      attr->setInvalid();
+      return ty;
 
-  // In SIL *only*, allow @moveOnly to specify a moveOnly type.
-  if ((options & TypeResolutionFlags::SILType) && attrs.has(TAK_moveOnly)) {
-    ty = SILMoveOnlyWrappedType::get(ty->getCanonicalType());
-    attrs.clearAttribute(TAK_moveOnly);
-  }
-
-  // In SIL *only*, allow @dynamic_self to specify a dynamic Self type.
-  if ((options & TypeResolutionFlags::SILMode) && attrs.has(TAK_dynamic_self)) {
-    ty = rebuildWithDynamicSelf(getASTContext(), ty);
-    attrs.clearAttribute(TAK_dynamic_self);
-  }
-
-  // In SIL *only*, allow @async to specify an async function
-  if ((options & TypeResolutionFlags::SILMode) && attrs.has(TAK_async)) {
-    if (fnRepr != nullptr) {
-      attrs.clearAttribute(TAK_async);
     }
+    break;
   }
 
-  for (unsigned i = 0; i != TypeAttrKind::TAK_Count; ++i)
-    if (attrs.has((TypeAttrKind)i)) {
-      diagnoseInvalid(repr, attrs.getLoc((TypeAttrKind)i),
-                      diag::attribute_does_not_apply_to_type);
-    }
+  if (!objType->allowsOwnership(resolution.getGenericSignature().getPointer())) {
+    diagnose(attr->getStartLoc(), diag::invalid_ownership_type,
+             ownership, objType);
+    attr->setInvalid();
+    return ty;
+  }
 
+  return ReferenceStorageType::get(ty, ownership, getASTContext());
+}
+
+NeverNullType
+TypeResolver::resolveSILMetatype(TypeRepr *repr,
+                                 TypeResolutionOptions options,
+                                 TypeAttribute *thicknessAttr) {
+  if (auto existential = dyn_cast<ExistentialTypeRepr>(repr))
+    repr = existential->getConstraint();
+
+  TypeRepr *base;
+  if (auto metatypeRepr = dyn_cast<MetatypeTypeRepr>(repr)) {
+    base = metatypeRepr->getBase();
+  } else if (auto protocolRepr = dyn_cast<ProtocolTypeRepr>(repr)) {
+    base = protocolRepr->getBase();
+  } else {
+    diagnose(thicknessAttr->getStartLoc(), diag::sil_metatype_not_metatype);
+    return getASTContext().TheErrorType;
+  }
+
+  // The instance type is not a SIL type.
+  auto instanceOptions = options;
+  TypeResolverContext context = TypeResolverContext::None;
+  if (isa<MetatypeTypeRepr>(repr)) {
+    context = TypeResolverContext::MetatypeBase;
+  } else if (isa<ProtocolTypeRepr>(repr)) {
+    context = TypeResolverContext::ProtocolMetatypeBase;
+  }
+  instanceOptions.setContext(context);
+  instanceOptions -= TypeResolutionFlags::SILType;
+
+  auto instanceTy = resolveType(base, instanceOptions);
+  if (instanceTy->hasError())
+    return instanceTy;
+
+  MetatypeRepresentation storedRepr = [&] {
+    if (isa<ThinTypeAttr>(thicknessAttr)) {
+      return MetatypeRepresentation::Thin;
+    } else if (isa<ThickTypeAttr>(thicknessAttr)) {
+      return MetatypeRepresentation::Thick;
+    } else {
+      assert(isa<ObjCMetatypeTypeAttr>(thicknessAttr));
+      return MetatypeRepresentation::ObjC;
+    }
+  }();
+
+  Type ty;
+  if (auto metatype = dyn_cast<MetatypeTypeRepr>(repr)) {
+    ty = buildMetatypeType(metatype, instanceTy, storedRepr);
+  } else {
+    ty = buildProtocolType(cast<ProtocolTypeRepr>(repr),
+                           instanceTy, storedRepr);
+  }
   return ty;
 }
 
@@ -3551,10 +3691,11 @@ TypeResolver::resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
     bool autoclosure = false;
     bool noDerivative = false;
 
-    if (auto *ATR = dyn_cast<AttributedTypeRepr>(nestedRepr)) {
-      autoclosure = ATR->getAttrs().has(TAK_autoclosure);
+    while (auto *ATR = dyn_cast<AttributedTypeRepr>(nestedRepr)) {
+      if (ATR->has(TAK_autoclosure))
+        autoclosure = true;
 
-      if (ATR->getAttrs().has(TAK_noDerivative)) {
+      if (ATR->has(TAK_noDerivative)) {
         if (diffKind == DifferentiabilityKind::NonDifferentiable &&
             isDifferentiableProgrammingEnabled(
                 *dc->getParentSourceFile()))
@@ -3690,12 +3831,61 @@ TypeResolver::resolveOpaqueReturnType(TypeRepr *repr, StringRef mangledName,
 
 NeverNullType TypeResolver::resolveASTFunctionType(
     FunctionTypeRepr *repr, TypeResolutionOptions parentOptions,
-    AnyFunctionType::Representation representation, bool noescape,
-    bool concurrent, const clang::Type *parsedClangFunctionType,
-    DifferentiabilityKind diffKind,
-    FunctionTypeIsolation isolationFromAttrs) {
+    TypeAttrSet *attrs) {
 
-  FunctionTypeIsolation isolation = isolationFromAttrs;
+  AnyFunctionType::Representation representation =
+    FunctionType::Representation::Swift;
+  const clang::Type *parsedClangFunctionType = nullptr;
+  if (auto conventionAttr = claim<ConventionTypeAttr>(attrs)) {
+    auto parsedRep =
+        llvm::StringSwitch<std::optional<FunctionType::Representation>>(
+            conventionAttr->getConventionName())
+            .Case("swift", FunctionType::Representation::Swift)
+            .Case("block", FunctionType::Representation::Block)
+            .Case("thin", FunctionType::Representation::Thin)
+            .Case("c", FunctionType::Representation::CFunctionPointer)
+            .Default(std::nullopt);
+    if (!parsedRep) {
+      diagnoseInvalid(repr, conventionAttr->getAtLoc(),
+                      diag::unsupported_convention,
+                      conventionAttr->getConventionName());
+      representation = FunctionType::Representation::Swift;
+    } else {
+      representation = *parsedRep;
+
+      parsedClangFunctionType = tryParseClangType(
+          conventionAttr, shouldStoreClangType(representation));
+
+      // Certain conventions are not compatible with autoclosures.
+      if (getWithoutClaiming<AutoclosureTypeAttr>(attrs)) {
+        if (representation == FunctionType::Representation::CFunctionPointer ||
+            representation == FunctionType::Representation::Block) {
+          diagnoseInvalid(repr, conventionAttr->getAtLoc(),
+                          diag::invalid_autoclosure_and_convention_attributes,
+                          conventionAttr->getConventionName());
+          representation = FunctionType::Representation::Swift;
+          parsedClangFunctionType = nullptr;
+        }
+      }
+    }
+  }
+
+  DifferentiabilityKind diffKind = DifferentiabilityKind::NonDifferentiable;
+  if (auto diffAttr = claim<DifferentiableTypeAttr>(attrs)) {
+    auto *SF = getDeclContext()->getParentSourceFile();
+    if (SF && isDifferentiableProgrammingEnabled(*SF)) {
+      diffKind = diffAttr->getDifferentiability();
+    } else {
+      diagnoseInvalid(
+          repr, diffAttr->getAtLoc(),
+          diag::differentiable_programming_attr_used_without_required_module,
+          diffAttr->getAttrName(), getASTContext().Id_Differentiation);
+    }
+  }
+
+  bool sendable = claim<SendableTypeAttr>(attrs);
+
+  auto isolation = FunctionTypeIsolation::forNonIsolated();
 
   // Check that we don't have more than one isolated parameter.
   unsigned numIsolatedParams = countIsolatedParamsUpTo(repr, 2);
@@ -3709,11 +3899,25 @@ NeverNullType TypeResolver::resolveASTFunctionType(
       repr->setWarned();
   }
 
-  // Use parameter isolation if we have any.  If we already have
-  // isolation from attributes, that should be ignored; that's diagnosed
-  // by the code processing the attribute.
+  // Use parameter isolation if we have any.  This overrides all other
+  // forms (and should cause conflict diagnostics).
   if (numIsolatedParams > 0) {
     isolation = FunctionTypeIsolation::forParameter();
+  }
+
+  if (attrs) {
+    CustomAttr *globalActorAttr = nullptr;
+    Type globalActor = resolveGlobalActor(repr->getLoc(), parentOptions,
+                                          globalActorAttr, *attrs);
+    if (globalActor && !globalActor->hasError() && !globalActorAttr->isInvalid()) {
+      if (numIsolatedParams == 0) {
+        isolation = FunctionTypeIsolation::forGlobalActor(globalActor);
+      } else {
+        diagnose(repr->getLoc(), diag::isolated_parameter_global_actor_type)
+            .warnUntilSwiftVersion(6);
+        globalActorAttr->setInvalid();
+      }
+    }
   }
 
   // Diagnose a couple of things that we can parse in SIL mode but we don't
@@ -3786,6 +3990,9 @@ NeverNullType TypeResolver::resolveASTFunctionType(
     }
   }
 
+  // TODO: maybe make this the place that claims @escaping.
+  bool noescape = isDefaultNoEscapeContext(parentOptions);
+
   // TODO: Handle LifetimeDependenceInfo here.
   FunctionType::ExtInfoBuilder extInfoBuilder(
       FunctionTypeRepresentation::Swift, noescape, repr->isThrowing(), thrownTy,
@@ -3798,7 +4005,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
         getASTContext().getClangFunctionType(params, outputTy, representation);
 
   auto extInfo = extInfoBuilder.withRepresentation(representation)
-                     .withConcurrent(concurrent)
+                     .withConcurrent(sendable)
                      .withAsync(repr->isAsync())
                      .withClangFunctionType(clangFnType)
                      .build();
@@ -3822,8 +4029,8 @@ NeverNullType TypeResolver::resolveASTFunctionType(
 }
 
 NeverNullType TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
-                                              bool capturesGenerics,
-                                              TypeResolutionOptions options) {
+                                              TypeResolutionOptions options,
+                                              TypeAttrSet *attrs) {
   assert(silContext && "resolving SIL box type outside of SIL");
 
   // Resolve the field types.
@@ -3879,21 +4086,109 @@ NeverNullType TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
         LookUpConformanceInModule(getDeclContext()->getParentModule()));
   }
 
+  bool capturesGenerics = claim<CapturesGenericsTypeAttr>(attrs);
+
   auto layout = SILLayout::get(getASTContext(), genericSig, fields,
                                capturesGenerics);
   return SILBoxType::get(getASTContext(), layout, subMap);
 }
 
-NeverNullType TypeResolver::resolveSILFunctionType(
-    FunctionTypeRepr *repr, TypeResolutionOptions options,
-    SILCoroutineKind coroutineKind,
-    SILFunctionType::ExtInfoBuilder extInfoBuilder, ParameterConvention callee,
-    TypeRepr *witnessMethodProtocol) {
+NeverNullType TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
+                                                   TypeResolutionOptions options,
+                                                   TypeAttrSet *attrs) {
   assert(silContext);
-
   options.setContext(llvm::None);
 
   bool hasError = false;
+
+  auto coroutineKind = SILCoroutineKind::None;
+  if (auto coroAttr = attrs ? attrs->claim(TAR_SILCoroutine) : nullptr) {
+    assert(isa<YieldOnceTypeAttr>(coroAttr) ||
+           isa<YieldManyTypeAttr>(coroAttr));
+    coroutineKind = (isa<YieldOnceTypeAttr>(coroAttr)
+                       ? SILCoroutineKind::YieldOnce
+                       : SILCoroutineKind::YieldMany);
+  }
+
+  ParameterConvention callee = ParameterConvention::Direct_Unowned;
+  if (auto calleeAttr = attrs ? attrs->claim(TAR_SILCalleeConvention) : nullptr) {
+    assert(isa<CalleeOwnedTypeAttr>(calleeAttr) ||
+           isa<CalleeGuaranteedTypeAttr>(calleeAttr));
+    callee = (isa<CalleeOwnedTypeAttr>(calleeAttr)
+                ? ParameterConvention::Direct_Owned
+                : ParameterConvention::Direct_Guaranteed);
+  }
+
+  SILFunctionType::Representation representation =
+    SILFunctionType::Representation::Thick;
+  const clang::Type *clangFnType = nullptr;
+  TypeRepr *witnessMethodProtocol = nullptr;
+  if (auto conventionAttr = claim<ConventionTypeAttr>(attrs)) {
+    auto parsedRep =
+      llvm::StringSwitch<std::optional<SILFunctionType::Representation>>(
+            conventionAttr->getConventionName())
+        .Case("thick", SILFunctionType::Representation::Thick)
+        .Case("block", SILFunctionType::Representation::Block)
+        .Case("thin", SILFunctionType::Representation::Thin)
+        .Case("c", SILFunctionType::Representation::CFunctionPointer)
+        .Case("method", SILFunctionType::Representation::Method)
+        .Case("objc_method",
+              SILFunctionType::Representation::ObjCMethod)
+        .Case("witness_method",
+              SILFunctionType::Representation::WitnessMethod)
+        .Case("keypath_accessor_getter",
+              SILFunctionType::Representation::KeyPathAccessorGetter)
+        .Case("keypath_accessor_setter",
+              SILFunctionType::Representation::KeyPathAccessorSetter)
+        .Case("keypath_accessor_equals",
+              SILFunctionType::Representation::KeyPathAccessorEquals)
+        .Case("keypath_accessor_hash",
+              SILFunctionType::Representation::KeyPathAccessorHash)
+        .Default(std::nullopt);
+    if (!parsedRep) {
+      conventionAttr->setInvalid();
+      diagnoseInvalid(repr, conventionAttr->getAtLoc(),
+                      diag::unsupported_sil_convention,
+                      conventionAttr->getConventionName());
+      hasError = true;
+    } else {
+      representation = *parsedRep;
+
+      clangFnType = tryParseClangType(conventionAttr,
+                                      shouldStoreClangType(representation));
+
+      if (*parsedRep == SILFunctionType::Representation::WitnessMethod) {
+        auto protocolName = conventionAttr->getWitnessMethodProtocol();
+        // FIXME: parse the DeclNameLoc to here
+        witnessMethodProtocol =
+          new (getASTContext()) SimpleIdentTypeRepr(DeclNameLoc(), protocolName);
+      }
+    }
+  }
+
+  DifferentiabilityKind diffKind = DifferentiabilityKind::NonDifferentiable;
+  if (auto diffAttr = claim<DifferentiableTypeAttr>(attrs)) {
+    auto *SF = getDeclContext()->getParentSourceFile();
+    if (SF && isDifferentiableProgrammingEnabled(*SF)) {
+      diffKind = diffAttr->getDifferentiability();
+    } else {
+      diagnoseInvalid(
+          repr, diffAttr->getAtLoc(),
+          diag::differentiable_programming_attr_used_without_required_module,
+          diffAttr->getAttrName(), getASTContext().Id_Differentiation);
+      hasError = true;
+    }
+  }
+
+  bool pseudogeneric = claim<PseudogenericTypeAttr>(attrs);
+  bool noescape = claim<NoEscapeTypeAttr>(attrs);
+  bool sendable = claim<SendableTypeAttr>(attrs);
+  bool async = claim<AsyncTypeAttr>(attrs);
+  bool unimplementable = claim<UnimplementableTypeAttr>(attrs);
+
+  auto extInfoBuilder = SILFunctionType::ExtInfoBuilder(
+        representation, pseudogeneric, noescape, sendable, async,
+        unimplementable, diffKind, clangFnType);
 
   // Resolve parameter and result types using the function's generic
   // environment.
@@ -4054,8 +4349,6 @@ NeverNullType TypeResolver::resolveSILFunctionType(
            "found witness_method without matching conformance");
   }
 
-  auto representation = extInfoBuilder.getRepresentation();
-  const clang::Type *clangFnType = extInfoBuilder.getClangTypeInfo().getType();
   if (shouldStoreClangType(representation) && !clangFnType) {
     assert(results.size() <= 1 && yields.size() == 0 &&
            "C functions and blocks have at most 1 result and 0 yields.");
@@ -4073,69 +4366,81 @@ NeverNullType TypeResolver::resolveSILFunctionType(
                               witnessMethodConformance);
 }
 
-SILYieldInfo TypeResolver::resolveSILYield(TypeAttributes &attrs,
-                                           TypeRepr *repr,
-                                           TypeResolutionOptions options) {
-  AttributedTypeRepr attrRepr(attrs, repr);
+SILYieldInfo TypeResolver::resolveSILYield(TypeRepr *repr,
+                                           TypeResolutionOptions options,
+                                           TypeAttrSet &attrs) {
   options.setContext(TypeResolverContext::FunctionInput);
-  SILParameterInfo paramInfo = resolveSILParameter(&attrRepr, options);
+  SILParameterInfo paramInfo = resolveSILParameter(repr, options, &attrs);
+
+  attrs.diagnoseUnclaimed(resolution, options, paramInfo.getInterfaceType());
+
   return SILYieldInfo(paramInfo.getInterfaceType(), paramInfo.getConvention());
 }
 
 SILParameterInfo TypeResolver::resolveSILParameter(
                                  TypeRepr *repr,
-                                 TypeResolutionOptions options) {
+                                 TypeResolutionOptions options,
+                                 TypeAttrSet *yieldAttrs) {
   assert(options.is(TypeResolverContext::FunctionInput) &&
          "Parameters should be marked as inputs");
+
   auto convention = DefaultParameterConvention;
-  Type type;
-  bool hadError = false;
   auto parameterOptions = SILParameterInfo::Options();
 
-  if (auto attrRepr = dyn_cast<AttributedTypeRepr>(repr)) {
-    auto attrs = attrRepr->getAttrs();
+  std::optional<TypeAttrSet> attrsBuffer;
+  TypeAttrSet *attrs = nullptr;
+  if (yieldAttrs) {
+    attrs = yieldAttrs;
+    assert(!isa<AttributedTypeRepr>(repr));
+  } else if (auto attrRepr = dyn_cast<AttributedTypeRepr>(repr)) {
+    attrsBuffer.emplace(getASTContext());
+    attrs = &*attrsBuffer;
+    repr = attrs->accumulate(attrRepr);
+  }
 
-    auto checkFor = [&](TypeAttrKind tak, ParameterConvention attrConv) {
-      if (!attrs.has(tak)) return;
-      if (convention != DefaultParameterConvention) {
-        diagnose(attrs.getLoc(tak), diag::sil_function_repeat_convention,
-                 /*input*/ 0);
-        hadError = true;
+  Type type;
+  if (attrs) {
+    attrs->claimAllWhere([&](TypeAttribute *attr) {
+      switch (attr->getKind()) {
+
+#define OWNERSHIP(SPELLING, KIND)                   \
+      case TAK_##SPELLING:                          \
+        convention = ParameterConvention::KIND;     \
+        return true;
+      OWNERSHIP(in_guaranteed, Indirect_In_Guaranteed)
+      OWNERSHIP(in, Indirect_In)
+      OWNERSHIP(in_constant, Indirect_In)
+      OWNERSHIP(inout, Indirect_Inout)
+      OWNERSHIP(inout_aliasable, Indirect_InoutAliasable)
+      OWNERSHIP(owned, Direct_Owned)
+      OWNERSHIP(guaranteed, Direct_Guaranteed)
+      OWNERSHIP(pack_owned, Pack_Owned)
+      OWNERSHIP(pack_guaranteed, Pack_Guaranteed)
+      OWNERSHIP(pack_inout, Pack_Inout)
+#undef OWNERSHIP
+
+      case TAK_noDerivative:
+        parameterOptions |= SILParameterInfo::NotDifferentiable;
+        return true;
+
+      case TAK_isolated:
+        parameterOptions |= SILParameterInfo::Isolated;
+        return true;
+
+      default:
+        return false;
       }
-      attrs.clearAttribute(tak);
-      convention = attrConv;
-    };
-    checkFor(TypeAttrKind::TAK_in_guaranteed,
-             ParameterConvention::Indirect_In_Guaranteed);
-    checkFor(TypeAttrKind::TAK_in, ParameterConvention::Indirect_In);
-    checkFor(TypeAttrKind::TAK_in_constant,
-             ParameterConvention::Indirect_In);
-    checkFor(TypeAttrKind::TAK_inout, ParameterConvention::Indirect_Inout);
-    checkFor(TypeAttrKind::TAK_inout_aliasable,
-             ParameterConvention::Indirect_InoutAliasable);
-    checkFor(TypeAttrKind::TAK_owned, ParameterConvention::Direct_Owned);
-    checkFor(TypeAttrKind::TAK_guaranteed,
-             ParameterConvention::Direct_Guaranteed);
-    checkFor(TypeAttrKind::TAK_pack_owned,
-             ParameterConvention::Pack_Owned);
-    checkFor(TypeAttrKind::TAK_pack_guaranteed,
-             ParameterConvention::Pack_Guaranteed);
-    checkFor(TypeAttrKind::TAK_pack_inout,
-             ParameterConvention::Pack_Inout);
-    if (attrs.has(TAK_noDerivative)) {
-      attrs.clearAttribute(TAK_noDerivative);
-      parameterOptions |= SILParameterInfo::NotDifferentiable;
-    }
-    if (attrs.has(TAK_isolated)) {
-      attrs.clearAttribute(TAK_isolated);
-      parameterOptions |= SILParameterInfo::Isolated;
-    }
+    });
 
-    type = resolveAttributedType(attrs, attrRepr->getTypeRepr(), options);
+    type = resolveAttributedType(repr, options, *attrs);
+
+    if (!yieldAttrs)
+      attrs->diagnoseUnclaimed(resolution, options, type);
   } else {
     type = resolveType(repr, options);
   }
 
+  bool hadError = false;
   if (!type || type->hasError()) {
     hadError = true;
 
@@ -4160,18 +4465,17 @@ bool TypeResolver::resolveSingleSILResult(
   auto convention = DefaultResultConvention;
   bool isErrorResult = false;
   SILResultInfo::Options resultInfoOptions;
+
   options.setContext(TypeResolverContext::FunctionResult);
 
   if (auto attrRepr = dyn_cast<AttributedTypeRepr>(repr)) {
-    // Copy the attributes out; we're going to destructively modify them.
-    auto attrs = attrRepr->getAttrs();
+    TypeAttrSet attrs(getASTContext());
+    auto repr = attrs.accumulate(attrRepr);
 
     // Recognize @yields.
-    if (attrs.has(TypeAttrKind::TAK_yields)) {
-      attrs.clearAttribute(TypeAttrKind::TAK_yields);
-
+    if (claim<YieldsTypeAttr>(attrs)) {
       // The treatment from this point on is basically completely different.
-      auto yield = resolveSILYield(attrs, attrRepr->getTypeRepr(), options);
+      auto yield = resolveSILYield(repr, options, attrs);
       if (yield.getInterfaceType()->hasError())
         return true;
 
@@ -4179,59 +4483,43 @@ bool TypeResolver::resolveSingleSILResult(
       return false;
     }
 
-    // Recognize @error.
-    if (attrs.has(TypeAttrKind::TAK_error)) {
-      assert(!isErrorResult);
-      attrs.clearAttribute(TypeAttrKind::TAK_error);
-      isErrorResult = true;
+    if (auto conventionAttr = attrs.claim(TAR_SILValueConvention)) {
+      switch (conventionAttr->getKind()) {
+#define ERROR(SPELLING, CONVENTION)                 \
+      case TAK_##SPELLING:                          \
+        isErrorResult = true;                       \
+        convention = ResultConvention::CONVENTION;  \
+        break;
+#define NORMAL(SPELLING, CONVENTION)                \
+      case TAK_##SPELLING:                          \
+        convention = ResultConvention::CONVENTION;  \
+        break;
 
-      // Error results are always implicitly @owned.
-      convention = ResultConvention::Owned;
-    }
-    if (attrs.has(TypeAttrKind::TAK_error_indirect)) {
-      assert(!isErrorResult);
-      attrs.clearAttribute(TypeAttrKind::TAK_error_indirect);
-      isErrorResult = true;
+      ERROR(error, Owned)
+      ERROR(error_indirect, Indirect)
+      ERROR(error_unowned, Unowned)
+      NORMAL(out, Indirect)
+      NORMAL(owned, Owned)
+      NORMAL(unowned_inner_pointer, UnownedInnerPointer)
+      NORMAL(autoreleased, Autoreleased)
+      NORMAL(pack_out, Pack)
+#undef NORMAL
+#undef ERROR
 
-      // Indirect error results are always implicitly @out.
-      convention = ResultConvention::Indirect;
-    }
-    if (attrs.has(TypeAttrKind::TAK_error_unowned)) {
-      assert(!isErrorResult);
-      attrs.clearAttribute(TypeAttrKind::TAK_error_unowned);
-      isErrorResult = true;
-
-      // Indirect error results are always implicitly @out.
-      convention = ResultConvention::Unowned;
+      default:
+        diagnose(conventionAttr->getStartLoc(),
+                 diag::sil_function_invalid_convention,
+                 /*result*/ 1);
+      }
     }
 
     // Recognize `@noDerivative`.
-    if (attrs.has(TAK_noDerivative)) {
-      attrs.clearAttribute(TAK_noDerivative);
+    if (claim<NoDerivativeTypeAttr>(attrs)) {
       resultInfoOptions |= SILResultInfo::NotDifferentiable;
     }
 
-    // Recognize result conventions.
-    bool hadError = false;
-    auto checkFor = [&](TypeAttrKind tak, ResultConvention attrConv) {
-      if (!attrs.has(tak)) return;
-      if (convention != DefaultResultConvention) {
-        diagnose(attrs.getLoc(tak), diag::sil_function_repeat_convention,
-                 /*result*/ 1);
-        hadError = true;
-      }
-      attrs.clearAttribute(tak);
-      convention = attrConv;
-    };
-    checkFor(TypeAttrKind::TAK_out, ResultConvention::Indirect);
-    checkFor(TypeAttrKind::TAK_owned, ResultConvention::Owned);
-    checkFor(TypeAttrKind::TAK_unowned_inner_pointer,
-             ResultConvention::UnownedInnerPointer);
-    checkFor(TypeAttrKind::TAK_autoreleased, ResultConvention::Autoreleased);
-    checkFor(TypeAttrKind::TAK_pack_out, ResultConvention::Pack);
-    if (hadError) return true;
-
-    type = resolveAttributedType(attrs, attrRepr->getTypeRepr(), options);
+    type = resolveAttributedType(repr, options, attrs);
+    attrs.diagnoseUnclaimed(resolution, options, type);
   } else {
     type = resolveType(repr, options);
   }
@@ -4826,7 +5114,7 @@ NeverNullType TypeResolver::resolveVarargType(VarargTypeRepr *repr,
 
 NeverNullType TypeResolver::resolvePackType(PackTypeRepr *repr,
                                             TypeResolutionOptions options,
-                                            bool silDirect) {
+                                            TypeAttrSet *attrs) {
   // This form is currently only allowed in SIL, so we're lax about
   // where we allow this.  If this is ever made a proper language feature,
   // it should only be allowed in contexts where an expansion would be
@@ -4849,6 +5137,8 @@ NeverNullType TypeResolver::resolvePackType(PackTypeRepr *repr,
   }
 
   if (options & TypeResolutionFlags::SILType) {
+    bool silDirect = claim<DirectTypeAttr>(attrs);
+
     SmallVector<CanType, 8> canElementTypes;
     canElementTypes.reserve(elementTypes.size());
     for (auto elementType : elementTypes)

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -86,6 +86,9 @@ enum class TypeResolutionFlags : uint16_t {
   /// Whether to suppress warnings about conversions from and bindings of type
   /// Never
   SilenceNeverWarnings = 1 << 13,
+
+  /// Whether the immediate context has an @escaping attribute.
+  DirectEscaping = 1 << 14,
 };
 
 /// Type resolution contexts that require special handling.
@@ -251,7 +254,8 @@ public:
   /// Set the current type resolution context.
   void setContext(Context newContext) {
     context = newContext;
-    flags &= ~unsigned(TypeResolutionFlags::Direct);
+    flags &= ~(unsigned(TypeResolutionFlags::Direct) |
+               unsigned(TypeResolutionFlags::DirectEscaping));
   }
   void setContext(llvm::NoneType) { setContext(Context::None); }
 

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -75,7 +75,7 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
 
   llvm::StringMap<AnyAttrKind> ExcludeAttrs;
 
-#define TYPE_ATTR(X) ExcludeAttrs.insert(std::make_pair("TAK_" #X, TAK_##X));
+#define TYPE_ATTR(X, C) ExcludeAttrs.insert(std::make_pair("TAK_" #X, TAK_##X));
 #include "swift/AST/Attr.def"
 
   // Allow the following type attributes:
@@ -131,7 +131,7 @@ SymbolGraph::getSubHeadingDeclarationFragmentsPrintOptions() const {
 
   #define DECL_ATTR(SPELLING, CLASS, OPTIONS, CODE) \
     Options.ExcludeAttrList.push_back(DAK_##CLASS);
-  #define TYPE_ATTR(X) \
+  #define TYPE_ATTR(X, C) \
     Options.ExcludeAttrList.push_back(TAK_##X);
   #include "swift/AST/Attr.def"
 

--- a/test/ModuleInterface/concurrency.swift
+++ b/test/ModuleInterface/concurrency.swift
@@ -58,8 +58,8 @@ func callFn() async {
 // CHECK: // swift-module-flags:{{.*}} -enable-experimental-concurrency
 // CHECK: public func fn() async
 // CHECK: public func reasyncFn(_: () async -> ()) reasync
-// CHECK: public func takesSendable(_ block: @escaping @Sendable () async throws ->
-// CHECK: public func takesMainActor(_ block: @escaping @{{_Concurrency.MainActor|MainActor}} () ->
+// CHECK: public func takesSendable(_ block: {{@escaping @Sendable|@Sendable @escaping}} () async throws ->
+// CHECK: public func takesMainActor(_ block: {{@escaping @_Concurrency.MainActor|@MainActor @escaping}} () ->
 
 // CHECK:      @_Concurrency.MainActor @preconcurrency public protocol UnsafeMainProtocol {
 // CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency func requirement()

--- a/test/Sema/moveonly_type_attr.swift
+++ b/test/Sema/moveonly_type_attr.swift
@@ -6,4 +6,4 @@ class Klass {}
 
 // Make sure we ignore this attribute and error in swift mode.
 
-let l: @moveOnly Klass = Klass() // expected-error {{attribute does not apply to type}}
+let l: @moveOnly Klass = Klass() // expected-error {{unknown attribute 'moveOnly'}}

--- a/test/attr/attr_noescape.swift
+++ b/test/attr/attr_noescape.swift
@@ -184,8 +184,8 @@ class SomeClass {
 // Implicit conversions (in this case to @convention(block)) are ok.
 @_silgen_name("whatever") 
 func takeNoEscapeAsObjCBlock(_: @noescape @convention(block) () -> Void)  // expected-error{{unknown attribute 'noescape'}}
-func takeNoEscapeTest2(_ fn : @noescape () -> ()) {  // expected-error{{unknown attribute 'noescape'}} expected-note {{parameter 'fn' is implicitly non-escaping}}
-  takeNoEscapeAsObjCBlock(fn) // expected-error {{passing non-escaping parameter 'fn' to function expecting an @escaping closure}}
+func takeNoEscapeTest2(_ fn : @noescape () -> ()) {  // expected-error{{unknown attribute 'noescape'}}
+  takeNoEscapeAsObjCBlock(fn)
 }
 
 // Autoclosure implies noescape..
@@ -211,8 +211,8 @@ func overloadedEach<P: P2, T>(_ source: P, _ transform: @escaping (P.Element) ->
 
 struct S : P2 {
   typealias Element = Int
-  func each(_ transform: @noescape (Int) -> ()) { // expected-error{{unknown attribute 'noescape'}}
-    overloadedEach(self, transform, 1)
+  func each(_ transform: @noescape (Int) -> ()) { // expected-error{{unknown attribute 'noescape'}} expected-note {{parameter 'transform' is implicitly non-escaping}}
+    overloadedEach(self, transform, 1) // expected-error {{passing non-escaping parameter 'transform' to function expecting an @escaping closure}}
   }
 }
 
@@ -265,15 +265,15 @@ func curriedFlatMap<A, B>(_ x: [A]) -> (@noescape (A) -> [B]) -> [B] { // expect
 }
 
 func curriedFlatMap2<A, B>(_ x: [A]) -> (@noescape (A) -> [B]) -> [B] { // expected-error {{unknown attribute 'noescape'}}
-  return { (f : @noescape (A) -> [B]) in
+  return { (f : @noescape (A) -> [B]) in // expected-error {{unknown attribute 'noescape'}}
     x.flatMap(f)
   }
 }
 
 func bad(_ a : @escaping (Int)-> Int) -> Int { return 42 }
 func escapeNoEscapeResult(_ x: [Int]) -> (@noescape (Int) -> Int) -> Int { // expected-error{{unknown attribute 'noescape'}}
-  return { f in
-    bad(f)
+  return { f in // expected-note {{parameter 'f' is implicitly non-escaping}} 
+    bad(f) // expected-error {{passing non-escaping parameter 'f' to function expecting an @escaping closure}}
   }
 }
 
@@ -295,8 +295,8 @@ var escapeOther : CompletionHandler
 func doThing1(_ completion: (_ success: Bool) -> ()) { // expected-note {{parameter 'completion' is implicitly non-escaping}}
   escape = completion // expected-error {{assigning non-escaping parameter 'completion' to an @escaping closure}}
 }
-func doThing2(_ completion: CompletionHandlerNE) {
-  escape = completion
+func doThing2(_ completion: CompletionHandlerNE) { // expected-note {{parameter 'completion' is implicitly non-escaping}} 
+  escape = completion // expected-error {{assigning non-escaping parameter 'completion' to an @escaping closure}}
 }
 func doThing3(_ completion: CompletionHandler) { // expected-note {{parameter 'completion' is implicitly non-escaping}}
   escape = completion // expected-error {{assigning non-escaping parameter 'completion' to an @escaping closure}}
@@ -306,8 +306,8 @@ func doThing4(_ completion: @escaping CompletionHandler) {
 }
 
 // <rdar://problem/19997680> @noescape doesn't work on parameters of function type
-func apply<T, U>(_ f: @noescape (T) -> U, g: @noescape (@noescape (T) -> U) -> U) -> U { 
-  // expected-error@-1 2{{unknown attribute 'noescape'}}
+func apply<T, U>(_ f: @noescape (T) -> U, g: @noescape (@noescape (T) -> U) -> U) -> U {
+  // expected-error@-1 3{{unknown attribute 'noescape'}}
   return g(f)
 }
 

--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -14,6 +14,7 @@ add_swift_unittest(SwiftBasicTests
   DemangleTest.cpp
   DiverseStackTest.cpp
   EditorPlaceholderTest.cpp
+  EnumMapTest.cpp
   EncodedSequenceTest.cpp
   ExponentialGrowthAppendingBinaryByteStreamTests.cpp
   FileSystemTest.cpp
@@ -28,6 +29,7 @@ add_swift_unittest(SwiftBasicTests
   PointerIntEnumTest.cpp
   PrefixMapTest.cpp
   RangeTest.cpp
+  SmallMapTest.cpp
   SourceManagerTest.cpp
   StableHasher.cpp
   STLExtrasTest.cpp

--- a/unittests/Basic/EnumMapTest.cpp
+++ b/unittests/Basic/EnumMapTest.cpp
@@ -1,0 +1,154 @@
+#include "swift/Basic/EnumMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+namespace {
+
+constexpr size_t MissingValue = ~(size_t) 0;
+
+enum class A : uint16_t {
+  lowerBound = 0,
+  numValues = 1000
+};
+
+} // end anonymous namespace
+
+template <>
+struct swift::EnumTraits<A> {
+  static constexpr size_t NumValues = (size_t) A::numValues;
+};
+
+namespace {
+
+static void insertSuccess(EnumMap<A, size_t> &map, size_t key, size_t value) {
+  auto result = map.insert(A(key), value);
+  EXPECT_TRUE(result.second);
+  EXPECT_NE(map.end(), result.first);
+  EXPECT_EQ(value, *result.first);
+}
+
+static void insertFailure(EnumMap<A, size_t> &map, size_t key, size_t value,
+                          size_t actualValue) {
+  auto result = map.insert(A(key), value);
+  EXPECT_FALSE(result.second);
+  EXPECT_NE(map.end(), result.first);
+  EXPECT_EQ(actualValue, *result.first);
+}
+
+static void lookupSuccess(EnumMap<A, size_t> &map, size_t key, size_t value) {
+  auto result = map.find(A(key));
+  EXPECT_NE(map.end(), result);
+  EXPECT_EQ(value, *result);
+}
+
+static void lookupFailure(EnumMap<A, size_t> &map, size_t key) {
+  auto result = map.find(A(key));
+  EXPECT_EQ(map.end(), result);
+}
+
+#define INSERT_SUCCESS(KEY, VALUE) \
+  insertSuccess(map, KEY, VALUE)
+#define INSERT_FAILURE(KEY, VALUE, ACTUAL) \
+  insertFailure(map, KEY, VALUE, ACTUAL)
+#define LOOKUP_SUCCESS(KEY, VALUE) \
+  lookupSuccess(map, KEY, VALUE)
+#define LOOKUP_FAILURE(KEY) \
+  lookupFailure(map, KEY)
+
+struct entry {
+  size_t key;
+  size_t value;
+};
+
+static const entry globalEntries[] = {
+  { 218, 110145 },
+  { 361, 927012 },
+  { 427, 608227 },
+  { 861, 158552 },
+  { 101, 466452 },
+  { 391, 920472 },
+  { 960, 522979 },
+  { 36, 433291 },
+  { 432, 110883 },
+  { 752, 903125 },
+  { 549, 887829 },
+  { 475, 748953 },
+  { 295, 214526 },
+  { 533, 896211 },
+  { 961, 684099 },
+  { 230, 387362 },
+  { 988, 205038 },
+  { 980, 838945 },
+  { 43, 319398 },
+  { 704, 960347 },
+  { 270, 837198 },
+  { 611, 310181 },
+  { 638, 44564 },
+  { 193, 210584 },
+  { 281, 620103 },
+  { 682, 462845 },
+  { 419, 85019 },
+  { 812, 541739 },
+  { 580, 266684 },
+  { 559, 101634 },
+  { 506, 639451 },
+  { 96, 782184 },
+  { 996, 927190 },
+  { 392, 586071 },
+  { 928, 50086 },
+  { 976, 681150 },
+  { 953, 172478 },
+  { 863, 512828 },
+  { 569, 947708 },
+  { 139, 131866 },
+  { 628, 884682 },
+  { 877, 636903 },
+  { 49, 871169 },
+  { 172, 524694 },
+  { 768, 211821 },
+  { 104, 126356 },
+  { 552, 262470 },
+  { 343, 857409 },
+  { 426, 535485 },
+  { 84, 954703 },
+  { 239, 889527 },
+};
+
+} // end anonymous namespace
+
+
+TEST(EnumMap, Basic) {
+  EnumMap<A, size_t> map;
+
+  auto entries = llvm::makeArrayRef(globalEntries);
+
+  for (size_t iteration : range(entries.size())) {
+    EXPECT_EQ(iteration, map.size());
+    EXPECT_EQ(iteration == 0, map.empty());
+
+    // Check that previous entries are still there.
+    for (size_t i : range(iteration)) {
+      LOOKUP_SUCCESS(entries[i].key, entries[i].value);
+      INSERT_FAILURE(entries[i].key, MissingValue, entries[i].value);
+    }
+
+    // Check that later entries are not there.
+    for (size_t i : range(iteration, entries.size())) {
+      LOOKUP_FAILURE(entries[i].key);
+    }
+
+    INSERT_SUCCESS(entries[iteration].key, entries[iteration].value);
+    LOOKUP_SUCCESS(entries[iteration].key, entries[iteration].value);
+  }
+
+  EXPECT_EQ(entries.size(), map.size());
+
+  size_t i = 0;
+  for (auto &value : map) {
+    EXPECT_EQ(entries[i].value, value);
+    i++;
+  }
+  EXPECT_EQ(entries.size(), i);
+}

--- a/unittests/Basic/SmallMapTest.cpp
+++ b/unittests/Basic/SmallMapTest.cpp
@@ -1,0 +1,273 @@
+#include "swift/Basic/SmallMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+namespace {
+
+constexpr size_t MissingValue = ~(size_t) 0;
+constexpr size_t EmptyKey = ~(size_t) 1;
+constexpr size_t TombstoneKey = ~(size_t) 2;
+
+template <class T>
+struct Tracker {
+  llvm::DenseSet<T> set;
+
+  Tracker() = default;
+  Tracker(const Tracker &) = delete;
+  Tracker &operator=(const Tracker &) = delete;
+
+  bool empty() const {
+    return set.empty();
+  }
+
+  void insert(T value) {
+    EXPECT_TRUE(set.insert(value).second);
+  }
+
+  void check(T value) {
+    EXPECT_TRUE(set.contains(value));
+  }
+
+  void remove(T value) {
+    EXPECT_TRUE(set.erase(value));
+  }
+};
+
+class A {
+  Tracker<const A *> *tracker;
+  size_t value;
+
+  explicit A(size_t specialValue) : tracker(nullptr), value(specialValue) {}
+
+  void assignTrackers(const A &other) {
+    if (tracker)
+      tracker->check(this);
+    if (other.tracker)
+      other.tracker->check(&other);
+    if (tracker != other.tracker) {
+      if (tracker)
+        tracker->remove(this);
+      if (other.tracker)
+        other.tracker->insert(this);
+      tracker = other.tracker;
+    }
+  }
+
+public:
+  static A getEmptyKey() {
+    return A(EmptyKey);
+  }
+  static A getTombstoneKey() {
+    return A(TombstoneKey);
+  }
+
+  A(Tracker<const A *> *tracker, size_t value) : tracker(tracker), value(value) {
+    if (tracker)
+      tracker->insert(this);
+  }
+
+  A(const A &other) : tracker(other.tracker), value(other.value) {
+    if (tracker) {
+      tracker->insert(this);
+      tracker->check(&other);
+    }
+  }
+
+  A(A &&other) : tracker(other.tracker), value(other.value) {
+    if (tracker) {
+      tracker->insert(this);
+      tracker->check(&other);
+    }
+  }
+
+  A &operator=(const A &other) {
+    assignTrackers(other);
+    value = other.value;
+    return *this;
+  }
+
+  A &operator=(A &&other) {
+    assignTrackers(other);
+    value = other.value;
+    return *this;
+  }
+
+  ~A() {
+    if (tracker)
+      tracker->remove(this);
+  }
+
+  size_t getValue() const {
+    if (tracker)
+      tracker->check(this);
+    return value;
+  }
+
+  friend bool operator==(const A &lhs, const A &rhs) {
+    return lhs.getValue() == rhs.getValue();
+  }
+};
+
+static void insertSuccess(SmallMap<A, A> &map, Tracker<const A*> &tracker,
+                          size_t key, size_t value) {
+  auto result = map.insert(A(&tracker, key), A(&tracker, value));
+  EXPECT_TRUE(result.second);
+  EXPECT_NE(map.end(), result.first);
+  EXPECT_EQ(value, result.first->getValue());
+}
+
+static void insertFailure(SmallMap<A, A> &map, Tracker<const A*> &tracker,
+                          size_t key, size_t value, size_t actualValue) {
+  auto result = map.insert(A(&tracker, key), A(&tracker, value));
+  EXPECT_FALSE(result.second);
+  EXPECT_NE(map.end(), result.first);
+  EXPECT_EQ(actualValue, result.first->getValue());
+}
+
+static void lookupSuccess(SmallMap<A, A> &map, Tracker<const A*> &tracker,
+                          size_t key, size_t value) {
+  auto result = map.find(A(&tracker, key));
+  EXPECT_NE(map.end(), result);
+  EXPECT_EQ(value, result->getValue());
+}
+
+static void lookupFailure(SmallMap<A, A> &map, Tracker<const A*> &tracker,
+                          size_t key) {
+  auto result = map.find(A(&tracker, key));
+  EXPECT_EQ(map.end(), result);
+}
+
+#define INSERT_SUCCESS(KEY, VALUE) \
+  insertSuccess(map, tracker, KEY, VALUE)
+#define INSERT_FAILURE(KEY, VALUE, ACTUAL) \
+  insertFailure(map, tracker, KEY, VALUE, ACTUAL)
+#define LOOKUP_SUCCESS(KEY, VALUE) \
+  lookupSuccess(map, tracker, KEY, VALUE)
+#define LOOKUP_FAILURE(KEY) \
+  lookupFailure(map, tracker, KEY)
+
+struct entry {
+  size_t key;
+  size_t value;
+};
+
+static const entry globalEntries[] = {
+  { 833286, 244010 },
+  { 21885, 583865 },
+  { 98803, 373843 },
+  { 757849, 280197 },
+  { 544837, 319456 },
+  { 301715, 409382 },
+  { 214164, 173603 },
+  { 90472, 679461 },
+  { 454735, 523445 },
+  { 726077, 442142 },
+  { 757356, 26085 },
+  { 83528, 609269 },
+  { 25506, 528950 },
+  { 66693, 225472 },
+  { 850311, 274721 },
+  { 575211, 385129 },
+  { 496336, 530893 },
+  { 753928, 460664 },
+  { 569603, 263213 },
+  { 863114, 294890 },
+  { 289913, 871387 },
+  { 567663, 970826 },
+  { 54922, 182147 },
+  { 234275, 516764 },
+  { 521608, 771620 },
+  { 38169, 832007 },
+  { 777822, 704626 },
+  { 608984, 769469 },
+  { 696833, 136927 },
+  { 336429, 615964 },
+  { 203555, 147525 },
+  { 759946, 740892 },
+  { 702926, 137033 },
+  { 86701, 400847 },
+  { 177435, 145944 },
+  { 424806, 194239 },
+  { 628673, 279972 },
+  { 843621, 449262 },
+  { 372083, 860665 },
+  { 642760, 534411 },
+  { 777604, 996069 },
+  { 942048, 227549 },
+  { 43009, 551907 },
+  { 814924, 532395 },
+  { 480414, 327500 },
+  { 49853, 745810 },
+  { 157379, 947358 },
+  { 313310, 851746 },
+  { 957411, 179233 },
+  { 32217, 35134 },
+  { 684458, 208518 },
+  { 944720, 998758 },
+  { 533638, 728837 },
+  { 670556, 946584 },
+  { 466090, 456504 },
+  { 213558, 326747 },
+  { 967293, 15416 },
+  { 370014, 356011 },
+};
+
+} // end anonymous namespace
+
+
+TEST(SmallMap, Basic) {
+  Tracker<const A *> tracker;
+  {
+    SmallMap<A, A> map;
+
+    auto entries = llvm::makeArrayRef(globalEntries);
+
+    for (size_t iteration : range(entries.size())) {
+      EXPECT_EQ(iteration, map.size());
+      EXPECT_EQ(iteration == 0, map.empty());
+
+      // Check that previous entries are still there.
+      for (size_t i : range(iteration)) {
+        LOOKUP_SUCCESS(entries[i].key, entries[i].value);
+        INSERT_FAILURE(entries[i].key, MissingValue, entries[i].value);
+      }
+
+      // Check that later entries are not there.
+      for (size_t i : range(iteration, entries.size())) {
+        LOOKUP_FAILURE(entries[i].key);
+      }
+
+      INSERT_SUCCESS(entries[iteration].key, entries[iteration].value);
+      LOOKUP_SUCCESS(entries[iteration].key, entries[iteration].value);
+    }
+
+    EXPECT_EQ(entries.size(), map.size());
+
+    size_t i = 0;
+    for (auto &value : map) {
+      EXPECT_EQ(entries[i].value, value.getValue());
+      i++;
+    }
+    EXPECT_EQ(entries.size(), i);
+  }
+  EXPECT_TRUE(tracker.empty());
+}
+
+template <>
+struct llvm::DenseMapInfo<A> {
+  static inline A getEmptyKey() {
+    return A::getEmptyKey();
+  }
+  static inline A getTombstoneKey() {
+    return A::getTombstoneKey();
+  }
+  static unsigned getHashValue(const A &val) {
+    return val.getValue();
+  }
+  static bool isEqual(const A &lhs, const A &rhs) {
+    return lhs == rhs;
+  }
+
+};

--- a/validation-test/SIL/crashers/031-swift-typechecker-configureinterfacetype.sil
+++ b/validation-test/SIL/crashers/031-swift-typechecker-configureinterfacetype.sil
@@ -1,3 +1,3 @@
-// RUN: not --crash %target-sil-opt %s
+// RUN: not %target-sil-opt %s
 // REQUIRES: asserts
 func y:@opened(Any


### PR DESCRIPTION
Introduce a proper `TypeAttribute` class hierarchy.
    
The old `TypeAttributes` representation wasn't too bad for a small number of simple attributes.  Unfortunately, the number of attributes has grown over the years by quite a bit, which made `TypeAttributes` fairly bulky even at just a single `SourceLoc` per attribute; that's okay as a temporary thing, but `TypeAttributes` was being stored as a whole in `AttributedTypeRepr`.  The bigger problem is that we do need to carry more information than just the presence and location of the attribute for some of these attributes, which is all super ad hoc and awkward.  And given that we want to do some things for each attribute we see, like diagnosing unapplied attributes, the linear data structure does require a fair amount of extra work.
    
I switched around the checking logic quite a bit in order to try to fit in with the new representation better.  The most significant change here is the change to how we handle implicit `noescape`, where now we're passing the escaping attribute's presence down in the context instead of resetting the context anytime we see any attributes at all.  This should be cleaner overall.
    
The source range changes around some of the `@escaping` checking is really a sort of bugfix --- the existing code was really jumping from the `@` sign all the way past the `autoclosure` keyword in a way that I'm not sure always works and is definitely a little unintentional-feeling.
    
I tried to make the parser logic more consistent around recognizing these parameter specifiers; it seems better now, at least.

Philosophically, there are some things that feel a little incomplete here, but this is a good stopping place.