### PR TITLE
NCGenerics: bifurcate the NoncopyableGenerics flag

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7583,6 +7583,9 @@ WARNING(redundant_inverse_constraint,none,
 ERROR(inverse_on_class, none,
       "classes cannot be '~%0'",
       (StringRef))
+ERROR(inverse_without_matching_stdlib, none,
+      "cannot use '~%0' here without a stdlib built with NoncopyableGenerics",
+      (StringRef))
 ERROR(inverse_with_class_constraint, none,
       "composition involving %select{class requirement %2|'AnyObject'}0 "
       "cannot contain '~%1'",

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -559,6 +559,13 @@ namespace swift {
     /// Enable implicit lifetime dependence for ~Escapable return types.
     bool EnableExperimentalLifetimeDependenceInference = false;
 
+    /// Whether this compiler makes the assumption NoncopyableGenerics exist.
+    /// This influences whether other modules need to be rebuilt from their
+    /// interface and whether generic parameters automatically get Copyable
+    /// conformances, etc.
+    bool AssumesNoncopyableGenerics =
+        SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS;
+
     /// Enables dumping type witness systems from associated type inference.
     bool DumpTypeWitnessSystems = false;
 

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -495,7 +495,7 @@ public:
   RequireNoncopyableGenerics_t(const ASTContext &ctx)
     : RequireNoncopyableGenerics_t(ctx.LangOpts) {}
   RequireNoncopyableGenerics_t(const LangOptions &opts)
-      : value(opts.hasFeature(Feature::NoncopyableGenerics)) {}
+      : value(opts.AssumesNoncopyableGenerics) {}
 
   explicit operator bool() const { return value; }
 };

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -164,11 +164,6 @@ public:
   // Note: This doesn't affect anything in non-SWIFT_BUILD_SWIFT_SYNTAX envs.
   bool IsForASTGen = false;
 
-  // A cached answer to
-  //     Context.LangOpts.hasFeature(Feature::NoncopyableGenerics)
-  // to ensure there's no parsing performance regression.
-  bool EnabledNoncopyableGenerics;
-
   /// Whether we should delay parsing nominal type, extension, and function
   /// bodies.
   bool isDelayedParsingEnabled() const;
@@ -1286,13 +1281,9 @@ public:
   ///
   /// \param allowClassRequirement whether to permit parsing of 'class'
   /// \param allowAnyObject whether to permit parsing of 'AnyObject'
-  /// \param parseTildeCopyable if non-null, permits parsing of `~Copyable`
-  ///   and writes out a valid source location if it was parsed. If null, then a
-  ///   parsing error will be emitted upon the appearance of `~` in the clause.
   ParserStatus parseInheritance(SmallVectorImpl<InheritedEntry> &Inherited,
                                 bool allowClassRequirement,
-                                bool allowAnyObject,
-                                SourceLoc *parseTildeCopyable = nullptr);
+                                bool allowAnyObject);
   ParserStatus parseDeclItem(bool &PreviousHadSemi,
                              llvm::function_ref<void(Decl *)> handler);
   std::pair<std::vector<Decl *>, llvm::Optional<Fingerprint>>

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6517,6 +6517,8 @@ Type ASTContext::getNamedSwiftType(ModuleDecl *module, StringRef name) {
 }
 
 bool ASTContext::supportsMoveOnlyTypes() const {
+  assert(!LangOpts.hasFeature(Feature::NoncopyableGenerics) ||
+          LangOpts.AssumesNoncopyableGenerics);
   // currently the only thing holding back whether the types can appear is this.
   return SILOpts.LexicalLifetimes != LexicalLifetimesOption::Off;
 }

--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -69,7 +69,7 @@ ModuleDecl::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
     return ProtocolConformanceRef::forInvalid();
 
   if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)
-      && !ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+      && !ctx.LangOpts.AssumesNoncopyableGenerics) {
     // Prior to noncopyable generics, all existentials conform to Copyable.
         return ProtocolConformanceRef(
             ctx.getBuiltinConformance(type, protocol,
@@ -357,7 +357,7 @@ static ProtocolConformanceRef getBuiltinMetaTypeTypeConformance(
     Type type, const AnyMetatypeType *metatypeType, ProtocolDecl *protocol) {
   ASTContext &ctx = protocol->getASTContext();
 
-  if (!ctx.LangOpts.hasFeature(swift::Feature::NoncopyableGenerics) &&
+  if (!ctx.LangOpts.AssumesNoncopyableGenerics &&
       protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
     // Only metatypes of Copyable types are Copyable.
     if (metatypeType->getInstanceType()->isNoncopyable()) {
@@ -468,7 +468,7 @@ LookupConformanceInModuleRequest::evaluate(
   if (auto archetype = type->getAs<ArchetypeType>()) {
 
     // Without noncopyable generics, all archetypes are Copyable
-    if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics))
+    if (!ctx.LangOpts.AssumesNoncopyableGenerics)
       if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable))
         return ProtocolConformanceRef(protocol);
 
@@ -614,7 +614,7 @@ LookupConformanceInModuleRequest::evaluate(
                || protocol->isSpecificProtocol(KnownProtocolKind::Escapable)) {
       const auto kp = protocol->getKnownProtocolKind().value();
 
-      if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)
+      if (!ctx.LangOpts.AssumesNoncopyableGenerics
           && kp == KnownProtocolKind::Copyable) {
         // Return an abstract conformance to maintain legacy compatability.
         // We only need to do this until we are properly dealing with or

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4921,7 +4921,7 @@ conformanceExists(TypeDecl const *decl, InvertibleProtocolKind ip) {
 }
 
 TypeDecl::CanBeInvertible::Result TypeDecl::canBeCopyable() const {
-  if (!getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (!getASTContext().LangOpts.AssumesNoncopyableGenerics) {
     auto copyable = getMarking(InvertibleProtocolKind::Copyable);
     return !copyable.getInverse() || bool(copyable.getPositive())
          ? CanBeInvertible::Always
@@ -4932,7 +4932,7 @@ TypeDecl::CanBeInvertible::Result TypeDecl::canBeCopyable() const {
 }
 
 TypeDecl::CanBeInvertible::Result TypeDecl::canBeEscapable() const {
-  if (!getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (!getASTContext().LangOpts.AssumesNoncopyableGenerics) {
     auto escapable = getMarking(InvertibleProtocolKind::Escapable);
     return !escapable.getInverse() || bool(escapable.getPositive())
          ? CanBeInvertible::Always

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1252,8 +1252,7 @@ void GenericSignatureImpl::getRequirementsWithInverses(
     SmallVector<InverseRequirement, 2> &inverses) const {
   auto &ctx = getASTContext();
 
-  if (!SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS &&
-      !ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (!ctx.LangOpts.AssumesNoncopyableGenerics) {
     reqs.append(getRequirements().begin(), getRequirements().end());
     return;
   }
@@ -1296,7 +1295,7 @@ void RequirementSignature::getRequirementsWithInverses(
     SmallVector<InverseRequirement, 2> &inverses) const {
   auto &ctx = owner->getASTContext();
 
-  if (!SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS &&
+  if (!ctx.LangOpts.AssumesNoncopyableGenerics &&
       !ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
     reqs.append(getRequirements().begin(), getRequirements().end());
     return;

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1077,7 +1077,7 @@ void NominalTypeDecl::prepareConformanceTable() const {
 
   SmallPtrSet<ProtocolDecl *, 2> protocols;
   const bool haveNoncopyableGenerics =
-      ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics);
+      ctx.LangOpts.AssumesNoncopyableGenerics;
 
   auto addSynthesized = [&](ProtocolDecl *proto) {
     if (!proto)
@@ -1281,8 +1281,7 @@ static SmallVector<ProtocolConformance *, 2> findSynthesizedConformances(
 
     // Triggers synthesis of a possibly conditional conformance.
     // For the unconditional ones, see NominalTypeDecl::prepareConformanceTable
-    if (nominal->getASTContext().LangOpts.hasFeature(
-            Feature::NoncopyableGenerics)) {
+    if (nominal->getASTContext().LangOpts.AssumesNoncopyableGenerics) {
       for (auto ip : InvertibleProtocolSet::full())
         trySynthesize(getKnownProtocolKind(ip));
     }

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -351,7 +351,7 @@ void InverseRequirement::expandDefaults(
     ASTContext &ctx,
     ArrayRef<Type> gps,
     SmallVectorImpl<StructuralRequirement> &result) {
-  if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics))
+  if (!ctx.LangOpts.AssumesNoncopyableGenerics)
     return;
 
   for (auto gp : gps) {

--- a/lib/AST/RequirementMachine/RequirementLowering.cpp
+++ b/lib/AST/RequirementMachine/RequirementLowering.cpp
@@ -779,7 +779,7 @@ void swift::rewriting::applyInverses(
     SmallVectorImpl<StructuralRequirement> &result,
     SmallVectorImpl<RequirementError> &errors) {
 
-  if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics))
+  if (!ctx.LangOpts.AssumesNoncopyableGenerics)
     return;
 
   // Summarize the inverses and flag ones that are incorrect.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -201,7 +201,7 @@ bool TypeBase::isNoncopyable() {
   auto &ctx = canType->getASTContext();
 
   // for legacy-mode queries that are not dependent on conformances to Copyable
-  if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics))
+  if (!ctx.LangOpts.AssumesNoncopyableGenerics)
     return alwaysNoncopyable(canType);
 
   assert(!hasTypeParameter()
@@ -215,7 +215,7 @@ bool TypeBase::isEscapable() {
   auto &ctx = canType->getASTContext();
 
   // for legacy-mode queries that are not dependent on conformances to Escapable
-  if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (!ctx.LangOpts.AssumesNoncopyableGenerics) {
     if (auto nom = canType.getAnyNominal())
       return nom->canBeEscapable();
     else
@@ -365,7 +365,7 @@ static void expandDefaultProtocols(
     SmallVectorImpl<ProtocolDecl*> &protocols) {
 
   // Skip unless noncopyable generics is enabled
-  if (!ctx.LangOpts.hasFeature(swift::Feature::NoncopyableGenerics))
+  if (!ctx.LangOpts.AssumesNoncopyableGenerics)
     return;
 
   // Try to add all invertible protocols, unless:

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -895,11 +895,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.enableFeature(Feature::LayoutPrespecialization);
 
-  if (SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS) {
-    Opts.enableFeature(Feature::NoncopyableGenerics);
-    Opts.EnableExperimentalAssociatedTypeInference = true;
-  }
-
   Opts.EnableAppExtensionLibraryRestrictions |= Args.hasArg(OPT_enable_app_extension_library);
   Opts.EnableAppExtensionRestrictions |= Args.hasArg(OPT_enable_app_extension);
   Opts.EnableAppExtensionRestrictions |= Opts.EnableAppExtensionLibraryRestrictions;
@@ -3261,7 +3256,7 @@ CompilerInvocation::loadFromSerializedAST(StringRef data) {
       serialization::validateSerializedAST(
         data,
         getSILOptions().EnableOSSAModules,
-        LangOpts.hasFeature(Feature::NoncopyableGenerics),
+        LangOpts.AssumesNoncopyableGenerics,
         LangOpts.SDKName,
         &extendedInfo);
 
@@ -3300,7 +3295,7 @@ CompilerInvocation::setUpInputForSILTool(
   auto result = serialization::validateSerializedAST(
       fileBufOrErr.get()->getBuffer(),
       getSILOptions().EnableOSSAModules,
-      LangOpts.hasFeature(Feature::NoncopyableGenerics),
+      LangOpts.AssumesNoncopyableGenerics,
       LangOpts.SDKName,
       &extendedInfo);
   bool hasSerializedAST = result.status == serialization::Status::Valid;

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1644,7 +1644,7 @@ void InterfaceSubContextDelegateImpl::inheritOptionsForBuildingInterface(
 
   if (bool(requireNCGenerics)) {
     genericSubInvocation.getLangOptions()
-                        .enableFeature(Feature::NoncopyableGenerics);
+                        .AssumesNoncopyableGenerics = true;
     genericSubInvocation.getLangOptions()
       .EnableExperimentalAssociatedTypeInference = true;
   }
@@ -2300,7 +2300,7 @@ bool ExplicitSwiftModuleLoader::canImportModule(
   auto metaData = serialization::validateSerializedAST(
       (*moduleBuf)->getBuffer(),
       Ctx.SILOpts.EnableOSSAModules,
-      Ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics),
+      Ctx.LangOpts.AssumesNoncopyableGenerics,
       Ctx.LangOpts.SDKName);
   versionInfo->setVersion(metaData.userModuleVersion,
                           ModuleVersionSourceKind::SwiftBinaryModule);
@@ -2639,7 +2639,7 @@ bool ExplicitCASModuleLoader::canImportModule(
   }
   auto metaData = serialization::validateSerializedAST(
       (*moduleBuf)->getBuffer(), Ctx.SILOpts.EnableOSSAModules,
-      Ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics),
+      Ctx.LangOpts.AssumesNoncopyableGenerics,
       Ctx.LangOpts.SDKName);
   versionInfo->setVersion(metaData.userModuleVersion,
                           ModuleVersionSourceKind::SwiftBinaryModule);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6556,32 +6556,6 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
   return DCC.fixupParserResult(ID);
 }
 
-static void addMoveOnlyAttrIf(SourceLoc const &parsedTildeCopyable,
-                              ASTContext &Context,
-                              Decl *decl) {
-  if (parsedTildeCopyable.isInvalid())
-    return;
-
-  if (Context.LangOpts.hasFeature(Feature::NoncopyableGenerics))
-    llvm_unreachable("unexpected use of legacy ~Copyable parsing");
-
-  auto &attrs = decl->getAttrs();
-
-  // Don't add if it's already explicitly written on the decl, but error about
-  // the duplication and point to the `~Copyable`.
-  if (auto attr = attrs.getAttribute<MoveOnlyAttr>()) {
-    const bool sayModifier = false;
-    Context.Diags.diagnose(attr->getLocation(), diag::duplicate_attribute,
-                           sayModifier)
-        .fixItRemove(attr->getRange());
-    Context.Diags.diagnose(parsedTildeCopyable, diag::previous_attribute,
-                           sayModifier);
-    return;
-  }
-
-  attrs.add(new(Context) MoveOnlyAttr(/*IsImplicit=*/true));
-}
-
 /// Parse an inheritance clause.
 ///
 /// \verbatim
@@ -6596,14 +6570,12 @@ static void addMoveOnlyAttrIf(SourceLoc const &parsedTildeCopyable,
 ParserStatus Parser::parseInheritance(
     SmallVectorImpl<InheritedEntry> &Inherited,
     bool allowClassRequirement,
-    bool allowAnyObject,
-    SourceLoc *parseTildeCopyable) {
+    bool allowAnyObject) {
   consumeToken(tok::colon);
 
   SourceLoc classRequirementLoc;
 
   ParserStatus Status;
-  SourceLoc TildeCopyableLoc;
   SourceLoc prevComma;
   bool HasNextType;
   do {
@@ -6657,49 +6629,6 @@ ParserStatus Parser::parseInheritance(
       continue;
     }
 
-    if (!EnabledNoncopyableGenerics && Tok.isTilde()) {
-      ErrorTypeRepr *error = nullptr;
-      if (parseTildeCopyable) {
-        const auto &nextTok = peekToken(); // lookahead
-        if (isIdentifier(nextTok, Context.Id_Copyable.str())) {
-          auto tildeLoc = consumeToken();
-          consumeToken(); // the 'Copyable' token
-
-          if (TildeCopyableLoc)
-            Inherited.push_back(InheritedEntry(
-                ErrorTypeRepr::create(Context, tildeLoc,
-                                      diag::already_suppressed_copyable)));
-          else
-            TildeCopyableLoc = tildeLoc;
-
-          continue; // success
-        }
-
-        if (nextTok.is(tok::code_complete)) {
-          consumeToken(); // consume '~'
-          Status.setHasCodeCompletionAndIsError();
-          if (CodeCompletionCallbacks) {
-            CodeCompletionCallbacks->completeWithoutConstraintType();
-          }
-          consumeToken(tok::code_complete);
-        }
-
-        // can't suppress whatever is between '~' and ',' or '{'.
-        error = ErrorTypeRepr::create(Context, consumeToken(),
-                                      diag::only_suppress_copyable);
-      } else {
-        // Otherwise, a suppression isn't allowed here unless noncopyable
-        // generics is enabled, so record a delayed error diagnostic and
-        // eat the token to prevent further parsing errors.
-        error = ErrorTypeRepr::create(Context, consumeToken(),
-                                      diag::cannot_suppress_here);
-      }
-
-      // Record the error parsing ~Copyable, but continue on to parseType.
-      if (error)
-        Inherited.push_back(InheritedEntry(error));
-    }
-
     auto ParsedTypeResult = parseType();
     Status |= ParsedTypeResult;
 
@@ -6707,9 +6636,6 @@ ParserStatus Parser::parseInheritance(
     if (ParsedTypeResult.isNonNull())
       Inherited.push_back(InheritedEntry(ParsedTypeResult.get()));
   } while (HasNextType);
-
-  if (parseTildeCopyable)
-    *parseTildeCopyable = TildeCopyableLoc;
 
   return Status;
 }
@@ -9006,14 +8932,10 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
   // Parse optional inheritance clause within the context of the enum.
   if (Tok.is(tok::colon)) {
     SmallVector<InheritedEntry, 2> Inherited;
-    SourceLoc parsedTildeCopyable;
     Status |= parseInheritance(Inherited,
                                /*allowClassRequirement=*/false,
-                               /*allowAnyObject=*/false,
-                               &parsedTildeCopyable);
+                               /*allowAnyObject=*/false);
     ED->setInherited(Context.AllocateCopy(Inherited));
-
-    addMoveOnlyAttrIf(parsedTildeCopyable, Context, ED);
   }
 
   diagnoseWhereClauseInGenericParamList(GenericParams);
@@ -9272,14 +9194,10 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
   // Parse optional inheritance clause within the context of the struct.
   if (Tok.is(tok::colon)) {
     SmallVector<InheritedEntry, 2> Inherited;
-    SourceLoc parsedTildeCopyable;
     Status |= parseInheritance(Inherited,
                                /*allowClassRequirement=*/false,
-                               /*allowAnyObject=*/false,
-                               &parsedTildeCopyable);
+                               /*allowAnyObject=*/false);
     SD->setInherited(Context.AllocateCopy(Inherited));
-
-    addMoveOnlyAttrIf(parsedTildeCopyable, Context, SD);
   }
 
   diagnoseWhereClauseInGenericParamList(GenericParams);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -307,13 +307,7 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
 
   // Wrap in an InverseTypeRepr if needed.
   if (tildeLoc) {
-    TypeRepr *repr;
-    if (EnabledNoncopyableGenerics)
-      repr = new (Context) InverseTypeRepr(tildeLoc, ty.get());
-    else
-      repr =
-          ErrorTypeRepr::create(Context, tildeLoc, diag::cannot_suppress_here);
-
+    TypeRepr *repr = new (Context) InverseTypeRepr(tildeLoc, ty.get());
     ty = makeParserResult(ty, repr);
   }
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -495,9 +495,6 @@ Parser::Parser(std::unique_ptr<Lexer> Lex, SourceFile &SF,
   // Set the token to a sentinel so that we know the lexer isn't primed yet.
   // This cannot be tok::unknown, since that is a token the lexer could produce.
   Tok.setKind(tok::NUM_TOKENS);
-
-  EnabledNoncopyableGenerics =
-      Context.LangOpts.hasFeature(Feature::NoncopyableGenerics);
 }
 
 Parser::~Parser() {

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1081,7 +1081,7 @@ bool SILType::isMoveOnly(bool orWrapped) const {
     return orWrapped;
 
   // Legacy check.
-  if (!getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (!getASTContext().LangOpts.AssumesNoncopyableGenerics) {
     return getASTType()->isNoncopyable();
   }
 

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -155,7 +155,7 @@ checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
       proto->isComputingRequirementSignature())
     return CheckTypeWitnessResult::forError();
 
-  if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)
+  if (!ctx.LangOpts.AssumesNoncopyableGenerics
       && type->isNoncopyable()) {
     // No move-only type can witness an associatedtype requirement.
     // Pretend the failure is a lack of Copyable conformance.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6386,7 +6386,7 @@ bool NotCopyableFailure::diagnoseAsError() {
   emitDiagnostic(diag::noncopyable_generics, noncopyableTy);
 
 #ifndef NDEBUG
-  if (getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (getASTContext().LangOpts.AssumesNoncopyableGenerics) {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
     getLocator()->dump(&getConstraintSystem());

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2036,7 +2036,7 @@ TypeVariableType *ConstraintSystem::openGenericParameter(
   assert(result.second);
   (void)result;
 
-  if (Context.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (Context.LangOpts.AssumesNoncopyableGenerics) {
     return typeVar;
   }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -6260,7 +6260,7 @@ bool swift::diagnoseUnhandledThrowsInAsyncContext(DeclContext *dc,
 void swift::diagnoseCopyableTypeContainingMoveOnlyType(
     NominalTypeDecl *copyableNominalType) {
   auto &ctx = copyableNominalType->getASTContext();
-  if (ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics))
+  if (ctx.LangOpts.AssumesNoncopyableGenerics)
     return; // taken care of in conformance checking
 
   // If we already have a move only type, just bail, we have no further work to

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -31,6 +31,7 @@
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/ImportCache.h"
+#include "swift/AST/InverseMarking.h"
 #include "swift/AST/ModuleNameLookup.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -791,7 +791,7 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
     // name of the generic parameter of BuiltinTupleDecl itself.
     if (extraReqs.empty() && !ext->getTrailingWhereClause() &&
         !isa<BuiltinTupleDecl>(extendedNominal) &&
-        !ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+        !ctx.LangOpts.AssumesNoncopyableGenerics) {
       // FIXME: Recover this optimization even with NoncopyableGenerics on.
       return parentSig;
     }

--- a/lib/Sema/TypeCheckInvertible.cpp
+++ b/lib/Sema/TypeCheckInvertible.cpp
@@ -216,7 +216,7 @@ static bool checkInvertibleConformanceCommon(ProtocolConformance *conformance,
   //    So, if the nominal has `~Copyable` but this conformance is
   //    written in an extension, then we do not raise an error.
   auto marking = nom->getMarking(ip);
-  if (marking.getInverse().getKind() == InverseMarking::Kind::Explicit) {
+  if (marking.getInverse().isPresent()) {
     if (isa<ClassDecl>(nom)) {
       ctx.Diags.diagnose(marking.getInverse().getLoc(),
                          diag::inverse_on_class,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -5948,7 +5948,7 @@ void TypeChecker::checkConformancesInContext(IterableDeclContext *idc) {
   // The conformance checker bundle that checks all conformances in the context.
   auto &Context = dc->getASTContext();
   const bool NoncopyableGenerics =
-      Context.LangOpts.hasFeature(Feature::NoncopyableGenerics);
+      Context.LangOpts.AssumesNoncopyableGenerics;
   MultiConformanceChecker groupChecker(Context);
 
   ProtocolConformance *SendableConformance = nullptr;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -420,7 +420,7 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
   serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
       "", "", std::move(newBuf), nullptr, nullptr,
       /*isFramework=*/isFramework, Ctx.SILOpts.EnableOSSAModules,
-      Ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics),
+      Ctx.LangOpts.AssumesNoncopyableGenerics,
       Ctx.LangOpts.SDKName, Ctx.SearchPathOpts.DeserializedPathRecoverer,
       loadedModuleFile);
   Name = loadedModuleFile->Name.str();

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1037,7 +1037,7 @@ void Serializer::writeHeader() {
     IsOSSA.emit(ScratchRecord, Options.IsOSSA);
 
     HasNoncopyableGenerics.emit(ScratchRecord,
-            getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics));
+            getASTContext().LangOpts.AssumesNoncopyableGenerics);
 
     {
       llvm::BCBlockRAII restoreBlock(Out, OPTIONS_BLOCK_ID, 4);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1024,7 +1024,7 @@ bool SerializedModuleLoaderBase::isRequiredOSSAModules() const {
 }
 
 bool SerializedModuleLoaderBase::isRequiredNoncopyableGenerics() const {
-  return Ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics);
+  return Ctx.LangOpts.AssumesNoncopyableGenerics;
 }
 
 void swift::serialization::diagnoseSerializedASTLoadFailure(
@@ -1405,7 +1405,7 @@ bool SerializedModuleLoaderBase::canImportModule(
     auto metaData = serialization::validateSerializedAST(
         moduleInputBuffer->getBuffer(),
         Ctx.SILOpts.EnableOSSAModules,
-        Ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics),
+        Ctx.LangOpts.AssumesNoncopyableGenerics,
         Ctx.LangOpts.SDKName);
     versionInfo->setVersion(metaData.userModuleVersion,
                             ModuleVersionSourceKind::SwiftBinaryModule);

--- a/test/ModuleInterface/moveonly_interface_flag.swift
+++ b/test/ModuleInterface/moveonly_interface_flag.swift
@@ -6,16 +6,16 @@
 // this test makes sure that decls containing a move-only type are guarded by the $MoveOnly feature flag
 
 // CHECK:       #if compiler(>=5.3) && $MoveOnly
-// CHECK-NEXT:    @_moveOnly public struct MoveOnlyStruct {
+// CHECK-NEXT:    public struct MoveOnlyStruct : ~Copyable {
 
 // CHECK:       #if compiler(>=5.3) && $MoveOnly
-// CHECK-NEXT:    @_moveOnly public struct MoveOnlyStructSupp {
+// CHECK-NEXT:    public struct MoveOnlyStructSupp : ~Copyable {
 
 // CHECK:      #if compiler(>=5.3) && $MoveOnly
-// CHECK-NEXT:   @_moveOnly public enum MoveOnlyEnum {
+// CHECK-NEXT:   public enum MoveOnlyEnum : ~Copyable {
 
 // CHECK:      #if compiler(>=5.3) && $MoveOnly
-// CHECK-NEXT:   @_moveOnly public enum MoveOnlyEnumSupp {
+// CHECK-NEXT:   public enum MoveOnlyEnumSupp : ~Copyable {
 
 // CHECK:      #if compiler(>=5.3) && $MoveOnly
 // CHECK-NEXT:   public func someFn() -> Library.MoveOnlyEnum

--- a/test/Parse/inverse_escapable_feature.swift
+++ b/test/Parse/inverse_escapable_feature.swift
@@ -1,5 +1,14 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift \
+// RUN:    -enable-experimental-feature NoncopyableGenerics
 
 // REQUIRES: noncopyable_generics
 
 struct S: ~Escapable {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonescapableTypes}}
+
+func whatever<T: ~Escapable>(_ t: T) {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonescapableTypes}}
+
+protocol P: ~Escapable {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonescapableTypes}}
+
+protocol Sendable: ~Escapable {}
+
+func example(_ t: any Sendable & ~Escapable) {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonescapableTypes}}

--- a/test/SILGen/raw_layout.swift
+++ b/test/SILGen/raw_layout.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature RawLayout %s | %FileCheck %s
 
-// CHECK: @_rawLayout(size: 4, alignment: 4) @_moveOnly struct Lock
-// CHECK: @_rawLayout(like: T) @_moveOnly struct Cell<T>
-// CHECK: @_rawLayout(likeArrayOf: T, count: 8) @_moveOnly struct SmallVectorBuf<T>
+// CHECK: @_rawLayout(size: 4, alignment: 4) struct Lock : ~Copyable
+// CHECK: @_rawLayout(like: T) struct Cell<T> : ~Copyable
+// CHECK: @_rawLayout(likeArrayOf: T, count: 8) struct SmallVectorBuf<T> : ~Copyable
 
 @_rawLayout(size: 4, alignment: 4)
 struct Lock: ~Copyable {

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -359,12 +359,10 @@ int main(int argc, char **argv) {
   Invocation.getLangOptions().EnableMemoryBufferImporter = true;
   Invocation.getSILOptions().EnableOSSAModules = EnableOSSAModules;
 
-  if (EnableNoncopyableGenerics)
-    Invocation.getLangOptions()
-      .enableFeature(swift::Feature::NoncopyableGenerics);
-  else
-    Invocation.getLangOptions()
-      .disableFeature(swift::Feature::NoncopyableGenerics);
+  Invocation.getLangOptions()
+    .AssumesNoncopyableGenerics = EnableNoncopyableGenerics;
+  Invocation.getLangOptions()
+      .EnableExperimentalAssociatedTypeInference |= EnableNoncopyableGenerics;
 
   if (!ResourceDir.empty()) {
     Invocation.setRuntimeResourcePath(ResourceDir);

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -151,7 +151,7 @@ protected:
     auto bufData = (*bufOrErr)->getBuffer();
     auto validationInfo = serialization::validateSerializedAST(
         bufData, silOpts.EnableOSSAModules,
-        langOpts.hasFeature(Feature::NoncopyableGenerics),
+        langOpts.AssumesNoncopyableGenerics,
         /*requiredSDK*/StringRef());
     ASSERT_EQ(serialization::Status::Valid, validationInfo.status);
     ASSERT_EQ(bufData, moduleBuffer->getBuffer());


### PR DESCRIPTION
This also moves ~Escapable out from behind the NonescapableTypes flag when used on a known protocol decl.
