### PR TITLE
[BitwiseCopyable] Fragile modules always infer.

### DIFF
--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -57,7 +57,8 @@ getImplicitCheckForNominal(NominalTypeDecl *nominal) {
   if (!nominal
            ->getFormalAccessScope(
                /*useDC=*/nullptr, /*treatUsableFromInlineAsPublic=*/true)
-           .isPublic())
+           .isPublic() ||
+      !nominal->isResilient())
     return {BitwiseCopyableCheck::Implicit};
 
   if (nominal->hasClangNode() ||

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -60,8 +60,7 @@ struct S_Explicit_With_Function_C : _BitwiseCopyable {
 public struct S_Public {}
 
 struct S_Explicit_With_S_Public : _BitwiseCopyable {
-  var s: S_Public // expected-error   {{non_bitwise_copyable_type_member}}
-                  // expected-note@-4 {{add_nominal_bitwise_copyable_conformance}}
+  var s: S_Public
 }
 
 struct S_Explicit_With_Generic<T> : _BitwiseCopyable {

--- a/test/Sema/bitwise_copyable_nonresilient.swift
+++ b/test/Sema/bitwise_copyable_nonresilient.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                           \
+// RUN:     %t/Library.swift                             \
+// RUN:     -emit-module                                 \
+// RUN:     -enable-experimental-feature BitwiseCopyable \
+// RUN:     -module-name Library                         \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-swift-frontend                           \
+// RUN:     %t/Downstream.swift                          \
+// RUN:     -typecheck -verify                           \
+// RUN:     -debug-diagnostic-names                      \
+// RUN:     -enable-experimental-feature BitwiseCopyable \
+// RUN:     -I %t
+
+//--- Library.swift
+public enum Oopsional<T> {
+case someone(Int)
+case nobody
+}
+
+@frozen public enum Woopsional<T> {
+case somebody(Int)
+case noone
+}
+
+//--- Downstream.swift
+import Library
+
+func take<T: _BitwiseCopyable>(_ t: T) {}
+
+struct S_Explicit_With_Oopsional<T> : _BitwiseCopyable {
+  var o: Oopsional<T>
+}
+
+func passOopsional<T>(_ t: Oopsional<T>) { take(t) }
+
+
+struct S_Explicit_With_Woopsional<T> : _BitwiseCopyable {
+  var o: Woopsional<T>
+}
+
+func passWoopsional<T>(_ t: Woopsional<T>) { take(t) }
+


### PR DESCRIPTION
Gating inference on visibility only makes sense in the context of a resilient module.
