### PR TITLE
[stdlib] Define OS version numbers for SwiftStdlib 5.10

### DIFF
--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -34,7 +34,7 @@ SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
 SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0
 SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
 SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
-SwiftStdlib 5.10:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4
 SwiftStdlib 5.11:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
 # TODO: Also update ASTContext::getSwift510Availability when needed
 # TODO: Also update ASTContext::getSwift511Availability when needed


### PR DESCRIPTION
macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4, and iPadOS 17.4 are currently in public beta testing, and they include the Swift 5.10 Standard Library.

Adjust the `SwiftStdlib 5.10` macro to resolve to these version numbers rather than the placeholder 9999 versions.

5.10 does not ship with new Stdlib ABI entry points, so we aren't using this macro anywhere outside behavioral tests. The impact of this change ought to be correspondingly minimal.

(Ideally this needs to be cherry-picked to release/5.10 too, although if there isn't anything using it, it's not super critical.)