### PR TITLE
[ExternalGenericMetadataBuilder] Add a test that validates built metadata against the runtime.

### DIFF
--- a/include/swift/Runtime/LibPrespecialized.h
+++ b/include/swift/Runtime/LibPrespecialized.h
@@ -51,4 +51,17 @@ Metadata *getLibPrespecializedMetadata(const TypeContextDescriptor *description,
 
 } // namespace swift
 
+// Validate the prespecialized metadata map by building each entry dynamically
+// and comparing. This should be called before any metadata is built for other
+// purposes, as any prespecialized entries that have already been cached will
+// not be rebuilt, so the validation will be comparing the prespecialized
+// metadata with itself.
+//
+// On return, outValidated is set to the total number of metadata records that
+// were validated (which is the total number in the table), and outFailed is set
+// to the number that failed validation.
+SWIFT_RUNTIME_EXPORT
+void _swift_validatePrespecializedMetadata(unsigned *outValidated,
+                                           unsigned *outFailed);
+
 #endif // SWIFT_LIB_PRESPECIALIZED_H

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -591,6 +591,12 @@ public:
   SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
   void *allocateMetadata(size_t size, size_t align);
 
+  // Compare two pieces of metadata that should be identical. Returns true if
+  // they are, false if they are not equal. Dumps the metadata contents to
+  // stderr if they are not equal.
+  bool compareGenericMetadata(const Metadata *original,
+                              const Metadata *newMetadata);
+
   void validateExternalGenericMetadataBuilder(
       const Metadata *original, const TypeContextDescriptor *description,
       const void * const *arguments);

--- a/test/ExternalGenericMetadataBuilder/Inputs/buildMetadataJSON.swift
+++ b/test/ExternalGenericMetadataBuilder/Inputs/buildMetadataJSON.swift
@@ -1,0 +1,52 @@
+import ExternalGenericMetadataBuilder
+import Foundation
+
+var args = CommandLine.arguments
+args.removeFirst() // Skip the program name.
+
+let arch = args.removeFirst()
+let dylibs = args
+
+let builder = swift_externalMetadataBuilder_create(1, arch)
+
+guard var jsonIn = try! FileHandle.standardInput.readToEnd() else {
+  fatalError("No data read from stdin, somehow")
+}
+
+// NULL terminate.
+jsonIn.append(contentsOf: [0])
+
+let readJSONErrorCStr = jsonIn.withUnsafeBytes {
+  swift_externalMetadataBuilder_readNamesJSON(builder, $0)
+}
+
+if let readJSONErrorCStr {
+  fatalError("Could not read JSON input: \(String(cString: readJSONErrorCStr))")
+}
+
+for dylib in dylibs {
+  let url = URL(fileURLWithPath: dylib)
+  let data = NSData(contentsOf: url)!
+
+  let machHeader = data.bytes.assumingMemoryBound(to: mach_header.self)
+  let addDylibErrorCStr =
+    swift_externalMetadataBuilder_addDylib(builder,
+                                           url.lastPathComponent,
+                                           machHeader,
+                                           UInt64(data.length));
+  if let addDylibErrorCStr {
+    fatalError("Could not add dylib at \(dylib): \(String(cString: addDylibErrorCStr))")
+  }
+}
+
+let buildErrorCStr = swift_externalMetadataBuilder_buildMetadata(builder)
+if let buildErrorCStr {
+  fatalError("Failed to build metadata: \(String(cString: buildErrorCStr))")
+}
+
+let outputJSONCStr = swift_externalMetadataBuilder_getMetadataJSON(builder)
+if outputJSONCStr == nil {
+  fatalError("JSON creation failed")
+}
+
+fputs(outputJSONCStr, stdout)

--- a/test/ExternalGenericMetadataBuilder/Inputs/json2c.swift
+++ b/test/ExternalGenericMetadataBuilder/Inputs/json2c.swift
@@ -1,0 +1,143 @@
+// A simple program that takes the JSON output of libswiftGenericMetadataBuilder
+// and converts it into C code that can be bulit as a library.
+import Foundation
+
+enum ParseError: Error {
+  case oddLengthHexString
+  case invalidHex(Substring)
+}
+
+struct Fixup: Decodable {
+  var target: String
+  var addend: Int64
+}
+
+enum AtomContent: Decodable {
+  case bytes([UInt8])
+  case pointer(Fixup)
+
+  static func getString(decoder: Decoder) -> String? {
+    do {
+      return try decoder.singleValueContainer().decode(String.self)
+    } catch {
+      return nil
+    }
+  }
+
+  init(from decoder: Decoder) throws {
+    if let string = Self.getString(decoder: decoder) {
+      var bytes: [UInt8] = []
+      var toParse = Substring(string)
+      while !toParse.isEmpty {
+        let prefix = toParse.prefix(2)
+        if prefix.count == 1 {
+          throw ParseError.oddLengthHexString
+        }
+        guard let byte = UInt8(prefix, radix: 16) else {
+          throw ParseError.invalidHex(prefix)
+        }
+        bytes.append(byte)
+        toParse = toParse.dropFirst(2)
+      }
+      self = .bytes(bytes)
+    } else {
+      let fixup = try Fixup(from: decoder)
+      self = .pointer(fixup)
+    }
+  }
+}
+
+struct Atom: Decodable {
+  var name: String
+  var contents: [AtomContent]
+}
+
+struct Document: Decodable {
+  var atoms: [Atom]
+}
+
+func deUnderscore(_ str: String) -> Substring {
+  guard str.hasPrefix("_") else {
+    fatalError("symbol/atom name '\(str)' does not have an underscore prefix")
+  }
+  return str.dropFirst()
+}
+
+func printHeader() {
+  print("#include <stdint.h>")
+}
+
+func printExternDeclarations(_ document: Document) {
+  var atomNames: Set<String> = []
+  var externNames: Set<String> = []
+  for atom in document.atoms {
+    atomNames.insert(atom.name)
+  }
+  for atom in document.atoms {
+    for content in atom.contents {
+      switch content {
+        case .bytes(_):
+          break
+        case .pointer(let fixup):
+          if !atomNames.contains(fixup.target) {
+            externNames.insert(fixup.target)
+          }
+      }
+    }
+  }
+  for name in externNames.sorted() {
+    print("extern char \(deUnderscore(name));")
+  }
+}
+
+func printDeclarations(_ document: Document) {
+  printExternDeclarations(document)
+  for atom in document.atoms {
+    print("struct __attribute__((packed)) __attribute__((aligned(sizeof(void *)))) \(deUnderscore(atom.name))_t {")
+    for (i, content) in atom.contents.enumerated() {
+      let name = "content\(i)"
+      switch content {
+        case .bytes(let bytes):
+          print("  uint8_t \(name)[\(bytes.count)];")
+        case .pointer(_):
+          print("  const char *\(name);")
+      }
+    }
+    print("};")
+    print("struct \(deUnderscore(atom.name))_t \(deUnderscore(atom.name));")
+    print("")
+  }
+}
+
+func printDefinitions(_ document: Document) {
+  for atom in document.atoms {
+    print("struct \(deUnderscore(atom.name))_t \(deUnderscore(atom.name)) = {")
+    for content in atom.contents {
+      switch content {
+        case .bytes(let bytes):
+          print("  {")
+          for byte in bytes {
+            print("    0x\(String(byte, radix: 16)),")
+          }
+          print("  },")
+        case .pointer(let fixup):
+          print("  (char *)&\(deUnderscore(fixup.target)) + \(fixup.addend),")
+      }
+    }
+    print("};")
+    print("")
+  }
+}
+
+func printC(_ document: Document) {
+  printHeader()
+  printDeclarations(document)
+  printDefinitions(document)
+}
+
+for arg in CommandLine.arguments.dropFirst() {
+  let data = try! Data(contentsOf: URL(fileURLWithPath: arg))
+  let decoder = JSONDecoder()
+  let decoded = try! decoder.decode(Document.self, from: data)
+  printC(decoded)
+}

--- a/test/ExternalGenericMetadataBuilder/VerifyExternalMetadata.swift
+++ b/test/ExternalGenericMetadataBuilder/VerifyExternalMetadata.swift
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -I %swift-lib-dir -I %swift_src_root/lib/ExternalGenericMetadataBuilder -L%swift-lib-dir -lswiftGenericMetadataBuilder -enable-experimental-feature Extern %s -o %t/VerifyExternalMetadata
+// RUN: %target-codesign %t/VerifyExternalMetadata
+//
+// RUN: %target-build-swift -I %swift-lib-dir -I %swift_src_root/lib/ExternalGenericMetadataBuilder -L%swift-lib-dir -lswiftGenericMetadataBuilder -enable-experimental-feature Extern %S/Inputs/buildMetadataJSON.swift -o %t/buildMetadataJSON
+// RUN: %target-codesign %t/buildMetadataJSON
+//
+// RUN: %target-build-swift %S/Inputs/json2c.swift -o %t/json2c
+// RUN: %target-codesign %t/json2c
+//
+// RUN: %target-run %t/VerifyExternalMetadata getJSON > %t/names.json
+// RUN: %target-run %t/buildMetadataJSON arm64 %t/VerifyExternalMetadata %stdlib_dir/libswiftCore.dylib < %t/names.json > %t/libswiftPrespecialized.json
+// RUN: %target-run %t/json2c %t/libswiftPrespecialized.json > %t/libswiftPrespecialized.c
+// RUN: %clang -isysroot %sdk -bundle %t/libswiftPrespecialized.c -L%stdlib_dir -lswiftCore -bundle_loader %t/VerifyExternalMetadata -o %t/libswiftPrespecialized.bundle
+//
+//
+// RUN: env SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_LOGGING=y SWIFT_DEBUG_LIB_PRESPECIALIZED_PATH=%t/libswiftPrespecialized.bundle %target-run %t/VerifyExternalMetadata
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx && CPU=arm64
+
+import ExternalGenericMetadataBuilder
+import Foundation
+import StdlibUnittest
+
+public struct GenericStruct<T, U, V> {
+  var t: T
+  var u: U
+  var v: V
+  var str: String
+}
+
+public struct GenericField<T, U> {
+  var field: GenericStruct<T, U, Double>
+  var int: Int
+}
+
+let args = CommandLine.arguments
+
+if args.count > 1 && args[1] == "getJSON" {
+  let types: [Any.Type] = [
+    Array<Double>.self,
+    GenericField<GenericField<Int8, Int16>,
+                 Array<GenericStruct<Double, String, Float>>>.self,
+    Array<Array<Array<Array<Array<Array<Array<Double>>>>>>>.self,
+  ]
+  let typeNames = types.map { _mangledTypeName($0)! }
+  let jsonNames = typeNames.map { [ "name": $0 ] }
+  let jsonStructure = [ "metadataNames": jsonNames ]
+  let jsonData = try! JSONSerialization.data(withJSONObject: jsonStructure)
+  FileHandle.standardOutput.write(jsonData)
+  exit(0)
+}
+
+var validated: CUnsignedInt = 0
+var failed: CUnsignedInt = 0
+
+@_extern(c)
+func _swift_validatePrespecializedMetadata(_ outValidated: UnsafeMutablePointer<CUnsignedInt>, _ outFailed: UnsafeMutablePointer<CUnsignedInt>)
+_swift_validatePrespecializedMetadata(&validated, &failed)
+if failed > 0 {
+  fatalError("\(failed) prespecialized metadata records failed validation")
+}
+if validated == 0 {
+  fatalError("zero prespecialized metadata records validated, there should be some")
+}
+
+print("Verified \(validated) records, success!")

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -253,3 +253,4 @@ Added: __swift_pod_copy
 Added: __swift_pod_destroy
 Added: __swift_pod_direct_initializeBufferWithCopyOfBuffer
 Added: __swift_pod_indirect_initializeBufferWithCopyOfBuffer
+Added: __swift_validatePrespecializedMetadata

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -253,3 +253,4 @@ Added: __swift_pod_copy
 Added: __swift_pod_destroy
 Added: __swift_pod_direct_initializeBufferWithCopyOfBuffer
 Added: __swift_pod_indirect_initializeBufferWithCopyOfBuffer
+Added: __swift_validatePrespecializedMetadata


### PR DESCRIPTION
We run the builder, then use a small program that converts the JSON output into C code that generates the data. Compile that into a bundle, then load it as the prespecializations library. Then scan all the entries in the table and compare them with what the runtime builds dynamically.