### PR TITLE
Parse `_borrowing x` in patterns as a borrow binding.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5909,7 +5909,21 @@ public:
     Let = 0,
     Var = 1,
     InOut = 2,
+    Borrowing = 3,
   };
+  
+  static StringRef getIntroducerStringRef(Introducer i) {
+    switch (i) {
+    case VarDecl::Introducer::Let:
+      return "let";
+    case VarDecl::Introducer::Var:
+      return "var";
+    case VarDecl::Introducer::InOut:
+      return "inout";
+    case VarDecl::Introducer::Borrowing:
+      return "_borrowing";
+    }
+  }
 
 protected:
   PointerUnion<PatternBindingDecl *,
@@ -6155,6 +6169,10 @@ public:
 
   Introducer getIntroducer() const {
     return Introducer(Bits.VarDecl.Introducer);
+  }
+  
+  StringRef getIntroducerStringRef() const {
+    return getIntroducerStringRef(getIntroducer());
   }
 
   CaptureListExpr *getParentCaptureList() const {

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -996,6 +996,8 @@ ERROR(extra_var_in_multiple_pattern_list,none,
       "%0 must be bound in every pattern", (Identifier))
 ERROR(let_pattern_in_immutable_context,none,
       "'let' pattern cannot appear nested in an already immutable context", ())
+ERROR(borrowing_subpattern_unsupported,none,
+      "'_borrowing' pattern modifier must be directly applied to pattern variable name", ())
 ERROR(specifier_must_have_type,none,
       "%0 arguments must have a type specified", (StringRef))
 ERROR(expected_rparen_parameter,PointsToFirstBadToken,

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -817,17 +817,8 @@ public:
     return VP;
   }
 
-  bool isLet() const { return getIntroducer() == VarDecl::Introducer::Let; }
-
   StringRef getIntroducerStringRef() const {
-    switch (getIntroducer()) {
-    case VarDecl::Introducer::Let:
-      return "let";
-    case VarDecl::Introducer::Var:
-      return "var";
-    case VarDecl::Introducer::InOut:
-      return "inout";
-    }
+    return VarDecl::getIntroducerStringRef(getIntroducer());
   }
 
   SourceLoc getLoc() const { return VarLoc; }

--- a/include/swift/Parse/PatternBindingState.h
+++ b/include/swift/Parse/PatternBindingState.h
@@ -90,6 +90,7 @@ struct PatternBindingState {
       : kind(NotInBinding) {
     switch (introducer) {
     case VarDecl::Introducer::Let:
+    case VarDecl::Introducer::Borrowing:
       kind = InLet;
       break;
     case VarDecl::Introducer::Var:

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -440,6 +440,9 @@ static StringRef getDumpString(RequirementKind kind) {
 
   llvm_unreachable("Unhandled RequirementKind in switch.");
 }
+static StringRef getDumpString(StringRef s) {
+  return s;
+}
 static unsigned getDumpString(unsigned value) {
   return value;
 }
@@ -1015,7 +1018,8 @@ namespace {
       printFoot();
     }
     void visitBindingPattern(BindingPattern *P, StringRef label) {
-      printCommon(P, P->isLet() ? "pattern_let" : "pattern_var", label);
+      printCommon(P, "pattern_binding", label);
+      printField(P->getIntroducerStringRef(), "kind");
       printRec(P->getSubPattern());
       printFoot();
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1415,7 +1415,7 @@ void PrintAST::printPattern(const Pattern *pattern) {
   case PatternKind::Binding: {
     auto bPattern = cast<BindingPattern>(pattern);
     Printer.printIntroducerKeyword(
-        bPattern->isLet() ? "let" : "var",
+        bPattern->getIntroducerStringRef(),
         Options, " ");
     printPattern(bPattern->getSubPattern());
   }
@@ -4634,7 +4634,10 @@ void PrintAST::visitVarDecl(VarDecl *decl) {
   if (decl->getKind() == DeclKind::Var || Options.PrintParameterSpecifiers) {
     // Map all non-let specifiers to 'var'.  This is not correct, but
     // SourceKit relies on this for info about parameter decls.
-    Printer.printIntroducerKeyword(decl->isLet() ? "let" : "var", Options, " ");
+    
+    Printer.printIntroducerKeyword(
+      decl->getIntroducer() == VarDecl::Introducer::Let ? "let" : "var",
+      Options, " ");
   }
   printContextIfNeeded(decl);
   recordDeclLoc(decl,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7758,7 +7758,8 @@ bool VarDecl::isLet() const {
   if (auto *PD = dyn_cast<ParamDecl>(this)) {
     return PD->isImmutableInFunctionBody();
   }
-  return getIntroducer() == Introducer::Let;
+  return getIntroducer() == Introducer::Let
+    || getIntroducer() == Introducer::Borrowing;
 }
 
 bool VarDecl::isAsyncLet() const {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3545,8 +3545,9 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
               foundVP = VP;
         });
 
-        if (foundVP && !foundVP->isLet())
+        if (foundVP && foundVP->getIntroducer() != VarDecl::Introducer::Let) {
           FixItLoc = foundVP->getLoc();
+        }
       }
 
       // If this is a parameter explicitly marked 'var', remove it.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 844; // remove IsolatedAttr
+const uint16_t SWIFTMODULE_VERSION_MINOR = 845; // borrowing var introducer
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -369,6 +369,7 @@ enum class VarDeclIntroducer : uint8_t {
   Let = 0,
   Var = 1,
   InOut = 2,
+  Borrowing = 3,
 };
 using VarDeclIntroducerField = BCFixed<2>;
 
@@ -1897,7 +1898,7 @@ namespace decls_block {
 
   using BindingPatternLayout = BCRecordLayout<
     VAR_PATTERN,
-    BCFixed<1>  // isLet?
+    BCFixed<2>  // introducer (var, let, etc.)
     // The sub-pattern trails the record.
   >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2560,6 +2560,8 @@ static uint8_t getRawStableVarDeclIntroducer(swift::VarDecl::Introducer intr) {
     return uint8_t(serialization::VarDeclIntroducer::Var);
   case swift::VarDecl::Introducer::InOut:
     return uint8_t(serialization::VarDeclIntroducer::InOut);
+  case swift::VarDecl::Introducer::Borrowing:
+    return uint8_t(serialization::VarDeclIntroducer::Borrowing);
   }
   llvm_unreachable("bad variable decl introducer kind");
 }
@@ -3674,7 +3676,7 @@ private:
 
       unsigned abbrCode = S.DeclTypeAbbrCodes[BindingPatternLayout::Code];
       BindingPatternLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
-                                       var->isLet());
+                           getRawStableVarDeclIntroducer(var->getIntroducer()));
       writePattern(var->getSubPattern());
       break;
     }

--- a/test/Parse/pattern_borrow_bindings.swift
+++ b/test/Parse/pattern_borrow_bindings.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-frontend -enable-experimental-feature BorrowingSwitch -typecheck -verify %s
+
+struct Payload: ~Copyable {
+    var x: Int
+    var y: String
+}
+
+enum Foo: ~Copyable {
+    case payload(Payload)
+    case noPayload
+}
+
+enum Bar: ~Copyable {
+    case payload(Foo)
+    case noPayload
+
+    var member: Bar { fatalError() }
+}
+
+struct SourceBreakTest {
+    func foo() -> Bar {}
+
+    func callAsFunction() -> Bar { fatalError() }
+}
+
+let _borrowing = SourceBreakTest()
+
+func ~=(_: borrowing Bar, _: borrowing Bar) -> Bool { fatalError() }
+
+func useBorrowBar(_: borrowing Bar) { fatalError() }
+func useBorrowFoo(_: borrowing Foo) { fatalError() }
+func useBorrowPayload(_: borrowing Payload) { fatalError() }
+
+func testBorrowingPatterns(bar: borrowing Bar) {
+    switch bar {
+    case _borrowing .foo(): // parses as `_borrowing.foo()` as before
+        break
+    case _borrowing (): // parses as `_borrowing()` as before
+        break
+
+    case _borrowing x: 
+        useBorrowBar(x)
+
+    case .payload(_borrowing x):
+        useBorrowFoo(x)
+
+    case _borrowing x.member: // expected-error{{'_borrowing' pattern modifier must be directly applied to pattern variable name}} expected-error{{cannot find 'x' in scope}}
+        break
+
+    default:
+        break
+    }
+}


### PR DESCRIPTION
Treat it as a contextual keyword when followed by an identifier, like our other ownership-related declarations and operators.