### PR TITLE
[AST] Cleanup AttrKind

### DIFF
--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -394,7 +394,7 @@ public:
   bool isImplicit() const { return IsImplicit; };
   bool isStatic() const { return IsStatic; };
   bool isOverriding() const { return IsOverriding; };
-  bool isOptional() const { return hasDeclAttribute(DeclAttrKind::DAK_Optional); }
+  bool isOptional() const { return hasDeclAttribute(DeclAttrKind::Optional); }
   bool isOpen() const { return IsOpen; }
   bool isInternal() const { return IsInternal; }
   bool isABIPlaceholder() const { return IsABIPlaceholder; }
@@ -492,9 +492,7 @@ public:
 class SDKNodeTypeFunc : public SDKNodeType {
 public:
   SDKNodeTypeFunc(SDKNodeInitInfo Info);
-  bool isEscaping() const {
-    return hasTypeAttribute(TypeAttrKind::TAK_NoEscape);
-  }
+  bool isEscaping() const { return hasTypeAttribute(TypeAttrKind::NoEscape); }
   static bool classof(const SDKNode *N);
   void diagnose(SDKNode *Right) override;
 };

--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -492,7 +492,9 @@ public:
 class SDKNodeTypeFunc : public SDKNodeType {
 public:
   SDKNodeTypeFunc(SDKNodeInitInfo Info);
-  bool isEscaping() const { return hasTypeAttribute(TypeAttrKind::TAK_noescape); }
+  bool isEscaping() const {
+    return hasTypeAttribute(TypeAttrKind::TAK_NoEscape);
+  }
   static bool classof(const SDKNode *N);
   void diagnose(SDKNode *Right) override;
 };

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -287,7 +287,7 @@ namespace swift {
   SWIFT_NAME("getter:Bridged" #CLASS "Attr.asDeclAttribute(self:)")            \
   BridgedDeclAttribute Bridged##CLASS##Attr_asDeclAttribute(                   \
       Bridged##CLASS##Attr attr);
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
 struct BridgedPatternBindingEntry {
   BridgedPattern pattern;
@@ -423,7 +423,7 @@ BridgedDeclContext BridgedPatternBindingInitializer_asDeclContext(
 
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedDeclAttrKind {
 #define DECL_ATTR(_, CLASS, ...) BridgedDeclAttrKind##CLASS,
-#include "swift/AST/Attr.def"
+#include "swift/AST/DelAttr.def"
   BridgedDeclAttrKindNone,
 };
 
@@ -1441,7 +1441,7 @@ void BridgedStmt_dump(BridgedStmt statement);
 // Bridged type attribute kinds, which mirror TypeAttrKind exactly.
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind {
 #define TYPE_ATTR(_, CLASS) BridgedTypeAttrKind##CLASS,
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   BridgedTypeAttrKindNone,
 };
 

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -1440,9 +1440,9 @@ void BridgedStmt_dump(BridgedStmt statement);
 
 // Bridged type attribute kinds, which mirror TypeAttrKind exactly.
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedTypeAttrKind {
-#define TYPE_ATTR(SPELLING, _) BridgedTypeAttrKind_##SPELLING,
+#define TYPE_ATTR(_, CLASS) BridgedTypeAttrKind##CLASS,
 #include "swift/AST/Attr.def"
-  BridgedTypeAttrKind_None,
+  BridgedTypeAttrKindNone,
 };
 
 SWIFT_NAME("BridgedTypeAttrKind.init(from:)")

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -423,7 +423,7 @@ BridgedDeclContext BridgedPatternBindingInitializer_asDeclContext(
 
 enum ENUM_EXTENSIBILITY_ATTR(closed) BridgedDeclAttrKind {
 #define DECL_ATTR(_, CLASS, ...) BridgedDeclAttrKind##CLASS,
-#include "swift/AST/DelAttr.def"
+#include "swift/AST/DeclAttr.def"
   BridgedDeclAttrKindNone,
 };
 

--- a/include/swift/AST/ASTBridgingWrappers.def
+++ b/include/swift/AST/ASTBridgingWrappers.def
@@ -61,7 +61,7 @@
 #include "swift/AST/PatternNodes.def"
 
 #ifndef DECL_ATTR
-#define SIMPLE_DECL_ATTR(X, CLASS, OPTIONS, CODE)
+#define SIMPLE_DECL_ATTR(...)
 #define DECL_ATTR(_, Id, ...) AST_BRIDGING_WRAPPER_NONNULL(Id##Attr)
 #endif
 #include "swift/AST/Attr.def"

--- a/include/swift/AST/ASTBridgingWrappers.def
+++ b/include/swift/AST/ASTBridgingWrappers.def
@@ -64,7 +64,7 @@
 #define SIMPLE_DECL_ATTR(...)
 #define DECL_ATTR(_, Id, ...) AST_BRIDGING_WRAPPER_NONNULL(Id##Attr)
 #endif
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
 // Some of the base classes need to be nullable to allow them to be used as
 // optional parameters.

--- a/include/swift/AST/ASTVisitor.h
+++ b/include/swift/AST/ASTVisitor.h
@@ -137,14 +137,13 @@ public:
 
   AttributeRetTy visit(DeclAttribute *A, Args... AA) {
     switch (A->getKind()) {
-#define DECL_ATTR(_, CLASS, ...)                           \
-    case DAK_##CLASS:                                              \
-      return static_cast<ImplClass*>(this)                        \
-               ->visit##CLASS##Attr(static_cast<CLASS##Attr*>(A), \
-                                    ::std::forward<Args>(AA)...);
+#define DECL_ATTR(_, CLASS, ...)                                               \
+  case DeclAttrKind::CLASS:                                                    \
+    return static_cast<ImplClass *>(this)->visit##CLASS##Attr(                 \
+        static_cast<CLASS##Attr *>(A), ::std::forward<Args>(AA)...);
 #include "swift/AST/Attr.def"
 
-    case DAK_Count:
+    case DeclAttrKind::Count:
       llvm_unreachable("Not an attribute kind");
     }
   }

--- a/include/swift/AST/ASTVisitor.h
+++ b/include/swift/AST/ASTVisitor.h
@@ -142,9 +142,6 @@ public:
     return static_cast<ImplClass *>(this)->visit##CLASS##Attr(                 \
         static_cast<CLASS##Attr *>(A), ::std::forward<Args>(AA)...);
 #include "swift/AST/DeclAttr.def"
-
-    case DeclAttrKind::Count:
-      llvm_unreachable("Not an attribute kind");
     }
   }
 

--- a/include/swift/AST/ASTVisitor.h
+++ b/include/swift/AST/ASTVisitor.h
@@ -141,7 +141,7 @@ public:
   case DeclAttrKind::CLASS:                                                    \
     return static_cast<ImplClass *>(this)->visit##CLASS##Attr(                 \
         static_cast<CLASS##Attr *>(A), ::std::forward<Args>(AA)...);
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
     case DeclAttrKind::Count:
       llvm_unreachable("Not an attribute kind");
@@ -153,7 +153,7 @@ public:
     return static_cast<ImplClass*>(this)->visitDeclAttribute(       \
              A, ::std::forward<Args>(AA)...);                       \
   }
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   
   bool visit(ParameterList *PL) {
     return static_cast<ImplClass*>(this)->visitParameterList(PL);

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3041,11 +3041,11 @@ public:
 template <TypeAttrKind Kind>
 using SimpleTypeAttrWithArgs = SimpleTypeAttr<Kind, AtTypeAttrWithArgsBase>;
 
-#define SIMPLE_TYPE_ATTR(SPELLING, CLASS)                \
-using CLASS##TypeAttr = SimpleTypeAttr<TAK_##SPELLING>;
+#define SIMPLE_TYPE_ATTR(SPELLING, CLASS)                                      \
+  using CLASS##TypeAttr = SimpleTypeAttr<TAK_##CLASS>;
 #include "swift/AST/Attr.def"
 
-class ConventionTypeAttr : public SimpleTypeAttrWithArgs<TAK_convention> {
+class ConventionTypeAttr : public SimpleTypeAttrWithArgs<TAK_Convention> {
   Located<StringRef> Name;
   DeclNameRef WitnessMethodProtocol;
   Located<StringRef> ClangType;
@@ -3075,7 +3075,8 @@ public:
   void printImpl(ASTPrinter &printer, const PrintOptions &options) const;
 };
 
-class DifferentiableTypeAttr : public SimpleTypeAttrWithArgs<TAK_differentiable> {
+class DifferentiableTypeAttr
+    : public SimpleTypeAttrWithArgs<TAK_Differentiable> {
   SourceLoc DifferentiabilityLoc;
 public:
   DifferentiableTypeAttr(SourceLoc atLoc, SourceLoc kwLoc,
@@ -3105,7 +3106,7 @@ public:
 };
 
 class OpaqueReturnTypeOfTypeAttr
-    : public SimpleTypeAttrWithArgs<TAK__opaqueReturnTypeOf> {
+    : public SimpleTypeAttrWithArgs<TAK_OpaqueReturnTypeOf> {
   Located<StringRef> MangledName;
   SourceLoc IndexLoc;
 public:
@@ -3124,7 +3125,7 @@ public:
   void printImpl(ASTPrinter &printer, const PrintOptions &options) const;
 };
 
-class OpenedTypeAttr : public SimpleTypeAttrWithArgs<TAK_opened> {
+class OpenedTypeAttr : public SimpleTypeAttrWithArgs<TAK_Opened> {
   Located<UUID> ID;
   TypeRepr *ConstraintType;
 public:
@@ -3146,7 +3147,7 @@ public:
   void printImpl(ASTPrinter &printer, const PrintOptions &options) const;
 };
 
-class PackElementTypeAttr : public SimpleTypeAttrWithArgs<TAK_pack_element> {
+class PackElementTypeAttr : public SimpleTypeAttrWithArgs<TAK_PackElement> {
   Located<UUID> ID;
 public:
   PackElementTypeAttr(SourceLoc atLoc, SourceLoc kwLoc, SourceRange parensRange,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -470,10 +470,9 @@ public:
   /// of the 'unowned(unsafe)' attribute, the string passed in is 'unowned'.
   ///
   /// Also note that this recognizes both attributes like '@inline' (with no @)
-  /// and decl modifiers like 'final'.  This returns DeclAttrKind::Count on
-  /// failure.
+  /// and decl modifiers like 'final'.
   ///
-  static DeclAttrKind getAttrKindFromString(StringRef Str);
+  static llvm::Optional<DeclAttrKind> getAttrKindFromString(StringRef Str);
 
   static DeclAttribute *createSimple(const ASTContext &context,
                                      DeclAttrKind kind, SourceLoc atLoc,

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -419,7 +419,7 @@ public:
   static constexpr bool isOptionSetFor##CLASS(DeclAttrOptions Bit) {                              \
     return (OPTIONS) & Bit;                                                                       \
   }
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
   static bool isAddingBreakingAPI(DeclAttrKind DK) {
     return getOptions(DK) & APIBreakingToAdd;
@@ -503,7 +503,7 @@ public:
 // Declare typedefs for all of the simple declaration attributes.
 #define SIMPLE_DECL_ATTR(_, CLASS, ...)                                        \
   typedef SimpleDeclAttr<DeclAttrKind::CLASS> CLASS##Attr;
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
 /// Defines the @_silgen_name attribute.
 class SILGenNameAttr : public DeclAttribute {
@@ -3040,7 +3040,7 @@ using SimpleTypeAttrWithArgs = SimpleTypeAttr<Kind, AtTypeAttrWithArgsBase>;
 
 #define SIMPLE_TYPE_ATTR(SPELLING, CLASS)                                      \
   using CLASS##TypeAttr = SimpleTypeAttr<TypeAttrKind::CLASS>;
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
 
 class ConventionTypeAttr
     : public SimpleTypeAttrWithArgs<TypeAttrKind::Convention> {

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -139,14 +139,14 @@ enum DeclAttrKind : unsigned {
 enum : unsigned { NumDeclAttrKindBits =
   countBitsUsed(static_cast<unsigned>(DeclAttrKind::DAK_Count - 1)) };
 
-// Define enumerators for each type attribute, e.g. TAK_weak.
+// Define enumerators for each type attribute, e.g. TAK_Weak.
 enum TypeAttrKind {
-#define TYPE_ATTR(X, C) TAK_##X,
+#define TYPE_ATTR(_, C) TAK_##C,
 #include "swift/AST/Attr.def"
 };
 
 enum : unsigned {
-#define TYPE_ATTR(X, C) _counting_TAK_##X,
+#define TYPE_ATTR(_, C) _counting_TAK_##C,
 #include "swift/AST/Attr.def"
   NumTypeAttrKinds,
 

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -132,29 +132,25 @@ enum : unsigned { NumExternKindBits =
 
 enum class DeclAttrKind : unsigned {
 #define DECL_ATTR(_, CLASS, ...) CLASS,
+#define LAST_DECL_ATTR(CLASS) Last_DeclAttr = CLASS,
 #include "swift/AST/DeclAttr.def"
 };
 
 enum : unsigned {
-#define DECL_ATTR(_, C, ...) _counting_DAK_##C,
-#include "swift/AST/DeclAttr.def"
-  NumDeclAttrKinds,
-
-  NumDeclAttrKindBits = countBitsUsed(NumDeclAttrKinds - 1)
+  NumDeclAttrKinds = static_cast<unsigned>(DeclAttrKind::Last_DeclAttr) + 1,
+  NumDeclAttrKindBits = countBitsUsed(NumDeclAttrKinds - 1),
 };
 
 // Define enumerators for each type attribute, e.g. TypeAttrKind::Weak.
 enum class TypeAttrKind {
 #define TYPE_ATTR(_, CLASS) CLASS,
+#define LAST_TYPE_ATTR(CLASS) Last_TypeAttr = CLASS,
 #include "swift/AST/TypeAttr.def"
 };
 
 enum : unsigned {
-#define TYPE_ATTR(_, C) _counting_TAK_##C,
-#include "swift/AST/TypeAttr.def"
-  NumTypeAttrKinds,
-
-  NumTypeAttrKindBits = countBitsUsed(NumTypeAttrKinds - 1)
+  NumTypeAttrKinds = static_cast<unsigned>(TypeAttrKind::Last_TypeAttr) + 1,
+  NumTypeAttrKindBits = countBitsUsed(NumTypeAttrKinds - 1),
 };
 
 } // end namespace swift

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -133,12 +133,14 @@ enum : unsigned { NumExternKindBits =
 enum class DeclAttrKind : unsigned {
 #define DECL_ATTR(_, CLASS, ...) CLASS,
 #include "swift/AST/DeclAttr.def"
-  Count
 };
 
 enum : unsigned {
-  NumDeclAttrKindBits =
-      countBitsUsed(static_cast<unsigned>(DeclAttrKind::Count) - 1)
+#define DECL_ATTR(_, C, ...) _counting_DAK_##C,
+#include "swift/AST/DeclAttr.def"
+  NumDeclAttrKinds,
+
+  NumDeclAttrKindBits = countBitsUsed(NumDeclAttrKinds - 1)
 };
 
 // Define enumerators for each type attribute, e.g. TypeAttrKind::Weak.

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -130,18 +130,20 @@ enum class ExternKind: uint8_t {
 enum : unsigned { NumExternKindBits =
   countBitsUsed(static_cast<unsigned>(ExternKind::Last_ExternKind)) };
 
-enum DeclAttrKind : unsigned {
-#define DECL_ATTR(_, NAME, ...) DAK_##NAME,
+enum class DeclAttrKind : unsigned {
+#define DECL_ATTR(_, CLASS, ...) CLASS,
 #include "swift/AST/Attr.def"
-  DAK_Count
+  Count
 };
 
-enum : unsigned { NumDeclAttrKindBits =
-  countBitsUsed(static_cast<unsigned>(DeclAttrKind::DAK_Count - 1)) };
+enum : unsigned {
+  NumDeclAttrKindBits =
+      countBitsUsed(static_cast<unsigned>(DeclAttrKind::Count) - 1)
+};
 
-// Define enumerators for each type attribute, e.g. TAK_Weak.
-enum TypeAttrKind {
-#define TYPE_ATTR(_, C) TAK_##C,
+// Define enumerators for each type attribute, e.g. TypeAttrKind::Weak.
+enum class TypeAttrKind {
+#define TYPE_ATTR(_, CLASS) CLASS,
 #include "swift/AST/Attr.def"
 };
 

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -132,7 +132,7 @@ enum : unsigned { NumExternKindBits =
 
 enum class DeclAttrKind : unsigned {
 #define DECL_ATTR(_, CLASS, ...) CLASS,
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   Count
 };
 
@@ -144,12 +144,12 @@ enum : unsigned {
 // Define enumerators for each type attribute, e.g. TypeAttrKind::Weak.
 enum class TypeAttrKind {
 #define TYPE_ATTR(_, CLASS) CLASS,
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
 };
 
 enum : unsigned {
 #define TYPE_ATTR(_, C) _counting_TAK_##C,
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   NumTypeAttrKinds,
 
   NumTypeAttrKindBits = countBitsUsed(NumTypeAttrKinds - 1)

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -42,6 +42,9 @@
                    DECL_ATTR_ALIAS(SPELLING, CLASS)
 #endif
 
+#ifndef LAST_DECL_ATTR
+#define LAST_DECL_ATTR(CLASS)
+#endif
 
 // Declaration Attributes and Modifers
 DECL_ATTR(_silgen_name, SILGenName,
@@ -482,6 +485,7 @@ SIMPLE_DECL_ATTR(_noExistentials, NoExistentials,
 SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
   OnAbstractFunction | OnSubscript | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   155)
+LAST_DECL_ATTR(NoObjCBridging)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS
@@ -489,3 +493,4 @@ SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
 #undef CONTEXTUAL_SIMPLE_DECL_ATTR
 #undef DECL_ATTR
 #undef CONTEXTUAL_DECL_ATTR
+#undef LAST_DECL_ATTR

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -1,8 +1,8 @@
-//===--- Attr.def - Swift Attributes Metaprogramming ------------*- C++ -*-===//
+//===--- DeclAttr.def - Swift Attributes Metaprogramming - ------*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines macros used for macro-metaprogramming with attributes.
+// This file defines macros used for macro-metaprogramming with decl attributes.
 //
 //===----------------------------------------------------------------------===//
 
@@ -42,97 +42,6 @@
                    DECL_ATTR_ALIAS(SPELLING, CLASS)
 #endif
 
-// A type attribute that is both a simple type attribute and a
-// SIL type attribute (see below).  Delegates to SIL_TYPE_ATTR if that
-// is set and SIMPLE_TYPE_ATTR is not; otherwise delegates to SIMPLE_TYPE_ATTR.
-#ifndef SIMPLE_SIL_TYPE_ATTR
-#ifdef SIL_TYPE_ATTR
-#ifdef SIMPLE_TYPE_ATTR
-#error ambiguous delegation, must set SIMPLE_SIL_TYPE_ATTR explicitly
-#else
-#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) SIL_TYPE_ATTR(SPELLING, CLASS)
-#endif
-#else
-#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) SIMPLE_TYPE_ATTR(SPELLING, CLASS)
-#endif
-#endif
-
-// Any kind of type attribute.
-#ifndef TYPE_ATTR
-#define TYPE_ATTR(SPELLING, CLASS)
-#endif
-
-// A type attribute that is only valid in SIL mode.  Usually this means
-// that it's only valid in lowered types, but sometimes SIL files
-// also allow things in formal types that aren't normally expressible.
-#ifndef SIL_TYPE_ATTR
-#define SIL_TYPE_ATTR(SPELLING, CLASS) TYPE_ATTR(SPELLING, CLASS)
-#endif
-
-// A type attribute that's always just spelled `@identifier` in source.
-#ifndef SIMPLE_TYPE_ATTR
-#define SIMPLE_TYPE_ATTR(SPELLING, CLASS) TYPE_ATTR(SPELLING, CLASS)
-#endif
-
-
-// Type attributes
-SIMPLE_TYPE_ATTR(autoclosure, Autoclosure)
-TYPE_ATTR(convention, Convention)
-SIMPLE_TYPE_ATTR(noescape, NoEscape)
-SIMPLE_TYPE_ATTR(escaping, Escaping)
-TYPE_ATTR(differentiable, Differentiable)
-SIMPLE_TYPE_ATTR(noDerivative, NoDerivative)
-SIMPLE_TYPE_ATTR(async, Async)
-SIMPLE_TYPE_ATTR(Sendable, Sendable)
-SIMPLE_TYPE_ATTR(retroactive, Retroactive)
-SIMPLE_TYPE_ATTR(unchecked, Unchecked)
-SIMPLE_TYPE_ATTR(preconcurrency, Preconcurrency)
-SIMPLE_TYPE_ATTR(_local, Local)
-SIMPLE_TYPE_ATTR(_noMetadata, NoMetadata)
-TYPE_ATTR(_opaqueReturnTypeOf, OpaqueReturnTypeOf)
-
-// SIL-specific attributes
-SIMPLE_SIL_TYPE_ATTR(block_storage, BlockStorage)
-SIMPLE_SIL_TYPE_ATTR(box, Box)
-SIMPLE_SIL_TYPE_ATTR(dynamic_self, DynamicSelf)
-#define REF_STORAGE(Name, name, ...) SIMPLE_TYPE_ATTR(sil_##name, SIL##Name)
-#include "swift/AST/ReferenceStorage.def"
-SIMPLE_SIL_TYPE_ATTR(error, Error)
-SIMPLE_SIL_TYPE_ATTR(error_indirect, ErrorIndirect)
-SIMPLE_SIL_TYPE_ATTR(error_unowned, ErrorUnowned)
-SIMPLE_SIL_TYPE_ATTR(out, Out)
-SIMPLE_SIL_TYPE_ATTR(direct, Direct)
-SIMPLE_SIL_TYPE_ATTR(in, In)
-SIMPLE_SIL_TYPE_ATTR(inout, Inout)
-SIMPLE_SIL_TYPE_ATTR(inout_aliasable, InoutAliasable)
-SIMPLE_SIL_TYPE_ATTR(in_guaranteed, InGuaranteed)
-SIMPLE_SIL_TYPE_ATTR(in_constant, InConstant)
-SIMPLE_SIL_TYPE_ATTR(pack_owned, PackOwned)
-SIMPLE_SIL_TYPE_ATTR(pack_guaranteed, PackGuaranteed)
-SIMPLE_SIL_TYPE_ATTR(pack_inout, PackInout)
-SIMPLE_SIL_TYPE_ATTR(pack_out, PackOut)
-SIMPLE_SIL_TYPE_ATTR(owned, Owned)
-SIMPLE_SIL_TYPE_ATTR(unowned_inner_pointer, UnownedInnerPointer)
-SIMPLE_SIL_TYPE_ATTR(guaranteed, Guaranteed)
-SIMPLE_SIL_TYPE_ATTR(autoreleased, Autoreleased)
-SIMPLE_SIL_TYPE_ATTR(callee_owned, CalleeOwned)
-SIMPLE_SIL_TYPE_ATTR(callee_guaranteed, CalleeGuaranteed)
-SIMPLE_SIL_TYPE_ATTR(objc_metatype, ObjCMetatype)
-SIL_TYPE_ATTR(opened, Opened)
-SIL_TYPE_ATTR(pack_element, PackElement)
-SIMPLE_SIL_TYPE_ATTR(pseudogeneric, Pseudogeneric)
-SIMPLE_SIL_TYPE_ATTR(unimplementable, Unimplementable)
-SIMPLE_SIL_TYPE_ATTR(yields, Yields)
-SIMPLE_SIL_TYPE_ATTR(yield_once, YieldOnce)
-SIMPLE_SIL_TYPE_ATTR(yield_many, YieldMany)
-SIMPLE_SIL_TYPE_ATTR(captures_generics, CapturesGenerics)
-// Used at the SIL level to mark a type as moveOnly.
-SIMPLE_SIL_TYPE_ATTR(moveOnly, MoveOnly)
-SIMPLE_SIL_TYPE_ATTR(isolated, Isolated)
-
-// SIL metatype attributes.
-SIMPLE_SIL_TYPE_ATTR(thin, Thin)
-SIMPLE_SIL_TYPE_ATTR(thick, Thick)
 
 // Declaration Attributes and Modifers
 DECL_ATTR(_silgen_name, SILGenName,
@@ -574,10 +483,6 @@ SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
   OnAbstractFunction | OnSubscript | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   155)
 
-#undef SIMPLE_SIL_TYPE_ATTR
-#undef SIMPLE_TYPE_ATTR
-#undef SIL_TYPE_ATTR
-#undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -55,7 +55,7 @@ namespace swift {
   enum class ReferenceOwnership : uint8_t;
   enum class StaticSpellingKind : uint8_t;
   enum class DescriptiveDeclKind : uint8_t;
-  enum DeclAttrKind : unsigned;
+  enum class DeclAttrKind : unsigned;
   enum class StmtKind;
 
   /// Enumeration describing all of possible diagnostics.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -93,8 +93,7 @@ public:
     static_assert(NumTypeAttrKinds < UINT_MAX, "TypeAttrKind is > 31 bits");
   }
   AnyAttrKind(DeclAttrKind K) : kind(static_cast<unsigned>(K)), isType(0) {
-    static_assert(static_cast<unsigned>(DeclAttrKind::Count) < UINT_MAX,
-                  "DeclAttrKind is > 31 bits");
+    static_assert(NumDeclAttrKinds < UINT_MAX, "DeclAttrKind is > 31 bits");
   }
   AnyAttrKind() : kind(NumTypeAttrKinds), isType(1) {}
 
@@ -103,10 +102,11 @@ public:
     if (!isType || kind == NumTypeAttrKinds) return {};
     return static_cast<TypeAttrKind>(kind);
   }
-  /// Returns the DeclAttrKind, or DeclAttrKind::Count if this is not a decl
-  /// attribute.
-  DeclAttrKind decl() const {
-    return isType ? DeclAttrKind::Count : static_cast<DeclAttrKind>(kind);
+  /// Returns the DeclAttrKind.
+  llvm::Optional<DeclAttrKind> decl() const {
+    if (isType || kind == NumDeclAttrKinds)
+      return {};
+    return static_cast<DeclAttrKind>(kind);
   }
 
   bool operator==(AnyAttrKind K) const {

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -36,7 +36,7 @@ class TypeBase;
 class DeclContext;
 class Type;
 class ModuleDecl;
-enum DeclAttrKind : unsigned;
+enum class DeclAttrKind : unsigned;
 class SynthesizedExtensionAnalyzer;
 struct PrintOptions;
 class SILPrintContext;
@@ -93,7 +93,8 @@ public:
     static_assert(NumTypeAttrKinds < UINT_MAX, "TypeAttrKind is > 31 bits");
   }
   AnyAttrKind(DeclAttrKind K) : kind(static_cast<unsigned>(K)), isType(0) {
-    static_assert(DAK_Count < UINT_MAX, "DeclAttrKind is > 31 bits");
+    static_assert(static_cast<unsigned>(DeclAttrKind::Count) < UINT_MAX,
+                  "DeclAttrKind is > 31 bits");
   }
   AnyAttrKind() : kind(NumTypeAttrKinds), isType(1) {}
 
@@ -102,9 +103,10 @@ public:
     if (!isType || kind == NumTypeAttrKinds) return {};
     return static_cast<TypeAttrKind>(kind);
   }
-  /// Returns the DeclAttrKind, or DAK_Count if this is not a decl attribute.
+  /// Returns the DeclAttrKind, or DeclAttrKind::Count if this is not a decl
+  /// attribute.
   DeclAttrKind decl() const {
-    return isType ? DAK_Count : static_cast<DeclAttrKind>(kind);
+    return isType ? DeclAttrKind::Count : static_cast<DeclAttrKind>(kind);
   }
 
   bool operator==(AnyAttrKind K) const {
@@ -371,9 +373,9 @@ struct PrintOptions {
   bool SuppressExpandedMacros = true;
 
   /// List of attribute kinds that should not be printed.
-  std::vector<AnyAttrKind> ExcludeAttrList = {DAK_Transparent, DAK_Effects,
-                                              DAK_FixedLayout,
-                                              DAK_ShowInInterface};
+  std::vector<AnyAttrKind> ExcludeAttrList = {
+      DeclAttrKind::Transparent, DeclAttrKind::Effects,
+      DeclAttrKind::FixedLayout, DeclAttrKind::ShowInInterface};
 
   /// List of attribute kinds that should be printed exclusively.
   /// Empty means allow all.
@@ -652,10 +654,10 @@ struct PrintOptions {
     result.SynthesizeSugarOnTypes = true;
     result.PrintUserInaccessibleAttrs = false;
     result.PrintImplicitAttrs = false;
-    result.ExcludeAttrList.push_back(DAK_Exported);
-    result.ExcludeAttrList.push_back(DAK_Inline);
-    result.ExcludeAttrList.push_back(DAK_Optimize);
-    result.ExcludeAttrList.push_back(DAK_Rethrows);
+    result.ExcludeAttrList.push_back(DeclAttrKind::Exported);
+    result.ExcludeAttrList.push_back(DeclAttrKind::Inline);
+    result.ExcludeAttrList.push_back(DeclAttrKind::Optimize);
+    result.ExcludeAttrList.push_back(DeclAttrKind::Rethrows);
     result.PrintOverrideKeyword = false;
     result.AccessFilter = accessFilter;
     result.PrintIfConfig = false;
@@ -773,7 +775,7 @@ struct PrintOptions {
   static PrintOptions printDeclarations() {
     PrintOptions result = printVerbose();
     result.ExcludeAttrList.clear();
-    result.ExcludeAttrList.push_back(DAK_FixedLayout);
+    result.ExcludeAttrList.push_back(DeclAttrKind::FixedLayout);
     result.PrintStorageRepresentationAttrs = true;
     result.AbstractAccessors = false;
     result.PrintAccess = true;
@@ -791,7 +793,7 @@ struct PrintOptions {
     PO.PrintFunctionRepresentationAttrs =
       PrintOptions::FunctionRepresentationMode::None;
     PO.PrintDocumentationComments = false;
-    PO.ExcludeAttrList.push_back(DAK_Available);
+    PO.ExcludeAttrList.push_back(DeclAttrKind::Available);
     PO.SkipPrivateStdlibDecls = true;
     PO.SkipUnsafeCXXMethods = true;
     PO.ExplodeEnumCaseDecls = true;

--- a/include/swift/AST/TypeAttr.def
+++ b/include/swift/AST/TypeAttr.def
@@ -46,6 +46,10 @@
 #define SIMPLE_TYPE_ATTR(SPELLING, CLASS) TYPE_ATTR(SPELLING, CLASS)
 #endif
 
+#ifndef LAST_TYPE_ATTR
+#define LAST_TYPE_ATTR(CLASS)
+#endif
+
 // Type attributes
 SIMPLE_TYPE_ATTR(autoclosure, Autoclosure)
 TYPE_ATTR(convention, Convention)
@@ -105,7 +109,10 @@ SIMPLE_SIL_TYPE_ATTR(isolated, Isolated)
 SIMPLE_SIL_TYPE_ATTR(thin, Thin)
 SIMPLE_SIL_TYPE_ATTR(thick, Thick)
 
+LAST_TYPE_ATTR(Thick)
+
 #undef SIMPLE_SIL_TYPE_ATTR
 #undef SIMPLE_TYPE_ATTR
 #undef SIL_TYPE_ATTR
 #undef TYPE_ATTR
+#undef LAST_TYPE_ATTR

--- a/include/swift/AST/TypeAttr.def
+++ b/include/swift/AST/TypeAttr.def
@@ -1,0 +1,111 @@
+//===--- TypeAttr.def - Swift Attributes Metaprogramming --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines macros used for macro-metaprogramming with type attributes.
+//
+//===----------------------------------------------------------------------===//
+
+// A type attribute that is both a simple type attribute and a
+// SIL type attribute (see below).  Delegates to SIL_TYPE_ATTR if that
+// is set and SIMPLE_TYPE_ATTR is not; otherwise delegates to SIMPLE_TYPE_ATTR.
+#ifndef SIMPLE_SIL_TYPE_ATTR
+#ifdef SIL_TYPE_ATTR
+#ifdef SIMPLE_TYPE_ATTR
+#error ambiguous delegation, must set SIMPLE_SIL_TYPE_ATTR explicitly
+#else
+#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) SIL_TYPE_ATTR(SPELLING, CLASS)
+#endif
+#else
+#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) SIMPLE_TYPE_ATTR(SPELLING, CLASS)
+#endif
+#endif
+
+// Any kind of type attribute.
+#ifndef TYPE_ATTR
+#define TYPE_ATTR(SPELLING, CLASS)
+#endif
+
+// A type attribute that is only valid in SIL mode.  Usually this means
+// that it's only valid in lowered types, but sometimes SIL files
+// also allow things in formal types that aren't normally expressible.
+#ifndef SIL_TYPE_ATTR
+#define SIL_TYPE_ATTR(SPELLING, CLASS) TYPE_ATTR(SPELLING, CLASS)
+#endif
+
+// A type attribute that's always just spelled `@identifier` in source.
+#ifndef SIMPLE_TYPE_ATTR
+#define SIMPLE_TYPE_ATTR(SPELLING, CLASS) TYPE_ATTR(SPELLING, CLASS)
+#endif
+
+// Type attributes
+SIMPLE_TYPE_ATTR(autoclosure, Autoclosure)
+TYPE_ATTR(convention, Convention)
+SIMPLE_TYPE_ATTR(noescape, NoEscape)
+SIMPLE_TYPE_ATTR(escaping, Escaping)
+TYPE_ATTR(differentiable, Differentiable)
+SIMPLE_TYPE_ATTR(noDerivative, NoDerivative)
+SIMPLE_TYPE_ATTR(async, Async)
+SIMPLE_TYPE_ATTR(Sendable, Sendable)
+SIMPLE_TYPE_ATTR(retroactive, Retroactive)
+SIMPLE_TYPE_ATTR(unchecked, Unchecked)
+SIMPLE_TYPE_ATTR(preconcurrency, Preconcurrency)
+SIMPLE_TYPE_ATTR(_local, Local)
+SIMPLE_TYPE_ATTR(_noMetadata, NoMetadata)
+TYPE_ATTR(_opaqueReturnTypeOf, OpaqueReturnTypeOf)
+
+// SIL-specific attributes
+SIMPLE_SIL_TYPE_ATTR(block_storage, BlockStorage)
+SIMPLE_SIL_TYPE_ATTR(box, Box)
+SIMPLE_SIL_TYPE_ATTR(dynamic_self, DynamicSelf)
+#define REF_STORAGE(Name, name, ...) SIMPLE_TYPE_ATTR(sil_##name, SIL##Name)
+#include "swift/AST/ReferenceStorage.def"
+SIMPLE_SIL_TYPE_ATTR(error, Error)
+SIMPLE_SIL_TYPE_ATTR(error_indirect, ErrorIndirect)
+SIMPLE_SIL_TYPE_ATTR(error_unowned, ErrorUnowned)
+SIMPLE_SIL_TYPE_ATTR(out, Out)
+SIMPLE_SIL_TYPE_ATTR(direct, Direct)
+SIMPLE_SIL_TYPE_ATTR(in, In)
+SIMPLE_SIL_TYPE_ATTR(inout, Inout)
+SIMPLE_SIL_TYPE_ATTR(inout_aliasable, InoutAliasable)
+SIMPLE_SIL_TYPE_ATTR(in_guaranteed, InGuaranteed)
+SIMPLE_SIL_TYPE_ATTR(in_constant, InConstant)
+SIMPLE_SIL_TYPE_ATTR(pack_owned, PackOwned)
+SIMPLE_SIL_TYPE_ATTR(pack_guaranteed, PackGuaranteed)
+SIMPLE_SIL_TYPE_ATTR(pack_inout, PackInout)
+SIMPLE_SIL_TYPE_ATTR(pack_out, PackOut)
+SIMPLE_SIL_TYPE_ATTR(owned, Owned)
+SIMPLE_SIL_TYPE_ATTR(unowned_inner_pointer, UnownedInnerPointer)
+SIMPLE_SIL_TYPE_ATTR(guaranteed, Guaranteed)
+SIMPLE_SIL_TYPE_ATTR(autoreleased, Autoreleased)
+SIMPLE_SIL_TYPE_ATTR(callee_owned, CalleeOwned)
+SIMPLE_SIL_TYPE_ATTR(callee_guaranteed, CalleeGuaranteed)
+SIMPLE_SIL_TYPE_ATTR(objc_metatype, ObjCMetatype)
+SIL_TYPE_ATTR(opened, Opened)
+SIL_TYPE_ATTR(pack_element, PackElement)
+SIMPLE_SIL_TYPE_ATTR(pseudogeneric, Pseudogeneric)
+SIMPLE_SIL_TYPE_ATTR(unimplementable, Unimplementable)
+SIMPLE_SIL_TYPE_ATTR(yields, Yields)
+SIMPLE_SIL_TYPE_ATTR(yield_once, YieldOnce)
+SIMPLE_SIL_TYPE_ATTR(yield_many, YieldMany)
+SIMPLE_SIL_TYPE_ATTR(captures_generics, CapturesGenerics)
+// Used at the SIL level to mark a type as moveOnly.
+SIMPLE_SIL_TYPE_ATTR(moveOnly, MoveOnly)
+SIMPLE_SIL_TYPE_ATTR(isolated, Isolated)
+
+// SIL metatype attributes.
+SIMPLE_SIL_TYPE_ATTR(thin, Thin)
+SIMPLE_SIL_TYPE_ATTR(thick, Thick)
+
+#undef SIMPLE_SIL_TYPE_ATTR
+#undef SIMPLE_TYPE_ATTR
+#undef SIL_TYPE_ATTR
+#undef TYPE_ATTR

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -190,7 +190,7 @@ public:
 #define CONTEXTUAL_DECL_ATTR(KW, ...) CONTEXTUAL_CASE(KW)
 #define CONTEXTUAL_DECL_ATTR_ALIAS(KW, ...) CONTEXTUAL_CASE(KW)
 #define CONTEXTUAL_SIMPLE_DECL_ATTR(KW, ...) CONTEXTUAL_CASE(KW)
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 #undef CONTEXTUAL_CASE
       .Case("macro", true)
       .Default(false);

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -711,7 +711,7 @@ SDKNode* SDKNode::constructSDKNode(SDKContext &Ctx,
           auto Result = llvm::StringSwitch<llvm::Optional<TypeAttrKind>>(
                             GetScalarString(&N))
 #define TYPE_ATTR(X, C) .Case(#X, TypeAttrKind::C)
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
                             .Default(llvm::None);
 
           if (!Result)
@@ -730,7 +730,7 @@ SDKNode* SDKNode::constructSDKNode(SDKContext &Ctx,
               auto Result =
                   llvm::StringSwitch<DeclAttrKind>(GetScalarString(&N))
 #define DECL_ATTR(_, NAME, ...) .Case(#NAME, DeclAttrKind::NAME)
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
                       .Default(DeclAttrKind::Count);
               if (Result == DeclAttrKind::Count)
                 Ctx.diagnose(&N, diag::sdk_node_unrecognized_decl_attr_kind,
@@ -2231,7 +2231,7 @@ struct ScalarEnumerationTraits<TypeAttrKind> {
 // NOTE: For historical reasons. TypeAttribute uses the spelling, but
 // DeclAttribute uses the kind name.
 #define TYPE_ATTR(X, C) out.enumCase(value, #X, TypeAttrKind::C);
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   }
 };
 
@@ -2241,7 +2241,7 @@ struct ScalarEnumerationTraits<DeclAttrKind> {
 // NOTE: For historical reasons. TypeAttribute uses the spelling, but
 // DeclAttribute uses the kind name.
 #define DECL_ATTR(_, Name, ...) out.enumCase(value, #Name, DeclAttrKind::Name);
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   }
 };
 
@@ -2780,7 +2780,7 @@ static StringRef getAttrName(DeclAttrKind Kind) {
   case DeclAttrKind::CLASS:                                                    \
     return DeclAttribute::isDeclModifier(DeclAttrKind::CLASS) ? #NAME          \
                                                               : "@" #NAME;
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   case DeclAttrKind::Count:
     llvm_unreachable("unrecognized attribute kind.");
   }

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -1944,22 +1944,22 @@ BridgedYieldStmt BridgedYieldStmt_createParsed(BridgedASTContext cContext,
 BridgedTypeAttrKind BridgedTypeAttrKind_fromString(BridgedStringRef cStr) {
   auto optKind = TypeAttribute::getAttrKindFromString(cStr.unbridged());
   if (!optKind)
-    return BridgedTypeAttrKind_None;
+    return BridgedTypeAttrKindNone;
   switch (*optKind) {
-#define TYPE_ATTR(SPELLING, _)                                                 \
-  case TAK_##SPELLING:                                                         \
-    return BridgedTypeAttrKind_##SPELLING;
+#define TYPE_ATTR(_, CLASS)                                                    \
+  case TAK_##CLASS:                                                            \
+    return BridgedTypeAttrKind##CLASS;
 #include "swift/AST/Attr.def"
   }
 }
 
 static llvm::Optional<TypeAttrKind> unbridged(BridgedTypeAttrKind kind) {
   switch (kind) {
-#define TYPE_ATTR(SPELLING, _)                                                 \
-  case BridgedTypeAttrKind_##SPELLING:                                         \
-    return TAK_##SPELLING;
+#define TYPE_ATTR(_, CLASS)                                                    \
+  case BridgedTypeAttrKind##CLASS:                                             \
+    return TAK_##CLASS;
 #include "swift/AST/Attr.def"
-  case BridgedTypeAttrKind_None:
+  case BridgedTypeAttrKindNone:
     return llvm::None;
   }
   llvm_unreachable("unhandled enum value");

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -355,10 +355,10 @@ BridgedDeclAttrKind BridgedDeclAttrKind_fromString(BridgedStringRef cStr) {
   auto kind = DeclAttribute::getAttrKindFromString(cStr.unbridged());
   switch (kind) {
 #define DECL_ATTR(_, CLASS, ...)                                               \
-  case DAK_##CLASS:                                                            \
+  case DeclAttrKind::CLASS:                                                    \
     return BridgedDeclAttrKind##CLASS;
 #include "swift/AST/Attr.def"
-  case DAK_Count:
+  case DeclAttrKind::Count:
     return BridgedDeclAttrKindNone;
   }
 }
@@ -367,10 +367,10 @@ DeclAttrKind unbridged(BridgedDeclAttrKind kind) {
   switch (kind) {
 #define DECL_ATTR(_, CLASS, ...)                                               \
   case BridgedDeclAttrKind##CLASS:                                             \
-    return DAK_##CLASS;
+    return DeclAttrKind::CLASS;
 #include "swift/AST/Attr.def"
   case BridgedDeclAttrKindNone:
-    return DAK_Count;
+    return DeclAttrKind::Count;
   }
 }
 
@@ -1947,7 +1947,7 @@ BridgedTypeAttrKind BridgedTypeAttrKind_fromString(BridgedStringRef cStr) {
     return BridgedTypeAttrKindNone;
   switch (*optKind) {
 #define TYPE_ATTR(_, CLASS)                                                    \
-  case TAK_##CLASS:                                                            \
+  case TypeAttrKind::CLASS:                                                    \
     return BridgedTypeAttrKind##CLASS;
 #include "swift/AST/Attr.def"
   }
@@ -1957,7 +1957,7 @@ static llvm::Optional<TypeAttrKind> unbridged(BridgedTypeAttrKind kind) {
   switch (kind) {
 #define TYPE_ATTR(_, CLASS)                                                    \
   case BridgedTypeAttrKind##CLASS:                                             \
-    return TAK_##CLASS;
+    return TypeAttrKind::CLASS;
 #include "swift/AST/Attr.def"
   case BridgedTypeAttrKindNone:
     return llvm::None;

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -352,33 +352,35 @@ BridgedDeclContext BridgedPatternBindingInitializer_asDeclContext(
 //===----------------------------------------------------------------------===//
 
 BridgedDeclAttrKind BridgedDeclAttrKind_fromString(BridgedStringRef cStr) {
-  auto kind = DeclAttribute::getAttrKindFromString(cStr.unbridged());
-  switch (kind) {
+  auto optKind = DeclAttribute::getAttrKindFromString(cStr.unbridged());
+  if (!optKind)
+    return BridgedDeclAttrKindNone;
+  switch (*optKind) {
 #define DECL_ATTR(_, CLASS, ...)                                               \
   case DeclAttrKind::CLASS:                                                    \
     return BridgedDeclAttrKind##CLASS;
 #include "swift/AST/DeclAttr.def"
-  case DeclAttrKind::Count:
-    return BridgedDeclAttrKindNone;
   }
 }
 
-DeclAttrKind unbridged(BridgedDeclAttrKind kind) {
+llvm::Optional<DeclAttrKind> unbridged(BridgedDeclAttrKind kind) {
   switch (kind) {
 #define DECL_ATTR(_, CLASS, ...)                                               \
   case BridgedDeclAttrKind##CLASS:                                             \
     return DeclAttrKind::CLASS;
 #include "swift/AST/DeclAttr.def"
   case BridgedDeclAttrKindNone:
-    return DeclAttrKind::Count;
+    return llvm::None;
   }
+  llvm_unreachable("unhandled enum value");
 }
 
 BridgedDeclAttribute BridgedDeclAttribute_createSimple(
     BridgedASTContext cContext, BridgedDeclAttrKind cKind,
     BridgedSourceLoc cAtLoc, BridgedSourceLoc cAttrLoc) {
-  auto kind = unbridged(cKind);
-  return DeclAttribute::createSimple(cContext.unbridged(), kind,
+  auto optKind = unbridged(cKind);
+  assert(optKind && "creating attribute of invalid kind?");
+  return DeclAttribute::createSimple(cContext.unbridged(), *optKind,
                                      cAtLoc.unbridged(), cAttrLoc.unbridged());
 }
 

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -177,7 +177,7 @@ bool BridgedASTContext_langOptsHasFeature(BridgedASTContext cContext,
       Bridged##CLASS##Attr attr) {                                             \
     return static_cast<DeclAttribute *>(attr.unbridged());                     \
   }
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
 //===----------------------------------------------------------------------===//
 // MARK: Diagnostics
@@ -357,7 +357,7 @@ BridgedDeclAttrKind BridgedDeclAttrKind_fromString(BridgedStringRef cStr) {
 #define DECL_ATTR(_, CLASS, ...)                                               \
   case DeclAttrKind::CLASS:                                                    \
     return BridgedDeclAttrKind##CLASS;
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   case DeclAttrKind::Count:
     return BridgedDeclAttrKindNone;
   }
@@ -368,7 +368,7 @@ DeclAttrKind unbridged(BridgedDeclAttrKind kind) {
 #define DECL_ATTR(_, CLASS, ...)                                               \
   case BridgedDeclAttrKind##CLASS:                                             \
     return DeclAttrKind::CLASS;
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   case BridgedDeclAttrKindNone:
     return DeclAttrKind::Count;
   }
@@ -1949,7 +1949,7 @@ BridgedTypeAttrKind BridgedTypeAttrKind_fromString(BridgedStringRef cStr) {
 #define TYPE_ATTR(_, CLASS)                                                    \
   case TypeAttrKind::CLASS:                                                    \
     return BridgedTypeAttrKind##CLASS;
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   }
 }
 
@@ -1958,7 +1958,7 @@ static llvm::Optional<TypeAttrKind> unbridged(BridgedTypeAttrKind kind) {
 #define TYPE_ATTR(_, CLASS)                                                    \
   case BridgedTypeAttrKind##CLASS:                                             \
     return TypeAttrKind::CLASS;
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   case BridgedTypeAttrKindNone:
     return llvm::None;
   }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2693,7 +2693,7 @@ void PrintAST::printInherited(const Decl *decl) {
     if (inherited.isUnchecked())
       Printer << "@unchecked ";
     if (inherited.isRetroactive() &&
-        !llvm::is_contained(Options.ExcludeAttrList, TAK_retroactive))
+        !llvm::is_contained(Options.ExcludeAttrList, TAK_Retroactive))
       Printer << "@retroactive ";
     if (inherited.isPreconcurrency())
       Printer << "@preconcurrency ";
@@ -3690,7 +3690,7 @@ static void suppressingFeatureRetroactiveAttribute(
   PrintOptions &options,
   llvm::function_ref<void()> action) {
   llvm::SaveAndRestore<PrintOptions> originalOptions(options);
-  options.ExcludeAttrList.push_back(TAK_retroactive);
+  options.ExcludeAttrList.push_back(TAK_Retroactive);
   action();
 }
 
@@ -4533,9 +4533,9 @@ static void printParameterFlags(ASTPrinter &printer,
                                 const ParamDecl *param,
                                 ParameterTypeFlags flags,
                                 bool escaping) {
-  if (!options.excludeAttrKind(TAK_autoclosure) && flags.isAutoClosure())
+  if (!options.excludeAttrKind(TAK_Autoclosure) && flags.isAutoClosure())
     printer.printAttrName("@autoclosure ");
-  if (!options.excludeAttrKind(TAK_noDerivative) && flags.isNoDerivative())
+  if (!options.excludeAttrKind(TAK_NoDerivative) && flags.isNoDerivative())
     printer.printAttrName("@noDerivative ");
   if (flags.isTransferring())
     printer.printAttrName("@transferring ");
@@ -4570,7 +4570,7 @@ static void printParameterFlags(ASTPrinter &printer,
   if (flags.hasResultDependsOn())
     printer.printKeyword("_resultDependsOn", options, " ");
 
-  if (!options.excludeAttrKind(TAK_escaping) && escaping)
+  if (!options.excludeAttrKind(TAK_Escaping) && escaping)
     printer.printKeyword("@escaping", options, " ");
 
   if (flags.isCompileTimeConst())
@@ -5021,7 +5021,7 @@ void PrintAST::printEnumElement(EnumElementDecl *elt) {
 
     // @escaping is not valid in enum element position, even though the
     // attribute is implicitly added. Ignore it when printing the parameters.
-    Options.ExcludeAttrList.push_back(TAK_escaping);
+    Options.ExcludeAttrList.push_back(TAK_Escaping);
     printParameterList(PL, params,
                        /*isAPINameByDefault*/true);
     Options.ExcludeAttrList.pop_back();
@@ -6883,7 +6883,7 @@ public:
     if (Options.SkipAttributes)
       return;
 
-    if (!Options.excludeAttrKind(TAK_differentiable)) {
+    if (!Options.excludeAttrKind(TAK_Differentiable)) {
       switch (info.getDifferentiabilityKind()) {
       case DifferentiabilityKind::Normal:
         Printer << "@differentiable ";
@@ -6919,7 +6919,7 @@ public:
       return;
     case PrintOptions::FunctionRepresentationMode::Full:
     case PrintOptions::FunctionRepresentationMode::NameOnly:
-      if (Options.excludeAttrKind(TAK_convention) ||
+      if (Options.excludeAttrKind(TAK_Convention) ||
           info.getSILRepresentation() == SILFunctionType::Representation::Thick)
         return;
 
@@ -6988,7 +6988,7 @@ public:
     if (Options.SkipAttributes)
       return;
 
-    if (!Options.excludeAttrKind(TAK_differentiable)) {
+    if (!Options.excludeAttrKind(TAK_Differentiable)) {
       switch (info.getDifferentiabilityKind()) {
       case DifferentiabilityKind::Normal:
         Printer << "@differentiable ";
@@ -7013,7 +7013,7 @@ public:
       break;
     case PrintOptions::FunctionRepresentationMode::NameOnly:
     case PrintOptions::FunctionRepresentationMode::Full:
-      if (Options.excludeAttrKind(TAK_convention) ||
+      if (Options.excludeAttrKind(TAK_Convention) ||
           info.getRepresentation() == SILFunctionType::Representation::Thick)
         break;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1245,7 +1245,7 @@ void PrintAST::printAttributes(const Decl *D) {
 #define CONTEXTUAL_DECL_ATTR(X, Class, Y, Z) EXCLUDE_ATTR(Class)
 #define CONTEXTUAL_SIMPLE_DECL_ATTR(X, Class, Y, Z) EXCLUDE_ATTR(Class)
 #define CONTEXTUAL_DECL_ATTR_ALIAS(X, Class) EXCLUDE_ATTR(Class)
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
     }
 
     // If the declaration is implicitly @objc, print the attribute now.

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -40,7 +40,7 @@ using namespace swift;
 #define DECL_ATTR(_, Id, ...) \
   static_assert(IsTriviallyDestructible<Id##Attr>::value, \
                 "Attrs are BumpPtrAllocated; the destructor is never called");
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 static_assert(IsTriviallyDestructible<DeclAttributes>::value,
               "DeclAttributes are BumpPtrAllocated; the d'tor is never called");
 
@@ -48,25 +48,25 @@ static_assert(IsTriviallyDestructible<DeclAttributes>::value,
 static_assert(DeclAttribute::isOptionSetFor##Id(DeclAttribute::DeclAttrOptions::ABIBreakingToAdd) != \
               DeclAttribute::isOptionSetFor##Id(DeclAttribute::DeclAttrOptions::ABIStableToAdd),     \
               #Name " needs to specify either ABIBreakingToAdd or ABIStableToAdd");
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
 #define DECL_ATTR(Name, Id, ...)                                                                        \
 static_assert(DeclAttribute::isOptionSetFor##Id(DeclAttribute::DeclAttrOptions::ABIBreakingToRemove) != \
               DeclAttribute::isOptionSetFor##Id(DeclAttribute::DeclAttrOptions::ABIStableToRemove),     \
               #Name " needs to specify either ABIBreakingToRemove or ABIStableToRemove");
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
 #define DECL_ATTR(Name, Id, ...)                                                                     \
 static_assert(DeclAttribute::isOptionSetFor##Id(DeclAttribute::DeclAttrOptions::APIBreakingToAdd) != \
               DeclAttribute::isOptionSetFor##Id(DeclAttribute::DeclAttrOptions::APIStableToAdd),     \
               #Name " needs to specify either APIBreakingToAdd or APIStableToAdd");
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
 #define DECL_ATTR(Name, Id, ...)                                                                        \
 static_assert(DeclAttribute::isOptionSetFor##Id(DeclAttribute::DeclAttrOptions::APIBreakingToRemove) != \
               DeclAttribute::isOptionSetFor##Id(DeclAttribute::DeclAttrOptions::APIStableToRemove),     \
               #Name " needs to specify either APIBreakingToRemove or APIStableToRemove");
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
 StringRef swift::getAccessLevelSpelling(AccessLevel value) {
   switch (value) {
@@ -86,7 +86,7 @@ SourceLoc TypeAttribute::getStartLoc() const {
 #define TYPE_ATTR(_, CLASS)                                                    \
   case TypeAttrKind::CLASS:                                                    \
     return static_cast<const CLASS##TypeAttr *>(this)->getStartLocImpl();
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   }
   llvm_unreachable("bad kind");
 }
@@ -96,7 +96,7 @@ SourceLoc TypeAttribute::getEndLoc() const {
 #define TYPE_ATTR(_, CLASS)                                                    \
   case TypeAttrKind::CLASS:                                                    \
     return static_cast<const CLASS##TypeAttr *>(this)->getEndLocImpl();
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   }
   llvm_unreachable("bad kind");
 }
@@ -108,7 +108,7 @@ SourceRange TypeAttribute::getSourceRange() const {
     auto attr = static_cast<const CLASS##TypeAttr *>(this);                    \
     return SourceRange(attr->getStartLocImpl(), attr->getEndLocImpl());        \
   }
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   }
   llvm_unreachable("bad kind");
 }
@@ -120,7 +120,7 @@ llvm::Optional<TypeAttrKind>
 TypeAttribute::getAttrKindFromString(StringRef Str) {
   return llvm::StringSwitch<llvm::Optional<TypeAttrKind>>(Str)
 #define TYPE_ATTR(X, C) .Case(#X, TypeAttrKind::C)
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
       .Default(llvm::None);
 }
 
@@ -130,7 +130,7 @@ const char *TypeAttribute::getAttrName(TypeAttrKind kind) {
 #define TYPE_ATTR(X, C)                                                        \
   case TypeAttrKind::C:                                                        \
     return #X;
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   }
   llvm_unreachable("unknown type attribute kind");
 }
@@ -150,7 +150,7 @@ TypeAttribute *TypeAttribute::createSimple(const ASTContext &context,
 #define SIMPLE_TYPE_ATTR(SPELLING, CLASS)                                      \
   case TypeAttrKind::CLASS:                                                    \
     return new (context) CLASS##TypeAttr(atLoc, attrLoc);
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   }
   llvm_unreachable("bad type attribute kind");
 }
@@ -166,7 +166,7 @@ void TypeAttribute::print(ASTPrinter &printer,
   switch (getKind()) {
 #define TYPE_ATTR(_, CLASS)
 #define SIMPLE_TYPE_ATTR(_, CLASS) case TypeAttrKind::CLASS:
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
     printer.printSimpleAttr(getAttrName(getKind()), /*needAt*/ true);
     return;
 
@@ -174,7 +174,7 @@ void TypeAttribute::print(ASTPrinter &printer,
   case TypeAttrKind::CLASS:                                                    \
     return cast<CLASS##TypeAttr>(this)->printImpl(printer, options);
 #define SIMPLE_TYPE_ATTR(_, C)
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   }
   llvm_unreachable("bad kind");
 }
@@ -258,7 +258,7 @@ DeclAttrKind DeclAttribute::getAttrKindFromString(StringRef Str) {
   return llvm::StringSwitch<DeclAttrKind>(Str)
 #define DECL_ATTR(X, CLASS, ...) .Case(#X, DeclAttrKind::CLASS)
 #define DECL_ATTR_ALIAS(X, CLASS) .Case(#X, DeclAttrKind::CLASS)
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
       .Case(SPI_AVAILABLE_ATTRNAME, DeclAttrKind::Available)
       .Default(DeclAttrKind::Count);
 }
@@ -276,7 +276,7 @@ DeclAttribute *DeclAttribute::createSimple(const ASTContext &context,
 #define SIMPLE_DECL_ATTR(SPELLING, CLASS, ...)                                 \
   case DeclAttrKind::CLASS:                                                    \
     return new (context) CLASS##Attr(atLoc, attrLoc);
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   case DeclAttrKind::Count:
     llvm_unreachable("bad decl attribute kind");
   }
@@ -1161,7 +1161,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   switch (getKind()) {
     // Handle all of the SIMPLE_DECL_ATTRs.
 #define SIMPLE_DECL_ATTR(X, CLASS, ...) case DeclAttrKind::CLASS:
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   case DeclAttrKind::Inline:
   case DeclAttrKind::AccessControl:
   case DeclAttrKind::ReferenceOwnership:
@@ -1707,7 +1707,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     llvm_unreachable("exceed declaration attribute kinds");
 
 #define SIMPLE_DECL_ATTR(X, CLASS, ...) case DeclAttrKind::CLASS:
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
     llvm_unreachable("handled above");
 
   default:
@@ -1742,7 +1742,7 @@ uint64_t DeclAttribute::getOptions(DeclAttrKind DK) {
 #define DECL_ATTR(_, CLASS, OPTIONS, ...)                                      \
   case DeclAttrKind::CLASS:                                                    \
     return OPTIONS;
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   }
   llvm_unreachable("bad DeclAttrKind");
 }
@@ -1754,7 +1754,7 @@ StringRef DeclAttribute::getAttrName() const {
 #define SIMPLE_DECL_ATTR(NAME, CLASS, ...)                                     \
   case DeclAttrKind::CLASS:                                                    \
     return #NAME;
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   case DeclAttrKind::SILGenName:
     return "_silgen_name";
   case DeclAttrKind::Alignment:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1553,9 +1553,9 @@ InheritedEntry::InheritedEntry(const TypeLoc &typeLoc)
     : InheritedEntry(typeLoc, /*isUnchecked=*/false, /*isRetroactive=*/false,
                      /*isPreconcurrency=*/false) {
   if (auto typeRepr = typeLoc.getTypeRepr()) {
-    IsUnchecked = typeRepr->findAttrLoc(TAK_unchecked).isValid();
-    IsRetroactive = typeRepr->findAttrLoc(TAK_retroactive).isValid();
-    IsPreconcurrency = typeRepr->findAttrLoc(TAK_preconcurrency).isValid();
+    IsUnchecked = typeRepr->findAttrLoc(TAK_Unchecked).isValid();
+    IsRetroactive = typeRepr->findAttrLoc(TAK_Retroactive).isValid();
+    IsPreconcurrency = typeRepr->findAttrLoc(TAK_Preconcurrency).isValid();
   }
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1553,9 +1553,10 @@ InheritedEntry::InheritedEntry(const TypeLoc &typeLoc)
     : InheritedEntry(typeLoc, /*isUnchecked=*/false, /*isRetroactive=*/false,
                      /*isPreconcurrency=*/false) {
   if (auto typeRepr = typeLoc.getTypeRepr()) {
-    IsUnchecked = typeRepr->findAttrLoc(TAK_Unchecked).isValid();
-    IsRetroactive = typeRepr->findAttrLoc(TAK_Retroactive).isValid();
-    IsPreconcurrency = typeRepr->findAttrLoc(TAK_Preconcurrency).isValid();
+    IsUnchecked = typeRepr->findAttrLoc(TypeAttrKind::Unchecked).isValid();
+    IsRetroactive = typeRepr->findAttrLoc(TypeAttrKind::Retroactive).isValid();
+    IsPreconcurrency =
+        typeRepr->findAttrLoc(TypeAttrKind::Preconcurrency).isValid();
   }
 }
 
@@ -4546,7 +4547,8 @@ void ValueDecl::copyFormalAccessFrom(const ValueDecl *source,
   if (source->getAttrs().hasAttribute<UsableFromInlineAttr>() &&
       !getAttrs().hasAttribute<UsableFromInlineAttr>() &&
       !getAttrs().hasAttribute<InlinableAttr>() &&
-      DeclAttribute::canAttributeAppearOnDecl(DAK_UsableFromInline, this)) {
+      DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::UsableFromInline,
+                                              this)) {
     auto &ctx = getASTContext();
     auto *clonedAttr = new (ctx) UsableFromInlineAttr(/*implicit=*/true);
     getAttrs().add(clonedAttr);

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3692,8 +3692,8 @@ void swift::getDirectlyInheritedNominalTypeDecls(
   auto inheritedTypes = InheritedTypes(decl);
   if (TypeRepr *typeRepr = inheritedTypes.getTypeRepr(i)) {
     loc = typeRepr->getLoc();
-    uncheckedLoc = typeRepr->findAttrLoc(TAK_Unchecked);
-    preconcurrencyLoc = typeRepr->findAttrLoc(TAK_Preconcurrency);
+    uncheckedLoc = typeRepr->findAttrLoc(TypeAttrKind::Unchecked);
+    preconcurrencyLoc = typeRepr->findAttrLoc(TypeAttrKind::Preconcurrency);
   }
 
   // Form the result.

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3692,8 +3692,8 @@ void swift::getDirectlyInheritedNominalTypeDecls(
   auto inheritedTypes = InheritedTypes(decl);
   if (TypeRepr *typeRepr = inheritedTypes.getTypeRepr(i)) {
     loc = typeRepr->getLoc();
-    uncheckedLoc = typeRepr->findAttrLoc(TAK_unchecked);
-    preconcurrencyLoc = typeRepr->findAttrLoc(TAK_preconcurrency);
+    uncheckedLoc = typeRepr->findAttrLoc(TAK_Unchecked);
+    preconcurrencyLoc = typeRepr->findAttrLoc(TAK_Preconcurrency);
   }
 
   // Form the result.

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -223,7 +223,7 @@ ReferenceOwnership AttributedTypeRepr::getSILOwnership() const {
     if (!typeAttr) continue;
     switch (typeAttr->getKind()) {
 #define REF_STORAGE(Name, name, ...)                                           \
-  case TAK_SIL##Name:                                                          \
+  case TypeAttrKind::SIL##Name:                                                \
     return ReferenceOwnership::Name;
 #include "swift/AST/ReferenceStorage.def"
     default: continue;

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -222,8 +222,9 @@ ReferenceOwnership AttributedTypeRepr::getSILOwnership() const {
     auto typeAttr = attr.dyn_cast<TypeAttribute*>();
     if (!typeAttr) continue;
     switch (typeAttr->getKind()) {
-#define REF_STORAGE(Name, name, ...) \
-    case TAK_sil_##name: return ReferenceOwnership::Name;
+#define REF_STORAGE(Name, name, ...)                                           \
+  case TAK_SIL##Name:                                                          \
+    return ReferenceOwnership::Name;
 #include "swift/AST/ReferenceStorage.def"
     default: continue;
     }

--- a/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
@@ -51,23 +51,23 @@ extension ASTGenVisitor {
       // Simple type attributes.
       case .autoclosure,
         .escaping,
-        .noescape,
+        .noEscape,
         .noDerivative,
         .async,
         .sendable,
         .retroactive,
         .unchecked,
         .preconcurrency,
-        ._local,
-        ._noMetadata,
-        .pack_owned,
-        .pack_guaranteed,
-        .pack_inout,
-        .pack_out,
+        .local,
+        .noMetadata,
+        .packGuaranteed,
+        .packInout,
+        .packOut,
+        .packOwned,
         .pseudogeneric,
         .yields,
-        .yield_once,
-        .yield_many,
+        .yieldMany,
+        .yieldOnce,
         .thin,
         .thick,
         .unimplementable:
@@ -75,42 +75,42 @@ extension ASTGenVisitor {
 
       case .opened:
         fatalError("unimplemented")
-      case .pack_element:
+      case .packElement:
         fatalError("unimplemented")
       case .differentiable:
         fatalError("unimplemented")
       case .convention:
         fatalError("unimplemented")
-      case ._opaqueReturnTypeOf:
+      case .opaqueReturnTypeOf:
         fatalError("unimplemented")
 
       // SIL type attributes are not supported.
       case .autoreleased,
-        .block_storage,
+        .blockStorage,
         .box,
-        .callee_guaranteed,
-        .callee_owned,
-        .captures_generics,
+        .calleeGuaranteed,
+        .calleeOwned,
+        .capturesGenerics,
         .direct,
-        .dynamic_self,
+        .dynamicSelf,
         .error,
-        .error_indirect,
-        .error_unowned,
+        .errorIndirect,
+        .errorUnowned,
         .guaranteed,
         .in,
-        .in_constant,
-        .in_guaranteed,
+        .inConstant,
+        .inGuaranteed,
         .inout,
-        .inout_aliasable,
+        .inoutAliasable,
         .isolated,
         .moveOnly,
-        .objc_metatype,
+        .objCMetatype,
         .out,
         .owned,
-        .sil_unmanaged,
-        .sil_unowned,
-        .sil_weak,
-        .unowned_inner_pointer:
+        .silUnmanaged,
+        .silUnowned,
+        .silWeak,
+        .unownedInnerPointer:
         break;
 
       // Not a type attribute.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5651,11 +5651,11 @@ DeclAttributes cloneImportedAttributes(ValueDecl *decl, ASTContext &context) {
   auto attrs = DeclAttributes();
   for (auto attr : decl->getAttrs()) {
     switch (attr->getKind()) {
-    case DAK_Available: {
+    case DeclAttrKind::Available: {
       attrs.add(cast<AvailableAttr>(attr)->clone(context, true));
       break;
     }
-    case DAK_Custom: {
+    case DeclAttrKind::Custom: {
       if (CustomAttr *cAttr = cast<CustomAttr>(attr)) {
         attrs.add(CustomAttr::create(context, SourceLoc(), cAttr->getTypeExpr(),
                                      cAttr->getInitContext(), cAttr->getArgs(),
@@ -5663,23 +5663,23 @@ DeclAttributes cloneImportedAttributes(ValueDecl *decl, ASTContext &context) {
       }
       break;
     }
-    case DAK_DiscardableResult: {
+    case DeclAttrKind::DiscardableResult: {
       attrs.add(new (context) DiscardableResultAttr(true));
       break;
     }
-    case DAK_Effects: {
+    case DeclAttrKind::Effects: {
       attrs.add(cast<EffectsAttr>(attr)->clone(context));
       break;
     }
-    case DAK_Final: {
+    case DeclAttrKind::Final: {
       attrs.add(new (context) FinalAttr(true));
       break;
     }
-    case DAK_Transparent: {
+    case DeclAttrKind::Transparent: {
       attrs.add(new (context) TransparentAttr(true));
       break;
     }
-    case DAK_WarnUnqualifiedAccess: {
+    case DeclAttrKind::WarnUnqualifiedAccess: {
       attrs.add(new (context) WarnUnqualifiedAccessAttr(true));
       break;
     }

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -563,7 +563,7 @@ static void diagnoseRemovedDecl(const SDKNodeDecl *D) {
     // Don't complain about removing @_alwaysEmitIntoClient if we are checking ABI.
     // We shouldn't include these decls in the ABI baseline file. This line is
     // added so the checker is backward compatible.
-    if (D->hasDeclAttribute(DeclAttrKind::DAK_AlwaysEmitIntoClient))
+    if (D->hasDeclAttribute(DeclAttrKind::AlwaysEmitIntoClient))
       return;
   }
   auto &Ctx = D->getSDKContext();
@@ -668,11 +668,11 @@ public:
     // Decls with @_alwaysEmitIntoClient aren't required to have an
     // @available attribute.
     if (!Ctx.getOpts().SkipOSCheck &&
-        DeclAttribute::canAttributeAppearOnDeclKind(DeclAttrKind::DAK_Available,
+        DeclAttribute::canAttributeAppearOnDeclKind(DeclAttrKind::Available,
                                                     D->getDeclKind()) &&
         !D->getIntroducingVersion().hasOSAvailability() &&
-        !D->hasDeclAttribute(DeclAttrKind::DAK_AlwaysEmitIntoClient) &&
-        !D->hasDeclAttribute(DeclAttrKind::DAK_Marker)) {
+        !D->hasDeclAttribute(DeclAttrKind::AlwaysEmitIntoClient) &&
+        !D->hasDeclAttribute(DeclAttrKind::Marker)) {
       D->emitDiag(D->getLoc(), diag::new_decl_without_intro);
     }
   }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -815,7 +815,7 @@ static void addDeclKeywords(CodeCompletionResultSink &Sink, DeclContext *DC,
 #define CONTEXTUAL_DECL_ATTR(KW, CLASS, ...) CONTEXTUAL_CASE(KW, CLASS)
 #define CONTEXTUAL_DECL_ATTR_ALIAS(KW, CLASS) CONTEXTUAL_CASE(KW, CLASS)
 #define CONTEXTUAL_SIMPLE_DECL_ATTR(KW, CLASS, ...) CONTEXTUAL_CASE(KW, CLASS)
-#include <swift/AST/Attr.def>
+#include <swift/AST/DeclAttr.def>
 #undef CONTEXTUAL_CASE
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -750,19 +750,19 @@ static void addDeclKeywords(CodeCompletionResultSink &Sink, DeclContext *DC,
       // These modifiers are invalid for decls in function body.
       if (DAK) {
         switch (*DAK) {
-        case DeclAttrKind::DAK_Lazy:
-        case DeclAttrKind::DAK_Final:
-        case DeclAttrKind::DAK_Infix:
-        case DeclAttrKind::DAK_Frozen:
-        case DeclAttrKind::DAK_Prefix:
-        case DeclAttrKind::DAK_Postfix:
-        case DeclAttrKind::DAK_Dynamic:
-        case DeclAttrKind::DAK_Override:
-        case DeclAttrKind::DAK_Optional:
-        case DeclAttrKind::DAK_Required:
-        case DeclAttrKind::DAK_Convenience:
-        case DeclAttrKind::DAK_AccessControl:
-        case DeclAttrKind::DAK_Nonisolated:
+        case DeclAttrKind::Lazy:
+        case DeclAttrKind::Final:
+        case DeclAttrKind::Infix:
+        case DeclAttrKind::Frozen:
+        case DeclAttrKind::Prefix:
+        case DeclAttrKind::Postfix:
+        case DeclAttrKind::Dynamic:
+        case DeclAttrKind::Override:
+        case DeclAttrKind::Optional:
+        case DeclAttrKind::Required:
+        case DeclAttrKind::Convenience:
+        case DeclAttrKind::AccessControl:
+        case DeclAttrKind::Nonisolated:
           return CodeCompletionFlairBit::RareKeywordAtCurrentPosition;
 
         default:
@@ -811,7 +811,7 @@ static void addDeclKeywords(CodeCompletionResultSink &Sink, DeclContext *DC,
     AddDeclKeyword(Name, CodeCompletionKeywordKind::None, Kind);
   };
 
-#define CONTEXTUAL_CASE(KW, CLASS) AddCSKeyword(#KW, DAK_##CLASS);
+#define CONTEXTUAL_CASE(KW, CLASS) AddCSKeyword(#KW, DeclAttrKind::CLASS);
 #define CONTEXTUAL_DECL_ATTR(KW, CLASS, ...) CONTEXTUAL_CASE(KW, CLASS)
 #define CONTEXTUAL_DECL_ATTR_ALIAS(KW, CLASS) CONTEXTUAL_CASE(KW, CLASS)
 #define CONTEXTUAL_SIMPLE_DECL_ATTR(KW, CLASS, ...) CONTEXTUAL_CASE(KW, CLASS)

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3030,7 +3030,7 @@ void CompletionLookup::getAttributeDeclCompletions(
   if (canUseAttributeOnDecl(DeclAttrKind::NAME, IsInSil, IsConcurrencyEnabled, \
                             DK, #KEYWORD))                                     \
     addDeclAttrKeyword(#KEYWORD, Description);
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 }
 
 void CompletionLookup::getAttributeDeclParamCompletions(

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3027,8 +3027,8 @@ void CompletionLookup::getAttributeDeclCompletions(
   std::string Description = TargetName.str() + " Attribute";
 #define DECL_ATTR_ALIAS(KEYWORD, NAME) DECL_ATTR(KEYWORD, NAME, 0, 0)
 #define DECL_ATTR(KEYWORD, NAME, ...)                                          \
-  if (canUseAttributeOnDecl(DAK_##NAME, IsInSil, IsConcurrencyEnabled, DK,     \
-                            #KEYWORD))                                         \
+  if (canUseAttributeOnDecl(DeclAttrKind::NAME, IsInSil, IsConcurrencyEnabled, \
+                            DK, #KEYWORD))                                     \
     addDeclAttrKeyword(#KEYWORD, Description);
 #include "swift/AST/Attr.def"
 }

--- a/lib/IDE/CompletionOverrideLookup.cpp
+++ b/lib/IDE/CompletionOverrideLookup.cpp
@@ -156,8 +156,8 @@ void CompletionOverrideLookup::addValueOverride(
 
   PO.SkipUnderscoredKeywords = true;
   PO.PrintImplicitAttrs = false;
-  PO.ExclusiveAttrList.push_back(TAK_escaping);
-  PO.ExclusiveAttrList.push_back(TAK_autoclosure);
+  PO.ExclusiveAttrList.push_back(TAK_Escaping);
+  PO.ExclusiveAttrList.push_back(TAK_Autoclosure);
   // Print certain modifiers only when the introducer is not written.
   // Otherwise, the user can add it after the completion.
   if (!hasDeclIntroducer) {

--- a/lib/IDE/CompletionOverrideLookup.cpp
+++ b/lib/IDE/CompletionOverrideLookup.cpp
@@ -156,12 +156,12 @@ void CompletionOverrideLookup::addValueOverride(
 
   PO.SkipUnderscoredKeywords = true;
   PO.PrintImplicitAttrs = false;
-  PO.ExclusiveAttrList.push_back(TAK_Escaping);
-  PO.ExclusiveAttrList.push_back(TAK_Autoclosure);
+  PO.ExclusiveAttrList.push_back(TypeAttrKind::Escaping);
+  PO.ExclusiveAttrList.push_back(TypeAttrKind::Autoclosure);
   // Print certain modifiers only when the introducer is not written.
   // Otherwise, the user can add it after the completion.
   if (!hasDeclIntroducer) {
-    PO.ExclusiveAttrList.push_back(DAK_Nonisolated);
+    PO.ExclusiveAttrList.push_back(DeclAttrKind::Nonisolated);
   }
 
   PO.PrintAccess = false;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -114,7 +114,7 @@ PrintOptions PrintOptions::printDocInterface() {
       PrintOptions::printModuleInterface(/*printFullConvention*/ false);
   result.PrintAccess = false;
   result.SkipUnavailable = false;
-  result.ExcludeAttrList.push_back(DAK_Available);
+  result.ExcludeAttrList.push_back(DeclAttrKind::Available);
   result.ArgAndParamPrinting =
       PrintOptions::ArgAndParamPrintingMode::BothAlways;
   result.PrintDocumentationComments = false;

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -135,8 +135,7 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
       // This token is following @, see if it's a known attribute name.
       // Type attribute, decl attribute, or '@unknown' for swift case statement.
       if (TypeAttribute::getAttrKindFromString(Tok.getText()).has_value() ||
-          DeclAttribute::getAttrKindFromString(Tok.getText()) !=
-              DeclAttrKind::Count ||
+          DeclAttribute::getAttrKindFromString(Tok.getText()).has_value() ||
           Tok.getText() == "unknown") {
         // It's a known attribute, so treat it as a syntactic attribute node for
         // syntax coloring. If swift gets user attributes then all identifiers

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -135,8 +135,9 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
       // This token is following @, see if it's a known attribute name.
       // Type attribute, decl attribute, or '@unknown' for swift case statement.
       if (TypeAttribute::getAttrKindFromString(Tok.getText()).has_value() ||
-          DeclAttribute::getAttrKindFromString(Tok.getText()) != DAK_Count ||
-          Tok.getText() == "unknown")  {
+          DeclAttribute::getAttrKindFromString(Tok.getText()) !=
+              DeclAttrKind::Count ||
+          Tok.getText() == "unknown") {
         // It's a known attribute, so treat it as a syntactic attribute node for
         // syntax coloring. If swift gets user attributes then all identifiers
         // will be treated as syntactic attribute nodes.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2911,7 +2911,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     llvm_unreachable("handled by DeclAttrKind::AccessControl");
 
 #define SIMPLE_DECL_ATTR(_, CLASS, ...) case DeclAttrKind::CLASS:
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
     if (!DiscardAttribute)
       Attributes.add(DeclAttribute::createSimple(Context, DK, AtLoc, Loc));
     break;
@@ -4759,7 +4759,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
   // Simple type attributes don't need any further checking.
 #define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS)
 #define SIMPLE_TYPE_ATTR(SPELLING, CLASS) case TypeAttrKind::CLASS:
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   SimpleAttr:
     if (!justChecking) {
       result = TypeAttribute::createSimple(Context, attr, AtLoc, attrLoc);
@@ -4769,7 +4769,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
   // For simple SIL type attributes, check whether we're parsing SIL,
   // then return to the SimpleAttr case.
 #define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) case TypeAttrKind::CLASS:
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
     if (!isInSILMode()) {
       if (!justChecking) {
         if (attr == TypeAttrKind::Inout) {
@@ -5165,7 +5165,7 @@ ParserStatus Parser::parseDeclModifierList(DeclAttributes &Attributes,
 #define CONTEXTUAL_DECL_ATTR(KW, CLASS, ...) CONTEXTUAL_CASE(KW, CLASS)
 #define CONTEXTUAL_DECL_ATTR_ALIAS(KW, CLASS) CONTEXTUAL_CASE(KW, CLASS)
 #define CONTEXTUAL_SIMPLE_DECL_ATTR(KW, CLASS, ...) CONTEXTUAL_CASE(KW, CLASS)
-#include <swift/AST/Attr.def>
+#include <swift/AST/DeclAttr.def>
 #undef CONTEXTUAL_CASE
                               .Default(DeclAttrKind::Count);
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -938,7 +938,7 @@ bool Parser::parseSpecializeAttributeArguments(
       for (auto req : requirements) {
         if (req.getKind() == RequirementReprKind::LayoutConstraint) {
           if (auto *attributedTy = dyn_cast<AttributedTypeRepr>(req.getSubjectRepr())) {
-            if (attributedTy->has(TAK_NoMetadata)) {
+            if (attributedTy->has(TypeAttrKind::NoMetadata)) {
               typeErasedParamsCount += 1;
             }
           }
@@ -1425,7 +1425,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
   // Parse @_extern(<language>, ...)
   if (!consumeIfAttributeLParen()) {
     diagnose(Loc, diag::attr_expected_lparen, AttrName,
-             DeclAttribute::isDeclModifier(DAK_Extern));
+             DeclAttribute::isDeclModifier(DeclAttrKind::Extern));
     return false;
   }
   auto diagnoseExpectLanguage = [&]() {
@@ -1440,7 +1440,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
       [&](std::optional<StringRef> fieldName) -> llvm::Optional<StringRef> {
     if (!consumeIf(tok::comma)) {
       diagnose(Loc, diag::attr_expected_comma, AttrName,
-               DeclAttribute::isDeclModifier(DAK_Extern));
+               DeclAttribute::isDeclModifier(DeclAttrKind::Extern));
       return std::nullopt;
     }
     if (fieldName) {
@@ -1503,7 +1503,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
   rParenLoc = Tok.getLoc();
   if (!consumeIf(tok::r_paren)) {
     diagnose(Loc, diag::attr_expected_rparen, AttrName,
-             DeclAttribute::isDeclModifier(DAK_Extern));
+             DeclAttribute::isDeclModifier(DeclAttrKind::Extern));
     return false;
   }
 
@@ -2281,7 +2281,7 @@ bool Parser::parseBackDeployedAttribute(DeclAttributes &Attributes,
   auto LeftLoc = Tok.getLoc();
   if (!consumeIfAttributeLParen()) {
     diagnose(Loc, diag::attr_expected_lparen, AtAttrName,
-             DeclAttribute::isDeclModifier(DAK_BackDeployed));
+             DeclAttribute::isDeclModifier(DeclAttrKind::BackDeployed));
     return false;
   }
 
@@ -2423,7 +2423,8 @@ bool Parser::parseDocumentationAttributeArgument(
 ParserResult<DocumentationAttr>
 Parser::parseDocumentationAttribute(SourceLoc AtLoc, SourceLoc Loc) {
   StringRef AttrName = "_documentation";
-  bool declModifier = DeclAttribute::isDeclModifier(DAK_Documentation);
+  bool declModifier =
+      DeclAttribute::isDeclModifier(DeclAttrKind::Documentation);
   llvm::Optional<AccessLevel> Visibility = llvm::None;
   llvm::Optional<StringRef> Metadata = llvm::None;
 
@@ -2874,14 +2875,14 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
   }
 
   if (Context.LangOpts.Target.isOSBinFormatCOFF()) {
-    if (DK == DAK_WeakLinked) {
+    if (DK == DeclAttrKind::WeakLinked) {
       diagnose(Loc, diag::attr_unsupported_on_target, AttrName,
                Context.LangOpts.Target.str());
       DiscardAttribute = true;
     }
   }
 
-  if (DK == DAK_ResultDependsOnSelf &&
+  if (DK == DeclAttrKind::ResultDependsOnSelf &&
       !Context.LangOpts.hasFeature(Feature::NonescapableTypes)) {
     diagnose(Loc, diag::requires_experimental_feature, AttrName, true,
              getFeatureName(Feature::NonescapableTypes));
@@ -2895,32 +2896,32 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
   ParserStatus Status;
 
   switch (DK) {
-  case DAK_Count:
-    llvm_unreachable("DAK_Count should not appear in parsing switch");
+  case DeclAttrKind::Count:
+    llvm_unreachable("DeclAttrKind::Count should not appear in parsing switch");
 
-  case DAK_RawDocComment:
-  case DAK_ObjCBridged:
-  case DAK_RestatedObjCConformance:
-  case DAK_SynthesizedProtocol:
-  case DAK_ClangImporterSynthesizedType:
-  case DAK_Custom:
+  case DeclAttrKind::RawDocComment:
+  case DeclAttrKind::ObjCBridged:
+  case DeclAttrKind::RestatedObjCConformance:
+  case DeclAttrKind::SynthesizedProtocol:
+  case DeclAttrKind::ClangImporterSynthesizedType:
+  case DeclAttrKind::Custom:
     llvm_unreachable("virtual attributes should not be parsed "
                      "by attribute parsing code");
-  case DAK_SetterAccess:
-    llvm_unreachable("handled by DAK_AccessControl");
+  case DeclAttrKind::SetterAccess:
+    llvm_unreachable("handled by DeclAttrKind::AccessControl");
 
-#define SIMPLE_DECL_ATTR(_, CLASS, ...) case DAK_##CLASS:
+#define SIMPLE_DECL_ATTR(_, CLASS, ...) case DeclAttrKind::CLASS:
 #include "swift/AST/Attr.def"
     if (!DiscardAttribute)
       Attributes.add(DeclAttribute::createSimple(Context, DK, AtLoc, Loc));
     break;
 
-  case DAK_MainType:
+  case DeclAttrKind::MainType:
     if (!DiscardAttribute)
       Attributes.add(new (Context) MainTypeAttr(AtLoc, Loc));
     break;
 
-  case DAK_Effects: {
+  case DeclAttrKind::Effects: {
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -2975,7 +2976,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_Inline: {
+  case DeclAttrKind::Inline: {
     auto kind = parseSingleAttrOption<InlineKind>(
         *this, Loc, AttrRange, AttrName, DK, {
           { Context.Id_never,   InlineKind::Never },
@@ -2990,7 +2991,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_Optimize: {
+  case DeclAttrKind::Optimize: {
     auto optMode = parseSingleAttrOption<OptimizationMode>(
         *this, Loc, AttrRange, AttrName, DK, {
           { Context.Id_speed, OptimizationMode::ForSpeed },
@@ -3006,7 +3007,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_Exclusivity: {
+  case DeclAttrKind::Exclusivity: {
     auto mode = parseSingleAttrOption<ExclusivityAttr::Mode>(
            *this, Loc, AttrRange, AttrName, DK, {
              { Context.Id_checked, ExclusivityAttr::Mode::Checked },
@@ -3021,7 +3022,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_ReferenceOwnership: {
+  case DeclAttrKind::ReferenceOwnership: {
     // Handle weak/unowned/unowned(unsafe).
     auto Kind = AttrName == "weak" ? ReferenceOwnership::Weak
                                    : ReferenceOwnership::Unowned;
@@ -3047,7 +3048,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_NonSendable: {
+  case DeclAttrKind::NonSendable: {
     auto kind = parseSingleAttrOption<NonSendableKind>(
         *this, Loc, AttrRange, AttrName, DK, {
           { Context.Id_assumed, NonSendableKind::Assumed }
@@ -3061,7 +3062,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_AccessControl: {
+  case DeclAttrKind::AccessControl: {
 
     // Diagnose using access control in a local scope, which isn't meaningful.
     if (CurDeclContext->isLocalContext()) {
@@ -3152,7 +3153,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_SPIAccessControl: {
+  case DeclAttrKind::SPIAccessControl: {
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -3191,9 +3192,9 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_CDecl:
-  case DAK_Expose:
-  case DAK_SILGenName: {
+  case DeclAttrKind::CDecl:
+  case DeclAttrKind::Expose:
+  case DeclAttrKind::SILGenName: {
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -3203,7 +3204,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     bool ParseSymbolName = true;
 
     ExposureKind ExpKind;
-    if (DK == DAK_Expose) {
+    if (DK == DeclAttrKind::Expose) {
       auto diagnoseExpectOption = [&]() {
         diagnose(Tok.getLoc(), diag::attr_expected_option_such_as, AttrName,
                  "Cxx");
@@ -3226,7 +3227,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
 
     bool Raw = false;
-    if (DK == DAK_SILGenName) {
+    if (DK == DeclAttrKind::SILGenName) {
       if (Tok.is(tok::identifier) && Tok.getText() == "raw") {
         consumeToken(tok::identifier);
         consumeToken(tok::colon);
@@ -3268,13 +3269,13 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
 
     if (!DiscardAttribute) {
-      if (DK == DAK_SILGenName)
+      if (DK == DeclAttrKind::SILGenName)
         Attributes.add(new (Context) SILGenNameAttr(AsmName.value(), Raw, AtLoc,
                                                 AttrRange, /*Implicit=*/false));
-      else if (DK == DAK_CDecl)
+      else if (DK == DeclAttrKind::CDecl)
         Attributes.add(new (Context) CDeclAttr(AsmName.value(), AtLoc,
                                                AttrRange, /*Implicit=*/false));
-      else if (DK == DAK_Expose) {
+      else if (DK == DeclAttrKind::Expose) {
         for (auto *EA : Attributes.getAttributes<ExposeAttr>()) {
           // A single declaration cannot have two @_exported attributes with
           // the same exposure kind.
@@ -3286,21 +3287,20 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         Attributes.add(new (Context) ExposeAttr(
             AsmName ? AsmName.value() : StringRef(""), AtLoc, AttrRange,
             ExpKind, /*Implicit=*/false));
-      }
-      else
+      } else
         llvm_unreachable("out of sync with switch");
     }
 
     break;
   }
 
-  case DAK_Extern: {
+  case DeclAttrKind::Extern: {
     if (!parseExternAttribute(Attributes, DiscardAttribute, AttrName, AtLoc, Loc))
       return makeParserSuccess();
     break;
   }
 
-  case DAK_Section: {
+  case DeclAttrKind::Section: {
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -3339,8 +3339,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
     break;
   }
-  
-  case DAK_Alignment: {
+
+  case DeclAttrKind::Alignment: {
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -3374,8 +3374,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     
     break;
   }
-  
-  case DAK_SwiftNativeObjCRuntimeBase: {
+
+  case DeclAttrKind::SwiftNativeObjCRuntimeBase: {
     SourceRange range;
     auto name = parseSingleAttrOptionIdentifier(*this, Loc, range, AttrName,
                                                 DK);
@@ -3386,8 +3386,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
                                             AtLoc, range, /*implicit*/ false));
     break;
   }
-  
-  case DAK_Semantics: {
+
+  case DeclAttrKind::Semantics: {
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -3421,7 +3421,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
                                                  /*Implicit=*/false));
     break;
   }
-  case DAK_OriginallyDefinedIn: {
+  case DeclAttrKind::OriginallyDefinedIn: {
     auto LeftLoc = Tok.getLoc();
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
@@ -3512,7 +3512,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
     break;
   }
-  case DAK_Available: {
+  case DeclAttrKind::Available: {
     if (!consumeIfAttributeLParen()) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -3524,7 +3524,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       return makeParserSuccess();
     break;
   }
-  case DAK_PrivateImport: {
+  case DeclAttrKind::PrivateImport: {
     // Parse the leading '('.
     if (Tok.isNot(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
@@ -3574,7 +3574,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
     break;
   }
-  case DAK_ObjC: {
+  case DeclAttrKind::ObjC: {
     // Unnamed @objc attribute.
     if (Tok.isNot(tok::l_paren)) {
       auto attr = ObjCAttr::createUnnamed(Context, AtLoc, Loc);
@@ -3618,7 +3618,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     Attributes.add(attr);
     break;
   }
-  case DAK_ObjCImplementation: {
+  case DeclAttrKind::ObjCImplementation: {
     SourceRange range;
     auto name = parseSingleAttrOptionIdentifier(*this, Loc, range, AttrName, DK,
                                                 /*allowOmitted=*/true);
@@ -3628,7 +3628,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     Attributes.add(new (Context) ObjCImplementationAttr(*name, AtLoc, range));
     break;
   }
-  case DAK_ObjCRuntimeName: {
+  case DeclAttrKind::ObjCRuntimeName: {
     SourceRange range;
     auto name =
         parseSingleAttrOptionIdentifier(*this, Loc, range, AttrName, DK);
@@ -3640,8 +3640,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-
-  case DAK_DynamicReplacement: {
+  case DeclAttrKind::DynamicReplacement: {
     // Parse the leading '('.
     if (Tok.isNot(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
@@ -3692,7 +3691,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_TypeEraser: {
+  case DeclAttrKind::TypeEraser: {
     // Parse leading '('
     if (Tok.isNot(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
@@ -3722,7 +3721,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_Specialize: {
+  case DeclAttrKind::Specialize: {
     if (Tok.isNot(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -3734,9 +3733,9 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
     Attributes.add(Attr);
     break;
-    }
+  }
 
-  case DAK_StorageRestrictions: {
+  case DeclAttrKind::StorageRestrictions: {
     ParserResult<StorageRestrictionsAttr> Attr =
         parseStorageRestrictionsAttribute(AtLoc, Loc);
     Status |= Attr;
@@ -3746,7 +3745,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_Implements: {
+  case DeclAttrKind::Implements: {
     ParserResult<ImplementsAttr> Attr = parseImplementsAttribute(AtLoc, Loc);
     Status |= Attr;
     if (Attr.isNonNull()) {
@@ -3755,7 +3754,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_Differentiable: {
+  case DeclAttrKind::Differentiable: {
     auto Attr = parseDifferentiableAttribute(AtLoc, Loc);
     Status |= Attr;
     if (Attr.isNonNull())
@@ -3763,7 +3762,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_Derivative: {
+  case DeclAttrKind::Derivative: {
     // `@derivative` in a local scope is not allowed.
     if (CurDeclContext->isLocalContext())
       diagnose(Loc, diag::attr_only_at_non_local_scope, '@' + AttrName.str());
@@ -3775,7 +3774,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_Transpose: {
+  case DeclAttrKind::Transpose: {
     // `@transpose` in a local scope is not allowed.
     if (CurDeclContext->isLocalContext())
       diagnose(Loc, diag::attr_only_at_non_local_scope, '@' + AttrName.str());
@@ -3787,7 +3786,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_ProjectedValueProperty: {
+  case DeclAttrKind::ProjectedValueProperty: {
     SourceRange range;
     auto name =
         parseSingleAttrOptionIdentifier(*this, Loc, range, AttrName, DK);
@@ -3799,7 +3798,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DAK_UnavailableFromAsync: {
+  case DeclAttrKind::UnavailableFromAsync: {
     StringRef message;
     if (consumeIfAttributeLParen()) {
       if (!Tok.is(tok::identifier)) {
@@ -3845,12 +3844,12 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         message, AtLoc, SourceRange(Loc, Tok.getLoc()), false));
     break;
   }
-  case DAK_BackDeployed: {
+  case DeclAttrKind::BackDeployed: {
     if (!parseBackDeployedAttribute(Attributes, AttrName, AtLoc, Loc))
       return makeParserSuccess();
     break;
   }
-  case DAK_Documentation: {
+  case DeclAttrKind::Documentation: {
     auto Attr = parseDocumentationAttribute(AtLoc, Loc);
     Status |= Attr;
     if (Attr.isNonNull())
@@ -3859,7 +3858,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       return makeParserSuccess();
     break;
   }
-  case DAK_Nonisolated: {
+  case DeclAttrKind::Nonisolated: {
     auto isUnsafe =
         parseSingleAttrOption<bool>(*this, Loc, AttrRange, AttrName, DK,
                                     {{Context.Id_unsafe, true}}, false);
@@ -3873,7 +3872,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
     break;
   }
-  case DAK_MacroRole: {
+  case DeclAttrKind::MacroRole: {
     auto syntax = (AttrName == "freestanding" ? MacroSyntax::Freestanding
                                               : MacroSyntax::Attached);
     auto Attr = parseMacroRoleAttribute(syntax, AtLoc, Loc);
@@ -3884,7 +3883,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       return Attr;
     break;
   }
-  case DAK_RawLayout: {
+  case DeclAttrKind::RawLayout: {
     if (Tok.isNot(tok::l_paren)) {
       diagnose(Loc, diag::attr_expected_lparen, AttrName,
                DeclAttribute::isDeclModifier(DK));
@@ -4250,13 +4249,17 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
   // If the attribute follows the new representation, switch
   // over to the alternate parsing path.
   DeclAttrKind DK = DeclAttribute::getAttrKindFromString(Tok.getText());
-  if (DK == DAK_Rethrows) { DK = DAK_AtRethrows; }
-  if (DK == DAK_Reasync) { DK = DAK_AtReasync; }
+  if (DK == DeclAttrKind::Rethrows) {
+    DK = DeclAttrKind::AtRethrows;
+  }
+  if (DK == DeclAttrKind::Reasync) {
+    DK = DeclAttrKind::AtReasync;
+  }
 
   auto checkInvalidAttrName =
       [&](StringRef invalidName, StringRef correctName, DeclAttrKind kind,
           llvm::Optional<Diag<StringRef, StringRef>> diag = llvm::None) {
-        if (DK == DAK_Count && Tok.getText() == invalidName) {
+        if (DK == DeclAttrKind::Count && Tok.getText() == invalidName) {
           DK = kind;
 
           if (diag) {
@@ -4267,55 +4270,64 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
       };
 
   // Check if attr is availability, and suggest available instead
-  checkInvalidAttrName("availability", "available", DAK_Available, diag::attr_renamed);
+  checkInvalidAttrName("availability", "available", DeclAttrKind::Available,
+                       diag::attr_renamed);
 
   // Check if attr is inlineable, and suggest inlinable instead
-  checkInvalidAttrName("inlineable", "inlinable", DAK_Inlinable, diag::attr_name_close_match);
+  checkInvalidAttrName("inlineable", "inlinable", DeclAttrKind::Inlinable,
+                       diag::attr_name_close_match);
 
   // In Swift 5 and above, these become hard errors. In Swift 4.2, emit a
   // warning for compatibility. Otherwise, don't diagnose at all.
   if (Context.isSwiftVersionAtLeast(5)) {
-    checkInvalidAttrName("_versioned", "usableFromInline", DAK_UsableFromInline, diag::attr_renamed);
-    checkInvalidAttrName("_inlineable", "inlinable", DAK_Inlinable, diag::attr_renamed);
+    checkInvalidAttrName("_versioned", "usableFromInline",
+                         DeclAttrKind::UsableFromInline, diag::attr_renamed);
+    checkInvalidAttrName("_inlineable", "inlinable", DeclAttrKind::Inlinable,
+                         diag::attr_renamed);
   } else if (Context.isSwiftVersionAtLeast(4, 2)) {
-    checkInvalidAttrName("_versioned", "usableFromInline", DAK_UsableFromInline, diag::attr_renamed_warning);
-    checkInvalidAttrName("_inlineable", "inlinable", DAK_Inlinable, diag::attr_renamed_warning);
+    checkInvalidAttrName("_versioned", "usableFromInline",
+                         DeclAttrKind::UsableFromInline,
+                         diag::attr_renamed_warning);
+    checkInvalidAttrName("_inlineable", "inlinable", DeclAttrKind::Inlinable,
+                         diag::attr_renamed_warning);
   } else {
-    checkInvalidAttrName("_versioned", "usableFromInline", DAK_UsableFromInline);
-    checkInvalidAttrName("_inlineable", "inlinable", DAK_Inlinable);
+    checkInvalidAttrName("_versioned", "usableFromInline",
+                         DeclAttrKind::UsableFromInline);
+    checkInvalidAttrName("_inlineable", "inlinable", DeclAttrKind::Inlinable);
   }
 
   // Other names of property wrappers...
   checkInvalidAttrName("propertyDelegate", "propertyWrapper",
-                       DAK_PropertyWrapper, diag::attr_renamed_warning);
+                       DeclAttrKind::PropertyWrapper,
+                       diag::attr_renamed_warning);
   checkInvalidAttrName("_propertyWrapper", "propertyWrapper",
-                       DAK_PropertyWrapper, diag::attr_renamed_warning);
+                       DeclAttrKind::PropertyWrapper,
+                       diag::attr_renamed_warning);
 
   // Historical name for result builders.
-  checkInvalidAttrName(
-      "_functionBuilder", "resultBuilder", DAK_ResultBuilder,
-      diag::attr_renamed_warning);
+  checkInvalidAttrName("_functionBuilder", "resultBuilder",
+                       DeclAttrKind::ResultBuilder, diag::attr_renamed_warning);
 
   // Historical name for @Sendable.
-  checkInvalidAttrName(
-      "concurrent", "Sendable", DAK_Sendable, diag::attr_renamed_warning);
+  checkInvalidAttrName("concurrent", "Sendable", DeclAttrKind::Sendable,
+                       diag::attr_renamed_warning);
 
   // Historical name for 'nonisolated'.
-  if (DK == DAK_Count && Tok.getText() == "actorIndependent") {
+  if (DK == DeclAttrKind::Count && Tok.getText() == "actorIndependent") {
     diagnose(
         Tok, diag::attr_renamed_to_modifier_warning, "actorIndependent", 
         "nonisolated")
       .fixItReplace(SourceRange(AtLoc, Tok.getLoc()), "nonisolated");
-    DK = DAK_Nonisolated;
+    DK = DeclAttrKind::Nonisolated;
     AtLoc = SourceLoc();
   }
 
   // Temporary name for @preconcurrency
-  checkInvalidAttrName(
-      "_predatesConcurrency", "preconcurrency", DAK_Preconcurrency,
-      diag::attr_renamed_warning);
+  checkInvalidAttrName("_predatesConcurrency", "preconcurrency",
+                       DeclAttrKind::Preconcurrency,
+                       diag::attr_renamed_warning);
 
-  if (DK == DAK_Count && Tok.getText() == "warn_unused_result") {
+  if (DK == DeclAttrKind::Count && Tok.getText() == "warn_unused_result") {
     // The behavior created by @warn_unused_result is now the default. Emit a
     // Fix-It to remove.
     SourceLoc attrLoc = consumeToken();
@@ -4352,9 +4364,8 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
   }
 
   // @_unsafeSendable and @_unsafeMainActor have been removed; warn about them.
-  if (DK == DAK_Count &&
-      (Tok.getText() == "_unsafeSendable" ||
-       Tok.getText() == "_unsafeMainActor")) {
+  if (DK == DeclAttrKind::Count && (Tok.getText() == "_unsafeSendable" ||
+                                    Tok.getText() == "_unsafeMainActor")) {
     StringRef attrName = Tok.getText();
     SourceLoc attrLoc = consumeToken();
     diagnose(AtLoc, diag::warn_attr_unsafe_removed, attrName)
@@ -4363,7 +4374,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
   }
 
   // Old spelling for @freestanding(expression).
-  if (DK == DAK_Count && Tok.getText() == "expression") {
+  if (DK == DeclAttrKind::Count && Tok.getText() == "expression") {
     SourceLoc attrLoc = consumeToken();
     diagnose(attrLoc, diag::macro_expression_attribute_removed)
       .fixItReplace(SourceRange(AtLoc, attrLoc), "@freestanding(expression)");
@@ -4377,7 +4388,7 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
 
   // Rewrite @_unavailableInEmbedded into @available(*, unavailable) when in
   // embedded Swift mode, or into nothing when in regular mode.
-  if (DK == DAK_Count && Tok.getText() == "_unavailableInEmbedded") {
+  if (DK == DeclAttrKind::Count && Tok.getText() == "_unavailableInEmbedded") {
     SourceLoc attrLoc = consumeToken();
     if (Context.LangOpts.hasFeature(Feature::Embedded)) {
       StringRef Message = "unavailable in embedded Swift", Renamed;
@@ -4394,7 +4405,8 @@ ParserStatus Parser::parseDeclAttribute(DeclAttributes &Attributes,
     return makeParserSuccess();
   }
 
-  if (DK != DAK_Count && !DeclAttribute::shouldBeRejectedByParser(DK)) {
+  if (DK != DeclAttrKind::Count &&
+      !DeclAttribute::shouldBeRejectedByParser(DK)) {
     return parseNewDeclAttribute(Attributes, AtLoc, DK, isFromClangAttribute);
   }
 
@@ -4669,12 +4681,12 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
       };
 
   // Historical name for @Sendable.
-  checkInvalidAttrName(
-      "concurrent", "Sendable", TAK_Sendable, diag::attr_renamed_warning);
+  checkInvalidAttrName("concurrent", "Sendable", TypeAttrKind::Sendable,
+                       diag::attr_renamed_warning);
 
   if (!optAttr) {
     auto declAttrID = DeclAttribute::getAttrKindFromString(Tok.getText());
-    if (declAttrID != DAK_Count) {
+    if (declAttrID != DeclAttrKind::Count) {
       // This is a valid decl attribute so they should have put it on the decl
       // instead of the type.
       if (justChecking) return makeParserError();
@@ -4746,7 +4758,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
 
   // Simple type attributes don't need any further checking.
 #define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS)
-#define SIMPLE_TYPE_ATTR(SPELLING, CLASS) case TAK_##CLASS:
+#define SIMPLE_TYPE_ATTR(SPELLING, CLASS) case TypeAttrKind::CLASS:
 #include "swift/AST/Attr.def"
   SimpleAttr:
     if (!justChecking) {
@@ -4756,11 +4768,11 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
 
   // For simple SIL type attributes, check whether we're parsing SIL,
   // then return to the SimpleAttr case.
-#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) case TAK_##CLASS:
+#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) case TypeAttrKind::CLASS:
 #include "swift/AST/Attr.def"
     if (!isInSILMode()) {
       if (!justChecking) {
-        if (attr == TAK_Inout) {
+        if (attr == TypeAttrKind::Inout) {
           diagnose(AtLoc, diag::inout_not_attribute);
         } else {
           // We could use diag::only_allowed_in_sil here, but it's better
@@ -4774,7 +4786,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
 
   // All the non-simple attributes should get explicit cases here.
 
-  case TAK_Opened: {
+  case TypeAttrKind::Opened: {
     // Parse the opened existential ID string in parens
     SourceLoc beginLoc = Tok.getLoc(), idLoc, endLoc;
     if (!consumeAttributeLParen()) {
@@ -4821,7 +4833,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
     return makeParserSuccess();
   }
 
-  case TAK_PackElement: {
+  case TypeAttrKind::PackElement: {
     if (!isInSILMode()) {
       if (!justChecking)
         diagnose(AtLoc, diag::only_allowed_in_sil, "pack_element");
@@ -4864,7 +4876,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
     return makeParserSuccess();
   }
 
-  case TAK_Differentiable: {
+  case TypeAttrKind::Differentiable: {
     auto diffKind = DifferentiabilityKind::Normal;
     SourceLoc diffKindLoc;
     SourceRange parensRange;
@@ -4889,7 +4901,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
     return makeParserSuccess();
   }
 
-  case TAK_Convention: {
+  case TypeAttrKind::Convention: {
     ConventionTypeAttr *convention = nullptr;
     if (parseConventionAttributeInternal(AtLoc, attrLoc, convention,
                                          justChecking)) {
@@ -4902,7 +4914,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
     return makeParserSuccess();
   }
 
-  case TAK_OpaqueReturnTypeOf: {
+  case TypeAttrKind::OpaqueReturnTypeOf: {
     // Parse the mangled decl name and index.
     auto beginLoc = Tok.getLoc();
     if (!consumeIfAttributeLParen()) {
@@ -5138,8 +5150,8 @@ ParserStatus Parser::parseDeclModifierList(DeclAttributes &Attributes,
     case tok::kw_internal:
     case tok::kw_public: {
       // We still model these specifiers as attributes.
-      status |=
-          parseNewDeclAttribute(Attributes, /*AtLoc=*/{}, DAK_AccessControl);
+      status |= parseNewDeclAttribute(Attributes, /*AtLoc=*/{},
+                                      DeclAttrKind::AccessControl);
       continue;
     }
 
@@ -5149,20 +5161,20 @@ ParserStatus Parser::parseDeclModifierList(DeclAttributes &Attributes,
         break;
 
       DeclAttrKind Kind = llvm::StringSwitch<DeclAttrKind>(Tok.getText())
-#define CONTEXTUAL_CASE(KW, CLASS) .Case(#KW, DAK_##CLASS)
+#define CONTEXTUAL_CASE(KW, CLASS) .Case(#KW, DeclAttrKind::CLASS)
 #define CONTEXTUAL_DECL_ATTR(KW, CLASS, ...) CONTEXTUAL_CASE(KW, CLASS)
 #define CONTEXTUAL_DECL_ATTR_ALIAS(KW, CLASS) CONTEXTUAL_CASE(KW, CLASS)
 #define CONTEXTUAL_SIMPLE_DECL_ATTR(KW, CLASS, ...) CONTEXTUAL_CASE(KW, CLASS)
 #include <swift/AST/Attr.def>
 #undef CONTEXTUAL_CASE
-        .Default(DAK_Count);
+                              .Default(DeclAttrKind::Count);
 
-      if (Kind == DAK_Count)
+      if (Kind == DeclAttrKind::Count)
         break;
 
       Tok.setKind(tok::contextual_keyword);
 
-      if (Kind == DAK_Actor) {
+      if (Kind == DeclAttrKind::Actor) {
         // If the next token is a startOfSwiftDecl, we are part of the modifier
         // list and should consume the actor token (e.g, actor public class Foo)
         // otherwise, it's the decl keyword (e.g. actor Foo) and shouldn't be.
@@ -5381,9 +5393,9 @@ static void diagnoseOperatorFixityAttributes(Parser &P,
                                              const Decl *D) {
   auto isFixityAttr = [](DeclAttribute *attr){
     DeclAttrKind kind = attr->getKind();
-    return attr->isValid() && (kind == DAK_Prefix ||
-                               kind == DAK_Infix ||
-                               kind == DAK_Postfix);
+    return attr->isValid() &&
+           (kind == DeclAttrKind::Prefix || kind == DeclAttrKind::Infix ||
+            kind == DeclAttrKind::Postfix);
   };
   
   SmallVector<DeclAttribute *, 3> fixityAttrs;
@@ -5408,7 +5420,8 @@ static void diagnoseOperatorFixityAttributes(Parser &P,
       P.diagnose(OD->getOperatorLoc(), diag::operator_decl_no_fixity);
     }
     for (auto it = Attrs.begin(); it != Attrs.end(); ++it) {
-      if (isFixityAttr(*it) || (*it)->getKind() == DAK_RawDocComment) {
+      if (isFixityAttr(*it) ||
+          (*it)->getKind() == DeclAttrKind::RawDocComment) {
         continue;
       }
       auto *attr = *it;
@@ -5687,7 +5700,7 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes,
   // this isn't considered a valid Swift decl start.
   if (Tok.isKeyword()) {
     auto DAK = DeclAttribute::getAttrKindFromString(Tok.getText());
-    if (DAK != DAK_Count && DeclAttribute::isDeclModifier(DAK)) {
+    if (DAK != DeclAttrKind::Count && DeclAttribute::isDeclModifier(DAK)) {
       BacktrackingScope backtrack(*this);
       consumeToken();
 
@@ -5792,7 +5805,7 @@ bool Parser::isStartOfSwiftDecl(bool allowPoundIfAttributes,
     
     // Handle 'package(set)' access modifier
     auto DAK = DeclAttribute::getAttrKindFromString(Tok.getText());
-    if (DAK != DAK_Count && DeclAttribute::isDeclModifier(DAK)) {
+    if (DAK != DeclAttrKind::Count && DeclAttribute::isDeclModifier(DAK)) {
       BacktrackingScope backtrack(*this);
       // First consume `package`
       consumeToken();
@@ -7701,15 +7714,19 @@ static ParserStatus parseAccessorIntroducer(Parser &P,
   // get and set.
   {
     if (P.Tok.isContextualKeyword("mutating")) {
-      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Mutating);
+      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DeclAttrKind::Mutating);
     } else if (P.Tok.isContextualKeyword("nonmutating")) {
-      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_NonMutating);
+      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {},
+                              DeclAttrKind::NonMutating);
     } else if (P.Tok.isContextualKeyword("__consuming")) {
-      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_LegacyConsuming);
+      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {},
+                              DeclAttrKind::LegacyConsuming);
     } else if (P.Tok.isContextualKeyword("consuming")) {
-      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Consuming);
+      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {},
+                              DeclAttrKind::Consuming);
     } else if (P.Tok.isContextualKeyword("borrowing")) {
-      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {}, DAK_Borrowing);
+      P.parseNewDeclAttribute(Attributes, /*AtLoc*/ {},
+                              DeclAttrKind::Borrowing);
     }
   }
 
@@ -9960,7 +9977,7 @@ Parser::parseDeclOperator(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     if (Tk.is(tok::identifier)) {
       if (Tk.getText().equals("$") ||
           DeclAttribute::getAttrKindFromString(Tk.getText()) ==
-              DeclAttrKind::DAK_Count) {
+              DeclAttrKind::Count) {
         diagnose(Tk, diag::identifier_within_operator_name, Tk.getText());
         return true;
       }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -938,7 +938,7 @@ bool Parser::parseSpecializeAttributeArguments(
       for (auto req : requirements) {
         if (req.getKind() == RequirementReprKind::LayoutConstraint) {
           if (auto *attributedTy = dyn_cast<AttributedTypeRepr>(req.getSubjectRepr())) {
-            if (attributedTy->has(TAK__noMetadata)) {
+            if (attributedTy->has(TAK_NoMetadata)) {
               typeErasedParamsCount += 1;
             }
           }
@@ -4746,8 +4746,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
 
   // Simple type attributes don't need any further checking.
 #define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS)
-#define SIMPLE_TYPE_ATTR(SPELLING, CLASS) \
-  case TAK_##SPELLING:
+#define SIMPLE_TYPE_ATTR(SPELLING, CLASS) case TAK_##CLASS:
 #include "swift/AST/Attr.def"
   SimpleAttr:
     if (!justChecking) {
@@ -4757,12 +4756,11 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
 
   // For simple SIL type attributes, check whether we're parsing SIL,
   // then return to the SimpleAttr case.
-#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) \
-  case TAK_##SPELLING:
+#define SIMPLE_SIL_TYPE_ATTR(SPELLING, CLASS) case TAK_##CLASS:
 #include "swift/AST/Attr.def"
     if (!isInSILMode()) {
       if (!justChecking) {
-        if (attr == TAK_inout) {
+        if (attr == TAK_Inout) {
           diagnose(AtLoc, diag::inout_not_attribute);
         } else {
           // We could use diag::only_allowed_in_sil here, but it's better
@@ -4776,7 +4774,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
 
   // All the non-simple attributes should get explicit cases here.
 
-  case TAK_opened: {
+  case TAK_Opened: {
     // Parse the opened existential ID string in parens
     SourceLoc beginLoc = Tok.getLoc(), idLoc, endLoc;
     if (!consumeAttributeLParen()) {
@@ -4823,7 +4821,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
     return makeParserSuccess();
   }
 
-  case TAK_pack_element: {
+  case TAK_PackElement: {
     if (!isInSILMode()) {
       if (!justChecking)
         diagnose(AtLoc, diag::only_allowed_in_sil, "pack_element");
@@ -4866,7 +4864,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
     return makeParserSuccess();
   }
 
-  case TAK_differentiable: {
+  case TAK_Differentiable: {
     auto diffKind = DifferentiabilityKind::Normal;
     SourceLoc diffKindLoc;
     SourceRange parensRange;
@@ -4891,7 +4889,7 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
     return makeParserSuccess();
   }
 
-  case TAK_convention: {
+  case TAK_Convention: {
     ConventionTypeAttr *convention = nullptr;
     if (parseConventionAttributeInternal(AtLoc, attrLoc, convention,
                                          justChecking)) {
@@ -4903,8 +4901,8 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
     result = convention;
     return makeParserSuccess();
   }
-      
-  case TAK__opaqueReturnTypeOf: {
+
+  case TAK_OpaqueReturnTypeOf: {
     // Parse the mangled decl name and index.
     auto beginLoc = Tok.getLoc();
     if (!consumeIfAttributeLParen()) {

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -587,7 +587,7 @@ mapParsedParameters(Parser &parser,
             // this parameter declaration as `autoclosure` because type has
             // not been resolved yet - it should either be a function type
             // or typealias with underlying function type.
-            if (ATR->has(TAK_autoclosure))
+            if (ATR->has(TAK_Autoclosure))
               param->setAutoClosure(true);
 
             unwrappedType = ATR->getTypeRepr();

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -587,7 +587,7 @@ mapParsedParameters(Parser &parser,
             // this parameter declaration as `autoclosure` because type has
             // not been resolved yet - it should either be a function type
             // or typealias with underlying function type.
-            if (ATR->has(TAK_Autoclosure))
+            if (ATR->has(TypeAttrKind::Autoclosure))
               param->setAutoClosure(true);
 
             unwrappedType = ATR->getTypeRepr();

--- a/lib/Refactoring/AddExplicitCodableImplementation.cpp
+++ b/lib/Refactoring/AddExplicitCodableImplementation.cpp
@@ -131,7 +131,7 @@ public:
     Options.VarInitializers = true;
     Options.PrintExprs = true;
     Options.TypeDefinitions = true;
-    Options.ExcludeAttrList.push_back(DAK_HasInitialValue);
+    Options.ExcludeAttrList.push_back(DeclAttrKind::HasInitialValue);
 
     Printer.printNewline();
     D->print(Printer, Options);

--- a/lib/Refactoring/MemberwiseInitLocalRefactoring.cpp
+++ b/lib/Refactoring/MemberwiseInitLocalRefactoring.cpp
@@ -38,7 +38,7 @@ static void generateMemberwiseInit(SourceEditConsumer &EditConsumer,
       // Unconditionally print '@escaping' if we print out a function type -
       // the assignments we generate below will escape this parameter.
       if (isa<AnyFunctionType>(memberData.MemberType->getCanonicalType())) {
-        OS << "@" << TypeAttribute::getAttrName(TAK_escaping) << " ";
+        OS << "@" << TypeAttribute::getAttrName(TAK_Escaping) << " ";
       }
       OS << memberData.MemberType.getString();
     }

--- a/lib/Refactoring/MemberwiseInitLocalRefactoring.cpp
+++ b/lib/Refactoring/MemberwiseInitLocalRefactoring.cpp
@@ -38,7 +38,7 @@ static void generateMemberwiseInit(SourceEditConsumer &EditConsumer,
       // Unconditionally print '@escaping' if we print out a function type -
       // the assignments we generate below will escape this parameter.
       if (isa<AnyFunctionType>(memberData.MemberType->getCanonicalType())) {
-        OS << "@" << TypeAttribute::getAttrName(TAK_Escaping) << " ";
+        OS << "@" << TypeAttribute::getAttrName(TypeAttrKind::Escaping) << " ";
       }
       OS << memberData.MemberType.getString();
     }

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -57,7 +57,7 @@ void SILFunctionBuilder::addFunctionAttributes(
   // function as force emitting all optremarks including assembly vision
   // remarks. This allows us to emit the assembly vision remarks without needing
   // to change any of the underlying optremark mechanisms.
-  if (auto *A = Attrs.getAttribute(DAK_EmitAssemblyVisionRemarks))
+  if (auto *A = Attrs.getAttribute(DeclAttrKind::EmitAssemblyVisionRemarks))
     F->addSemanticsAttr(semantics::FORCE_EMIT_OPT_REMARK_PREFIX);
 
   // Propagate @_specialize.

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -650,7 +650,7 @@ void SILParser::convertRequirements(ArrayRef<RequirementRepr> From,
 
       if (SILMod.getASTContext().LangOpts.hasFeature(Feature::LayoutPrespecialization)) {
         if (auto *attributedTy = dyn_cast<AttributedTypeRepr>(Req.getSubjectRepr())) {
-          if (attributedTy->has(TAK__noMetadata)) {
+          if (attributedTy->has(TAK_NoMetadata)) {
             typeErasedParams.push_back(Subject);
           }
         }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -650,7 +650,7 @@ void SILParser::convertRequirements(ArrayRef<RequirementRepr> From,
 
       if (SILMod.getASTContext().LangOpts.hasFeature(Feature::LayoutPrespecialization)) {
         if (auto *attributedTy = dyn_cast<AttributedTypeRepr>(Req.getSubjectRepr())) {
-          if (attributedTy->has(TAK_NoMetadata)) {
+          if (attributedTy->has(TypeAttrKind::NoMetadata)) {
             typeErasedParams.push_back(Subject);
           }
         }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1180,7 +1180,7 @@ bool AttributedFuncToTypeConversionFailure::
 
   TypeAttribute *autoclosureAttr = nullptr;
   if (auto attrRepr = dyn_cast<AttributedTypeRepr>(argRepr)) {
-    autoclosureAttr = attrRepr->get(TAK_Autoclosure);
+    autoclosureAttr = attrRepr->get(TypeAttrKind::Autoclosure);
   }
 
   if (autoclosureAttr) {
@@ -1275,7 +1275,7 @@ bool AttributedFuncToTypeConversionFailure::diagnoseParameterUse() const {
   } else {
     SourceLoc autoclosureEndLoc;
     if (auto *attrRepr = dyn_cast<AttributedTypeRepr>(repr)) {
-      if (auto *attr = attrRepr->get(TAK_Autoclosure))
+      if (auto *attr = attrRepr->get(TypeAttrKind::Autoclosure))
         autoclosureEndLoc = attr->getEndLoc();
     }
     if (autoclosureEndLoc.isValid()) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1180,7 +1180,7 @@ bool AttributedFuncToTypeConversionFailure::
 
   TypeAttribute *autoclosureAttr = nullptr;
   if (auto attrRepr = dyn_cast<AttributedTypeRepr>(argRepr)) {
-    autoclosureAttr = attrRepr->get(TAK_autoclosure);
+    autoclosureAttr = attrRepr->get(TAK_Autoclosure);
   }
 
   if (autoclosureAttr) {
@@ -1275,7 +1275,7 @@ bool AttributedFuncToTypeConversionFailure::diagnoseParameterUse() const {
   } else {
     SourceLoc autoclosureEndLoc;
     if (auto *attrRepr = dyn_cast<AttributedTypeRepr>(repr)) {
-      if (auto *attr = attrRepr->get(TAK_autoclosure))
+      if (auto *attr = attrRepr->get(TAK_Autoclosure))
         autoclosureEndLoc = attr->getEndLoc();
     }
     if (autoclosureEndLoc.isValid()) {

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -661,7 +661,7 @@ void UnboundImport::validatePrivate(ModuleDecl *topLevelModule) {
   if (topLevelModule->arePrivateImportsEnabled())
     return;
 
-  diagnoseInvalidAttr(DAK_PrivateImport, ctx.Diags,
+  diagnoseInvalidAttr(DeclAttrKind::PrivateImport, ctx.Diags,
                       diag::module_not_compiled_for_private_import);
   import.sourceFileArg = StringRef();
 }
@@ -685,8 +685,9 @@ void UnboundImport::validateRestrictedImport(ASTContext &ctx) {
   for (auto iter = conflicts.begin(); iter != std::prev(conflicts.end()); iter ++)
     import.options -= *iter;
 
-  DeclAttrKind attrToRemove = conflicts[0] == ImportFlags::ImplementationOnly?
-                                      DAK_Exported : DAK_ImplementationOnly;
+  DeclAttrKind attrToRemove = conflicts[0] == ImportFlags::ImplementationOnly
+                                  ? DeclAttrKind::Exported
+                                  : DeclAttrKind::ImplementationOnly;
 
   // More dense enum with some cases of ImportFlags,
   // used by import_restriction_conflict.
@@ -734,7 +735,8 @@ void UnboundImport::validateTestable(ModuleDecl *topLevelModule) {
       !ctx.LangOpts.EnableTestableAttrRequiresTestableModule)
     return;
 
-  diagnoseInvalidAttr(DAK_Testable, ctx.Diags, diag::module_not_testable);
+  diagnoseInvalidAttr(DeclAttrKind::Testable, ctx.Diags,
+                      diag::module_not_testable);
 }
 
 void UnboundImport::validateAllowableClient(ModuleDecl *importee,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3088,7 +3088,7 @@ SerializeAttrGenericSignatureRequest::evaluate(Evaluator &evaluator,
          attr->getTrailingWhereClause()->getRequirements()) {
       if (reqRepr.getKind() == RequirementReprKind::LayoutConstraint) {
         if (auto *attributedTy = dyn_cast<AttributedTypeRepr>(reqRepr.getSubjectRepr())) {
-          if (attributedTy->has(TAK__noMetadata)) {
+          if (attributedTy->has(TAK_NoMetadata)) {
             const auto resolution = TypeResolution::forInterface(
                 FD->getDeclContext(), genericSig, llvm::None,
                 /*unboundTyOpener*/ nullptr,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -477,19 +477,19 @@ void AttributeChecker::visitMutationAttr(DeclAttribute *attr) {
 
   SelfAccessKind attrModifier;
   switch (attr->getKind()) {
-  case DeclAttrKind::DAK_LegacyConsuming:
+  case DeclAttrKind::LegacyConsuming:
     attrModifier = SelfAccessKind::LegacyConsuming;
     break;
-  case DeclAttrKind::DAK_Mutating:
+  case DeclAttrKind::Mutating:
     attrModifier = SelfAccessKind::Mutating;
     break;
-  case DeclAttrKind::DAK_NonMutating:
+  case DeclAttrKind::NonMutating:
     attrModifier = SelfAccessKind::NonMutating;
     break;
-  case DeclAttrKind::DAK_Consuming:
+  case DeclAttrKind::Consuming:
     attrModifier = SelfAccessKind::Consuming;
     break;
-  case DeclAttrKind::DAK_Borrowing:
+  case DeclAttrKind::Borrowing:
     attrModifier = SelfAccessKind::Borrowing;
     break;
   default:
@@ -1293,8 +1293,8 @@ static bool checkObjCDeclContext(Decl *D) {
 static void diagnoseObjCAttrWithoutFoundation(DeclAttribute *attr, Decl *decl,
                                               ObjCReason reason,
                                               DiagnosticBehavior behavior) {
-  assert(attr->getKind() == DeclAttrKind::DAK_ObjC ||
-         attr->getKind() == DeclAttrKind::DAK_ObjCMembers);
+  assert(attr->getKind() == DeclAttrKind::ObjC ||
+         attr->getKind() == DeclAttrKind::ObjCMembers);
   auto *SF = decl->getDeclContext()->getParentSourceFile();
   assert(SF);
 
@@ -3088,7 +3088,7 @@ SerializeAttrGenericSignatureRequest::evaluate(Evaluator &evaluator,
          attr->getTrailingWhereClause()->getRequirements()) {
       if (reqRepr.getKind() == RequirementReprKind::LayoutConstraint) {
         if (auto *attributedTy = dyn_cast<AttributedTypeRepr>(reqRepr.getSubjectRepr())) {
-          if (attributedTy->has(TAK_NoMetadata)) {
+          if (attributedTy->has(TypeAttrKind::NoMetadata)) {
             const auto resolution = TypeResolution::forInterface(
                 FD->getDeclContext(), genericSig, llvm::None,
                 /*unboundTyOpener*/ nullptr,
@@ -4770,7 +4770,7 @@ void TypeChecker::addImplicitDynamicAttribute(Decl *D) {
 
   // Add the attribute if the decl kind allows it and it is not an accessor
   // decl. Accessor decls should always infer the var/subscript's attribute.
-  if (!DeclAttribute::canAttributeAppearOnDecl(DAK_Dynamic, D) ||
+  if (!DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::Dynamic, D) ||
       isa<AccessorDecl>(D))
     return;
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1667,10 +1667,8 @@ static const Decl *ancestorMemberLevelDeclForAvailabilityFixit(const Decl *D) {
   while (D) {
     D = relatedDeclForAvailabilityFixit(D);
 
-    if (!D->isImplicit() &&
-        D->getDeclContext()->isTypeContext() &&
-        DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::DAK_Available,
-                                                D)) {
+    if (!D->isImplicit() && D->getDeclContext()->isTypeContext() &&
+        DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::Available, D)) {
       break;
     }
 
@@ -1685,8 +1683,7 @@ static const Decl *ancestorMemberLevelDeclForAvailabilityFixit(const Decl *D) {
 /// type, an extension, or a global function) and can support an @available
 /// attribute.
 static bool isTypeLevelDeclForAvailabilityFixit(const Decl *D) {
-  if (!DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::DAK_Available,
-                                               D)) {
+  if (!DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::Available, D)) {
     return false;
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1164,7 +1164,7 @@ IsStaticRequest::evaluate(Evaluator &evaluator, FuncDecl *decl) const {
 bool
 IsDynamicRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
   // If we can't infer dynamic here, don't.
-  if (!DeclAttribute::canAttributeAppearOnDecl(DAK_Dynamic, decl))
+  if (!DeclAttribute::canAttributeAppearOnDecl(DeclAttrKind::Dynamic, decl))
     return false;
 
   // Add dynamic if -enable-implicit-dynamic was requested.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1683,7 +1683,7 @@ static void diagnoseRetroactiveConformances(
         // check to make sure it's not erroneously marked @retroactive when it's
         // not actually retroactive.
         if (decl == proto && entry.isRetroactive()) {
-          auto loc = entry.getTypeRepr()->findAttrLoc(TAK_retroactive);
+          auto loc = entry.getTypeRepr()->findAttrLoc(TAK_Retroactive);
           bool typeIsSameModule =
               extTypeModule->isSameModuleLookingThroughOverlays(module);
           auto incorrectTypeName = typeIsSameModule ? 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1683,7 +1683,8 @@ static void diagnoseRetroactiveConformances(
         // check to make sure it's not erroneously marked @retroactive when it's
         // not actually retroactive.
         if (decl == proto && entry.isRetroactive()) {
-          auto loc = entry.getTypeRepr()->findAttrLoc(TAK_Retroactive);
+          auto loc =
+              entry.getTypeRepr()->findAttrLoc(TypeAttrKind::Retroactive);
           bool typeIsSameModule =
               extTypeModule->isSameModuleLookingThroughOverlays(module);
           auto incorrectTypeName = typeIsSameModule ? 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3542,17 +3542,17 @@ printRequirementStub(ValueDecl *Requirement, DeclContext *Adopter,
     // Skip 'mutating' only inside classes: mutating methods usually
     // don't have a sensible non-mutating implementation.
     if (AdopterIsClass)
-      Options.ExcludeAttrList.push_back(DAK_Mutating);
+      Options.ExcludeAttrList.push_back(DeclAttrKind::Mutating);
     // 'nonmutating' is only meaningful on value type member accessors.
     if (AdopterIsClass || !isa<AbstractStorageDecl>(Requirement))
-      Options.ExcludeAttrList.push_back(DAK_NonMutating);
+      Options.ExcludeAttrList.push_back(DeclAttrKind::NonMutating);
 
     // FIXME: Once we support move-only types in generics, remove this if the
     //        conforming type is move-only. Until then, don't suggest printing
     //        ownership modifiers on a protocol requirement.
-    Options.ExcludeAttrList.push_back(DAK_LegacyConsuming);
-    Options.ExcludeAttrList.push_back(DAK_Consuming);
-    Options.ExcludeAttrList.push_back(DAK_Borrowing);
+    Options.ExcludeAttrList.push_back(DeclAttrKind::LegacyConsuming);
+    Options.ExcludeAttrList.push_back(DeclAttrKind::Consuming);
+    Options.ExcludeAttrList.push_back(DeclAttrKind::Borrowing);
 
     Options.FunctionBody = [&](const ValueDecl *VD, ASTPrinter &Printer) {
       Printer << " {";

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1989,7 +1989,7 @@ static bool validateAutoClosureAttributeUse(DiagnosticEngine &Diags,
   // If is a parameter declaration marked as @autoclosure.
   if (options.is(TypeResolverContext::FunctionInput)) {
     if (auto *ATR = dyn_cast<AttributedTypeRepr>(TR)) {
-      const auto attrLoc = ATR->getAttrLoc(TAK_autoclosure);
+      const auto attrLoc = ATR->getAttrLoc(TAK_Autoclosure);
       if (attrLoc.isValid())
         return validateAutoClosureAttr(Diags, attrLoc, type);
     }
@@ -2961,60 +2961,59 @@ static unsigned countIsolatedParamsUpTo(FunctionTypeRepr* fnTy,
 // is likely also structurally invalid on the value.  (This is useful
 // for that specific case because some of the attributes are used for
 // multiple roles, like `owned`.)
-static constexpr TypeAttrKind TAR_SILValueConvention = TAK_owned;
-static constexpr TypeAttrKind TAR_SILMetatype = TAK_thin;
-static constexpr TypeAttrKind TAR_TypeTransformer = TAK_opened;
-static constexpr TypeAttrKind TAR_SILCoroutine = TAK_yield_once;
-static constexpr TypeAttrKind TAR_SILCalleeConvention = TAK_callee_owned;
-static constexpr TypeAttrKind TAR_SILReferenceStorage = TAK_sil_weak;
+static constexpr TypeAttrKind TAR_SILValueConvention = TAK_Owned;
+static constexpr TypeAttrKind TAR_SILMetatype = TAK_Thin;
+static constexpr TypeAttrKind TAR_TypeTransformer = TAK_Opened;
+static constexpr TypeAttrKind TAR_SILCoroutine = TAK_YieldOnce;
+static constexpr TypeAttrKind TAR_SILCalleeConvention = TAK_CalleeOwned;
+static constexpr TypeAttrKind TAR_SILReferenceStorage = TAK_SILWeak;
 
 TypeAttrKind TypeAttrSet::getRepresentative(TypeAttrKind kind) {
   switch (kind) {
   // Most attributes are singleton for the purposes of this analysis.
   default: return kind;
 
-  case TAK_autoreleased:
-  case TAK_in_guaranteed: 
-  case TAK_in:
-  case TAK_in_constant:
-  case TAK_inout:
-  case TAK_inout_aliasable:
-  case TAK_owned:
-  case TAK_guaranteed:
-  case TAK_pack_owned:
-  case TAK_pack_guaranteed:
-  case TAK_pack_inout:
-  case TAK_out:
-  case TAK_pack_out:
-  case TAK_unowned_inner_pointer:
-  case TAK_error:
-  case TAK_error_indirect:
-  case TAK_error_unowned:
+  case TAK_Autoreleased:
+  case TAK_InGuaranteed:
+  case TAK_In:
+  case TAK_InConstant:
+  case TAK_Inout:
+  case TAK_InoutAliasable:
+  case TAK_Owned:
+  case TAK_Guaranteed:
+  case TAK_PackOwned:
+  case TAK_PackGuaranteed:
+  case TAK_PackInout:
+  case TAK_Out:
+  case TAK_PackOut:
+  case TAK_UnownedInnerPointer:
+  case TAK_Error:
+  case TAK_ErrorIndirect:
+  case TAK_ErrorUnowned:
     return TAR_SILValueConvention;
 
-  case TAK_thin:
-  case TAK_thick:
-  case TAK_objc_metatype:
+  case TAK_Thin:
+  case TAK_Thick:
+  case TAK_ObjCMetatype:
     return TAR_SILMetatype;
 
-  case TAK_yield_many:
-  case TAK_yield_once:
+  case TAK_YieldMany:
+  case TAK_YieldOnce:
     return TAR_SILCoroutine;
 
-  case TAK_callee_owned:
-  case TAK_callee_guaranteed:
+  case TAK_CalleeOwned:
+  case TAK_CalleeGuaranteed:
     return TAR_SILCalleeConvention;
 
-#define REF_STORAGE(Name, name, ...) \
-  case TAK_sil_##name:
+#define REF_STORAGE(Name, name, ...) case TAK_SIL##Name:
 #include "swift/AST/ReferenceStorage.def"
     return TAR_SILReferenceStorage;
 
   // These are total transforms on the type, and one of them can apply
   // at once.
-  case TAK_opened:
-  case TAK_pack_element:
-  case TAK__opaqueReturnTypeOf:
+  case TAK_Opened:
+  case TAK_PackElement:
+  case TAK_OpaqueReturnTypeOf:
     return TAR_TypeTransformer;
   };
 }
@@ -3135,10 +3134,9 @@ void TypeAttrSet::diagnoseUnclaimed(CustomAttr *attr,
 
 static bool isSILAttribute(TypeAttrKind attrKind) {
   switch (attrKind) {
-#define SIL_TYPE_ATTR(SPELLING, CLASS) \
-  case TAK_##SPELLING:
+#define SIL_TYPE_ATTR(SPELLING, CLASS) case TAK_##CLASS:
 #include "swift/AST/Attr.def"
-  case TAK_noescape: // noescape is only used in SIL now
+  case TAK_NoEscape: // noescape is only used in SIL now
     return true;
 
   default:
@@ -3148,10 +3146,11 @@ static bool isSILAttribute(TypeAttrKind attrKind) {
 
 static bool isFunctionAttribute(TypeAttrKind attrKind) {
   static const TypeAttrKind FunctionAttrs[] = {
-    TAK_convention, TAK_pseudogeneric, TAK_unimplementable,
-    TAK_callee_owned, TAK_callee_guaranteed, TAK_noescape, TAK_autoclosure,
-    TAK_differentiable, TAK_escaping, TAK_Sendable,
-    TAK_yield_once, TAK_yield_many, TAK_async
+      TAK_Convention,  TAK_Pseudogeneric,    TAK_Unimplementable,
+      TAK_CalleeOwned, TAK_CalleeGuaranteed, TAK_NoEscape,
+      TAK_Autoclosure, TAK_Differentiable,   TAK_Escaping,
+      TAK_Sendable,    TAK_YieldOnce,        TAK_YieldMany,
+      TAK_Async,
   };
   return llvm::any_of(FunctionAttrs, [attrKind](TypeAttrKind functionAttr) {
                         return functionAttr == attrKind;
@@ -3467,7 +3466,7 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
       diagnose(
           noDerivativeAttr->getAtLoc(),
           diag::differentiable_programming_attr_used_without_required_module,
-          TypeAttribute::getAttrName(TAK_noDerivative),
+          TypeAttribute::getAttrName(TAK_NoDerivative),
           getASTContext().Id_Differentiation);
     } else if (!isNoDerivativeAllowed) {
       bool isVariadicFunctionParam =
@@ -3494,7 +3493,7 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
     // "recursive structure" of the type constructors.
     attrs.reversedClaimAllWhere([&](TypeAttribute *attr) {
       switch (attrs.getRepresentative(attr->getKind())) {
-      case TAK_dynamic_self:
+      case TAK_DynamicSelf:
         ty = rebuildWithDynamicSelf(getASTContext(), ty);
         return true;
 
@@ -3502,21 +3501,21 @@ TypeResolver::resolveAttributedType(TypeRepr *repr, TypeResolutionOptions option
         ty = resolveSILReferenceStorage(attr, ty);
         return true;
 
-      case TAK_block_storage:
+      case TAK_BlockStorage:
         if (options & TypeResolutionFlags::SILType) {
           ty = SILBlockStorageType::get(ty->getCanonicalType());;
           return true;
         }
         return false;
 
-      case TAK_box:
+      case TAK_Box:
         if (options & TypeResolutionFlags::SILType) {
           ty = SILBoxType::get(ty->getCanonicalType());
           return true;
         }
         return false;
 
-      case TAK_moveOnly:
+      case TAK_MoveOnly:
         if (options & TypeResolutionFlags::SILType) {
           ty = SILMoveOnlyWrappedType::get(ty->getCanonicalType());
           return true;
@@ -3692,10 +3691,10 @@ TypeResolver::resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
     bool noDerivative = false;
 
     while (auto *ATR = dyn_cast<AttributedTypeRepr>(nestedRepr)) {
-      if (ATR->has(TAK_autoclosure))
+      if (ATR->has(TAK_Autoclosure))
         autoclosure = true;
 
-      if (ATR->has(TAK_noDerivative)) {
+      if (ATR->has(TAK_NoDerivative)) {
         if (diffKind == DifferentiabilityKind::NonDifferentiable &&
             isDifferentiableProgrammingEnabled(
                 *dc->getParentSourceFile()))
@@ -4404,27 +4403,27 @@ SILParameterInfo TypeResolver::resolveSILParameter(
     attrs->claimAllWhere([&](TypeAttribute *attr) {
       switch (attr->getKind()) {
 
-#define OWNERSHIP(SPELLING, KIND)                   \
-      case TAK_##SPELLING:                          \
-        convention = ParameterConvention::KIND;     \
-        return true;
-      OWNERSHIP(in_guaranteed, Indirect_In_Guaranteed)
-      OWNERSHIP(in, Indirect_In)
-      OWNERSHIP(in_constant, Indirect_In)
-      OWNERSHIP(inout, Indirect_Inout)
-      OWNERSHIP(inout_aliasable, Indirect_InoutAliasable)
-      OWNERSHIP(owned, Direct_Owned)
-      OWNERSHIP(guaranteed, Direct_Guaranteed)
-      OWNERSHIP(pack_owned, Pack_Owned)
-      OWNERSHIP(pack_guaranteed, Pack_Guaranteed)
-      OWNERSHIP(pack_inout, Pack_Inout)
+#define OWNERSHIP(ATTR, KIND)                                                  \
+  case TAK_##ATTR:                                                             \
+    convention = ParameterConvention::KIND;                                    \
+    return true;
+        OWNERSHIP(InGuaranteed, Indirect_In_Guaranteed)
+        OWNERSHIP(In, Indirect_In)
+        OWNERSHIP(InConstant, Indirect_In)
+        OWNERSHIP(Inout, Indirect_Inout)
+        OWNERSHIP(InoutAliasable, Indirect_InoutAliasable)
+        OWNERSHIP(Owned, Direct_Owned)
+        OWNERSHIP(Guaranteed, Direct_Guaranteed)
+        OWNERSHIP(PackOwned, Pack_Owned)
+        OWNERSHIP(PackGuaranteed, Pack_Guaranteed)
+        OWNERSHIP(PackInout, Pack_Inout)
 #undef OWNERSHIP
 
-      case TAK_noDerivative:
+      case TAK_NoDerivative:
         parameterOptions |= SILParameterInfo::NotDifferentiable;
         return true;
 
-      case TAK_isolated:
+      case TAK_Isolated:
         parameterOptions |= SILParameterInfo::Isolated;
         return true;
 
@@ -4486,24 +4485,24 @@ bool TypeResolver::resolveSingleSILResult(
 
     if (auto conventionAttr = attrs.claim(TAR_SILValueConvention)) {
       switch (conventionAttr->getKind()) {
-#define ERROR(SPELLING, CONVENTION)                 \
-      case TAK_##SPELLING:                          \
-        isErrorResult = true;                       \
-        convention = ResultConvention::CONVENTION;  \
-        break;
-#define NORMAL(SPELLING, CONVENTION)                \
-      case TAK_##SPELLING:                          \
-        convention = ResultConvention::CONVENTION;  \
-        break;
+#define ERROR(ATTR, CONVENTION)                                                \
+  case TAK_##ATTR:                                                             \
+    isErrorResult = true;                                                      \
+    convention = ResultConvention::CONVENTION;                                 \
+    break;
+#define NORMAL(ATTR, CONVENTION)                                               \
+  case TAK_##ATTR:                                                             \
+    convention = ResultConvention::CONVENTION;                                 \
+    break;
 
-      ERROR(error, Owned)
-      ERROR(error_indirect, Indirect)
-      ERROR(error_unowned, Unowned)
-      NORMAL(out, Indirect)
-      NORMAL(owned, Owned)
-      NORMAL(unowned_inner_pointer, UnownedInnerPointer)
-      NORMAL(autoreleased, Autoreleased)
-      NORMAL(pack_out, Pack)
+        ERROR(Error, Owned)
+        ERROR(ErrorIndirect, Indirect)
+        ERROR(ErrorUnowned, Unowned)
+        NORMAL(Out, Indirect)
+        NORMAL(Owned, Owned)
+        NORMAL(UnownedInnerPointer, UnownedInnerPointer)
+        NORMAL(Autoreleased, Autoreleased)
+        NORMAL(PackOut, Pack)
 #undef NORMAL
 #undef ERROR
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3136,7 +3136,7 @@ void TypeAttrSet::diagnoseUnclaimed(CustomAttr *attr,
 static bool isSILAttribute(TypeAttrKind attrKind) {
   switch (attrKind) {
 #define SIL_TYPE_ATTR(SPELLING, CLASS) case TypeAttrKind::CLASS:
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
   case TypeAttrKind::NoEscape: // noescape is only used in SIL now
     return true;
 

--- a/lib/Serialization/DeclTypeRecordNodes.def
+++ b/lib/Serialization/DeclTypeRecordNodes.def
@@ -217,7 +217,7 @@ OTHER(LIFETIME_DEPENDENCE, 158)
 #ifndef DECL_ATTR
 #define DECL_ATTR(NAME, CLASS, OPTIONS, CODE) RECORD_VAL(CLASS##_DECL_ATTR, 180+CODE)
 #endif
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
 #undef RECORD
 #undef DECLTYPERECORDNODES_HAS_RECORD_VAL

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6109,7 +6109,7 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         Attr = new (ctx) CLASS##Attr(isImplicit); \
         break; \
       }
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
       default:
         // We don't know how to deserialize this kind of attribute.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2342,7 +2342,7 @@ namespace decls_block {
     CLASS##_DECL_ATTR, \
     BCFixed<1> /* implicit flag */ \
   >;
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
   using DynamicReplacementDeclAttrLayout = BCRecordLayout<
     DynamicReplacement_DECL_ATTR,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2694,9 +2694,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DeclAttrKind::PrivateImport:
       llvm_unreachable("cannot serialize attribute");
 
-    case DeclAttrKind::Count:
-      llvm_unreachable("not a real attribute");
-
 #define SIMPLE_DECL_ATTR(_, CLASS, ...)                                        \
   case DeclAttrKind::CLASS: {                                                  \
     auto abbrCode = S.DeclTypeAbbrCodes[CLASS##DeclAttrLayout::Code];          \

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2682,31 +2682,31 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
 
     switch (DA->getKind()) {
-    case DAK_RawDocComment:
-    case DAK_ReferenceOwnership: // Serialized as part of the type.
-    case DAK_AccessControl:
-    case DAK_SetterAccess:
-    case DAK_ObjCBridged:
-    case DAK_SynthesizedProtocol:
-    case DAK_ObjCRuntimeName:
-    case DAK_RestatedObjCConformance:
-    case DAK_ClangImporterSynthesizedType:
-    case DAK_PrivateImport:
+    case DeclAttrKind::RawDocComment:
+    case DeclAttrKind::ReferenceOwnership: // Serialized as part of the type.
+    case DeclAttrKind::AccessControl:
+    case DeclAttrKind::SetterAccess:
+    case DeclAttrKind::ObjCBridged:
+    case DeclAttrKind::SynthesizedProtocol:
+    case DeclAttrKind::ObjCRuntimeName:
+    case DeclAttrKind::RestatedObjCConformance:
+    case DeclAttrKind::ClangImporterSynthesizedType:
+    case DeclAttrKind::PrivateImport:
       llvm_unreachable("cannot serialize attribute");
 
-    case DAK_Count:
+    case DeclAttrKind::Count:
       llvm_unreachable("not a real attribute");
 
-  #define SIMPLE_DECL_ATTR(_, CLASS, ...)\
-    case DAK_##CLASS: { \
-      auto abbrCode = S.DeclTypeAbbrCodes[CLASS##DeclAttrLayout::Code]; \
-      CLASS##DeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode, \
-                                        DA->isImplicit()); \
-      return; \
-    }
-  #include "swift/AST/Attr.def"
+#define SIMPLE_DECL_ATTR(_, CLASS, ...)                                        \
+  case DeclAttrKind::CLASS: {                                                  \
+    auto abbrCode = S.DeclTypeAbbrCodes[CLASS##DeclAttrLayout::Code];          \
+    CLASS##DeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,        \
+                                      DA->isImplicit());                       \
+    return;                                                                    \
+  }
+#include "swift/AST/Attr.def"
 
-    case DAK_SILGenName: {
+    case DeclAttrKind::SILGenName: {
       auto *theAttr = cast<SILGenNameAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[SILGenNameDeclAttrLayout::Code];
       SILGenNameDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -2715,7 +2715,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Implements: {
+    case DeclAttrKind::Implements: {
       auto *theAttr = cast<ImplementsAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[ImplementsDeclAttrLayout::Code];
 
@@ -2738,7 +2738,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_CDecl: {
+    case DeclAttrKind::CDecl: {
       auto *theAttr = cast<CDeclAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[CDeclDeclAttrLayout::Code];
       CDeclDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -2747,7 +2747,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_SPIAccessControl: {
+    case DeclAttrKind::SPIAccessControl: {
       auto theAttr = cast<SPIAccessControlAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[SPIAccessControlDeclAttrLayout::Code];
 
@@ -2765,7 +2765,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Alignment: {
+    case DeclAttrKind::Alignment: {
       auto *theAlignment = cast<AlignmentAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[AlignmentDeclAttrLayout::Code];
       AlignmentDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -2774,7 +2774,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_SwiftNativeObjCRuntimeBase: {
+    case DeclAttrKind::SwiftNativeObjCRuntimeBase: {
       auto *theBase = cast<SwiftNativeObjCRuntimeBaseAttr>(DA);
       auto abbrCode
         = S.DeclTypeAbbrCodes[SwiftNativeObjCRuntimeBaseDeclAttrLayout::Code];
@@ -2786,7 +2786,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Semantics: {
+    case DeclAttrKind::Semantics: {
       auto *theAttr = cast<SemanticsAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[SemanticsDeclAttrLayout::Code];
       SemanticsDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -2795,7 +2795,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Inline: {
+    case DeclAttrKind::Inline: {
       auto *theAttr = cast<InlineAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[InlineDeclAttrLayout::Code];
       InlineDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -2803,7 +2803,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_NonSendable: {
+    case DeclAttrKind::NonSendable: {
       auto *theAttr = cast<NonSendableAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[NonSendableDeclAttrLayout::Code];
       NonSendableDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -2811,7 +2811,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Optimize: {
+    case DeclAttrKind::Optimize: {
       auto *theAttr = cast<OptimizeAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[OptimizeDeclAttrLayout::Code];
       OptimizeDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -2819,7 +2819,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Exclusivity: {
+    case DeclAttrKind::Exclusivity: {
       auto *theAttr = cast<ExclusivityAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[ExclusivityDeclAttrLayout::Code];
       ExclusivityDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -2827,7 +2827,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Effects: {
+    case DeclAttrKind::Effects: {
       auto *theAttr = cast<EffectsAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[EffectsDeclAttrLayout::Code];
       IdentifierID customStringID = 0;
@@ -2840,7 +2840,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_OriginallyDefinedIn: {
+    case DeclAttrKind::OriginallyDefinedIn: {
       auto *theAttr = cast<OriginallyDefinedInAttr>(DA);
       ENCODE_VER_TUPLE(Moved, llvm::Optional<llvm::VersionTuple>(theAttr->MovedVersion));
       auto abbrCode = S.DeclTypeAbbrCodes[OriginallyDefinedInDeclAttrLayout::Code];
@@ -2856,7 +2856,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Available: {
+    case DeclAttrKind::Available: {
       auto *theAttr = cast<AvailableAttr>(DA);
       ENCODE_VER_TUPLE(Introduced, theAttr->Introduced)
       ENCODE_VER_TUPLE(Deprecated, theAttr->Deprecated)
@@ -2886,7 +2886,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_BackDeployed: {
+    case DeclAttrKind::BackDeployed: {
       auto *theAttr = cast<BackDeployedAttr>(DA);
       ENCODE_VER_TUPLE(Version, llvm::Optional<llvm::VersionTuple>(theAttr->Version));
       auto abbrCode = S.DeclTypeAbbrCodes[BackDeployedDeclAttrLayout::Code];
@@ -2898,7 +2898,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_ObjC: {
+    case DeclAttrKind::ObjC: {
       auto *theAttr = cast<ObjCAttr>(DA);
       SmallVector<IdentifierID, 4> pieces;
       unsigned numArgs = 0;
@@ -2915,7 +2915,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_ObjCImplementation: {
+    case DeclAttrKind::ObjCImplementation: {
       auto *theAttr = cast<ObjCImplementationAttr>(DA);
       auto categoryNameID = S.addDeclBaseNameRef(theAttr->CategoryName);
       auto abbrCode =
@@ -2926,14 +2926,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_MainType: {
+    case DeclAttrKind::MainType: {
       auto abbrCode = S.DeclTypeAbbrCodes[MainTypeDeclAttrLayout::Code];
       MainTypeDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                          DA->isImplicit());
       return;
     }
 
-    case DAK_Specialize: {
+    case DeclAttrKind::Specialize: {
       auto abbrCode = S.DeclTypeAbbrCodes[SpecializeDeclAttrLayout::Code];
       auto attr = cast<SpecializeAttr>(DA);
       auto targetFun = attr->getTargetFunctionName();
@@ -2982,7 +2982,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_StorageRestrictions: {
+    case DeclAttrKind::StorageRestrictions: {
       auto abbrCode = S.DeclTypeAbbrCodes[StorageRestrictionsDeclAttrLayout::Code];
       auto attr = cast<StorageRestrictionsAttr>(DA);
 
@@ -3006,7 +3006,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_DynamicReplacement: {
+    case DeclAttrKind::DynamicReplacement: {
       auto abbrCode =
           S.DeclTypeAbbrCodes[DynamicReplacementDeclAttrLayout::Code];
       auto theAttr = cast<DynamicReplacementAttr>(DA);
@@ -3023,7 +3023,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_TypeEraser: {
+    case DeclAttrKind::TypeEraser: {
       auto abbrCode = S.DeclTypeAbbrCodes[TypeEraserDeclAttrLayout::Code];
       auto attr = cast<TypeEraserAttr>(DA);
       auto typeEraser = attr->getResolvedType(cast<ProtocolDecl>(D));
@@ -3034,7 +3034,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Custom: {
+    case DeclAttrKind::Custom: {
       auto abbrCode = S.DeclTypeAbbrCodes[CustomDeclAttrLayout::Code];
       auto theAttr = cast<CustomAttr>(DA);
 
@@ -3054,7 +3054,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_ProjectedValueProperty: {
+    case DeclAttrKind::ProjectedValueProperty: {
       auto abbrCode =
           S.DeclTypeAbbrCodes[ProjectedValuePropertyDeclAttrLayout::Code];
       auto theAttr = cast<ProjectedValuePropertyAttr>(DA);
@@ -3064,7 +3064,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       break;
     }
 
-    case DAK_Differentiable: {
+    case DeclAttrKind::Differentiable: {
       auto abbrCode = S.DeclTypeAbbrCodes[DifferentiableDeclAttrLayout::Code];
       auto *attr = cast<DifferentiableAttr>(DA);
       assert(attr->getOriginalDeclaration() &&
@@ -3084,7 +3084,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Derivative: {
+    case DeclAttrKind::Derivative: {
       auto abbrCode = S.DeclTypeAbbrCodes[DerivativeDeclAttrLayout::Code];
       auto *attr = cast<DerivativeAttr>(DA);
       auto &ctx = S.getASTContext();
@@ -3113,7 +3113,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Transpose: {
+    case DeclAttrKind::Transpose: {
       auto abbrCode = S.DeclTypeAbbrCodes[TransposeDeclAttrLayout::Code];
       auto *attr = cast<TransposeAttr>(DA);
       assert(attr->getOriginalFunction() &&
@@ -3133,7 +3133,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_UnavailableFromAsync: {
+    case DeclAttrKind::UnavailableFromAsync: {
       auto abbrCode =
           S.DeclTypeAbbrCodes[UnavailableFromAsyncDeclAttrLayout::Code];
       auto *theAttr = cast<UnavailableFromAsyncAttr>(DA);
@@ -3143,7 +3143,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Expose: {
+    case DeclAttrKind::Expose: {
       auto *theAttr = cast<ExposeAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[ExposeDeclAttrLayout::Code];
       ExposeDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -3151,7 +3151,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Extern: {
+    case DeclAttrKind::Extern: {
       auto *theAttr = cast<ExternAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[ExternDeclAttrLayout::Code];
       llvm::SmallString<32> blob;
@@ -3166,7 +3166,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Section: {
+    case DeclAttrKind::Section: {
       auto *theAttr = cast<SectionAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[SectionDeclAttrLayout::Code];
       SectionDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -3175,7 +3175,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Documentation: {
+    case DeclAttrKind::Documentation: {
       auto *theAttr = cast<DocumentationAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[DocumentationDeclAttrLayout::Code];
       auto metadataIDPair = S.addUniquedString(theAttr->Metadata);
@@ -3192,7 +3192,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_Nonisolated: {
+    case DeclAttrKind::Nonisolated: {
       auto *theAttr = cast<NonisolatedAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[NonisolatedDeclAttrLayout::Code];
       NonisolatedDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
@@ -3201,7 +3201,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
-    case DAK_MacroRole: {
+    case DeclAttrKind::MacroRole: {
       auto *theAttr = cast<MacroRoleAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[MacroRoleDeclAttrLayout::Code];
       auto rawMacroRole =
@@ -3243,8 +3243,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           introducedDeclNames);
       return;
     }
-    
-    case DAK_RawLayout: {
+
+    case DeclAttrKind::RawLayout: {
       auto *attr = cast<RawLayoutAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[RawLayoutDeclAttrLayout::Code];
       

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2704,7 +2704,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
                                       DA->isImplicit());                       \
     return;                                                                    \
   }
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
     case DeclAttrKind::SILGenName: {
       auto *theAttr = cast<SILGenNameAttr>(DA);
@@ -6007,7 +6007,7 @@ void Serializer::writeAllDeclsAndTypes() {
 
 #define DECL_ATTR(X, NAME, ...) \
   registerDeclTypeAbbr<NAME##DeclAttrLayout>();
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
   bool wroteSomething;
   do {

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -75,30 +75,39 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
 
   llvm::StringMap<AnyAttrKind> ExcludeAttrs;
 
-#define TYPE_ATTR(X, C) ExcludeAttrs.insert(std::make_pair("TAK_" #C, TAK_##C));
+#define TYPE_ATTR(X, C)                                                        \
+  ExcludeAttrs.insert(std::make_pair("TypeAttrKind::" #C, TypeAttrKind::C));
 #include "swift/AST/Attr.def"
 
   // Allow the following type attributes:
-  ExcludeAttrs.erase("TAK_Autoclosure");
-  ExcludeAttrs.erase("TAK_Convention");
-  ExcludeAttrs.erase("TAK_NoEscape");
-  ExcludeAttrs.erase("TAK_Escaping");
-  ExcludeAttrs.erase("TAK_Inout");
+  ExcludeAttrs.erase("TypeAttrKind::Autoclosure");
+  ExcludeAttrs.erase("TypeAttrKind::Convention");
+  ExcludeAttrs.erase("TypeAttrKind::NoEscape");
+  ExcludeAttrs.erase("TypeAttrKind::Escaping");
+  ExcludeAttrs.erase("TypeAttrKind::Inout");
 
   // Don't allow the following decl attributes:
   // These can be large and are already included elsewhere in
   // symbol graphs.
-  ExcludeAttrs.insert(std::make_pair("DAK_Available", DAK_Available));
-  ExcludeAttrs.insert(std::make_pair("DAK_Inline", DAK_Inline));
-  ExcludeAttrs.insert(std::make_pair("DAK_Inlinable", DAK_Inlinable));
-  ExcludeAttrs.insert(std::make_pair("DAK_Prefix", DAK_Prefix));
-  ExcludeAttrs.insert(std::make_pair("DAK_Postfix", DAK_Postfix));
-  ExcludeAttrs.insert(std::make_pair("DAK_Infix", DAK_Infix));
+  ExcludeAttrs.insert(
+      std::make_pair("DeclAttrKind::Available", DeclAttrKind::Available));
+  ExcludeAttrs.insert(
+      std::make_pair("DeclAttrKind::Inline", DeclAttrKind::Inline));
+  ExcludeAttrs.insert(
+      std::make_pair("DeclAttrKind::Inlinable", DeclAttrKind::Inlinable));
+  ExcludeAttrs.insert(
+      std::make_pair("DeclAttrKind::Prefix", DeclAttrKind::Prefix));
+  ExcludeAttrs.insert(
+      std::make_pair("DeclAttrKind::Postfix", DeclAttrKind::Postfix));
+  ExcludeAttrs.insert(
+      std::make_pair("DeclAttrKind::Infix", DeclAttrKind::Infix));
 
   // In "emit modules separately" jobs, access modifiers show up as attributes,
   // but we don't want them to be printed in declarations
-  ExcludeAttrs.insert(std::make_pair("DAK_AccessControl", DAK_AccessControl));
-  ExcludeAttrs.insert(std::make_pair("DAK_SetterAccess", DAK_SetterAccess));
+  ExcludeAttrs.insert(std::make_pair("DeclAttrKind::AccessControl",
+                                     DeclAttrKind::AccessControl));
+  ExcludeAttrs.insert(
+      std::make_pair("DeclAttrKind::SetterAccess", DeclAttrKind::SetterAccess));
 
   for (const auto &Entry : ExcludeAttrs) {
     Opts.ExcludeAttrList.push_back(Entry.getValue());
@@ -129,16 +138,16 @@ SymbolGraph::getSubHeadingDeclarationFragmentsPrintOptions() const {
   Options.PrintOverrideKeyword = false;
   Options.PrintGenericRequirements = false;
 
-  #define DECL_ATTR(SPELLING, CLASS, OPTIONS, CODE) \
-    Options.ExcludeAttrList.push_back(DAK_##CLASS);
-#define TYPE_ATTR(X, C) Options.ExcludeAttrList.push_back(TAK_##C);
+#define DECL_ATTR(SPELLING, CLASS, OPTIONS, CODE)                              \
+  Options.ExcludeAttrList.push_back(DeclAttrKind::CLASS);
+#define TYPE_ATTR(X, C) Options.ExcludeAttrList.push_back(TypeAttrKind::C);
 #include "swift/AST/Attr.def"
 
   // Don't include these attributes in subheadings.
-  Options.ExcludeAttrList.push_back(DAK_Final);
-  Options.ExcludeAttrList.push_back(DAK_Mutating);
-  Options.ExcludeAttrList.push_back(DAK_NonMutating);
-  Options.ExcludeAttrList.push_back(TAK_Escaping);
+  Options.ExcludeAttrList.push_back(DeclAttrKind::Final);
+  Options.ExcludeAttrList.push_back(DeclAttrKind::Mutating);
+  Options.ExcludeAttrList.push_back(DeclAttrKind::NonMutating);
+  Options.ExcludeAttrList.push_back(TypeAttrKind::Escaping);
 
   return Options;
 }

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -77,7 +77,7 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
 
 #define TYPE_ATTR(X, C)                                                        \
   ExcludeAttrs.insert(std::make_pair("TypeAttrKind::" #C, TypeAttrKind::C));
-#include "swift/AST/Attr.def"
+#include "swift/AST/TypeAttr.def"
 
   // Allow the following type attributes:
   ExcludeAttrs.erase("TypeAttrKind::Autoclosure");
@@ -141,7 +141,7 @@ SymbolGraph::getSubHeadingDeclarationFragmentsPrintOptions() const {
 #define DECL_ATTR(SPELLING, CLASS, OPTIONS, CODE)                              \
   Options.ExcludeAttrList.push_back(DeclAttrKind::CLASS);
 #define TYPE_ATTR(X, C) Options.ExcludeAttrList.push_back(TypeAttrKind::C);
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
 
   // Don't include these attributes in subheadings.
   Options.ExcludeAttrList.push_back(DeclAttrKind::Final);

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -75,15 +75,15 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
 
   llvm::StringMap<AnyAttrKind> ExcludeAttrs;
 
-#define TYPE_ATTR(X, C) ExcludeAttrs.insert(std::make_pair("TAK_" #X, TAK_##X));
+#define TYPE_ATTR(X, C) ExcludeAttrs.insert(std::make_pair("TAK_" #C, TAK_##C));
 #include "swift/AST/Attr.def"
 
   // Allow the following type attributes:
-  ExcludeAttrs.erase("TAK_autoclosure");
-  ExcludeAttrs.erase("TAK_convention");
-  ExcludeAttrs.erase("TAK_noescape");
-  ExcludeAttrs.erase("TAK_escaping");
-  ExcludeAttrs.erase("TAK_inout");
+  ExcludeAttrs.erase("TAK_Autoclosure");
+  ExcludeAttrs.erase("TAK_Convention");
+  ExcludeAttrs.erase("TAK_NoEscape");
+  ExcludeAttrs.erase("TAK_Escaping");
+  ExcludeAttrs.erase("TAK_Inout");
 
   // Don't allow the following decl attributes:
   // These can be large and are already included elsewhere in
@@ -131,15 +131,14 @@ SymbolGraph::getSubHeadingDeclarationFragmentsPrintOptions() const {
 
   #define DECL_ATTR(SPELLING, CLASS, OPTIONS, CODE) \
     Options.ExcludeAttrList.push_back(DAK_##CLASS);
-  #define TYPE_ATTR(X, C) \
-    Options.ExcludeAttrList.push_back(TAK_##X);
-  #include "swift/AST/Attr.def"
+#define TYPE_ATTR(X, C) Options.ExcludeAttrList.push_back(TAK_##C);
+#include "swift/AST/Attr.def"
 
   // Don't include these attributes in subheadings.
   Options.ExcludeAttrList.push_back(DAK_Final);
   Options.ExcludeAttrList.push_back(DAK_Mutating);
   Options.ExcludeAttrList.push_back(DAK_NonMutating);
-  Options.ExcludeAttrList.push_back(TAK_escaping);
+  Options.ExcludeAttrList.push_back(TAK_Escaping);
 
   return Options;
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -105,7 +105,7 @@ private:
       SwiftLangSupport::UIDsFromDeclAttributes(decl->getAttrs());
 
     // check if we should report an implicit @objc attribute
-    if (!decl->getAttrs().getAttribute(DeclAttrKind::DAK_ObjC)) {
+    if (!decl->getAttrs().getAttribute(DeclAttrKind::ObjC)) {
       if (auto *VD = dyn_cast<ValueDecl>(decl)) {
         if (VD->isObjC()) {
             uidAttrs.push_back(SwiftLangSupport::getUIDForObjCAttr());

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -856,7 +856,7 @@ SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttribute *Attr) {
     static UIdent Attr_##X("source.decl.attribute." #X);                       \
     return Attr_##X;                                                           \
   }
-#include "swift/AST/Attr.def"
+#include "swift/AST/DeclAttr.def"
   }
 
   return llvm::None;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -779,83 +779,83 @@ llvm::Optional<UIdent>
 SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttribute *Attr) {
   // Check special-case names first.
   switch (Attr->getKind()) {
-    case DAK_IBAction: {
-      return Attr_IBAction;
+  case DeclAttrKind::IBAction: {
+    return Attr_IBAction;
+  }
+  case DeclAttrKind::IBSegueAction: {
+    static UIdent Attr_IBSegueAction("source.decl.attribute.ibsegueaction");
+    return Attr_IBSegueAction;
+  }
+  case DeclAttrKind::IBOutlet: {
+    return Attr_IBOutlet;
+  }
+  case DeclAttrKind::IBDesignable: {
+    return Attr_IBDesignable;
+  }
+  case DeclAttrKind::IBInspectable: {
+    return Attr_IBInspectable;
+  }
+  case DeclAttrKind::GKInspectable: {
+    return Attr_GKInspectable;
+  }
+  case DeclAttrKind::ObjC: {
+    if (cast<ObjCAttr>(Attr)->hasName()) {
+      return Attr_ObjcNamed;
+    } else {
+      return Attr_Objc;
     }
-    case DAK_IBSegueAction: {
-      static UIdent Attr_IBSegueAction("source.decl.attribute.ibsegueaction");
-      return Attr_IBSegueAction;
+  }
+  case DeclAttrKind::AccessControl: {
+    switch (cast<AbstractAccessControlAttr>(Attr)->getAccess()) {
+    case AccessLevel::Private:
+      return Attr_Private;
+    case AccessLevel::FilePrivate:
+      return Attr_FilePrivate;
+    case AccessLevel::Internal:
+      return Attr_Internal;
+    case AccessLevel::Package:
+      return Attr_Package;
+    case AccessLevel::Public:
+      return Attr_Public;
+    case AccessLevel::Open:
+      return Attr_Open;
     }
-    case DAK_IBOutlet: {
-      return Attr_IBOutlet;
+  }
+  case DeclAttrKind::SetterAccess: {
+    switch (cast<AbstractAccessControlAttr>(Attr)->getAccess()) {
+    case AccessLevel::Private:
+      return Attr_Setter_Private;
+    case AccessLevel::FilePrivate:
+      return Attr_Setter_FilePrivate;
+    case AccessLevel::Internal:
+      return Attr_Setter_Internal;
+    case AccessLevel::Package:
+      return Attr_Setter_Package;
+    case AccessLevel::Public:
+      return Attr_Setter_Public;
+    case AccessLevel::Open:
+      return Attr_Setter_Open;
     }
-    case DAK_IBDesignable: {
-      return Attr_IBDesignable;
-    }
-    case DAK_IBInspectable: {
-      return Attr_IBInspectable;
-    }
-    case DAK_GKInspectable: {
-      return Attr_GKInspectable;
-    }
-    case DAK_ObjC: {
-      if (cast<ObjCAttr>(Attr)->hasName()) {
-        return Attr_ObjcNamed;
-      } else {
-        return Attr_Objc;
-      }
-    }
-    case DAK_AccessControl: {
-      switch (cast<AbstractAccessControlAttr>(Attr)->getAccess()) {
-        case AccessLevel::Private:
-          return Attr_Private;
-        case AccessLevel::FilePrivate:
-          return Attr_FilePrivate;
-        case AccessLevel::Internal:
-          return Attr_Internal;
-        case AccessLevel::Package:
-          return Attr_Package;
-        case AccessLevel::Public:
-          return Attr_Public;
-        case AccessLevel::Open:
-          return Attr_Open;
-      }
-    }
-    case DAK_SetterAccess: {
-      switch (cast<AbstractAccessControlAttr>(Attr)->getAccess()) {
-        case AccessLevel::Private:
-          return Attr_Setter_Private;
-        case AccessLevel::FilePrivate:
-          return Attr_Setter_FilePrivate;
-        case AccessLevel::Internal:
-          return Attr_Setter_Internal;
-        case AccessLevel::Package:
-          return Attr_Setter_Package;
-        case AccessLevel::Public:
-          return Attr_Setter_Public;
-        case AccessLevel::Open:
-          return Attr_Setter_Open;
-      }
-    }
+  }
 
     // Ignore these.
-    case DAK_ShowInInterface:
-    case DAK_RawDocComment:
-    case DAK_HasInitialValue:
-    case DAK_HasStorage:
-      return llvm::None;
-    default:
-      break;
+  case DeclAttrKind::ShowInInterface:
+  case DeclAttrKind::RawDocComment:
+  case DeclAttrKind::HasInitialValue:
+  case DeclAttrKind::HasStorage:
+    return llvm::None;
+  default:
+    break;
   }
 
   switch (Attr->getKind()) {
-    case DAK_Count:
-      break;
-#define DECL_ATTR(X, CLASS, ...)\
-    case DAK_##CLASS: {\
-      static UIdent Attr_##X("source.decl.attribute."#X); \
-      return Attr_##X; \
-    }
+  case DeclAttrKind::Count:
+    break;
+#define DECL_ATTR(X, CLASS, ...)                                               \
+  case DeclAttrKind::CLASS: {                                                  \
+    static UIdent Attr_##X("source.decl.attribute." #X);                       \
+    return Attr_##X;                                                           \
+  }
 #include "swift/AST/Attr.def"
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -849,8 +849,6 @@ SwiftLangSupport::getUIDForDeclAttribute(const swift::DeclAttribute *Attr) {
   }
 
   switch (Attr->getKind()) {
-  case DeclAttrKind::Count:
-    break;
 #define DECL_ATTR(X, CLASS, ...)                                               \
   case DeclAttrKind::CLASS: {                                                  \
     static UIdent Attr_##X("source.decl.attribute." #X);                       \


### PR DESCRIPTION
The main motivation is to make `DeclAttrKind`/`TypeAttrKind` align with other "kind" enums e.g. `DeclKind`.

* In `TypeAttrKind`, use the class names instead of the spelling as the enum case names.
* Use scoped enums i.e. `DeclAttrKind::Available` instead of `DAK_Available`
* Split `Attr.def` to `DeclAttr.def` and `TypeAttr.def`. Nothing was handling both attribute kind at the same time.
* Remove `DAK_Count`(`DeclAttrKind::Count`). Instead, introduce `NumDeclAttrKinds` for the number of the enum cases, and use optional to represent invalid attribute kind. (aligning with `TypeAttrKind`)
* Introduce `LAST_TYPE_ATTR` metaprogramming macro to get the number of the enum cases, instead of using dummy `_counting_TAK_*` globally visible symbols. This aligns with other "kind" enums.