### PR TITLE
CMake: run `generate_xcode.test` only for the host platform

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -399,6 +399,15 @@ if run_vers.endswith('-simulator'):
 else:
     run_environment=''
 
+# Parse the host triple
+(host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
+
+if f"{host_cpu}-{host_vendor}-{host_os}" == f"{run_cpu}-{run_vendor}-{run_os}":
+    # Ignore the version on purpose, to account for scenario
+    # in which the compiler has a different deployment target
+    # than the standard library
+    config.available_features.add('target-same-as-host')
+
 target_arch = run_cpu
 if run_os == 'openbsd' and run_cpu == 'amd64':
    target_arch = run_cpu
@@ -581,8 +590,6 @@ else:
             config.swift_driver_test_options,
         )
     )
-    # Parse the host triple.
-    (host_cpu, host_vendor, host_os, host_vers) = re.match('([^-]+)-([^-]+)-([^0-9-]+)(.*)', config.host_triple).groups()
     toolchain_lib_dir = make_path(config.swift_lib_dir, 'swift', host_os)
     config.host_build_swift = (
         "%s -target %s -g %s -I %s -L %s %s" % (

--- a/validation-test/BuildSystem/generate_xcode.test
+++ b/validation-test/BuildSystem/generate_xcode.test
@@ -15,3 +15,4 @@
 
 # REQUIRES: standalone_build
 # REQUIRES: OS=macosx
+# REQUIRES: target-same-as-host


### PR DESCRIPTION
Currently the test assumes that when we are testing for macOS we are targeting the host architecture (since we need to reuse existing build products to contain the test time) -- however there are some Apple internal configurations in which that's not the case.

Addresses rdar://118337598