### PR TITLE
Remove -warn-redundant-requirements flag

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -19,7 +19,6 @@
 
 #include "swift/AST/ASTAllocated.h"
 #include "swift/AST/Evaluator.h"
-#include "swift/AST/GenericSignature.h"
 #include "swift/AST/Identifier.h"
 #include "swift/AST/Import.h"
 #include "swift/AST/SILOptions.h"
@@ -86,6 +85,7 @@ namespace swift {
   class ForeignRepresentationInfo;
   class FuncDecl;
   class GenericContext;
+  class GenericSignature;
   class InFlightDiagnostic;
   class IterableDeclContext;
   class LazyContextData;

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -27,7 +27,6 @@
 #include "swift/AST/MacroDeclaration.h"
 #include "swift/AST/Ownership.h"
 #include "swift/AST/PlatformKind.h"
-#include "swift/AST/Requirement.h"
 #include "swift/AST/StorageImpl.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/EnumTraits.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3194,8 +3194,6 @@ ERROR(recursive_superclass_constraint,none,
       "superclass constraint %0 : %1 is recursive", (Type, Type))
 ERROR(requires_same_concrete_type,none,
       "generic signature requires types %0 and %1 to be the same", (Type, Type))
-WARNING(redundant_conformance_constraint,none,
-        "redundant conformance constraint %0 : %1", (Type, Type))
 
 WARNING(missing_protocol_refinement, none,
         "protocol %0 should be declared to refine %1 due to a same-type constraint on 'Self'",
@@ -3204,17 +3202,9 @@ WARNING(missing_protocol_refinement, none,
 ERROR(requirement_conflict,none,
       "no type for %0 can satisfy both %1",
       (Type, StringRef))
-WARNING(redundant_same_type_to_concrete,none,
-        "redundant same-type constraint %0 == %1", (Type, Type))
 ERROR(conflicting_superclass_constraints,none,
       "type %0 cannot be a subclass of both %1 and %2",
       (Type, Type, Type))
-WARNING(redundant_superclass_constraint,none,
-        "redundant superclass constraint %0 : %1", (Type, Type))
-
-WARNING(redundant_layout_constraint,none,
-        "redundant constraint %0 : %1",
-        (Type, LayoutConstraint))
 
 WARNING(redundant_same_type_constraint,none,
         "redundant same-type constraint %0 == %1", (Type, Type))
@@ -7578,8 +7568,6 @@ ERROR(inverse_but_also_conforms, none,
 ERROR(inverse_generic_but_also_conforms, none,
       "%0 required to be '%1' but is marked with '~%1'",
       (Type, StringRef))
-WARNING(redundant_inverse_constraint,none,
-        "redundant constraint %0 : '~%1'", (Type, StringRef))
 ERROR(inverse_on_class, none,
       "classes cannot be '~%0'",
       (StringRef))

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -17,7 +17,6 @@
 #define SWIFT_AST_PROTOCOLCONFORMANCEREF_H
 
 #include "swift/AST/ProtocolConformanceRef.h"
-#include "swift/AST/Requirement.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/Basic/Debug.h"
@@ -36,6 +35,7 @@ class BuiltinProtocolConformance;
 class ConcreteDeclRef;
 class PackConformance;
 class ProtocolConformance;
+class Requirement;
 enum class EffectKind : uint8_t;
 
 /// A ProtocolConformanceRef is a handle to a protocol conformance which

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -233,24 +233,11 @@ CheckRequirementsResult checkRequirements(
 /// A requirement as written in source, together with a source location. See
 /// ProtocolDecl::getStructuralRequirements().
 struct StructuralRequirement {
-  /// The actual requirement, where the types were resolved with the
-  /// 'Structural' type resolution stage.
+  /// A requirement with resolved in the structural resolution stage.
   Requirement req;
 
-  /// The source location where the requirement is written, used for redundancy
-  /// and conflict diagnostics.
+  /// The source location where the requirement is written, for diagnostics.
   SourceLoc loc;
-
-  /// A flag indicating whether the requirement was inferred from the
-  /// application of a type constructor. Also used for diagnostics, because
-  /// an inferred requirement made redundant by an explicit requirement is not
-  /// diagnosed as redundant, since we want to give users the option of
-  /// spelling out these requirements explicitly.
-  bool inferred = false;
-
-  /// A flag indicating whether this requirement was produced via the expansion
-  /// of default conformances to invertible protocols.
-  bool fromDefault = false;
 };
 
 /// An "anti-conformance" requirement `Subject: ~Protocol`.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -27,7 +27,6 @@
 #include "swift/AST/KnownProtocols.h"
 #include "swift/AST/Ownership.h"
 #include "swift/AST/ProtocolConformanceRef.h"
-#include "swift/AST/Requirement.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeAlignments.h"

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -550,9 +550,6 @@ namespace swift {
     /// rewrite system.
     bool EnableRequirementMachineOpaqueArchetypes = false;
 
-    /// Enable warnings for redundant requirements in generic signatures.
-    bool WarnRedundantRequirements = false;
-
     /// Enable experimental associated type inference improvements.
     bool EnableExperimentalAssociatedTypeInference = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -425,9 +425,6 @@ def disable_requirement_machine_reuse : Flag<["-"], "disable-requirement-machine
 def enable_requirement_machine_opaque_archetypes : Flag<["-"], "enable-requirement-machine-opaque-archetypes">,
   HelpText<"Enable more correct opaque archetype support, which is off by default because it might fail to produce a convergent rewrite system">;
 
-def warn_redundant_requirements : Flag<["-"], "warn-redundant-requirements">,
-  HelpText<"Emit warnings for redundant requirements in generic signatures">;
-
 def dump_type_witness_systems : Flag<["-"], "dump-type-witness-systems">,
   HelpText<"Enables dumping type witness systems from associated type inference">;
 

--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -363,10 +363,7 @@ void InverseRequirement::expandDefaults(
       
       auto protoTy = proto->getDeclaredInterfaceType();
       result.push_back({{RequirementKind::Conformance, gp, protoTy},
-                        SourceLoc(),
-                        /*inferred=*/true,
-                        /*default=*/true,
-                       });
+                        SourceLoc()});
     }
   }
 }

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -691,24 +691,7 @@ bool ConcreteContraction::performConcreteContraction(
     // requirement where the left hand side is not a type parameter.
     SmallVector<Requirement, 4> reqs;
     SmallVector<InverseRequirement, 4> ignoreInverses;
-    if (req.inferred) {
-      // Discard errors from desugaring a substituted requirement that
-      // was inferred. For example, if we have something like
-      //
-      //   <T, U where T == Int, U == Set<T>>
-      //
-      // The inferred requirement 'T : Hashable' from 'Set<>' will
-      // be substituted with 'T == Int' to get 'Int : Hashable'.
-      //
-      // Desugaring will diagnose a redundant conformance requirement,
-      // but we want to ignore that, since the user did not explicitly
-      // write 'Int : Hashable' (or 'T : Hashable') anywhere.
-      SmallVector<RequirementError, 4> discardErrors;
-      desugarRequirement(substReq, SourceLoc(), reqs,
-                         ignoreInverses, discardErrors);
-    } else {
-      desugarRequirement(substReq, req.loc, reqs, ignoreInverses, errors);
-    }
+    desugarRequirement(substReq, req.loc, reqs, ignoreInverses, errors);
 
     for (auto desugaredReq : reqs) {
       if (Debug) {
@@ -716,7 +699,7 @@ bool ConcreteContraction::performConcreteContraction(
         desugaredReq.dump(llvm::dbgs());
         llvm::dbgs() << "\n";
       }
-      result.push_back({desugaredReq, req.loc, req.inferred});
+      result.push_back({desugaredReq, req.loc});
     }
 
     if (preserveSameTypeRequirement(req.req) &&
@@ -730,7 +713,7 @@ bool ConcreteContraction::performConcreteContraction(
 
       // Make the duplicated requirement 'inferred' so that we don't diagnose
       // it as redundant.
-      result.push_back({req.req, SourceLoc(), /*inferred=*/true});
+      result.push_back({req.req, SourceLoc()});
     }
   }
 

--- a/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
+++ b/lib/AST/RequirementMachine/ConcreteTypeWitness.cpp
@@ -599,7 +599,6 @@ void PropertyMap::inferConditionalRequirements(
                                           substitutions);
 
   assert(builder.PermanentRules.empty());
-  assert(builder.WrittenRequirements.empty());
 
   System.addRules(std::move(builder.ImportedRules),
                   std::move(builder.PermanentRules),

--- a/lib/AST/RequirementMachine/Debug.h
+++ b/lib/AST/RequirementMachine/Debug.h
@@ -69,19 +69,15 @@ enum class DebugFlags : unsigned {
   /// Print debug output from the concrete contraction pre-processing pass.
   ConcreteContraction = (1<<15),
 
-  /// Print debug output from propagating explicit requirement
-  /// IDs from redundant rules.
-  PropagateRequirementIDs = (1<<16),
-
   /// Print a trace of requirement machines constructed and how long each took.
-  Timers = (1<<17),
+  Timers = (1<<16),
 
   /// Print conflicting rules.
-  ConflictingRules = (1<<18),
+  ConflictingRules = (1<<17),
 
   /// Print debug output from concrete equivalence class splitting during
   /// minimization.
-  SplitConcreteEquivalenceClass = (1<<19),
+  SplitConcreteEquivalenceClass = (1<<18),
 };
 
 using DebugOptions = OptionSet<DebugFlags>;

--- a/lib/AST/RequirementMachine/Diagnostics.h
+++ b/lib/AST/RequirementMachine/Diagnostics.h
@@ -50,10 +50,6 @@ struct RequirementError {
     ConflictingInverseRequirement,
     /// A recursive requirement, e.g. T == G<T.A>.
     RecursiveRequirement,
-    /// A redundant requirement, e.g. T == T.
-    RedundantRequirement,
-    /// A redundant requirement, e.g. T : ~Copyable, T : ~Copyable.
-    RedundantInverseRequirement,
     /// A not-yet-supported same-element requirement, e.g. each T == Int.
     UnsupportedSameElement,
   } kind;
@@ -89,14 +85,12 @@ private:
 public:
   Requirement getRequirement() const {
     assert(!(kind == Kind::InvalidInverseOuterSubject ||
-             kind == Kind::RedundantInverseRequirement ||
              kind == Kind::ConflictingInverseRequirement));
     return requirement;
   }
 
   InverseRequirement getInverse() const {
     assert(kind == Kind::InvalidInverseOuterSubject ||
-           kind == Kind::RedundantInverseRequirement ||
            kind == Kind::ConflictingInverseRequirement);
     return inverse;
   }
@@ -143,16 +137,6 @@ public:
                                                     Requirement second,
                                                     SourceLoc loc) {
     return {Kind::ConflictingRequirement, first, second, loc};
-  }
-
-  static RequirementError forRedundantRequirement(Requirement req,
-                                                  SourceLoc loc) {
-    return {Kind::RedundantRequirement, req, loc};
-  }
-
-  static
-  RequirementError forRedundantInverseRequirement(InverseRequirement req) {
-    return {Kind::RedundantInverseRequirement, req, req.loc};
   }
 
   static RequirementError forRecursiveRequirement(Requirement req,

--- a/lib/AST/RequirementMachine/HomotopyReduction.cpp
+++ b/lib/AST/RequirementMachine/HomotopyReduction.cpp
@@ -120,66 +120,6 @@ void RewriteSystem::propagateExplicitBits() {
   }
 }
 
-/// Propagate requirement IDs from redundant rules to their
-/// replacements that appear once in empty context.
-void RewriteSystem::propagateRedundantRequirementIDs() {
-  if (Debug.contains(DebugFlags::PropagateRequirementIDs)) {
-    llvm::dbgs() << "\nPropagating requirement IDs: {";
-  }
-
-  for (const auto &ruleAndReplacement : RedundantRules) {
-    unsigned ruleID = ruleAndReplacement.first;
-    const auto &rewritePath = ruleAndReplacement.second;
-    const auto &rule = Rules[ruleID];
-
-    auto requirementID = rule.getRequirementID();
-    if (!requirementID.has_value()) {
-      if (Debug.contains(DebugFlags::PropagateRequirementIDs)) {
-        llvm::dbgs() << "\n- rule does not have a requirement ID: "
-                     << rule;
-      }
-      continue;
-    }
-
-    MutableTerm lhs(rule.getLHS());
-    for (auto ruleID : rewritePath.findRulesAppearingOnceInEmptyContext(lhs, *this)) {
-      auto &replacement = Rules[ruleID];
-      if (replacement.isPermanent()) {
-        if (Debug.contains(DebugFlags::PropagateRequirementIDs)) {
-          llvm::dbgs() << "\n- skipping permanent rule: " << rule;
-        }
-        continue;
-      }
-
-      // If the replacement rule already has a requirementID, overwrite
-      // it if the existing ID corresponds to an inferred requirement.
-      // This effectively makes the inferred requirement the redundant
-      // one, which makes it easier to suppress redundancy warnings for
-      // inferred requirements later on.
-      auto existingID = replacement.getRequirementID();
-      if (existingID.has_value() && !WrittenRequirements[*existingID].inferred) {
-        if (Debug.contains(DebugFlags::PropagateRequirementIDs)) {
-          llvm::dbgs() << "\n- rule already has a requirement ID: "
-                       << rule;
-        }
-        continue;
-      }
-
-      if (Debug.contains(DebugFlags::PropagateRequirementIDs)) {
-        llvm::dbgs() << "\n- propagating ID = " << requirementID
-                     << "\n  from " << rule;
-        llvm::dbgs() << "\n  to " << replacement;
-      }
-
-      replacement.setRequirementID(requirementID);
-    }
-  }
-
-  if (Debug.contains(DebugFlags::PropagateRequirementIDs)) {
-    llvm::dbgs() << "\n}\n";
-  }
-}
-
 /// Find concrete type or superclass rules where the right hand side occurs as a
 /// proper prefix of one of its substitutions.
 ///
@@ -614,7 +554,6 @@ void RewriteSystem::minimizeRewriteSystem(const PropertyMap &map) {
     return false;
   });
 
-  propagateRedundantRequirementIDs();
   computeRecursiveRules();
 
   // Check invariants after homotopy reduction.

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -126,16 +126,10 @@
 // redundant rules. This is implemented in HomotopyReduction.cpp and
 // MinimalConformances.cpp.
 //
-// Minimization emits warnings about redundant rules by producing that
-// correspond to user-written requirements by producing RequirementError
-// values.
-//
 // After minimization, the remaining non-redundant rules are converted into
-// the Requirements of a minimal generic signature using the
-// RequirementBuilder.
-//
-// After minimization, the requirement machine undergoes a final state
-// transition into the immutable "frozen" state:
+// the Requirements of a minimal generic signature by the RequirementBuilder.
+// Then, the requirement machine undergoes a final state transition into the
+// immutable "frozen" state:
 //
 //   /-----------------------------\
 //  |  Complete RequirementMachine  |

--- a/lib/AST/RequirementMachine/RequirementMachine.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachine.cpp
@@ -279,7 +279,6 @@ RequirementMachine::initWithProtocolSignatureRequirements(
 
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/false, protos,
-                    std::move(builder.WrittenRequirements),
                     std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
@@ -329,7 +328,6 @@ RequirementMachine::initWithGenericSignature(GenericSignature sig) {
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/false,
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
-                    std::move(builder.WrittenRequirements),
                     std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
@@ -382,7 +380,6 @@ RequirementMachine::initWithProtocolWrittenRequirements(
 
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/true, component,
-                    std::move(builder.WrittenRequirements),
                     std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));
@@ -431,7 +428,6 @@ RequirementMachine::initWithWrittenRequirements(
   // Add the initial set of rewrite rules to the rewrite system.
   System.initialize(/*recordLoops=*/true,
                     /*protos=*/ArrayRef<const ProtocolDecl *>(),
-                    std::move(builder.WrittenRequirements),
                     std::move(builder.ImportedRules),
                     std::move(builder.PermanentRules),
                     std::move(builder.RequirementRules));

--- a/lib/AST/RequirementMachine/RewriteContext.cpp
+++ b/lib/AST/RequirementMachine/RewriteContext.cpp
@@ -180,8 +180,6 @@ static DebugOptions parseDebugFlags(StringRef debugFlags) {
             .Case("redundant-rules", DebugFlags::RedundantRules)
             .Case("redundant-rules-detail", DebugFlags::RedundantRulesDetail)
             .Case("concrete-contraction", DebugFlags::ConcreteContraction)
-            .Case("propagate-requirement-ids",
-                  DebugFlags::PropagateRequirementIDs)
             .Case("timers", DebugFlags::Timers)
             .Case("conflicting-rules", DebugFlags::ConflictingRules)
             .Case("split-concrete-equiv-class",

--- a/lib/AST/RequirementMachine/RewriteSystem.h
+++ b/lib/AST/RequirementMachine/RewriteSystem.h
@@ -134,11 +134,9 @@ public:
 
   void initialize(
       bool recordLoops, ArrayRef<const ProtocolDecl *> protos,
-      std::vector<StructuralRequirement> &&writtenRequirements,
       std::vector<Rule> &&importedRules,
       std::vector<std::pair<MutableTerm, MutableTerm>> &&permanentRules,
-      std::vector<std::tuple<MutableTerm, MutableTerm,
-                             llvm::Optional<unsigned>>> &&requirementRules);
+      std::vector<std::pair<MutableTerm, MutableTerm>> &&requirementRules);
 
   unsigned getLongestInitialRule() const {
     return LongestInitialRule;
@@ -183,14 +181,12 @@ public:
 
   bool addPermanentRule(MutableTerm lhs, MutableTerm rhs);
 
-  bool addExplicitRule(MutableTerm lhs, MutableTerm rhs,
-                       llvm::Optional<unsigned> requirementID);
+  bool addExplicitRule(MutableTerm lhs, MutableTerm rhs);
 
   void addRules(
       std::vector<Rule> &&importedRules,
       std::vector<std::pair<MutableTerm, MutableTerm>> &&permanentRules,
-      std::vector<std::tuple<MutableTerm, MutableTerm,
-                             llvm::Optional<unsigned>>> &&requirementRules);
+      std::vector<std::pair<MutableTerm, MutableTerm>> &&requirementRules);
 
   bool simplify(MutableTerm &term, RewritePath *path=nullptr) const;
 
@@ -229,8 +225,6 @@ public:
   /// Diagnostics
   ///
   //////////////////////////////////////////////////////////////////////////////
-
-  void computeRedundantRequirementDiagnostics(SmallVectorImpl<RequirementError> &errors);
 
   void computeConflictingRequirementDiagnostics(SmallVectorImpl<RequirementError> &errors,
                                                 SourceLoc signatureLoc,

--- a/lib/AST/RequirementMachine/Rule.h
+++ b/lib/AST/RequirementMachine/Rule.h
@@ -111,21 +111,6 @@ public:
   const Term &getLHS() const { return LHS; }
   const Term &getRHS() const { return RHS; }
 
-  llvm::Optional<unsigned> getRequirementID() const {
-    if (RequirementID == 0)
-      return llvm::None;
-    else
-      return RequirementID - 1;
-  }
-
-  void setRequirementID(llvm::Optional<unsigned> requirementID) {
-    assert(!Frozen);
-    if (!requirementID)
-      RequirementID = 0;
-    else
-      RequirementID = *requirementID + 1;
-  }
-
   llvm::Optional<Symbol> isPropertyRule() const;
 
   const ProtocolDecl *isProtocolConformanceRule() const;

--- a/lib/AST/RequirementMachine/RuleBuilder.cpp
+++ b/lib/AST/RequirementMachine/RuleBuilder.cpp
@@ -280,8 +280,7 @@ void RuleBuilder::addAssociatedType(const AssociatedTypeDecl *type,
 /// will be added in the corresponding term from the substitution array.
 void RuleBuilder::addRequirement(const Requirement &req,
                                  const ProtocolDecl *proto,
-                                 llvm::Optional<ArrayRef<Term>> substitutions,
-                                 llvm::Optional<unsigned> requirementID) {
+                                 llvm::Optional<ArrayRef<Term>> substitutions) {
   if (Dump) {
     llvm::dbgs() << "+ ";
     req.dump(llvm::dbgs());
@@ -394,17 +393,12 @@ void RuleBuilder::addRequirement(const Requirement &req,
   }
   }
 
-  RequirementRules.emplace_back(
-      std::move(subjectTerm), std::move(constraintTerm),
-      requirementID);
+  RequirementRules.emplace_back(std::move(subjectTerm), std::move(constraintTerm));
 }
 
 void RuleBuilder::addRequirement(const StructuralRequirement &req,
                                  const ProtocolDecl *proto) {
-  WrittenRequirements.push_back(req);
-  unsigned requirementID = WrittenRequirements.size() - 1;
-  addRequirement(req.req.getCanonical(), proto, /*substitutions=*/llvm::None,
-                 requirementID);
+  addRequirement(req.req.getCanonical(), proto, /*substitutions=*/llvm::None);
 }
 
 /// Lowers a protocol typealias to a rewrite rule.
@@ -436,8 +430,7 @@ void RuleBuilder::addTypeAlias(const ProtocolTypeAlias &alias,
     constraintTerm.add(Symbol::forConcreteType(concreteType, result, Context));
   }
 
-  RequirementRules.emplace_back(subjectTerm, constraintTerm,
-                                /*requirementID=*/llvm::None);
+  RequirementRules.emplace_back(subjectTerm, constraintTerm);
 }
 
 /// If we haven't seen this protocol yet, save it for later so that we can

--- a/lib/AST/RequirementMachine/RuleBuilder.h
+++ b/lib/AST/RequirementMachine/RuleBuilder.h
@@ -74,12 +74,7 @@ struct RuleBuilder {
 
   /// New rules derived from requirements written by the user, which can be
   /// eliminated by homotopy reduction.
-  std::vector<std::tuple<MutableTerm, MutableTerm, llvm::Optional<unsigned>>>
-      RequirementRules;
-
-  /// Requirements written in source code. The requirement ID in the above
-  /// \c RequirementRules vector is an index into this array.
-  std::vector<StructuralRequirement> WrittenRequirements;
+  std::vector<std::pair<MutableTerm, MutableTerm>> RequirementRules;
 
   /// Enables debugging output. Controlled by the -dump-requirement-machine
   /// frontend flag.
@@ -115,8 +110,7 @@ private:
   void addAssociatedType(const AssociatedTypeDecl *type,
                          const ProtocolDecl *proto);
   void addRequirement(const Requirement &req, const ProtocolDecl *proto,
-                      llvm::Optional<ArrayRef<Term>> substitutions = llvm::None,
-                      llvm::Optional<unsigned> requirementID = llvm::None);
+                      llvm::Optional<ArrayRef<Term>> substitutions = llvm::None);
   void addRequirement(const StructuralRequirement &req,
                       const ProtocolDecl *proto);
   void addTypeAlias(const ProtocolTypeAlias &alias,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1336,9 +1336,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Args.hasArg(OPT_enable_requirement_machine_opaque_archetypes))
     Opts.EnableRequirementMachineOpaqueArchetypes = true;
 
-  if (Args.hasArg(OPT_warn_redundant_requirements))
-    Opts.WarnRedundantRequirements = true;
-
   Opts.EnableExperimentalAssociatedTypeInference = true;
 
   if (Args.hasArg(OPT_enable_experimental_associated_type_inference))

--- a/test/AutoDiff/SILGen/differentiability_witness_generic_signature.swift
+++ b/test/AutoDiff/SILGen/differentiability_witness_generic_signature.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-silgen -verify -module-name main %s -warn-redundant-requirements | %FileCheck %s
-// RUN: %target-swift-emit-sil -verify -module-name main %s -warn-redundant-requirements
+// RUN: %target-swift-emit-silgen -verify -module-name main %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -verify -module-name main %s
 
 // NOTE: SILParser crashes for SILGen round-trip
 // (https://github.com/apple/swift/issues/54370).
@@ -85,7 +85,7 @@ extension AllConcrete where T == Float {
   // Derivative generic signature: `<T where T == Float>` (explicit `where` clause)
   //    Witness generic signature: none
   @_silgen_name("allconcrete_where_gensig")
-  @differentiable(reverse where T == Float) // expected-warning {{redundant same-type constraint 'T' == 'Float'}}
+  @differentiable(reverse where T == Float)
   func whereClauseGenericSignature() -> AllConcrete {
     return self
   }
@@ -159,7 +159,7 @@ extension NotAllConcrete where T == Float {
   // Derivative generic signature: `<T, U where T == Float>` (explicit `where` clause)
   //    Witness generic signature: `<T, U where T == Float>` (not all concrete)
   @_silgen_name("notallconcrete_where_gensig")
-  @differentiable(reverse where T == Float) // expected-warning {{redundant same-type constraint 'T' == 'Float'}}
+  @differentiable(reverse where T == Float)
   func whereClauseGenericSignature() -> NotAllConcrete {
     return self
   }

--- a/test/AutoDiff/SILOptimizer/generics.swift
+++ b/test/AutoDiff/SILOptimizer/generics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -verify %s -warn-redundant-requirements | %FileCheck %s -check-prefix=CHECK-SIL
+// RUN: %target-swift-emit-sil -verify %s | %FileCheck %s -check-prefix=CHECK-SIL
 
 import _Differentiation
 
@@ -51,14 +51,12 @@ func foo<T>(_ x: Wrapper<T>) {
 
 // Test case where associated derivative function's requirements are met.
 extension Wrapper where Scalar : Numeric {
-  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint) // expected-warning {{redundant conformance constraint 'Scalar' : 'Differentiable'}}
-  // expected-warning@-1 {{redundant conformance constraint 'Scalar' : 'Numeric'}}
+  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint) 
   func mean() -> Wrapper {
     return self
   }
 
-  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint) // expected-warning {{redundant conformance constraint 'Scalar' : 'Differentiable'}}
-  // expected-warning@-1 {{redundant conformance constraint 'Scalar' : 'Numeric'}}
+  @differentiable(reverse, wrt: self where Scalar : Differentiable & FloatingPoint)
   func variance() -> Wrapper {
     return mean() // ok
   }
@@ -219,7 +217,7 @@ let _: @differentiable(reverse) (Float, Float) -> TF_546<Float> = { r, i in
 struct TF_652<Scalar> {}
 extension TF_652 : Differentiable where Scalar : FloatingPoint {}
 
-@differentiable(reverse, wrt: x where Scalar: FloatingPoint) // expected-warning {{redundant conformance constraint 'Scalar' : 'Numeric'}}
+@differentiable(reverse, wrt: x where Scalar: FloatingPoint)
 func test<Scalar: Numeric>(x: TF_652<Scalar>) -> TF_652<Scalar> {
   for _ in 0..<10 {
     let _ = x
@@ -295,7 +293,7 @@ struct TF_697_Sequential<Layer1: TF_697_Module, Layer2: TF_697_Layer>: TF_697_Mo
         layer2.callLayer(layer1.callModule(input))
     }
 }
-extension TF_697_Sequential: TF_697_Layer where Layer1: TF_697_Layer { // expected-warning {{redundant conformance constraint 'Layer1' : 'TF_697_Module'}}
+extension TF_697_Sequential: TF_697_Layer where Layer1: TF_697_Layer {
     @differentiable(reverse)
     func callLayer(_ input: Layer1.Input) -> Layer2.Output {
         layer2.callLayer(layer1.callLayer(input))

--- a/test/Compatibility/anyobject_class.swift
+++ b/test/Compatibility/anyobject_class.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -swift-version 4
 // RUN: not %target-swift-frontend -typecheck -swift-version 5
 
 protocol P : class, AnyObject { } // expected-warning{{redundant inheritance from 'AnyObject' and Swift 3 'class' keyword}}{{14-21=}}
-// expected-warning@-1{{redundant constraint 'Self' : 'AnyObject'}}
+

--- a/test/Constraints/generic_super_constraint.swift
+++ b/test/Constraints/generic_super_constraint.swift
@@ -1,16 +1,14 @@
-// RUN: %target-typecheck-verify-swift %s -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift %s
 
 class Base<T> { }
 class Derived: Base<Int> { }
 
-// expected-warning@+1 {{redundant superclass constraint 'T' : 'Base<Int>'}}
 func foo<T>(_ x: T) -> Derived where T: Base<Int>, T: Derived {
   return x
 }
 
-// FIXME: There is no explicit same-type requirement written.
-// expected-warning@+1{{same-type requirement makes generic parameter 'T' non-generic}}
 func bar<T, U>(_ x: U, y: T) -> (Derived, Int) where U: Base<T>, U: Derived {
+// expected-warning@-1 {{same-type requirement makes generic parameter 'T' non-generic}}
   return (x, y)
 }
 

--- a/test/Constraints/same_types.swift
+++ b/test/Constraints/same_types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol Fooable {
@@ -57,7 +57,6 @@ func test2a<T: Fooable, U: Fooable>(_ t: T, u: U) -> (X, X)
 // CHECK-NEXT: Generic signature: <T, U where T : Fooable, U : Fooable, T.[Fooable]Foo == X, U.[Fooable]Foo == X>
 func test3<T: Fooable, U: Fooable>(_ t: T, u: U) -> (X, X)
   where T.Foo == X, U.Foo == X, T.Foo == U.Foo {
-	// expected-warning@-1{{redundant same-type constraint 'T.Foo' == 'X'}}
   return (t.foo, u.foo)
 }
 
@@ -101,7 +100,6 @@ func test6<T: Barrable>(_ t: T) -> (Y, X) where T.Bar == Y {
 // CHECK-LABEL: same_types.(file).test7@
 // CHECK-NEXT: Generic signature: <T where T : Barrable, T.[Barrable]Bar == Y>
 func test7<T: Barrable>(_ t: T) -> (Y, X) where T.Bar == Y, T.Bar.Foo == X {
-	// expected-warning@-1{{redundant same-type constraint 'Y.Foo' (aka 'X') == 'X'}}
   return (t.bar, t.bar.foo)
 }
 
@@ -143,7 +141,7 @@ func fail6<T>(_ t: T) -> Int where T == Int { // expected-warning{{same-type req
 // CHECK-NEXT: Generic signature: <T, U where T : Barrable, U : Barrable, T.[Barrable]Bar == Y, U.[Barrable]Bar == Y>
 func test8<T: Barrable, U: Barrable>(_ t: T, u: U) -> (Y, Y, X, X)
   where T.Bar == Y,
-        U.Bar.Foo == X, T.Bar == U.Bar { // expected-warning{{redundant same-type constraint 'U.Bar.Foo' == 'X'}}
+        U.Bar.Foo == X, T.Bar == U.Bar {
   return (t.bar, u.bar, t.bar.foo, u.bar.foo)
 }
 
@@ -152,14 +150,14 @@ func test8<T: Barrable, U: Barrable>(_ t: T, u: U) -> (Y, Y, X, X)
 func test8a<T: Barrable, U: Barrable>(_ t: T, u: U) -> (Y, Y, X, X)
   where
   T.Bar == Y,
-  U.Bar.Foo == X, U.Bar == T.Bar { // expected-warning{{redundant same-type constraint 'U.Bar.Foo' == 'X'}}
+  U.Bar.Foo == X, U.Bar == T.Bar {
   return (t.bar, u.bar, t.bar.foo, u.bar.foo)
 }
 
 // CHECK-LABEL: same_types.(file).test8b(_:u:)@
 // CHECK-NEXT: Generic signature: <T, U where T : Barrable, U : Barrable, T.[Barrable]Bar == Y, U.[Barrable]Bar == Y>
 func test8b<T: Barrable, U: Barrable>(_ t: T, u: U)
-  where U.Bar.Foo == X, // expected-warning{{redundant same-type constraint 'U.Bar.Foo' == 'X'}}
+  where U.Bar.Foo == X,
         T.Bar == Y,
         T.Bar == U.Bar {
 }
@@ -205,7 +203,6 @@ struct S2<T : P> where T.A == T.B {
   // CHECK-LABEL: same_types.(file).S2.foo(x:y:)@
   // CHECK-NEXT: <T, X, Y where T : P, X == Y, Y == T.[P]A, T.[P]A == T.[P]B>
   func foo<X, Y>(x: X, y: Y) where X == T.A, Y == T.B {  // expected-warning{{same-type requirement makes generic parameters 'Y' and 'X' equivalent}}
-  // expected-warning@-1 {{redundant same-type constraint 'X' == 'T.A'}}
     print(X.self)
     print(Y.self)
     print(x)
@@ -278,7 +275,6 @@ func structuralSameType3<T, U, V, W>(_: T, _: U, _: V, _: W)
   where X1<T, U> == X1<V, W> { }
 // expected-warning@-2{{same-type requirement makes generic parameters 'V' and 'T' equivalent}}
 // expected-warning@-3{{same-type requirement makes generic parameters 'W' and 'U' equivalent}}
-// expected-warning@-3{{redundant same-type constraint 'X1<T, U>' == 'X1<V, W>'}}
 
 protocol P2 {
   associatedtype Assoc1
@@ -337,7 +333,6 @@ func test9<T: P6, U: P6>(_ t: T, u: U) // expected-error{{no type for 'T.Bar.Foo
 func testMetatypeSameType<T, U>(_ t: T, _ u: U)
   where T.Type == U.Type { }
 // expected-warning@-2{{same-type requirement makes generic parameters 'U' and 'T' equivalent}}
-// expected-warning@-2{{redundant same-type constraint 'T.Type' == 'U.Type'}}
 
 // CHECK-LABEL: same_types.(file).testSameTypeCommutativity1@
 // CHECK-NEXT: Generic signature: <U, T where U == T.Type>

--- a/test/Generics/associated_type_typo.swift
+++ b/test/Generics/associated_type_typo.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 // RUN: not %target-swift-frontend -typecheck -debug-generic-signatures %s > %t.dump 2>&1 
 // RUN: %FileCheck -check-prefix CHECK-GENERIC %s < %t.dump
@@ -62,9 +62,10 @@ protocol Pattern {
 
   // FIXME: This works for all of the wrong reasons, but it is correct that
   // it works.
-  // FIXME(rqm-diagnostics): Bogus warning here.
+  // CHECK-GENERIC-LABEL: .matched(atStartOf:)@
+  // CHECK-GENERIC-NEXT: Generic signature: <Self, C where Self : Pattern, C : Sequence, C : Indexable, Self.[Pattern]Element == C.[Sequence]Element, C.[Sequence]Element == C.[_Indexable1]Slice.[Sequence]Element, C.[_Indexable1]Slice : Sequence>
   func matched<C: Indexable>(atStartOf c: C)
-  where Element_<C> == Element // expected-warning {{redundant same-type constraint 'Element_<C>' (aka 'C.Iterator.Element') == 'Self.Element'}}
+  where Element_<C> == Element
   , Element_<C.Slice> == Element
 }
 

--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 func needsSameType<T>(_: T.Type, _: T.Type) {}
 
@@ -134,7 +134,6 @@ struct X { }
 protocol P {
 	associatedtype P1 where P1 == X
 	associatedtype P2 where P2 == P1, P2 == X
-	// expected-warning@-1{{redundant same-type constraint 'Self.P2' == 'X'}}
 }
 
 // Lookup of same-named associated types aren't ambiguous in this context.

--- a/test/Generics/canonicalization.swift
+++ b/test/Generics/canonicalization.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // rdar://problem/23149063
 protocol P0 { }
@@ -11,8 +12,11 @@ protocol Q : P {
   associatedtype A
 }
 
+// CHECK-LABEL: .f(t:)@
+// CHECK-NEXT: Generic signature: <T where T : Q, T.[P]A : P0>
 func f<T>(t: T) where T : P, T : Q, T.A : P0 { } // expected-note{{'f(t:)' previously declared here}}
-// expected-warning@-1{{redundant conformance constraint 'T' : 'P'}}
 
+// CHECK-LABEL: .f(t:)@
+// CHECK-NEXT: Generic signature: <T where T : Q, T.[P]A : P0>
 func f<T>(t: T) where T : Q, T : P, T.A : P0 { } // expected-error{{invalid redeclaration of 'f(t:)'}}
-// expected-warning@-1{{redundant conformance constraint 'T' : 'P'}}
+

--- a/test/Generics/concrete_conformances_in_protocol.swift
+++ b/test/Generics/concrete_conformances_in_protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P {
@@ -13,7 +13,6 @@ struct S : P {
 
 protocol R0 {
   associatedtype A where A : P, A == S
-  // expected-warning@-1 {{redundant conformance constraint 'S' : 'P'}}
 }
 
 ////
@@ -26,7 +25,6 @@ struct G<T> : P {}
 protocol R1 {
   associatedtype A
   associatedtype B where B : P, B == G<A>
-  // expected-warning@-1 {{redundant conformance constraint 'G<Self.A>' : 'P'}}
 }
 
 // CHECK-LABEL: concrete_conformances_in_protocol.(file).R2@
@@ -34,7 +32,6 @@ protocol R1 {
 
 protocol R2 {
   associatedtype A where A : P, A == G<B>
-  // expected-warning@-1 {{redundant conformance constraint 'G<Self.B>' : 'P'}}
   associatedtype B
 }
 
@@ -52,7 +49,6 @@ struct GG<T : P> : PP {}
 protocol RR3 {
   associatedtype A : P
   associatedtype B where B : PP, B == GG<A>
-  // expected-warning@-1 {{redundant conformance constraint 'GG<Self.A>' : 'PP'}}
 }
 
 // CHECK-LABEL: concrete_conformances_in_protocol.(file).RR4@
@@ -60,7 +56,6 @@ protocol RR3 {
 
 protocol RR4 {
   associatedtype A where A : PP, A == GG<B>
-  // expected-warning@-1 {{redundant conformance constraint 'GG<Self.B>' : 'PP'}}
   associatedtype B : P
 }
 
@@ -70,7 +65,6 @@ protocol RR4 {
 protocol RR5 {
   associatedtype A : PP
   associatedtype B where B : PP, B == GG<A.T>
-  // expected-warning@-1 {{redundant conformance constraint 'GG<Self.A.T>' : 'PP'}}
 }
 
 // CHECK-LABEL: concrete_conformances_in_protocol.(file).RR6@
@@ -78,7 +72,6 @@ protocol RR5 {
 
 protocol RR6 {
   associatedtype A where A : PP, A == GG<B.T>
-  // expected-warning@-1 {{redundant conformance constraint 'GG<Self.B.T>' : 'PP'}}
   associatedtype B : PP
 }
 
@@ -95,7 +88,6 @@ struct GGG<U : P1> : P1 {
 
 protocol P2 {
   associatedtype T : P1 where T == GGG<U>
-  // expected-warning@-1 {{redundant conformance constraint 'GGG<Self.U>' : 'P1'}}
   associatedtype U : P1
 }
 

--- a/test/Generics/concrete_contraction_unrelated_typealias.swift
+++ b/test/Generics/concrete_contraction_unrelated_typealias.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify %s -debug-generic-signatures -warn-redundant-requirements 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -verify %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // Another GenericSignatureBuilder oddity, reduced from RxSwift.
 //
@@ -25,10 +25,10 @@ class GenericDelegateProxy<P : AnyObject, D> {
 
   // CHECK-LABEL: .GenericDelegateProxy.init(_:)@
   // CHECK-NEXT: <P, D, Proxy where P == Proxy.[DelegateProxyType]Parent, D == Proxy.[DelegateProxyType]Delegate, Proxy : GenericDelegateProxy<P, D>, Proxy : DelegateProxyType>
-  init<Proxy: DelegateProxyType>(_: Proxy.Type) // expected-warning {{redundant constraint 'P' : 'AnyObject'}}
+  init<Proxy: DelegateProxyType>(_: Proxy.Type)
     where Proxy: GenericDelegateProxy<P, D>,
-          Proxy.Parent == P, // expected-warning {{redundant same-type constraint 'GenericDelegateProxy<P, D>.Parent' (aka 'P') == 'P'}}
-          Proxy.Delegate == D {} // expected-warning {{redundant same-type constraint 'GenericDelegateProxy<P, D>.Delegate' (aka 'D') == 'D'}}
+          Proxy.Parent == P,
+          Proxy.Delegate == D {}
 }
 
 class SomeClass {}

--- a/test/Generics/concrete_same_type_versus_anyobject.swift
+++ b/test/Generics/concrete_same_type_versus_anyobject.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: not %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 
 struct S {}
@@ -13,7 +13,7 @@ extension G1 where T == S {}
 
 // CHECK: ExtensionDecl line={{.*}} base=G1
 // CHECK-NEXT: Generic signature: <T where T == C>
-extension G1 where T == C {} // expected-warning {{redundant constraint 'T' : 'AnyObject'}}
+extension G1 where T == C {}
 
 struct G2<U> {}
 
@@ -25,12 +25,10 @@ extension G2 where U == S, U : AnyObject {}
 // CHECK: ExtensionDecl line={{.*}} base=G2
 // CHECK-NEXT: Generic signature: <U where U == C>
 extension G2 where U == C, U : AnyObject {}
-// expected-warning@-1 {{redundant constraint 'U' : 'AnyObject'}}
 
 // CHECK: ExtensionDecl line={{.*}} base=G2
 // CHECK-NEXT: Generic signature: <U where U : C>
 extension G2 where U : C, U : AnyObject {}
-// expected-warning@-1 {{redundant constraint 'U' : 'AnyObject'}}
 
 // Explicit AnyObject conformance vs derived same-type
 protocol P {
@@ -40,4 +38,3 @@ protocol P {
 // CHECK: .explicitAnyObjectIsRedundant@
 // CHECK-NEXT: Generic signature: <T where T : P>
 func explicitAnyObjectIsRedundant<T : P>(_: T) where T.A : AnyObject {}
-// expected-warning@-1 {{redundant constraint 'T.A' : 'AnyObject'}}

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures -warn-redundant-requirements > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P1 {}
@@ -49,14 +48,12 @@ struct RedundantSame<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSame
 // CHECK-NEXT: (normal_conformance type="RedundantSame<T>" protocol="P2")
 extension RedundantSame: P2 where T: P1 {}
-// expected-warning@-1 {{redundant conformance constraint 'T' : 'P1'}}
 
 struct RedundantSuper<T: P4> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundantSuper
 // CHECK-NEXT: (normal_conformance type="RedundantSuper<T>" protocol="P2")
 extension RedundantSuper: P2 where T: P1 {}
-// expected-warning@-1 {{redundant conformance constraint 'T' : 'P1'}}
 
 struct OverlappingSub<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub
@@ -64,7 +61,6 @@ struct OverlappingSub<T: P1> {}
 // CHECK-NEXT: (normal_conformance type="OverlappingSub<T>" protocol="P2"
 // CHECK-NEXT:   (requirement "T" conforms_to "P4"))
 extension OverlappingSub: P2 where T: P4 {} // expected-note {{requirement from conditional conformance of 'OverlappingSub<U>' to 'P2'}}
-// expected-warning@-1 {{redundant conformance constraint 'T' : 'P1'}}
 func overlapping_sub_good<U: P4>(_: U) {
     takes_P2(OverlappingSub<U>())
 }
@@ -176,7 +172,6 @@ struct ClassMoreSpecific<T: C1> {}
 // CHECK-NEXT: (normal_conformance type="ClassMoreSpecific<T>" protocol="P2"
 // CHECK-NEXT:   (requirement "T" subclass_of "C3"))
 extension ClassMoreSpecific: P2 where T: C3 {} // expected-note {{requirement from conditional conformance of 'ClassMoreSpecific<U>' to 'P2'}}
-// expected-warning@-1 {{redundant superclass constraint 'T' : 'C1'}}
 func class_more_specific_good<U: C3>(_: U) {
     takes_P2(ClassMoreSpecific<U>())
 }
@@ -191,7 +186,6 @@ struct ClassLessSpecific<T: C3> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassLessSpecific
 // CHECK-NEXT: (normal_conformance type="ClassLessSpecific<T>" protocol="P2")
 extension ClassLessSpecific: P2 where T: C1 {}
-// expected-warning@-1 {{redundant superclass constraint 'T' : 'C1'}}
 
 
 // Inherited conformances:
@@ -339,7 +333,6 @@ struct RedundancyOrderDependenceGood<T: P1, U> {}
 // CHECK-NEXT: (normal_conformance type="RedundancyOrderDependenceGood<T, U>" protocol="P2"
 // CHECK-NEXT:   (requirement "T" same_type "U"))
 extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
-// expected-warning@-1 {{redundant conformance constraint 'U' : 'P1'}}
 
 struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad
@@ -347,7 +340,7 @@ struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-NEXT: (normal_conformance type="RedundancyOrderDependenceBad<T, U>" protocol="P2"
 // CHECK-NEXT:   (requirement "T" conforms_to "P1")
 // CHECK-NEXT:   (requirement "T" same_type "U"))
-extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
+extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {}
 
 // Checking of conditional requirements for existential conversions.
 func existential_good<T: P1>(_: T.Type) {

--- a/test/Generics/conditional_requirement_inference_in_protocol.swift
+++ b/test/Generics/conditional_requirement_inference_in_protocol.swift
@@ -1,22 +1,18 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
-
-// FIXME(rqm-diagnostics): The redundant conformance warnings here should not be emitted, since
-// these requirements participate in conditional requirement inference.
 
 // CHECK-LABEL: conditional_requirement_inference_in_protocol.(file).Good@
 // CHECK-LABEL: Requirement signature: <Self where Self.[Good]T == [Self.[Good]U], Self.[Good]U : Equatable>
 
 protocol Good {
-  associatedtype T : Equatable // expected-warning {{redundant conformance constraint 'Array<Self.U>' : 'Equatable'}}
+  associatedtype T : Equatable
   associatedtype U : Equatable where T == Array<U>
-  // expected-warning@-1 {{redundant conformance constraint 'Self.U' : 'Equatable'}}
 }
 
 // CHECK-LABEL: conditional_requirement_inference_in_protocol.(file).Bad@
 // CHECK-LABEL: Requirement signature: <Self where Self.[Bad]T == [Self.[Bad]U], Self.[Bad]U : Equatable>
 
 protocol Bad {
-  associatedtype T : Equatable // expected-warning {{redundant conformance constraint 'Array<Self.U>' : 'Equatable'}}
+  associatedtype T : Equatable
   associatedtype U where T == Array<U>
 }

--- a/test/Generics/conformance_access_path.swift
+++ b/test/Generics/conformance_access_path.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P0 { }
 protocol Q0: P0 { }
@@ -48,9 +49,10 @@ func testPaths3<V: P5>(_ v: V) {
 	acceptQ0(v.getAssocP3())
 }
 
+// CHECK-LABEL: .P6Unordered@
+// CHECK-NEXT: Requirement signature: <Self where Self : P5Unordered>
 protocol P6Unordered: P5Unordered {
-	associatedtype A: P0 // expected-warning{{redundant conformance constraint 'Self.A' : 'P0'}}
-                       // expected-warning@-1{{redeclaration of associated type 'A'}}
+	associatedtype A: P0 // expected-warning{{redeclaration of associated type 'A'}}
 }
 
 protocol P5Unordered {

--- a/test/Generics/derived_via_concrete.swift
+++ b/test/Generics/derived_via_concrete.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P {}
@@ -24,37 +24,31 @@ protocol W {
 // CHECK-NEXT: Generic signature: <A, B where A : X<B>, B : P>
 func derivedViaConcreteX1<A, B>(_: A, _: B)
   where A : U, A : X<B> {}
-// expected-warning@-1 {{redundant conformance constraint 'X<B>' : 'U'}}
 
 // CHECK-LABEL: .derivedViaConcreteX2@
 // CHECK-NEXT: Generic signature: <A, B where A : X<B>, B : P>
 func derivedViaConcreteX2<A, B>(_: A, _: B)
   where A : U, B : P, A : X<B> {}
-// expected-warning@-1 {{redundant conformance constraint 'X<B>' : 'U'}}
 
 // CHECK-LABEL: .derivedViaConcreteY1@
 // CHECK-NEXT: Generic signature: <A, B where A : Y<B>, B : C>
 func derivedViaConcreteY1<A, B>(_: A, _: B)
   where A : V, A : Y<B> {}
-// expected-warning@-1 {{redundant conformance constraint 'Y<B>' : 'V'}}
 
 // CHECK-LABEL: .derivedViaConcreteY2@
 // CHECK-NEXT: Generic signature: <A, B where A : Y<B>, B : C>
 func derivedViaConcreteY2<A, B>(_: A, _: B)
   where A : V, B : C, A : Y<B> {}
-// expected-warning@-1 {{redundant conformance constraint 'Y<B>' : 'V'}}
 
 // CHECK-LABEL: .derivedViaConcreteZ1@
 // CHECK-NEXT: Generic signature: <A, B where A : Z<B>, B : AnyObject>
 func derivedViaConcreteZ1<A, B>(_: A, _: B)
   where A : W, A : Z<B> {}
-// expected-warning@-1 {{redundant conformance constraint 'Z<B>' : 'W'}}
 
 // CHECK-LABEL: .derivedViaConcreteZ2@
 // CHECK-NEXT: Generic signature: <A, B where A : Z<B>, B : AnyObject>
 func derivedViaConcreteZ2<A, B>(_: A, _: B)
   where A : W, B : AnyObject, A : Z<B> {}
-// expected-warning@-1 {{redundant conformance constraint 'Z<B>' : 'W'}}
 
 class Base {}
 class Derived<T : C> : Base, V {}
@@ -63,4 +57,4 @@ struct G<X : Base, Y> {}
 
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=G
 // CHECK-NEXT: Generic signature: <X, Y where X == Derived<Y>, Y : C>
-extension G where X == Derived<Y> {} // expected-warning {{redundant superclass constraint 'X' : 'Base'}}
+extension G where X == Derived<Y> {}

--- a/test/Generics/derived_via_concrete_in_protocol.swift
+++ b/test/Generics/derived_via_concrete_in_protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s 2>&1 | %FileCheck %s
 
 protocol P24 {
@@ -24,7 +24,7 @@ class X3 { }
 // CHECK-LABEL: .P25a@
 // CHECK-NEXT: Requirement signature: <Self where Self.[P25a]A == X24<Self.[P25a]B>, Self.[P25a]B : P20>
 protocol P25a {
-  associatedtype A: P24 // expected-warning{{redundant conformance constraint 'X24<Self.B>' : 'P24'}}
+  associatedtype A: P24
   associatedtype B: P20 where A == X24<B>
 }
 
@@ -38,7 +38,7 @@ protocol P25b {
 // CHECK-LABEL: .P27a@
 // CHECK-NEXT: Requirement signature: <Self where Self.[P27a]A == X26<Self.[P27a]B>, Self.[P27a]B : X3>
 protocol P27a {
-  associatedtype A: P26 // expected-warning{{redundant conformance constraint 'X26<Self.B>' : 'P26'}}
+  associatedtype A: P26
 
   associatedtype B: X3 where A == X26<B>
 }

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 //===----------------------------------------------------------------------===//
 // Type-check function definitions
@@ -278,7 +278,6 @@ func badProtocolReq<T>(_: T) where T : Int {} // expected-error{{type 'T' constr
 func nonTypeSameType<T>(_: T) where T == Wibble {} // expected-error{{cannot find type 'Wibble' in scope}}
 func nonTypeSameType2<T>(_: T) where Wibble == T {} // expected-error{{cannot find type 'Wibble' in scope}}
 func sameTypeEq<T>(_: T) where T = T {} // expected-error{{use '==' for same-type requirements rather than '='}} {{34-35===}}
-// expected-warning@-1{{redundant same-type constraint 'T' == 'T'}}
 
 func badTypeConformance1<T>(_: T) where Int : EqualComparable {} // expected-error{{type 'Int' in conformance requirement does not refer to a generic parameter or associated type}}
 
@@ -293,8 +292,8 @@ func badTypeConformance4<T>(_: T) where @escaping (inout T) throws -> () : Equal
 func badTypeConformance5<T>(_: T) where T & Sequence : EqualComparable { }
 // expected-error@-1 {{non-protocol, non-class type 'T' cannot be used within a protocol-constrained type}}
 
+// This is not bad! Array<T> conforms to Collection.
 func badTypeConformance6<T>(_: T) where [T] : Collection { }
-// expected-warning@-1{{redundant conformance constraint '[T]' : 'Collection'}}
 
 func badTypeConformance7<T, U>(_: T, _: U) where T? : U { }
 // expected-error@-1{{type 'T?' constrained to non-protocol, non-class type 'U'}}

--- a/test/Generics/interdependent_protocol_conformance_example_1.swift
+++ b/test/Generics/interdependent_protocol_conformance_example_1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %s -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift %s
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // The GenericSignatureBuilder was unable to derive the redundant conformance requirement 'B: P4'
@@ -12,7 +12,6 @@
 protocol P1 {
   associatedtype A: P2 where Self.A.B == Self.B
   associatedtype B: P4
-  // expected-warning@-1 {{redundant conformance constraint 'Self.B' : 'P4'}}
 }
 
 // CHECK-LABEL: .P2@

--- a/test/Generics/interdependent_protocol_conformance_example_3.swift
+++ b/test/Generics/interdependent_protocol_conformance_example_3.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -disable-requirement-machine-reuse 2>&1 | %FileCheck %s
 
@@ -18,8 +18,6 @@ public protocol MultiPoint {
   associatedtype C: CoordinateSystem
 
   typealias P = Self.C.P
-  // expected-warning@-1 {{redundant same-type constraint 'Self.P' == 'Self.C.P'}}
-  // FIXME(rqm-diagnostics): This is bogus
 
   associatedtype X: NonEmptyProtocol
     where X.C: NonEmptyProtocol,

--- a/test/Generics/interdependent_protocol_conformance_example_5.swift
+++ b/test/Generics/interdependent_protocol_conformance_example_5.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures -disable-requirement-machine-reuse 2>&1 | %FileCheck %s
 
@@ -17,7 +17,6 @@ public protocol NonEmptyProtocol: Collection
 public protocol MultiPoint {
   associatedtype C: CoordinateSystem
   associatedtype P: Point where Self.P == Self.C.P
-  // expected-warning@-1 {{redundant conformance constraint 'Self.P' : 'Point'}}
 
   associatedtype X: NonEmptyProtocol
     where X.C: NonEmptyProtocol,

--- a/test/Generics/issue-48296.swift
+++ b/test/Generics/issue-48296.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // https://github.com/apple/swift/issues/48296
 
@@ -8,8 +8,8 @@ protocol Foo
   var bar: Bar { get }
 }
 
-extension Foo where Self: Collection, Bar: Collection, Self.SubSequence == Bar.SubSequence, /*redundant: */Self.Index == Bar.Index // expected-warning {{redundant same-type constraint 'Self.Index' == 'Self.Bar.Index'}}
-{
+// CHECK: Generic signature: <Self where Self : Collection, Self : Foo, Self.[Foo]Bar : Collection, Self.[Collection]SubSequence == Self.[Foo]Bar.[Collection]SubSequence>
+extension Foo where Self: Collection, Bar: Collection, Self.SubSequence == Bar.SubSequence, /*redundant: */Self.Index == Bar.Index {
   subscript(_ bounds: Range<Index>) -> SubSequence
   {
     return bar[bounds]

--- a/test/Generics/issue-53142.swift
+++ b/test/Generics/issue-53142.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures -warn-redundant-requirements 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // https://github.com/apple/swift/issues/53142
 
@@ -11,6 +11,6 @@ protocol P {
 // CHECK-LABEL: .Q@
 // CHECK-NEXT: Requirement signature: <Self where Self.[Q]A == Self.[Q]C.[P]A, Self.[Q]C : P>
 protocol Q {
-  associatedtype A : P // expected-warning {{redundant conformance constraint 'Self.A' : 'P'}}
+  associatedtype A : P
   associatedtype C : P where A == C.A
 }

--- a/test/Generics/issue-54555.swift
+++ b/test/Generics/issue-54555.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures -warn-redundant-requirements 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // https://github.com/apple/swift/issues/54555
 
@@ -8,7 +8,7 @@ protocol Swappable1 {
   associatedtype A
   associatedtype B
   associatedtype Swapped : Swappable1
-    where Swapped.B == A, // expected-warning {{redundant same-type constraint 'Self.Swapped.B' == 'Self.A'}}
+    where Swapped.B == A,
           Swapped.A == B,
           Swapped.Swapped == Self
 }

--- a/test/Generics/issue-56840.swift
+++ b/test/Generics/issue-56840.swift
@@ -1,12 +1,10 @@
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures -warn-redundant-requirements 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // https://github.com/apple/swift/issues/56840
 
 // CHECK-LABEL: .P@
 // CHECK-NEXT: Requirement signature: <Self where Self.[P]Input == Self.[P]Output.[Numeric]Magnitude, Self.[P]Output : FixedWidthInteger, Self.[P]Output : SignedInteger>
 protocol P {
-  // expected-warning@+2 {{redundant conformance constraint 'Self.Input' : 'FixedWidthInteger'}}
-  // expected-warning@+1 {{redundant conformance constraint 'Self.Input' : 'UnsignedInteger'}}
   associatedtype Input: FixedWidthInteger & UnsignedInteger & BinaryInteger
   associatedtype Output: FixedWidthInteger & SignedInteger & BinaryInteger
     where Output.Magnitude == Input

--- a/test/Generics/issue-56862.swift
+++ b/test/Generics/issue-56862.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -debug-generic-signatures -typecheck %s 2>&1 | %FileCheck %s
 
 // https://github.com/apple/swift/issues/56862
@@ -29,5 +29,4 @@ protocol P {
   associatedtype A : P where A == B.C
   associatedtype B : P where B == A.C
   associatedtype C : P where C == A.B
-  // expected-warning@-1 {{redundant conformance constraint 'Self.C' : 'P'}}
 }

--- a/test/Generics/issue-57264.swift
+++ b/test/Generics/issue-57264.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // https://github.com/apple/swift/issues/57264
 
@@ -12,18 +12,23 @@ protocol Q {
 }
 
 struct S1<T : P> where T.AS.B == T.A {}
-// expected-warning@-1 {{redundant same-type constraint 'T.AS.B' == 'T.A'}}
+// CHECK-LABEL: .S1@
+// CHECK-NEXT: Generic signature: <T where T : P>
 
 struct S2<T: P> {
   struct Nested where T.AS.B == T.A {}
-  // expected-warning@-1 {{redundant same-type constraint 'T.AS.B' == 'T.A'}}
+  // CHECK-LABEL: .S2.Nested@
+  // CHECK-NEXT: Generic signature: <T where T : P>
 }
 
 extension S2 where T.AS.B == T.A {}
-// expected-warning@-1 {{redundant same-type constraint 'T.AS.B' == 'T.A'}}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=S2
+// CHECK-NEXT: Generic signature: <T where T : P>
 
 extension P where AS.B == A {}
-// expected-warning@-1 {{redundant same-type constraint 'Self.AS.B' == 'Self.A'}}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=P
+// CHECK-NEXT: Generic signature: <Self where Self : P>
 
 extension P where Self : P {}
-// expected-warning@-1 {{redundant conformance constraint 'Self' : 'P'}}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=P
+// CHECK-NEXT: Generic signature: <Self where Self : P>

--- a/test/Generics/issue-61192.swift
+++ b/test/Generics/issue-61192.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -verify %s -debug-generic-signatures -warn-redundant-requirements 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -verify %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 struct C {}
 
@@ -11,6 +11,5 @@ struct G<A>: P {}
 struct Body<T: P> where T.A == C {
   // CHECK-LABEL: .init(_:)@
   // CHECK-NEXT: <T, U where T == G<C>, U : P, U.[P]A == C>
-  init<U: P>(_: U) where T == G<T.A>, U.A == T.A {} // expected-warning {{redundant same-type constraint 'T.A' == 'C'}} 
-  // expected-warning@-1 {{redundant conformance constraint 'T' : 'P'}}
+  init<U: P>(_: U) where T == G<T.A>, U.A == T.A {} 
 }

--- a/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
+++ b/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures -disable-requirement-machine-concrete-contraction %s 2>&1 | %FileCheck %s
 
@@ -42,11 +42,9 @@ public class FinalD : Q {
 
 // CHECK-LABEL: Generic signature: <T where T : C>
 public func takesBoth1<T>(_: T) where T : P, T : C {}
-// expected-warning@-1 {{redundant conformance constraint 'C' : 'P'}}
 
 // CHECK-LABEL: Generic signature: <U where U : C>
 public func takesBoth2<U>(_: U) where U : C, U : P {}
-// expected-warning@-1 {{redundant conformance constraint 'C' : 'P'}}
 
 // 'Self' can also occur inside of a concrete type or superclass requirement.
 public class G<T> {}

--- a/test/Generics/protocol_requirement_signatures.swift
+++ b/test/Generics/protocol_requirement_signatures.swift
@@ -1,5 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures -warn-redundant-requirements > %t.dump 2>&1
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 // CHECK-LABEL: .P1@
@@ -50,7 +49,7 @@ protocol Q5: Q2, Q3, Q4 {}
 // CHECK-NEXT: Requirement signature: <Self where Self : Q2, Self : Q3, Self : Q4>
 protocol Q6: Q2,
              Q3, Q4 {
-    associatedtype X: P1 // expected-warning{{redundant conformance constraint 'Self.X' : 'P1'}}
+    associatedtype X: P1
                    // expected-warning@-1{{redeclaration of associated type 'X' from protocol 'Q1' is}}
 }
 

--- a/test/Generics/protocol_type_aliases.swift
+++ b/test/Generics/protocol_type_aliases.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures > %t.dump 2>&1
 
 
@@ -59,10 +59,8 @@ protocol Q4: P {
     typealias A = Int // expected-warning{{typealias overriding associated type 'A' from protocol 'P'}}
 }
 
-// FIXME(rqm-diagnostics): Bogus warning
-
 protocol Q5: P {
-    typealias X = Int // expected-warning{{redundant same-type constraint 'Self.X' == 'Int'}}
+    typealias X = Int
 }
 
 // fully generic functions that manipulate the archetypes in a P

--- a/test/Generics/protocol_typealias_cycle_5.swift
+++ b/test/Generics/protocol_typealias_cycle_5.swift
@@ -1,7 +1,6 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 protocol P : Sequence {
   typealias Element = Iterator.Element
   // expected-warning@-1 {{typealias overriding associated type 'Element' from protocol 'Sequence' is better expressed as same-type constraint on the protocol}}
-  // expected-warning@-2 {{redundant same-type constraint 'Self.Element' == 'Self.Iterator.Element'}}
 }

--- a/test/Generics/rdar51908331.swift
+++ b/test/Generics/rdar51908331.swift
@@ -1,24 +1,36 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
-// Reduced from https://github.com/plx/HDXLSIMDSupport.
+// Performance test case reduced from https://github.com/plx/HDXLSIMDSupport.
 
+// CHECK-LABEL: .PA@
+// CHECK-NEXT: Requirement signature: <Self where Self : PB, Self : PC, Self : PD>
 protocol PA: PB, PC, PD {}
 
+// CHECK-LABEL: .PB@
+// CHECK-NEXT: Requirement signature: <Self where Self : PE, Self == Self.[PF]A1, Self.[PG]A2 == Self.[PG]A4>
 protocol PB: PE where A2 == A3, A4 == A2, A5 == A6, A1 == Self {}
-// expected-warning@-1 {{redundant same-type constraint 'Self.A2' == 'Self.A3'}}
-// expected-warning@-2 {{redundant same-type constraint 'Self.A5' == 'Self.A6'}}
 
+// CHECK-LABEL: .PC@
+// CHECK-NEXT: Requirement signature: <Self where Self : PG, Self.[PG]A3 == Self.[PH]A7.[PI]A8, Self.[PG]A5 == (Self.[PG]A2, Self.[PG]A2)>
 protocol PC: PG where A5 == (A2, A2), A3 == A7.A8 {}
 
+// CHECK-LABEL: .PD@
+// CHECK-NEXT: Requirement signature: <Self where Self : PG, Self.[PG]A2 == Self.[PH]A7.[PI]A8, Self.[PG]A6 == (Self.[PG]A3, Self.[PG]A3)>
 protocol PD: PG where A6 == (A3, A3), A2 == A7.A8 {}
 
+// CHECK-LABEL: .PE@
+// CHECK-NEXT: Requirement signature: <Self where Self : PF, Self == Self.[PF]A1.[PF]A1>
 protocol PE: PF where A1.A1 == Self {}
 
+// CHECK-LABEL: .PF@
+// CHECK-NEXT: Requirement signature: <Self where Self : PG, Self.[PF]A1 : PF, Self.[PG]A2 == Self.[PF]A1.[PG]A3, Self.[PG]A3 == Self.[PF]A1.[PG]A2, Self.[PG]A5 == Self.[PF]A1.[PG]A6, Self.[PG]A6 == Self.[PF]A1.[PG]A5>
 protocol PF: PG {
   associatedtype A1: PF where A1.A7 == A7, A1.A2 == A3, A1.A3 == A2, A1.A5 == A6, A1.A6 == A5
-  // expected-warning@-1 {{redundant same-type constraint 'Self.A1.A7' == 'Self.A7'}}
 }
 
+// CHECK-LABEL: .PG@
+// CHECK-NEXT: Requirement signature: <Self where Self : PH, Self.[PG]A2 : PJ, Self.[PG]A3 : PJ, Self.[PG]A4 : PJ, Self.[PH]A7 : BinaryFloatingPoint, Self.[PH]A7 : PI, Self.[PH]A7 == Self.[PG]A2.[PH]A7, Self.[PG]A2.[PH]A7 == Self.[PG]A3.[PH]A7, Self.[PG]A3.[PH]A7 == Self.[PG]A4.[PH]A7>
 protocol PG: PH where A7: PI, A7: BinaryFloatingPoint {
   associatedtype A2: PJ where A2.A7 == A7
   associatedtype A3: PJ where A3.A7 == A7
@@ -27,51 +39,71 @@ protocol PG: PH where A7: PI, A7: BinaryFloatingPoint {
   associatedtype A6
 }
 
+// CHECK-LABEL: .PH@
+// CHECK-NEXT: Requirement signature: <Self where Self.[PH]A7 : SIMDScalar>
 protocol PH {
   associatedtype A7: SIMDScalar
 }
 
+// CHECK-LABEL: .PI@
+// CHECK-NEXT: Requirement signature: <Self where Self == Self.[PI]A10.[PH]A7, Self.[PI]A10 == Self.[PI]A11.[PN]A10, Self.[PI]A11 == Self.[PI]A12.[PM]A11, Self.[PI]A12 == Self.[PI]A13.[PL]A12, Self.[PI]A13 == Self.[PI]A14.[PK]A13, Self.[PI]A14 : PK, Self.[PI]A8 == Self.[PI]A10.[PO]A8, Self.[PI]A9 == Self.[PI]A10.[PO]A9, Self.[PI]A10.[PO]A8 == Self.[PI]A9.[PP]A8>
 protocol PI {
 // expected-warning@-1 {{protocol 'PI' should be declared to refine 'Decodable' due to a same-type constraint on 'Self'}}
 // expected-warning@-2 {{protocol 'PI' should be declared to refine 'Encodable' due to a same-type constraint on 'Self'}}
 // expected-warning@-3 {{protocol 'PI' should be declared to refine 'Hashable' due to a same-type constraint on 'Self'}}
 // expected-warning@-4 {{protocol 'PI' should be declared to refine 'SIMDScalar' due to a same-type constraint on 'Self'}}
-  associatedtype A8 where A8.A7 == Self // expected-warning {{redundant same-type constraint 'Self.A8.A7' == 'Self'}}
+  associatedtype A8 where A8.A7 == Self
   associatedtype A9 where A9.A7 == Self, A9.A8 == A8
-  associatedtype A10 where A10.A7 == Self, A10.A8 == A8, A10.A9 == A9 // expected-warning {{redundant same-type constraint 'Self.A10.A7' == 'Self'}}
-  associatedtype A11 where A11.A7 == Self, A11.A10 == A10 // expected-warning {{redundant same-type constraint 'Self.A11.A7' == 'Self'}}
-  associatedtype A12 where A12.A7 == Self, A12.A11 == A11 // expected-warning {{redundant same-type constraint 'Self.A12.A7' == 'Self'}}
-  associatedtype A13 where A13.A7 == Self, A13.A12 == A12 // expected-warning {{redundant same-type constraint 'Self.A13.A7' == 'Self'}}
-  associatedtype A14: PK where A14.A7 == Self, A14.A13 == A13 // expected-warning {{redundant same-type constraint 'Self.A14.A7' == 'Self'}}
+  associatedtype A10 where A10.A7 == Self, A10.A8 == A8, A10.A9 == A9
+  associatedtype A11 where A11.A7 == Self, A11.A10 == A10
+  associatedtype A12 where A12.A7 == Self, A12.A11 == A11
+  associatedtype A13 where A13.A7 == Self, A13.A12 == A12
+  associatedtype A14: PK where A14.A7 == Self, A14.A13 == A13
 }
 
+// CHECK-LABEL: .PJ@
+// CHECK-NEXT: Requirement signature: <Self where Self : SIMD, Self : PH, Self.[PH]A7 == Self.[SIMDStorage]Scalar>
 protocol PJ: SIMD, PH where Scalar == A7 {}
 
+// CHECK-LABEL: .PK@
+// CHECK-NEXT: Requirement signature: <Self where Self : SIMD, Self : PH, Self.[PK]A13 : PL, Self.[PH]A7 == Self.[SIMDStorage]Scalar, Self.[SIMDStorage]Scalar == Self.[PK]A13.[PH]A7>
 protocol PK: SIMD, PH where Scalar == A7 {
   associatedtype A13: PL where A13.Scalar == Scalar
 }
 
+// CHECK-LABEL: .PL@
+// CHECK-NEXT: Requirement signature: <Self where Self : SIMD, Self : PH, Self.[PL]A12 : PM, Self.[PH]A7 == Self.[SIMDStorage]Scalar, Self.[SIMDStorage]Scalar == Self.[PL]A12.[PH]A7>
 protocol PL: SIMD, PH where Scalar == A7 {
   associatedtype A12: PM where A12.Scalar == Scalar
 }
 
+// CHECK-LABEL: .PM@
+// CHECK-NEXT: Requirement signature: <Self where Self : SIMD, Self : PH, Self.[PM]A11 : PN, Self.[PH]A7 == Self.[SIMDStorage]Scalar, Self.[SIMDStorage]Scalar == Self.[PM]A11.[PH]A7>
 protocol PM: SIMD, PH where Scalar == A7 {
   associatedtype A11: PN where A11.Scalar == Scalar
 }
 
+// CHECK-LABEL: .PN@
+// CHECK-NEXT: Requirement signature: <Self where Self : SIMD, Self : PH, Self.[PN]A10 : PO, Self.[PH]A7 == Self.[SIMDStorage]Scalar, Self.[SIMDStorage]Scalar == Self.[PN]A10.[PH]A7>
 protocol PN: SIMD, PH where Scalar == A7 {
   associatedtype A10: PO where A10.Scalar == Scalar
 }
 
+// CHECK-LABEL: .PO@
+// CHECK-NEXT: Requirement signature: <Self where Self : SIMD, Self : PH, Self.[PH]A7 == Self.[SIMDStorage]Scalar, Self.[PO]A8 : PQ, Self.[PO]A9 : PP, Self.[SIMDStorage]Scalar == Self.[PO]A8.[PH]A7, Self.[PO]A8.[PH]A7 == Self.[PO]A9.[PH]A7>
 protocol PO: SIMD, PH where Scalar == A7 {
   associatedtype A8: PQ where A8.Scalar == Scalar
   associatedtype A9: PP where A9.Scalar == Scalar
 }
 
+// CHECK-LABEL: .PP@
+// CHECK-NEXT: Requirement signature: <Self where Self : SIMD, Self : PH, Self.[PH]A7 == Self.[SIMDStorage]Scalar, Self.[PP]A8 : PQ, Self.[SIMDStorage]Scalar == Self.[PP]A8.[PH]A7>
 protocol PP: SIMD, PH where Scalar == A7 {
   associatedtype A8: PQ where A8.Scalar == Scalar
 }
 
+// CHECK-LABEL: .PQ@
+// CHECK-NEXT: Requirement signature: <Self where Self : SIMD, Self : PH, Self.[PH]A7 == Self.[SIMDStorage]Scalar>
 protocol PQ: SIMD, PH where Scalar == A7 {}
 
 func sameType<T>(_: T, _: T) {}

--- a/test/Generics/rdar62903491.swift
+++ b/test/Generics/rdar62903491.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 
 protocol P {
@@ -7,22 +7,18 @@ protocol P {
 
 // Anything that mentions 'T : P' and 'U : P' minimizes to 'U : P'.
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P'}}
 func oneProtocol1<T, U>(_: T, _: U) where T : P, U : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol1
 // CHECK: Generic signature: <T, U where T : P, T == U.[P]X, U == T.[P]X>
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P'}}
 func oneProtocol2<T, U>(_: T, _: U) where U : P, T : P, T.X == U, U.X == T {}
 // CHECK-LABEL: oneProtocol2
 // CHECK: Generic signature: <T, U where T : P, T == U.[P]X, U == T.[P]X>
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P'}}
 func oneProtocol3<T, U>(_: T, _: U) where T : P, T.X == U, U : P, U.X == T {}
 // CHECK-LABEL: oneProtocol3
 // CHECK: Generic signature: <T, U where T : P, T == U.[P]X, U == T.[P]X>
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P'}}
 func oneProtocol4<T, U>(_: T, _: U) where U : P, T.X == U, T : P, U.X == T {}
 // CHECK-LABEL: oneProtocol4
 // CHECK: Generic signature: <T, U where T : P, T == U.[P]X, U == T.[P]X>
@@ -55,27 +51,22 @@ protocol P2 {
   associatedtype Y : P1
 }
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols1<T, U>(_: T, _: U) where T : P1, U : P2, T.X == U, U.Y == T {}
 // CHECK-LABEL: twoProtocols1
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols2<T, U>(_: T, _: U) where U : P2, T : P1, T.X == U, U.Y == T {}
 // CHECK-LABEL: twoProtocols2
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols3<T, U>(_: T, _: U) where T : P1, T.X == U, U : P2, U.Y == T {}
 // CHECK-LABEL: twoProtocols3
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols4<T, U>(_: T, _: U) where U : P2, T.X == U, T : P1, U.Y == T {}
 // CHECK-LABEL: twoProtocols4
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols5<T, U>(_: T, _: U) where T : P1, T.X == U, U.Y == T, U : P2 {}
 // CHECK-LABEL: twoProtocols5
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>
@@ -91,7 +82,6 @@ func twoProtocols5<T, U>(_: T, _: U) where T : P1, T.X == U, U.Y == T, U : P2 {}
 // requirements here are redundant, the user can omit one or the other to
 // specify the result that they desire.
 
-// expected-warning@+1 {{redundant conformance constraint 'U' : 'P2'}}
 func twoProtocols6<T, U>(_: T, _: U) where U : P2, T.X == U, U.Y == T, T : P1 {}
 // CHECK-LABEL: twoProtocols6
 // CHECK: Generic signature: <T, U where T : P1, T == U.[P2]Y, U == T.[P1]X>

--- a/test/Generics/rdar65263302.swift
+++ b/test/Generics/rdar65263302.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -warn-redundant-requirements 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -verify -emit-ir %s -warn-redundant-requirements
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -verify -emit-ir %s
 
 public protocol P {
     associatedtype Element
@@ -11,7 +11,7 @@ public class C<O: P>: P {
 
 // CHECK: Generic signature: <T, O, E where T : C<E>, O : P, E : P, O.[P]Element == E.[P]Element>
 public func toe1<T, O, E>(_: T, _: O, _: E, _: T.Element)
-    where T : P, // expected-warning {{redundant conformance constraint 'C<E>' : 'P'}}
+    where T : P,
           O : P,
           O.Element == T.Element,
           T : C<E> {}

--- a/test/Generics/rdar74890907.swift
+++ b/test/Generics/rdar74890907.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
-// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s -warn-redundant-requirements 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 
 protocol P1 {
   associatedtype A : P2
@@ -11,7 +11,6 @@ protocol P2 {
 
 // CHECK: Generic signature: <T, U where T : P2, T == U.[P2]A.[P1]A, U == T.[P2]A.[P1]A, T.[P2]A : P1, U.[P2]A : P1>
 func testTU<T : P2, U : P2>(_: T, _: U) where T.A : P1, T.A.A == U, U.A : P1, U.A.A == T {}
-// expected-warning@-1 {{redundant conformance constraint 'U' : 'P2'}}
 
 // CHECK: Generic signature: <T, U where T == U.[P2]A.[P1]A, U : P2, U == T.[P2]A.[P1]A, T.[P2]A : P1, U.[P2]A : P1>
 func testU<T, U : P2>(_: T, _: U) where T.A : P1, T.A.A == U, U.A : P1, U.A.A == T {}

--- a/test/Generics/rdar75656022.swift
+++ b/test/Generics/rdar75656022.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 
 protocol P1 {
@@ -40,24 +40,20 @@ struct UnresolvedWithConcreteBase<A, B> {
 // Make sure that we drop the conformance requirement
 // 'A : P2' and rebuild the generic signature with the
 // correct same-type requirements.
-//
-// The original test case in the bug report (correctly)
-// produces two warnings about redundant requirements.
-struct OriginalExampleWithWarning<A, B> where A : P2, B : P2, A.T == B.T {
+struct OriginalExampleWithRedundancy<A, B> where A : P2, B : P2, A.T == B.T {
   // CHECK-LABEL: Generic signature: <A, B, C, D, E where A == S1<C, E, S2<D>>, B : P2, C : P1, D == B.[P2]T, E == D.[P1]T, B.[P2]T == C.[P1]T>
-  init<C, D, E>(_: C) // expected-warning {{redundant conformance constraint 'S1<C, C.T.T, S2<C.T>>' : 'P2'}}
+  init<C, D, E>(_: C)
     where C : P1,
-          D : P1, // expected-warning {{redundant conformance constraint 'D' : 'P1'}}
-          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
+          D : P1,
+          C.T : P1,
           A == S1<C, C.T.T, S2<C.T>>,
           C.T == D,
           E == D.T { }
 }
 
-// Same as above but without the warnings.
-struct OriginalExampleWithoutWarning<A, B> where A : P2, B : P2, A.T == B.T {
+struct OriginalExampleWithoutRedundancy<A, B> where A : P2, B : P2, A.T == B.T {
   // CHECK-LABEL: Generic signature: <A, B, C, D, E where A == S1<C, E, S2<D>>, B : P2, C : P1, D == B.[P2]T, E == D.[P1]T, B.[P2]T == C.[P1]T>
-  init<C, D, E>(_: C) // expected-warning {{redundant conformance constraint 'S1<C, C.T.T, S2<C.T>>' : 'P2'}}
+  init<C, D, E>(_: C)
     where C : P1,
           A == S1<C, C.T.T, S2<C.T>>,
           C.T == D,
@@ -65,19 +61,17 @@ struct OriginalExampleWithoutWarning<A, B> where A : P2, B : P2, A.T == B.T {
 }
 
 // Same as above but without unnecessary generic parameters.
-struct WithoutBogusGenericParametersWithWarning<A, B> where A : P2, B : P2, A.T == B.T {
+struct WithoutBogusGenericParametersWithRedundancy<A, B> where A : P2, B : P2, A.T == B.T {
   // CHECK-LABEL: Generic signature: <A, B, C where A == S1<C, B.[P2]T.[P1]T, S2<B.[P2]T>>, B : P2, C : P1, B.[P2]T == C.[P1]T>
-  init<C>(_: C) // expected-warning {{redundant conformance constraint 'S1<C, C.T.T, S2<C.T>>' : 'P2'}}
+  init<C>(_: C)
     where C : P1,
-          C.T : P1, // expected-warning {{redundant conformance constraint 'C.T' : 'P1'}}
+          C.T : P1,
           A == S1<C, C.T.T, S2<C.T>> {}
 }
 
-// Same as above but without unnecessary generic parameters
-// or the warning.
-struct WithoutBogusGenericParametersWithoutWarning<A, B> where A : P2, B : P2, A.T == B.T {
+struct WithoutBogusGenericParametersWithoutRedundancy<A, B> where A : P2, B : P2, A.T == B.T {
   // CHECK-LABEL: Generic signature: <A, B, C where A == S1<C, B.[P2]T.[P1]T, S2<B.[P2]T>>, B : P2, C : P1, B.[P2]T == C.[P1]T>
-  init<C>(_: C) // expected-warning {{redundant conformance constraint 'S1<C, C.T.T, S2<C.T>>' : 'P2'}}
+  init<C>(_: C)
     where C : P1,
           A == S1<C, C.T.T, S2<C.T>> {}
 }

--- a/test/Generics/rdar77462797.swift
+++ b/test/Generics/rdar77462797.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P {}
@@ -11,25 +11,20 @@ class S<T : P> : Q {}
 
 struct G<X, Y> where X : Q {
   // no redundancies
-  func foo1() where X == S<Y> {} // expected-warning {{redundant conformance constraint 'S<Y>' : 'Q'}}
+  func foo1() where X == S<Y> {}
   // CHECK: Generic signature: <X, Y where X == S<Y>, Y : P>
 
-  // 'Y : P' is redundant, but only via an inferred requirement from S<Y>,
-  // so we should not diagnose it
-  func foo2() where X == S<Y>, Y : P {} // expected-warning {{redundant conformance constraint 'S<Y>' : 'Q'}}
+  func foo2() where X == S<Y>, Y : P {} 
   // CHECK: Generic signature: <X, Y where X == S<Y>, Y : P>
 
   // 'X : Q' is redundant
-  func foo3() where X : Q, X == S<Y>, Y : P {} // expected-warning {{redundant conformance constraint 'S<Y>' : 'Q'}}
-  // expected-warning@-1 {{redundant conformance constraint 'S<Y>' : 'Q'}}
+  func foo3() where X : Q, X == S<Y>, Y : P {}
   // CHECK: Generic signature: <X, Y where X == S<Y>, Y : P>
 
   // 'T.T : P' is redundant
-  func foo4<T : Q>(_: T) where X == S<Y>, T.T : P {} // expected-warning {{redundant conformance constraint 'S<Y>' : 'Q'}}
-  // expected-warning@-1 {{redundant conformance constraint 'T.T' : 'P'}}
+  func foo4<T : Q>(_: T) where X == S<Y>, T.T : P {}
   // CHECK: Generic signature: <X, Y, T where X == S<Y>, Y : P, T : Q>
 }
 
 func foo<X, Y>(_: X, _: Y) where X : Q, X : S<Y>, Y : P {}
-// expected-warning@-1 {{redundant conformance constraint 'S<Y>' : 'Q'}}
 // CHECK: Generic signature: <X, Y where X : S<Y>, Y : P>

--- a/test/Generics/rdar83308672.swift
+++ b/test/Generics/rdar83308672.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures -warn-redundant-requirements 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // CHECK: rdar83308672.(file).A@
 // CHECK-NEXT: Requirement signature: <Self where Self == Self.[A]X.[P1]T, Self.[A]X : P1, Self.[A]Y : P2>
@@ -40,13 +40,13 @@ protocol G1 {
 // CHECK: rdar83308672.(file).G2@
 // CHECK-NEXT: Requirement signature: <Self where Self.[G2]T : A, Self.[G2]T.[A]X == Self.[G2]T.[A]Y>
 protocol G2 {
-  associatedtype T : A where T : B, T.X == T.Y // expected-warning {{redundant conformance constraint 'Self.T' : 'B'}}
+  associatedtype T : A where T : B, T.X == T.Y
 }
 
 // CHECK: rdar83308672.(file).G3@
 // CHECK-NEXT: Requirement signature: <Self where Self.[G3]T : A, Self.[G3]T.[A]X == Self.[G3]T.[A]Y>
 protocol G3 {
-  associatedtype T : A where T.X == T.Y, T : B // expected-warning {{redundant conformance constraint 'Self.T' : 'B'}}
+  associatedtype T : A where T.X == T.Y, T : B
 }
 
 // CHECK: rdar83308672.(file).G4@

--- a/test/Generics/rdar83687967.swift
+++ b/test/Generics/rdar83687967.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir %s
 
@@ -28,7 +28,6 @@ public func caller11<Child: P3>(_: Child)
 // CHECK: Generic signature: <Child where Child : P3, Child.[P3]B == G<Child.[P3]A>>
 public func caller12<Child: P3>(_: Child)
     where Child.B == G<Child.A>, Child.A : P1 {
-    // expected-warning@-1 {{redundant conformance constraint 'Child.A' : 'P1'}}
 
   // Make sure IRGen can evaluate the conformance access path
   // (Child : P3)(Self.B : P2)(Self.A : P1).
@@ -48,7 +47,6 @@ public protocol X1 {
 public protocol X2 {
   associatedtype Child: P3
     where Child.B == G<Child.A>, Child.A : P1
-    // expected-warning@-1 {{redundant conformance constraint 'Self.Child.A' : 'P1'}}
 }
 
 public func caller21<T : X1>(_: T) {

--- a/test/Generics/rdar91771352.swift
+++ b/test/Generics/rdar91771352.swift
@@ -1,25 +1,22 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 public struct G<T: P1, U: P1> {
   // CHECK-LABEL: .f1()@
   // CHECK-NEXT: Generic signature: <T, U where T : P1, T == U>
-  public func f1() where T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
+  public func f1() where T == U {}
 
   // CHECK-LABEL: .f2()@
   // CHECK-NEXT: Generic signature: <T, U where T : P1, T == U>
-  public func f2() where T == U, T.A.B == T {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
-  // expected-warning@-1 {{redundant same-type constraint 'T.A.B' == 'T'}}
+  public func f2() where T == U, T.A.B == T {}
 
   // CHECK-LABEL: .f3()@
   // CHECK-NEXT: Generic signature: <T, U where T : P1, T == U>
-  public func f3() where T.A.B == T, T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
-  // expected-warning@-1 {{redundant same-type constraint 'T.A.B' == 'T'}}
+  public func f3() where T.A.B == T, T == U {}
 
   // CHECK-LABEL: .f4()@
   // CHECK-NEXT: Generic signature: <T, U where T : P1, T == U>
-  public func f4() where U.A.B == U, T == U {} // expected-warning {{redundant conformance constraint 'U' : 'P1'}}
-  // expected-warning@-1 {{redundant same-type constraint 'U.A.B' == 'U'}}
+  public func f4() where U.A.B == U, T == U {}
 }
 
 public protocol P1 {

--- a/test/Generics/redundant_concrete_conformance.swift
+++ b/test/Generics/redundant_concrete_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P1 {}
 protocol P2 : P1 {}
@@ -10,7 +10,9 @@ protocol P3 {
 struct S : P2 {}
 
 func f1<T : P3>(_: T) where T.A : P1 {}
-// expected-warning@-1 {{redundant conformance constraint 'T.A' : 'P1'}}
+// CHECK-LABEL: .f1@
+// CHECK-NEXT: Generic signature: <T where T : P3>
 
 func f2<T : P3>(_: T) where T.A : P2 {}
-// expected-warning@-1 {{redundant conformance constraint 'T.A' : 'P2'}}
+// CHECK-LABEL: .f2@
+// CHECK-NEXT: Generic signature: <T where T : P3>

--- a/test/Generics/redundant_inferred_requirement_order.swift
+++ b/test/Generics/redundant_inferred_requirement_order.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P {}
 
@@ -6,9 +6,14 @@ struct S<T : P> {}
 
 struct G<A, B> {}
 
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <A, B where A == S<B>, B : P>
 extension G where A == S<B>, B : P {}
 
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <A, B where A == S<B>, B : P>
 extension G where B : P, A == S<B> {}
 
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=G
+// CHECK-NEXT: Generic signature: <A, B where A == S<B>, B : P>
 extension G where B : P, A == S<B>, B : P {}
-// expected-warning@-1 {{redundant conformance constraint 'B' : 'P'}}

--- a/test/Generics/redundant_protocol_composition.swift
+++ b/test/Generics/redundant_protocol_composition.swift
@@ -1,19 +1,24 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // The GenericSignatureBuilder did not diagnose the first two.
 
+// CHECK-LABEL: .G1@
+// CHECK-NEXT: Generic signature: <T where T : Decodable, T : Encodable, T : FixedWidthInteger, T : UnsignedInteger>
 struct G1<T : BinaryInteger & FixedWidthInteger & UnsignedInteger & Codable> {}
-// expected-warning@-1 {{redundant conformance constraint 'T' : 'BinaryInteger'}}
 
+// CHECK-LABEL: .G2@
+// CHECK-NEXT: Generic signature: <T where T : Decodable, T : Encodable, T : FixedWidthInteger, T : UnsignedInteger>
 struct G2<T> where T : BinaryInteger & FixedWidthInteger & UnsignedInteger & Codable {}
-// expected-warning@-1 {{redundant conformance constraint 'T' : 'BinaryInteger'}}
 
+// CHECK-LABEL: .G3@
+// CHECK-NEXT: Generic signature: <T where T : Decodable, T : Encodable, T : FixedWidthInteger, T : UnsignedInteger>
 struct G3<T> where T : BinaryInteger, T : FixedWidthInteger, T : UnsignedInteger & Codable {}
-// expected-warning@-1 {{redundant conformance constraint 'T' : 'BinaryInteger'}}
 
-// FIXME(rqm-diagnostics): These should also diagnose, but do not due to overly-eager
-// canonicalization in ProtocolCompositionType::get().
-
+// CHECK-LABEL: .G1a@
+// CHECK-NEXT: Generic signature: <T where T : FixedWidthInteger, T : UnsignedInteger>
 struct G1a<T : BinaryInteger & FixedWidthInteger & UnsignedInteger> {}
+
+// CHECK-LABEL: .G2a@
+// CHECK-NEXT: Generic signature: <T where T : FixedWidthInteger, T : UnsignedInteger>
 struct G2a<T> where T : BinaryInteger & FixedWidthInteger & UnsignedInteger {}
 

--- a/test/Generics/redundant_protocol_refinement.swift
+++ b/test/Generics/redundant_protocol_refinement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 
 // CHECK-LABEL: redundant_protocol_refinement.(file).Base@
@@ -12,7 +12,6 @@ protocol Middle : Base {}
 // CHECK-LABEL: redundant_protocol_refinement.(file).Derived@
 // CHECK-LABEL: Requirement signature: <Self where Self : Middle>
 protocol Derived : Middle, Base {}
-// expected-warning@-1 {{redundant conformance constraint 'Self' : 'Base'}}
 
 // CHECK-LABEL: redundant_protocol_refinement.(file).Derived2@
 // CHECK-LABEL: Requirement signature: <Self where Self : Middle>
@@ -21,7 +20,6 @@ protocol Derived2 : Middle {}
 // CHECK-LABEL: redundant_protocol_refinement.(file).MoreDerived@
 // CHECK-LABEL: Requirement signature: <Self where Self : Derived2>
 protocol MoreDerived : Derived2, Base {}
-// expected-warning@-1 {{redundant conformance constraint 'Self' : 'Base'}}
 
 protocol P1 {}
 

--- a/test/Generics/redundant_requirement_self_conforming_protocol.swift
+++ b/test/Generics/redundant_requirement_self_conforming_protocol.swift
@@ -1,8 +1,7 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 
 struct G<T> {}
 
 // CHECK-LABEL: Generic signature: <T where T == any Error>
 extension G where T : Error, T == Error {}
-// expected-warning@-1 {{redundant conformance constraint 'any Error' : 'Error'}}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P1 { 
@@ -74,7 +74,7 @@ struct V<T : Canidae> {}
 
 // CHECK-LABEL: .inferSuperclassRequirement1@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Canidae>
-func inferSuperclassRequirement1<T : Carnivora>( // expected-warning {{redundant superclass constraint 'T' : 'Carnivora'}}
+func inferSuperclassRequirement1<T : Carnivora>(
 	_ v: V<T>) {}
 
 // CHECK-LABEL: .inferSuperclassRequirement2@
@@ -113,7 +113,6 @@ func inferSameType1<T, U>(_ x: Model_P3_P4_Eq<T, U>) {
 }
 
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}
-// expected-warning@-1{{redundant conformance constraint 'U.P4Assoc' : 'P2'}}
 
 func inferSameType3<T : PCommonAssoc1>(_: T) where T.CommonAssoc : P1, T : PCommonAssoc2 {
 }
@@ -132,7 +131,7 @@ protocol P7 : P6 {
 
 // CHECK-LABEL: P7@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P7, τ_0_0.[P6]AssocP6.[P5]Element : P6, τ_0_0.[P6]AssocP6.[P5]Element == τ_0_0.[P7]AssocP7.[P6]AssocP6.[P5]Element>
-extension P7 where AssocP6.Element : P6, // expected-warning{{redundant conformance constraint 'Self.AssocP6.Element' : 'P6'}}
+extension P7 where AssocP6.Element : P6,
         AssocP7.AssocP6.Element : P6,
         AssocP6.Element == AssocP7.AssocP6.Element {
   func nestedSameType1() { }
@@ -160,7 +159,6 @@ func sameTypeConcrete1<T : P9 & P10>(_: T) where T.A == X3, T.C == T.B, T.C == I
 // CHECK-LABEL: sameTypeConcrete2@
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P10, τ_0_0 : P9, τ_0_0.[P8]B == X3, τ_0_0.[P10]C == X3>
 func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3 { }
-// expected-warning@-1{{redundant superclass constraint 'T.B' : 'X3'}}
 
 // Note: a standard-library-based stress test to make sure we don't inject
 // any additional requirements.
@@ -172,17 +170,11 @@ extension RangeReplaceableCollection
 	func f() { }
 }
 
-// FIXME(rqm-diagnostics): Bogus warning
-
 // CHECK-LABEL: X14.recursiveConcreteSameType
 // CHECK: Generic signature: <T, V where T == Range<Int>>
 // CHECK-NEXT: Canonical generic signature: <τ_0_0, τ_1_0 where τ_0_0 == Range<Int>>
 struct X14<T> where T.Iterator == IndexingIterator<T> {
-	func recursiveConcreteSameType<V>(_: V) where T == Range<Int> { } // expected-warning {{redundant conformance constraint 'Range<Int>' : 'Collection'}}
-  // expected-warning@-1 {{redundant conformance constraint 'Int' : 'Strideable'}}
-  // expected-warning@-2 {{redundant conformance constraint 'Int' : 'SignedInteger'}}
-  // expected-warning@-3 {{redundant same-type constraint 'Range<Int>.Iterator' (aka 'IndexingIterator<Range<Int>>') == 'IndexingIterator<T>'}}
-  // expected-warning@-4 {{redundant same-type constraint 'T' == 'Range<Int>'}}
+	func recursiveConcreteSameType<V>(_: V) where T == Range<Int> { }
 }
 
 // rdar://problem/30478915
@@ -208,7 +200,7 @@ struct X9<T: P12, U: P12> where T.B == U.B {
   // CHECK-LABEL: X9.upperSameTypeConstraint
 	// CHECK: Generic signature: <T, U, V where T == X8, U : P12, U.[P12]B == X7>
   // CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 == X8, τ_0_1 : P12, τ_0_1.[P12]B == X7>
-	func upperSameTypeConstraint<V>(_: V) where T == X8 { } // expected-warning {{redundant conformance constraint 'X8' : 'P12'}}
+	func upperSameTypeConstraint<V>(_: V) where T == X8 { }
 }
 
 protocol P13 {
@@ -224,7 +216,7 @@ struct X11<T: P12, U: P12> where T.B == U.B.A {
 	// CHECK-LABEL: X11.upperSameTypeConstraint
 	// CHECK: Generic signature: <T, U, V where T : P12, U == X10, T.[P12]B == X10>
 	// CHECK: Canonical generic signature: <τ_0_0, τ_0_1, τ_1_0 where τ_0_0 : P12, τ_0_1 == X10, τ_0_0.[P12]B == X10>
-	func upperSameTypeConstraint<V>(_: V) where U == X10 { } // expected-warning {{redundant conformance constraint 'X10' : 'P12'}}
+	func upperSameTypeConstraint<V>(_: V) where U == X10 { }
 }
 
 protocol P16 {
@@ -240,8 +232,7 @@ struct X16<X, Y> : P16 {
 // CHECK-LABEL: .X17.bar@
 // CHECK: Generic signature: <S, T, U, V where S == X16<X3, X15>, T == X3, U == X15>
 struct X17<S: P16, T, U> where S.A == (T, U) {
-	func bar<V>(_: V) where S == X16<X3, X15> { } // expected-warning {{redundant conformance constraint 'X16<X3, X15>' : 'P16'}}
-  // expected-warning@-1 {{redundant same-type constraint 'X16<X3, X15>.A' (aka '(X3, X15)') == '(T, U)'}}
+	func bar<V>(_: V) where S == X16<X3, X15> { }
 }
 
 // Same-type constraints that are self-derived via a parent need to be
@@ -261,8 +252,7 @@ struct X18: P18, P17 {
 // CHECK-LABEL: .X19.foo@
 // CHECK: Generic signature: <T, U where T == X18>
 struct X19<T: P18> where T == T.A {
-  func foo<U>(_: U) where T == X18 { } // expected-warning {{redundant conformance constraint 'X18' : 'P18'}}
-  // expected-warning@-1 {{redundant same-type constraint 'T' == 'X18'}}
+  func foo<U>(_: U) where T == X18 { }
 }
 
 // rdar://problem/31520386

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -247,8 +247,6 @@ struct X18: P18, P17 {
   typealias A = X18
 }
 
-// FIXME(rqm-diagnostics): Bogus warning
-
 // CHECK-LABEL: .X19.foo@
 // CHECK: Generic signature: <T, U where T == X18>
 struct X19<T: P18> where T == T.A {

--- a/test/Generics/requirement_inference_objc.swift
+++ b/test/Generics/requirement_inference_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 
@@ -6,14 +6,18 @@
 @objc protocol P14 { }
 
 class X12<S: AnyObject> {
-  func bar<V>(v: V) where S == P14 { // expected-warning {{redundant constraint 'S' : 'AnyObject'}}
+  // CHECK-LABEL: .X12.bar(v:)@
+  // CHECK-NEXT: Generic signature: <S, V where S == any P14>
+  func bar<V>(v: V) where S == any P14 {
   }
 }
 
 @objc protocol P15: P14 { }
 
 class X13<S: P14> {
-  func bar<V>(v: V) where S == P15 { // expected-warning {{redundant conformance constraint 'any P15' : 'P14'}}
+  // CHECK-LABEL: .X13.bar(v:)@
+  // CHECK-NEXT: Generic signature: <S, V where S == any P15>
+  func bar<V>(v: V) where S == any P15 {
   }
 }
 

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 func testInvalidConformance() {
   // expected-error@+1 {{type 'T' constrained to non-protocol, non-class type 'Int'}}
@@ -39,44 +40,36 @@ func badTypeConformance4<T>(_: T) where (inout T) throws -> () : EqualComparable
 func badTypeConformance5<T>(_: T) where T & Sequence : EqualComparable { }
 // expected-error@-1 {{non-protocol, non-class type 'T' cannot be used within a protocol-constrained type}}
 
-func badTypeConformance6<T>(_: T) where [T] : Collection { }
-// expected-warning@-1{{redundant conformance constraint '[T]' : 'Collection'}}
+func redundantTypeConformance6<T>(_: T) where [T] : Collection { }
 
 func concreteSameTypeRedundancy<T>(_: T) where Int == Int {}
-// expected-warning@-1{{redundant same-type constraint 'Int' == 'Int'}}
 
 func concreteSameTypeRedundancy<T>(_: T) where Array<Int> == Array<T> {}
-// expected-warning@-1{{redundant same-type constraint 'Array<Int>' == 'Array<T>'}}
-// expected-warning@-2{{same-type requirement makes generic parameter 'T' non-generic}}
+// expected-warning@-1{{same-type requirement makes generic parameter 'T' non-generic}}
 
 protocol P {}
 struct S: P {}
 func concreteConformanceRedundancy<T>(_: T) where S : P {}
-// expected-warning@-1{{redundant conformance constraint 'S' : 'P'}}
 
 class C {}
 func concreteLayoutRedundancy<T>(_: T) where C : AnyObject {}
-// expected-warning@-1{{redundant constraint 'C' : 'AnyObject'}}
 
 func concreteLayoutConflict<T>(_: T) where Int : AnyObject {}
 // expected-error@-1{{type 'Int' in conformance requirement does not refer to a generic parameter or associated type}}
 
 class C2: C {}
 func concreteSubclassRedundancy<T>(_: T) where C2 : C {}
-// expected-warning@-1{{redundant superclass constraint 'C2' : 'C'}}
 
 class D {}
 func concreteSubclassConflict<T>(_: T) where D : C {}
 // expected-error@-1{{type 'D' in conformance requirement does not refer to a generic parameter or associated type}}
 
 protocol UselessProtocolWhereClause where Int == Int {}
-// expected-warning@-1 {{redundant same-type constraint 'Int' == 'Int'}}
 
 protocol InvalidProtocolWhereClause where Self: Int {}
 // expected-error@-1 {{type 'Self' constrained to non-protocol, non-class type 'Int'}}
 
 typealias Alias<T> = T where Int == Int
-// expected-warning@-1 {{redundant same-type constraint 'Int' == 'Int'}}
 
 func cascadingConflictingRequirement<T>(_: T) where DoesNotExist : EqualComparable { }
 // expected-error@-1 {{cannot find type 'DoesNotExist' in scope}}
@@ -85,32 +78,23 @@ func cascadingInvalidConformance<T>(_: T) where T : DoesNotExist { }
 // expected-error@-1 {{cannot find type 'DoesNotExist' in scope}}
 
 func trivialRedundant1<T>(_: T) where T: P, T: P {}
-// expected-warning@-1 {{redundant conformance constraint 'T' : 'P'}}
 
 func trivialRedundant2<T>(_: T) where T: AnyObject, T: AnyObject {}
-// expected-warning@-1 {{redundant constraint 'T' : 'AnyObject'}}
 
 func trivialRedundant3<T>(_: T) where T: C, T: C {}
-// expected-warning@-1 {{redundant superclass constraint 'T' : 'C'}}
 
 func trivialRedundant4<T>(_: T) where T == T {}
-// expected-warning@-1 {{redundant same-type constraint 'T' == 'T'}}
 
 protocol TrivialRedundantConformance: P, P {}
-// expected-warning@-1 {{redundant conformance constraint 'Self' : 'P'}}
 
 protocol TrivialRedundantLayout: AnyObject, AnyObject {}
-// expected-warning@-1 {{redundant constraint 'Self' : 'AnyObject'}}
-// expected-error@-2 {{duplicate inheritance from 'AnyObject'}}
+// expected-error@-1 {{duplicate inheritance from 'AnyObject'}}
 
 protocol TrivialRedundantSuperclass: C, C {}
-// expected-warning@-1 {{redundant superclass constraint 'Self' : 'C'}}
-// expected-error@-2 {{duplicate inheritance from 'C'}}
+// expected-error@-1 {{duplicate inheritance from 'C'}}
 
 protocol TrivialRedundantSameType where Self == Self {
-// expected-warning@-1 {{redundant same-type constraint 'Self' == 'Self'}}
   associatedtype T where T == T
-  // expected-warning@-1 {{redundant same-type constraint 'Self.T' == 'Self.T'}}
 }
 
 struct G<T> { }
@@ -120,8 +104,9 @@ protocol Pair {
   associatedtype B
 }
 
+// CHECK-LABEL: .test1@
+// CHECK-NEXT: Generic signature: <T where T : Pair, T.[Pair]A == G<Int>, T.[Pair]B == Int>
 func test1<T: Pair>(_: T) where T.A == G<Int>, T.A == G<T.B>, T.B == Int { }
-// expected-warning@-1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 
 
 protocol P1 {
@@ -138,8 +123,9 @@ protocol P4 {
   associatedtype P4Assoc : P1
 }
 
+// CHECK-LABEL: .inferSameType2@
+// CHECK-NEXT: Generic signature: <T, U where T : P3, U : P4, T.[P3]P3Assoc == U.[P4]P4Assoc>
 func inferSameType2<T : P3, U : P4>(_: T, _: U) where U.P4Assoc : P2, T.P3Assoc == U.P4Assoc {}
-// expected-warning@-1{{redundant conformance constraint 'U.P4Assoc' : 'P2'}}
 
 protocol P5 {
   associatedtype Element
@@ -153,7 +139,8 @@ protocol P7 : P6 {
   associatedtype AssocP7: P6
 }
 
-// expected-warning@+1{{redundant conformance constraint 'Self.AssocP6.Element' : 'P6'}}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=P7
+// CHECK-NEXT: Generic signature: <Self where Self : P7, Self.[P6]AssocP6.[P5]Element : P6, Self.[P6]AssocP6.[P5]Element == Self.[P7]AssocP7.[P6]AssocP6.[P5]Element
 extension P7 where AssocP6.Element : P6,
         AssocP7.AssocP6.Element : P6,
         AssocP6.Element == AssocP7.AssocP6.Element {
@@ -177,11 +164,12 @@ protocol P10 {
 
 class X3 { }
 
+// CHECK-LABEL: .sameTypeConcrete2@
+// CHECK-NEXT: Generic signature: <T where T : P10, T : P9, T.[P8]B == X3, T.[P10]C == X3>
 func sameTypeConcrete2<T : P9 & P10>(_: T) where T.B : X3, T.C == T.B, T.C == X3 { }
-// expected-warning@-1{{redundant superclass constraint 'T.B' : 'X3'}}
 
 
-// Redundant requirement warnings are suppressed for inferred requirements.
+// Test inferred requirements.
 
 protocol P11 {
  associatedtype X
@@ -189,17 +177,32 @@ protocol P11 {
  associatedtype Z
 }
 
+// CHECK-LABEL: .inferred1@
+// CHECK-NEXT: Generic signature: <T where T : Hashable>
 func inferred1<T : Hashable>(_: Set<T>) {}
+
+// CHECK-LABEL: .inferred2@
+// CHECK-NEXT: Generic signature: <T where T : Hashable>
 func inferred2<T>(_: Set<T>) where T: Hashable {}
+
+// CHECK-LABEL: .inferred3@
+// CHECK-NEXT: Generic signature:  <T where T : P11, T.[P11]X : Hashable, T.[P11]X == T.[P11]Y, T.[P11]Z == Set<T.[P11]X>>
 func inferred3<T : P11>(_: T) where T.X : Hashable, T.Z == Set<T.Y>, T.X == T.Y {}
+
+// CHECK-LABEL: .inferred4@
+// CHECK-NEXT: Generic signature:  <T where T : P11, T.[P11]X : Hashable, T.[P11]X == T.[P11]Y, T.[P11]Z == Set<T.[P11]X>>
 func inferred4<T : P11>(_: T) where T.Z == Set<T.Y>, T.X : Hashable, T.X == T.Y {}
+
+// CHECK-LABEL: .inferred5@
+// CHECK-NEXT: Generic signature:  <T where T : P11, T.[P11]X : Hashable, T.[P11]X == T.[P11]Y, T.[P11]Z == Set<T.[P11]X>>
 func inferred5<T : P11>(_: T) where T.Z == Set<T.X>, T.Y : Hashable, T.X == T.Y {}
+
+// CHECK-LABEL: .inferred6@
+// CHECK-NEXT: Generic signature:  <T where T : P11, T.[P11]X : Hashable, T.[P11]X == T.[P11]Y, T.[P11]Z == Set<T.[P11]X>>
 func inferred6<T : P11>(_: T) where T.Y : Hashable, T.Z == Set<T.X>, T.X == T.Y {}
 
 func typeMatcherSugar<T>(_: T) where Array<Int> == Array<T>, Array<Int> == Array<T> {}
-// expected-warning@-1 2{{redundant same-type constraint 'Array<Int>' == 'Array<T>'}}
-// expected-warning@-2{{redundant same-type constraint 'T' == 'Int'}}
-// expected-warning@-3{{same-type requirement makes generic parameter 'T' non-generic}}
+// expected-warning@-1{{same-type requirement makes generic parameter 'T' non-generic}}
 
 
 struct ConcreteSelf: ConcreteProtocol {}

--- a/test/Generics/same_type_constraints.swift
+++ b/test/Generics/same_type_constraints.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4 -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol Fooable {
   associatedtype Foo
@@ -158,7 +159,9 @@ protocol P {
 }
 
 struct S<A: P> {
-	init<Q: P>(_ q: Q) where Q.T == A {} // expected-warning {{redundant conformance constraint 'A' : 'P'}}
+  // CHECK-LABEL: .S.init(_:)@
+  // CHECK-NEXT: Generic signature:  <A, Q where A == Q.[P]T, Q : P>
+	init<Q: P>(_ q: Q) where Q.T == A {}
 }
 
 // rdar://problem/19371678
@@ -177,7 +180,9 @@ struct SpecificAnimal<F:Food> : Animal {
     typealias EdibleFood=F
     let _eat:(_ f:F) -> ()
 
-    init<A:Animal>(_ selfie:A) where A.EdibleFood == F { // expected-warning {{redundant conformance constraint 'F' : 'Food'}}
+    // CHECK-LABEL: .SpecificAnimal.init(_:)@
+    // CHECK-NEXT: Generic signature: <F, A where F == A.[Animal]EdibleFood, A : Animal>
+    init<A:Animal>(_ selfie:A) where A.EdibleFood == F {
         _eat = { selfie.eat($0) }
     }
     func eat(_ f:F) {
@@ -345,34 +350,35 @@ protocol P10 {
 
 protocol P11: P10 where A == B { }
 
+// CHECK-LABEL: .intracomponent@
+// CHECK-NEXT: Generic signature: <T where T : P11>
 func intracomponent<T: P11>(_: T)
-  where T.A == T.B { } // expected-warning{{redundant same-type constraint 'T.A' == 'T.B'}}
+  where T.A == T.B { }
 
+// CHECK-LABEL: .intercomponentSameComponents@
+// CHECK-NEXT: Generic signature: <T where T : P10, T.[P10]A == T.[P10]B>
 func intercomponentSameComponents<T: P10>(_: T)
   where T.A == T.B,
-        T.B == T.A { } // expected-warning{{redundant same-type constraint 'T.B' == 'T.A'}}
+        T.B == T.A { }
 
+// CHECK-LABEL: .intercomponentMoreThanSpanningTree@
+// CHECK-NEXT: Generic signature: <T where T : P10, T.[P10]A == T.[P10]B, T.[P10]B == T.[P10]C, T.[P10]C == T.[P10]D, T.[P10]D == T.[P10]E>
 func intercomponentMoreThanSpanningTree<T: P10>(_: T)
   where T.A == T.B,
         T.B == T.C,
         T.D == T.E,
         T.D == T.B,
-        T.E == T.B  // expected-warning{{redundant same-type constraint 'T.E' == 'T.B'}}
+        T.E == T.B
         { }
 
-func trivialRedundancy<T: P10>(_: T) where T.A == T.A { } // expected-warning{{redundant same-type constraint 'T.A' == 'T.A'}}
+// CHECK-LABEL: .trivialRedundancy@
+// CHECK-NEXT: Generic signature: <T where T : P10>
+func trivialRedundancy<T: P10>(_: T) where T.A == T.A { }
 
 struct X11<T: P10> where T.A == T.B { }
 
 func intracomponentInferred<T>(_: X11<T>)
   where T.A == T.B { }
-
-// Suppress redundant same-type constraint warnings from result types.
-struct StructTakingP1<T: P1> { }
-
-func resultTypeSuppress<T: P1>() -> StructTakingP1<T> {
-  return StructTakingP1()
-}
 
 // Check directly-concrete same-type constraints
 typealias NotAnInt = Double
@@ -396,17 +402,24 @@ protocol ObserverType {
   associatedtype E
 }
 
+// CHECK-LABEL: .Bad@
+// CHECK-NEXT: Generic signature: <S, O where S : FakeSequence, O == S.[FakeSequence]Element.[ObserverType]E, S.[FakeSequence]Element : ObserverType>
 struct Bad<S: FakeSequence, O> where S.Element : ObserverType, S.Element.E == O {}
 
+// CHECK-LABEL: .good@
+// CHECK-NEXT: Generic signature: <S, O where S : FakeSequence, O == S.[FakeSequence]Element.[ObserverType]E, S.[FakeSequence]Element : ObserverType>
 func good<S: FakeSequence, O>(_: S, _: O) where S.Element : ObserverType, O == S.Element.E {
   _ = Bad<S, O>()
 }
 
+// CHECK-LABEL: .bad@
+// CHECK-NEXT: Generic signature: <S, O where S : FakeSequence, O == S.[FakeSequence]Element.[ObserverType]E, S.[FakeSequence]Element : ObserverType>
 func bad<S: FakeSequence, O>(_: S, _: O) where S.Element : ObserverType, O == S.Iterator.Element.E {
   _ = Bad<S, O>()
 }
 
+// CHECK-LABEL: .ugly@
+// CHECK-NEXT: Generic signature: <S, O where S : FakeSequence, O == S.[FakeSequence]Element.[ObserverType]E, S.[FakeSequence]Element : ObserverType>
 func ugly<S: FakeSequence, O>(_: S, _: O) where S.Element : ObserverType, O == S.Iterator.Element.E, O == S.Element.E {
-// expected-warning@-1 {{redundant same-type constraint 'O' == 'S.Element.E'}}
   _ = Bad<S, O>()
 }

--- a/test/Generics/same_type_minimize_concrete.swift
+++ b/test/Generics/same_type_minimize_concrete.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
-// RUN: %target-typecheck-verify-swift -debug-generic-signatures -warn-redundant-requirements 2>&1 | %FileCheck %s
+// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 struct G<T> { }
 
@@ -8,27 +8,21 @@ protocol P {
   associatedtype B
 }
 
-// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test1<T: P>(_: T) where T.A == G<Int>, T.A == G<T.B>, T.B == Int { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
-// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test2<T: P>(_: T) where T.A == G<Int>, T.B == Int, T.A == G<T.B> { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
-// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test3<T: P>(_: T) where T.A == G<T.B>, T.A == G<Int>, T.B == Int { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
-// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test4<T: P>(_: T) where T.A == G<T.B>, T.B == Int, T.A == G<Int> { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
-// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test5<T: P>(_: T) where T.B == Int, T.A == G<Int>, T.A == G<T.B> { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 
-// expected-warning@+1 {{redundant same-type constraint 'T.A' == 'G<T.B>'}}
 func test6<T: P>(_: T) where T.B == Int, T.A == G<T.B>, T.A == G<Int> { }
 // CHECK: Generic signature: <T where T : P, T.[P]A == G<Int>, T.[P]B == Int>
 

--- a/test/Generics/superclass_and_concrete_requirement.swift
+++ b/test/Generics/superclass_and_concrete_requirement.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 class C {}
@@ -9,7 +9,6 @@ struct S {}
 // CHECK-NEXT: Requirement signature: <Self where Self.[P1]T == C>
 protocol P1 {
   associatedtype T where T : C, T == C
-  // expected-warning@-1 {{redundant superclass constraint 'Self.T' : 'C'}}
 }
 
 // CHECK-LABEL: .P2@

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
@@ -14,8 +14,9 @@ class Other { }
 
 func f1<T : A>(_: T) where T : Other {} // expected-error{{no type for 'T' can satisfy both 'T : Other' and 'T : A'}}
 
+// CHECK-LABEL: .f2@
+// CHECK-NEXT: Generic signature: <T where T : B>
 func f2<T : A>(_: T) where T : B {}
-// expected-warning@-1{{redundant superclass constraint 'T' : 'A'}}
 
 class GA<T> {}
 class GB<T> : GA<T> {}
@@ -30,11 +31,13 @@ func f7<U, T>(_: T, _: U) where U : GA<T>, T : P {}
 
 func f8<T : GA<A>>(_: T) where T : GA<B> {} // expected-error{{no type for 'T' can satisfy both 'T : GA<B>' and 'T : GA<A>'}}
 
+// CHECK-LABEL: .f9@
+// CHECK-NEXT: Generic signature: <T where T : GB<A>>
 func f9<T : GA<A>>(_: T) where T : GB<A> {}
-// expected-warning@-1{{redundant superclass constraint 'T' : 'GA<A>'}}
 
+// CHECK-LABEL: .f10@
+// CHECK-NEXT: Generic signature: <T where T : GB<A>>
 func f10<T : GB<A>>(_: T) where T : GA<A> {}
-// expected-warning@-1{{redundant superclass constraint 'T' : 'GA<A>'}}
 
 func f11<T : GA<T>>(_: T) { }
 func f12<T : GA<U>, U : GB<T>>(_: T, _: U) { }
@@ -63,7 +66,7 @@ class S : P2 {
 // CHECK-NEXT: Generic signature: <T where T : C>
 func superclassConformance1<T>(t: T)
   where T : C,
-        T : P3 {} // expected-warning{{redundant conformance constraint 'C' : 'P3'}}
+        T : P3 {}
 
 
 
@@ -71,7 +74,7 @@ func superclassConformance1<T>(t: T)
 // CHECK-NEXT: Generic signature: <T where T : C>
 func superclassConformance2<T>(t: T)
   where T : C,
-   T : P3 {} // expected-warning{{redundant conformance constraint 'C' : 'P3'}}
+   T : P3 {}
 
 protocol P4 { }
 
@@ -80,8 +83,6 @@ class C2 : C, P4 { }
 // CHECK-LABEL: .superclassConformance3(t:)@
 // CHECK-NEXT: Generic signature: <T where T : C2>
 func superclassConformance3<T>(t: T) where T : C, T : P4, T : C2 {}
-// expected-warning@-1{{redundant superclass constraint 'T' : 'C'}}
-// expected-warning@-2{{redundant conformance constraint 'T' : 'P4'}}
 
 protocol P5: A { }
 
@@ -101,7 +102,7 @@ protocol P7 {
 // CHECK-LABEL: .superclassConformance4@
 // CHECK-NEXT: Generic signature: <T, U where T : P3, U : P3, T.[P3]T : C, T.[P3]T == U.[P3]T>
 func superclassConformance4<T: P3, U: P3>(_: T, _: U)
-  where T.T: C, // expected-warning{{redundant superclass constraint 'T.T' : 'C'}}
+  where T.T: C,
         U.T: C,
         T.T == U.T { }
 
@@ -171,8 +172,9 @@ protocol Rump : Tail {
 
 class Horse<T>: Rump { }
 
+// CHECK-LABEL: .hasRedundantConformanceConstraint@
+// CHECK-NEXT: Generic signature: <X, T where X : Horse<T>>
 func hasRedundantConformanceConstraint<X : Horse<T>, T>(_: X) where X : Rump {}
-// expected-warning@-1 {{redundant conformance constraint 'Horse<T>' : 'Rump'}}
 
 // https://github.com/apple/swift/issues/48432
 
@@ -232,7 +234,10 @@ extension Animal: Pony { }
 
 public struct AnimalWrapper<Friend: Animal> { }
 
-// FIXME: Generic signature: <Friend where Friend : Animal, Friend : Pony>
-// Generic signature: <Friend where Friend : Animal>
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=AnimalWrapper
+
+// FIXME: This should be <Friend where Friend : Animal, Friend : Pony>
+// taking into account conformance availability.
+
+// CHECK-NEXT: Generic signature: <Friend where Friend : Animal>
 extension AnimalWrapper: Pony where Friend: Pony { }
-// expected-warning@-1{{redundant conformance constraint 'Animal' : 'Pony'}}

--- a/test/Generics/superclass_requirement_and_objc_existential.swift
+++ b/test/Generics/superclass_requirement_and_objc_existential.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-objc-attr-requires-foundation-module -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -disable-objc-attr-requires-foundation-module
 // RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures -disable-objc-attr-requires-foundation-module 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
@@ -17,7 +17,6 @@ protocol Q {
 // CHECK-LABEL: .f1@
 // CHECK-NEXT: Generic signature: <T where T : Q, T.[Q]A == any C & P1>
 func f1<T : Q>(_: T) where T.A : C, T.A == any (C & P1) {}
-// expected-warning@-1 {{redundant superclass constraint 'T.A' : 'C'}}
 
 /// These are not allowed.
 

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
 
 // REQUIRES: noncopyable_generics
 
@@ -25,21 +25,17 @@ func blah<T>(_ t: borrowing T) where T: ~Copyable,
 func foo<T: ~Copyable>(x: borrowing T) {}
 
 struct Buurap<T: ~Copyable> where T: ~Copyable {}
-// expected-warning@-1 {{redundant constraint 'T' : '~Copyable'}}
 
 struct ExtraNoncopyStruct: ~Copyable, ~Copyable {}
 struct ExtraNoncopyEnum: ~Copyable, ~Copyable {}
 
 protocol ExtraNoncopyProto: ~Copyable, ~Copyable {}
-// expected-warning@-1 {{redundant constraint 'Self' : '~Copyable'}}
 
 protocol Foo: ~Copyable
          where Self: ~Copyable {
-         // expected-warning@-1 {{redundant constraint 'Self' : '~Copyable'}}
 
     associatedtype Touch : ~Copyable,
                            ~Copyable
-    // expected-warning@-1 {{redundant constraint 'Self.Touch' : '~Copyable'}}
 
     func test<T>(_ t: T) where T: ~Self  // expected-error {{type 'Self' is not invertible}}
 }

--- a/test/decl/ext/extensions.swift
+++ b/test/decl/ext/extensions.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 extension extension_for_invalid_type_1 { // expected-error {{cannot find type 'extension_for_invalid_type_1' in scope}}
   func f() { }
@@ -138,7 +139,9 @@ class JustAClass: DoesNotImposeClassReq_1 {
   var property: String = ""
 }
 
-extension DoesNotImposeClassReq_1 where Self: JustAClass { // expected-warning{{redundant conformance constraint 'JustAClass' : 'DoesNotImposeClassReq_1'}}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=DoesNotImposeClassReq_1
+// CHECK-NEXT: Generic signature: <Self where Self : JustAClass>
+extension DoesNotImposeClassReq_1 where Self: JustAClass {
   var wrappingProperty1: String {
     get { return property }
     set { property = newValue } // Okay
@@ -191,6 +194,8 @@ protocol DoesNotImposeClassReq_2 {
   var property: String { get set }
 }
 
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=DoesNotImposeClassReq_2
+// CHECK-NEXT: Generic signature: <Self where Self : AnyObject, Self : DoesNotImposeClassReq_2>
 extension DoesNotImposeClassReq_2 where Self : AnyObject {
   var wrappingProperty1: String {
     get { property }
@@ -239,7 +244,9 @@ class JustAClass1: DoesNotImposeClassReq_3 {
   var someProperty = 0
 }
 
-extension DoesNotImposeClassReq_3 where Self: JustAClass1 { // expected-warning {{redundant conformance constraint 'JustAClass1' : 'DoesNotImposeClassReq_3'}}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=DoesNotImposeClassReq_3
+// CHECK-NEXT: Generic signature: <Self where Self : JustAClass1>
+extension DoesNotImposeClassReq_3 where Self: JustAClass1 {
   var anotherProperty1: Int {
     get { return someProperty }
     set { someProperty = newValue } // Okay
@@ -263,7 +270,9 @@ class JustAClass2: ImposeClassReq1 {
   var someProperty = 0
 }
 
-extension ImposeClassReq1 where Self: AnyObject { // expected-warning {{redundant constraint 'Self' : 'AnyObject'}}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=ImposeClassReq1
+// CHECK-NEXT: Generic signature: <Self where Self : ImposeClassReq1>
+extension ImposeClassReq1 where Self: AnyObject {
   var wrappingProperty1: Int {
     get { return someProperty }
     set { someProperty = newValue }

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 protocol P1 { associatedtype AssocType }
 protocol P2 : P1 { }
@@ -148,7 +148,6 @@ extension GenericClass : P3 where T : P3 { }
 
 extension GenericClass where Self : P3 { }
 // expected-error@-1{{covariant 'Self' or 'Self?' can only appear as the type of a property, subscript or method result; did you mean 'GenericClass'?}} {{30-34=GenericClass}}
-// expected-warning@-2{{redundant conformance constraint 'GenericClass<T>' : 'P3'}}
 
 protocol P4 {
   associatedtype T

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 // ----------------------------------------------------------------------------
 // Using protocol requirements from inside protocol extensions
@@ -181,11 +181,11 @@ extension S1 {
 // ----------------------------------------------------------------------------
 
 protocol FooProtocol {}
-extension FooProtocol where Self: FooProtocol {} // expected-warning {{redundant conformance constraint 'Self' : 'FooProtocol'}}
+extension FooProtocol where Self: FooProtocol {}
 
 protocol AnotherFooProtocol {}
 protocol BazProtocol {}
-extension AnotherFooProtocol where Self: BazProtocol, Self: AnotherFooProtocol {} // expected-warning {{redundant conformance constraint 'Self' : 'AnotherFooProtocol'}}
+extension AnotherFooProtocol where Self: BazProtocol, Self: AnotherFooProtocol {}
 
 protocol AnotherBazProtocol {
   associatedtype BazValue

--- a/test/decl/protocol/protocol_with_superclass.swift
+++ b/test/decl/protocol/protocol_with_superclass.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 // Protocols with superclass-constrained Self.
 
@@ -26,7 +26,6 @@ func duplicateOverload<T : ProtoRefinesClass>(_: T) {}
 
 func duplicateOverload<T : ProtoRefinesClass & Generic<Int>>(_: T) {}
 // expected-error@-1 {{invalid redeclaration of 'duplicateOverload'}}
-// expected-warning@-2 {{redundant superclass constraint 'T' : 'Generic<Int>'}}
 
 extension ProtoRefinesClass {
   func extensionMethodUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
@@ -321,10 +320,8 @@ class FirstConformer : FirstClass, SecondProtocol {}
 class SecondConformer : SecondClass, SecondProtocol {}
 
 // Duplicate superclass
-// FIXME: Duplicate diagnostics
 protocol DuplicateSuper : Concrete, Concrete {}
-// expected-warning@-1 {{redundant superclass constraint 'Self' : 'Concrete'}}
-// expected-error@-2 {{duplicate inheritance from 'Concrete'}}
+// expected-error@-1 {{duplicate inheritance from 'Concrete'}}
 
 // Ambiguous name lookup situation
 protocol Amb : Concrete {}

--- a/test/decl/protocol/protocol_with_superclass_where_clause.swift
+++ b/test/decl/protocol/protocol_with_superclass_where_clause.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 // Protocols with superclass-constrained Self.
 
@@ -27,7 +27,6 @@ func duplicateOverload<T : ProtoRefinesClass>(_: T) {}
 
 func duplicateOverload<T : ProtoRefinesClass & Generic<Int>>(_: T) {}
 // expected-error@-1 {{invalid redeclaration of 'duplicateOverload'}}
-// expected-warning@-2 {{redundant superclass constraint 'T' : 'Generic<Int>'}}
 
 extension ProtoRefinesClass {
   func extensionMethodUsesClassTypes(_ x: ConcreteAlias, _ y: GenericAlias) {
@@ -324,9 +323,7 @@ class SecondConformer : SecondClass, SecondProtocol {}
 // Duplicate superclass
 // FIXME: Should be an error here too
 protocol DuplicateSuper1 : Concrete where Self : Concrete {}
-// expected-warning@-1 {{redundant superclass constraint 'Self' : 'Concrete'}}
 protocol DuplicateSuper2 where Self : Concrete, Self : Concrete {}
-// expected-warning@-1 {{redundant superclass constraint 'Self' : 'Concrete'}}
 
 // Ambiguous name lookup situation
 protocol Amb where Self : Concrete {}

--- a/test/decl/protocol/recursive_requirement.swift
+++ b/test/decl/protocol/recursive_requirement.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
+// RUN: not %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // -----
 
@@ -52,8 +53,9 @@ protocol P3 {
 
 protocol P4 : P3 {}
 
-protocol DeclaredP : P3, // expected-warning{{redundant conformance constraint 'Self' : 'P3'}}
-P4 {}
+// CHECK-LABEL: .DeclaredP@
+// CHECK-NEXT: Requirement signature: <Self where Self : P4>
+protocol DeclaredP : P3, P4 {}
 
 struct Y3 : DeclaredP {
 }
@@ -76,8 +78,10 @@ protocol Gamma {
   associatedtype Delta: Alpha
 }
 
+// CHECK-LABEL: .Epsilon@
+// CHECK-NEXT: Generic signature: <T, U where T : Alpha, T == U.[Gamma]Delta, U == T.[Alpha]Beta>
 struct Epsilon<T: Alpha,
-               U: Gamma> // expected-warning{{redundant conformance constraint 'U' : 'Gamma'}}
+               U: Gamma>
   where T.Beta == U,
         U.Delta == T {}
 

--- a/test/decl/protocol/req/associated_type_ambiguity.swift
+++ b/test/decl/protocol/req/associated_type_ambiguity.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
 
 protocol P1 {
@@ -9,18 +9,16 @@ protocol P2 {
   associatedtype T
 }
 
-// Note: the warnings should probably be emitted.
-
 // CHECK: ExtensionDecl line={{.*}} base=P1
 // CHECK-NEXT: Generic signature: <Self where Self : P1, Self : P2, Self.[P2]T == Int>
-extension P1 where Self : P2, T == Int { // expected-warning {{redundant same-type constraint 'Self.T' == 'Int'}}
+extension P1 where Self : P2, T == Int {
   func takeT11(_: T) {}
   func takeT12(_: Self.T) {}
 }
 
 // CHECK: ExtensionDecl line={{.*}} base=P1
 // CHECK-NEXT: Generic signature: <Self where Self : P1, Self : P2, Self.[P2]T == Int>
-extension P1 where Self : P2, Self.T == Int { // expected-warning {{redundant same-type constraint 'Self.T' == 'Int'}}
+extension P1 where Self : P2, Self.T == Int {
   func takeT21(_: T) {}
   func takeT22(_: Self.T) {}
 }

--- a/test/decl/protocol/req/class.swift
+++ b/test/decl/protocol/req/class.swift
@@ -1,10 +1,9 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 protocol P1 : class { }
 
 protocol P2 : class, class { } // expected-error{{redundant 'class' requirement}}{{20-27=}}
 
 protocol P3 : P2, class { } // expected-error{{'class' must come first in the requirement list}}{{15-15=class, }}{{17-24=}}
-// expected-warning@-1 {{redundant constraint 'Self' : 'AnyObject'}}
 
 struct X : class { } // expected-error{{'class' constraint can only appear on protocol declarations}}

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 // Tests for typealias inside protocols
 
@@ -146,15 +146,12 @@ protocol P3 {
 // FIXME: Nonsense redundant requirement warnings
 protocol Circular {
   typealias Y = Self.Y // expected-error {{type alias 'Y' references itself}} expected-note {{while resolving type 'Self.Y'}}
-  // expected-warning@-1 {{redundant same-type constraint 'Self.Y' == 'Self.Y'}}
 
   typealias Y2 = Y2 // expected-error {{type alias 'Y2' references itself}} expected-note {{while resolving type 'Y2'}}
-  // expected-warning@-1 {{redundant same-type constraint 'Self.Y2' == 'Self.Y2'}}
 
   typealias Y3 = Y4 // expected-error {{type alias 'Y3' references itself}} expected-note {{while resolving type 'Y4'}}
 
   typealias Y4 = Y3 // expected-note {{through reference here}} expected-note {{while resolving type 'Y3'}}
-  // expected-warning@-1 {{redundant same-type constraint 'Self.Y4' == 'Self.Y3'}}
 }
 
 // Qualified and unqualified references to protocol typealiases from concrete type
@@ -285,7 +282,7 @@ protocol P10 {
   typealias U = Float
 }
 
-extension P10 where T == Int { } // expected-warning{{redundant same-type constraint 'Self.T' == 'Int'}}
+extension P10 where T == Int { }
 
 extension P10 where A == X<T> { }
 
@@ -294,7 +291,6 @@ extension P10 where A == X<U> { }
 extension P10 where A == X<Self.U> { }
 
 extension P10 where V == Int { } // expected-warning {{'V' is deprecated: just use Int, silly}}
-// expected-warning@-1{{redundant same-type constraint 'Self.V' == 'Int'}}
 
 // rdar://problem/36003312
 protocol P11 {

--- a/test/type/implicit_some/explicit_existential.swift
+++ b/test/type/implicit_some/explicit_existential.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-redundant-requirements  -enable-experimental-feature ImplicitSome
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature ImplicitSome
 
 // REQUIRES: asserts
 

--- a/test/type/implicit_some/opaque_parameters.swift
+++ b/test/type/implicit_some/opaque_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-redundant-requirements  -enable-experimental-feature ImplicitSome
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature ImplicitSome
 
 // REQUIRES: asserts
 

--- a/test/type/implicit_some/opaque_return.swift
+++ b/test/type/implicit_some/opaque_return.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-redundant-requirements  -enable-experimental-feature ImplicitSome
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature ImplicitSome
 
 // REQUIRES: asserts
 

--- a/test/type/opaque_parameters.swift
+++ b/test/type/opaque_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
 
 protocol P { }
 
@@ -21,7 +21,7 @@ extension Array: Q where Element: P, Element: Equatable {
   func takesA(_: Element) {}
 }
 
-extension Set: Q where Element: P, Element: Equatable { // expected-warning {{redundant conformance constraint 'Element' : 'Equatable'}}
+extension Set: Q where Element: P, Element: Equatable {
   func f() -> Element {
     return first!
   }

--- a/validation-test/compiler_crashers_2_fixed/0145-issue-49645.swift
+++ b/validation-test/compiler_crashers_2_fixed/0145-issue-49645.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 // RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -o -
 
@@ -14,7 +14,7 @@ protocol P2 {
 // CHECK-NEXT: Requirement signature: <Self where Self : P2, Self.[P2]Assoc == ConformsToP1>
 protocol P3 : P2 { }
 
-struct S0<M: P3> where M.Assoc: P1 { } // expected-warning{{redundant conformance constraint 'M.Assoc' : 'P1'}}
+struct S0<M: P3> where M.Assoc: P1 { }
 
 struct ConformsToP1: P1 { }
 

--- a/validation-test/compiler_crashers_2_fixed/0162-issue-50552.swift
+++ b/validation-test/compiler_crashers_2_fixed/0162-issue-50552.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift
 
 // https://github.com/apple/swift/issues/50552
 
 protocol P {}
 struct A<C> {}
-extension A: P where A: P {} // expected-warning {{redundant conformance constraint 'A<C>' : 'P'}}
+extension A: P where A: P {}

--- a/validation-test/compiler_crashers_2_fixed/0164-issue-50522.swift
+++ b/validation-test/compiler_crashers_2_fixed/0164-issue-50522.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -warn-redundant-requirements
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
 
 // https://github.com/apple/swift/issues/50522
 
@@ -10,4 +10,7 @@ struct Var<N> {}
 extension Var : P2 where N : P1 { }
 
 protocol P3 {}
-extension Var : P3 where Self : P2 {} // expected-warning {{redundant conformance constraint 'Var<N>' : 'P2'}}
+
+// CHECK: ExtensionDecl line={{.*}} base=Var
+// CHECK: Generic signature: <N where N : P1>
+extension Var : P3 where Self : P2 {}


### PR DESCRIPTION
The back story:
- In the old days, the GenericSignatureBuilder would diagnose requirements it could prove redundant. This was partially motivated by Swift 3 ABI stability; we wanted to get the minimized generic signatures in the stdlib right.
- The Requirement Machine replaced the GenericSignatureBuilder, and started producing more diagnostics because its analysis was more accurate.
- People complained about all the new warnings.
- We made the warnings conditional behind the `-warn-redundant-requirements` frontend flag.
- Nobody has complained about the absence of these warnings since.
- Non-copyable generics are coming, and the new code emits bogus `redundant 'Foo : Copyable'` warnings.
- We can't be bothered fixing the redundancy diagnostics.

This PR updates a few remaining tests that used them to use `-debug-generic-signatures` instead, and FileCheck the exact generic signature, before removing the new flag entirely, and all associated bookkeeping in the Requirement Machine.