### PR TITLE
[5.10][stdlib] Define OS version numbers for SwiftStdlib 5.10

### DIFF
--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -34,7 +34,7 @@ SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
 SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0
 SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
 SwiftStdlib 5.9:macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0
-SwiftStdlib 5.10:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+SwiftStdlib 5.10:macOS 14.4, iOS 17.4, watchOS 10.4, tvOS 17.4
 # TODO: Also update ASTContext::getSwift510Availability when needed
 
 # Local Variables:


### PR DESCRIPTION
(cherry picked from https://github.com/apple/swift/pull/71297)

Explanation: Routine prerelease task that publicly defines the OS versions that we expect will ship the Swift 5.10 Standard Library. These are used for availability declarations & conditions. (5.10 does not currently have any new declarations with `SwiftStdlib 5.10`, but there are two behavioral tests for the stdlib that are conditional on 5.10 availability.)
Scope: CMake & lit compiler invocations (textual change to an existing command-line argument), two test cases in the Stdlib test suite.
Issue: n.a.
Risk: Minimal. The `SwiftStdlib 5.10` macro is only used in two tests; setting the versions will have the side effect of temporarily disabling those tests on ci.swift.org until executors get updated to matching OS versions.
Testing: Routine PR testing
Reviewer: @Azoy @tshortli @stephentyrone 
