### PR TITLE
ASTGen: Suppress warnings about handling unknown enum cases

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -103,6 +103,7 @@ endif()
 
 set(compile_options
   ${c_include_paths_args}
+  "SHELL: -DRESILIENT_SWIFT_SYNTAX"
   "SHELL: ${cxx_interop_flag}"
   "SHELL: -Xcc -std=c++17 -Xcc -DCOMPILED_WITH_SWIFT -Xcc -DSWIFT_TARGET"
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -58,6 +58,10 @@ extension ASTGenVisitor {
         addAttribute(self.generateDeclAttribute(attribute: node))
       case .ifConfigDecl:
         fatalError("unimplemented")
+#if RESILIENT_SWIFT_SYNTAX
+      @unknown default:
+        fatalError()
+#endif
       }
     }
 

--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -68,6 +68,10 @@ extension ASTGenVisitor {
       return self.generate(typeAliasDecl: node).asDecl
     case .variableDecl(let node):
       return self.generate(variableDecl: node).asDecl
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
     return self.generateWithLegacy(node)
   }
@@ -421,6 +425,10 @@ extension ASTGenVisitor {
         accessors: CollectionOfOne(accessor).bridgedArray(in: self),
         rBraceLoc: rightBrace
       )
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
   }
 
@@ -726,6 +734,10 @@ extension ASTGenVisitor {
         } else {
           body.associativity = associativity
         }
+#if RESILIENT_SWIFT_SYNTAX
+      @unknown default:
+        fatalError()
+#endif
       }
     }
 

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -73,6 +73,11 @@ fileprivate func emitDiagnosticParts(
       replaceStartLoc = bridgedSourceLoc(at: oldToken.endPositionBeforeTrailingTrivia)
       replaceEndLoc = bridgedSourceLoc(at: oldToken.endPosition)
       newText = newTrivia.description
+
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
 
     newText.withBridgedString { bridgedMessage in
@@ -208,6 +213,11 @@ extension SourceManager {
           at: oldToken.endPosition
         )
         newText = newTrivia.description
+
+#if RESILIENT_SWIFT_SYNTAX
+      @unknown default:
+        fatalError()
+#endif
       }
 
       newText.withBridgedString { bridgedMessage in

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -197,6 +197,10 @@ extension ASTGenVisitor {
       preconditionFailure("should be handled in generate(sequenceExpr:)")
     case .unresolvedTernaryExpr:
       preconditionFailure("should be handled in generate(sequenceExpr:)")
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
     preconditionFailure("isExprMigrated() mismatch")
   }

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -69,6 +69,10 @@ extension ASTGenVisitor {
       case .layoutRequirement(_):
         // FIXME: Implement layout requirement translation.
         fatalError("Translation of layout requirements not implemented!")
+#if RESILIENT_SWIFT_SYNTAX
+      @unknown default:
+        fatalError()
+#endif
       }
     }
 

--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -88,6 +88,10 @@ extension ASTGenVisitor {
       colonLocs = elementNodes.lazy
         .map({ self.generateSourceLoc($0.colon) })
         .bridgedArray(in: self)
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
     return .createParsed(
       self.ctx,

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -359,6 +359,10 @@ func checkMacroDefinition(
       replacementsPtr.pointee = replacementBuffer.baseAddress
       numReplacementsPtr.pointee = replacements.count
       return Int(BridgedMacroDefinitionKind.expandedMacro.rawValue)
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
   } catch let errDiags as DiagnosticsError {
     let srcMgr = SourceManager(cxxDiagnosticEngine: diagEnginePtr)
@@ -501,6 +505,9 @@ func expandFreestandingMacroIPC(
   case .expression: pluginMacroRole = .expression
   case .declaration: pluginMacroRole = .declaration
   case .codeItem: pluginMacroRole = .codeItem
+#if RESILIENT_SWIFT_SYNTAX
+  @unknown default: fatalError()
+#endif
   }
 
   // Send the message.
@@ -790,6 +797,11 @@ func expandAttachedMacroIPC(
     .declaration,
     .codeItem:
     preconditionFailure("unhandled macro role for attached macro")
+
+#if RESILIENT_SWIFT_SYNTAX
+  @unknown default:
+    fatalError()
+#endif
   }
 
   // Prepare syntax nodes to transfer.
@@ -990,6 +1002,10 @@ fileprivate extension SyntaxProtocol {
       formatted = self.formatted()
     case .disabled:
       formatted = Syntax(self)
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
     return formatted.trimmedDescription(matching: { $0.isWhitespace })
   }

--- a/lib/ASTGen/Sources/ASTGen/Patterns.swift
+++ b/lib/ASTGen/Sources/ASTGen/Patterns.swift
@@ -45,6 +45,10 @@ extension ASTGenVisitor {
       return self.generate(valueBindingPattern: node).asPattern
     case .wildcardPattern(let node):
       return self.generate(wildcardPattern: node).asPattern
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
   }
 

--- a/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
@@ -131,6 +131,11 @@ extension SourceManager.MacroExpansionContext: MacroExpansionContext {
 
     case .afterTrailingTrivia:
       rawPosition = node.endPosition
+
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
 
     let offsetWithinSyntaxNode =
@@ -164,6 +169,11 @@ extension SourceManager.MacroExpansionContext: MacroExpansionContext {
 
     case .filePath:
       break
+
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
 
     // Do the location lookup.

--- a/lib/ASTGen/Sources/ASTGen/Stmts.swift
+++ b/lib/ASTGen/Sources/ASTGen/Stmts.swift
@@ -51,6 +51,10 @@ extension ASTGenVisitor {
       return self.generate(whileStmt: node).asStmt
     case .yieldStmt(let node):
       return self.generate(yieldStmt: node).asStmt
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
     return self.generateWithLegacy(node)
   }
@@ -64,6 +68,10 @@ extension ASTGenVisitor {
       return .stmt(self.generate(stmt: node))
     case .expr(let node):
       return .expr(self.generate(expr: node))
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
   }
 
@@ -145,6 +153,10 @@ extension ASTGenVisitor {
         pattern: pat,
         initializer: initializer
       )
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
   }
 
@@ -306,6 +318,10 @@ extension ASTGenVisitor {
           return self.generate(codeBlock: node).asStmt
         case .ifExpr(let node):
           return self.generateIfStmt(ifExpr: node).asStmt
+#if RESILIENT_SWIFT_SYNTAX
+        @unknown default:
+          fatalError()
+#endif
         }
       }.asNullable
     )
@@ -423,6 +439,10 @@ extension ASTGenVisitor {
       )
       items = CollectionOfOne(item).bridgedArray(in: self)
       terminatorLoc = self.generateSourceLoc(node.colon)
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
     let body = BridgedBraceStmt.createParsed(
       self.ctx,
@@ -448,6 +468,10 @@ extension ASTGenVisitor {
         return ASTNode.stmt(self.generate(switchCase: node).asStmt).bridged
       case .ifConfigDecl(_):
         fatalError("unimplemented")
+#if RESILIENT_SWIFT_SYNTAX
+      @unknown default:
+        fatalError()
+#endif
       }
     }).bridgedArray(in: self)
   }
@@ -501,6 +525,10 @@ extension ASTGenVisitor {
       lParenLoc = nil
       rParenLoc = nil
       yields = CollectionOfOne(self.generate(expr: node)).bridgedArray(in: self)
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
     return .createParsed(
       self.ctx,

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -101,6 +101,10 @@ extension ASTGenVisitor {
       return self.generate(suppressedType: node).asTypeRepr
     case .tupleType(let node):
       return self.generate(tupleType: node).asTypeRepr
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default:
+      fatalError()
+#endif
     }
     preconditionFailure("isTypeMigrated() mismatch")
   }

--- a/lib/ASTGen/Sources/SwiftIDEUtilsBridging/NameMatcherBridging.swift
+++ b/lib/ASTGen/Sources/SwiftIDEUtilsBridging/NameMatcherBridging.swift
@@ -52,6 +52,9 @@ fileprivate extension IDEBridging.LabelRangeType {
     case .parameters: self = .Param
     case .noncollapsibleParameters: self = .NoncollapsibleParam
     case .selector: self = .CompoundName
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default: fatalError()
+#endif
     }
   }
 }
@@ -71,6 +74,9 @@ extension BridgedResolvedLoc {
     case .parameters(let arguments2): arguments = arguments2
     case .noncollapsibleParameters(let arguments2): arguments = arguments2
     case .selector(let arguments2): arguments = arguments2
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default: fatalError()
+#endif
     }
     self.init(
       range: BridgedCharSourceRange(from: resolvedLoc.baseNameRange, in: sourceFile),
@@ -90,6 +96,9 @@ fileprivate extension IDEBridging.ResolvedLocContext {
     case .selector: self = .Selector
     case .comment: self = .Comment
     case .stringLiteral: self = .StringLiteral
+#if RESILIENT_SWIFT_SYNTAX
+    @unknown default: fatalError()
+#endif
     }
   }
 }


### PR DESCRIPTION
When built as part of the compiler toolchain SwiftSyntax is built with library evolution enabled. This means that switches over enums from SwiftSyntax must include a default case to be considered exhaustive, or a warning will be emitted. This change suppresses those warnings by adding `@unknown default` cases wherever they are expected. As a compromise, these `@unknown default` cases are wrapped with a `#if` to ensure they are only included in the CMake build of ASTGen, but continue to be omitted from the SPM build which compiler engineers use to iterate on ASTGen's implementation. This is needed to avoid generating the opposite warning during the SPM build, since the compiler thinks the `@unknown default` case is superfluous when SwiftSyntax is built non-resiliently. As an aside, this catch-22 is a bummer and I think we should change the compiler to suppress the unreachable default warning when the default is annotated `@unknown`.
