### PR TITLE
[embedded] Implicitly define __APPLE__ and __MACH__ when on -apple-none triples

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -631,13 +631,13 @@ importer::getNormalInvocationArguments(
       });
     }
 
-    // To support -apple-none triples, which are non-Darwin, we need to #define
-    // a few things that the Apple SDKs expect.
+    // To support -apple-none, -apple-none-macho, -unknown-none-wasm triples.
     if (triple.getVendor() == llvm::Triple::VendorType::Apple) {
-      invocationArgStrs.insert(invocationArgStrs.end(),
-                               {"-D__APPLE__", "-D__MACH__"});
+      invocationArgStrs.insert(invocationArgStrs.end(), {"-D__APPLE__"});
     }
-
+    if (triple.isOSBinFormatMachO()) {
+      invocationArgStrs.insert(invocationArgStrs.end(), {"-D__MACH__"});
+    }
     if (triple.isOSBinFormatWasm()) {
       invocationArgStrs.insert(invocationArgStrs.end(), {"-D__wasi__"});
     }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -631,6 +631,17 @@ importer::getNormalInvocationArguments(
       });
     }
 
+    // To support -apple-none triples, which are non-Darwin, we need to #define
+    // a few things that the Apple SDKs expect.
+    if (triple.getVendor() == llvm::Triple::VendorType::Apple) {
+      invocationArgStrs.insert(invocationArgStrs.end(),
+                               {"-D__APPLE__", "-D__MACH__"});
+    }
+
+    if (triple.isOSBinFormatWasm()) {
+      invocationArgStrs.insert(invocationArgStrs.end(), {"-D__wasi__"});
+    }
+
     if (triple.isOSWindows()) {
       switch (triple.getArch()) {
       default: llvm_unreachable("unsupported Windows architecture");

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -638,9 +638,6 @@ importer::getNormalInvocationArguments(
     if (triple.isOSBinFormatMachO()) {
       invocationArgStrs.insert(invocationArgStrs.end(), {"-D__MACH__"});
     }
-    if (triple.isOSBinFormatWasm()) {
-      invocationArgStrs.insert(invocationArgStrs.end(), {"-D__wasi__"});
-    }
 
     if (triple.isOSWindows()) {
       switch (triple.getArch()) {

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -218,8 +218,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       if(NOT "${mod}" MATCHES "-macos$")
         continue()
       endif()
-      set(extra_c_compile_flags -D__MACH__ -D__APPLE__ -ffreestanding)
-      set(extra_swift_compile_flags -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding)
+      set(extra_c_compile_flags -ffreestanding)
+      set(extra_swift_compile_flags -Xcc -ffreestanding)
     endif()
     
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -113,9 +113,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
         Darwin.swift.gyb
       
       SWIFT_COMPILE_FLAGS
-        -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
+        -Xcc -ffreestanding -enable-experimental-feature Embedded
       C_COMPILE_FLAGS
-        -D__MACH__ -D__APPLE__ -ffreestanding
+        -ffreestanding
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"
       ARCHITECTURE "${arch}"

--- a/stdlib/public/SwiftShims/swift/shims/Visibility.h
+++ b/stdlib/public/SwiftShims/swift/shims/Visibility.h
@@ -134,7 +134,7 @@
 // right for Windows, we have everything set up to get it right on
 // other targets as well, and doing so lets the compiler use more
 // efficient symbol access patterns.
-#if defined(__MACH__) || defined(__wasi__)
+#if defined(__MACH__) || defined(__wasm__)
 
 // On Mach-O and WebAssembly, we use non-hidden visibility.  We just use
 // default visibility on both imports and exports, both because these

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -422,7 +422,7 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       ${SWIFTLIB_EMBEDDED_SOURCES}
       GYB_SOURCES ${SWIFTLIB_EMBEDDED_GYB_SOURCES}
       SWIFT_COMPILE_FLAGS
-        ${swift_stdlib_compile_flags} -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding -enable-experimental-feature Embedded
+        ${swift_stdlib_compile_flags} -Xcc -ffreestanding -enable-experimental-feature Embedded
         -Xfrontend -enable-ossa-modules
       MODULE_DIR "${CMAKE_BINARY_DIR}/lib/swift/embedded"
       SDK "embedded"

--- a/test/embedded/fragile-reference.swift
+++ b/test/embedded/fragile-reference.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -module-name main -parse-as-library -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -module-name main -parse-as-library -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 // REQUIRES: swift_in_compiler
 // REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/ouroboros-bug.swift
+++ b/test/embedded/ouroboros-bug.swift
@@ -3,8 +3,8 @@
 // code, but in the embedded Swift's runtime that's somewhat reasonable thing
 // to do (but is to be avoided because of this).
 
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -assert-config Debug -Osize -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -assert-config Debug -Osize -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -assert-config Debug -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/stdlib-array.swift
+++ b/test/embedded/stdlib-array.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: CODEGENERATOR=ARM

--- a/test/embedded/stdlib-dictionary.swift
+++ b/test/embedded/stdlib-dictionary.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/stdlib-random.swift
+++ b/test/embedded/stdlib-random.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/stdlib-set.swift
+++ b/test/embedded/stdlib-set.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/stdlib-types.swift
+++ b/test/embedded/stdlib-types.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -target armv7-apple-none-macho -Xcc -D__MACH__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
-// RUN: %target-swift-frontend -target arm64-apple-none-macho -Xcc -D__MACH__ -Xcc -D__arm64__ -Xcc -D__APPLE__ -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target armv7-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-frontend -target arm64-apple-none-macho -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib


### PR DESCRIPTION
This removes the need for the stdlib and other modules to -Xcc those defines manually, and also drops this requirement from users of the -apple-none triples (see the lit test changes).