### PR TITLE
SILGen: Separate borrow from consume phase for destructive pattern matches.

### DIFF
--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -142,6 +142,14 @@ void CleanupManager::endScope(CleanupsDepth depth, CleanupLocation loc) {
   emitCleanups(depth, loc, NotForUnwind, /*popCleanups*/ true);
 }
 
+/// Leave a scope, emitting all the cleanups that are currently active but leaving them on the stack so they
+/// can be reenabled on other pattern match branches.
+void CleanupManager::endNoncopyablePatternMatchBorrow(CleanupsDepth depth,
+                                                      CleanupLocation loc,
+                                                      bool popCleanups) {
+  emitCleanups(depth, loc, NotForUnwind, popCleanups);
+}
+
 bool CleanupManager::hasAnyActiveCleanups(CleanupsDepth from,
                                           CleanupsDepth to) {
   return ::hasAnyActiveCleanups(stack.find(from), stack.find(to));

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -159,7 +159,7 @@ typedef DiverseStackImpl<Cleanup>::stable_iterator CleanupHandle;
 class LLVM_LIBRARY_VISIBILITY CleanupManager {
   friend class Scope;
   friend class CleanupCloner;
-
+  
   SILGenFunction &SGF;
 
   /// Stack - Currently active cleanups in this scope tree.
@@ -288,6 +288,9 @@ public:
 
   /// Verify that the given cleanup handle is valid.
   void checkIterator(CleanupHandle handle) const;
+
+  void endNoncopyablePatternMatchBorrow(CleanupsDepth depth, CleanupLocation l,
+                                        bool finalEndBorrow = false);
 
 private:
   // Look up the flags and optionally the writeback address associated with the

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -520,10 +520,25 @@ public:
 
   /// Return a managed value that's appropriate for borrowing this
   /// value and promising not to consume it.
+  ///
+  /// TODO: Should be superseded by `asBorrowedOperand2` once existing code is
+  /// updated to tolerate address-only values being borrowed.
   ConsumableManagedValue asBorrowedOperand(SILGenFunction &SGF,
                                            SILLocation loc) const {
     if (getType().isAddress())
       return {asUnmanagedOwnedValue(), CastConsumptionKind::CopyOnSuccess};
+
+    if (Value.getOwnershipKind() == OwnershipKind::Guaranteed)
+      return {Value, CastConsumptionKind::BorrowAlways};
+
+    return {asUnmanagedOwnedValue().borrow(SGF, loc),
+            CastConsumptionKind::BorrowAlways};
+  }
+
+  ConsumableManagedValue asBorrowedOperand2(SILGenFunction &SGF,
+                                           SILLocation loc) const {
+    if (getType().isAddress())
+      return {asUnmanagedOwnedValue(), CastConsumptionKind::BorrowAlways};
 
     if (Value.getOwnershipKind() == OwnershipKind::Guaranteed)
       return {Value, CastConsumptionKind::BorrowAlways};


### PR DESCRIPTION
We don't want the dispatch phase of a pattern match to invalidate the subject, because we don't define the order in which patterns are evaluated, and if a particular match attempt fails, we need to still have an intact subject value on hand to try a potentially arbitrary other pattern against it. For noncopyable types, this means we have to always emit the match phase as a borrow, including the variable bindings for a guard expression if any. For a consuming pattern match, end the borrow scope and reproject the variable bindings by using consuming destructuring operations on the subject in the match block.

For now, this new code path only handles single-case-label-per-block switches without fallthroughs.