### PR TITLE
[CodeComplete] A couple of contextual type handling tweaks

### DIFF
--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -189,23 +189,27 @@ void PostfixCompletionCallback::sawSolutionImpl(
 
   bool BaseIsStaticMetaType = S.isStaticallyDerivedMetatype(ParsedExpr);
 
+  bool ExpectsNonVoid = false;
   SmallVector<Type, 4> ExpectedTypes;
   if (ExpectedTy) {
     ExpectedTypes.push_back(ExpectedTy);
-  }
+    ExpectsNonVoid = !ExpectedTy->isVoid();
+  } else {
+    // If we don't know what the expected type is, assume it must be non-Void
+    // if we have a contextual type that is not unused. This prevents us from
+    // suggesting Void values for e.g bindings without explicit types.
+    ExpectsNonVoid |= !ParentExpr &&
+                      CS.getContextualTypePurpose(CompletionExpr) != CTP_Unused;
 
-  bool ExpectsNonVoid = false;
-  ExpectsNonVoid |= ExpectedTy && !ExpectedTy->isVoid();
-  ExpectsNonVoid |=
-      !ParentExpr && CS.getContextualTypePurpose(CompletionExpr) != CTP_Unused;
-
-  for (auto SAT : S.targets) {
-    if (ExpectsNonVoid) {
-      // ExpectsNonVoid is already set. No need to iterate further.
-      break;
-    }
-    if (SAT.second.getAsExpr() == CompletionExpr) {
-      ExpectsNonVoid |= SAT.second.getExprContextualTypePurpose() != CTP_Unused;
+    for (auto SAT : S.targets) {
+      if (ExpectsNonVoid) {
+        // ExpectsNonVoid is already set. No need to iterate further.
+        break;
+      }
+      if (SAT.second.getAsExpr() == CompletionExpr) {
+        ExpectsNonVoid |=
+            SAT.second.getExprContextualTypePurpose() != CTP_Unused;
+      }
     }
   }
 

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -47,8 +47,11 @@ void TypeCheckCompletionCallback::fallbackTypeCheck(DeclContext *DC) {
 
 Type swift::ide::getTypeForCompletion(const constraints::Solution &S,
                                       ASTNode Node) {
+  // Use the contextual type, unless it is still unresolved, in which case fall
+  // back to getting the type from the expression.
   if (auto ContextualType = S.getContextualType(Node)) {
-    return ContextualType;
+    if (!ContextualType->hasUnresolvedType())
+      return ContextualType;
   }
 
   if (!S.hasType(Node)) {

--- a/test/IDE/complete_issue-55711.swift
+++ b/test/IDE/complete_issue-55711.swift
@@ -1,6 +1,4 @@
-// RUN: %swift-ide-test -code-completion -source-filename=%s -code-completion-token=A | %FileCheck %s --check-prefix=A
-// RUN: %swift-ide-test -code-completion -source-filename=%s -code-completion-token=B | %FileCheck %s --check-prefix=B
-// RUN: %swift-ide-test -code-completion -source-filename=%s -code-completion-token=D | %FileCheck %s --check-prefix=D
+// RUN: %batch-code-completion
 
 // https://github.com/apple/swift/issues/55711
 // https://forums.swift.org/t/code-completion-enhancement-request/38677
@@ -36,6 +34,10 @@ struct D <T> {
 func test() {
   C(.a) {
     .#^A^#
+  }
+  C(.a) {
+    ()
+    return .#^A_MULTISTMT?check=A^#
   }
 // A: Begin completions, 2 items
 // A-DAG: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]: foo({#arg: Bool#})[#A<X>#];

--- a/test/IDE/complete_single_expression_return.swift
+++ b/test/IDE/complete_single_expression_return.swift
@@ -128,6 +128,55 @@ struct TestSingleExprClosureGlobal {
 // TestSingleExprClosureGlobal-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
 }
 
+struct TestSingleExprClosureBinding {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  func test() -> Int {
+    let fn = {
+      self.#^TestSingleExprClosureBinding^#
+    }
+    return fn()
+  }
+// Void is always valid in an implicit single expr closure.
+// TestSingleExprClosureBinding-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
+// TestSingleExprClosureBinding-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// TestSingleExprClosureBinding-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+}
+
+struct TestExplicitSingleExprClosureBinding {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  func test() {
+    let fn = {
+      return self.#^TestExplicitSingleExprClosureBinding^#
+    }
+  }
+// FIXME: Because we have an explicit return, and no expected type, we shouldn't suggest Void.
+// TestExplicitSingleExprClosureBinding-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
+// TestExplicitSingleExprClosureBinding-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// TestExplicitSingleExprClosureBinding-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+}
+
+struct TestExplicitSingleExprClosureBindingWithContext {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  func test() {
+    let fn: () -> Void = {
+      return self.#^TestExplicitSingleExprClosureBindingWithContext^#
+    }
+  }
+// We know Void is valid.
+// TestExplicitSingleExprClosureBindingWithContext-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
+// TestExplicitSingleExprClosureBindingWithContext-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// TestExplicitSingleExprClosureBindingWithContext-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: void()[#Void#];
+}
+
 struct TestNonSingleExprClosureGlobal {
   func void() -> Void {}
   func str() -> String { return "" }
@@ -188,6 +237,21 @@ struct TestSingleExprFunc {
 // TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal:   str()[#String#];
 // TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: int()[#Int#];
 // TestSingleExprFunc-DAG: Decl[InstanceMethod]/CurrNominal: void()[#Void#];
+}
+
+struct TestSingleExprFuncReturnVoid {
+  func void() -> Void {}
+  func str() -> String { return "" }
+  func int() -> Int { return 0 }
+
+  func test() {
+    return self.#^TestSingleExprFuncReturnVoid^#
+  }
+
+// Void is the only possible type that can be used here.
+// TestSingleExprFuncReturnVoid-DAG: Decl[InstanceMethod]/CurrNominal: str()[#String#];
+// TestSingleExprFuncReturnVoid-DAG: Decl[InstanceMethod]/CurrNominal: int()[#Int#];
+// TestSingleExprFuncReturnVoid-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Convertible]: void()[#Void#];
 }
 
 struct TestSingleExprFuncUnresolved {


### PR DESCRIPTION
Found while cleaning up the constraint system's handling of ReturnStmts, improve the handling of contextual types in a couple of cases.