### PR TITLE
[cxx-interop] Make automatic conformances work with the bridging header

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2808,7 +2808,7 @@ namespace {
       // If this module is declared as a C++ module, try to synthesize
       // conformances to Swift protocols from the Cxx module.
       auto clangModule = Impl.getClangOwningModule(result->getClangNode());
-      if (clangModule && requiresCPlusPlus(clangModule)) {
+      if (!clangModule || requiresCPlusPlus(clangModule)) {
         if (auto nominalDecl = dyn_cast<NominalTypeDecl>(result)) {
           conformToCxxIteratorIfNeeded(Impl, nominalDecl, decl);
           conformToCxxSequenceIfNeeded(Impl, nominalDecl, decl);

--- a/test/Interop/Cxx/stdlib/Inputs/std-vector.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-vector.h
@@ -17,4 +17,9 @@ class VectorSubclass: public Vector {
 public:
 };
 
+class VectorOfStringSubclass : public std::vector<std::string> {
+public:
+  using std::vector<std::string>::vector;
+};
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_VECTOR_H

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -1,12 +1,20 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-//
+
+// Also test this with a bridging header instead of the StdMap module.
+// RUN: %empty-directory(%t2)
+// RUN: cp %S/Inputs/std-map.h %t2/std-map-bridging-header.h
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-map-bridging-header.h -cxx-interoperability-mode=upcoming-swift)
+
 // REQUIRES: executable_test
 //
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 import StdlibUnittest
+#if !BRIDGING_HEADER
 import StdMap
+#endif
 import CxxStdlib
 import Cxx
 

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -1,13 +1,21 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
-//
+
+// Also test this with a bridging header instead of the StdSet module.
+// RUN: %empty-directory(%t2)
+// RUN: cp %S/Inputs/std-set.h %t2/std-set-bridging-header.h
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-set-bridging-header.h -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-D BRIDGING_HEADER -import-objc-header %t2/std-set-bridging-header.h -cxx-interoperability-mode=upcoming-swift)
+
 // REQUIRES: executable_test
 //
 // Enable this everywhere once we have a solution for modularizing other C++ stdlibs: rdar://87654514
 // REQUIRES: OS=macosx || OS=linux-gnu
 
 import StdlibUnittest
+#if !BRIDGING_HEADER
 import StdSet
+#endif
 import CxxStdlib
 import Cxx
 


### PR DESCRIPTION
For C++ types that are defined in the bridging header, or are `#include`-d from the bridging header, we did not generate the automatic conformances to `CxxSequence`, `CxxRandomAccessCollection` protocols.

To check whether we should try to conform a C++ type to those protocols, the compiler checks for the presence of `requires cplusplus` in the module declaration in a modulemap file. This check is there to prevent us from accidentally pulling in `Cxx`/`CxxStdlib` modules when a client is importing a C library.

This change makes sure those conformances are generated.

rdar://121927459