### PR TITLE
[Statistics] Add a frontend counter for Swift 6 errors diagnosed via `warnUntilSwiftVersion(6)`.

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -22,6 +22,7 @@
 #include "swift/AST/DeclNameLoc.h"
 #include "swift/AST/DiagnosticConsumer.h"
 #include "swift/AST/TypeLoc.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/Basic/Version.h"
 #include "swift/Localization/LocalizationFormat.h"
 #include "llvm/ADT/BitVector.h"
@@ -888,6 +889,10 @@ namespace swift {
     /// until a specific language version, e.g. Swift 6.
     version::Version languageVersion;
 
+    /// The stats reporter used to keep track of Swift 6 errors
+    /// diagnosed via \c warnUntilSwiftVersion(6).
+    UnifiedStatsReporter *statsReporter = nullptr;
+
     /// Whether we are actively pretty-printing a declaration as part of
     /// diagnostics.
     bool IsPrettyPrintingDecl = false;
@@ -958,6 +963,10 @@ namespace swift {
     bool isPrettyPrintingDecl() const { return IsPrettyPrintingDecl; }
 
     void setLanguageVersion(version::Version v) { languageVersion = v; }
+
+    void setStatsReporter(UnifiedStatsReporter *stats) {
+      statsReporter = stats;
+    }
 
     void setLocalization(StringRef locale, StringRef path) {
       assert(!locale.empty());

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -252,6 +252,10 @@ FRONTEND_STATISTIC(Sema, NumTypesDeserialized)
 /// Number of lazy iterable declaration contexts left unloaded.
 FRONTEND_STATISTIC(Sema, NumUnloadedLazyIterableDeclContexts)
 
+/// Number of Swift 6 errors, including those that are downgraded to
+/// warnings in Swift 5 mode.
+FRONTEND_STATISTIC(Sema, NumSwift6Errors)
+
 /// Number of lookups into a module and its imports.
 
 /// All type check requests go into the Sema area.

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -334,6 +334,12 @@ InFlightDiagnostic::warnUntilSwiftVersion(unsigned majorVersion) {
       .wrapIn(diag::error_in_future_swift_version, majorVersion);
   }
 
+  if (majorVersion == 6) {
+    if (auto stats = Engine->statsReporter) {
+      ++stats->getFrontendCounters().NumSwift6Errors;
+    }
+  }
+
   return *this;
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -375,6 +375,7 @@ void CompilerInstance::setupStatsReporter() {
   // Hand the stats reporter down to the ASTContext so the rest of the compiler
   // can use it.
   getASTContext().setStatsReporter(Reporter.get());
+  Diagnostics.setStatsReporter(Reporter.get());
   Stats = std::move(Reporter);
 }
 


### PR DESCRIPTION
This is useful for gathering how many Swift 6 errors a project has without scraping the diagnostics output for the text `; this is an error in Swift 6`.

For example, to gather all concurrency diagnostics that a project will have when enabling Swift 6, you can build with `-strict-concurrency=complete -stats-output-dir <path-to-dir>` where `<path-to-dir>` is the path to output the JSON file. In the JSON file, the value for `"Sema.NumSwift6Errors"` is the number of errors Swift 6 errors diagnosed, which includes errors that are downgraded to warnings in Swift 5 mode.