### PR TITLE
Make autdiff more robust in presence of unreachable blocks

### DIFF
--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -143,7 +143,9 @@ void LinearMapInfo::populateBranchingTraceDecl(SILBasicBlock *originalBB,
       decl->setInterfaceType(astCtx.TheRawPointerType);
     } else { // Otherwise the payload is the linear map tuple.
       auto *linearMapStructTy = getLinearMapTupleType(predBB);
-      assert(linearMapStructTy && "must have linear map struct type for predecessor BB");
+      // Do not create entries for unreachable predecessors
+      if (!linearMapStructTy)
+        continue;
       auto canLinearMapStructTy = linearMapStructTy->getCanonicalType();
       decl->setInterfaceType(
           canLinearMapStructTy->hasArchetype()

--- a/test/AutoDiff/compiler_crashers_fixed/issue-71164-unreachable-blocks.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-71164-unreachable-blocks.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+
+// https://github.com/apple/swift/issues/71164
+
+// There are few unreachble blocks created due to mandatory boolean constant
+// propagation
+// Ensure we do not ceeate linear map types for unreachable BB and that they
+// are skipped during VJP and pullback generation
+import _Differentiation
+
+struct A: Differentiable {}
+
+struct B: Differentiable {
+    @differentiable(reverse)
+    func c(b: B) -> A {
+        while true {
+            if true {
+                break
+            }
+        };
+        
+        return A()
+    }
+
+    @differentiable(reverse)
+    func d(b: B) -> A {
+        while true {
+            if true {
+                return c(b : b)
+            }
+            if true {
+                break
+            }
+            if false {
+                return c(b : b)
+            } else {
+                break
+            }
+        };
+        return A()
+    }
+
+}

--- a/test/AutoDiff/compiler_crashers_fixed/issue-71164-unreachable-blocks.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/issue-71164-unreachable-blocks.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
-
+// REQUIRES: swift_in_compiler
 
 // https://github.com/apple/swift/issues/71164
 


### PR DESCRIPTION
Unreachable blocks possess some challenges to autodiff since in reverse pass (pullback generation) we need to execute the function backwards, pushing the values from return BB back to entry block. As a result, unreachable blocks might become reachable from the return BB and this might cause all kind of issues.

This PR aims to make autodiff a bit more robust with respect to unreachable blocks. I tried to find what are the cases where we might hit or miss unreachable blocks and here is the breakdown:

1. When building the linear map types and branch tracing enums we traverse the function in reverse post order traversal. Therefore unreachable blocks are naturally excluded from RPOT and we do not have linear map tuples for them. Ensure that when we are building branch tracing enums we're excluding predecessor BBs without linear map tuples.
2. VJP cloner does BFS from entry block, so it does not see / clone unreachable blocks. We are fine here
3. Pulllback cloner does BFS starting from function return block and therefore might see unreachable blocks. Ensure they are:
   - Skipped for cloning / pullback codegen
   - Since we have not created branch tracing enum entries (due to 1.), ensure we skip them while forming pullback successor blocks

I think this covers all cases. At least I was unable to bring more testcases that fail :)

Fixes #71164 

Complements #71339