### PR TITLE
[stdlib] Start preparing the standard library for strict concurrency checking

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
@@ -127,6 +127,14 @@ private func isEmptyCOWSingleton(_ value: Value) -> Bool {
         return name == "_swiftEmptyArrayStorage" ||
                name == "_swiftEmptyDictionarySingleton" ||
                name == "_swiftEmptySetSingleton"
+      case let apply as ApplyInst:
+        guard let name = apply.referencedFunction?.name else {
+          return false
+        }
+
+        return name == "_swift_stdlib_getEmptyArrayStorage" ||
+               name == "_swift_stdlib_getEmptyDictionarySingleton" ||
+               name == "_swift_stdlib_getEmptySetSingleton"
       default:
         return false
     }

--- a/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/swift/shims/GlobalObjects.h
@@ -40,8 +40,12 @@ struct _SwiftEmptyArrayStorage {
   struct _SwiftArrayBodyStorage body;
 };
 
-SWIFT_RUNTIME_STDLIB_API
-struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
+SWIFT_RUNTIME_STDLIB_API SWIFT_CONSTANT_RELOCATABLE_DATA
+const struct _SwiftEmptyArrayStorage _swiftEmptyArrayStorage;
+
+static inline const void * _Nonnull _swift_stdlib_getEmptyArrayStorage() {
+  return &_swiftEmptyArrayStorage;
+}
 
 struct _SwiftDictionaryBodyStorage {
   __swift_intptr_t count;
@@ -51,8 +55,8 @@ struct _SwiftDictionaryBodyStorage {
   __swift_int16_t extra;
   __swift_int32_t age;
   __swift_intptr_t seed;
-  void *rawKeys;
-  void *rawValues;
+  __swift_uintptr_t rawKeys;
+  __swift_uintptr_t rawValues;
 };
 
 struct _SwiftSetBodyStorage {
@@ -63,7 +67,7 @@ struct _SwiftSetBodyStorage {
   __swift_int16_t extra;
   __swift_int32_t age;
   __swift_intptr_t seed;
-  void *rawElements;
+  __swift_uintptr_t rawElements;
 };
 
 struct _SwiftEmptyDictionarySingleton {
@@ -78,11 +82,19 @@ struct _SwiftEmptySetSingleton {
   __swift_uintptr_t metadata;
 };
 
-SWIFT_RUNTIME_STDLIB_API
-struct _SwiftEmptyDictionarySingleton _swiftEmptyDictionarySingleton;
+SWIFT_RUNTIME_STDLIB_API SWIFT_CONSTANT_RELOCATABLE_DATA
+const struct _SwiftEmptyDictionarySingleton _swiftEmptyDictionarySingleton;
 
-SWIFT_RUNTIME_STDLIB_API
-struct _SwiftEmptySetSingleton _swiftEmptySetSingleton;
+static inline const void * _Nonnull _swift_stdlib_getEmptyDictionarySingleton() {
+  return &_swiftEmptyDictionarySingleton;
+}
+
+SWIFT_RUNTIME_STDLIB_API SWIFT_CONSTANT_RELOCATABLE_DATA
+const struct _SwiftEmptySetSingleton _swiftEmptySetSingleton;
+
+static inline const void * _Nonnull _swift_stdlib_getEmptySetSingleton() {
+  return &_swiftEmptySetSingleton;
+}
 
 struct _SwiftHashingParameters {
   __swift_uint64_t seed0;
@@ -91,7 +103,7 @@ struct _SwiftHashingParameters {
 };
   
 SWIFT_RUNTIME_STDLIB_API
-struct _SwiftHashingParameters _swift_stdlib_Hashing_parameters;
+const struct _SwiftHashingParameters _swift_stdlib_Hashing_parameters;
 
 #ifdef __cplusplus
 

--- a/stdlib/public/SwiftShims/swift/shims/Visibility.h
+++ b/stdlib/public/SwiftShims/swift/shims/Visibility.h
@@ -144,6 +144,8 @@
 # define SWIFT_ATTRIBUTE_FOR_EXPORTS __attribute__((__visibility__("default")))
 # define SWIFT_ATTRIBUTE_FOR_IMPORTS __attribute__((__visibility__("default")))
 
+# define SWIFT_CONSTANT_RELOCATABLE_DATA __attribute__((section("__DATA,__const")))
+
 #elif defined(__ELF__)
 
 // On ELF, we use non-hidden visibility.  For exports, we must use
@@ -159,11 +161,15 @@
 # define SWIFT_ATTRIBUTE_FOR_EXPORTS __attribute__((__visibility__("protected")))
 # define SWIFT_ATTRIBUTE_FOR_IMPORTS __attribute__((__visibility__("default")))
 
+# define SWIFT_CONSTANT_RELOCATABLE_DATA __attribute__((section(".data.rel.ro")))
+
 #elif defined(__CYGWIN__)
 
 // For now, we ignore all this on Cygwin.
 # define SWIFT_ATTRIBUTE_FOR_EXPORTS
 # define SWIFT_ATTRIBUTE_FOR_IMPORTS
+
+# define SWIFT_CONSTANT_RELOCATABLE_DATA
 
 // FIXME: this #else should be some sort of #elif Windows
 #else // !__MACH__ && !__ELF__
@@ -171,6 +177,9 @@
 // On PE/COFF, we use dllimport and dllexport.
 # define SWIFT_ATTRIBUTE_FOR_EXPORTS __declspec(dllexport)
 # define SWIFT_ATTRIBUTE_FOR_IMPORTS __declspec(dllimport)
+
+// FIXME: Is there such section on Windows?
+# define SWIFT_CONSTANT_RELOCATABLE_DATA
 
 #endif
 

--- a/stdlib/public/SwiftShims/swift/shims/Visibility.h
+++ b/stdlib/public/SwiftShims/swift/shims/Visibility.h
@@ -178,8 +178,7 @@
 # define SWIFT_ATTRIBUTE_FOR_EXPORTS __declspec(dllexport)
 # define SWIFT_ATTRIBUTE_FOR_IMPORTS __declspec(dllimport)
 
-// FIXME: Is there such section on Windows?
-# define SWIFT_CONSTANT_RELOCATABLE_DATA
+# define SWIFT_CONSTANT_RELOCATABLE_DATA __attribute__((section(".rdata")))
 
 #endif
 

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -120,12 +120,19 @@ internal func _connectNSBaseClasses() -> Bool
 
 
 private let _bridgeInitializedSuccessfully = _connectNSBaseClasses()
-internal var _orphanedFoundationSubclassesReparented: Bool = false
+
+// Note: This is marked nonisolated unsafe because we will only ever set this
+// value to true. Even if multiple threads race to call
+// _connectOrphanedFoundationSubclassesIfNeeded, all invocations will write the
+// same value. Readers of this variable should never see an in-between value
+// during a write since this is just a boolean.
+internal nonisolated(unsafe)
+var _orphanedFoundationSubclassesReparented: Bool = false
 
 /// Reparents the SwiftNativeNS*Base classes to be subclasses of their respective
 /// Foundation types, or is false if they couldn't be reparented. Must be run
 /// in order to bridge Swift Strings, Arrays, Dictionaries, Sets, or Enumerators to ObjC.
- internal func _connectOrphanedFoundationSubclassesIfNeeded() -> Void {
+internal func _connectOrphanedFoundationSubclassesIfNeeded() -> Void {
   let bridgeWorks = _bridgeInitializedSuccessfully
   _debugPrecondition(bridgeWorks)
   _orphanedFoundationSubclassesReparented = true

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3574,7 +3574,8 @@ public enum EncodingError: Error {
   ///
   /// As associated values, this case contains the attempted value and context
   /// for debugging.
-  case invalidValue(Any, Context)
+  @preconcurrency
+  case invalidValue(Any & Sendable, Context)
 
   // MARK: - NSError Bridging
 

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -34,16 +34,26 @@ extension CommandLine : _BitwiseCopyable {}
 extension CommandLine {
   /// The backing static variable for argument count may come either from the
   /// entry point or it may need to be computed e.g. if we're in the REPL.
+  ///
+  /// Note: It is an abomination that this is marked nonisolated unsafe.
+  /// In theory, this variable is only set once and threads attempting to race
+  /// to set it will all update it to the same value. We hope there are no
+  /// tears in the write.
   @usableFromInline
-  internal static var _argc: Int32 = Int32()
+  internal nonisolated(unsafe) static var _argc: Int32 = 0
 
   /// The backing static variable for arguments may come either from the
   /// entry point or it may need to be computed e.g. if we're in the REPL.
   ///
   /// Care must be taken to ensure that `_swift_stdlib_getUnsafeArgvArgc` is
   /// not invoked more times than is necessary (at most once).
+  ///
+  /// Note: It is an abomination that this is marked nonisolated unsafe.
+  /// In theory, this variable is only set once and threads attempting to race
+  /// to set it will all update it to the same value. We hope there are no
+  /// tears in the write.
   @usableFromInline
-  internal static var _unsafeArgv:
+  internal nonisolated(unsafe) static var _unsafeArgv:
     UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
       =  _swift_stdlib_getUnsafeArgvArgc(&_argc)
 

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -75,6 +75,22 @@ extension __EmptyArrayStorage: Sendable {}
 // non-writable memory (can't be a let, Builtin.addressof below requires a var).
 public var _swiftEmptyArrayStorage: (Int, Int, Int, Int) =
     (/*isa*/0, /*refcount*/-1, /*count*/0, /*flags*/1)
+
+/// The empty array prototype.  We use the same object for all empty
+/// `[Native]Array<Element>`s.
+@inlinable
+internal var _emptyArrayStorage: __EmptyArrayStorage {
+  Builtin.bridgeFromRawPointer(Builtin.addressof(&_swiftEmptyArrayStorage))
+}
+#else
+/// The empty array prototype.  We use the same object for all empty
+/// `[Native]Array<Element>`s.
+@inlinable
+internal var _emptyArrayStorage: __EmptyArrayStorage {
+  Builtin.bridgeFromRawPointer(
+    _swift_stdlib_getEmptyArrayStorage()._rawValue
+  )
+}
 #endif
 
 /// The storage for static read-only arrays.
@@ -122,15 +138,6 @@ internal final class __StaticArrayStorage
 
 @available(*, unavailable)
 extension __StaticArrayStorage: Sendable {}
-
-/// The empty array prototype.  We use the same object for all empty
-/// `[Native]Array<Element>`s.
-@inlinable
-internal var _emptyArrayStorage: __EmptyArrayStorage {
-  Builtin.bridgeFromRawPointer(
-    _swift_stdlib_getEmptyArrayStorage()._rawValue
-  )
-}
 
 // The class that implements the storage for a ContiguousArray<Element>
 @_fixed_layout

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -127,8 +127,9 @@ extension __StaticArrayStorage: Sendable {}
 /// `[Native]Array<Element>`s.
 @inlinable
 internal var _emptyArrayStorage: __EmptyArrayStorage {
-  return Builtin.bridgeFromRawPointer(
-    Builtin.addressof(&_swiftEmptyArrayStorage))
+  Builtin.bridgeFromRawPointer(
+    _swift_stdlib_getEmptyArrayStorage()._rawValue
+  )
 }
 
 // The class that implements the storage for a ContiguousArray<Element>

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -223,8 +223,9 @@ extension __RawDictionaryStorage {
   @inlinable
   @nonobjc
   internal static var empty: __EmptyDictionarySingleton {
-    return Builtin.bridgeFromRawPointer(
-      Builtin.addressof(&_swiftEmptyDictionarySingleton))
+    Builtin.bridgeFromRawPointer(
+      _swift_stdlib_getEmptyDictionarySingleton()._rawValue
+    )
   }
   
   @_alwaysEmitIntoClient

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -214,8 +214,20 @@ public var _swiftEmptyDictionarySingleton: (Int, Int, Int, Int, UInt8, UInt8, UI
       /*rawValues*/1,
       /*metadata*/~1
     )
-#endif
 
+extension __RawDictionaryStorage {
+  /// The empty singleton that is used for every single Dictionary that is
+  /// created without any elements. The contents of the storage should never
+  /// be mutated.
+  @inlinable
+  @nonobjc
+  internal static var empty: __EmptyDictionarySingleton {
+    Builtin.bridgeFromRawPointer(
+      Builtin.addressof(&_swiftEmptyDictionarySingleton)
+    )
+  }
+}
+#else
 extension __RawDictionaryStorage {
   /// The empty singleton that is used for every single Dictionary that is
   /// created without any elements. The contents of the storage should never
@@ -227,7 +239,10 @@ extension __RawDictionaryStorage {
       _swift_stdlib_getEmptyDictionarySingleton()._rawValue
     )
   }
-  
+}
+#endif
+
+extension __RawDictionaryStorage {
   @_alwaysEmitIntoClient
   @inline(__always)
   internal final func uncheckedKey<Key: Hashable>(at bucket: _HashTable.Bucket) -> Key {

--- a/stdlib/public/core/LegacyABI.swift
+++ b/stdlib/public/core/LegacyABI.swift
@@ -87,3 +87,40 @@ extension String.UTF16View {
   @inlinable @inline(__always)
   internal var _shortHeuristic: Int { return 32 }
 }
+
+// Note: These 4 functions are previous setters and modifies for
+// _EachFieldOptions.classType and _EachFieldOptions.ignoreUnknown. These were
+// defined as static vars which allow for shared mutable data when the intention
+// was just an option for an option set which should be constant static data.
+
+@available(SwiftStdlib 5.2, *)
+@usableFromInline
+@_silgen_name("$ss17_EachFieldOptionsV13ignoreUnknownABvsZ")
+@_spi(Reflection)
+internal func _eachFieldOptionsIgnoreUnknownSetter(_: _EachFieldOptions) {
+  fatalError()
+}
+
+@available(SwiftStdlib 5.2, *)
+@usableFromInline
+@_silgen_name("$ss17_EachFieldOptionsV13ignoreUnknownABvMZ")
+@_spi(Reflection)
+internal func _eachFieldOptionsIgnoreUnknownModify(_: UnsafeRawPointer) {
+  fatalError()
+}
+
+@available(SwiftStdlib 5.2, *)
+@usableFromInline
+@_silgen_name("$ss17_EachFieldOptionsV9classTypeABvsZ")
+@_spi(Reflection)
+internal func _eachFieldOptionsClassTypeSetter(_: _EachFieldOptions) {
+  fatalError()
+}
+
+@available(SwiftStdlib 5.2, *)
+@usableFromInline
+@_silgen_name("$ss17_EachFieldOptionsV9classTypeABvMZ")
+@_spi(Reflection)
+internal func _eachFieldOptionsClassTypeModify(_: UnsafeRawPointer) {
+  fatalError()
+}

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -618,7 +618,11 @@ extension Unicode.Scalar: TextOutputStreamable {
 }
 
 /// A hook for playgrounds to print through.
-public var _playgroundPrintHook: ((String) -> Void)? = nil
+///
+/// Note: This is marked nonisolated unsafe because we are not responisble for
+/// the synchronization needed to update this variable. Either a debugger or a
+/// playground environment is setting this hook up.
+public nonisolated(unsafe) var _playgroundPrintHook: ((String) -> Void)? = nil
 
 internal struct _TeeStream<L: TextOutputStream, R: TextOutputStream>
   : TextOutputStream

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -204,13 +204,17 @@ public struct _EachFieldOptions: OptionSet {
   ///
   /// If this is not set, the top-level type is required to be a struct or
   /// tuple.
-  public static var classType = _EachFieldOptions(rawValue: 1 << 0)
+  public static var classType: _EachFieldOptions {
+    _EachFieldOptions(rawValue: 1 << 0)
+  }
 
   /// Ignore fields that can't be introspected.
   ///
   /// If not set, the presence of things that can't be introspected causes
   /// the function to immediately return `false`.
-  public static var ignoreUnknown = _EachFieldOptions(rawValue: 1 << 1)
+  public static var ignoreUnknown: _EachFieldOptions {
+    _EachFieldOptions(rawValue: 1 << 1)
+  }
 }
 
 @available(SwiftStdlib 5.2, *)

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -153,8 +153,17 @@ public var _swiftEmptySetSingleton: (Int, Int, Int, Int, UInt8, UInt8, UInt16, U
       /*rawElements*/1, 
       /*metadata*/~1
     )
-#endif
 
+extension __RawSetStorage {
+  /// The empty singleton that is used for every single Set that is created
+  /// without any elements. The contents of the storage must never be mutated.
+  @inlinable
+  @nonobjc
+  internal static var empty: __EmptySetSingleton {
+    Builtin.bridgeFromRawPointer(Builtin.addressof(&_swiftEmptySetSingleton))
+  }
+}
+#else
 extension __RawSetStorage {
   /// The empty singleton that is used for every single Set that is created
   /// without any elements. The contents of the storage must never be mutated.
@@ -164,6 +173,7 @@ extension __RawSetStorage {
     Builtin.bridgeFromRawPointer(_swift_stdlib_getEmptySetSingleton()._rawValue)
   }
 }
+#endif
 
 extension __EmptySetSingleton: _NSSetCore {
 #if _runtime(_ObjC)

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -161,8 +161,7 @@ extension __RawSetStorage {
   @inlinable
   @nonobjc
   internal static var empty: __EmptySetSingleton {
-    return Builtin.bridgeFromRawPointer(
-      Builtin.addressof(&_swiftEmptySetSingleton))
+    Builtin.bridgeFromRawPointer(_swift_stdlib_getEmptySetSingleton()._rawValue)
   }
 }
 

--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -27,8 +27,14 @@ internal func _makeSwiftNSFastEnumerationState()
 
 /// A dummy value to be used as the target for `mutationsPtr` in fast
 /// enumeration implementations.
+///
+/// Note: This is marked nonisolated unsafe because we _never_ write to this
+/// value. It is unfortunate that this is not a let, but we need to take the
+/// address of this variable which is currently only possible with vars in
+/// Swift.
 @usableFromInline
-internal var _fastEnumerationStorageMutationsTarget: CUnsignedLong = 0
+internal nonisolated(unsafe)
+var _fastEnumerationStorageMutationsTarget: CUnsignedLong = 0
 
 /// A dummy pointer to be used as `mutationsPtr` in fast enumeration
 /// implementations.

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -720,7 +720,12 @@ final internal class __VaListBuilder {
   internal var retainer = [CVarArg]()
 #endif
 
-  internal static var alignedStorageForEmptyVaLists: Double = 0
+  /// Note: This is nonisolated unsafe because we will _never_ write to this
+  /// value. It is marked as a var because we need to take the address of it,
+  /// and that pointer may be passed to user code under the guise of a
+  /// CVaListPointer. We cannot enforce any synchronization guarantees if the
+  /// somehow writes to the underlying pointer value in that type.
+  internal nonisolated(unsafe) static var alignedStorageForEmptyVaLists: Double = 0
 }
 
 #endif

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -38,8 +38,8 @@ SWIFT_RUNTIME_STDLIB_API
 ClassMetadata CLASS_METADATA_SYM(s19__EmptySetSingleton);
 } // namespace swift
 
-SWIFT_RUNTIME_STDLIB_API
-swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
+SWIFT_RUNTIME_STDLIB_API SWIFT_CONSTANT_RELOCATABLE_DATA
+const swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
   // HeapObject header;
   {
     &swift::CLASS_METADATA_SYM(s19__EmptyArrayStorage), // isa pointer
@@ -85,8 +85,8 @@ __asm__("  .globl __swiftImmortalRefCount\n");
 
 #endif
 
-SWIFT_RUNTIME_STDLIB_API
-swift::_SwiftEmptyDictionarySingleton swift::_swiftEmptyDictionarySingleton = {
+SWIFT_RUNTIME_STDLIB_API SWIFT_CONSTANT_RELOCATABLE_DATA
+const swift::_SwiftEmptyDictionarySingleton swift::_swiftEmptyDictionarySingleton = {
   // HeapObject header;
   {
     &swift::CLASS_METADATA_SYM(s26__EmptyDictionarySingleton), // isa pointer
@@ -105,16 +105,16 @@ swift::_SwiftEmptyDictionarySingleton swift::_swiftEmptyDictionarySingleton = {
     0, // int16 extra;
     0, // int32 age;
     0, // int seed;
-    (void *)1, // void* keys; (non-null garbage)
-    (void *)1  // void* values; (non-null garbage)
+    1, // void* keys; (non-null garbage)
+    1  // void* values; (non-null garbage)
   },
 
   // bucket 0 is unoccupied; other buckets are out-of-bounds
   static_cast<__swift_uintptr_t>(~1) // int metadata; 
 };
 
-SWIFT_RUNTIME_STDLIB_API
-swift::_SwiftEmptySetSingleton swift::_swiftEmptySetSingleton = {
+SWIFT_RUNTIME_STDLIB_API SWIFT_CONSTANT_RELOCATABLE_DATA
+const swift::_SwiftEmptySetSingleton swift::_swiftEmptySetSingleton = {
   // HeapObject header;
   {
     &swift::CLASS_METADATA_SYM(s19__EmptySetSingleton), // isa pointer
@@ -133,7 +133,7 @@ swift::_SwiftEmptySetSingleton swift::_swiftEmptySetSingleton = {
     0, // int16 extra;
     0, // int32 age;
     0, // int seed;
-    (void *)1, // void *rawElements; (non-null garbage)
+    1, // void *rawElements; (non-null garbage)
   },
 
   // bucket 0 is unoccupied; other buckets are out-of-bounds
@@ -156,7 +156,7 @@ static swift::_SwiftHashingParameters initializeHashingParameters() {
 }
 
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
-swift::_SwiftHashingParameters swift::_swift_stdlib_Hashing_parameters =
+const swift::_SwiftHashingParameters swift::_swift_stdlib_Hashing_parameters =
   initializeHashingParameters();
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 

--- a/test/SILOptimizer/cross-module-optimization.swift
+++ b/test/SILOptimizer/cross-module-optimization.swift
@@ -28,8 +28,6 @@
 
 import Test
 
-// CHECK-SIL: sil_global public_external [serialized] @_swiftEmptySetSingleton : $_SwiftEmptySetSingleton
-
 func testNestedTypes() {
   let c = Container()
 
@@ -164,6 +162,8 @@ func testImplementationOnly() {
   print(callCImplementationOnly(0))
   // CHECK-SIL2: } // end sil function '$s4Main22testImplementationOnlyyyF'
 }
+
+// CHECK-SIL: sil shared [clang _swift_stdlib_getEmptySetSingleton] @_swift_stdlib_getEmptySetSingleton : $@convention(c) () -> UnsafeRawPointer
 
 testNestedTypes()
 testClass()

--- a/test/SILOptimizer/immortal-arc-elimination.swift
+++ b/test/SILOptimizer/immortal-arc-elimination.swift
@@ -12,7 +12,7 @@
 // But only with a Swift 5.1 runtime (which supports immortal objects).
 
 // CHECK-LABEL: sil hidden [noinline] @$s4test10emptyArraySaySiGyF
-// CHECK:       global_addr
+// CHECK:       function_ref @_swift_stdlib_getEmptyArrayStorage
 // CHECK-NOT:   retain
 // CHECK: } // end sil function '$s4test10emptyArraySaySiGyF'
 @inline(never)

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -235,7 +235,7 @@ func closueWhichModifiesLocalVar() -> Int {
 
 @_noAllocation
 func createEmptyArray() {
-  _ = [Int]() // expected-error {{ending the lifetime of a value of type}}
+  _ = [Int]() // expected-error {{called function is not available in this module and can have unpredictable performance}}
 }
 
 struct Buffer {

--- a/test/SILOptimizer/set.swift
+++ b/test/SILOptimizer/set.swift
@@ -6,7 +6,10 @@
 // Test optimal code generation for creating empty sets.
 
 // CHECK-LABEL: sil {{.*}}@$s4test30createEmptySetFromArrayLiteralShySiGyF
-// CHECK:         global_addr @_swiftEmptySetSingleton
+// CHECK:         [[ARRAY:%.*]] = function_ref @_swift_stdlib_getEmptyArrayStorage
+// CHECK:         apply [[ARRAY]]
+// CHECK:         [[SET:%.*]] = function_ref @_swift_stdlib_getEmptySetSingleton
+// CHECK:         apply [[SET]]
 // CHECK-NOT:     apply
 // CHECK:       } // end sil function '$s4test30createEmptySetFromArrayLiteralShySiGyF'
 public func createEmptySetFromArrayLiteral() -> Set<Int> {
@@ -14,7 +17,8 @@ public func createEmptySetFromArrayLiteral() -> Set<Int> {
 }
 
 // CHECK-LABEL: sil {{.*}}@$s4test29createEmptySetWithInitializerShySiGyF
-// CHECK:         global_addr @_swiftEmptySetSingleton
+// CHECK:         [[SET:%.*]] = function_ref @_swift_stdlib_getEmptySetSingleton
+// CHECK:         apply [[SET]]
 // CHECK-NOT:     apply
 // CHECK:       } // end sil function '$s4test29createEmptySetWithInitializerShySiGyF'
 public func createEmptySetWithInitializer() -> Set<Int> {

--- a/test/Sema/availability_stored_unavailable_maccatalyst.swift
+++ b/test/Sema/availability_stored_unavailable_maccatalyst.swift
@@ -1,13 +1,13 @@
-// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-ios13.1-macabi -parse-as-library -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-ios13.1-macabi -parse-as-library -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -parse-stdlib
 
 // REQUIRES: OS=macosx
 
 struct BadStruct {
   @available(macCatalyst 13.1, *)
   @available(iOS, unavailable) // This attribute is inactive so we don't expect a diagnostic
-  var availableOnCatalyst: Int
+  var availableOnCatalyst: Builtin.Int1
 
   @available(macCatalyst, unavailable) // expected-error {{stored properties cannot be marked unavailable with '@available'}}
   @available(iOS 13, *)
-  var unavailableOnCatalyst: Int
+  var unavailableOnCatalyst: Builtin.Int1
 }

--- a/test/TBD/linker-directives-ld-previous-macos.swift
+++ b/test/TBD/linker-directives-ld-previous-macos.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-frontend -target-variant x86_64-apple-ios13.1-macabi -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives_macos_macabi.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json -tbd-install_name toasterkit
 // RUN: %llvm-nm %t/linker_directives_macos_macabi.tbd | %FileCheck -check-prefixes=CHECK,CHECK-MAC,CHECK-MACCATALYST %s
 
-// RUN: %target-swift-frontend -target x86_64-apple-ios13.1-macabi -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives_macabi.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json -tbd-install_name toasterkit
+// RUN: %target-swift-frontend -target x86_64-apple-ios13.1-macabi -typecheck %S/Inputs/linker-directive.swift -emit-tbd -emit-tbd-path %t/linker_directives_macabi.tbd -previous-module-installname-map-file %S/Inputs/install-name-map-toasterkit.json -tbd-install_name toasterkit -parse-stdlib
 // R/UN: %llvm-nm %t/linker_directives_macabi.tbd | %FileCheck -check-prefixes=CHECK,CHECK-MACCATALYST %s --implicit-check-not "System/Previous/macOS"
 
 // CHECK-MACCATALYST: D $ld$previous$/System/Previous/macCatalyst/ToasterKit.dylib$$6$10.2$13.0$_$s10ToasterKit5toastyyF$


### PR DESCRIPTION
This patch marks some global variables in the standard library as `nonisolated(unsafe)` where appropriate with some justification on why marking them that way is \_ok\_. I've also gone ahead and marked the empty singletons as `const` and the hashing parameters as `const`. C/C++ won't put just a regular `const` in some read only memory, so I forced these special variables in constant relocatable memory instead (because they have pointers to metadata) which will cause a bad access when trying to write to these symbols.

With `-strict-concurrency=complete`, this cleans up most of the warnings we have in the standard library. The only other warning we get is with `CommandLine.arguments` which I'm hoping we can revive this PR https://github.com/apple/swift/pull/69981 to deprecate and eventually move to a safer interface for this API.