### PR TITLE
utils: adjust CMake flags for debug info handling

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -581,7 +581,8 @@ function Build-CMakeProject {
         $UseBuiltCompilers.Contains("C") -Or $UseBuiltCompilers.Contains("CXX") -Or
         $UsePinnedCompilers.Contains("C") -Or $UsePinnedCompilers.Contains("CXX")) {
       if ($DebugInfo) {
-        $CFlags += if ($EnableCaching) { "/Z7" } else { "/Zi" }
+        Append-FlagsDefine $Defines CMAKE_MSVC_DEBUG_INFORMATION_FORMAT Embedded
+        Append-FlagsDefine $Defines CMAKE_POLICY_CMP0141 NEW
         # Add additional linker flags for generating the debug info.
         Append-FlagsDefine $Defines CMAKE_SHARED_LINKER_FLAGS "/debug"
         Append-FlagsDefine $Defines CMAKE_EXE_LINKER_FLAGS "/debug"


### PR DESCRIPTION
Use the new CMake options for controlling debug information generation. This matches the recommendations from sccache and avoids us trying to map flags manually.