### PR TITLE
[stdlib] Make expected actor isolation checking crash by default

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -353,7 +353,7 @@ static bool swift_task_isCurrentExecutorImpl(SerialExecutorRef executor) {
 /// 0 - no logging
 /// 1 - warn on each instance
 /// 2 - fatal error
-static unsigned unexpectedExecutorLogLevel = 1;
+static unsigned unexpectedExecutorLogLevel = 2;
 
 static void checkUnexpectedExecutorLogLevel(void *context) {
 #if SWIFT_STDLIB_HAS_ENVIRON


### PR DESCRIPTION
Only affects projects compiled with `-enable-actor-data-race-checks` flag.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
