### PR TITLE
Ensure that member macros can introduce subscripts and deinits

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2284,3 +2284,35 @@ public struct WrapperMacro: PeerMacro {
     []
   }
 }
+
+public struct AddDeinit: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      deinit {
+        print("deinit was called")
+      }
+      """
+    ]
+  }
+}
+
+public struct AddSubscript: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      """
+      subscript(unchecked index: Int) -> String {
+        return "\\(index)"
+      }
+      """
+    ]
+  }
+}

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -112,3 +112,32 @@ struct S2 {
   }
 }
 #endif
+
+@attached(
+  member,
+  names: named(deinit)
+)
+macro addDeinit() = #externalMacro(module: "MacroDefinition", type: "AddDeinit")
+
+@attached(
+  member,
+  names: named(subscript(unchecked:))
+)
+macro addSubscript() = #externalMacro(module: "MacroDefinition", type: "AddSubscript")
+
+@addDeinit
+@addSubscript
+class C2 {
+  init() {
+    print("Created a C2")
+  }
+}
+
+func testC2() {
+  // CHECK: Created a C2
+  let c2 = C2()
+  // CHECK: 17
+  print(c2[unchecked: 17])
+  // CHECK: deinit was called
+}
+testC2()


### PR DESCRIPTION
The only fix needed here was to the new Swift parser, but add some tests to ensure everything else works. rdar://121687968
