### PR TITLE
ObjectOutliner: don't outline objects with tail allocations

### DIFF
--- a/test/SILOptimizer/static_objects.swift
+++ b/test/SILOptimizer/static_objects.swift
@@ -44,6 +44,12 @@ public func testit() -> C {
   return c
 }
 
+// Cannot allocate a ManagedBuffer in a data section, because it calls malloc_size on the class instance.
+// CHECK-LABEL: sil private [global_init_once_fn] @$s4test10managedBuf_WZ :
+// CHECK:         alloc_ref [tail_elems $UInt8 * %{{[0-9]*}} : $Builtin.Word] $ManagedBuffer<(), UInt8>
+// CHECK:       } // end sil function '$s4test10managedBuf_WZ'
+public let managedBuf = ManagedBuffer<Void, UInt8>.create(minimumCapacity: 0, makingHeaderWith: { _ in })
+
 @main struct Main {
   static func main() {
     // CHECK-OUTPUT: c.x=27


### PR DESCRIPTION
An object with tail allocated elements is in risk of being passed to malloc_size, which does not work for non-heap allocated objects. Conservatively, disable objects with tail allocations.

rdar://121886093
