### PR TITLE
Implement ReflectionContext::readInstanceStartFromTypeRef

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -617,7 +617,7 @@ public:
 
   /// Given a remote pointer to class metadata, attempt to discover its class
   /// instance size and whether fields should use the resilient layout strategy.
-  llvm::Optional<unsigned> readInstanceStartAndAlignmentFromClassMetadata(
+  llvm::Optional<unsigned> readInstanceStartFromClassMetadata(
       StoredPointer MetadataAddress) {
     auto meta = readMetadata(MetadataAddress);
     if (!meta || meta->getKind() != MetadataKind::Class)


### PR DESCRIPTION
Implement ReflectionContext::readInstanceStartFromTypeRef as an alternative way to finding out the start of an instance's field when reading the field's start from binary is not possible (for example, embedded Swift doesn't emit any reflection metadata on the binary).
