### PR TITLE
[PlaygroundTransform] Disable logging `~Copyable` types as they can’t be passed to the generic logging function

### DIFF
--- a/test/PlaygroundTransform/noncopyable_assignment.swift
+++ b/test/PlaygroundTransform/noncopyable_assignment.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
+// RUN: %target-codesign %t/main2
+// RUN: %target-run %t/main2 | %FileCheck %s
+// REQUIRES: executable_test
+
+import PlaygroundSupport
+
+struct A: ~Copyable {}
+
+var a: A
+a = A()
+
+struct B {}
+
+var b: B
+b = B()
+// note: a should not be logged (at least until move-only types can be passed to the generic logging functions)
+// CHECK: [{{.*}}] __builtin_log[b='B()']

--- a/test/PlaygroundTransform/noncopyable_declaration.swift
+++ b/test/PlaygroundTransform/noncopyable_declaration.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
+// RUN: %target-codesign %t/main2
+// RUN: %target-run %t/main2 | %FileCheck %s
+// REQUIRES: executable_test
+
+import PlaygroundSupport
+
+struct A: ~Copyable {}
+
+let a = A()
+
+struct B {}
+
+let b = B()
+// note: a should not be logged (at least until move-only types can be passed to the generic logging functions)
+// CHECK: [{{.*}}] __builtin_log[b='B()']

--- a/test/PlaygroundTransform/noncopyable_functions.swift
+++ b/test/PlaygroundTransform/noncopyable_functions.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -playground -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift -module-name main
+// RUN: %target-codesign %t/main2
+// RUN: %target-run %t/main2 | %FileCheck %s
+// REQUIRES: executable_test
+
+import PlaygroundSupport
+
+struct A: ~Copyable {}
+
+func f(_ a: consuming A) -> A {
+    return a
+}
+
+f(A())
+// note: a should not be logged (at least until move-only types can be passed to the generic logging functions)
+// CHECK: [{{.*}}] __builtin_log_scope_entry
+// CHECK-NEXT: [{{.*}}] __builtin_log_scope_exit
+// CHECK-NOT: __builtin_log


### PR DESCRIPTION
### Summary 

Xcode Playgrounds cannot execute code with `~Copyable` types, as the Playground Transform tries to pass them to the generic logging function, which is not supported yet. These changes disable logging them altogether for now, which can be reverted once generics start supporting move-only types. Another approach would be to introduce a placeholder log, which could be recognized by the clients in order to inform the user about the reason for the missing logs. 

### Changes

* Add a new function in Playground Transform `shouldLogType(Type)` to check the `isNoncopyable` flag and use it in all paths that can lead to creating a playground log.
* Add unit tests verifying that the move-only types are omitted by the Playground Transform in various scenarios.

rdar://115035973