### PR TITLE
[SourceKit] Fix a crash when performing related identiifers request on `self`

### DIFF
--- a/test/SourceKit/RelatedIdents/self.swift
+++ b/test/SourceKit/RelatedIdents/self.swift
@@ -1,0 +1,9 @@
+struct Test {
+  func foo() {
+// RUN: %sourcekitd-test -req=related-idents -pos=%(line + 1):6 %s -- %s | %FileCheck %s
+    self
+  }
+}
+
+// CHECK: START RANGES
+// CHECK-NEXT: END RANGES

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -792,10 +792,10 @@ struct RelatedIdentInfo {
 /// Result of `findRelatedIdentifiersInFile`.
 struct RelatedIdentsResult {
   SmallVector<RelatedIdentInfo, 8> RelatedIdents;
-  std::string OldName;
+  std::optional<std::string> OldName;
 
   RelatedIdentsResult(SmallVector<RelatedIdentInfo, 8> RelatedIdents,
-                      std::string OldName)
+                      std::optional<std::string> OldName)
       : RelatedIdents(RelatedIdents), OldName(OldName) {}
 
   static RelatedIdentsResult empty() { return RelatedIdentsResult({}, ""); }

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -2550,7 +2550,10 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
 
       RenameLocs Locs = localRenameLocs(SrcFile, Info->VD);
 
-      std::string OldName = Locs.getLocations().front().OldName.str();
+      std::optional<std::string> OldName;
+      if (!Locs.getLocations().empty()) {
+        OldName = Locs.getLocations().front().OldName.str();
+      }
 #ifndef NDEBUG
       for (auto loc : Locs.getLocations()) {
         assert(loc.OldName == OldName &&

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -2903,7 +2903,9 @@ static void findRelatedIdents(StringRef PrimaryFilePath,
           Elem.set(KeyLength, R.Length);
           Elem.set(KeyNameType, renameLocUsageUID(R.Usage));
         }
-        RespBuilder.getDictionary().set(KeyName, Info.OldName);
+        if (Info.OldName) {
+          RespBuilder.getDictionary().set(KeyName, *Info.OldName);
+        }
 
         Rec(RespBuilder.createResponse());
       });


### PR DESCRIPTION
Performing a related identifiers request on `self` returns an empty result because `self` is not an identifier. We thus can’t retrieve the first location to compute the old name.

rdar://121668042
