### PR TITLE
Tests: Loosen CHECK: lines matching `_diagnoseUnavailableCodeReached()`

### DIFF
--- a/test/Interpreter/unavailable_decl_optimization_stub.swift
+++ b/test/Interpreter/unavailable_decl_optimization_stub.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -module-name main %s -o %t/a.out
+// RUN: %target-build-swift -module-name main -Xfrontend -unavailable-decl-optimization=stub %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out > %t/output 2>&1 || true
 // RUN: %FileCheck %s < %t/output

--- a/test/SILGen/unavailable_decl_optimization_stub.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub.swift
@@ -3,7 +3,7 @@
 public struct S {}
 
 // CHECK-LABEL: sil{{.*}}@$s4Test15unavailableFuncAA1SVyF
-// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF)]] : $@convention(thin) () -> Never
+// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
 // CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:         function_ref @$s4Test1SVACycfC
 // CHECK:       } // end sil function '$s4Test15unavailableFuncAA1SVyF'

--- a/test/SILGen/unavailable_decl_optimization_stub_class.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_class.swift
@@ -7,7 +7,7 @@ func foo() {}
 public class ExplicitInitClass {
   // ExplicitInitClass.s.getter
   // CHECK-LABEL: sil{{.*}}@$s4Test17ExplicitInitClassC1sAA1SVvg
-  // CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF)]] : $@convention(thin) () -> Never
+  // CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
   // CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
   // CHECK:         load
   // CHECK:       } // end sil function '$s4Test17ExplicitInitClassC1sAA1SVvg'

--- a/test/SILGen/unavailable_decl_optimization_stub_objc.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_objc.swift
@@ -10,7 +10,7 @@ func foo() {}
 @objc public class C: NSObject {
   // C.__allocating_init()
   // CHECK-LABEL: sil{{.*}}@$s4Test1CCACycfC
-  // CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF)]] : $@convention(thin) () -> Never
+  // CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
   // CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
   // CHECK:         {{%.*}} = function_ref @$s4Test1CCACycfcTD
   // CHECK:       } // end sil function '$s4Test1CCACycfC'

--- a/test/SILGen/unavailable_decl_optimization_stub_opaque_type.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_opaque_type.swift
@@ -5,7 +5,7 @@ public struct S {}
 extension S: P {}
 
 // CHECK-LABEL: sil{{.*}}@$s4Test27unavailableOpaqueReturnFuncQryF
-// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF)]] : $@convention(thin) () -> Never
+// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
 // CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:         function_ref @$s4Test1SVACycfC
 // CHECK:       } // end sil function '$s4Test27unavailableOpaqueReturnFuncQryF'

--- a/test/SILGen/unavailable_decl_optimization_stub_protocol_witness.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_protocol_witness.swift
@@ -17,7 +17,7 @@ extension EnumWithProtocolWitness: P {}
 // protocol witness for static P.requirement(_:) in conformance EnumWithProtocolWitness
 //
 // CHECK-LABEL: sil{{.*}}@$s4Test23EnumWithProtocolWitnessOAA1PA2aDP11requirementyxAA1SVFZTW
-// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF)]] : $@convention(thin) () -> Never
+// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
 // CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK:         {{%.*}} = function_ref @$s4Test23EnumWithProtocolWitnessO11requirementyAcA1SVcACmF
 // CHECK:       } // end sil function '$s4Test23EnumWithProtocolWitnessOAA1PA2aDP11requirementyxAA1SVFZTW'

--- a/test/SILGen/unavailable_decl_optimization_stub_struct.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_struct.swift
@@ -5,7 +5,7 @@ public struct S {}
 @available(*, unavailable)
 public struct ImplicitInitStruct {
   // CHECK-LABEL: sil hidden {{.*}} @$s4Test18ImplicitInitStructVACycfC
-  // CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF)]] : $@convention(thin) () -> Never
+  // CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
   // CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
   // CHECK:         return
   // CHECK:       } // end sil function '$s4Test18ImplicitInitStructVACycfC'

--- a/test/SILOptimizer/unavailable_decl_optimization_stub.swift
+++ b/test/SILOptimizer/unavailable_decl_optimization_stub.swift
@@ -3,7 +3,7 @@
 public struct S {}
 
 // CHECK-LABEL: sil{{.*}}@$s4Test15unavailableFuncAA1SVyF
-// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF)]] : $@convention(thin) () -> Never
+// CHECK:         [[FNREF:%.*]] = function_ref @$[[DIAGNOSEFN:(ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyF|ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb)]] : $@convention(thin) () -> Never
 // CHECK-NEXT:    [[APPLY:%.*]] = apply [[FNREF]]()
 // CHECK-NEXT:    unreachable
 // CHECK-NEXT:  } // end sil function '$s4Test15unavailableFuncAA1SVyF'


### PR DESCRIPTION
Depending on deployment target and platform, the function called to diagnose reaching unavailable code could be `_diagnoseUnavailableCodeReached()` itself, the back-deployment thunk, or the `@_alwaysEmitIntoClient` variant of the function.
    
Resolves rdar://121344690