### PR TITLE
[Abstraction pattern] Eliminate unnecessary assertion for typed throws

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1270,11 +1270,6 @@ AbstractionPattern::getFunctionThrownErrorType(
     if (!substErrorType)
       return llvm::None;
 
-    if (!(*substErrorType)->isEqual(ctx.getErrorExistentialType())) {
-      llvm::errs() << "unsupported reabstraction\n";
-      abort();
-    }
-
     return std::make_pair(AbstractionPattern(*substErrorType),
                           (*substErrorType)->getCanonicalType());
   }

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -7,7 +7,7 @@
 // XFAIL: CPU=arm64e
 // REQUIRES: PTRSIZE=64
 
-enum MyBigError: Error {
+public enum MyBigError: Error {
   case epicFail
 }
 
@@ -21,6 +21,10 @@ func requiresP<T: P>(_: T.Type) { }
 func createsP() {
   requiresP(X.self)
 }
+
+// This is for TypeH.method
+// CHECK-NOMANGLE: @"$s12typed_throws5TypeHV6methodySSSiAA10MyBigErrorOYKcvpMV" = alias
+
 
 // CHECK-LABEL: define {{.*}}hidden swiftcc ptr @"$s12typed_throws13buildMetatypeypXpyF"()
 func buildMetatype() -> Any.Type {
@@ -77,4 +81,9 @@ func callee() throws (S) {
 // This used to crash at compile time.
 func testit() throws (S) {
   try callee()
+}
+
+// Used to crash in abstract pattern creation.
+public struct TypeH {
+  public var method: (Int) throws(MyBigError) -> String
 }

--- a/test/IRGen/typed_throws.swift
+++ b/test/IRGen/typed_throws.swift
@@ -23,7 +23,7 @@ func createsP() {
 }
 
 // This is for TypeH.method
-// CHECK-NOMANGLE: @"$s12typed_throws5TypeHV6methodySSSiAA10MyBigErrorOYKcvpMV" = alias
+// CHECK-NOMANGLE: @"$s12typed_throws5TypeHV6methodySSSiAA10MyBigErrorOYKcvpMV" =
 
 
 // CHECK-LABEL: define {{.*}}hidden swiftcc ptr @"$s12typed_throws13buildMetatypeypXpyF"()


### PR DESCRIPTION
Abstraction patterns can handle conversions involving typed throws nowdays. Remove the assertion, fixing rdar://121617307.
