### PR TITLE
[SwiftSyntax] Reflects the API changes in swift-syntax

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -76,7 +76,7 @@ struct ASTGenVisitor {
 
   let ctx: BridgedASTContext
 
-  fileprivate let allocator: SwiftSyntax.BumpPtrAllocator = .init(slabSize: 256)
+  fileprivate let allocator: SwiftSyntax.BumpPtrAllocator = .init(initialSlabSize: 256)
 
   /// Fallback legacy parser used when ASTGen doesn't have the generate(_:)
   /// implementation for the AST node kind.


### PR DESCRIPTION
This PR reflects [the API changes to the BumpPtrAllocator class](https://github.com/apple/swift-syntax/pull/2441) in the swift-syntax package. 
This is supposed to be cross-tested with [the corresponding PR](https://github.com/apple/swift-syntax/pull/2441) in the swift-syntax repository.
@rintaro 