### PR TITLE
[DRAFT] Restore new semantics for ObjC metatype casts

### DIFF
--- a/include/swift/Runtime/Bincompat.h
+++ b/include/swift/Runtime/Bincompat.h
@@ -39,7 +39,12 @@ bool useLegacyOptionalNilInjectionInCasting();
 bool useLegacyObjCBoxingInCasting();
 
 /// Whether to use legacy semantics when unboxing __SwiftValue
+/// Default false starting with Swift 5.9
 bool useLegacySwiftValueUnboxingInCasting();
+
+/// Whether to use legacy semantics when casting ObjC Metatypes
+bool useLegacyObjCMetatypeCasting();
+
 
 /// Legacy semantics use trivial implementations for -hashValue/-isEqual:
 /// requests from ObjC to Swift values.

--- a/stdlib/public/runtime/Bincompat.cpp
+++ b/stdlib/public/runtime/Bincompat.cpp
@@ -229,6 +229,31 @@ bool useLegacySwiftValueUnboxingInCasting() {
 #endif
 }
 
+// Should Obj-C metatypes successfully cast to an Obj-C protocol if the type
+// satisfies the protocol?
+
+// This bug made Obj-C metatype casting unsound; whether a type satisfies a
+// protocol is different from whether the METAtype satisfies it.  Exception: All
+// Obj-C metatypes are in fact NSObjects, so satisfy NSObjectProtocol.
+
+// Sordid history: Behavior was changed in PR#69435, but that incorrectly
+// forbade casting metatypes to NSObject, so was reverted in PR#71065.  Then
+// redone in PR ##### with ####.
+
+// For example, this cast
+//  ### TODO ###
+// always succeeded with the legacy semantics.
+
+bool useLegacyObjCMetatypeCasting() {
+#if BINARY_COMPATIBILITY_APPLE
+  return true; // For now, use compatibility behavior on Apple OSes
+#elif SWIFT_TARGET_OS_DARWIN
+  return true; // For now, use legacy behavior on open-source builds for Apple platforms
+#else
+  return false; // Always use the new behavior on non-Apple OSes
+#endif
+}
+
 // Controls how ObjC -hashValue and -isEqual are handled
 // by Swift objects.
 // There are two basic semantics:

--- a/stdlib/public/runtime/DynamicCast.cpp
+++ b/stdlib/public/runtime/DynamicCast.cpp
@@ -533,6 +533,26 @@ tryCastToObjectiveCClass(
     break;
   }
 
+  case MetadataKind::Metatype: { // Metatype  => Obj-C Class
+    auto metatypePtr = reinterpret_cast<const Metadata **>(srcValue);
+    auto metatype = *metatypePtr;
+    // ObjC metatypes can always be cast to NSObject
+    // (but not to any other class)
+    if (destType == getNSObjectMetadata()) {
+      if (metatype->getKind() == MetadataKind::Class) {
+	auto resultObject = (id)metatype->getObjCClassObject();
+	*reinterpret_cast<id *>(destLocation) = resultObject;
+	if (takeOnSuccess) {
+	  return DynamicCastResult::SuccessViaTake;
+	} else {
+	  objc_retain(resultObject);
+	  return DynamicCastResult::SuccessViaCopy;
+	}
+      }
+    }
+    break;
+  }
+
   default:
     break;
   }

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1348,12 +1348,15 @@ id swift_dynamicCastObjCProtocolUnconditional(id object,
     return object;
   }
   if (object_isClass(object)) {
-//    XXX TODO: ObjC classes do conform to some protocols ...
+    // Shield old apps from this behavior change
     if (!runtime::bincompat::useLegacyObjCMetatypeCasting()) {
-      // Shield old apps from this behavior change
-      Class sourceType = object_getClass(object);
-      swift_dynamicCastFailure(sourceType, class_getName(sourceType),
+      // Obj-C metatypes can conform to NSObject protocol,
+      // but no others. (TODO: Check with @MikeAsh)
+      if (numProtocols > 1 || protocols[0] != @protocol(NSObject)) {
+	Class sourceType = object_getClass(object);
+	swift_dynamicCastFailure(sourceType, class_getName(sourceType),
 			       protocols[0], protocol_getName(protocols[0]));
+      }
     }
   }
   for (size_t i = 0; i < numProtocols; ++i) {
@@ -1381,10 +1384,13 @@ id swift_dynamicCastObjCProtocolConditional(id object,
     return object;
   }
   if (object_isClass(object)) {
-//    XXX TODO: ObjC classes do conform to some protocols ...
+    // Shield old apps from this behavior change
     if (!runtime::bincompat::useLegacyObjCMetatypeCasting()) {
-      // Shield old apps from this behavior change
-      return nil;
+      // Obj-C metatypes can conform to NSObject protocol,
+      // but no others. (TODO: Check with @MikeAsh)
+      if (numProtocols > 1 || protocols[0] != @protocol(NSObject)) {
+	return nil;
+      }
     }
   }
   for (size_t i = 0; i < numProtocols; ++i) {

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -1344,6 +1344,18 @@ id swift_dynamicCastObjCProtocolUnconditional(id object,
                                               Protocol * const *protocols,
                                               const char *filename,
                                               unsigned line, unsigned column) {
+  if (numProtocols == 0) {
+    return object;
+  }
+  if (object_isClass(object)) {
+//    XXX TODO: ObjC classes do conform to some protocols ...
+    if (!runtime::bincompat::useLegacyObjCMetatypeCasting()) {
+      // Shield old apps from this behavior change
+      Class sourceType = object_getClass(object);
+      swift_dynamicCastFailure(sourceType, class_getName(sourceType),
+			       protocols[0], protocol_getName(protocols[0]));
+    }
+  }
   for (size_t i = 0; i < numProtocols; ++i) {
     if (![object conformsToProtocol:protocols[i]]) {
       Class sourceType = object_getClass(object);
@@ -1362,6 +1374,16 @@ id swift_dynamicCastObjCProtocolConditional(id object,
   if (!runtime::bincompat::useLegacySwiftValueUnboxingInCasting()) {
     if (getAsSwiftValue(object) != nil) {
       // SwiftValue wrapper never holds a class object
+      return nil;
+    }
+  }
+  if (numProtocols == 0) {
+    return object;
+  }
+  if (object_isClass(object)) {
+//    XXX TODO: ObjC classes do conform to some protocols ...
+    if (!runtime::bincompat::useLegacyObjCMetatypeCasting()) {
+      // Shield old apps from this behavior change
       return nil;
     }
   }

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1108,6 +1108,9 @@ CastsTests.test("Class metatype values should not cast to Obj-C existentials") {
   expectNil(C106973771.self as? any P106973771)
   // The following will crash if the cast succeeds
   (C106973771.self as? any P106973771)?.sayHello()
+
+  // But it's fine to cast a metatype to NSObjectProtocol:
+  expectTrue(C106973771.self is any NSObjectProtocol)
 }
 #endif
 

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1092,4 +1092,23 @@ CastsTests.test("type(of:) should look through __SwiftValue")
   expectEqual(t, "S")  // Fails: currently says `__SwiftValue`
 }
 
+#if _runtime(_ObjC)
+@objc protocol P106973771 {
+  func sayHello()
+}
+CastsTests.test("Class metatype values should not cast to Obj-C existentials") {
+  class C106973771: NSObject, P106973771 {
+    func sayHello() { print("Hello") }
+  }
+  // A class instance clearly conforms to the protocol
+  expectTrue(C106973771() is any P106973771)
+  // But the metatype definitely does not
+  expectFalse(C106973771.self is any P106973771)
+  // The cast should not succeed
+  expectNil(C106973771.self as? any P106973771)
+  // The following will crash if the cast succeeds
+  (C106973771.self as? any P106973771)?.sayHello()
+}
+#endif
+
 runAllTests()

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1096,11 +1096,13 @@ CastsTests.test("type(of:) should look through __SwiftValue")
 @objc protocol P106973771 {
   func sayHello()
 }
+@objc protocol P106973771a { }
+extension NSObject : P106973771a {}
 CastsTests.test("Class metatype values should not cast to Obj-C existentials") {
-  class C106973771: NSObject, P106973771 {
+  @objc class C106973771: NSObject, P106973771 {
     func sayHello() { print("Hello") }
   }
-  // A class instance clearly conforms to the protocol
+  // A class instance clearly conforms to this protocol
   expectTrue(C106973771() is any P106973771)
   // But the metatype definitely does not
   expectFalse(C106973771.self is any P106973771)
@@ -1109,8 +1111,13 @@ CastsTests.test("Class metatype values should not cast to Obj-C existentials") {
   // The following will crash if the cast succeeds
   (C106973771.self as? any P106973771)?.sayHello()
 
-  // But it's fine to cast a metatype to NSObjectProtocol:
+  // We should also follow ObjC rules for
+  // ObjC metatypes:
   expectTrue(C106973771.self is any NSObjectProtocol)
+  expectTrue(C106973771.self is NSObject.Type)
+  expectTrue(C106973771.self is NSObject) // FIXME
+  expectTrue(C106973771.self as AnyObject is any P106973771a)
+  expectTrue(C106973771.self is any P106973771a)
 }
 #endif
 

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1102,22 +1102,31 @@ CastsTests.test("Class metatype values should not cast to Obj-C existentials") {
   @objc class C106973771: NSObject, P106973771 {
     func sayHello() { print("Hello") }
   }
+
   // A class instance clearly conforms to this protocol
   expectTrue(C106973771() is any P106973771)
+  expectNotNil(runtimeCast(C106973771(), to: (any P106973771).self))
   // But the metatype definitely does not
   expectFalse(C106973771.self is any P106973771)
-  // The cast should not succeed
   expectNil(C106973771.self as? any P106973771)
+  expectNil(runtimeCast(C106973771.self, to: (any P106973771).self))
   // The following will crash if the cast succeeds
   (C106973771.self as? any P106973771)?.sayHello()
 
   // We should also follow ObjC rules for
   // ObjC metatypes:
   expectTrue(C106973771.self is any NSObjectProtocol)
+  expectNotNil(runtimeCast(C106973771.self, to: (any NSObjectProtocol).self))
   expectTrue(C106973771.self is NSObject.Type)
-  expectTrue(C106973771.self is NSObject) // FIXME
+  expectNotNil(runtimeCast(C106973771.self, to: NSObject.Type.self))
+  // FIXME: Optimizer breaks this in -O and -Onone builds
+  // expectTrue(C106973771.self is NSObject)
+  // FIXME: Optimizer breaks this in -O builds
+  // expectNotNil(runtimeCast(C106973771.self, to: NSObject.self))
   expectTrue(C106973771.self as AnyObject is any P106973771a)
+  expectNotNil(runtimeCast(C106973771.self as AnyObject, to: (any P106973771a).self))
   expectTrue(C106973771.self is any P106973771a)
+  expectNotNil(runtimeCast(C106973771.self, to: (any P106973771a).self))
 }
 #endif
 


### PR DESCRIPTION
This was originally merged in in PR#69435, but that had two serious problems that prompted it to be reverted in PR#71065:
* It unconditionally changed the semantics, which broke some existing code
* It forbade casting ObjC metatypes to NSObject, which is in fact valid

This is still WiP -- I've outlined the necessary backwards-compatibility logic to keep old code running, but still need to work through the ObjC metatype semantics.