### PR TITLE
[MoveChecker] Separate partial reinit feature from partial consume feature.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -151,6 +151,7 @@ EXPERIMENTAL_FEATURE(OldOwnershipOperatorSpellings, true)
 EXPERIMENTAL_FEATURE(MoveOnlyEnumDeinits, true)
 EXPERIMENTAL_FEATURE(MoveOnlyTuples, true)
 EXPERIMENTAL_FEATURE(MoveOnlyPartialConsumption, true)
+EXPERIMENTAL_FEATURE(MoveOnlyPartialReinitialization, true)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(LayoutPrespecialization, true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3631,6 +3631,10 @@ static bool usesFeatureMoveOnlyPartialConsumption(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureMoveOnlyPartialReinitialization(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureNoncopyableGenerics(Decl *decl) {
   auto checkMarking = [](auto &marking) -> bool {
     switch (marking.getInverse().getKind()) {

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial_reinit.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_without_partial_reinit.swift
@@ -1,0 +1,45 @@
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses -enable-experimental-feature MoveOnlyPartialConsumption %s
+
+// Test diagnostics for partial-consumption without partial-reinitialization.
+
+struct Ur : ~Copyable {
+  deinit {}
+}
+
+struct Agg : ~Copyable {
+  var u1: Ur
+  var u2: Ur
+}
+
+func borrow(_ u1: borrowing Ur) {}
+func consume(_ u1: consuming Ur) {}
+func consume(_ u1: consuming Agg) {}
+func rewrite(_ u: inout Ur) {}
+
+// First consumes and then reinits each field.
+func reinit_1(agg: inout Agg, u1: consuming Ur, u2: consuming Ur) {
+  consume(agg.u1)
+  consume(agg.u2)
+  agg.u1 = u1 // expected-error{{cannot partially reinitialize 'agg' after it has been consumed; only full reinitialization is allowed}}
+              // expected-note@-3{{consumed here}}
+  agg.u2 = u2 // expected-error{{cannot partially reinitialize 'agg' after it has been consumed; only full reinitialization is allowed}}
+              // expected-note@-4{{consumed here}}
+}
+
+// Just replace fields of inout argument, no reinitialization.
+func not_reinit_1(agg: inout Agg, u1: consuming Ur, u2: consuming Ur) {
+  agg.u1 = u1
+  agg.u2 = u2
+}
+
+// Full reinitialization is legal.
+func not_reinit_2(agg: inout Agg, agg2: consuming Agg) {
+  consume(agg)
+  agg = agg2
+}
+
+// Passing fields as inout is allowed.
+func not_reinit_3(agg: inout Agg) {
+  rewrite(&agg.u1)
+  rewrite(&agg.u2)
+}

--- a/test/SILOptimizer/moveonly_generics_basic.swift
+++ b/test/SILOptimizer/moveonly_generics_basic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-swift-frontend %s -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoncopyableGenerics
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //


### PR DESCRIPTION
To allow enabling one but not the other.
