### PR TITLE
[Concurrency] Audit diagnostics for Swift 6.

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -575,6 +575,17 @@ namespace swift {
       return limitBehavior(limit);
     }
 
+    /// Conditionally limit the diagnostic behavior if the given \c limit
+    /// is not \c None.
+    InFlightDiagnostic &limitBehaviorIf(
+        llvm::Optional<DiagnosticBehavior> limit) {
+      if (!limit) {
+        return *this;
+      }
+
+      return limitBehavior(*limit);
+    }
+
     /// Limit the diagnostic behavior to \c limit until the specified
     /// version.
     ///

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -575,6 +575,14 @@ namespace swift {
       return limitBehavior(limit);
     }
 
+    /// Limit the diagnostic behavior to \c limit until the specified
+    /// version.
+    ///
+    /// This helps stage in fixes for stricter diagnostics as warnings
+    /// until the next major language version.
+    InFlightDiagnostic &limitBehaviorUntilSwiftVersion(
+        DiagnosticBehavior limit, unsigned majorVersion);
+
     /// Limit the diagnostic behavior to warning until the specified version.
     ///
     /// This helps stage in fixes for stricter diagnostics as warnings

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5270,7 +5270,10 @@ NOTE(note_add_async_and_throws_to_decl,none,
 NOTE(note_add_distributed_to_decl,none,
      "add 'distributed' to %0 to make this %kindonly0 satisfy the protocol requirement",
      (const ValueDecl *))
-ERROR(add_globalactor_to_function,none,
+ERROR(invalid_isolated_calls_in_body,none,
+     "calls to '@%0'-isolated' code in %kind1",
+     (StringRef, const ValueDecl *))
+NOTE(add_globalactor_to_function,none,
      "add '@%0' to make %kind1 part of global actor %2",
      (StringRef, const ValueDecl *, Type))
 FIXIT(insert_globalactor_attr, "@%0 ", (Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5565,43 +5565,43 @@ ERROR(isolation_macro_experimental,none,
 NOTE(in_derived_conformance, none,
      "in derived conformance to %0",
      (Type))
-WARNING(non_sendable_param_type,none,
-        "non-sendable type %0 %select{passed in call to %3 %kind2|"
-        "exiting %3 context in call to non-isolated %kind2|"
-        "passed in implicitly asynchronous call to %3 %kind2|"
-        "in parameter of the protocol requirement satisfied by %3 %kind2|"
-        "in parameter of superclass method overridden by %3 %kind2|"
-        "in parameter of %3 '@objc' %kind2}1 cannot cross actor boundary",
-        (Type, unsigned, const ValueDecl *, ActorIsolation))
-WARNING(non_sendable_call_argument,none,
-        "passing argument of non-sendable type %0 %select{into %2 context|"
-        "outside of %2 context}1 may introduce data races",
-        (Type, bool, ActorIsolation))
-WARNING(non_sendable_result_type,none,
-        "non-sendable type %0 returned by %select{call to %3 %kind2|"
-        "call from %4 context to non-isolated %kind2|"
-        "implicitly asynchronous call to %3 %kind2|"
-        "%3 %kind2 satisfying protocol requirement|"
-        "%3 overriding %kind2|"
-        "%3 '@objc' %kind2}1 cannot cross actor boundary",
-        (Type, unsigned, const ValueDecl *, ActorIsolation))
-WARNING(non_sendable_call_result_type,none,
-        "non-sendable type %0 returned by %select{implicitly asynchronous |}1"
-        "call to %2 function cannot cross actor boundary",
-        (Type, bool, ActorIsolation))
-WARNING(non_sendable_property_type,none,
-        "non-sendable type %0 in %select{"
-        "%select{asynchronous access to %4 %kind1|"
-        "asynchronous access from %4 context to non-isolated %kind1|"
-        "implicitly asynchronous access to %4 %kind1|"
-        "conformance of %4 %kind1 to protocol requirement|"
-        "%4 overriding %kind1|"
-        "%4 '@objc' %kind1}3|captured local %1}2 cannot "
-        "cross %select{actor|task}2 boundary",
-        (Type, const ValueDecl *, bool, unsigned, ActorIsolation))
-WARNING(non_sendable_keypath_capture,none,
-        "cannot form key path that captures non-sendable type %0",
-        (Type))
+ERROR(non_sendable_param_type,none,
+      "non-sendable type %0 %select{passed in call to %3 %kind2|"
+      "exiting %3 context in call to non-isolated %kind2|"
+      "passed in implicitly asynchronous call to %3 %kind2|"
+      "in parameter of the protocol requirement satisfied by %3 %kind2|"
+      "in parameter of superclass method overridden by %3 %kind2|"
+      "in parameter of %3 '@objc' %kind2}1 cannot cross actor boundary",
+      (Type, unsigned, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_call_argument,none,
+      "passing argument of non-sendable type %0 %select{into %2 context|"
+      "outside of %2 context}1 may introduce data races",
+      (Type, bool, ActorIsolation))
+ERROR(non_sendable_result_type,none,
+      "non-sendable type %0 returned by %select{call to %3 %kind2|"
+      "call from %4 context to non-isolated %kind2|"
+      "implicitly asynchronous call to %3 %kind2|"
+      "%3 %kind2 satisfying protocol requirement|"
+      "%3 overriding %kind2|"
+      "%3 '@objc' %kind2}1 cannot cross actor boundary",
+      (Type, unsigned, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_call_result_type,none,
+      "non-sendable type %0 returned by %select{implicitly asynchronous |}1"
+      "call to %2 function cannot cross actor boundary",
+      (Type, bool, ActorIsolation))
+ERROR(non_sendable_property_type,none,
+      "non-sendable type %0 in %select{"
+      "%select{asynchronous access to %4 %kind1|"
+      "asynchronous access from %4 context to non-isolated %kind1|"
+      "implicitly asynchronous access to %4 %kind1|"
+      "conformance of %4 %kind1 to protocol requirement|"
+      "%4 overriding %kind1|"
+      "%4 '@objc' %kind1}3|captured local %1}2 cannot "
+      "cross %select{actor|task}2 boundary",
+      (Type, const ValueDecl *, bool, unsigned, ActorIsolation))
+ERROR(non_sendable_keypath_capture,none,
+      "cannot form key path that captures non-sendable type %0",
+      (Type))
 ERROR(non_concurrent_type_member,none,
       "%select{stored property %2|associated value %2}1 of "
       "'Sendable'-conforming %kind3 has non-sendable type %0",

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -331,8 +331,14 @@ InFlightDiagnostic &
 InFlightDiagnostic::limitBehaviorUntilSwiftVersion(
     DiagnosticBehavior limit, unsigned majorVersion) {
   if (!Engine->languageVersion.isVersionAtLeast(majorVersion)) {
-    limitBehavior(limit)
-      .wrapIn(diag::error_in_future_swift_version, majorVersion);
+    // If the behavior limit is a warning or less, wrap the diagnostic
+    // in a message that this will become an error in a later Swift
+    // version. We do this before limiting the behavior, because
+    // wrapIn will result in the behavior of the wrapping diagnostic.
+    if (limit >= DiagnosticBehavior::Warning)
+      wrapIn(diag::error_in_future_swift_version, majorVersion);
+
+    limitBehavior(limit);
   }
 
   if (majorVersion == 6) {

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -328,9 +328,10 @@ InFlightDiagnostic::limitBehavior(DiagnosticBehavior limit) {
 }
 
 InFlightDiagnostic &
-InFlightDiagnostic::warnUntilSwiftVersion(unsigned majorVersion) {
+InFlightDiagnostic::limitBehaviorUntilSwiftVersion(
+    DiagnosticBehavior limit, unsigned majorVersion) {
   if (!Engine->languageVersion.isVersionAtLeast(majorVersion)) {
-    limitBehavior(DiagnosticBehavior::Warning)
+    limitBehavior(limit)
       .wrapIn(diag::error_in_future_swift_version, majorVersion);
   }
 
@@ -341,6 +342,12 @@ InFlightDiagnostic::warnUntilSwiftVersion(unsigned majorVersion) {
   }
 
   return *this;
+}
+
+InFlightDiagnostic &
+InFlightDiagnostic::warnUntilSwiftVersion(unsigned majorVersion) {
+  return limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning,
+                                        majorVersion);
 }
 
 InFlightDiagnostic &

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -882,7 +882,9 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
     if (sourceFile)
       sourceFile->setImportUsedPreconcurrency(*import);
 
-    return nominal->getASTContext().LangOpts.isSwiftVersionAtLeast(6)
+    // `@preconcurrency` suppresses diagnostics until the imported
+    // module enables Swift 6.
+    return import->module.importedModule->isConcurrencyChecked()
         ? DiagnosticBehavior::Warning
         : DiagnosticBehavior::Ignore;
   }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -734,16 +734,6 @@ static bool shouldDiagnoseExistingDataRaces(const DeclContext *dc) {
   });
 }
 
-/// Determine the default diagnostic behavior for this language mode.
-static DiagnosticBehavior defaultSendableDiagnosticBehavior(
-    const LangOptions &langOpts) {
-  // Prior to Swift 6, all Sendable-related diagnostics are warnings at most.
-  if (!langOpts.isSwiftVersionAtLeast(6))
-    return DiagnosticBehavior::Warning;
-
-  return DiagnosticBehavior::Unspecified;
-}
-
 bool SendableCheckContext::isExplicitSendableConformance() const {
   if (!conformanceCheck)
     return false;
@@ -766,7 +756,7 @@ DiagnosticBehavior SendableCheckContext::defaultDiagnosticBehavior() const {
       !shouldDiagnoseExistingDataRaces(fromDC))
     return DiagnosticBehavior::Ignore;
 
-  return defaultSendableDiagnosticBehavior(fromDC->getASTContext().LangOpts);
+  return DiagnosticBehavior::Warning;
 }
 
 DiagnosticBehavior
@@ -856,38 +846,8 @@ findImportFor(const DeclContext *dc, const DeclContext *fromDC) {
 /// nominal type.
 DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
     NominalTypeDecl *nominal) const {
-  // Determine whether this nominal type is visible via a @preconcurrency
-  // import.
-  auto import = findImportFor(nominal, fromDC);
-  auto sourceFile = fromDC->getParentSourceFile();
-
-  // When the type is explicitly non-Sendable...
-  if (hasExplicitSendableConformance(nominal)) {
-    // @preconcurrency imports downgrade the diagnostic to a warning in Swift 6,
-    if (import && import->options.contains(ImportFlags::Preconcurrency)) {
-      if (sourceFile)
-        sourceFile->setImportUsedPreconcurrency(*import);
-
-      return DiagnosticBehavior::Warning;
-    }
-
-    return defaultSendableDiagnosticBehavior(fromDC->getASTContext().LangOpts);
-  }
-
-  // When the type is implicitly non-Sendable...
-
-  // @preconcurrency suppresses the diagnostic in Swift 5.x, and
-  // downgrades it to a warning in Swift 6 and later.
-  if (import && import->options.contains(ImportFlags::Preconcurrency)) {
-    if (sourceFile)
-      sourceFile->setImportUsedPreconcurrency(*import);
-
-    // `@preconcurrency` suppresses diagnostics until the imported
-    // module enables Swift 6.
-    return import->module.importedModule->isConcurrencyChecked()
-        ? DiagnosticBehavior::Warning
-        : DiagnosticBehavior::Ignore;
-  }
+  if (hasExplicitSendableConformance(nominal))
+    return DiagnosticBehavior::Warning;
 
   DiagnosticBehavior defaultBehavior = implicitSendableDiagnosticBehavior();
 
@@ -900,6 +860,38 @@ DiagnosticBehavior SendableCheckContext::diagnosticBehavior(
     return DiagnosticBehavior::Warning;
 
   return defaultBehavior;
+}
+
+llvm::Optional<DiagnosticBehavior>
+SendableCheckContext::preconcurrencyBehavior(Decl *decl) const {
+  if (!decl)
+    return llvm::None;
+
+  if (auto *nominal = dyn_cast<NominalTypeDecl>(decl)) {
+    // Determine whether this nominal type is visible via a @preconcurrency
+    // import.
+    auto import = findImportFor(nominal, fromDC);
+    auto sourceFile = fromDC->getParentSourceFile();
+
+    if (!import || !import->options.contains(ImportFlags::Preconcurrency))
+      return llvm::None;
+
+    if (sourceFile)
+      sourceFile->setImportUsedPreconcurrency(*import);
+
+    // When the type is explicitly non-Sendable, @preconcurrency imports
+    // downgrade the diagnostic to a warning in Swift 6.
+    if (hasExplicitSendableConformance(nominal))
+      return DiagnosticBehavior::Warning;
+
+    // When the type is implicitly non-Sendable, `@preconcurrency` suppresses
+    // diagnostics until the imported module enables Swift 6.
+    return import->module.importedModule->isConcurrencyChecked()
+        ? DiagnosticBehavior::Warning
+        : DiagnosticBehavior::Ignore;
+  }
+
+  return llvm::None;
 }
 
 static bool shouldDiagnosePreconcurrencyImports(SourceFile &sf) {
@@ -2106,7 +2098,8 @@ namespace {
 
     /// Note when the enclosing context could be put on a global actor.
     // FIXME: This should handle closures too.
-    static bool missingGlobalActorOnContext(DeclContext *dc, Type globalActor, DiagnosticBehavior behavior) {
+    static bool missingGlobalActorOnContext(DeclContext *dc, Type globalActor,
+                                            DiagnosticBehavior behavior) {
       // If we are in a synchronous function on the global actor,
       // suggest annotating with the global actor itself.
       if (auto fn = findAnnotatableFunction(dc)) {
@@ -2125,13 +2118,19 @@ namespace {
               return false;
 
           case ActorIsolation::Unspecified:
+            if (behavior != DiagnosticBehavior::Note) {
+              fn->diagnose(diag::invalid_isolated_calls_in_body,
+                           globalActor->getWithoutParens().getString(), fn)
+                  .limitBehaviorUntilSwiftVersion(behavior, 6);
+            }
+
+            // Always emit the note with fix-it.
             fn->diagnose(diag::add_globalactor_to_function,
                          globalActor->getWithoutParens().getString(),
                          fn, globalActor)
-            .limitBehavior(behavior)
-            .fixItInsert(fn->getAttributeInsertionLoc(false),
-                         diag::insert_globalactor_attr, globalActor);
-              return true;
+                .fixItInsert(fn->getAttributeInsertionLoc(false),
+                             diag::insert_globalactor_attr, globalActor);
+            return true;
           }
         }
       }
@@ -2163,7 +2162,7 @@ namespace {
           // Diagnose actor_isolated_non_self_reference as note
           // if fix-it provided in missingGlobalActorOnContext
           ctx.Diags.diagnose(error.loc, error.diag)
-              .limitBehavior(behavior);
+              .limitBehaviorUntilSwiftVersion(behavior, 6);
         }
       }
 
@@ -2188,7 +2187,7 @@ namespace {
           // Diagnose actor_isolated_call as note if
           // fix-it provided in missingGlobalActorOnContext
           ctx.Diags.diagnose(error.loc, error.diag)
-              .limitBehavior(behavior);
+              .limitBehaviorUntilSwiftVersion(behavior, 6);
         }
       }
 
@@ -3012,12 +3011,21 @@ namespace {
           import && import->options.contains(ImportFlags::Preconcurrency);
       const auto isPreconcurrencyUnspecifiedIsolation =
           isPreconcurrencyImport && isolation.isUnspecified();
+
+      // If the global variable is preconcurrency without an explicit
+      // isolation, ignore the warning. Otherwise, limit the behavior
+      // to a warning until Swift 6.
+      DiagnosticBehavior limit;
+      if (isPreconcurrencyUnspecifiedIsolation) {
+        limit = DiagnosticBehavior::Ignore;
+      } else {
+        limit = DiagnosticBehavior::Warning;
+      }
+
       ctx.Diags.diagnose(loc, diag::shared_mutable_state_access, value)
-          .warnUntilSwiftVersionIf(!isPreconcurrencyUnspecifiedIsolation, 6)
-          .limitBehaviorIf(isPreconcurrencyImport, DiagnosticBehavior::Warning)
-          .limitBehaviorIf(!ctx.isSwiftVersionAtLeast(6) &&
-                               isPreconcurrencyUnspecifiedIsolation,
-                           DiagnosticBehavior::Ignore);
+          .limitBehaviorUntilSwiftVersion(limit, 6)
+          // Preconcurrency global variables are warnings even in Swift 6
+          .limitBehaviorIf(isPreconcurrencyImport, DiagnosticBehavior::Warning);
       value->diagnose(diag::kind_declared_here, value->getDescriptiveKind());
       if (const auto sourceFile = getDeclContext()->getParentSourceFile();
           sourceFile && isPreconcurrencyImport) {
@@ -5248,7 +5256,7 @@ void swift::checkOverrideActorIsolation(ValueDecl *value) {
   value->diagnose(
       diag::actor_isolation_override_mismatch, isolation,
       value, overriddenIsolation)
-    .limitBehavior(behavior);
+    .limitBehaviorUntilSwiftVersion(behavior, 6);
   overridden->diagnose(diag::overridden_here);
 }
 
@@ -5346,7 +5354,7 @@ static bool checkSendableInstanceStorage(
           && SendableCheckContext(dc, check)
                .defaultDiagnosticBehavior() != DiagnosticBehavior::Ignore) {
         sd->diagnose(diag::sendable_raw_storage, sd->getName())
-          .limitBehavior(behavior);
+          .limitBehaviorUntilSwiftVersion(behavior, 6);
       }
       return true;
     }
@@ -5381,7 +5389,7 @@ static bool checkSendableInstanceStorage(
             property
                 ->diagnose(diag::concurrent_value_class_mutable_property,
                            property->getName(), nominal)
-                .limitBehavior(behavior);
+                .limitBehaviorUntilSwiftVersion(behavior, 6);
           }
           invalid = invalid || (behavior == DiagnosticBehavior::Unspecified);
           return true;
@@ -5393,10 +5401,13 @@ static bool checkSendableInstanceStorage(
       }
 
       // Check that the property type is Sendable.
+      SendableCheckContext context(dc, check);
       diagnoseNonSendableTypes(
-          propertyType, SendableCheckContext(dc, check),
+          propertyType, context,
           /*inDerivedConformance*/Type(), property->getLoc(),
           [&](Type type, DiagnosticBehavior behavior) {
+            auto preconcurrency =
+                context.preconcurrencyBehavior(type->getAnyNominal());
             if (isImplicitSendableCheck(check)) {
               // If this is for an externally-visible conformance, fail.
               if (check == SendableCheck::ImplicitForExternallyVisible) {
@@ -5405,8 +5416,9 @@ static bool checkSendableInstanceStorage(
               }
 
               // If we are to ignore this diagnostic, just continue.
-              if (behavior == DiagnosticBehavior::Ignore)
-                return false;
+              if (behavior == DiagnosticBehavior::Ignore ||
+                  preconcurrency == DiagnosticBehavior::Ignore)
+                return true;
 
               invalid = true;
               return true;
@@ -5415,7 +5427,8 @@ static bool checkSendableInstanceStorage(
             property->diagnose(diag::non_concurrent_type_member,
                                propertyType, false, property->getName(),
                                nominal)
-                .limitBehavior(behavior);
+                .limitBehaviorUntilSwiftVersion(behavior, 6)
+                .limitBehaviorIf(preconcurrency);
             return false;
           });
 
@@ -5430,10 +5443,13 @@ static bool checkSendableInstanceStorage(
 
     /// Handle an enum associated value.
     bool operator()(EnumElementDecl *element, Type elementType) override {
+      SendableCheckContext context (dc, check);
       diagnoseNonSendableTypes(
-          elementType, SendableCheckContext(dc, check),
+          elementType, context,
           /*inDerivedConformance*/Type(), element->getLoc(),
           [&](Type type, DiagnosticBehavior behavior) {
+            auto preconcurrency =
+                context.preconcurrencyBehavior(elementType->getAnyNominal());
             if (isImplicitSendableCheck(check)) {
               // If this is for an externally-visible conformance, fail.
               if (check == SendableCheck::ImplicitForExternallyVisible) {
@@ -5442,7 +5458,8 @@ static bool checkSendableInstanceStorage(
               }
 
               // If we are to ignore this diagnostic, just continue.
-              if (behavior == DiagnosticBehavior::Ignore)
+              if (behavior == DiagnosticBehavior::Ignore ||
+                  preconcurrency == DiagnosticBehavior::Ignore)
                 return false;
 
               invalid = true;
@@ -5451,7 +5468,8 @@ static bool checkSendableInstanceStorage(
 
             element->diagnose(diag::non_concurrent_type_member, type,
                               true, element->getName(), nominal)
-                .limitBehavior(behavior);
+                .limitBehaviorUntilSwiftVersion(behavior, 6)
+                .limitBehaviorIf(preconcurrency);
             return false;
           });
 
@@ -5510,7 +5528,7 @@ bool swift::checkSendableConformance(
       nominal->getOutermostParentSourceFile()) {
     conformanceDecl->diagnose(diag::concurrent_value_outside_source_file,
                               nominal)
-      .limitBehavior(behavior);
+      .limitBehaviorUntilSwiftVersion(behavior, 6);
 
     if (behavior == DiagnosticBehavior::Unspecified)
       return true;
@@ -5523,7 +5541,7 @@ bool swift::checkSendableConformance(
     if (!classDecl->isSemanticallyFinal()) {
       classDecl->diagnose(diag::concurrent_value_nonfinal_class,
                           classDecl->getName())
-        .limitBehavior(behavior);
+        .limitBehaviorUntilSwiftVersion(behavior, 6);
 
       if (behavior == DiagnosticBehavior::Unspecified)
         return true;
@@ -5538,7 +5556,7 @@ bool swift::checkSendableConformance(
               ->diagnose(diag::concurrent_value_inherit,
                          nominal->getASTContext().LangOpts.EnableObjCInterop,
                          classDecl->getName())
-              .limitBehavior(behavior);
+              .limitBehaviorUntilSwiftVersion(behavior, 6);
 
           if (behavior == DiagnosticBehavior::Unspecified)
             return true;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -560,7 +560,8 @@ static void diagnoseGeneralOverrideFailure(ValueDecl *decl,
     diagnoseSendabilityErrorBasedOn(baseDeclClass, fromContext,
                                     [&](DiagnosticBehavior limit) {
       diags.diagnose(decl, diag::override_sendability_mismatch, decl->getName())
-          .limitBehavior(limit);
+          .limitBehaviorUntilSwiftVersion(limit, 6)
+          .limitBehaviorIf(fromContext.preconcurrencyBehavior(baseDeclClass));
       return false;
     });
     break;
@@ -1301,9 +1302,9 @@ bool OverrideMatcher::checkOverride(ValueDecl *baseDecl,
                                     [&](DiagnosticBehavior limit) {
       diags.diagnose(decl, diag::override_sendability_mismatch,
                      decl->getName())
-        .limitBehavior(limit);
-      diags.diagnose(baseDecl, diag::overridden_here)
-        .limitBehavior(limit);
+        .limitBehaviorUntilSwiftVersion(limit, 6)
+        .limitBehaviorIf(fromContext.preconcurrencyBehavior(baseDeclClass));
+      diags.diagnose(baseDecl, diag::overridden_here);
       return false;
     });
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3230,7 +3230,7 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
   witness->diagnose(diag::actor_isolated_witness,
                     isDistributed && !isDistributedDecl(witness),
                     refResult.isolation, witness, requirementIsolation)
-    .limitBehavior(behavior);
+    .limitBehaviorUntilSwiftVersion(behavior, 6);
 
   // If we need 'distributed' on the witness, add it.
   if (missingOptions.contains(MissingFlags::WitnessDistributed)) {
@@ -4093,14 +4093,15 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
       SendableCheckContext sendFrom(witness->getDeclContext(),
                                     SendableCheck::Explicit);
 
-      auto behavior = sendFrom.diagnosticBehavior(Conformance->getProtocol());
+      auto *nominal = Conformance->getProtocol();
+      auto behavior = sendFrom.diagnosticBehavior(nominal);
       if (behavior != DiagnosticBehavior::Ignore) {
         bool isError = behavior < DiagnosticBehavior::Warning;
         
         // Avoid relying on the lifetime of 'this'.
         const DeclContext *DC = this->DC;
         getASTContext().addDelayedConformanceDiag(Conformance, isError,
-                        [DC, requirement, witness, sendFrom](
+                        [DC, requirement, witness, sendFrom, nominal](
                           NormalProtocolConformance *conformance) {
           diagnoseSendabilityErrorBasedOn(conformance->getProtocol(), sendFrom,
                                           [&](DiagnosticBehavior limit) {
@@ -4108,9 +4109,9 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
             diags.diagnose(getLocForDiagnosingWitness(conformance, witness),
                            diag::witness_not_as_sendable,
                            witness, conformance->getProtocol())
-                .limitBehavior(limit);
-            diags.diagnose(requirement, diag::less_sendable_reqt_here)
-                .limitBehavior(limit);
+                .limitBehaviorUntilSwiftVersion(limit, 6)
+                .limitBehaviorIf(sendFrom.preconcurrencyBehavior(nominal));
+            diags.diagnose(requirement, diag::less_sendable_reqt_here);
             return false;
           });
         });

--- a/test/ClangImporter/predates_concurrency_import_swift6.swift
+++ b/test/ClangImporter/predates_concurrency_import_swift6.swift
@@ -12,6 +12,6 @@
 func acceptSendable<T: Sendable>(_: T) { }
 
 func useSendable(ns: NSString) {
-  // Note: warning below is downgraded due to @preconcurrency
-  acceptSendable(ns) // expected-warning{{type 'NSString' does not conform to the 'Sendable' protocol}}
+  // Note: warning below is suppressed due to @preconcurrency
+  acceptSendable(ns)
 }

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend -disable-availability-checking -strict-concurrency=complete -swift-version 6 -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -strict-concurrency=complete -swift-version 6 -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation %s
+// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 -emit-sil -o /dev/null -verify %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -62,7 +61,7 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
 
   // these do need await, regardless of reference or value type
   _ = await (formance as any MainCounter).counter
-  // expected-warning@-1 {{non-sendable type 'any MainCounter' passed in implicitly asynchronous call to main actor-isolated property 'counter' cannot cross actor boundary}}
+  // expected-error@-1 {{non-sendable type 'any MainCounter' passed in implicitly asynchronous call to main actor-isolated property 'counter' cannot cross actor boundary}}
   _ = await ext[1]
   _ = await formance.ticker
   _ = await ext.polygon

--- a/test/Concurrency/global_actor_serialized.swift
+++ b/test/Concurrency/global_actor_serialized.swift
@@ -2,7 +2,6 @@
 // RUN: %target-swift-frontend -emit-module -swift-version 5 -emit-module-path %t/SerializedStruct.swiftmodule -module-name SerializedStruct %S/Inputs/SerializedStruct.swift
 
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t
-// RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify -disable-availability-checking -swift-version 6 -I %t -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -16,5 +15,5 @@ import SerializedStruct // expected-warning {{add '@preconcurrency' to treat 'Se
 // use it to force the right checks happen.
 func test() async -> Int {
   let x = MySerializedStruct()
-  return await x.counter // expected-warning {{non-sendable type 'MySerializedStruct' passed in implicitly asynchronous call to main actor-isolated property 'counter' cannot cross actor boundary}}
+  return await x.counter // expected-error {{non-sendable type 'MySerializedStruct' passed in implicitly asynchronous call to main actor-isolated property 'counter' cannot cross actor boundary}}
 }

--- a/test/Concurrency/grouped_actor_isolation_diagnostics.swift
+++ b/test/Concurrency/grouped_actor_isolation_diagnostics.swift
@@ -9,11 +9,12 @@ protocol P {
 
 struct S_P: P {
   func f() { }
-  // expected-complete-sns-note @-1 {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
   func g() { }
 }
 
-func testP(x: S_P, p: P) { // expected-error{{add '@MainActor' to make global function 'testP(x:p:)' part of global actor 'MainActor'}}
+// expected-error@+2{{calls to '@MainActor'-isolated' code in global function 'testP(x:p:)'}}
+// expected-note@+1{{add '@MainActor' to make global function 'testP(x:p:)' part of global actor 'MainActor'}}
+func testP(x: S_P, p: P) {
   p.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   p.f() // expected-note{{call to main actor-isolated instance method 'f()' in a synchronous nonisolated context}}
@@ -55,12 +56,17 @@ struct HasWrapperOnActor {
   @WrapperOnActor var y: String = ""
   @WrapperOnActor var z: (Double, Double) = (1.0,2.0)
 
-  func testWrapped() { // expected-error{{add '@MainActor' to make instance method 'testWrapped()' part of global actor 'MainActor'}}
+  // expected-error@+2{{calls to '@MainActor'-isolated' code in instance method 'testWrapped()'}}
+  // expected-note@+1{{add '@MainActor' to make instance method 'testWrapped()' part of global actor 'MainActor'}}
+  func testWrapped() {
     _ = x // expected-note{{main actor-isolated property 'x' can not be referenced from a non-isolated context}}
     _ = y // expected-note{{main actor-isolated property 'y' can not be referenced from a non-isolated context}}
     _ = z // expected-note{{main actor-isolated property 'z' can not be referenced from a non-isolated context}}
   }
-  func testProjected(){ // expected-error{{add '@SomeGlobalActor' to make instance method 'testProjected()' part of global actor 'SomeGlobalActor'}}
+
+  // expected-error@+2{{calls to '@SomeGlobalActor'-isolated' code in instance method 'testProjected()'}}
+  // expected-note@+1{{add '@SomeGlobalActor' to make instance method 'testProjected()' part of global actor 'SomeGlobalActor'}}
+  func testProjected(){
     _ = $x // expected-note{{global actor 'SomeGlobalActor'-isolated property '$x' can not be referenced from a non-isolated context}}
     _ = $y // expected-note{{global actor 'SomeGlobalActor'-isolated property '$y' can not be referenced from a non-isolated context}}
     _ = $z // expected-note{{global actor 'SomeGlobalActor'-isolated property '$z' can not be referenced from a non-isolated context}}
@@ -69,7 +75,9 @@ struct HasWrapperOnActor {
   @MainActor
   func testMA(){ }
 
-  func testErrors() { // expected-error{{add '@MainActor' to make instance method 'testErrors()' part of global actor 'MainActor'}}
+  // expected-error@+2{{calls to '@MainActor'-isolated' code in instance method 'testErrors()'}}
+  // expected-note@+1{{add '@MainActor' to make instance method 'testErrors()' part of global actor 'MainActor'}}
+  func testErrors() {
     testMA() // expected-error{{call to main actor-isolated instance method 'testMA()' in a synchronous nonisolated context}}
   }
 }

--- a/test/Concurrency/predates_concurrency_import_swift6.swift
+++ b/test/Concurrency/predates_concurrency_import_swift6.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -strict-concurrency=complete %S/Inputs/StrictModule.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 
 // RUN: %target-swift-frontend -swift-version 6 -I %t %s %s -emit-sil -o /dev/null -verify
@@ -15,5 +15,5 @@ func acceptSendable<T: Sendable>(_: T) { }
 @available(SwiftStdlib 5.1, *)
 func test(ss: StrictStruct, ns: NonStrictClass) {
   acceptSendable(ss) // expected-warning{{type 'StrictStruct' does not conform to the 'Sendable' protocol}}
-  acceptSendable(ns) // expected-warning{{type 'NonStrictClass' does not conform to the 'Sendable' protocol}}
+  acceptSendable(ns)
 }

--- a/test/Concurrency/sendable_without_preconcurrency.swift
+++ b/test/Concurrency/sendable_without_preconcurrency.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete-
-// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -enable-experimental-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -strict-concurrency=minimal -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil
+// RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix targeted-complete-
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -verify-additional-prefix targeted-complete-
+// RUN: %target-swift-frontend -strict-concurrency=complete -disable-availability-checking -I %t -verify %s -o /dev/null -emit-sil -verify-additional-prefix complete- -verify-additional-prefix targeted-complete- -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -15,23 +16,23 @@ actor A {
   func f() -> [StrictStruct: NonStrictClass] { [:] }
 }
 
-class NS { } // expected-note{{class 'NS' does not conform to the 'Sendable' protocol}}
+class NS { } // expected-targeted-complete-note{{class 'NS' does not conform to the 'Sendable' protocol}}
 
 struct MyType { // expected-complete-note {{consider making struct 'MyType' conform to the 'Sendable' protocol}}
   var nsc: NonStrictClass
 }
 
-struct MyType2 { // expected-note{{consider making struct 'MyType2' conform to the 'Sendable' protocol}}
+struct MyType2 { // expected-targeted-complete-note{{consider making struct 'MyType2' conform to the 'Sendable' protocol}}
   var nsc: NonStrictClass
   var ns: NS
 }
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
   Task {
-    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(ns) // expected-targeted-complete-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
     print(mt) // no warning by default: MyType is Sendable because we suppressed NonStrictClass's warning
     // expected-complete-warning @-1 {{capture of 'mt' with non-sendable type 'MyType' in a `@Sendable` closure}}
-    print(mt2) // expected-warning{{capture of 'mt2' with non-sendable type 'MyType2' in a `@Sendable` closure}}
+    print(mt2) // expected-targeted-complete-warning{{capture of 'mt2' with non-sendable type 'MyType2' in a `@Sendable` closure}}
     print(sc) // expected-warning{{capture of 'sc' with non-sendable type 'StrictClass' in a `@Sendable` closure}}
   }
 }

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -1,9 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/StrictModule.swiftmodule -module-name StrictModule -swift-version 6 %S/Inputs/StrictModule.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
-// RUN: %target-swift-frontend -strict-concurrency=targeted -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null -enable-experimental-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -strict-concurrency=minimal -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=targeted -verify-additional-prefix targeted-complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -15,7 +16,8 @@ actor A {
   func f() -> [StrictStruct: NonStrictClass] { [:] }
 }
 
-class NS { } // expected-note 2{{class 'NS' does not conform to the 'Sendable' protocol}}
+class NS { } // expected-note {{class 'NS' does not conform to the 'Sendable' protocol}}
+// expected-targeted-complete-note@-1 {{class 'NS' does not conform to the 'Sendable' protocol}}
 
 struct MyType { // expected-complete-note {{consider making struct 'MyType' conform to the 'Sendable' protocol}}
   var nsc: NonStrictClass
@@ -28,12 +30,12 @@ struct MyType2: Sendable {
 
 func testA(ns: NS, mt: MyType, mt2: MyType2, sc: StrictClass, nsc: NonStrictClass) async {
   Task {
-    print(ns) // expected-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
+    print(ns) // expected-targeted-complete-warning{{capture of 'ns' with non-sendable type 'NS' in a `@Sendable` closure}}
     print(mt) // no warning with targeted: MyType is Sendable because we suppressed NonStrictClass's warning
     // expected-complete-warning @-1 {{capture of 'mt' with non-sendable type 'MyType' in a `@Sendable` closure}}
     print(mt2)
     print(sc) // expected-warning {{capture of 'sc' with non-sendable type 'StrictClass' in a `@Sendable` closure}}
-    print(nsc) // expected-warning {{capture of 'nsc' with non-sendable type 'NonStrictClass' in a `@Sendable` closure}}
+    print(nsc) // expected-targeted-complete-warning {{capture of 'nsc' with non-sendable type 'NonStrictClass' in a `@Sendable` closure}}
   }
 }
 


### PR DESCRIPTION
This patch makes a few functional changes to strict concurrency diagnostics:
* `@preconcurrency` warnings should only come back when the imported module has enabled Swift 6. Warnings when the client enables Swift 6 are not useful because that's not the point when the library API has been audited.
* `Sendable` diagnostics are errors in Swift 6.

This change also adds a new `.limitBehaviorUntilSwiftVersion` API on `InFlightDiagnostic` and uses it for all concurrency diagnostics that are suppressed or downgraded until Swift 6. There are a few benefits to using a `UntilSwiftVersion` diagnostic engine API, including the diagnostic wrapping to communicate that the mistake will be an error in Swift 6, and to include the mistake in the frontend statistic for Swift 6 errors.