### PR TITLE
Disallow multi-line filenames and non-decimal line numbers in `#sourceLocation` directive in Swift 6 mode

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -88,6 +88,8 @@ WARNING(escaped_parameter_name,none,
 
 ERROR(forbidden_interpolated_string,none,
       "%0 cannot be an interpolated string literal", (StringRef))
+ERROR(forbidden_multiline_string,none,
+      "%0 cannot be a multi-line string literal", (StringRef))
 ERROR(forbidden_extended_escaping_string,none,
       "%0 cannot be an extended escaping string literal", (StringRef))
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -706,8 +706,11 @@ public:
   ///
   /// \param Loc where to diagnose.
   /// \param DiagText name for the string literal in the diagnostic.
+  /// \param AllowMultiline Whether the string literal can be a multiline string
+  ///        literal.
   llvm::Optional<StringRef>
-  getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText);
+  getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText,
+                                    bool AllowMultiline);
 
   /// Returns true to indicate that experimental concurrency syntax should be
   /// parsed if the parser is generating only a syntax tree or if the user has

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -568,7 +568,8 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
       }
 
       auto Value = getStringLiteralIfNotInterpolated(
-          AttrLoc, ("'" + ArgumentKindStr + "'").str());
+          AttrLoc, ("'" + ArgumentKindStr + "'").str(),
+          /*AllowMultiline=*/true);
       consumeToken();
       if (!Value) {
         AnyArgumentInvalid = true;
@@ -1453,7 +1454,8 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
       return std::nullopt;
     }
     llvm::Optional<StringRef> importModuleName =
-        getStringLiteralIfNotInterpolated(Loc, ("'" + AttrName + "'").str());
+        getStringLiteralIfNotInterpolated(Loc, ("'" + AttrName + "'").str(),
+                                          /*AllowMultiline=*/false);
     consumeToken(tok::string_literal);
 
     if (!importModuleName.has_value()) {
@@ -3233,8 +3235,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
 
-      AsmName =
-          getStringLiteralIfNotInterpolated(Loc, ("'" + AttrName + "'").str());
+      AsmName = getStringLiteralIfNotInterpolated(
+          Loc, ("'" + AttrName + "'").str(), /*AllowMultiline=*/false);
 
       consumeToken(tok::string_literal);
 
@@ -3305,7 +3307,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
 
     auto Name = getStringLiteralIfNotInterpolated(
-        Loc, ("'" + AttrName + "'").str());
+        Loc, ("'" + AttrName + "'").str(), /*AllowMultiline=*/false);
 
     consumeToken(tok::string_literal);
 
@@ -3392,7 +3394,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
 
     auto Value = getStringLiteralIfNotInterpolated(
-        Loc, ("'" + AttrName + "'").str());
+        Loc, ("'" + AttrName + "'").str(), /*AllowMultiline=*/false);
 
     consumeToken(tok::string_literal);
 
@@ -3455,8 +3457,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         // Parse the next string literal as the original module name.
         auto ModuleNameLoc = Tok.getLoc();
         if (Tok.is(tok::string_literal)) {
-          auto NameOp = getStringLiteralIfNotInterpolated(Tok.getLoc(),
-                                                          "original module name");
+          auto NameOp = getStringLiteralIfNotInterpolated(
+              Tok.getLoc(), "original module name", /*AllowMultiline=*/false);
           if (NameOp.has_value())
             OriginalModuleName = *NameOp;
           consumeToken();
@@ -3545,7 +3547,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         diagnose(ColonLoc, diag::attr_private_import_expected_sourcefile_name);
         return makeParserSuccess();
       }
-      filename = getStringLiteralIfNotInterpolated(Loc, "_private");
+      filename = getStringLiteralIfNotInterpolated(Loc, "_private",
+                                                   /*AllowMultiline=*/false);
       if (!filename.has_value()) {
         diagnose(ColonLoc, diag::attr_private_import_expected_sourcefile_name);
         return makeParserSuccess();
@@ -3818,8 +3821,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
 
-      llvm::Optional<StringRef> value =
-          getStringLiteralIfNotInterpolated(Tok.getLoc(), flag);
+      llvm::Optional<StringRef> value = getStringLiteralIfNotInterpolated(
+          Tok.getLoc(), flag, /*AllowMultiline=*/false);
       if (!value)
         return makeParserSuccess();
       Token stringTok = Tok;
@@ -4533,7 +4536,8 @@ bool Parser::parseConventionAttributeInternal(SourceLoc atLoc, SourceLoc attrLoc
         diagnose(Tok, diag::convention_attribute_ctype_expected_string);
       return true;
     }
-    if (auto ty = getStringLiteralIfNotInterpolated(Tok.getLoc(), "(C type)")) {
+    if (auto ty = getStringLiteralIfNotInterpolated(Tok.getLoc(), "(C type)",
+                                                    /*AllowMultiline=*/false)) {
       cType = Located<StringRef>(ty.value(), Tok.getLoc());
     }
     consumeToken(tok::string_literal);
@@ -7167,8 +7171,8 @@ ParserStatus Parser::parseLineDirective(bool isLine) {
         return makeParserError();
       }
 
-      Filename =
-          getStringLiteralIfNotInterpolated(Loc, "'#sourceLocation'");
+      Filename = getStringLiteralIfNotInterpolated(Loc, "'#sourceLocation'",
+                                                   /*AllowMultiline=*/false);
       if (!Filename.has_value())
         return makeParserError();
       SourceLoc filenameLoc = consumeToken(tok::string_literal);
@@ -7238,8 +7242,9 @@ ParserStatus Parser::parseLineDirective(bool isLine) {
       diagnose(Tok, diag::expected_line_directive_name);
       return makeParserError();
     }
-    
-    Filename = getStringLiteralIfNotInterpolated(Loc, "'#line'");
+
+    Filename = getStringLiteralIfNotInterpolated(Loc, "'#line'",
+                                                 /*AllowMultiline=*/false);
     if (!Filename.has_value())
       return makeParserError();
   }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7186,6 +7186,11 @@ ParserStatus Parser::parseLineDirective(bool isLine) {
       }
       SmallString<16> buffer;
       auto text = stripUnderscoresIfNeeded(Tok.getText(), buffer);
+      if (text.find_first_not_of("0123456789") != StringRef::npos) {
+        // Disallow non-decimal line numbers in Swift 6.
+        diagnose(Tok, diag::expected_line_directive_number)
+            .warnUntilSwiftVersion(6);
+      }
       if (text.getAsInteger(0, StartLine)) {
         diagnose(Tok, diag::expected_line_directive_number);
         return makeParserError();

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2773,8 +2773,9 @@ ParserResult<Stmt> Parser::parseStmtPoundAssert() {
       return makeParserError();
     }
 
-    auto messageOpt = getStringLiteralIfNotInterpolated(Tok.getLoc(),
-                                                        "'#assert' message");
+    auto messageOpt =
+        getStringLiteralIfNotInterpolated(Tok.getLoc(), "'#assert' message",
+                                          /*AllowMultiline=*/true);
     consumeToken();
     if (!messageOpt)
       return makeParserError();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1080,13 +1080,18 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
 }
 
 llvm::Optional<StringRef>
-Parser::getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText) {
+Parser::getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText,
+                                          bool AllowMultiline) {
   assert(Tok.is(tok::string_literal));
 
   // FIXME: Support extended escaping string literal.
   if (Tok.getCustomDelimiterLen()) {
     diagnose(Loc, diag::forbidden_extended_escaping_string, DiagText);
     return llvm::None;
+  }
+  if (!AllowMultiline && Tok.isMultilineString()) {
+    diagnose(Loc, diag::forbidden_multiline_string, DiagText)
+        .warnUntilSwiftVersion(6);
   }
 
   SmallVector<Lexer::StringSegment, 1> Segments;

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -14,6 +14,9 @@ x // expected-error {{parameterless closing #sourceLocation() directive without 
 
 #sourceLocation(file: x.swift, line: 1) // expected-error{{expected filename string literal}}
 
+// expected-warning@+1 {{expected starting line number}}
+#sourceLocation(file: "x.swift", line: 0xff)
+
 #sourceLocation(file: "x.swift", line: 42)
 x x ; // should be ignored by expected_error because it is in a different file
 x

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -14,8 +14,16 @@ x // expected-error {{parameterless closing #sourceLocation() directive without 
 
 #sourceLocation(file: x.swift, line: 1) // expected-error{{expected filename string literal}}
 
-// expected-warning@+1 {{expected starting line number}}
+// expected-warning@+1 {{expected starting line number for #sourceLocation directive; this is an error in Swift 6}}
 #sourceLocation(file: "x.swift", line: 0xff)
+
+#sourceLocation()
+
+// expected-warning@+1 {{'#sourceLocation' cannot be a multi-line string literal; this is an error in Swift 6}}
+#sourceLocation(file: """
+x.swift
+y.swift
+""", line: 42)
 
 #sourceLocation(file: "x.swift", line: 42)
 x x ; // should be ignored by expected_error because it is in a different file


### PR DESCRIPTION
- Disallow non-decimal line numbers to `#sourceLocation` directive
  - Non-decimal line numbers in a `#sourceLocation` directive are simply confusing in my opinion and should be banned.
- Disallow multiline string literals for filename in #sourceLocation and similar locations
  - This should allow us to eventually simplify parsing of simple string literals in the new parse by not having to handle indentation of multiline string literals.