### PR TITLE
tools: demote swift-refactor to testing

### DIFF
--- a/tools/swift-refactor/CMakeLists.txt
+++ b/tools/swift-refactor/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_swift_host_tool(swift-refactor
   swift-refactor.cpp
-  SWIFT_COMPONENT tools
+  SWIFT_COMPONENT testsuite-tools
   LLVM_LINK_COMPONENTS support
 )
 target_link_libraries(swift-refactor


### PR DESCRIPTION
This is not currently shipped with the toolchain and is meant for testing purposes. Mark the component as testing-tools.