### PR TITLE
MandatoryPerformanceOptimizations: clear all serialized flags in the module in embedded mode

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/MandatoryPerformanceOptimizations.swift
@@ -29,6 +29,16 @@ import SIL
 let mandatoryPerformanceOptimizations = ModulePass(name: "mandatory-performance-optimizations") {
   (moduleContext: ModulePassContext) in
 
+  if moduleContext.options.enableEmbeddedSwift {
+    // SILGen generates some functions with the serialized flag. This can prevent generic specialization.
+    // By clearing all serialized flags we make sure that all functions can be specialized.
+    // The CMO pass later in the pipeline can then decide which functions should be serialized and set the
+    // serialized flags again.
+    // Unfortunately we cannot clear the serialized flags in non-embedded mode. Therefore this problem still
+    // persists with performance-annotations.
+    moduleContext.removeSerializedFlagFromAllFunctions()
+  }
+
   var worklist = FunctionWorklist()
   // For embedded Swift, optimize all the functions (there cannot be any
   // generics, type metadata, etc.)

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
@@ -123,6 +123,10 @@ struct ModulePassContext : Context, CustomStringConvertible {
     _bridged.endTransformFunction();
   }
 
+  func removeSerializedFlagFromAllFunctions() {
+    _bridged.removeSerializedFlagFromAllFunctions()
+  }
+
   func mangleAsyncRemoved(from function: Function) -> String {
     return String(taking: _bridged.mangleAsyncRemoved(function.bridged))
   }

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -175,6 +175,7 @@ struct BridgedPassContext {
   BRIDGED_INLINE SILStage getSILStage() const;
   BRIDGED_INLINE bool hadError() const;
   BRIDGED_INLINE bool moduleIsSerialized() const;
+  BRIDGED_INLINE void removeSerializedFlagFromAllFunctions() const;
 
   // Analysis
 

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -155,6 +155,11 @@ bool BridgedPassContext::moduleIsSerialized() const {
   return invocation->getPassManager()->getModule()->isSerialized();
 }
 
+void BridgedPassContext::removeSerializedFlagFromAllFunctions() const {
+  auto *pm = invocation->getPassManager();
+  swift::removeSerializedFlagFromAllFunctions(*pm->getModule(), pm);
+}
+
 BridgedAliasAnalysis BridgedPassContext::getAliasAnalysis() const {
   return {invocation->getPassManager()->getAnalysis<swift::AliasAnalysis>(invocation->getFunction())};
 }

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -596,6 +596,12 @@ bool specializeClassMethodInst(ClassMethodInst *cm);
 bool specializeAppliesInFunction(SILFunction &F,
                                  SILTransform *transform,
                                  bool isMandatory);
+
+/// Removes all serialized flags from all functions and tables.
+///
+/// Implemented in the SerializeSILPass.
+void removeSerializedFlagFromAllFunctions(SILModule &M, SILPassManager *pm);
+
 } // end namespace swift
 
 #endif // SWIFT_SILOPTIMIZER_UTILS_INSTOPTUTILS_H

--- a/test/embedded/default-arguments.swift
+++ b/test/embedded/default-arguments.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -o /dev/null
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// Check that this doesn't crash the compiler in embedded mode.
+
+public func foo<T>(_ t: T) -> T {
+  t
+}
+
+public func testit(_ x: Int = foo(27)) -> Int {
+  x
+}
+
+public func callit() -> Int {
+  testit()
+}


### PR DESCRIPTION
SILGen generates some functions with the serialized flag. This can prevent generic specialization. By clearing all serialized flags we make sure that all functions can be specialized.
The CMO pass later in the pipeline can then decide which functions should be serialized and set the serialized flags again.

rdar://121675461
