### PR TITLE
Fix nondeterminism in explicitly-specified generic macro arguments

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13701,6 +13701,25 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
   if (simplifiedBoundType->isTypeVariableOrMember())
     return formUnsolved();
 
+  std::function<GenericParamList *(ValueDecl *)> getGenericParams =
+      [&](ValueDecl *decl) -> GenericParamList * {
+    auto genericContext = decl->getAsGenericContext();
+    if (!genericContext)
+      return nullptr;
+
+    auto genericParams = genericContext->getGenericParams();
+    if (!genericParams) {
+      // If declaration is a non-generic typealias, let's point
+      // to the underlying generic declaration.
+      if (auto *TA = dyn_cast<TypeAliasDecl>(decl)) {
+        if (auto *UGT = TA->getUnderlyingType()->getAs<AnyGenericType>())
+          return getGenericParams(UGT->getDecl());
+      }
+    }
+
+    return genericParams;
+  };
+
   ValueDecl *decl;
   SmallVector<OpenedType, 2> openedTypes;
   if (auto *bound = dyn_cast<TypeAliasType>(type1.getPointer())) {
@@ -13757,27 +13776,19 @@ ConstraintSystem::simplifyExplicitGenericArgumentsConstraint(
     decl = overloadChoice.getDecl();
 
     auto openedOverloadTypes = getOpenedTypes(overloadLocator);
-    openedTypes.append(openedOverloadTypes.begin(), openedOverloadTypes.end());
-  }
 
-  std::function<GenericParamList *(ValueDecl *)> getGenericParams =
-      [&](ValueDecl *decl) -> GenericParamList * {
-    auto genericContext = decl->getAsGenericContext();
-    if (!genericContext)
-      return nullptr;
-
-    auto genericParams = genericContext->getGenericParams();
-    if (!genericParams) {
-      // If declaration is a non-generic typealias, let's point
-      // to the underlying generic declaration.
-      if (auto *TA = dyn_cast<TypeAliasDecl>(decl)) {
-        if (auto *UGT = TA->getUnderlyingType()->getAs<AnyGenericType>())
-          return getGenericParams(UGT->getDecl());
+    auto genericParams = getGenericParams(decl);
+    if (genericParams) {
+      for (auto gp : *genericParams) {
+        auto found = find_if(openedOverloadTypes, [&](auto entry) {
+          return entry.first->getDepth() == gp->getDepth() &&
+              entry.first->getIndex() == gp->getIndex();
+        });
+        assert(found != openedOverloadTypes.end());
+        openedTypes.push_back(*found);
       }
     }
-
-    return genericParams;
-  };
+  }
 
   if (!decl->getAsGenericContext())
     return SolutionKind::Error;

--- a/test/Macros/macro_explicit_generic_args.swift
+++ b/test/Macros/macro_explicit_generic_args.swift
@@ -1,0 +1,24 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+protocol P {
+  associatedtype A
+}
+
+@freestanding(expression)
+macro resolve<T, U: P>(_ first: U.A, _ second: U) -> T = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{external macro implementation type 'A.B' could not be found}}
+// expected-note@-2{{'resolve' declared here}}
+
+protocol Q { }
+
+struct X: P {
+  typealias A = Int
+}
+
+func test(i: Int) {
+  _ = #resolve<any Q, X>(i, X())
+  // expected-error@-1{{external macro implementation type 'A.B' could not be found for macro 'resolve'; plugin for module 'A' not found}}
+}
+


### PR DESCRIPTION
A hash table got flattened into an array without any ordering guarantees, and then we assumed it was in order. Fixes rdar://121397992.
