### PR TITLE
AST/Sema: Adjust `@backDeployed` attribute diagnostics for unavailable decls

### DIFF
--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -51,6 +51,12 @@ llvm::Optional<StringRef> closestCorrectedPlatformString(StringRef candidate);
 /// for emission in diagnostics (e.g., "macOS").
 StringRef prettyPlatformString(PlatformKind platform);
 
+/// Returns the base platform for an application-extension platform. For example
+/// `iOS` would be returned for `iOSApplicationExtension`. Returns `None` for
+/// platforms which are not application extension platforms.
+llvm::Optional<PlatformKind>
+basePlatformForExtensionPlatform(PlatformKind Platform);
+
 /// Returns whether the passed-in platform is active, given the language
 /// options. A platform is active if either it is the target platform or its
 /// AppExtension variant is the target platform. For example, OS X is

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -551,8 +551,10 @@ Decl::getIntroducedOSVersion(PlatformKind Kind) const {
 
 llvm::Optional<llvm::VersionTuple>
 Decl::getBackDeployedBeforeOSVersion(ASTContext &Ctx) const {
-  if (auto *attr = getAttrs().getBackDeployed(Ctx))
-    return attr->Version;
+  if (auto *attr = getAttrs().getBackDeployed(Ctx)) {
+    auto version = attr->Version;
+    return version;
+  }
 
   // Accessors may inherit `@backDeployed`.
   if (auto *AD = dyn_cast<AccessorDecl>(this))

--- a/test/attr/attr_availability_transitive_ios_appext.swift
+++ b/test/attr/attr_availability_transitive_ios_appext.swift
@@ -8,7 +8,7 @@
 func ios() {} // expected-note 2{{'ios()' has been explicitly marked unavailable here}}
 
 @available(iOSApplicationExtension, unavailable)
-func ios_extension() {} // expected-note 2{{'ios_extension()' has been explicitly marked unavailable here}}
+func ios_extension() {} // expected-note {{'ios_extension()' has been explicitly marked unavailable here}}
 
 func call_ios_extension() {
     ios_extension() // expected-error {{'ios_extension()' is unavailable}}
@@ -19,7 +19,7 @@ func call_ios() {
 
 @available(iOS, unavailable)
 func ios_call_ios_extension() {
-    ios_extension() // expected-error {{'ios_extension()' is unavailable}}
+    ios_extension()
 }
 
 @available(iOS, unavailable)

--- a/test/attr/attr_availability_transitive_osx_appext.swift
+++ b/test/attr/attr_availability_transitive_osx_appext.swift
@@ -7,7 +7,7 @@
 func osx() {} // expected-note 3{{'osx()' has been explicitly marked unavailable here}}
 
 @available(OSXApplicationExtension, unavailable)
-func osx_extension() {} // expected-note 3{{'osx_extension()' has been explicitly marked unavailable here}}
+func osx_extension() {} // expected-note {{'osx_extension()' has been explicitly marked unavailable here}}
 
 func call_osx_extension() {
     osx_extension() // expected-error {{'osx_extension()' is unavailable}}
@@ -18,7 +18,7 @@ func call_osx() {
 
 @available(OSX, unavailable)
 func osx_call_osx_extension() {
-    osx_extension() // expected-error {{'osx_extension()' is unavailable}}
+    osx_extension()
 }
 
 @available(OSX, unavailable)
@@ -46,7 +46,7 @@ extension NotOnOSX {
   }
 
   func osx_call_osx_extension() {
-    osx_extension() // expected-error {{'osx_extension()' is unavailable in application extensions for macOS}}
+    osx_extension()
   }
 }
 


### PR DESCRIPTION
Use `inheritsAvailabilityFromPlatform()` to determine whether to suppress diagnostics about back deployed functions being unavailable. Previously, if the platform of the `@backDeployed` attribute and the platform of the `@available` attribute did not match exactly the diagnostic was always suppressed, which was too permissive. Adjust `inheritsAvailabilityFromPlatform()` so that it always returns true for application extension platforms and their base platforms.