### PR TITLE
AST: Cache underlying clang module during import resolution

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -406,6 +406,13 @@ public:
   /// resolution.
   void setImports(ArrayRef<AttributedImport<ImportedModule>> imports);
 
+  /// Set the imported underlying clang module for this source file. This gets
+  /// called by import resolution.
+  void setImportedUnderlyingModule(ModuleDecl *module) {
+    assert(!ImportedUnderlyingModule && "underlying module already set");
+    ImportedUnderlyingModule = module;
+  }
+
   /// Whether the given import has used @preconcurrency.
   bool hasImportUsedPreconcurrency(
       AttributedImport<ImportedModule> import) const;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2566,20 +2566,6 @@ void
 SourceFile::setImports(ArrayRef<AttributedImport<ImportedModule>> imports) {
   assert(!Imports && "Already computed imports");
   Imports = getASTContext().AllocateCopy(imports);
-
-  // Find and cache the import of the underlying module, if present.
-  auto parentModuleName = getParentModule()->getName();
-  for (auto import : imports) {
-    if (!import.options.contains(ImportFlags::Exported))
-      continue;
-
-    auto importedModule = import.module.importedModule;
-    if (importedModule->getName() == parentModuleName &&
-        importedModule->findUnderlyingClangModule()) {
-      ImportedUnderlyingModule = import.module.importedModule;
-      break;
-    }
-  }
 }
 
 bool SourceFile::hasImportUsedPreconcurrency(


### PR DESCRIPTION
As recommended in feedback on https://github.com/apple/swift/pull/71302, cache the underlying clang module after loading it in `ImportResolver`, rather than filtering it out of the overall set of resolved imports. This is more efficient and results in less duplicated code that must identify the underlying clang module.
