### PR TITLE
Sema: Fix problems with checkTypeWitness() 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2905,11 +2905,6 @@ NOTE(default_associated_type_unsatisfied_superclass,none,
      "default type %0 for associated type %1 (from protocol %2) "
      "does not inherit from %3",
      (Type, const AssociatedTypeDecl *, Type, Type))
-NOTE(default_associated_type_tuple,none,
-     "default type %0 for associated type %1 (from protocol %2) "
-     "is unsuitable for tuple conformance; the associated type requirement "
-     "must be fulfilled by a type alias with underlying type %3",
-     (Type, const AssociatedTypeDecl *, Type, Type))
 ERROR(associated_type_access,none,
       "associated type in "
       "%select{a private|a fileprivate|an internal|a package|a public|%error}0 protocol "
@@ -2944,11 +2939,6 @@ NOTE(associated_type_deduction_unsatisfied_conformance,none,
 NOTE(associated_type_deduction_unsatisfied_superclass,none,
      "candidate would match and infer %0 = %1 if %1 "
      "inherited from %2",
-     (const AssociatedTypeDecl *, Type, Type))
-NOTE(associated_type_deduction_tuple,none,
-     "cannot infer %0 = %1 in tuple conformance because "
-     "the associated type requirement must be fulfilled by a type alias with "
-     "underlying type %2",
      (const AssociatedTypeDecl *, Type, Type))
 NOTE(associated_type_witness_conform_impossible,none,
      "candidate can not infer %0 = %1 because %1 "

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -87,11 +87,7 @@ public:
 
     /// Type witness does not satisfy a layout requirement on
     /// the associated type.
-    Layout,
-
-    /// Type witness of a tuple conformance does not have the form
-    /// (repeat (each Element).A).
-    Tuple
+    Layout
   } kind;
 
 private:
@@ -125,24 +121,35 @@ public:
     return CheckTypeWitnessResult(Layout, reqt);
   }
 
-  static CheckTypeWitnessResult forTuple(Type reqt) {
-    return CheckTypeWitnessResult(Tuple, reqt);
-  }
-
   Kind getKind() const { return kind; }
   Type getRequirement() const { return reqt; }
 
   explicit operator bool() const { return kind != Success; }
 };
 
+/// Checks a potential witness for an associated type A against the "local"
+/// requirements of the type parameter Self.[P]A. We call this to check
+/// type witnesses found by name lookup, as well as candidate witnesses during
+/// inference.
+///
+/// This does not completely check the witness; we check the entire requirement
+/// signature at the end. However, rejecting witnesses that are definitely
+/// invalid here can cut down the search space.
 static CheckTypeWitnessResult
 checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
                  const NormalProtocolConformance *Conf,
                  SubstOptions options) {
+  assert(!type->hasTypeParameter());
+
   auto &ctx = assocType->getASTContext();
 
   if (type->hasError())
     return CheckTypeWitnessResult::forError();
+
+  // If the type witness is equivalent to some other unresolved witness,
+  // we cannot check anything, so accept the witness.
+  if (type->is<DependentMemberType>())
+    return CheckTypeWitnessResult::forSuccess();
 
   const auto proto = Conf->getProtocol();
   const auto dc = Conf->getDeclContext();
@@ -167,53 +174,43 @@ checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
   const auto depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
                                               assocType);
 
-  Type contextType = type->hasTypeParameter() ? dc->mapTypeIntoContext(type)
-                                              : type;
-
   if (auto superclass = sig->getSuperclassBound(depTy)) {
-    if (superclass->hasTypeParameter()) {
-      // Replace type parameters with other known or tentative type witnesses.
-      superclass = superclass.subst(
-          [&](SubstitutableType *type) {
-            if (type->isEqual(proto->getSelfInterfaceType()))
-              return Conf->getType();
+    // We only check that the type's superclass declaration is correct.
+    // If the superclass bound is generic, we may not have resolved all of
+    // the type witnesses that appear in generic arguments yet, and doing so
+    // here might run into a request cycle.
+    auto superclassDecl = superclass->getClassOrBoundGenericClass();
+    assert(superclassDecl);
 
-            return Type();
-          },
-          LookUpConformanceInModule(dc->getParentModule()), options);
-
-      if (superclass->hasTypeParameter())
-        superclass = dc->mapTypeIntoContext(superclass);
+    // Fish a class declaration out of the type witness.
+    auto classDecl = type->getClassOrBoundGenericClass();
+    if (!classDecl) {
+      if (auto archetype = type->getAs<ArchetypeType>()) {
+        if (auto superclassType = archetype->getSuperclass())
+          classDecl = superclassType->getClassOrBoundGenericClass();
+      }
     }
-    if (!superclass->isExactSuperclassOf(contextType))
+
+    if (!classDecl || !superclassDecl->isSuperclassOf(classDecl))
       return CheckTypeWitnessResult::forSuperclass(superclass);
   }
 
   auto *module = dc->getParentModule();
 
-  // Check protocol conformances.
+  // Check protocol conformances. We don't check conditional requirements here.
   for (const auto reqProto : sig->getRequiredProtocols(depTy)) {
     if (module->lookupConformance(
-            contextType, reqProto,
+            type, reqProto,
             /*allowMissing=*/reqProto->isSpecificProtocol(
                 KnownProtocolKind::Sendable))
             .isInvalid())
       return CheckTypeWitnessResult::forConformance(reqProto);
   }
 
+  // We can completely check an AnyObject layout constraint.
   if (sig->requiresClass(depTy) &&
-      !contextType->satisfiesClassConstraint()) {
-    return CheckTypeWitnessResult::forLayout(
-        module->getASTContext().getAnyObjectType());
-  }
-
-  // Tuple conformances can only witness associated types by projecting them
-  // element-wise.
-  if (isa<BuiltinTupleDecl>(dc->getSelfNominalTypeDecl())) {
-    auto expectedTy = getTupleConformanceTypeWitness(dc, assocType);
-    if (!expectedTy->isEqual(type)) {
-      return CheckTypeWitnessResult::forTuple(expectedTy);
-    }
+      !type->satisfiesClassConstraint()) {
+    return CheckTypeWitnessResult::forLayout(ctx.getAnyObjectType());
   }
 
   // Success!
@@ -222,10 +219,21 @@ checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
 
 }
 
+static bool containsConcreteDependentMemberType(Type ty) {
+  return ty.findIf([](Type t) -> bool {
+    if (auto *dmt = t->getAs<DependentMemberType>())
+      return !dmt->isTypeParameter();
+
+    return false;
+  });
+}
+
 static void recordTypeWitness(NormalProtocolConformance *conformance,
                               AssociatedTypeDecl *assocType,
                               Type type,
                               TypeDecl *typeDecl) {
+  assert(!containsConcreteDependentMemberType(type));
+
   // If we already recoded this type witness, there's nothing to do.
   if (conformance->hasTypeWitness(assocType)) {
     assert(conformance->getTypeWitnessUncached(assocType)
@@ -473,9 +481,12 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
     if (!viableTypes.insert(memberType->getCanonicalType()).second)
       continue;
 
+    auto memberTypeInContext = dc->mapTypeIntoContext(memberType);
+
     // Check this type against the protocol requirements.
     if (auto checkResult =
-            checkTypeWitness(memberType, assocType, conformance, llvm::None)) {
+            checkTypeWitness(memberTypeInContext, assocType,
+                             conformance, llvm::None)) {
       nonViable.push_back({typeDecl, checkResult});
     } else {
       viable.push_back({typeDecl, memberType, nullptr});
@@ -548,14 +559,6 @@ static ResolveWitnessResult resolveTypeWitnessViaLookup(
           diags.diagnose(
              candidate.first,
              diag::protocol_type_witness_unsatisfied_superclass,
-             candidate.first->getDeclaredInterfaceType(),
-             candidate.second.getRequirement());
-          break;
-
-        case CheckTypeWitnessResult::Tuple:
-          diags.diagnose(
-             candidate.first,
-             diag::protocol_type_witness_tuple,
              candidate.first->getDeclaredInterfaceType(),
              candidate.second.getRequirement());
           break;
@@ -1353,7 +1356,6 @@ enum class InferenceCandidateKind {
 
 static InferenceCandidateKind checkInferenceCandidate(
     std::pair<AssociatedTypeDecl *, Type> *result,
-    bool *canInferFromOtherAssociatedType,
     NormalProtocolConformance *conformance,
     ValueDecl *witness) {
   auto isTautological = [&](Type t) -> bool {
@@ -1418,7 +1420,6 @@ static InferenceCandidateKind checkInferenceCandidate(
                   return otherDMT;
                 return t;
               });
-              *canInferFromOtherAssociatedType = true;
               LLVM_DEBUG(llvm::dbgs() << "++ we can same-type to:\n";
                          result->second->dump(llvm::dbgs()));
               return InferenceCandidateKind::Good;
@@ -1543,11 +1544,7 @@ AssociatedTypeInference::getPotentialTypeWitnessesFromRequirement(
       // Filter out circular possibilities, e.g. that
       // AssocType == S.AssocType or
       // AssocType == Foo<S.AssocType>.
-      bool canInferFromOtherAssociatedType = false;
-
-      switch (checkInferenceCandidate(&result,
-                                      &canInferFromOtherAssociatedType,
-                                      conformance, witness)) {
+      switch (checkInferenceCandidate(&result, conformance, witness)) {
       case InferenceCandidateKind::Good:
         // Continued below.
         break;
@@ -1588,23 +1585,19 @@ AssociatedTypeInference::getPotentialTypeWitnessesFromRequirement(
         }
       }
 
-      // If we same-typed to another unresolved associated type, we won't
-      // be able to check conformances yet.
-      if (!canInferFromOtherAssociatedType) {
-        // Check that the type witness meets the
-        // requirements on the associated type.
-        if (auto failed =
-                checkTypeWitness(result.second, result.first, conformance,
-                                 llvm::None)) {
-          witnessResult.NonViable.push_back(
-                          std::make_tuple(result.first,result.second,failed));
-          LLVM_DEBUG(llvm::dbgs() << "-- doesn't fulfill requirements\n");
+      // Check that the type witness meets the requirements on the
+      // associated type.
+      if (auto failed =
+              checkTypeWitness(result.second, result.first, conformance,
+                               llvm::None)) {
+        witnessResult.NonViable.push_back(
+                        std::make_tuple(result.first,result.second,failed));
+        LLVM_DEBUG(llvm::dbgs() << "-- doesn't fulfill requirements\n");
 
-          // By adding an element to NonViable we ensure the witness is rejected
-          // below, so we continue to consider other bindings to generate better
-          // diagnostics later.
-          REJECT;
-        }
+        // By adding an element to NonViable we ensure the witness is rejected
+        // below, so we continue to consider other bindings to generate better
+        // diagnostics later.
+        REJECT;
       }
 
       LLVM_DEBUG(llvm::dbgs() << "++ seems legit\n");
@@ -2286,6 +2279,8 @@ AssociatedTypeInference::computeDerivedTypeWitness(
   if (!result.first)
     return std::make_pair(Type(), nullptr);
 
+  assert(!containsConcreteDependentMemberType(result.first));
+
   // Make sure that the derived type satisfies requirements.
   if (checkTypeWitness(result.first, assocType, conformance, llvm::None)) {
     /// FIXME: Diagnose based on this.
@@ -2647,15 +2642,6 @@ bool AssociatedTypeInference::checkConstrainedExtension(ExtensionDecl *ext) {
     return true;
   }
   llvm_unreachable("unhandled result");
-}
-
-static bool containsConcreteDependentMemberType(Type ty) {
-  return ty.findIf([](Type t) -> bool {
-    if (auto *dmt = t->getAs<DependentMemberType>())
-      return !dmt->isTypeParameter();
-
-    return false;
-  });
 }
 
 AssociatedTypeDecl *AssociatedTypeInference::inferAbstractTypeWitnesses(
@@ -3560,16 +3546,6 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
              proto->getDeclaredInterfaceType(),
              failedDefaultedResult.getRequirement());
           break;
-
-        case CheckTypeWitnessResult::Tuple:
-          diags.diagnose(
-             failedDefaultedAssocType,
-             diag::default_associated_type_tuple,
-             failedDefaultedWitness,
-             failedDefaultedAssocType,
-             proto->getDeclaredInterfaceType(),
-             failedDefaultedResult.getRequirement());
-          break;
         }
       });
 
@@ -3672,14 +3648,6 @@ bool AssociatedTypeInference::diagnoseNoSolutions(
             diags.diagnose(
                failed.Witness,
                diag::associated_type_deduction_unsatisfied_superclass,
-               assocType, failed.TypeWitness,
-               failed.Result.getRequirement());
-            break;
-
-          case CheckTypeWitnessResult::Tuple:
-            diags.diagnose(
-               failed.Witness,
-               diag::associated_type_deduction_tuple,
                assocType, failed.TypeWitness,
                failed.Result.getRequirement());
             break;

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -218,9 +218,6 @@ void diagnoseConformanceFailure(Type T,
                                 DeclContext *DC,
                                 SourceLoc ComplainLoc);
 
-Type getTupleConformanceTypeWitness(DeclContext *dc,
-                                    AssociatedTypeDecl *assocType);
-
 /// Find an associated type declaration that provides a default definition.
 AssociatedTypeDecl *findDefaultedAssociatedType(
     DeclContext *dc, NominalTypeDecl *adoptee,

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -136,27 +136,25 @@ struct S3b: P3b {
   typealias A = Never
 }
 
-// FIXME: resolveTypeWitnessViaLookup must not happen independently in the
-// general case.
 protocol P4 {
-  associatedtype A: GenClass<B> // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype A: GenClass<B>
   associatedtype B
 }
-struct S4: P4 { // expected-error {{type 'S4' does not conform to protocol 'P4'}}
-  typealias A = GenClass<B> // expected-note {{possibly intended match 'S4.A' (aka 'GenClass<Never>') does not inherit from 'GenClass<S4.B>'}}
+struct S4: P4 {
+  typealias A = GenClass<B>
   typealias B = Never
 }
 
-// FIXME: Associated type inference via value witnesses should consider
-// tentative witnesses when checking a candidate.
+// Associated type inference via value witnesses should consider tentative
+// witnesses when checking a candidate.
 protocol P5 {
   associatedtype X = Never
 
-  associatedtype A: GenClass<X> // expected-note {{unable to infer associated type 'A' for protocol 'P5'}}
+  associatedtype A: GenClass<X>
   func foo(arg: A)
 }
-struct S5: P5 { // expected-error {{type 'S5' does not conform to protocol 'P5'}}
-  func foo(arg: GenClass<Never>) {} // expected-note {{candidate would match and infer 'A' = 'GenClass<Never>' if 'GenClass<Never>' inherited from 'GenClass<S5.X>'}}
+struct S5: P5 {
+  func foo(arg: GenClass<Never>) {}
 }
 
 // Abstract type witnesses.

--- a/test/decl/protocol/req/associated_type_inference_abstract.swift
+++ b/test/decl/protocol/req/associated_type_inference_abstract.swift
@@ -1,0 +1,96 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Q {}
+
+extension Int: Q {}
+
+///
+
+protocol P1 {
+  associatedtype A: Q
+  associatedtype B: Q
+
+  func f(_: A)
+  func g(_: B)
+}
+
+extension P1 {
+  func f(_: B) {}
+  func g(_: A) {}
+}
+
+struct S1a: P1 {
+  func f(_: Int) {}
+}
+
+struct S1b: P1 {
+  func g(_: Int) {}
+}
+
+///
+
+protocol P2 {
+  associatedtype A: Q
+  associatedtype B: Q
+
+  func f(_: A)
+  func g(_: B)
+}
+
+extension P2 where A == B {
+  func f(_: B) {}
+}
+
+struct S2a: P2 {
+  func g(_: Int) {}
+}
+
+extension P2 where A == B {
+  func g(_: A) {}
+}
+
+struct S2b: P2 {
+  func f(_: Int) {}
+}
+
+///
+
+protocol P3 {
+  associatedtype A: Q
+
+  func f(_: A)
+}
+
+extension P3 {
+  func f(_: Self) {}
+}
+
+struct S3: P3, Q {}
+
+///
+
+protocol P4 {
+  associatedtype A: Q
+
+  func f(_: A)
+}
+
+extension P4 where Self == A {
+  func f(_: A) {}
+}
+
+struct S4: P4, Q {}
+
+///
+
+protocol P5 {
+  associatedtype A: Q
+
+  func f(_: A)
+}
+
+extension P5 where Self: Q {
+  func f(_: Self) {}
+}
+
+struct S5: P5, Q {}

--- a/test/decl/protocol/req/associated_type_inference_generic_class.swift
+++ b/test/decl/protocol/req/associated_type_inference_generic_class.swift
@@ -1,0 +1,89 @@
+// RUN: %target-typecheck-verify-swift
+
+class C<T> {}
+
+protocol P {
+  associatedtype A: C<B> // expected-note 2{{protocol requires nested type 'A'; add nested type 'A' for conformance}}
+  associatedtype B // expected-note 2{{protocol requires nested type 'B'; add nested type 'B' for conformance}}
+
+  func f() -> A
+  func g() -> B
+}
+
+class D: C<Int> {}
+
+struct S11: P {
+  typealias A = C<Int>
+  typealias B = Int
+
+  func f() -> C<Int> { fatalError() }
+  func g() -> Int { fatalError() }
+}
+
+struct S12: P {
+  typealias A = D
+  typealias B = Int
+
+  func f() -> D { fatalError() }
+  func g() -> Int { fatalError() }
+}
+
+struct S21: P {
+  typealias A = C<Int>
+
+  func f() -> C<Int> { fatalError() }
+  func g() -> Int { fatalError() }
+}
+
+struct S22: P {
+  typealias A = D
+
+  func f() -> D { fatalError() }
+  func g() -> Int { fatalError() }
+}
+
+struct S31: P {
+  typealias B = Int
+
+  func f() -> C<Int> { fatalError() }
+  func g() -> Int { fatalError() }
+}
+
+struct S32: P {
+  typealias B = Int
+
+  func f() -> D { fatalError() }
+  func g() -> Int { fatalError() }
+}
+
+struct S41: P {
+  func f() -> C<Int> { fatalError() }
+  func g() -> Int { fatalError() }
+}
+
+struct S42: P {
+  func f() -> D { fatalError() }
+  func g() -> Int { fatalError() }
+}
+
+struct SBad1: P { // expected-error {{type 'SBad1' does not conform to protocol 'P'}}
+  func f() -> D { fatalError() }
+  func g() -> String { fatalError() }
+}
+
+struct SBad2: P { // expected-error {{type 'SBad2' does not conform to protocol 'P'}}
+  func f() -> C<Int> { fatalError() }
+  func g() -> String { fatalError() }
+}
+
+protocol Q {
+  associatedtype A: C<Self>
+
+  func f() -> A
+}
+
+extension Q {
+  func f() -> C<Self> { fatalError() }
+}
+
+struct QQ: Q {}

--- a/test/decl/protocol/req/associated_type_tuple.swift
+++ b/test/decl/protocol/req/associated_type_tuple.swift
@@ -11,16 +11,18 @@ protocol P1 {
 extension Tuple: P1 where repeat each T: P1 {} // expected-error {{type '(repeat each T)' does not conform to protocol 'P1'}}
 
 protocol P2 {
-  associatedtype B = Int // expected-note {{default type 'Int' for associated type 'B' (from protocol 'P2') is unsuitable for tuple conformance; the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).B)'}}
+  associatedtype B = Int
 }
 
 extension Tuple: P2 where repeat each T: P2 {} // expected-error {{type '(repeat each T)' does not conform to protocol 'P2'}}
+// expected-note@-1 {{possibly intended match 'Int' is unsuitable for tuple conformance; the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).B)'}}
 
 protocol P3 {
-  associatedtype C // expected-note {{unable to infer associated type 'C' for protocol 'P3'}}
+  associatedtype C
   func f() -> C
 }
 
 extension Tuple: P3 where repeat each T: P3 { // expected-error {{type '(repeat each T)' does not conform to protocol 'P3'}}
-  func f() -> Int {} // expected-note {{cannot infer 'C' = 'Int' in tuple conformance because the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).C)'}}
+  // expected-note@-1 {{possibly intended match 'Int' is unsuitable for tuple conformance; the associated type requirement must be fulfilled by a type alias with underlying type '(repeat (each T).C)'}}
+  func f() -> Int {}
 }

--- a/test/decl/protocol/req/issue-10831.swift
+++ b/test/decl/protocol/req/issue-10831.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift
+
+struct G<T> {}
+  
+protocol P {
+  associatedtype T
+  associatedtype U
+}
+
+protocol Q: P where T == G<U> {}
+
+protocol R: Q where U == Int {}
+
+struct X: R {}

--- a/test/decl/protocol/req/issue-12943.swift
+++ b/test/decl/protocol/req/issue-12943.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Composite<Foo> { }
+
+protocol Chain {
+  associatedtype Next: Chain
+  associatedtype Foo = Composite<Next.Foo>
+}
+
+// expected-error@+3 {{cannot build rewrite system for protocol; rule length limit exceeded}}
+// expected-note@+2 {{failed rewrite rule}}
+// expected-error@+1 {{'Foo' is not a member type of type 'Self.Next'}}
+protocol OtherChain where Foo == Composite<Next.Foo> {
+  associatedtype Next: OtherChain
+  associatedtype Foo
+}

--- a/test/decl/protocol/req/rdar118998138.swift
+++ b/test/decl/protocol/req/rdar118998138.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
-// RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 public protocol FakeCopyable {}
 

--- a/validation-test/compiler_crashers_2_fixed/0163-issue-50566.swift
+++ b/validation-test/compiler_crashers_2_fixed/0163-issue-50566.swift
@@ -8,7 +8,7 @@ protocol P1 {
     associatedtype A // expected-note {{protocol requires nested type 'A'; add nested type 'A' for conformance}}
 }
 extension Foo: P1 where A : P1 {}
-// expected-error@-1 {{extension of generic struct 'Foo' has self-referential generic requirements}}
-// expected-note@-2 {{while resolving type 'A'}}
-// expected-note@-3 2{{through reference here}}
+// expected-error@-1 2{{extension of generic struct 'Foo' has self-referential generic requirements}}
+// expected-note@-2 2{{while resolving type 'A'}}
+// expected-note@-3 4{{through reference here}}
 // expected-error@-4 {{type 'Foo<T>' does not conform to protocol 'P1'}}


### PR DESCRIPTION
This came up while running our existing tests with NoncopyableGenerics turned on, but it's an old issue and closely related to a problem with superclass requirements in protocols as well.

Fixes https://github.com/apple/swift/issues/48770, fixes https://github.com/apple/swift/issues/50561, fixes https://github.com/apple/swift/issues/50779, fixes https://github.com/apple/swift/issues/51772, fixes https://github.com/apple/swift/issues/53012, rdar://42012633, rdar://95729075.