### PR TITLE
Non-copyable generics fixes part 2

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -465,9 +465,22 @@ public:
   /// Given a type parameter, compute the most specific supertype (upper bound),
   /// possibly dependent on other type parameters.
   ///
+  ///
+  /// \param forExistentialSelf If true, we ensure the result does not include
+  /// any type parameters rooted in the same generic parameter as the one given.
+  ///
+  /// \param includeParameterizedProtocols If true, we form parameterized
+  /// protocol types if we find that the given type's primary associated types
+  /// are sufficiently constrained.
+  ///
   /// \note If the upper bound is a protocol or protocol composition,
   /// will return an instance of \c ExistentialType.
-  Type getUpperBound(Type type) const;
+  Type getUpperBound(Type type,
+                     bool forExistentialSelf,
+                     bool includeParameterizedProtocols) const;
+
+  /// Utility wrapper for use when this is an opened existential signature.
+  Type getExistentialType(Type type) const;
 
   static void Profile(llvm::FoldingSetNodeID &ID,
                       ArrayRef<GenericTypeParamType *> genericParams,

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -5943,22 +5943,19 @@ class ProtocolCompositionType final : public TypeBase,
   
 public:
   /// Retrieve an instance of a protocol composition type with the
-  /// given set of members. A "hidden member" is an implicit constraint that
-  /// is present for all protocol compositions.
+  /// given set of members.
   ///
-  /// \param Members the regular members of this composition.
-  /// \param Inverses the set of inverses that are a member of the composition,
-  ///                 i.e., if \c IP is in this set, then \c ~IP is a member of
-  ///                 this composition.
-  /// \param HasExplicitAnyObject indicates whether this composition should be
-  /// treated as if \c AnyObject was a member.
+  /// This presents a syntactic view of the world, where an empty composition
+  /// has implicit Copyable and Escapable members, unless they are supressed
+  /// with the Inverses field.
+  ///
+  /// The list of members consists of zero or more ProtocolType,
+  /// ProtocolCompositionType, ParameterizedProtocolType, together with at
+  /// most one ClassType or BoundGenericClassType.
+  ///
+  /// HasExplicitAnyObject is the 'AnyObject' member.
   static Type get(const ASTContext &C, ArrayRef<Type> Members,
                   InvertibleProtocolSet Inverses,
-                  bool HasExplicitAnyObject);
-
-  /// Retrieve an instance of a protocol composition type with the
-  /// given set of members. Assumes no inverses are present in \c Members.
-  static Type get(const ASTContext &C, ArrayRef<Type> Members,
                   bool HasExplicitAnyObject);
 
   /// Constructs a protocol composition corresponding to the `Any` type.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3837,6 +3837,15 @@ ProtocolCompositionType::build(const ASTContext &C, ArrayRef<Type> Members,
                                bool HasExplicitAnyObject) {
   assert(Members.size() != 1 || HasExplicitAnyObject || !Inverses.empty());
 
+#ifndef NDEBUG
+  for (auto member : Members) {
+    if (auto *proto = member->getAs<ProtocolType>()) {
+      assert(!proto->getDecl()->getInvertibleProtocolKind() &&
+             "Should have been folded away");
+    }
+  }
+#endif
+
   // Check to see if we've already seen this protocol composition before.
   void *InsertPos = nullptr;
   llvm::FoldingSetNodeID ID;

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -673,7 +673,10 @@ Type ASTBuilder::createProtocolCompositionType(
   if (superclass && superclass->getClassOrBoundGenericClass())
     members.push_back(superclass);
 
-  Type composition = ProtocolCompositionType::get(Ctx, members, isClassBound);
+  // FIXME: move-only generics
+  InvertibleProtocolSet inverses;
+  Type composition = ProtocolCompositionType::get(Ctx, members, inverses,
+                                                  isClassBound);
   if (forRequirement)
     return composition;
 

--- a/lib/AST/ExistentialGeneralization.cpp
+++ b/lib/AST/ExistentialGeneralization.cpp
@@ -107,6 +107,7 @@ private:
       newMembers.push_back(generalizeStructure(origMember));
     }
     return ProtocolCompositionType::get(ctx, newMembers,
+                                        origType->getInverses(),
                                         origType->hasExplicitAnyObject());
   }
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -667,58 +667,91 @@ unsigned GenericSignatureImpl::getGenericParamOrdinal(
   return GenericParamKey(param).findIndexIn(getGenericParams());
 }
 
-Type GenericSignatureImpl::getUpperBound(Type type) const {
+Type GenericSignatureImpl::getUpperBound(Type type,
+                                         bool forExistentialSelf,
+                                         bool includeParameterizedProtocols) const {
   assert(type->isTypeParameter());
 
   llvm::SmallVector<Type, 2> types;
   unsigned rootDepth = type->getRootGenericParam()->getDepth();
 
+  auto accept = [forExistentialSelf, rootDepth](Type t) {
+    if (!forExistentialSelf)
+      return true;
+
+    return !t.findIf([rootDepth](Type t) {
+      if (auto *paramTy = t->getAs<GenericTypeParamType>())
+        return (paramTy->getDepth() == rootDepth);
+      return false;
+    });
+  };
+
+  // We start with the assumption we'll add a '& AnyObject' member to our
+  // composition, but we might clear this below.
   bool hasExplicitAnyObject = requiresClass(type);
 
-  if (Type superclass = getSuperclassBound(type)) {
+  // Look for the most derived superclass that does not involve the type
+  // being erased.
+  Type superclass = getSuperclassBound(type);
+  if (superclass) {
     do {
       superclass = getReducedType(superclass);
-
-      if (!superclass.findIf([&](Type t) {
-            if (auto *paramTy = t->getAs<GenericTypeParamType>())
-              return (paramTy->getDepth() == rootDepth);
-            return false;
-          })) {
+      if (accept(superclass))
         break;
-      }
     } while ((superclass = superclass->getSuperclass()));
 
+    // If we're going to have a superclass, we can drop the '& AnyObject'.
     if (superclass) {
-      types.push_back(superclass);
+      types.push_back(getSugaredType(superclass));
       hasExplicitAnyObject = false;
     }
   }
 
+  auto &ctx = getASTContext();
+
+  // Record the absence of Copyable and Escapable conformance, but only if
+  // we didn't have a superclass or require AnyObject.
+  InvertibleProtocolSet inverses;
+
+  if (SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS ||
+      ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+    if (!superclass && !hasExplicitAnyObject) {
+      for (auto ip : InvertibleProtocolSet::full()) {
+        auto *kp = ctx.getProtocol(::getKnownProtocolKind(ip));
+        if (!requiresProtocol(type, kp))
+          inverses.insert(ip);
+      }
+    }
+  }
+
   for (auto *proto : getRequiredProtocols(type)) {
+    if (SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS ||
+      ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+      // Don't add invertible protocols to the composition, because we recorded
+      // their absence above.
+      if (proto->getInvertibleProtocolKind())
+        continue;
+    }
+
     if (proto->requiresClass())
       hasExplicitAnyObject = false;
 
     auto *baseType = proto->getDeclaredInterfaceType()->castTo<ProtocolType>();
 
     auto primaryAssocTypes = proto->getPrimaryAssociatedTypes();
-    if (!primaryAssocTypes.empty()) {
+    if (includeParameterizedProtocols && !primaryAssocTypes.empty()) {
       SmallVector<Type, 2> argTypes;
 
       // Attempt to recover same-type requirements on primary associated types.
       for (auto *assocType : primaryAssocTypes) {
         // For each primary associated type A of P, compute the reduced type
         // of T.[P]A.
-        auto *memberType = DependentMemberType::get(type, assocType);
-        auto reducedType = getReducedType(memberType);
+        auto memberType = getReducedType(DependentMemberType::get(type, assocType));
 
         // If the reduced type is at a lower depth than the root generic
         // parameter of T, then it's constrained.
-        if (!reducedType.findIf([&](Type t) {
-            if (auto *paramTy = t->getAs<GenericTypeParamType>())
-              return (paramTy->getDepth() == rootDepth);
-            return false;
-          })) {
-          argTypes.push_back(reducedType);
+        if (accept(memberType)) {
+          argTypes.push_back(getSugaredType(memberType));
         }
       }
 
@@ -740,15 +773,18 @@ Type GenericSignatureImpl::getUpperBound(Type type) const {
     types.push_back(baseType);
   }
 
-  auto constraint = ProtocolCompositionType::get(getASTContext(), types,
-                                                 hasExplicitAnyObject);
+  return ProtocolCompositionType::get(ctx, types, inverses,
+                                      hasExplicitAnyObject);
+}
 
-  if (!constraint->isConstraintType()) {
-    assert(constraint->getClassOrBoundGenericClass());
-    return constraint;
-  }
-
-  return ExistentialType::get(constraint);
+Type GenericSignatureImpl::getExistentialType(Type paramTy) const {
+  auto upperBound = getUpperBound(paramTy,
+                                  /*forExistentialSelf=*/true,
+                                  /*includeParameterizedProtocols=*/true);
+  if (upperBound->isConstraintType())
+    return ExistentialType::get(upperBound);
+  assert(upperBound->getClassOrBoundGenericClass());
+  return upperBound;
 }
 
 void GenericSignature::Profile(llvm::FoldingSetNodeID &id) const {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1141,6 +1141,7 @@ Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
     if (!newMembers.empty()) {
       return ProtocolCompositionType::get(
           getASTContext(), newMembers,
+          protocolCompositionType->getInverses(),
           protocolCompositionType->hasExplicitAnyObject());
     }
 
@@ -1606,6 +1607,7 @@ static void addProtocols(Type T,
                          SmallVectorImpl<ProtocolDecl *> &Protocols,
                          ParameterizedProtocolMap &Parameterized,
                          Type &Superclass,
+                         InvertibleProtocolSet &Inverses,
                          bool &HasExplicitAnyObject) {
   if (auto Proto = T->getAs<ProtocolType>()) {
     Protocols.push_back(Proto->getDecl());
@@ -1613,11 +1615,12 @@ static void addProtocols(Type T,
   }
 
   if (auto PC = T->getAs<ProtocolCompositionType>()) {
-    if (PC->hasExplicitAnyObject())
-      HasExplicitAnyObject = true;
-    for (auto P : PC->getMembers())
-      addProtocols(P, Protocols, Parameterized, Superclass,
+    Inverses.insertAll(PC->getInverses());
+    HasExplicitAnyObject |= PC->hasExplicitAnyObject();
+    for (auto P : PC->getMembers()) {
+      addProtocols(P, Protocols, Parameterized, Superclass, Inverses,
                    HasExplicitAnyObject);
+    }
     return;
   }
 
@@ -1918,6 +1921,7 @@ CanType TypeBase::computeCanonicalType() {
     assert(!CanProtos.empty() && "Non-canonical empty composition?");
     const ASTContext &C = CanProtos[0]->getASTContext();
     Type Composition = ProtocolCompositionType::get(C, CanProtos,
+                                                    PCT->getInverses(),
                                                     PCT->hasExplicitAnyObject());
     Result = Composition.getPointer();
     break;
@@ -4009,25 +4013,20 @@ bool ProtocolCompositionType::requiresClass() {
 
 /// Constructs a protocol composition corresponding to the `Any` type.
 Type ProtocolCompositionType::theAnyType(const ASTContext &C) {
-  return ProtocolCompositionType::get(C, {}, /*HasExplicitAnyObject=*/false);
+  return ProtocolCompositionType::get(C, {}, /*Inverses=*/{},
+                                      /*HasExplicitAnyObject=*/false);
 }
 
 /// Constructs a protocol composition containing the `AnyObject` constraint.
 Type ProtocolCompositionType::theAnyObjectType(const ASTContext &C) {
-  return ProtocolCompositionType::get(C, {}, /*HasExplicitAnyObject=*/true);
+  return ProtocolCompositionType::get(C, {}, /*Inverses=*/{},
+                                      /*HasExplicitAnyObject=*/true);
 }
 
 Type ProtocolCompositionType::getInverseOf(const ASTContext &C,
                                            InvertibleProtocolKind IP) {
-  return ProtocolCompositionType::get(C, {}, {IP},
+  return ProtocolCompositionType::get(C, {}, /*Inverses=*/{IP},
                                       /*HasExplicitAnyObject=*/false);
-}
-
-Type ProtocolCompositionType::get(const ASTContext &C, ArrayRef<Type> Members,
-                                  bool HasExplicitAnyObject) {
-  return ProtocolCompositionType::get(C, Members,
-                                      /*Inverses=*/{},
-                                      HasExplicitAnyObject);
 }
 
 Type ProtocolCompositionType::get(const ASTContext &C,
@@ -4055,29 +4054,29 @@ Type ProtocolCompositionType::get(const ASTContext &C,
     if (!t->isCanonical())
       return build(C, Members, Inverses, HasExplicitAnyObject);
   }
-    
+
   Type Superclass;
   SmallVector<ProtocolDecl *, 4> Protocols;
   ParameterizedProtocolMap Parameterized;
   for (Type t : Members) {
-    addProtocols(t, Protocols, Parameterized, Superclass, HasExplicitAnyObject);
+    addProtocols(t, Protocols, Parameterized, Superclass,
+                 Inverses, HasExplicitAnyObject);
   }
-
-  // The presence of a superclass constraint makes AnyObject redundant.
-  if (Superclass)
-    HasExplicitAnyObject = false;
-
-  // If there are any parameterized protocols, the canonicalization
-  // algorithm gets more complex.
 
   // Form the set of canonical component types.
   SmallVector<Type, 4> CanTypes;
-  if (Superclass)
-    CanTypes.push_back(Superclass->getCanonicalType());
 
+  // The presence of a superclass constraint makes AnyObject redundant.
+  if (Superclass) {
+    HasExplicitAnyObject = false;
+    CanTypes.push_back(Superclass->getCanonicalType());
+  }
+
+  // If there are any parameterized protocols, the canonicalization
+  // algorithm gets more complex.
   canonicalizeProtocols(Protocols, &Parameterized);
 
-  for (auto proto: Protocols) {
+  for (auto proto : Protocols) {
     // If we have a parameterized type for this protocol, use the
     // canonical type of that.  Sema should prevent us from building
     // compositions with the same protocol and conflicting constraints.
@@ -5346,6 +5345,7 @@ case TypeKind::Id:
     
     return ProtocolCompositionType::get(Ptr->getASTContext(),
                                         substMembers,
+                                        pc->getInverses(),
                                         pc->hasExplicitAnyObject());
   }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3727,9 +3727,8 @@ Type ArchetypeType::getExistentialType() const {
   auto interfaceType = getInterfaceType();
   auto genericSig = genericEnv->getGenericSignature();
 
-  auto upperBound = genericSig->getUpperBound(interfaceType);
-
-  return genericEnv->mapTypeIntoContext(upperBound);
+  auto existentialType = genericSig->getExistentialType(interfaceType);
+  return genericEnv->mapTypeIntoContext(existentialType);
 }
 
 bool ArchetypeType::requiresClass() const {

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -404,7 +404,8 @@ CanType TypeJoin::computeProtocolCompositionJoin(ArrayRef<Type> firstMembers,
     return TheAnyType;
 
   auto &ctx = result[0]->getASTContext();
-  return ProtocolCompositionType::get(ctx, result, false)->getCanonicalType();
+  return ProtocolCompositionType::get(ctx, result, /*inverses=*/{},
+                                      false)->getCanonicalType();
 }
 
 CanType TypeJoin::visitProtocolCompositionType(CanType second) {
@@ -431,8 +432,12 @@ CanType TypeJoin::visitProtocolCompositionType(CanType second) {
     protocolType.push_back(First);
     firstMembers = protocolType;
   } else {
+    assert(cast<ProtocolCompositionType>(First)->getInverses().empty() &&
+           "FIXME: move-only generics");
     firstMembers = cast<ProtocolCompositionType>(First)->getMembers();
   }
+  assert(cast<ProtocolCompositionType>(second)->getInverses().empty() &&
+         "FIXME: move-only generics");
   auto secondMembers = cast<ProtocolCompositionType>(second)->getMembers();
 
   return computeProtocolCompositionJoin(firstMembers, secondMembers);

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1243,6 +1243,7 @@ namespace {
 
         importedType = ExistentialType::get(
             ProtocolCompositionType::get(Impl.SwiftContext, members,
+                                         /*Inverses=*/{},
                                          /*HasExplicitAnyObject=*/false));
       }
 

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -652,6 +652,9 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
     Invocation.getLangOptions().enableFeature(
         Feature::OldOwnershipOperatorSpellings);
   }
+  if (SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS)
+    Invocation.getLangOptions().enableFeature(Feature::NoncopyableGenerics);
+
   Invocation.getLangOptions().BypassResilienceChecks =
       options.BypassResilienceChecks;
   Invocation.getDiagnosticOptions().PrintDiagnosticNames =

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1521,6 +1521,7 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
     Opts.DeferToRuntime = true;
 
   Opts.DebugGenericSignatures |= Args.hasArg(OPT_debug_generic_signatures);
+  Opts.DebugInverseRequirements |= Args.hasArg(OPT_debug_inverse_requirements);
 
   Opts.EnableLazyTypecheck |= Args.hasArg(OPT_experimental_lazy_typecheck);
   Opts.EnableLazyTypecheck |=

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -383,10 +383,16 @@ private:
           printMembers(SD->getMembers());
           for (const auto *ed :
                owningPrinter.interopContext.getExtensionsForNominalType(SD)) {
-            auto sign = ed->getGenericSignature();
-            // FIXME: support requirements.
-            if (!sign.getRequirements().empty())
-              continue;
+            SmallVector<Requirement, 2> reqs;
+            SmallVector<InverseRequirement, 2> inverseReqs;
+            if (auto sig = ed->getGenericSignature()) {
+              sig->getRequirementsWithInverses(reqs, inverseReqs);
+              assert(inverseReqs.empty() &&
+                     "Non-copyable generics not supported here!");
+              // FIXME: support requirements.
+              if (!reqs.empty())
+                continue;
+            }
             printMembers(ed->getMembers());
           }
         },

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -700,9 +700,14 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
   }
   if (FD->isGeneric()) {
     auto Signature = FD->getGenericSignature().getCanonicalSignature();
-    auto Requirements = Signature.getRequirements();
+
     // FIXME: Support generic requirements.
-    if (!Requirements.empty())
+    SmallVector<Requirement, 2> reqs;
+    SmallVector<InverseRequirement, 2> inverseReqs;
+    Signature->getRequirementsWithInverses(reqs, inverseReqs);
+    assert(inverseReqs.empty() && "Non-copyable generics not supported here!");
+
+    if (!reqs.empty())
       return ClangRepresentation::unsupported;
     // Print the template and requires clauses for this function.
     if (kind == FunctionSignatureKind::CxxInlineThunk)

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2464,9 +2464,11 @@ public:
   void visitOpenPackElementInst(OpenPackElementInst *OPEI) {
     auto env = OPEI->getOpenedGenericEnvironment();
     auto subs = env->getPackElementContextSubstitutions();
-    *this << Ctx.getID(OPEI->getIndexOperand())
-          << " of " << subs.getGenericSignature()
-          << " at ";
+    *this << Ctx.getID(OPEI->getIndexOperand()) << " of ";
+    PrintOptions Opts;
+    Opts.PrintInverseRequirements = true;
+    subs.getGenericSignature().print(PrintState.OS, Opts);
+    *this << " at ";
     printSubstitutions(subs);
     // The shape class in the opened environment is a canonical interface
     // type, which won't resolve in the generic signature we just printed.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -593,7 +593,7 @@ static Type getKeyPathType(ASTContext &ctx, KeyPathCapability capability,
     auto *sendable = ctx.getProtocol(KnownProtocolKind::Sendable);
     keyPathTy = ProtocolCompositionType::get(
         ctx, {keyPathTy, sendable->getDeclaredInterfaceType()},
-        /*hasExplicitAnyObject=*/false);
+        /*inverses=*/{}, /*hasExplicitAnyObject=*/false);
     return ExistentialType::get(keyPathTy);
   }
 
@@ -2203,6 +2203,7 @@ static Type getOptionalSuperclass(Type type) {
 
       superclass = ExistentialType::get(
           ProtocolCompositionType::get(type->getASTContext(), members,
+                                       compositionTy->getInverses(),
                                        compositionTy->hasExplicitAnyObject()));
     } else {
       // Avoid producing superclass for situations like `any P` where `P` is

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2343,7 +2343,7 @@ static Type typeEraseExistentialSelfReferences(Type refTy, Type baseTy,
       if (paramTy->is<GenericTypeParamType>()) {
         erasedTy = baseTy;
       } else {
-        erasedTy = existentialSig->getUpperBound(paramTy);
+        erasedTy = existentialSig->getExistentialType(paramTy);
       }
 
       if (metatypeDepth) {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2043,39 +2043,26 @@ bool TypeChecker::getDefaultGenericArgumentsString(
       return;
     }
 
-    auto contextTy = typeDecl->mapTypeIntoContext(genericParamTy);
-    if (auto archetypeTy = contextTy->getAs<ArchetypeType>()) {
-      SmallVector<Type, 2> members;
+    auto genericSig = typeDecl->getGenericSignature();
 
-      bool hasExplicitAnyObject = archetypeTy->requiresClass();
-      if (auto superclass = archetypeTy->getSuperclass()) {
-        hasExplicitAnyObject = false;
-        members.push_back(superclass);
-      }
-
-      for (auto proto : archetypeTy->getConformsTo()) {
-        members.push_back(proto->getDeclaredInterfaceType());
-        if (proto->requiresClass())
-          hasExplicitAnyObject = false;
-      }
-
-      if (hasExplicitAnyObject)
-        members.push_back(typeDecl->getASTContext().getAnyObjectConstraint());
-
-      auto type = ProtocolCompositionType::get(typeDecl->getASTContext(),
-                                               members, hasExplicitAnyObject);
-
-      if (type->isObjCExistentialType() || type->isAny()) {
-        genericParamText << type;
-        return;
-      }
-
-      genericParamText << "<#" << genericParam->getName() << ": ";
-      genericParamText << type << "#>";
+    auto concreteTy = genericSig->getConcreteType(genericParamTy);
+    if (concreteTy) {
+      genericParamText << concreteTy;
       return;
     }
 
-    genericParamText << contextTy;
+    auto upperBound = genericSig->getUpperBound(
+        genericParamTy,
+        /*forExistentialSelf=*/false,
+        /*withParameterizedProtocols=*/false);
+
+    if (upperBound->isObjCExistentialType() || upperBound->isAny()) {
+      genericParamText << upperBound;
+      return;
+    }
+
+    genericParamText << "<#" << genericParam->getName() << ": ";
+    genericParamText << upperBound << "#>";
   };
 
   llvm::interleave(typeDecl->getInnermostGenericParamTypes(),

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2078,7 +2078,7 @@ static void dumpGenericSignature(ASTContext &ctx, GenericContext *GC) {
       PrintOptions Opts;
       Opts.ProtocolQualifiedDependentMemberTypes = true;
       Opts.PrintInverseRequirements =
-          ctx.TypeCheckerOpts.DebugInverseRequirements;
+          !ctx.TypeCheckerOpts.DebugInverseRequirements;
       sig->print(llvm::errs(), Opts);
       llvm::errs() << "\n";
       llvm::errs() << "Canonical generic signature: ";
@@ -3456,7 +3456,7 @@ public:
       PrintOptions Opts;
       Opts.ProtocolQualifiedDependentMemberTypes = true;
       Opts.PrintInverseRequirements =
-          Ctx.TypeCheckerOpts.DebugInverseRequirements;
+          !Ctx.TypeCheckerOpts.DebugInverseRequirements;
       sig.print(PD, llvm::errs(), Opts);
       llvm::errs() << "\n";
     }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4426,6 +4426,9 @@ int main(int argc, char *argv[]) {
     InitInvok.getLangOptions().EnableExperimentalStringProcessing = true;
   }
 
+  if (SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS)
+    InitInvok.getLangOptions().enableFeature(Feature::NoncopyableGenerics);
+
   if (!options::Triple.empty())
     InitInvok.setTargetTriple(options::Triple);
   if (!options::SwiftVersion.empty()) {


### PR DESCRIPTION
This fixes some validation test failures when non-copyable generics are enabled. Should be NFC otherwise.