### PR TITLE
Conditionally enable bounds checking for unsafe buffer pointers

### DIFF
--- a/docs/StandardLibraryProgrammersManual.md
+++ b/docs/StandardLibraryProgrammersManual.md
@@ -415,11 +415,15 @@ return
 This should be rarely used. It informs the SIL optimizer that any code dominated by it should be treated as the innermost loop of a performance critical section of code. It cranks optimizer heuristics to 11. Injudicious use of this will degrade performance and bloat binary size.
 
 
-#### <a name="precondition"></a>`_precondition`, `_debugPrecondition`, and `_internalInvariant`
+#### <a name="precondition"></a>`_precondition`, `_debugPrecondition`, `_boundsCheckPrecondition`, and `_internalInvariant`
 
-These three functions are assertions that will trigger a run time trap if violated.
+These four functions are assertions that will trigger a run time trap if violated.
 
 * `_precondition` executes in all build configurations. Use this for invariant enforcement in all user code build configurations
+* `_boundsCheckPrecondition` executes in **used code** is built in either a debug build, or when the upcoming feature `UnsafePointerBoundsSafety`
+    has been enabled. Use this only for `_debugPreconditions` that have
+    historically only been `_debugPrecondition`, but are being updated
+    for Swift 6.
 * `_debugPrecondition` will execute when **user code** is built with assertions enabled. Use this for invariant enforcement that's useful while debugging, but might be prohibitively expensive when user code is configured without assertions.
 * `_internalInvariant` will execute when **standard library code** is built with assertions enabled. Use this for internal only invariant checks that useful for debugging the standard library itself.
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -198,6 +198,7 @@ public:
     Debug = 0,     // Enables all asserts.
     Release = 1,   // Disables asserts.
     Unchecked = 2, // Disables asserts, preconditions, and runtime checks.
+    ReleaseWithBoundsSafety = 3, // Enables all asserts + bounds checks for unsafe pointers
 
     // Leave the assert_configuration instruction around.
     DisableReplacement = UINT_MAX

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -129,6 +129,8 @@ UPCOMING_FEATURE(FullTypedThrows, 413, 6)
 
 UPCOMING_FEATURE(ExistentialAny, 335, 7)
 
+EXPERIMENTAL_FEATURE(UnsafePointerBoundsSafety, true)
+
 EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1055,7 +1055,7 @@ def debug_info_store_invocation : Flag<["-"], "debug-info-store-invocation">,
 def AssertConfig : Separate<["-"], "assert-config">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Specify the assert_configuration replacement. "
-           "Possible values are Debug, Release, Unchecked, DisableReplacement.">;
+           "Possible values are Debug, Release, Unchecked, ReleaseWithBoundsSafety, DisableReplacement.">;
 
 // Code formatting options
 

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -298,7 +298,8 @@ struct BridgedPassContext {
   enum class AssertConfiguration {
     Debug = 0,
     Release = 1,
-    Unchecked = 2
+    Unchecked = 2,
+    ReleaseWithBoundsSafety = 3,
   };
 
   BRIDGED_INLINE bool enableStackProtection() const;

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -443,6 +443,7 @@ static_assert((int)BridgedPassContext::SILStage::Lowered == (int)swift::SILStage
 static_assert((int)BridgedPassContext::AssertConfiguration::Debug == (int)swift::SILOptions::Debug);
 static_assert((int)BridgedPassContext::AssertConfiguration::Release == (int)swift::SILOptions::Release);
 static_assert((int)BridgedPassContext::AssertConfiguration::Unchecked == (int)swift::SILOptions::Unchecked);
+static_assert((int)BridgedPassContext::AssertConfiguration::ReleaseWithBoundsSafety == (int)swift::SILOptions::ReleaseWithBoundsSafety);
 
 SWIFT_END_NULLABILITY_ANNOTATIONS
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3944,6 +3944,10 @@ static bool usesFeaturePreconcurrencyConformances(Decl *decl) {
 
 static bool usesFeatureBorrowingSwitch(Decl *decl) { return false; }
 
+static bool usesFeatureUnsafePointerBoundsSafety(Decl *decl) {
+  return false;
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -608,7 +608,7 @@ func findSyntaxNodeInSourceFile<Node: SyntaxProtocol>(
 
   let sourceFilePtr = sourceFilePtr.assumingMemoryBound(to: ExportedSourceFile.self)
 
-  // Find the offset.
+  // Find the offset in this buffer.
   let buffer = sourceFilePtr.pointee.buffer
   let offset = sourceLocationPtr - buffer.baseAddress!
   if offset < 0 || offset >= buffer.count {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2030,6 +2030,7 @@ void parseExclusivityEnforcementOptions(const llvm::opt::Arg *A,
 
 static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
                          IRGenOptions &IRGenOpts,
+                         const LangOptions &LangOpts,
                          const FrontendOptions &FEOpts,
                          const TypeCheckerOptions &TCOpts,
                          DiagnosticEngine &Diags,
@@ -2118,6 +2119,8 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       Opts.AssertConfig = SILOptions::Release;
     } else if (Configuration == "Unchecked") {
       Opts.AssertConfig = SILOptions::Unchecked;
+    } else if (Configuration == "ReleaseWithBoundsSafety") {
+      Opts.AssertConfig = SILOptions::ReleaseWithBoundsSafety;
     } else {
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
@@ -2131,7 +2134,11 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     // Set the assert configuration according to the optimization level if it
     // has not been set by the -Ounchecked flag.
     Opts.AssertConfig =
-        (IRGenOpts.shouldOptimize() ? SILOptions::Release : SILOptions::Debug);
+        IRGenOpts.shouldOptimize()
+         ? (LangOpts.hasFeature(Feature::UnsafePointerBoundsSafety)
+              ? SILOptions::ReleaseWithBoundsSafety
+              : SILOptions::Release)
+         : SILOptions::Debug;
   }
 
   // -Ounchecked might also set removal of runtime asserts (cond_fail).
@@ -3203,7 +3210,7 @@ bool CompilerInvocation::parseArgs(
     return true;
   }
 
-  if (ParseSILArgs(SILOpts, ParsedArgs, IRGenOpts, FrontendOpts,
+  if (ParseSILArgs(SILOpts, ParsedArgs, IRGenOpts, LangOpts, FrontendOpts,
                    TypeCheckerOpts, Diags,
                    LangOpts.Target, ClangImporterOpts)) {
     return true;

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -53,7 +53,8 @@ extension SerialExecutor {
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
   ) {
-    guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
+    guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() ||
+        _isReleaseAssertWithBoundsSafetyConfiguration() else {
       return
     }
 
@@ -102,7 +103,8 @@ extension Actor {
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
   ) {
-    guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
+    guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() ||
+        _isReleaseAssertWithBoundsSafetyConfiguration() else {
       return
     }
 

--- a/stdlib/public/Differentiation/ArrayDifferentiation.swift
+++ b/stdlib/public/Differentiation/ArrayDifferentiation.swift
@@ -193,7 +193,7 @@ extension Array: Differentiable where Element: Differentiable {
 
 extension Array where Element: Differentiable {
   @usableFromInline
-  @derivative(of: subscript)
+  @derivative(of: subscript(_:))
   func _vjpSubscript(index: Int) -> (
     value: Element, pullback: (Element.TangentVector) -> TangentVector
   ) {
@@ -208,7 +208,7 @@ extension Array where Element: Differentiable {
   }
 
   @usableFromInline
-  @derivative(of: subscript)
+  @derivative(of: subscript(_:))
   func _jvpSubscript(index: Int) -> (
     value: Element, differential: (TangentVector) -> Element.TangentVector
   ) {

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -47,7 +47,8 @@ extension DistributedActor {
       _ message: @autoclosure () -> String = String(),
       file: StaticString = #fileID, line: UInt = #line
   ) {
-    guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
+    guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() ||
+        _isReleaseAssertWithBoundsSafetyConfiguration() else {
       return
     }
 

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -405,6 +405,7 @@ extension Array {
   @inlinable
   @_semantics("array.check_subscript")
   @_effects(notEscaping self.**)
+  @_alwaysEmitIntoClient
   public // @testable
   func _debugCheckSubscript(
     _ index: Int, wasNativeTypeChecked: Bool
@@ -458,6 +459,7 @@ extension Array {
   @inlinable
   @_semantics("array.check_index")
   @_effects(notEscaping self.**)
+  @_alwaysEmitIntoClient
   internal func _debugCheckIndex(_ index: Int) {
     _debugPrecondition(index <= endIndex, "Array index is out of range")
     _debugPrecondition(index >= startIndex, "Negative Array index is out of range")

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -471,6 +471,7 @@ extension _ArrayBuffer {
   /// `0 ≤ index < count`.
   ///
   /// - Precondition: The buffer must be mutable.
+  @inlinable
   @_alwaysEmitIntoClient
   internal func _debugCheckValidSubscriptMutating(_ index: Int) {
     _native._debugCheckValidSubscriptMutating(index)

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -467,6 +467,14 @@ extension _ArrayBuffer {
     _native._checkValidSubscriptMutating(index)
   }
 
+  /// Traps unless the given `index` is valid for subscripting, i.e.
+  /// `0 ≤ index < count`.
+  ///
+  /// - Precondition: The buffer must be mutable.
+  @_alwaysEmitIntoClient
+  internal func _debugCheckValidSubscriptMutating(_ index: Int) {
+    _native._debugCheckValidSubscriptMutating(index)
+  }
   /// The number of elements the buffer can store without reallocation.
   ///
   /// This property is obsolete. It's only used for the ArrayBufferProtocol and

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -110,7 +110,7 @@ public func precondition(
       _assertionFailure("Precondition failed", message(), file: file, line: line,
         flags: _fatalErrorFlags())
     }
-  } else if _isReleaseAssertConfiguration() {
+  } else if _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() {
     let error = !condition()
     Builtin.condfail_message(error._value,
       StaticString("precondition failure").unsafeRawPointer)
@@ -130,7 +130,7 @@ public func precondition(
       _assertionFailure("Precondition failed", message(), file: file, line: line,
         flags: _fatalErrorFlags())
     }
-  } else if _isReleaseAssertConfiguration() {
+  } else if _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() {
     let error = !condition()
     Builtin.condfail_message(error._value,
       StaticString("precondition failure").unsafeRawPointer)
@@ -229,7 +229,7 @@ public func preconditionFailure(
   if _isDebugAssertConfiguration() {
     _assertionFailure("Fatal error", message(), file: file, line: line,
       flags: _fatalErrorFlags())
-  } else if _isReleaseAssertConfiguration() {
+  } else if _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() {
     Builtin.condfail_message(true._value,
       StaticString("precondition failure").unsafeRawPointer)
   }
@@ -246,7 +246,7 @@ public func preconditionFailure(
   if _isDebugAssertConfiguration() {
     _assertionFailure("Fatal error", message(), file: file, line: line,
       flags: _fatalErrorFlags())
-  } else if _isReleaseAssertConfiguration() {
+  } else if _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() {
     Builtin.condfail_message(true._value,
       StaticString("precondition failure").unsafeRawPointer)
   }
@@ -300,7 +300,7 @@ internal func _precondition(
       _assertionFailure("Fatal error", message, file: file, line: line,
         flags: _fatalErrorFlags())
     }
-  } else if _isReleaseAssertConfiguration() {
+  } else if _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() {
     let error = !condition()
     Builtin.condfail_message(error._value, message.unsafeRawPointer)
   }
@@ -441,7 +441,7 @@ internal func _precondition(
       _assertionFailure("Fatal error", message, file: file, line: line,
         flags: _fatalErrorFlags())
     }
-  } else if _isReleaseAssertConfiguration() {
+  } else if _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() {
     let error = (!condition() && _isExecutableLinkedOnOrAfter(version))
     Builtin.condfail_message(error._value, message.unsafeRawPointer)
   }

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -377,6 +377,31 @@ internal func _debugPreconditionFailure(
 #endif
 }
 
+/// Precondition checks for bounds-checking of unsafe pointers.
+///
+/// Debug library precondition checks are on in debug mode and in release
+/// mode with additional bounds safety enabled. If release and unchecked
+/// modes, they are disabled.
+/// They are meant to be used for bounds-safety checks.
+@usableFromInline @_transparent @_alwaysEmitIntoClient
+internal func _boundsCheckPrecondition(
+  _ condition: @autoclosure () -> Bool, _ message: StaticString = StaticString(),
+  file: StaticString = #file, line: UInt = #line
+) {
+#if SWIFT_STDLIB_ENABLE_DEBUG_PRECONDITIONS_IN_RELEASE
+  _precondition(condition(), message, file: file, line: line)
+#else
+  // Only check in debug and release w/ bounds checks.
+  if _isDebugAssertConfiguration() ||
+      _isReleaseAssertWithBoundsSafetyConfiguration() {
+    if !_fastPath(condition()) {
+      _fatalErrorMessage("Fatal error", message, file: file, line: line,
+        flags: _fatalErrorFlags())
+    }
+  }
+#endif
+}
+
 /// Internal checks.
 ///
 /// Internal checks are to be used for checking correctness conditions in the

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -26,6 +26,7 @@ func _isDebugAssertConfiguration() -> Bool {
   // 0: Debug
   // 1: Release
   // 2: Fast
+  // 3: Release w/ UnsafePointerBoundsSafety
   return Int32(Builtin.assert_configuration()) == 0
 }
 
@@ -36,7 +37,20 @@ func _isReleaseAssertConfiguration() -> Bool {
   // 0: Debug
   // 1: Release
   // 2: Fast
+  // 3: Release w/ UnsafePointerBoundsSafety
   return Int32(Builtin.assert_configuration()) == 1
+}
+
+@_transparent
+@_alwaysEmitIntoClient
+public // @testable, used in _Concurrency executor preconditions
+func _isReleaseAssertWithBoundsSafetyConfiguration() -> Bool {
+  // The values for the assert_configuration call are:
+  // 0: Debug
+  // 1: Release
+  // 2: Fast
+  // 3: Release w/ UnsafePointerBoundsSafety
+  return Int32(Builtin.assert_configuration()) == 3
 }
 
 @_transparent
@@ -46,6 +60,7 @@ func _isFastAssertConfiguration() -> Bool {
   // 0: Debug
   // 1: Release
   // 2: Fast
+  // 3: Release w/ UnsafePointerBoundsSafety
   return Int32(Builtin.assert_configuration()) == 2
 }
 

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -174,7 +174,7 @@ extension Character :
   public init(_ s: String) {
     _precondition(!s.isEmpty,
       "Can't form a Character from an empty String")
-    _debugPrecondition(s.index(after: s.startIndex) == s.endIndex,
+    _boundsCheckPrecondition(s.index(after: s.startIndex) == s.endIndex,
       "Can't form a Character from a String containing more than one extended grapheme cluster")
 
     if _fastPath(s._guts._object.isPreferredRepresentation) {

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -425,6 +425,15 @@ public protocol Collection<Element>: Sequence {
   @_borrowed
   subscript(position: Index) -> Element { get }
 
+  /// Accesses the element at the specified position without bounds checking.
+  ///
+  /// This unsafe operation should only be used when performance analysis
+  /// has determined that the bounds checks are not being eliminated
+  /// by the optimizer despite being ensured by a higher-level invariant.
+  @available(SwiftStdlib 5.11, *)
+  @_borrowed
+  subscript(unchecked position: Index) -> Element { get }
+
   /// Accesses a contiguous subrange of the collection's elements.
   ///
   /// For example, using a `PartialRangeFrom` range expression with an array
@@ -462,6 +471,15 @@ public protocol Collection<Element>: Sequence {
   ///
   /// - Complexity: O(1)
   subscript(bounds: Range<Index>) -> SubSequence { get }
+
+  /// Accesses a contiguous subrange of the collection's elements without
+  /// bounds checking.
+  ///
+  /// This unsafe operation should only be used when performance analysis
+  /// has determined that the bounds checks are not being eliminated
+  /// by the optimizer despite being ensured by a higher-level invariant.
+  @available(SwiftStdlib 5.11, *)
+  subscript(uncheckedBounds bounds: Range<Index>) -> SubSequence { get }
 
   /// A type that represents the indices that are valid for subscripting the
   /// collection, in ascending order.
@@ -1688,5 +1706,24 @@ extension Collection where SubSequence == Self {
         "Can't remove more items from a collection than it contains")
     }
     self = self[idx..<endIndex]
+  }
+}
+
+extension Collection {
+  /// Default implementation of `[_:]` that uses the checked
+  /// subscript implementation.
+  @inlinable
+  @_alwaysEmitIntoClient
+  @_borrowed
+  public subscript(unchecked position: Index) -> Element {
+    self[position]
+  }
+
+  /// Default implementation of `[uncheckedBounds:]` that uses the checked
+  /// subscript implementation.
+  @inlinable
+  @_alwaysEmitIntoClient
+  public subscript(uncheckedBounds bounds: Range<Index>) -> SubSequence {
+    self[bounds]
   }
 }

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -95,6 +95,7 @@ extension ContiguousArray {
   /// `0 ≤ index < count`, but only in debug builds.
   @inlinable
   @inline(__always)
+  @_alwaysEmitIntoClient
   internal func _debugCheckSubscript_native(_ index: Int) {
     _buffer._debugCheckValidSubscript(index)
   }
@@ -130,6 +131,7 @@ extension ContiguousArray {
   /// Check that the specified `index` is valid, i.e. `0 ≤ index ≤ count`, but only in debug builds.
   @inlinable
   @_semantics("array.check_index")
+  @_alwaysEmitIntoClient
   internal func _debugCheckIndex(_ index: Int) {
     _debugPrecondition(index <= endIndex, "ContiguousArray index is out of range")
     _debugPrecondition(index >= startIndex, "Negative ContiguousArray index is out of range")

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -670,6 +670,19 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   }
 
   /// Traps unless the given `index` is valid for subscripting, i.e.
+  /// `0 ≤ index < count`, but only in debug mode.
+  ///
+  /// - Precondition: The buffer must be immutable.
+  @inlinable
+  @inline(__always)
+  internal func _debugCheckValidSubscript(_ index: Int) {
+    _debugPrecondition(
+      (index >= 0) && (index < immutableCount),
+      "Index out of range"
+    )
+  }
+
+  /// Traps unless the given `index` is valid for subscripting, i.e.
   /// `0 ≤ index < count`.
   ///
   /// - Precondition: The buffer must be mutable.
@@ -677,6 +690,19 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   @inline(__always)
   internal func _checkValidSubscriptMutating(_ index: Int) {
     _precondition(
+      (index >= 0) && (index < mutableCount),
+      "Index out of range"
+    )
+  }
+
+  /// Traps unless the given `index` is valid for subscripting, i.e.
+  /// `0 ≤ index < count`, but only in debug builds.
+  ///
+  /// - Precondition: The buffer must be mutable.
+  @_alwaysEmitIntoClient
+  @inline(__always)
+  internal func _debugCheckValidSubscriptMutating(_ index: Int) {
+    _debugPrecondition(
       (index >= 0) && (index < mutableCount),
       "Index out of range"
     )

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -675,6 +675,7 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// - Precondition: The buffer must be immutable.
   @inlinable
   @inline(__always)
+  @_alwaysEmitIntoClient
   internal func _debugCheckValidSubscript(_ index: Int) {
     _debugPrecondition(
       (index >= 0) && (index < immutableCount),
@@ -686,8 +687,8 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// `0 ≤ index < count`.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
   @inline(__always)
+  @_alwaysEmitIntoClient
   internal func _checkValidSubscriptMutating(_ index: Int) {
     _precondition(
       (index >= 0) && (index < mutableCount),
@@ -699,8 +700,8 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   /// `0 ≤ index < count`, but only in debug builds.
   ///
   /// - Precondition: The buffer must be mutable.
-  @_alwaysEmitIntoClient
   @inline(__always)
+  @_alwaysEmitIntoClient
   internal func _debugCheckValidSubscriptMutating(_ index: Int) {
     _debugPrecondition(
       (index >= 0) && (index < mutableCount),

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -110,12 +110,12 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   @inlinable // trivial-implementation
   public subscript(bounds: Range<Index>) -> SubSequence {
     get {
-      _debugPrecondition(bounds.lowerBound == 0 && bounds.upperBound == 0,
+      _boundsCheckPrecondition(bounds.lowerBound == 0 && bounds.upperBound == 0,
         "Index out of range")
       return self
     }
     set {
-      _debugPrecondition(bounds.lowerBound == 0 && bounds.upperBound == 0,
+      _boundsCheckPrecondition(bounds.lowerBound == 0 && bounds.upperBound == 0,
         "Index out of range")
     }
   }
@@ -128,7 +128,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
 
   @inlinable // trivial-implementation
   public func index(_ i: Index, offsetBy n: Int) -> Index {
-    _debugPrecondition(i == startIndex && n == 0, "Index out of range")
+    _boundsCheckPrecondition(i == startIndex && n == 0, "Index out of range")
     return i
   }
 
@@ -136,7 +136,7 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   public func index(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
-    _debugPrecondition(i == startIndex && limit == startIndex,
+    _boundsCheckPrecondition(i == startIndex && limit == startIndex,
       "Index out of range")
     return n == 0 ? i : nil
   }
@@ -144,23 +144,23 @@ extension EmptyCollection: RandomAccessCollection, MutableCollection {
   /// The distance between two indexes (always zero).
   @inlinable // trivial-implementation
   public func distance(from start: Index, to end: Index) -> Int {
-    _debugPrecondition(start == 0, "From must be startIndex (or endIndex)")
-    _debugPrecondition(end == 0, "To must be endIndex (or startIndex)")
+    _boundsCheckPrecondition(start == 0, "From must be startIndex (or endIndex)")
+    _boundsCheckPrecondition(end == 0, "To must be endIndex (or startIndex)")
     return 0
   }
 
   @inlinable // trivial-implementation
   public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
-    _debugPrecondition(index == 0, "out of bounds")
-    _debugPrecondition(bounds == indices, "invalid bounds for an empty collection")
+    _boundsCheckPrecondition(index == 0, "out of bounds")
+    _boundsCheckPrecondition(bounds == indices, "invalid bounds for an empty collection")
   }
 
   @inlinable // trivial-implementation
   public func _failEarlyRangeCheck(
     _ range: Range<Index>, bounds: Range<Index>
   ) {
-    _debugPrecondition(range == indices, "invalid range for an empty collection")
-    _debugPrecondition(bounds == indices, "invalid bounds for an empty collection")
+    _boundsCheckPrecondition(range == indices, "invalid range for an empty collection")
+    _boundsCheckPrecondition(bounds == indices, "invalid bounds for an empty collection")
   }
 }
 

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -539,7 +539,7 @@ public func swap<T>(_ a: inout T, _ b: inout T) {
   let p1 = Builtin.addressof(&a)
   let p2 = Builtin.addressof(&b)
 #endif
-  _debugPrecondition(
+  _boundsCheckPrecondition(
     p1 != p2,
     "swapping a location with itself is not supported")
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -301,8 +301,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger
   ///   index.
   @inlinable
   public subscript(position: Index) -> Element {
-    // FIXME: swift-3-indexing-model: tests for the range check.
-    _debugPrecondition(self.contains(position), "Index out of range")
+    _boundsCheckPrecondition(self.contains(position), "Index out of range")
     return position
   }
 }

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -310,6 +310,7 @@ internal struct _SliceBuffer<Element>
   /// Traps unless the given `index` is valid for subscripting, i.e.
   /// `startIndex ≤ index < endIndex`, but only in debug builkds.
   @inlinable
+  @_alwaysEmitIntoClient
   internal func _debugCheckValidSubscript(_ index: Int) {
     _debugPrecondition(
       index >= startIndex && index < endIndex, "Index out of bounds")

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -307,6 +307,14 @@ internal struct _SliceBuffer<Element>
       index >= startIndex && index < endIndex, "Index out of bounds")
   }
 
+  /// Traps unless the given `index` is valid for subscripting, i.e.
+  /// `startIndex ≤ index < endIndex`, but only in debug builkds.
+  @inlinable
+  internal func _debugCheckValidSubscript(_ index: Int) {
+    _debugPrecondition(
+      index >= startIndex && index < endIndex, "Index out of bounds")
+  }
+
   @inlinable
   internal var capacity: Int {
     let count = self.count

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -201,15 +201,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
     // optimizer is not capable of creating partial specializations yet.
-    // NOTE: Range checks are not performed here, because it is done later by
-    // the subscript function.
-    // NOTE: Wrapping math because we allow unsafe buffer pointers not to verify
-    // index preconditions in release builds. Our (optimistic) assumption is
-    // that the caller is already ensuring that indices are valid, so we can
-    // elide the usual checks to help the optimizer generate better code.
-    // However, we still check for overflow in debug mode.
     let result = i.addingReportingOverflow(1)
-    _debugPrecondition(!result.overflow)
+    _boundsCheckPrecondition(!result.overflow)
     return result.partialValue
   }
 
@@ -217,12 +210,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   public func formIndex(after i: inout Int) {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
-    // optimizer is not capable of creating partial specializations yet.
-    // NOTE: Range checks are not performed here, because it is done later by
-    // the subscript function.
-    // See note on wrapping arithmetic in `index(after:)` above.
     let result = i.addingReportingOverflow(1)
-    _debugPrecondition(!result.overflow)
+    _boundsCheckPrecondition(!result.overflow)
     i = result.partialValue
   }
 
@@ -231,11 +220,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
     // optimizer is not capable of creating partial specializations yet.
-    // NOTE: Range checks are not performed here, because it is done later by
-    // the subscript function.
-    // See note on wrapping arithmetic in `index(after:)` above.
     let result = i.subtractingReportingOverflow(1)
-    _debugPrecondition(!result.overflow)
+    _boundsCheckPrecondition(!result.overflow)
     return result.partialValue
   }
 
@@ -244,11 +230,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
     // optimizer is not capable of creating partial specializations yet.
-    // NOTE: Range checks are not performed here, because it is done later by
-    // the subscript function.
-    // See note on wrapping arithmetic in `index(after:)` above.
     let result = i.subtractingReportingOverflow(1)
-    _debugPrecondition(!result.overflow)
+    _boundsCheckPrecondition(!result.overflow)
     i = result.partialValue
   }
 
@@ -257,11 +240,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
     // optimizer is not capable of creating partial specializations yet.
-    // NOTE: Range checks are not performed here, because it is done later by
-    // the subscript function.
-    // See note on wrapping arithmetic in `index(after:)` above.
     let result = i.addingReportingOverflow(n)
-    _debugPrecondition(!result.overflow)
+    _boundsCheckPrecondition(!result.overflow)
     return result.partialValue
   }
 
@@ -270,11 +250,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
     // optimizer is not capable of creating partial specializations yet.
-    // NOTE: Range checks are not performed here, because it is done later by
-    // the subscript function.
-    // See note on wrapping arithmetic in `index(after:)` above.
     let maxOffset = limit.subtractingReportingOverflow(i)
-    _debugPrecondition(!maxOffset.overflow)
+    _boundsCheckPrecondition(!maxOffset.overflow)
     let l = maxOffset.partialValue
 
     if n > 0 ? l >= 0 && l < n : l <= 0 && n < l {
@@ -282,7 +259,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     }
 
     let result = i.addingReportingOverflow(n)
-    _debugPrecondition(!result.overflow)
+    _boundsCheckPrecondition(!result.overflow)
     return result.partialValue
   }
 
@@ -291,15 +268,13 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
     // optimizer is not capable of creating partial specializations yet.
-    // NOTE: Range checks are not performed here, because it is done later by
-    // the subscript function.
     // NOTE: We allow the subtraction to silently overflow in release builds
     // to eliminate a superfluous check when `start` and `end` are both valid
     // indices. (The operation can only overflow if `start` is negative, which
     // implies it's an invalid index.) `Collection` does not specify what
     // `distance` should return when given an invalid index pair.
     let result = end.subtractingReportingOverflow(start)
-    _debugPrecondition(!result.overflow)
+    _boundsCheckPrecondition(!result.overflow)
     return result.partialValue
   }
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -353,6 +353,28 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
 %end
   }
 
+  /// Accesses the element at the specified position without bounds
+  /// checking.
+  ///
+  /// This unsafe operation should only be used when performance analysis
+  /// has determined that the bounds checks are not being eliminated
+  /// by the optimizer despite being ensured by a higher-level invariant.
+  @inlinable @_alwaysEmitIntoClient
+  public subscript(unchecked i: Int) -> Element {
+    get {
+      _debugPrecondition(i >= 0)
+      _debugPrecondition(i < endIndex)
+      return _position._unsafelyUnwrappedUnchecked[i]
+    }
+%if Mutable:
+    nonmutating _modify {
+      _debugPrecondition(i >= 0)
+      _debugPrecondition(i < endIndex)
+      yield &_position._unsafelyUnwrappedUnchecked[i]
+    }
+%end
+  }
+
   // Skip all debug and runtime checks
 
   @inlinable // unsafe-performance
@@ -433,6 +455,38 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     }
 %  end
   }
+
+  /// Accesses a contiguous subrange of the buffer's elements without
+  /// bounds checking.
+  ///
+  /// This unsafe operation should only be used when performance analysis
+  /// has determined that the bounds checks are not being eliminated
+  /// by the optimizer despite being ensured by a higher-level invariant.
+  @inlinable @_alwaysEmitIntoClient
+  public subscript(uncheckedBounds bounds: Range<Int>)
+    -> Slice<Unsafe${Mutable}BufferPointer<Element>>
+  {
+    get {
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
+      return Slice(
+        base: self, bounds: bounds)
+    }
+%  if Mutable:
+    nonmutating set {
+      _debugPrecondition(bounds.lowerBound >= startIndex)
+      _debugPrecondition(bounds.upperBound <= endIndex)
+      _debugPrecondition(bounds.count == newValue.count)
+
+      if !newValue.isEmpty {
+        (_position! + bounds.lowerBound).update(
+          from: newValue.base._position! + newValue.startIndex,
+          count: newValue.count)
+      }
+    }
+%  end
+  }
+
 % if mutable:
 
   /// Exchanges the values at the specified indices of the buffer.

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -67,9 +67,9 @@ public struct Unsafe${Mutable}BufferPointer<Element>
   public init(
     @_nonEphemeral start: Unsafe${Mutable}Pointer<Element>?, count: Int
   ) {
-    _debugPrecondition(
+    _boundsCheckPrecondition(
       count >= 0, "Unsafe${Mutable}BufferPointer with negative count")
-    _debugPrecondition(
+    _boundsCheckPrecondition(
       count == 0 || start != nil,
       "Unsafe${Mutable}BufferPointer has a nil start and nonzero count")
     self.init(_uncheckedStart: start, count: _assumeNonNegative(count))
@@ -499,7 +499,7 @@ extension Unsafe${Mutable}BufferPointer {
   ) rethrows -> R? {
     let (oldBase, oldCount) = (self.baseAddress, self.count)
     defer { 
-      _debugPrecondition((oldBase, oldCount) == (self.baseAddress, self.count),
+      _boundsCheckPrecondition((oldBase, oldCount) == (self.baseAddress, self.count),
       "UnsafeMutableBufferPointer.withContiguousMutableStorageIfAvailable: replacing the buffer is not allowed")
     } 
     return try body(&self)
@@ -1140,7 +1140,7 @@ extension Unsafe${Mutable}BufferPointer {
       return try body(.init(start: nil, count: 0))
     }
 
-    _debugPrecondition(
+    _boundsCheckPrecondition(
       Int(bitPattern: .init(base)) & (MemoryLayout<T>.alignment-1) == 0,
       "baseAddress must be a properly aligned pointer for types Element and T"
     )
@@ -1150,7 +1150,7 @@ extension Unsafe${Mutable}BufferPointer {
       newCount = count
     } else {
       newCount = count * MemoryLayout<Element>.stride / MemoryLayout<T>.stride
-      _debugPrecondition(
+      _boundsCheckPrecondition(
         MemoryLayout<T>.stride > MemoryLayout<Element>.stride
         ? MemoryLayout<T>.stride % MemoryLayout<Element>.stride == 0
         : MemoryLayout<Element>.stride % MemoryLayout<T>.stride == 0,

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -305,16 +305,15 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
 
   @inlinable // unsafe-performance
   public func _failEarlyRangeCheck(_ index: Int, bounds: Range<Int>) {
-    // NOTE: In release mode, this method is a no-op for performance reasons.
-    _debugPrecondition(index >= bounds.lowerBound)
-    _debugPrecondition(index < bounds.upperBound)
+    _boundsCheckPrecondition(index >= bounds.lowerBound && index < bounds.upperBound)
   }
 
   @inlinable // unsafe-performance
   public func _failEarlyRangeCheck(_ range: Range<Int>, bounds: Range<Int>) {
-    // NOTE: In release mode, this method is a no-op for performance reasons.
-    _debugPrecondition(range.lowerBound >= bounds.lowerBound)
-    _debugPrecondition(range.upperBound <= bounds.upperBound)
+    _boundsCheckPrecondition(
+      range.lowerBound >= bounds.lowerBound &&
+      range.upperBound <= bounds.upperBound
+    )
   }
 
   @inlinable // unsafe-performance
@@ -366,14 +365,14 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   @inlinable // unsafe-performance
   public subscript(i: Int) -> Element {
     get {
-      _debugPrecondition(i >= 0)
-      _debugPrecondition(i < endIndex)
+      _boundsCheckPrecondition(i >= 0)
+      _boundsCheckPrecondition(i < endIndex)
       return _position._unsafelyUnwrappedUnchecked[i]
     }
 %if Mutable:
     nonmutating _modify {
-      _debugPrecondition(i >= 0)
-      _debugPrecondition(i < endIndex)
+      _boundsCheckPrecondition(i >= 0)
+      _boundsCheckPrecondition(i < endIndex)
       yield &_position._unsafelyUnwrappedUnchecked[i]
     }
 %end
@@ -439,16 +438,16 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     -> Slice<Unsafe${Mutable}BufferPointer<Element>>
   {
     get {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
+      _boundsCheckPrecondition(bounds.lowerBound >= startIndex)
+      _boundsCheckPrecondition(bounds.upperBound <= endIndex)
       return Slice(
         base: self, bounds: bounds)
     }
 %  if Mutable:
     nonmutating set {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
-      _debugPrecondition(bounds.count == newValue.count)
+      _boundsCheckPrecondition(bounds.lowerBound >= startIndex)
+      _boundsCheckPrecondition(bounds.upperBound <= endIndex)
+      _boundsCheckPrecondition(bounds.count == newValue.count)
 
       // FIXME: swift-3-indexing-model: tests.
       if !newValue.isEmpty {
@@ -473,8 +472,8 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   @inlinable // unsafe-performance
   public func swapAt(_ i: Int, _ j: Int) {
     guard i != j else { return }
-    _debugPrecondition(i >= 0 && j >= 0)
-    _debugPrecondition(i < endIndex && j < endIndex)
+    _boundsCheckPrecondition(i >= 0 && j >= 0)
+    _boundsCheckPrecondition(i < endIndex && j < endIndex)
     let pi = (_position! + i)
     let pj = (_position! + j)
     let tmp = pi.move()
@@ -555,7 +554,7 @@ extension Unsafe${Mutable}BufferPointer {
     // We only do this in debug builds to prevent a measurable performance
     // degradation wrt passing around pointers not wrapped in a BufferPointer
     // construct.
-    _debugPrecondition(
+    _boundsCheckPrecondition(
       slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
       "Invalid slice")
     let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
@@ -1030,7 +1029,7 @@ extension Unsafe${Mutable}BufferPointer {
   @inlinable
   @_alwaysEmitIntoClient
   public func initializeElement(at index: Index, to value: Element) {
-    _debugPrecondition(startIndex <= index && index < endIndex)
+    _boundsCheckPrecondition(startIndex <= index && index < endIndex)
     let p = baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index)
     p.initialize(to: value)
   }
@@ -1048,7 +1047,7 @@ extension Unsafe${Mutable}BufferPointer {
   @inlinable
   @_alwaysEmitIntoClient
   public func moveElement(from index: Index) -> Element {
-    _debugPrecondition(startIndex <= index && index < endIndex)
+    _boundsCheckPrecondition(startIndex <= index && index < endIndex)
     return baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index).move()
   }
 
@@ -1063,7 +1062,7 @@ extension Unsafe${Mutable}BufferPointer {
   @inlinable
   @_alwaysEmitIntoClient
   public func deinitializeElement(at index: Index) {
-    _debugPrecondition(startIndex <= index && index < endIndex)
+    _boundsCheckPrecondition(startIndex <= index && index < endIndex)
     let p = baseAddress._unsafelyUnwrappedUnchecked.advanced(by: index)
     p.deinitialize(count: 1)
   }

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -112,8 +112,8 @@ public struct Unsafe${Mutable}RawBufferPointer {
   public init(
     @_nonEphemeral start: Unsafe${Mutable}RawPointer?, count: Int
   ) {
-    _debugPrecondition(count >= 0, "${Self} with negative count")
-    _debugPrecondition(count == 0 || start != nil,
+    _boundsCheckPrecondition(count >= 0, "${Self} with negative count")
+    _boundsCheckPrecondition(count == 0 || start != nil,
       "${Self} has a nil start and nonzero count")
     _position = start
     _end = start.map { $0 + _assumeNonNegative(count) }
@@ -159,7 +159,7 @@ extension UnsafeRawBufferPointer.Iterator: IteratorProtocol, Sequence {
     //
     // We check these invariants in debug builds to defend against invalidly constructed
     // pointers.
-    _debugPrecondition(_position! < _end!)
+    _boundsCheckPrecondition(_position! < _end!)
     let position = _position._unsafelyUnwrappedUnchecked
     let result = position.load(as: UInt8.self)
     _position = position + 1
@@ -239,14 +239,14 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
   @inlinable
   public subscript(i: Int) -> Element {
     get {
-      _debugPrecondition(i >= 0)
-      _debugPrecondition(i < endIndex)
+      _boundsCheckPrecondition(i >= 0)
+      _boundsCheckPrecondition(i < endIndex)
       return _position._unsafelyUnwrappedUnchecked.load(fromByteOffset: i, as: UInt8.self)
     }
 %  if mutable:
     nonmutating set {
-      _debugPrecondition(i >= 0)
-      _debugPrecondition(i < endIndex)
+      _boundsCheckPrecondition(i >= 0)
+      _boundsCheckPrecondition(i < endIndex)
       _position._unsafelyUnwrappedUnchecked.storeBytes(of: newValue, toByteOffset: i, as: UInt8.self)
     }
 %  end # mutable
@@ -259,15 +259,15 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
   @inlinable
   public subscript(bounds: Range<Int>) -> SubSequence {
     get {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
+      _boundsCheckPrecondition(bounds.lowerBound >= startIndex)
+      _boundsCheckPrecondition(bounds.upperBound <= endIndex)
       return Slice(base: self, bounds: bounds)
     }
 %  if mutable:
     nonmutating set {
-      _debugPrecondition(bounds.lowerBound >= startIndex)
-      _debugPrecondition(bounds.upperBound <= endIndex)
-      _debugPrecondition(bounds.count == newValue.count)
+      _boundsCheckPrecondition(bounds.lowerBound >= startIndex)
+      _boundsCheckPrecondition(bounds.upperBound <= endIndex)
+      _boundsCheckPrecondition(bounds.count == newValue.count)
 
       if !newValue.isEmpty {
         (baseAddress! + bounds.lowerBound).copyMemory(
@@ -292,8 +292,8 @@ extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
   @inlinable
   public func swapAt(_ i: Int, _ j: Int) {
     guard i != j else { return }
-    _debugPrecondition(i >= 0 && j >= 0)
-    _debugPrecondition(i < endIndex && j < endIndex)
+    _boundsCheckPrecondition(i >= 0 && j >= 0)
+    _boundsCheckPrecondition(i < endIndex && j < endIndex)
     let pi = (_position! + i)
     let pj = (_position! + j)
     let tmp = pi.load(fromByteOffset: 0, as: UInt8.self)
@@ -394,8 +394,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   memory.
   @inlinable
   public func load<T>(fromByteOffset offset: Int = 0, as type: T.Type) -> T {
-    _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
-    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+    _boundsCheckPrecondition(offset >= 0, "${Self}.load with negative offset")
+    _boundsCheckPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.load out of bounds")
     return baseAddress!.load(fromByteOffset: offset, as: T.self)
   }
@@ -436,8 +436,8 @@ extension Unsafe${Mutable}RawBufferPointer {
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {
-    _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
-    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+    _boundsCheckPrecondition(offset >= 0, "${Self}.load with negative offset")
+    _boundsCheckPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.load out of bounds")
     return baseAddress!.loadUnaligned(fromByteOffset: offset, as: T.self)
   }
@@ -447,8 +447,8 @@ extension Unsafe${Mutable}RawBufferPointer {
     fromByteOffset offset: Int = 0,
     as type: T.Type
   ) -> T {
-    _debugPrecondition(offset >= 0, "${Self}.load with negative offset")
-    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+    _boundsCheckPrecondition(offset >= 0, "${Self}.load with negative offset")
+    _boundsCheckPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.load out of bounds")
     return baseAddress!.loadUnaligned(fromByteOffset: offset, as: T.self)
   }
@@ -495,8 +495,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   public func storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
-    _debugPrecondition(offset >= 0, "${Self}.storeBytes with negative offset")
-    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+    _boundsCheckPrecondition(offset >= 0, "${Self}.storeBytes with negative offset")
+    _boundsCheckPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.storeBytes out of bounds")
 
     let pointer = baseAddress._unsafelyUnwrappedUnchecked
@@ -511,8 +511,8 @@ extension Unsafe${Mutable}RawBufferPointer {
   @usableFromInline func _legacy_se0349_storeBytes<T>(
     of value: T, toByteOffset offset: Int = 0, as type: T.Type
   ) {
-    _debugPrecondition(offset >= 0, "${Self}.storeBytes with negative offset")
-    _debugPrecondition(offset + MemoryLayout<T>.size <= self.count,
+    _boundsCheckPrecondition(offset >= 0, "${Self}.storeBytes with negative offset")
+    _boundsCheckPrecondition(offset + MemoryLayout<T>.size <= self.count,
       "${Self}.storeBytes out of bounds")
 
     baseAddress!._legacy_se0349_storeBytes_internal(
@@ -538,7 +538,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   ///   be less than or equal to this buffer's `count`.
   @inlinable
   public func copyMemory(from source: UnsafeRawBufferPointer) {
-    _debugPrecondition(source.count <= self.count,
+    _boundsCheckPrecondition(source.count <= self.count,
       "${Self}.copyMemory source has too many elements")
     if let baseAddress = baseAddress, let sourceAddress = source.baseAddress {
       baseAddress.copyMemory(from: sourceAddress, byteCount: source.count)
@@ -568,7 +568,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     
     if source.withContiguousStorageIfAvailable({
       (buffer: UnsafeBufferPointer<UInt8>) -> Void in
-      _debugPrecondition(source.count <= self.count,
+      _boundsCheckPrecondition(source.count <= self.count,
         "${Self}.copyBytes source has too many elements")
       if let base = buffer.baseAddress {
         position.copyMemory(from: base, byteCount: buffer.count)
@@ -578,7 +578,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     }
 
     for (index, byteValue) in source.enumerated() {
-      _debugPrecondition(index < self.count,
+      _boundsCheckPrecondition(index < self.count,
         "${Self}.copyBytes source has too many elements")
       position.storeBytes(
         of: byteValue, toByteOffset: index, as: UInt8.self)
@@ -666,7 +666,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     // We only do this in debug builds to prevent a measurable performance
     // degradation wrt passing around pointers not wrapped in a BufferPointer
     // construct.
-    _debugPrecondition(
+    _boundsCheckPrecondition(
       slice.startIndex >= 0 && slice.endIndex <= slice.base.count,
       "Invalid slice")
     let base = slice.base.baseAddress?.advanced(by: slice.startIndex)
@@ -783,7 +783,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     let elementStride = MemoryLayout<S.Element>.stride
     
     // This has to be a debug precondition due to the cost of walking over some collections.
-    _debugPrecondition(source.underestimatedCount <= (count / elementStride),
+    _boundsCheckPrecondition(source.underestimatedCount <= (count / elementStride),
       "insufficient space to accommodate source.underestimatedCount elements")
     guard let base = baseAddress else {
       // this can be a precondition since only an invalid argument should be costly
@@ -792,7 +792,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       return (it, UnsafeMutableBufferPointer(start: nil, count: 0))
     }  
 
-    _debugPrecondition(
+    _boundsCheckPrecondition(
       Int(bitPattern: base) & (MemoryLayout<S.Element>.alignment-1) == 0,
       "buffer base address must be properly aligned to access S.Element"
     )
@@ -852,7 +852,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       guard let sourceAddress = $0.baseAddress, !$0.isEmpty else {
         return .init(start: nil, count: 0)
       }
-      _debugPrecondition(
+      _boundsCheckPrecondition(
         Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
         "buffer base address must be properly aligned to access C.Element"
       )
@@ -877,7 +877,7 @@ extension Unsafe${Mutable}RawBufferPointer {
       return .init(start: nil, count: 0)
     }
     _internalInvariant(_end != nil)
-    _debugPrecondition(
+    _boundsCheckPrecondition(
       Int(bitPattern: baseAddress) & (MemoryLayout<C.Element>.alignment-1) == 0,
       "buffer base address must be properly aligned to access C.Element"
     )
@@ -939,7 +939,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     guard let sourceAddress = source.baseAddress, !source.isEmpty else {
       return .init(start: nil, count: 0)
     }
-    _debugPrecondition(
+    _boundsCheckPrecondition(
       Int(bitPattern: baseAddress) & (MemoryLayout<T>.alignment-1) == 0,
       "buffer base address must be properly aligned to access T"
     )
@@ -1081,7 +1081,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     guard let s = _position else {
       return try body(.init(start: nil, count: 0))
     }
-    _debugPrecondition(
+    _boundsCheckPrecondition(
       Int(bitPattern: s) & (MemoryLayout<T>.alignment-1) == 0,
       "baseAddress must be a properly aligned pointer for type T"
     )
@@ -1134,7 +1134,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     try withMemoryRebound(to: Element.self) { b in
       var buffer = b
       defer {
-        _debugPrecondition(
+        _boundsCheckPrecondition(
           (b.baseAddress, b.count) == (buffer.baseAddress, buffer.count),
           "UnsafeMutableRawBufferPointer.withContiguousMutableStorageIfAvailable: replacing the buffer is not allowed"
         )

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -631,8 +631,8 @@ func rdar_50467583_and_50909555() {
     // rdar://problem/50467583
     let _: Set = [Int][] // expected-error {{no 'subscript' candidates produce the expected contextual result type 'Set'}}
     // expected-error@-1 {{no exact matches in call to subscript}}
-    // expected-note@-2 {{found candidate with type '(Int) -> Int'}}
-    // expected-note@-3 {{found candidate with type '(Range<Int>) -> ArraySlice<Int>'}}
+    // expected-note@-2 2{{found candidate with type '(Int) -> Int'}}
+    // expected-note@-3 2{{found candidate with type '(Range<Int>) -> ArraySlice<Int>'}}
     // expected-note@-4 {{found candidate with type '((UnboundedRange_) -> ()) -> ArraySlice<Int>'}}
     // expected-note@-5 * {{found candidate with type '(RangeSet<Array<Int>.Index>) -> DiscontiguousSlice<[Int]>' (aka '(RangeSet<Int>) -> DiscontiguousSlice<Array<Int>>')}}
   }

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -248,6 +248,12 @@ Added: _$sSMsSmRzrlE15removeSubrangesyys8RangeSetVy5IndexSlQzGF
 // (extension in Swift):Swift.MutableCollection.moveSubranges(_: Swift.RangeSet<A.Index>, to: A.Index) -> Swift.Range<A.Index>
 Added: _$sSMsE13moveSubranges_2toSny5IndexQzGs8RangeSetVyADG_ADtF
 
+// Collection.subscript(unchecked:) and Collection.subscript(uncheckedBounds:)
+Added: _$sSl15uncheckedBounds11SubSequenceQzSny5IndexQzG_tcigTj
+Added: _$sSl15uncheckedBounds11SubSequenceQzSny5IndexQzG_tcigTq
+Added: _$sSl9unchecked7ElementQz5IndexQz_tcirTj
+Added: _$sSl9unchecked7ElementQz5IndexQz_tcirTq
+
 // Property descriptors for newly-added, @_alwaysEmitIntoClient properties
 Added: _$sSR15uncheckedBoundss5SliceVySRyxGGSnySiG_tcipMV
 Added: _$sSR9uncheckedxSi_tcipMV
@@ -257,6 +263,8 @@ Added: _$sSr15uncheckedBoundss5SliceVySryxGGSnySiG_tcipMV
 Added: _$sSr9uncheckedxSi_tcipMV
 Added: _$ss15ContiguousArrayV15uncheckedBoundss0B5SliceVyxGSnySiG_tcipMV
 Added: _$ss15ContiguousArrayV9uncheckedxSi_tcipMV
+Added: _$sSlsE15uncheckedBounds11SubSequenceQzSny5IndexQzG_tcipMV
+Added: _$sSlsE9unchecked7ElementQz5IndexQz_tcipMV
 
 // Runtime Symbols
 Added: __swift_pod_copy

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -248,6 +248,16 @@ Added: _$sSMsSmRzrlE15removeSubrangesyys8RangeSetVy5IndexSlQzGF
 // (extension in Swift):Swift.MutableCollection.moveSubranges(_: Swift.RangeSet<A.Index>, to: A.Index) -> Swift.Range<A.Index>
 Added: _$sSMsE13moveSubranges_2toSny5IndexQzGs8RangeSetVyADG_ADtF
 
+// Property descriptors for newly-added, @_alwaysEmitIntoClient properties
+Added: _$sSR15uncheckedBoundss5SliceVySRyxGGSnySiG_tcipMV
+Added: _$sSR9uncheckedxSi_tcipMV
+Added: _$sSa15uncheckedBoundss10ArraySliceVyxGSnySiG_tcipMV
+Added: _$sSa9uncheckedxSi_tcipMV
+Added: _$sSr15uncheckedBoundss5SliceVySryxGGSnySiG_tcipMV
+Added: _$sSr9uncheckedxSi_tcipMV
+Added: _$ss15ContiguousArrayV15uncheckedBoundss0B5SliceVyxGSnySiG_tcipMV
+Added: _$ss15ContiguousArrayV9uncheckedxSi_tcipMV
+
 // Runtime Symbols
 Added: __swift_pod_copy
 Added: __swift_pod_destroy

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -248,6 +248,12 @@ Added: _$sSMsSmRzrlE15removeSubrangesyys8RangeSetVy5IndexSlQzGF
 // (extension in Swift):Swift.MutableCollection.moveSubranges(_: Swift.RangeSet<A.Index>, to: A.Index) -> Swift.Range<A.Index>
 Added: _$sSMsE13moveSubranges_2toSny5IndexQzGs8RangeSetVyADG_ADtF
 
+// Collection.subscript(unchecked:) and Collection.subscript(uncheckedBounds:)
+Added: _$sSl15uncheckedBounds11SubSequenceQzSny5IndexQzG_tcigTj
+Added: _$sSl15uncheckedBounds11SubSequenceQzSny5IndexQzG_tcigTq
+Added: _$sSl9unchecked7ElementQz5IndexQz_tcirTj
+Added: _$sSl9unchecked7ElementQz5IndexQz_tcirTq
+
 // Property descriptors for newly-added, @_alwaysEmitIntoClient properties
 Added: _$sSR15uncheckedBoundss5SliceVySRyxGGSnySiG_tcipMV
 Added: _$sSR9uncheckedxSi_tcipMV
@@ -257,6 +263,8 @@ Added: _$sSr15uncheckedBoundss5SliceVySryxGGSnySiG_tcipMV
 Added: _$sSr9uncheckedxSi_tcipMV
 Added: _$ss15ContiguousArrayV15uncheckedBoundss0B5SliceVyxGSnySiG_tcipMV
 Added: _$ss15ContiguousArrayV9uncheckedxSi_tcipMV
+Added: _$sSlsE15uncheckedBounds11SubSequenceQzSny5IndexQzG_tcipMV
+Added: _$sSlsE9unchecked7ElementQz5IndexQz_tcipMV
 
 // Runtime Symbols
 Added: __swift_pod_copy

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -248,6 +248,16 @@ Added: _$sSMsSmRzrlE15removeSubrangesyys8RangeSetVy5IndexSlQzGF
 // (extension in Swift):Swift.MutableCollection.moveSubranges(_: Swift.RangeSet<A.Index>, to: A.Index) -> Swift.Range<A.Index>
 Added: _$sSMsE13moveSubranges_2toSny5IndexQzGs8RangeSetVyADG_ADtF
 
+// Property descriptors for newly-added, @_alwaysEmitIntoClient properties
+Added: _$sSR15uncheckedBoundss5SliceVySRyxGGSnySiG_tcipMV
+Added: _$sSR9uncheckedxSi_tcipMV
+Added: _$sSa15uncheckedBoundss10ArraySliceVyxGSnySiG_tcipMV
+Added: _$sSa9uncheckedxSi_tcipMV
+Added: _$sSr15uncheckedBoundss5SliceVySryxGGSnySiG_tcipMV
+Added: _$sSr9uncheckedxSi_tcipMV
+Added: _$ss15ContiguousArrayV15uncheckedBoundss0B5SliceVyxGSnySiG_tcipMV
+Added: _$ss15ContiguousArrayV9uncheckedxSi_tcipMV
+
 // Runtime Symbols
 Added: __swift_pod_copy
 Added: __swift_pod_destroy

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -181,6 +181,7 @@ Protocol _Pointer has added inherited protocol _BitwiseCopyable
 Protocol _Pointer has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable> to <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable, Self : Swift._BitwiseCopyable>
 Protocol FixedWidthInteger has added inherited protocol _BitwiseCopyable
 Protocol FixedWidthInteger has generic signature change from <Self : Swift.BinaryInteger, Self : Swift.LosslessStringConvertible, Self.Magnitude : Swift.FixedWidthInteger, Self.Magnitude : Swift.UnsignedInteger, Self.Stride : Swift.FixedWidthInteger, Self.Stride : Swift.SignedInteger> to <Self : Swift.BinaryInteger, Self : Swift.LosslessStringConvertible, Self : Swift._BitwiseCopyable, Self.Magnitude : Swift.FixedWidthInteger, Self.Magnitude : Swift.UnsignedInteger, Self.Stride : Swift.FixedWidthInteger, Self.Stride : Swift.SignedInteger>
-
+Subscript Collection.subscript(unchecked:) has been added as a protocol requirement
+Subscript Collection.subscript(uncheckedBounds:) has been added as a protocol requirement
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/stdlib/BoundsCheckTraps.swift
+++ b/test/stdlib/BoundsCheckTraps.swift
@@ -36,6 +36,20 @@ BoundsCheckTraps.test("UnsafeMutableBufferPointer")
   _blackHole(array)
 }
 
+BoundsCheckTraps.test("UnsafeMutableBufferPointerIndexes")
+  .skip(.custom(
+    { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen"))
+  .code {
+  expectCrashLater()
+  var array = [1, 2, 3]
+  array.withUnsafeBufferPointer { buffer in
+    let i = buffer.index(after: Int.max)
+    _blackHole(i)
+  }
+  _blackHole(array)
+}
+
 BoundsCheckTraps.test("UnsafeRawBufferPointer")
   .skip(.custom(
     { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() },

--- a/test/stdlib/BoundsCheckTraps.swift
+++ b/test/stdlib/BoundsCheckTraps.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/a.out_Debug -Onone
+// RUN: %target-build-swift %s -o %t/a.out_Release -O
+// RUN: %target-build-swift %s -o %t/a.out_ReleaseWithBoundsSafety -O -enable-experimental-feature UnsafePointerBoundsSafety
+// RUN: %target-codesign %t/a.out_Debug
+// RUN: %target-codesign %t/a.out_Release
+// RUN: %target-codesign %t/a.out_ReleaseWithBoundsSafety
+//
+// RUN: %target-run %t/a.out_Debug
+// RUN: %target-run %t/a.out_Release
+// RUN: %target-run %t/a.out_ReleaseWithBoundsSafety
+// REQUIRES: executable_test
+// REQUIRES: asserts
+// UNSUPPORTED: OS=wasi
+
+import StdlibUnittest
+
+let testSuiteSuffix = _isDebugAssertConfiguration() ? "_debug"
+  : _isReleaseAssertConfiguration() ? "_release" : "_releaseWithBoundsSafety"
+
+var BoundsCheckTraps = TestSuite("BoundsCheckTraps" + testSuiteSuffix)
+
+BoundsCheckTraps.test("UnsafeMutableBufferPointer")
+  .skip(.custom(
+    { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen"))
+  .code {
+  expectCrashLater()
+  var array = [1, 2, 3]
+  array.withUnsafeBufferPointer { buffer in
+    print(buffer[3])
+  }
+  array.withUnsafeMutableBufferPointer { buffer in
+    buffer[3] = 17
+  }
+  _blackHole(array)
+}
+
+runAllTests()

--- a/test/stdlib/BoundsCheckTraps.swift
+++ b/test/stdlib/BoundsCheckTraps.swift
@@ -88,4 +88,52 @@ BoundsCheckTraps.test("Character")
   _blackHole(char)
 }
 
+BoundsCheckTraps.test("ArrayUnchecked")
+  .skip(.custom(
+    { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() },
+    reason: "this trap is not guaranteed to happen"))
+  .code {
+  expectCrashLater()
+  var array = [1, 2]
+  array.append(3)
+  let value = array[unchecked: 3]
+  _blackHole(value)
+}
+
+BoundsCheckTraps.test("ArrayUncheckedBounds")
+  .skip(.custom(
+    { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() },
+    reason: "this trap is not guaranteed to happen"))
+  .code {
+  expectCrashLater()
+  var array = [1, 2]
+  array.append(3)
+  let value = array[uncheckedBounds: 3..<4]
+  _blackHole(value)
+}
+
+BoundsCheckTraps.test("ContiguousArrayUnchecked")
+  .skip(.custom(
+    { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() },
+    reason: "this trap is not guaranteed to happen"))
+  .code {
+  expectCrashLater()
+  var array: ContiguousArray = [1, 2]
+  array.append(3)
+  let value = array[unchecked: 3]
+  _blackHole(value)
+}
+
+BoundsCheckTraps.test("ContiguousArrayUncheckedBounds")
+  .skip(.custom(
+    { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() || _isReleaseAssertWithBoundsSafetyConfiguration() },
+    reason: "this trap is not guaranteed to happen"))
+  .code {
+  expectCrashLater()
+  var array: ContiguousArray = [1, 2]
+  array.append(3)
+  let value = array[uncheckedBounds: 3..<4]
+  _blackHole(value)
+}
+
 runAllTests()

--- a/test/stdlib/BoundsCheckTraps.swift
+++ b/test/stdlib/BoundsCheckTraps.swift
@@ -52,4 +52,26 @@ BoundsCheckTraps.test("UnsafeRawBufferPointer")
   _blackHole(array)
 }
 
+BoundsCheckTraps.test("EmptyCollection")
+  .skip(.custom(
+    { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen"))
+  .code {
+  expectCrashLater()
+  var empty = EmptyCollection<Int>()
+  print(empty[0])
+  _blackHole(empty)
+}
+
+BoundsCheckTraps.test("Character")
+  .skip(.custom(
+    { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen"))
+  .code {
+  expectCrashLater()
+  let twoChars = "ab"
+  let char = Character(twoChars)
+  _blackHole(char)
+}
+
 runAllTests()

--- a/test/stdlib/BoundsCheckTraps.swift
+++ b/test/stdlib/BoundsCheckTraps.swift
@@ -36,4 +36,20 @@ BoundsCheckTraps.test("UnsafeMutableBufferPointer")
   _blackHole(array)
 }
 
+BoundsCheckTraps.test("UnsafeRawBufferPointer")
+  .skip(.custom(
+    { _isFastAssertConfiguration() || _isReleaseAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen"))
+  .code {
+  expectCrashLater()
+  var array = [1, 2, 3]
+  array.withUnsafeBufferPointer { buffer in
+    print(UnsafeRawBufferPointer(buffer).load(fromByteOffset: MemoryLayout<Int>.stride * 3, as: Int.self))
+  }
+  array.withUnsafeMutableBufferPointer { buffer in
+    UnsafeMutableRawBufferPointer(buffer).storeBytes(of: 17, toByteOffset: MemoryLayout<Int>.stride * 3, as: Int.self)
+  }
+  _blackHole(array)
+}
+
 runAllTests()


### PR DESCRIPTION
Currently, bounds checking is only enabled for unsafe buffer pointers in debug builds. Introduce a new precondition check kind, `_boundsCheckPrecondition`, and use it for the bounds checking of unsafe buffer pointers. This check is enabled both in debug builds and in builds where the experimental feature `UnsafePointerBoundsSafety` is enabled.

Also add `[unchecked:]` and `[uncheckedBounds:]` subscripts to `Collection` and the various array and buffer types, which only perform bounds checking in debug builds. These can be used in places where the optimizer is not eliminating bounds checks that it should be.