### PR TITLE
GenericCloner: make sure that we can always specialize in mandatory mode

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/ModulePassContext.swift
@@ -131,7 +131,7 @@ struct ModulePassContext : Context, CustomStringConvertible {
     return function.isDefinition
   }
 
-  func createSpecializedFunctionDeclaration(
+  func createEmptyFunction(
     name: String,
     parameters: [ParameterInfo],
     hasSelfParameter: Bool,
@@ -140,8 +140,8 @@ struct ModulePassContext : Context, CustomStringConvertible {
     return name._withBridgedStringRef { nameRef in
       let bridgedParamInfos = parameters.map { $0._bridged }
       return bridgedParamInfos.withUnsafeBufferPointer { paramBuf in
-        _bridged.createSpecializedFunction(nameRef, paramBuf.baseAddress, paramBuf.count,
-                                           hasSelfParameter, originalFunction.bridged).function
+        _bridged.createEmptyFunction(nameRef, paramBuf.baseAddress, paramBuf.count,
+                                     hasSelfParameter, originalFunction.bridged).function
       }
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/FunctionSignatureTransforms.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/FunctionSignatureTransforms.swift
@@ -82,7 +82,7 @@ private func createSpecializedFunction(
 ) -> Function {
   let (aliveParameters, hasSelfParameter) = getAliveParameters(of: originalFunction)
 
-  let specializedFunction = context.createSpecializedFunctionDeclaration(
+  let specializedFunction = context.createEmptyFunction(
     name: name,
     parameters: aliveParameters,
     hasSelfParameter: hasSelfParameter,

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -286,11 +286,11 @@ struct BridgedPassContext {
   SWIFT_IMPORT_UNSAFE OptionalBridgedFunction lookUpNominalDeinitFunction(BridgedNominalTypeDecl nominal) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap getContextSubstitutionMap(BridgedType type) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getBuiltinIntegerType(SwiftInt bitWidth) const;
-  SWIFT_IMPORT_UNSAFE BridgedFunction createSpecializedFunction(BridgedStringRef name,
-                                                                const BridgedParameterInfo * _Nullable bridgedParams,
-                                                                SwiftInt paramCount,
-                                                                bool hasSelfParam,
-                                                                BridgedFunction fromFunc) const;
+  SWIFT_IMPORT_UNSAFE BridgedFunction createEmptyFunction(BridgedStringRef name,
+                                                          const BridgedParameterInfo * _Nullable bridgedParams,
+                                                          SwiftInt paramCount,
+                                                          bool hasSelfParam,
+                                                          BridgedFunction fromFunc) const;
   void moveFunctionBody(BridgedFunction sourceFunc, BridgedFunction destFunc) const;
 
   // Passmanager housekeeping

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1731,11 +1731,11 @@ bool BridgedPassContext::enableSimplificationFor(BridgedInstruction inst) const 
 }
 
 BridgedFunction BridgedPassContext::
-createSpecializedFunction(BridgedStringRef name,
-                          const BridgedParameterInfo * _Nullable bridgedParams,
-                          SwiftInt paramCount,
-                          bool hasSelfParam,
-                          BridgedFunction fromFunc) const {
+createEmptyFunction(BridgedStringRef name,
+                    const BridgedParameterInfo * _Nullable bridgedParams,
+                    SwiftInt paramCount,
+                    bool hasSelfParam,
+                    BridgedFunction fromFunc) const {
   swift::SILModule *mod = invocation->getPassManager()->getModule();
   SILFunction *fromFn = fromFunc.getFunction();
 
@@ -1761,7 +1761,7 @@ createSpecializedFunction(BridgedStringRef name,
   SILOptFunctionBuilder functionBuilder(*invocation->getTransform());
 
   SILFunction *newF = functionBuilder.createFunction(
-    SILLinkage::Shared, name.unbridged(), newTy, nullptr, fromFn->getLocation(), fromFn->isBare(),
+    fromFn->getLinkage(), name.unbridged(), newTy, nullptr, fromFn->getLocation(), fromFn->isBare(),
     fromFn->isTransparent(), fromFn->isSerialized(), IsNotDynamic, IsNotDistributed,
     IsNotRuntimeAccessible, fromFn->getEntryCount(), fromFn->isThunk(),
     fromFn->getClassSubclassScope(), fromFn->getInlineStrategy(), fromFn->getEffectsKind(),

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -32,8 +32,6 @@ using namespace swift;
 SILFunction *GenericCloner::createDeclaration(
     SILOptFunctionBuilder &FunctionBuilder, SILFunction *Orig,
     const ReabstractionInfo &ReInfo, StringRef NewName) {
-  assert((!ReInfo.isSerialized() || Orig->isSerialized())
-         && "Specialization cannot make body more resilient");
   assert((Orig->isTransparent() || Orig->isBare() || Orig->getLocation())
          && "SILFunction missing location");
   assert((Orig->isTransparent() || Orig->isBare() || Orig->getDebugScope())

--- a/test/SILOptimizer/mandatory_performance_optimizations.sil
+++ b/test/SILOptimizer/mandatory_performance_optimizations.sil
@@ -256,14 +256,14 @@ bb0(%0 : $Int, %1 : $@thick Int.Type, %2 : @owned $Builtin.NativeObject):
   return %2 : $Builtin.NativeObject
 }
 
-// CHECK-LABEL: sil shared [ossa] @$s12metatype_argTf4dnn_n : $@convention(thin) (Int, @owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
+// CHECK-LABEL: sil [ossa] @$s12metatype_argTf4dnn_n : $@convention(thin) (Int, @owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 // CHECK:       bb0(%0 : $Int, %1 : @owned $Builtin.NativeObject):
 // CHECK:         %2 = metatype $@thick Int.Type
 // CHECK:         fix_lifetime %2 : $@thick Int.Type
 // CHECK:         return %1 : $Builtin.NativeObject
 // CHECK:       } // end sil function '$s12metatype_argTf4dnn_n'
 
-// CHECK-LABEL: sil shared [ossa] @$s19metatype_arg_throwsTf4dnn_n : $@convention(thin) (Int, @owned Builtin.NativeObject) -> (@owned Builtin.NativeObject, @error any Error) {
+// CHECK-LABEL: sil [ossa] @$s19metatype_arg_throwsTf4dnn_n : $@convention(thin) (Int, @owned Builtin.NativeObject) -> (@owned Builtin.NativeObject, @error any Error) {
 // CHECK:       bb0(%0 : $Int, %1 : @owned $Builtin.NativeObject):
 // CHECK:         %2 = metatype $@thick Int.Type
 // CHECK:         fix_lifetime %2 : $@thick Int.Type

--- a/test/embedded/default-arguments.swift
+++ b/test/embedded/default-arguments.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded -o /dev/null
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: VENDOR=apple
+// REQUIRES: OS=macosx
+
+// Check that this doesn't crash the compiler in embedded mode.
+
+public func foo<T>(_ t: T) -> T {
+  t
+}
+
+public func testit(_ x: Int = foo(27)) -> Int {
+  x
+}
+
+public func callit() -> Int {
+  testit()
+}


### PR DESCRIPTION
This may involve changing the linkage of the specialized function.
If called from a serialized function we cannot make the specialized function shared and non-serialized.
The only other option is to keep the original function's linkage.

Fixes a crash in embedded mode.

rdar://121675461