### PR TITLE
utils: tweak cmark wiring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -802,7 +802,7 @@ if(SWIFT_PATH_TO_CMARK_BUILD)
     OUTPUT_STRIP_TRAILING_WHITESPACE)
   message(STATUS "CMark Version: ${_CMARK_VERSION}")
 elseif(SWIFT_INCLUDE_TOOLS)
-  find_package(cmark-gfm REQUIRED)
+  find_package(cmark-gfm CONFIG REQUIRED)
 endif()
 message(STATUS "")
 

--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -902,7 +902,7 @@ function Build-BuildTools($Arch) {
       SWIFT_INCLUDE_APINOTES = "NO";
       SWIFT_INCLUDE_DOCS = "NO";
       SWIFT_INCLUDE_TESTS = "NO";
-      "cmark-gfm_DIR" = "$($HostArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13";
+      "cmark-gfm_DIR" = "$($Arch.ToolchainInstallRoot)\usr\lib\cmake";
     }
 }
 
@@ -982,7 +982,7 @@ function Build-Compilers() {
         SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE = "$SourceCache\swift-syntax";
         SWIFT_PATH_TO_STRING_PROCESSING_SOURCE = "$SourceCache\swift-experimental-string-processing";
         SWIFT_PATH_TO_SWIFT_SDK = (Get-PinnedToolchainSDK);
-        "cmark-gfm_DIR" = "$($HostArch.BinaryCache)\cmark-gfm-0.29.0.gfm.13";
+        "cmark-gfm_DIR" = "$($Arch.ToolchainInstallRoot)\usr\lib\cmake";
       })
   }
 }
@@ -1621,7 +1621,7 @@ function Build-Markdown($Arch) {
     -Defines @{
       BUILD_SHARED_LIBS = "NO";
       ArgumentParser_DIR = "$BinaryCache\6\cmake\modules";
-      "cmark-gfm_DIR" = "$($Arch.BinaryCache)\cmark-gfm-0.29.0.gfm.13";
+      "cmark-gfm_DIR" = "$($Arch.ToolchainInstallRoot)\usr\lib\cmake";
     }
 }
 
@@ -1639,7 +1639,7 @@ function Build-Format($Arch) {
       BUILD_SHARED_LIBS = "YES";
       ArgumentParser_DIR = "$BinaryCache\6\cmake\modules";
       SwiftSyntax_DIR = "$BinaryCache\1\cmake\modules";
-      "cmark-gfm_DIR" = "$($Arch.BinaryCache)\cmark-gfm-0.29.0.gfm.13";
+      "cmark-gfm_DIR" = "$($Arch.ToolchainInstallRoot)\usr\lib\cmake";
       SwiftMarkdown_DIR = "$BinaryCache\13\cmake\modules";
     }
 }


### PR DESCRIPTION
Use the installed image rather than the build tree for wiring up CMark. This may be used across phases of the build, so it is better to use the staged image.