### PR TITLE
[CS] Don't walk into local decls in TypeVariableRefFinder

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -178,6 +178,12 @@ public:
     return Action::Continue(stmt);
   }
 
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    /// Decls get type-checked separately, except for PatternBindingDecls,
+    /// whose initializers we want to walk into.
+    return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+  }
+
 private:
   DeclContext *currentClosureDC() const {
     return ClosureDCs.empty() ? nullptr : ClosureDCs.back();

--- a/test/Constraints/issue-71273.swift
+++ b/test/Constraints/issue-71273.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift
+
+// https://github.com/apple/swift/issues/71273
+
+func bar<R>(_ fn: () -> R) {}
+
+// Make sure we don't error here.
+func testLocalFn() {
+  bar() {
+    func foo() -> Int { return 0 }
+    return ()
+  }
+}
+
+func testLocalBinding() {
+  bar() {
+    let _ = if .random() { return () } else { 0 }
+    // expected-error@-1 {{cannot 'return' in 'if' when used as expression}}
+    return ()
+  }
+}


### PR DESCRIPTION
This could result in us incorrectly walking into local functions and picking up type variables that weren't being referenced.

Resolves #71273