### PR TITLE
[5.10][Sema] Exempt some imports from the warning on ioi use from non-resilient module

### DIFF
--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -796,16 +796,29 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
   if (topLevelModule.get() == ctx.TheBuiltinModule)
     return;
 
+  Identifier importerName = SF.getParentModule()->getName(),
+             targetName = topLevelModule.get()->getName();
+
   // @_implementationOnly is only supported when used from modules built with
   // library-evolution. Otherwise it can lead to runtime crashes from a lack
   // of memory layout information when building clients unaware of the
   // dependency. The missing information is provided at run time by resilient
   // modules.
+  // We exempt some imports using @_implementationOnly in a safe way from
+  // packages that cannot be resilient.
   if (import.options.contains(ImportFlags::ImplementationOnly) &&
-      !SF.getParentModule()->isResilient() && topLevelModule) {
+      !SF.getParentModule()->isResilient() && topLevelModule &&
+      !(((targetName.str() == "CCryptoBoringSSL" ||
+          targetName.str() == "CCryptoBoringSSLShims") &&
+         (importerName.str() == "Crypto" ||
+          importerName.str() == "_CryptoExtras" ||
+          importerName.str() == "CryptoBoringWrapper")) ||
+        ((targetName.str() == "CNIOBoringSSL" ||
+          targetName.str() == "CNIOBoringSSLShims") &&
+         importerName.str() == "NIOSSL"))) {
     ctx.Diags.diagnose(import.importLoc,
                        diag::implementation_only_requires_library_evolution,
-                       SF.getParentModule()->getName());
+                       importerName);
   }
 
   if (import.options.contains(ImportFlags::ImplementationOnly) ||
@@ -818,8 +831,7 @@ void UnboundImport::validateResilience(NullablePtr<ModuleDecl> topLevelModule,
 
   auto inFlight = ctx.Diags.diagnose(import.module.getModulePath().front().Loc,
                                      diag::module_not_compiled_with_library_evolution,
-                                     topLevelModule.get()->getName(),
-                                     SF.getParentModule()->getName());
+                                     targetName, importerName);
 
   if (ctx.LangOpts.hasFeature(Feature::AccessLevelOnImport)) {
     SourceLoc attrLoc = import.accessLevelLoc;

--- a/test/Sema/implementation-only-import-from-non-resilient.swift
+++ b/test/Sema/implementation-only-import-from-non-resilient.swift
@@ -12,6 +12,13 @@
 // RUN: %target-swift-frontend -typecheck %t/client-resilient.swift -I %t -verify \
 // RUN:   -enable-library-evolution -swift-version 5
 
+/// Some imports are exempt.
+// RUN: %target-swift-frontend -emit-module %t/empty.swift \
+// RUN:   -o %t/CCryptoBoringSSL.swiftmodule \
+// RUN:   -enable-library-evolution -swift-version 5
+// RUN: %target-swift-frontend -typecheck %t/Crypto.swift -I %t -verify \
+// RUN:   -module-name Crypto
+
 //--- empty.swift
 
 //--- client-non-resilient.swift
@@ -21,3 +28,8 @@ import B
 //--- client-resilient.swift
 @_implementationOnly import A
 import B
+
+//--- Crypto.swift
+@_implementationOnly import A // expected-warning {{using '@_implementationOnly' without enabling library evolution for 'Crypto' may lead to instability during execution}}
+import B
+@_implementationOnly import CCryptoBoringSSL


### PR DESCRIPTION
Silence the warning about using implementation-only import from non-resilient modules for a few specific set of import edges. These uses have been verified as working and using these modules is more reliable than building one's own solution.

Risk: Low, it only affects a warning.
Scope: 4 modules are affected.

Cherry-pick of #70850