### PR TITLE
SILGen: Avoid unnecessary use of a back deployment thunk for calls to `_diagnoseUnavailableCodeReached()`

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -6192,7 +6192,7 @@ void SILGenFunction::emitApplyOfUnavailableCodeReached() {
   }
 
   auto declRef = SILDeclRef(fd);
-  if (fd->isBackDeployed(getASTContext())) {
+  if (SGM.requiresBackDeploymentThunk(fd, F.getResilienceExpansion())) {
     // The standard library entry point for the diagnostic function was
     // introduced in Swift 5.9 so we call the back deployment thunk in case this
     // code will execute on an older runtime.

--- a/test/SILGen/unavailable_decl_optimization_stub_macos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-emit-silgen -target %target-swift-abi-5.8-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK-SWIFT5_8
+// RUN: %target-swift-emit-silgen -target %target-swift-abi-5.9-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK-SWIFT5_9
+
+// REQUIRES: OS=macosx
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test15unavailableFuncyyF
+// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF : $@convention(thin) () -> Never
+// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test15unavailableFuncyyF'
+@available(*, unavailable)
+public func unavailableFunc() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test24unavailableInlinableFuncyyF
+// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF : $@convention(thin) () -> Never
+// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyFTwb : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test24unavailableInlinableFuncyyF'
+@available(*, unavailable)
+@inlinable public func unavailableInlinableFunc() {}
+


### PR DESCRIPTION
When the deployment target is Swift 5.9 aligned or higher, we should not need to call `_diagnoseUnavailableCodeReached()` via a back-deployment thunk since the function will always be available in the standard library. However, the thunk must still be used in fragile functions (e.g. `@inlinable`) since the deployment targets of module clients cannot be predicted.

Resolves rdar://121878128
