### PR TITLE
[macros] allow forwarding generic arguments through macro declarations

### DIFF
--- a/include/swift/AST/MacroDefinition.h
+++ b/include/swift/AST/MacroDefinition.h
@@ -78,16 +78,25 @@ class ExpandedMacroDefinition {
   /// The macro replacements, ASTContext-allocated.
   ArrayRef<ExpandedMacroReplacement> replacements;
 
+  /// Same as above but for generic argument replacements
+  ArrayRef<ExpandedMacroReplacement> genericReplacements;
+
   ExpandedMacroDefinition(
     StringRef expansionText,
-    ArrayRef<ExpandedMacroReplacement> replacements
-  ) : expansionText(expansionText), replacements(replacements) { }
+    ArrayRef<ExpandedMacroReplacement> replacements,
+    ArrayRef<ExpandedMacroReplacement> genericReplacements
+  ) : expansionText(expansionText),
+          replacements(replacements),
+          genericReplacements(genericReplacements) { }
 
 public:
   StringRef getExpansionText() const { return expansionText; }
 
   ArrayRef<ExpandedMacroReplacement> getReplacements() const {
     return replacements;
+  }
+  ArrayRef<ExpandedMacroReplacement> getGenericReplacements() const {
+    return genericReplacements;
   }
 };
 
@@ -162,7 +171,8 @@ public:
   static MacroDefinition forExpanded(
       ASTContext &ctx,
       StringRef expansionText,
-      ArrayRef<ExpandedMacroReplacement> replacements
+      ArrayRef<ExpandedMacroReplacement> replacements,
+      ArrayRef<ExpandedMacroReplacement> genericReplacements
   );
 
   /// Retrieve the external macro being referenced.

--- a/include/swift/Bridging/ASTGen.h
+++ b/include/swift/Bridging/ASTGen.h
@@ -73,7 +73,9 @@ ptrdiff_t swift_ASTGen_checkMacroDefinition(
     const void *_Nonnull macroSourceLocation,
     BridgedStringRef *_Nonnull expansionSourceOutPtr,
     ptrdiff_t *_Nullable *_Nonnull replacementsPtr,
-    ptrdiff_t *_Nonnull numReplacements);
+    ptrdiff_t *_Nonnull numReplacements,
+    ptrdiff_t *_Nullable *_Nonnull genericReplacementsPtr,
+    ptrdiff_t *_Nonnull numGenericReplacements);
 void swift_ASTGen_freeExpansionReplacements(
     ptrdiff_t *_Nullable replacementsPtr, ptrdiff_t numReplacements);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11846,10 +11846,12 @@ llvm::Optional<BuiltinMacroKind> MacroDecl::getBuiltinKind() const {
 MacroDefinition MacroDefinition::forExpanded(
     ASTContext &ctx,
     StringRef expansionText,
-    ArrayRef<ExpandedMacroReplacement> replacements
+    ArrayRef<ExpandedMacroReplacement> replacements,
+    ArrayRef<ExpandedMacroReplacement> genericReplacements
 ) {
   return ExpandedMacroDefinition{ctx.AllocateCopy(expansionText),
-                                 ctx.AllocateCopy(replacements)};
+                                 ctx.AllocateCopy(replacements),
+                                 ctx.AllocateCopy(genericReplacements)};
 }
 
 MacroExpansionDecl::MacroExpansionDecl(DeclContext *dc,

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -200,7 +200,9 @@ func checkMacroDefinition(
   macroLocationPtr: UnsafePointer<UInt8>,
   externalMacroOutPtr: UnsafeMutablePointer<BridgedStringRef>,
   replacementsPtr: UnsafeMutablePointer<UnsafeMutablePointer<Int>?>,
-  numReplacementsPtr: UnsafeMutablePointer<Int>
+  numReplacementsPtr: UnsafeMutablePointer<Int>,
+  genericReplacementsPtr: UnsafeMutablePointer<UnsafeMutablePointer<Int>?>,
+  numGenericReplacementsPtr: UnsafeMutablePointer<Int>
 ) -> Int {
   // Assert "out" parameters are initialized.
   assert(externalMacroOutPtr.pointee.isEmptyInitialized)
@@ -293,7 +295,7 @@ func checkMacroDefinition(
       )
       return Int(BridgedMacroDefinitionKind.externalMacro.rawValue)
 
-    case let .expansion(expansionSyntax, replacements: _)
+    case let .expansion(expansionSyntax, replacements: _, genericReplacements: _)
     where expansionSyntax.macroName.text == "externalMacro":
       // Extract the identifier from the "module" argument.
       guard let firstArg = expansionSyntax.arguments.first,
@@ -334,13 +336,15 @@ func checkMacroDefinition(
         allocateBridgedString("\(module).\(type)")
       return Int(BridgedMacroDefinitionKind.externalMacro.rawValue)
 
-    case let .expansion(expansionSyntax, replacements: replacements):
+    case let .expansion(expansionSyntax,
+      replacements: replacements, genericReplacements: genericReplacements):
       // Provide the expansion syntax.
       externalMacroOutPtr.pointee =
         allocateBridgedString(expansionSyntax.trimmedDescription)
 
       // If there are no replacements, we're done.
-      if replacements.isEmpty {
+      let totalReplacementsCount = replacements.count + genericReplacements.count
+      guard totalReplacementsCount > 0 else {
         return Int(BridgedMacroDefinitionKind.expandedMacro.rawValue)
       }
 
@@ -355,9 +359,24 @@ func checkMacroDefinition(
           replacement.reference.endPositionBeforeTrailingTrivia.utf8Offset - expansionStart
         replacementBuffer[index * 3 + 2] = replacement.parameterIndex
       }
-
       replacementsPtr.pointee = replacementBuffer.baseAddress
       numReplacementsPtr.pointee = replacements.count
+
+      // The replacements are triples: (startOffset, endOffset, parameter index).
+      let genericReplacementBuffer = UnsafeMutableBufferPointer<Int>.allocate(capacity: 3 * genericReplacements.count)
+      for (index, genericReplacement) in genericReplacements.enumerated() {
+        let expansionStart = expansionSyntax.positionAfterSkippingLeadingTrivia.utf8Offset
+
+        genericReplacementBuffer[index * 3] =
+          genericReplacement.reference.positionAfterSkippingLeadingTrivia.utf8Offset - expansionStart
+        genericReplacementBuffer[index * 3 + 1] =
+          genericReplacement.reference.endPositionBeforeTrailingTrivia.utf8Offset - expansionStart
+        genericReplacementBuffer[index * 3 + 2] =
+          genericReplacement.parameterIndex
+      }
+      genericReplacementsPtr.pointee = genericReplacementBuffer.baseAddress
+      numGenericReplacementsPtr.pointee = genericReplacements.count
+
       return Int(BridgedMacroDefinitionKind.expandedMacro.rawValue)
     }
   } catch let errDiags as DiagnosticsError {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -148,15 +148,19 @@ MacroDefinition MacroDefinitionRequest::evaluate(
   BridgedStringRef externalMacroName{nullptr, 0};
   ptrdiff_t *replacements = nullptr;
   ptrdiff_t numReplacements = 0;
+  ptrdiff_t *genericReplacements = nullptr;
+  ptrdiff_t numGenericReplacements = 0;
   auto checkResult = swift_ASTGen_checkMacroDefinition(
       &ctx.Diags, sourceFile->getExportedSourceFile(),
       macro->getLoc().getOpaquePointerValue(), &externalMacroName,
-      &replacements, &numReplacements);
+      &replacements, &numReplacements,
+      &genericReplacements, &numGenericReplacements);
 
   // Clean up after the call.
   SWIFT_DEFER {
     swift_ASTGen_freeBridgedString(externalMacroName);
     swift_ASTGen_freeExpansionReplacements(replacements, numReplacements);
+    // swift_ASTGen_freeExpansionGenericReplacements(genericReplacements, numGenericReplacements); // FIXME: !!!!!!
   };
 
   if (checkResult < 0 && ctx.CompletionCallback) {
@@ -177,6 +181,7 @@ MacroDefinition MacroDefinitionRequest::evaluate(
   case BridgedExternalMacro: {
     // An external macro described as ModuleName.TypeName. Get both identifiers.
     assert(!replacements && "External macro doesn't have replacements");
+    assert(!genericReplacements && "External macro doesn't have genericReplacements");
     StringRef externalMacroStr = externalMacroName.unbridged();
     StringRef externalModuleName, externalTypeName;
     std::tie(externalModuleName, externalTypeName) = externalMacroStr.split('.');
@@ -232,8 +237,16 @@ MacroDefinition MacroDefinitionRequest::evaluate(
           static_cast<unsigned>(replacements[3*i+1]),
           static_cast<unsigned>(replacements[3*i+2])});
   }
+  // Copy over the genericReplacements.
+  SmallVector<ExpandedMacroReplacement, 2> genericReplacementsVec;
+  for (unsigned i: range(0, numGenericReplacements)) {
+    genericReplacementsVec.push_back(
+        { static_cast<unsigned>(genericReplacements[3*i]),
+          static_cast<unsigned>(genericReplacements[3*i+1]),
+          static_cast<unsigned>(genericReplacements[3*i+2])});
+  }
 
-  return MacroDefinition::forExpanded(ctx, expansionText, replacementsVec);
+  return MacroDefinition::forExpanded(ctx, expansionText, replacementsVec, genericReplacementsVec);
 #else
   macro->diagnose(diag::macro_unsupported);
   return MacroDefinition::forInvalid();
@@ -781,24 +794,70 @@ static bool isFromExpansionOfMacro(SourceFile *sourceFile, MacroDecl *macro,
 
 /// Expand a macro definition.
 static std::string expandMacroDefinition(
-    ExpandedMacroDefinition def, MacroDecl *macro, ArgumentList *args) {
+    ExpandedMacroDefinition def, MacroDecl *macro,
+    SubstitutionMap subs,
+    ArgumentList *args) {
   ASTContext &ctx = macro->getASTContext();
 
   std::string expandedResult;
 
   StringRef originalText = def.getExpansionText();
+
   unsigned startIdx = 0;
-  for (const auto replacement: def.getReplacements()) {
+  unsigned replacementsIdx = 0;
+  unsigned genericReplacementsIdx = 0;
+  auto totalReplacementsCount =
+      def.getReplacements().size() + def.getGenericReplacements().size();
+
+  while (replacementsIdx + genericReplacementsIdx < totalReplacementsCount) {
+    ExpandedMacroReplacement replacement;
+    bool isExpressionReplacement = true;
+
+    // TODO: simplify... basically we need "pick replacements in order of lowest startOffset"
+    // Pick the "next" replacement, in order as they appear in the source text
+    if (replacementsIdx < def.getReplacements().size()) {
+       auto expressionReplacement = def.getReplacements()[replacementsIdx];
+
+       if (genericReplacementsIdx < def.getGenericReplacements().size()) {
+        auto genericReplacement = def.getGenericReplacements()[genericReplacementsIdx];
+          isExpressionReplacement =
+              expressionReplacement.startOffset < genericReplacement.startOffset;
+          replacement = isExpressionReplacement ? expressionReplacement : genericReplacement;
+      } else {
+          isExpressionReplacement = true;
+          replacement = expressionReplacement;
+       }
+    } else if (genericReplacementsIdx < def.getGenericReplacements().size()) {
+      auto genericReplacement = def.getGenericReplacements()[replacementsIdx];
+
+      isExpressionReplacement = false;
+      replacement = genericReplacement;
+    } else {
+      assert(false && "should always select a requirement explicitly rather "
+                      "than fall through");
+    }
+
+    replacementsIdx += isExpressionReplacement ? 1 : 0;
+    genericReplacementsIdx += isExpressionReplacement ? 1 : 0;
+
     // Add the original text up to the first replacement.
-    expandedResult.append(
-        originalText.begin() + startIdx,
-        originalText.begin() + replacement.startOffset);
+    expandedResult.append(originalText.begin() + startIdx,
+                          originalText.begin() + replacement.startOffset);
 
     // Add the replacement text.
-    auto argExpr = args->getArgExprs()[replacement.parameterIndex];
-    SmallString<32> argTextBuffer;
-    auto argText = extractInlinableText(ctx.SourceMgr, argExpr, argTextBuffer);
-    expandedResult.append(argText);
+    if (isExpressionReplacement) {
+      auto argExpr = args->getArgExprs()[replacement.parameterIndex];
+      SmallString<32> argTextBuffer;
+      auto argText =
+          extractInlinableText(ctx.SourceMgr, argExpr, argTextBuffer);
+      expandedResult.append(argText);
+    } else {
+      auto typeArgType = subs.getReplacementTypes()[replacement.parameterIndex];
+      std::string typeNameString;
+      llvm::raw_string_ostream os(typeNameString);
+      typeArgType.print(os);
+      expandedResult.append(typeNameString);
+    }
 
     // Update the starting position.
     startIdx = replacement.endOffset;
@@ -1093,6 +1152,7 @@ evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
   case MacroDefinition::Kind::Expanded: {
     // Expand the definition with the given arguments.
     auto result = expandMacroDefinition(macroDef.getExpanded(), macro,
+                                        expansion->getMacroRef().getSubstitutions(),
                                         expansion->getArgs());
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
         result, adjustMacroExpansionBufferName(*discriminator));
@@ -1397,7 +1457,9 @@ static SourceFile *evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo,
   case MacroDefinition::Kind::Expanded: {
     // Expand the definition with the given arguments.
     auto result = expandMacroDefinition(
-        macroDef.getExpanded(), macro, attr->getArgs());
+        macroDef.getExpanded(), macro,
+        /*genericArgs=*/{}, // attached macros don't have generic parameters
+        attr->getArgs());
     evaluatedSource = llvm::MemoryBuffer::getMemBufferCopy(
         result, adjustMacroExpansionBufferName(*discriminator));
     break;

--- a/test/Macros/Inputs/freestanding_macro_library.swift
+++ b/test/Macros/Inputs/freestanding_macro_library.swift
@@ -18,3 +18,20 @@ public macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "M
 
 @freestanding(declaration, names: named(value))
 public macro varValue() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")
+
+// Macros that pass along generic arguments
+
+@freestanding(expression)
+public macro checkGeneric_root<DAS>() = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
+@freestanding(expression)
+public macro checkGeneric<DAS>() = #checkGeneric_root<DAS>()
+
+@freestanding(expression)
+public macro checkGeneric2_root<A, B>() = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
+@freestanding(expression)
+public macro checkGeneric2<A, B>() = #checkGeneric2_root<A, B>()
+
+@freestanding(expression)
+public macro checkGenericHashableCodable_root<A: Hashable, B: Codable>() = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
+@freestanding(expression)
+public macro checkGenericHashableCodable<A: Hashable, B: Codable>() = #checkGenericHashableCodable_root<A, B>()

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1819,6 +1819,17 @@ public struct VarValueMacro: DeclarationMacro, PeerMacro {
   }
 }
 
+public struct GenericToVoidMacro: ExpressionMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> ExprSyntax {
+    return """
+           ()
+           """
+  }
+}
+
 public struct SingleMemberMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/top_level_freestanding.swift
+++ b/test/Macros/top_level_freestanding.swift
@@ -35,6 +35,16 @@ macro freestandingWithClosure<T>(_ value: T, body: (T) -> T) = #externalMacro(mo
 @freestanding(declaration, names: arbitrary) macro bitwidthNumberedStructs(_ baseName: String) = #externalMacro(module: "MacroDefinition", type: "DefineBitwidthNumberedStructsMacro")
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 @freestanding(declaration, names: named(value)) macro varValue() = #externalMacro(module: "MacroDefinition", type: "VarValueMacro")
+
+@freestanding(expression) macro checkGeneric_root<A>() = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
+@freestanding(expression) macro checkGeneric<A>() = #checkGeneric_root<A>()
+
+@freestanding(expression) macro checkGeneric2_root<A, B>() = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
+@freestanding(expression) macro checkGeneric2<A, B>() = #checkGeneric2_root<A, B>()
+
+@freestanding(expression) macro checkGenericHashableCodable_root<A: Hashable, B: Codable>() = #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
+@freestanding(expression) macro checkGenericHashableCodable<A: Hashable, B: Codable>() = #checkGenericHashableCodable_root<A, B>()
+
 #endif
 
 // Test unqualified lookup from within a macro expansion
@@ -128,3 +138,10 @@ protocol Initializable {
 struct S {
   init(a: Int, b: Int) {}
 }
+
+// Check that generic type arguments are passed along in expansions,
+// when macro is implemented using another macro.
+
+#checkGeneric<String>()
+#checkGeneric2<String, Int>()
+#checkGenericHashableCodable<String, Int>()

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -262,9 +262,10 @@ struct MacroExpansionInfo {
     };
     std::string expansionText;
     std::vector<Replacement> replacements;
+    std::vector<Replacement> genericReplacements;
 
     ExpandedMacroDefinition(StringRef expansionText)
-        : expansionText(expansionText), replacements(){};
+        : expansionText(expansionText), replacements(), genericReplacements() {};
   };
 
   // Offset of the macro expansion syntax (i.e. attribute or #<macro name>) from

--- a/tools/SourceKit/lib/SwiftLang/SwiftSyntacticMacroExpansion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSyntacticMacroExpansion.cpp
@@ -60,8 +60,16 @@ void SwiftLangSupport::expandMacroSyntactically(
                    reqReplacement.range.Length,
                /*parameterIndex=*/reqReplacement.parameterIndex});
         }
+        SmallVector<ExpandedMacroReplacement, 2> genericReplacements;
+        for (auto &genReqReplacement : expanded->genericReplacements) {
+          genericReplacements.push_back(
+              {/*startOffset=*/genReqReplacement.range.Offset,
+               /*endOffset=*/genReqReplacement.range.Offset +
+                   genReqReplacement.range.Length,
+               /*parameterIndex=*/genReqReplacement.parameterIndex});
+        }
         return MacroDefinition::forExpanded(ctx, expanded->expansionText,
-                                            replacements);
+                                            replacements, genericReplacements);
       } else if (auto *externalRef =
                      std::get_if<MacroExpansionInfo::ExternalMacroReference>(
                          &req.macroDefinition)) {


### PR DESCRIPTION
- Depends on: SwiftSyntax change https://github.com/apple/swift-syntax/pull/2450
- Unblocks: https://github.com/apple/swift/pull/71090 distributed actor's `#resolve` macro.
- Resolves rdar://122004157
---

Specifically, this pattern is necessary: 

```swift
@freestanding(expression) macro checkGenericHashableCodable_root<A: Hashable, B: Codable>() = 
  #externalMacro(module: "MacroDefinition", type: "GenericToVoidMacro")
@freestanding(expression) macro checkGenericHashableCodable<A: Hashable, B: Codable>() = 
  #checkGenericHashableCodable_root<A, B>()

#checkGenericHashableCodable<String, Int>
```

it seems we never considered this requirement, so this adds the ability to "replace" the `A` and `B` inside the "outer" macro's expansion such that the "root" also gets to see `String` and `Int`, and not just `A` and `B`.

I'll need some help figuring out what can be changed as is in this PR, and what changes we need to stage in - so we don't get compat issues with swift syntax.