### PR TITLE
[CSApply] Teach `adjustSelfTypeForMember` about init accessors

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7578,6 +7578,12 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
   abort();
 }
 
+static bool isSelfRefInInitializer(Expr *baseExpr,
+                                   DeclContext *useDC) {
+  auto *CD = dyn_cast<ConstructorDecl>(useDC);
+  return CD && baseExpr->isSelfExprOf(CD);
+}
+
 /// Detect whether an assignment to \c baseExpr.member in the given
 /// decl context can potentially be initialization of a property wrapper.
 static bool isPotentialPropertyWrapperInit(Expr *baseExpr,
@@ -7590,15 +7596,19 @@ static bool isPotentialPropertyWrapperInit(Expr *baseExpr,
 
   // Assignment to a wrapped property can only be re-written to
   // initialization in an init.
-  auto *CD = dyn_cast<ConstructorDecl>(UseDC);
-  if (!CD)
+  return isSelfRefInInitializer(baseExpr, UseDC);
+}
+
+/// Detect whether an assignment to \c baseExpr.member in the given
+/// decl context can potentially be initialization via an init accessor.
+static bool isPotentialInitViaInitAccessor(Expr *baseExpr,
+                                           ValueDecl *member,
+                                           DeclContext *useDC) {
+  auto *VD = dyn_cast<VarDecl>(member);
+  if (!(VD && VD->hasInitAccessor()))
     return false;
 
-  // This is not an assignment on self
-  if (!baseExpr->isSelfExprOf(CD))
-    return false;
-
-  return true;
+  return isSelfRefInInitializer(baseExpr, useDC);
 }
 
 /// Adjust the given type to become the self type when referring to
@@ -7635,12 +7645,13 @@ static Type adjustSelfTypeForMember(Expr *baseExpr,
 
   // If neither the property's getter nor its setter are mutating,
   // the base can be an rvalue unless the assignment is potentially
-  // initializing a property wrapper. If the assignment can be re-
-  // written to property wrapper initialization, the base type should
-  // be an lvalue.
+  // initializing a property wrapper or using init accessor. If the
+  // assignment can be re-written to property wrapper or init accessor
+  // initialization, the base type should be an lvalue.
   if (!SD->isGetterMutating() &&
       (!isSettableFromHere || !SD->isSetterMutating()) &&
-      !isPotentialPropertyWrapperInit(baseExpr, member, UseDC))
+      !isPotentialPropertyWrapperInit(baseExpr, member, UseDC) &&
+      !isPotentialInitViaInitAccessor(baseExpr, member, UseDC))
     return baseObjectTy;
 
   if (isa<SubscriptDecl>(member))

--- a/test/SILOptimizer/issue-68875.swift
+++ b/test/SILOptimizer/issue-68875.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend %s -emit-silgen | %FileCheck %s
+
+public struct ID {
+  var a: Int = 0
+  var b: Int = 1
+  var c: Int = 2
+  var d: Int = 3
+  var e: Int = 4
+  var description: String = ""
+  var mirror: Mirror
+}
+
+struct Test {
+  let id: ID
+  private var _name: String
+
+  var name: String {
+    @storageRestrictions(initializes: _name)
+    init { _name = newValue }
+
+    get { _name }
+
+    nonmutating set {}
+  }
+
+  // CHECK-LABEL: sil hidden [ossa] @$s4main4TestV2id4nameAcA2IDV_SStcfC : $@convention(method) (@in ID, @owned String, @thin Test.Type) -> @out Test
+  // CHECK: [[SELF:%.*]] = project_box {{.*}} : ${ var Test }, 0
+  // CHECK: [[SELF_REF:%.*]] = begin_access [read] [unknown] [[SELF]] : $*Test
+  // CHECK: [[INIT_REF:%.*]] = function_ref @$s4main4TestV4nameSSvi : $@convention(thin) (@owned String, @thin Test.Type) -> @out String
+  // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin Test.Type
+  // CHECK-NEXT: [[INIT:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[INIT_REF]]([[METATYPE]]) : $@convention(thin) (@owned String, @thin Test.Type) -> @out String
+  // CHECK: [[SETTER_REF:%.*]] = function_ref @$s4main4TestV4nameSSvs : $@convention(method) (@owned String, @in_guaranteed Test) -> ()
+  // CHECK-NEXT: [[SETTER:%.*]] = partial_apply [callee_guaranteed] [on_stack] [[SETTER_REF]]([[SELF_REF]]) : $@convention(method) (@owned String, @in_guaranteed Test) -> ()
+  // CHECK-NEXT: assign_or_init #Test.name, self [[SELF_REF]] : $*Test, value {{.*}} : $String, init [[INIT]] : $@noescape @callee_guaranteed (@owned String) -> @out String, set [[SETTER]] : $@noescape @callee_guaranteed (@owned String) -> ()
+  init(id: ID, name: String) {
+    self.id = id
+    self.name = name
+  }
+}


### PR DESCRIPTION
`adjustSelfTypeForMember` shouldn't load base if member reference is a potential 
init accessor use, the proper use of `self` would be determined during lowering of 
the `assign_or_init` instruction and defensive load for `nonmutating` sets is unnecessary
in this case.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
