### PR TITLE
[ClangImporter] Support lazy member loading for import-as-member globals in extensions

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1277,6 +1277,10 @@ public:
   /// Add the given members to the lookup table.
   void addMembers(DeclRange members);
 
+  /// Add the members of the extension to the lookup table, if necessary
+  /// registering it for future lazy member loading.
+  void addExtension(ExtensionDecl *ext);
+
   void addExtensionWithLazyMembers(ExtensionDecl *ext) {
     ExtensionsWithLazyMembers.push_back(ext);
   }
@@ -1467,6 +1471,26 @@ void MemberLookupTable::addMembers(DeclRange members) {
   }
 }
 
+void MemberLookupTable::addExtension(ExtensionDecl *ext) {
+  // If we can lazy-load this extension, only take the members we've loaded
+  // so far.
+  //
+  // FIXME: This should be 'e->hasLazyMembers()' but that crashes` because
+  // some imported extensions don't have a Clang node, and only support
+  // LazyMemberLoader::loadAllMembers() and not
+  // LazyMemberLoader::loadNamedMembers().
+  if (ext->wasDeserialized() || ext->hasClangNode()) {
+    addMembers(ext->getCurrentMembersWithoutLoading());
+    clearLazilyCompleteCache();
+    clearLazilyCompleteForMacroExpansionCache();
+    addExtensionWithLazyMembers(ext);
+  } else {
+    // Else, load all the members into the table.
+    addMembers(ext->getMembers());
+  }
+  addContainerWithMacroExpansions(ext);
+}
+
 void NominalTypeDecl::addedExtension(ExtensionDecl *ext) {
   if (!LookupTable.getInt())
     return;
@@ -1474,16 +1498,7 @@ void NominalTypeDecl::addedExtension(ExtensionDecl *ext) {
   auto *table = LookupTable.getPointer();
   assert(table);
 
-  if (ext->wasDeserialized() || ext->hasClangNode()) {
-    table->addMembers(ext->getCurrentMembersWithoutLoading());
-    table->clearLazilyCompleteCache();
-    table->clearLazilyCompleteForMacroExpansionCache();
-    table->addExtensionWithLazyMembers(ext);
-  } else {
-    table->addMembers(ext->getMembers());
-  }
-
-  table->addContainerWithMacroExpansions(ext);
+  table->addExtension(ext);
 }
 
 void NominalTypeDecl::addedMember(Decl *member) {
@@ -1952,21 +1967,7 @@ void NominalTypeDecl::prepareLookupTable() {
 
   // Note: this calls prepareExtensions()
   for (auto e : getExtensions()) {
-    // If we can lazy-load this extension, only take the members we've loaded
-    // so far.
-    //
-    // FIXME: This should be 'e->hasLazyMembers()' but that crashes` because
-    // some imported extensions don't have a Clang node, and only support
-    // LazyMemberLoader::loadAllMembers() and not
-    // LazyMemberLoader::loadNamedMembers().
-    if (e->wasDeserialized() || e->hasClangNode()) {
-      table->addMembers(e->getCurrentMembersWithoutLoading());
-      table->addExtensionWithLazyMembers(e);
-      continue;
-    }
-
-    // Else, load all the members into the table.
-    table->addMembers(e->getMembers());
+    table->addExtension(e);
   }
 
   // Any extensions added after this point will add their members to the

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1474,12 +1474,7 @@ void MemberLookupTable::addMembers(DeclRange members) {
 void MemberLookupTable::addExtension(ExtensionDecl *ext) {
   // If we can lazy-load this extension, only take the members we've loaded
   // so far.
-  //
-  // FIXME: This should be 'e->hasLazyMembers()' but that crashes` because
-  // some imported extensions don't have a Clang node, and only support
-  // LazyMemberLoader::loadAllMembers() and not
-  // LazyMemberLoader::loadNamedMembers().
-  if (ext->wasDeserialized() || ext->hasClangNode()) {
+  if (ext->hasLazyMembers()) {
     addMembers(ext->getCurrentMembersWithoutLoading());
     clearLazilyCompleteCache();
     clearLazilyCompleteForMacroExpansionCache();
@@ -1618,8 +1613,6 @@ populateLookupTableEntryFromExtensions(ASTContext &ctx,
       continue;
     }
 
-    assert(e->wasDeserialized() || e->hasClangNode() &&
-           "Extension without deserializable content has lazy members!");
     assert(!e->hasUnparsedMembers());
 
     populateLookupTableEntryFromLazyIDCLoader(ctx, table, name, e);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6281,7 +6281,7 @@ ClangImporter::Implementation::loadNamedMembers(
     if (member->getDeclContext() != CDC) continue;
 
     SmallVector<Decl*, 4> tmp;
-    insertMembersAndAlternates(member, tmp);
+    insertMembersAndAlternates(member, tmp, DC);
     for (auto *TD : tmp) {
       if (auto *V = dyn_cast<ValueDecl>(TD)) {
         // Skip ValueDecls if they import under different names.
@@ -6313,7 +6313,7 @@ ClangImporter::Implementation::loadNamedMembers(
     if (member->getDeclContext() != CDC) continue;
 
     SmallVector<Decl*, 4> tmp;
-    insertMembersAndAlternates(member, tmp);
+    insertMembersAndAlternates(member, tmp, DC);
     for (auto *TD : tmp) {
       if (auto *V = dyn_cast<ValueDecl>(TD)) {
         // Skip ValueDecls if they import under different names.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1621,7 +1621,8 @@ private:
                            Decl *D, DeclContext *DC,
                            SmallVectorImpl<Decl *> &members);
   void insertMembersAndAlternates(const clang::NamedDecl *nd,
-                                  SmallVectorImpl<Decl *> &members);
+                                  SmallVectorImpl<Decl *> &members,
+                                  DeclContext *expectedDC = nullptr);
   void loadAllMembersIntoExtension(Decl *D, uint64_t extra);
 
   /// Imports \p decl under \p nameVersion with the name \p newName, and adds


### PR DESCRIPTION
In #71027, I addressed a cycle that could occur when loading import-as-member globals into an extension. However, that fix was minimal—it simply broke the cycle after it occurred. This PR is a more comprehensive fix that eliminates the cycle entirely by making import-as-member importing lazier.

The cycle was caused by the compiler forcing the extension to load its members immediately; it did that because the selective lazy member loading path (the `loadNamedMembers()` method) would crash for these specific extensions because they didn't have a clang node. This PR modifies `loadNamedMembers()` to work correctly, using the context parameter (instead of the absent clang node) to determine the submodule and skipping over lookup for the clang node's members. That allows us to modify name lookup to avoid forcing import-as-members extensions early. In addition to simplifying lazy member loader use sites, I expect this to reduce the number of members imported by ClangImporter, especially in code that uses `NSNotification.Name`, which uses this mechanism for a *massive* number of members.

The first commit also refactors the two code paths that add extension members to the member lookup table so that they share most of their code. It appears to be very difficult to write tests that are guaranteed to hit both of these, so in lieu of doing that, we can at least combine them to increase our confidence that both will work even if only one has been tested. This commit fixes rdar://121479725.