### PR TITLE
utils: fix debug info generation for the standard library

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -578,6 +578,7 @@ function Build-CMakeProject {
 
     $CFlags = @("/GS-", "/Gw", "/Gy", "/Oi", "/Oy", "/Zc:inline")
     if ($UseMSVCCompilers.Contains("C") -Or $UseMSVCCompilers.Contains("CXX") -Or
+        $UseBuiltCompilers.Contains("C") -Or $UseBuiltCompilers.Contains("CXX") -Or
         $UsePinnedCompilers.Contains("C") -Or $UsePinnedCompilers.Contains("CXX")) {
       if ($DebugInfo) {
         $CFlags += if ($EnableCaching) { "/Z7" } else { "/Zi" }


### PR DESCRIPTION
When we build the standard library, we use the just built compilers. However, we would not pass the necessary flags to the linker to generate the debug information (PDBs) which would then make debugging more challenging than it already is.