### PR TITLE
[Runtime] Correctly initialize side tables of immortal objects on 32-bit.

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/RefCount.h
+++ b/stdlib/public/SwiftShims/swift/shims/RefCount.h
@@ -466,11 +466,16 @@ class RefCountBitsT {
     }
     else {
       // this is out-of-line and not the same layout as inline newbits.
-      // Copy field-by-field.
-      copyFieldFrom(newbits, UnownedRefCount);
-      copyFieldFrom(newbits, IsDeiniting);
-      copyFieldFrom(newbits, StrongExtraRefCount);
-      copyFieldFrom(newbits, UseSlowRC);
+      // Copy field-by-field. If it's immortal, just set that.
+      if (newbits.isImmortal(false)) {
+        setField(IsImmortal, Offsets::IsImmortalMask);
+      } else {
+        copyFieldFrom(newbits, PureSwiftDealloc);
+        copyFieldFrom(newbits, UnownedRefCount);
+        copyFieldFrom(newbits, IsDeiniting);
+        copyFieldFrom(newbits, StrongExtraRefCount);
+        copyFieldFrom(newbits, UseSlowRC);
+      }
     }
   }
 

--- a/test/Interpreter/weak.swift
+++ b/test/Interpreter/weak.swift
@@ -115,3 +115,19 @@ func test_rdar15293354() {
 
 test_rdar15293354()
 
+
+
+
+func testStaticObject() {
+  print("testStaticObject")                     // CHECK: testStaticObject
+
+  enum Static {
+    static let staticObject = SwiftClassBase()
+  }
+  weak var w: SwiftClassBase?
+  printState(w)                                 // CHECK-NEXT: is nil
+  w = Static.staticObject
+  printState(w)                                 // CHECK-NEXT: is present
+}
+
+testStaticObject()


### PR DESCRIPTION
The code to copy the refcounts from the object to a new side table wasn't quite right on 32-bit. Fix it to copy the PureSwiftDealloc field, and if the object is immortal, mark the side table's refcount as immortal too.

rdar://121943608