### PR TITLE
[BitwiseCopyable] Fixed TypeInfo flags.

### DIFF
--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -179,8 +179,8 @@ class BitwiseCopyableArchetypeTypeInfo
   using Super = WitnessSizedTypeInfo<Self>;
   BitwiseCopyableArchetypeTypeInfo(llvm::Type *type,
                                    IsABIAccessible_t abiAccessible)
-      : Super(type, Alignment(1), IsTriviallyDestroyable, IsBitwiseTakable,
-              IsCopyable, abiAccessible) {}
+      : Super(type, Alignment(1), IsNotTriviallyDestroyable,
+              IsNotBitwiseTakable, IsCopyable, abiAccessible) {}
 
 public:
   static const BitwiseCopyableArchetypeTypeInfo *

--- a/test/IRGen/bitwise_copyable_onone.swift
+++ b/test/IRGen/bitwise_copyable_onone.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend                           \
+// RUN:     -primary-file %s                             \
+// RUN:     -emit-ir                                     \
+// RUN:     -disable-availability-checking               \
+// RUN:     -enable-experimental-feature BitwiseCopyable \
+// RUN:     -enable-builtin-module                       \
+// RUN: |                                                \
+// RUN: %FileCheck %s
+
+
+// CHECK-LABEL: define{{.*}} ptr @"$s22bitwise_copyable_onone1EOy1AQzGAA1PRzs16_BitwiseCopyableAERQlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %I.A, 
+// CHECK-SAME:      ptr %"E<I.A>"
+// CHECK-SAME:  )
+enum E<Element> {
+  case next(Element)
+  case error(Any)
+}
+
+protocol P {
+  associatedtype A
+}
+
+class C<I: P> where I.A: _BitwiseCopyable {
+  func takeE(_ event: E<I.A>) {}
+  func run(_ e: I.A) {
+    takeE(.next(e))
+  }
+}


### PR DESCRIPTION
Although a concrete type that is bitwise copyable is bitwise takable and trivially destroyable, neither is true for a conforming archetype in the relevant sense.
