### PR TITLE
Remove FindLocalVal

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -442,8 +442,8 @@ public:
                  DynamicLookupInfo dynamicLookupInfo = {}) override;
 };
 
-/// Filters out decls that are not usable based on their source location, eg.
-/// a decl inside its own initializer or a non-type decl before its definition.
+/// Filters out decls that are not usable based on their source location, e.g.
+/// a top-level decl inside its own initializer or shadowed decls.
 class UsableFilteringDeclConsumer final : public VisibleDeclConsumer {
   const SourceManager &SM;
   const DeclContext *DC;
@@ -465,7 +465,7 @@ public:
   }
 
   void foundDecl(ValueDecl *D, DeclVisibilityKind reason,
-                 DynamicLookupInfo dynamicLookupInfo) override;
+                 DynamicLookupInfo dynamicLookupInfo = {}) override;
 };
 
 /// Remove any declarations in the given set that were overridden by
@@ -504,14 +504,11 @@ bool removeShadowedDecls(TinyPtrVector<OperatorDecl *> &decls,
 bool removeShadowedDecls(TinyPtrVector<PrecedenceGroupDecl *> &decls,
                          const DeclContext *dc);
 
-/// Finds decls visible in the given context and feeds them to the given
-/// VisibleDeclConsumer.  If the current DeclContext is nested in a function,
-/// the SourceLoc is used to determine which declarations in that function
-/// are visible.
-void lookupVisibleDecls(VisibleDeclConsumer &Consumer,
-                        const DeclContext *DC,
-                        bool IncludeTopLevel,
-                        SourceLoc Loc = SourceLoc());
+/// Finds decls visible in the given context at the given location and feeds
+/// them to the given VisibleDeclConsumer. The \p Loc must be valid, and \p DC
+/// must be in a SourceFile.
+void lookupVisibleDecls(VisibleDeclConsumer &Consumer, SourceLoc Loc,
+                        const DeclContext *DC, bool IncludeTopLevel);
 
 /// Finds decls visible as members of the given type and feeds them to the given
 /// VisibleDeclConsumer.
@@ -630,70 +627,6 @@ SelfBounds getSelfBoundsFromGenericSignature(const ExtensionDecl *extDecl);
 
 namespace namelookup {
 
-/// Searches through statements and patterns for local variable declarations.
-class FindLocalVal : public StmtVisitor<FindLocalVal> {
-  friend class ASTVisitor<FindLocalVal>;
-
-  const SourceManager &SM;
-  SourceLoc Loc;
-  VisibleDeclConsumer &Consumer;
-
-public:
-  FindLocalVal(const SourceManager &SM, SourceLoc Loc,
-               VisibleDeclConsumer &Consumer)
-      : SM(SM), Loc(Loc), Consumer(Consumer) {}
-
-  void checkValueDecl(ValueDecl *D, DeclVisibilityKind Reason);
-
-  void checkPattern(const Pattern *Pat, DeclVisibilityKind Reason);
-  
-  void checkParameterList(const ParameterList *params);
-
-  void checkGenericParams(GenericParamList *Params);
-
-  void checkSourceFile(const SourceFile &SF);
-
-private:
-  bool isReferencePointInRange(SourceRange R) {
-    return SM.rangeContainsTokenLoc(R, Loc);
-  }
-
-  void visitBreakStmt(BreakStmt *) {}
-  void visitContinueStmt(ContinueStmt *) {}
-  void visitFallthroughStmt(FallthroughStmt *) {}
-  void visitFailStmt(FailStmt *) {}
-  void visitReturnStmt(ReturnStmt *) {}
-  void visitYieldStmt(YieldStmt *) {}
-  void visitThenStmt(ThenStmt *) {}
-  void visitThrowStmt(ThrowStmt *) {}
-  void visitDiscardStmt(DiscardStmt *) {}
-  void visitPoundAssertStmt(PoundAssertStmt *) {}
-  void visitDeferStmt(DeferStmt *DS) {
-    // Nothing in the defer is visible.
-  }
-
-  void checkStmtCondition(const StmtCondition &Cond);
-
-  void visitIfStmt(IfStmt *S);
-  void visitGuardStmt(GuardStmt *S);
-
-  void visitWhileStmt(WhileStmt *S);
-  void visitRepeatWhileStmt(RepeatWhileStmt *S);
-  void visitDoStmt(DoStmt *S);
-
-  void visitForEachStmt(ForEachStmt *S);
-
-  void visitBraceStmt(BraceStmt *S, bool isTopLevelCode = false);
-  
-  void visitSwitchStmt(SwitchStmt *S);
-
-  void visitCaseStmt(CaseStmt *S);
-
-  void visitDoCatchStmt(DoCatchStmt *S);
-  
-};
-
-
 /// The bridge between the legacy UnqualifiedLookupFactory and the new ASTScope
 /// lookup system
 class AbstractASTScopeDeclConsumer {
@@ -737,9 +670,9 @@ public:
   }
 
 #ifndef NDEBUG
-  virtual void startingNextLookupStep() = 0;
-  virtual void finishingLookup(std::string) const = 0;
-  virtual bool isTargetLookup() const = 0;
+  virtual void startingNextLookupStep() {}
+  virtual void finishingLookup(std::string) const {}
+  virtual bool isTargetLookup() const { return false; }
 #endif
 };
   

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -261,7 +261,7 @@ inline UnqualifiedLookupOptions operator|(UnqualifiedLookupFlags flag1,
 /// Describes the reason why a certain declaration is visible.
 enum class DeclVisibilityKind {
   /// Declaration is a local variable or type.
-  LocalVariable,
+  LocalDecl,
 
   /// Declaration is a function parameter.
   FunctionParameter,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -137,61 +137,21 @@ void AccessFilteringDeclConsumer::foundDecl(
   ChainedConsumer.foundDecl(D, reason, dynamicLookupInfo);
 }
 
-void UsableFilteringDeclConsumer::foundDecl(ValueDecl *D,
-    DeclVisibilityKind reason, DynamicLookupInfo dynamicLookupInfo) {
-  // Skip when Loc is within the decl's own initializer
-  if (auto *VD = dyn_cast<VarDecl>(D)) {
-    Expr *init = VD->getParentInitializer();
-    if (auto *PD = dyn_cast<ParamDecl>(D)) {
-      init = PD->getStructuralDefaultExpr();
-    }
-
-    // Only check if the VarDecl has the same (or parent) context to avoid
-    // grabbing the end location for every decl with an initializer
-    if (init != nullptr) {
-      auto *varContext = VD->getDeclContext();
-      if (DC == varContext || DC->isChildContextOf(varContext)) {
-        auto initRange = Lexer::getCharSourceRangeFromSourceRange(
-            SM, init->getSourceRange());
-        if (initRange.isValid() && initRange.contains(Loc))
-          return;
-      }
-    }
-  }
-
+void UsableFilteringDeclConsumer::foundDecl(
+    ValueDecl *D, DeclVisibilityKind reason,
+    DynamicLookupInfo dynamicLookupInfo) {
   switch (reason) {
   case DeclVisibilityKind::LocalDecl:
   case DeclVisibilityKind::FunctionParameter:
-    // Skip if Loc is before the found decl if the decl is a var/let decl.
-    // Type and func decls can be referenced before its declaration, or from
-    // within nested type decls.
-    if (isa<VarDecl>(D)) {
-      if (reason == DeclVisibilityKind::LocalDecl) {
-        // Workaround for fast-completion. A loc in the current context might be
-        // in a loc
-        auto tmpLoc = Loc;
-        if (D->getDeclContext() != DC) {
-          if (auto *contextD = DC->getAsDecl())
-            tmpLoc = contextD->getStartLoc();
-        }
-        auto declLoc = DC->getParentModule()->getOriginalLocation(D->getLoc()).second;
-        if (!SM.isBeforeInBuffer(declLoc, tmpLoc))
-          return;
-      }
-
-      // A type context cannot close over values defined in outer type contexts.
-      if (D->getDeclContext()->getInnermostTypeContext() != typeContext)
-        return;
+    // A type context cannot close over variables defined in outer type
+    // contexts.
+    if (isa<VarDecl>(D) &&
+        D->getDeclContext()->getInnermostTypeContext() != typeContext) {
+      return;
     }
     break;
 
   case DeclVisibilityKind::MemberOfOutsideNominal:
-    // A type context cannot close over members of outer type contexts, except
-    // for type decls.
-    if (!isa<TypeDecl>(D) && !D->isStatic())
-      return;
-    break;
-
   case DeclVisibilityKind::MemberOfCurrentNominal:
   case DeclVisibilityKind::MemberOfSuper:
   case DeclVisibilityKind::MemberOfProtocolConformedToByCurrentNominal:
@@ -204,10 +164,25 @@ void UsableFilteringDeclConsumer::foundDecl(ValueDecl *D,
     // Generic params are type decls and are always usable from nested context.
     break;
 
-  case DeclVisibilityKind::VisibleAtTopLevel:
-    // The rest of the file is currently skipped, so no need to check
-    // decl location for VisibleAtTopLevel.
+  case DeclVisibilityKind::VisibleAtTopLevel: {
+    // Skip when Loc is within the decl's own initializer. We only need to do
+    // this for top-level decls since local decls are already excluded from
+    // their own initializer by virtue of the ASTScope lookup.
+    if (auto *VD = dyn_cast<VarDecl>(D)) {
+      // Only check if the VarDecl has the same (or parent) context to avoid
+      // grabbing the end location for every decl with an initializer
+      if (auto *init = VD->getParentInitializer()) {
+        auto *varContext = VD->getDeclContext();
+        if (DC == varContext || DC->isChildContextOf(varContext)) {
+          auto initRange = Lexer::getCharSourceRangeFromSourceRange(
+              SM, init->getSourceRange());
+          if (initRange.isValid() && initRange.contains(Loc))
+            return;
+        }
+      }
+    }
     break;
+  }
   }
 
   // Filter out shadowed decls. Do this for only usable values even though
@@ -3913,238 +3888,6 @@ FuncDecl *LookupIntrinsicRequest::evaluate(Evaluator &evaluator,
     return nullptr;
 
   return dyn_cast<FuncDecl>(decls[0]);
-}
-
-void FindLocalVal::checkPattern(const Pattern *Pat, DeclVisibilityKind Reason) {
-  Pat->forEachVariable([&](VarDecl *VD) { checkValueDecl(VD, Reason); });
-}
-void FindLocalVal::checkValueDecl(ValueDecl *D, DeclVisibilityKind Reason) {
-  if (!D)
-    return;
-  if (auto var = dyn_cast<VarDecl>(D)) {
-    auto dc = var->getDeclContext();
-    if ((isa<AbstractFunctionDecl>(dc) || isa<ClosureExpr>(dc)) &&
-        var->hasAttachedPropertyWrapper()) {
-      // FIXME: This is currently required to set the interface type of the
-      // auxiliary variables (unless 'var' is a closure param).
-      (void)var->getPropertyWrapperBackingPropertyType();
-
-      auto vars = var->getPropertyWrapperAuxiliaryVariables();
-      if (vars.backingVar) {
-        Consumer.foundDecl(vars.backingVar, Reason);
-      }
-      if (vars.projectionVar) {
-        Consumer.foundDecl(vars.projectionVar, Reason);
-      }
-      if (vars.localWrappedValueVar) {
-        Consumer.foundDecl(vars.localWrappedValueVar, Reason);
-
-        // If 'localWrappedValueVar' exists, the original var is shadowed.
-        return;
-      }
-    }
-  }
-  Consumer.foundDecl(D, Reason);
-}
-
-void FindLocalVal::checkParameterList(const ParameterList *params) {
-  for (auto param : *params) {
-    checkValueDecl(param, DeclVisibilityKind::FunctionParameter);
-  }
-}
-
-void FindLocalVal::checkGenericParams(GenericParamList *Params) {
-  if (!Params)
-    return;
-
-  for (auto P : *Params) {
-    if (P->isOpaqueType()) {
-      // Generic param for 'some' parameter type is not "visible".
-      continue;
-    }
-    checkValueDecl(P, DeclVisibilityKind::GenericParameter);
-  }
-}
-
-void FindLocalVal::checkSourceFile(const SourceFile &SF) {
-  for (Decl *D : SF.getTopLevelDecls())
-    if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
-      visitBraceStmt(TLCD->getBody(), /*isTopLevel=*/true);
-}
-
-void FindLocalVal::checkStmtCondition(const StmtCondition &Cond) {
-  SourceLoc start = SourceLoc();
-  for (auto entry : Cond) {
-    if (start.isInvalid())
-      start = entry.getStartLoc();
-    if (auto *P = entry.getPatternOrNull()) {
-      SourceRange previousConditionsToHere = SourceRange(start, entry.getEndLoc());
-      if (!isReferencePointInRange(previousConditionsToHere))
-        checkPattern(P, DeclVisibilityKind::LocalDecl);
-    }
-  }
-}
-
-void FindLocalVal::visitIfStmt(IfStmt *S) {
-  if (!isReferencePointInRange(S->getSourceRange()))
-    return;
-
-  if (!S->getElseStmt() ||
-      !isReferencePointInRange(S->getElseStmt()->getSourceRange())) {
-    checkStmtCondition(S->getCond());
-  }
-
-  visit(S->getThenStmt());
-  if (S->getElseStmt())
-    visit(S->getElseStmt());
-}
-
-void FindLocalVal::visitGuardStmt(GuardStmt *S) {
-  if (SM.isBeforeInBuffer(Loc, S->getStartLoc()))
-    return;
-
-  // Names in the guard aren't visible until after the body.
-  if (S->getBody()->isImplicit() ||
-      !isReferencePointInRange(S->getBody()->getSourceRange()))
-    checkStmtCondition(S->getCond());
-
-  visit(S->getBody());
-}
-
-void FindLocalVal::visitWhileStmt(WhileStmt *S) {
-  if (!isReferencePointInRange(S->getSourceRange()))
-    return;
-
-  checkStmtCondition(S->getCond());
-  visit(S->getBody());
-}
-void FindLocalVal::visitRepeatWhileStmt(RepeatWhileStmt *S) {
-  visit(S->getBody());
-}
-void FindLocalVal::visitDoStmt(DoStmt *S) {
-  visit(S->getBody());
-}
-
-void FindLocalVal::visitForEachStmt(ForEachStmt *S) {
-  if (!isReferencePointInRange(S->getSourceRange()))
-    return;
-  visit(S->getBody());
-  if (!isReferencePointInRange(S->getParsedSequence()->getSourceRange()))
-    checkPattern(S->getPattern(), DeclVisibilityKind::LocalDecl);
-}
-
-void FindLocalVal::visitBraceStmt(BraceStmt *S, bool isTopLevelCode) {
-  if (isTopLevelCode) {
-    if (SM.isBeforeInBuffer(Loc, S->getStartLoc()))
-      return;
-  } else {
-    SourceRange CheckRange = S->getSourceRange();
-    if (S->isImplicit()) {
-      // If the brace statement is implicit, it doesn't have an explicit '}'
-      // token. Thus, the last token in the brace stmt could be a string
-      // literal token, which can *contain* its interpolation segments.
-      // If one of these interpolation segments is the reference point, we'd
-      // return false from `isReferencePointInRange` because the string
-      // literal token's start location is before the interpolation token.
-      // To fix this, adjust the range we are checking to range until the end of
-      // the potential string interpolation token.
-      CheckRange.End = Lexer::getLocForEndOfToken(SM, CheckRange.End);
-    }
-    if (!isReferencePointInRange(CheckRange))
-      return;
-  }
-
-  // Visit inner statements first before reporting local decls in the current
-  // scope.
-  for (auto elem : S->getElements()) {
-    // If we have a SingleValueStmtExpr, there may be local bindings in the
-    // wrapped statement.
-    if (auto *E = elem.dyn_cast<Expr *>()) {
-      if (auto *SVE = dyn_cast<SingleValueStmtExpr>(E))
-        visit(SVE->getStmt());
-      continue;
-    }
-
-    if (auto *S = elem.dyn_cast<Stmt*>()) {
-      visit(S);
-      continue;
-    }
-  }
-
-  std::function<void(Decl *)> visitDecl;
-  visitDecl = [&](Decl *D) {
-    if (auto *VD = dyn_cast<ValueDecl>(D))
-      checkValueDecl(VD, DeclVisibilityKind::LocalDecl);
-    D->visitAuxiliaryDecls(visitDecl);
-  };
-  for (auto elem : S->getElements()) {
-    if (auto *E = elem.dyn_cast<Expr *>()) {
-      // 'MacroExpansionExpr' at code-item position may introduce value decls.
-      // NOTE: the expression must be type checked.
-      // FIXME: In code-completion local expressions are _not_ type checked.
-      if (auto *mee = dyn_cast<MacroExpansionExpr>(E)) {
-        if (auto *med = mee->getSubstituteDecl()) {
-          visitDecl(med);
-        }
-      }
-      continue;
-    }
-    if (auto *D = elem.dyn_cast<Decl*>()) {
-      visitDecl(D);
-      continue;
-    }
-  }
-}
-  
-void FindLocalVal::visitSwitchStmt(SwitchStmt *S) {
-  if (!isReferencePointInRange(S->getSourceRange()))
-    return;
-  for (CaseStmt *C : S->getCases()) {
-    visit(C);
-  }
-}
-
-void FindLocalVal::visitCaseStmt(CaseStmt *S) {
-  // The last token in a case stmt can be a string literal token, which can
-  // *contain* its interpolation segments. If one of these interpolation
-  // segments is the reference point, we'd return false from
-  // `isReferencePointInRange` because the string literal token's start location
-  // is before the interpolation token. To fix this, adjust the range we are
-  // checking to range until the end of the potential string interpolation
-  // token.
-  SourceRange CheckRange = {S->getStartLoc(),
-                            Lexer::getLocForEndOfToken(SM, S->getEndLoc())};
-  if (!isReferencePointInRange(CheckRange))
-    return;
-  // Pattern names aren't visible in the patterns themselves,
-  // just in the body or in where guards.
-  bool inPatterns = isReferencePointInRange(S->getLabelItemsRange());
-  auto items = S->getCaseLabelItems();
-  if (inPatterns) {
-    for (const auto &CLI : items) {
-      auto guard = CLI.getGuardExpr();
-      if (guard && isReferencePointInRange(guard->getSourceRange())) {
-        checkPattern(CLI.getPattern(), DeclVisibilityKind::LocalDecl);
-        break;
-      }
-    }
-  }
-
-  if (!inPatterns && !items.empty()) {
-    for (auto *vd : S->getCaseBodyVariablesOrEmptyArray()) {
-      checkValueDecl(vd, DeclVisibilityKind::LocalDecl);
-    }
-  }
-  visit(S->getBody());
-}
-
-void FindLocalVal::visitDoCatchStmt(DoCatchStmt *S) {
-  if (!isReferencePointInRange(S->getSourceRange()))
-    return;
-  visit(S->getBody());
-  for (CaseStmt *C : S->getCatches()) {
-    visit(C);
-  }
 }
 
 void swift::simple_display(llvm::raw_ostream &out, NLKind kind) {

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2774,8 +2774,8 @@ void CompletionLookup::getValueCompletionsInDeclContext(SourceLoc Loc,
   AccessFilteringDeclConsumer AccessFilteringConsumer(CurrDeclContext, *this);
   FilteredDeclConsumer FilteringConsumer(AccessFilteringConsumer, Filter);
 
-  lookupVisibleDecls(FilteringConsumer, CurrDeclContext,
-                     /*IncludeTopLevel=*/false, Loc);
+  lookupVisibleDecls(FilteringConsumer, Loc, CurrDeclContext,
+                     /*IncludeTopLevel=*/false);
 
   CodeCompletionFilter filter{CodeCompletionFilterFlag::Expr,
                               CodeCompletionFilterFlag::Type};
@@ -3258,8 +3258,8 @@ void CompletionLookup::getTypeCompletionsInDeclContext(SourceLoc Loc,
   Kind = LookupKind::TypeInDeclContext;
 
   AccessFilteringDeclConsumer AccessFilteringConsumer(CurrDeclContext, *this);
-  lookupVisibleDecls(AccessFilteringConsumer, CurrDeclContext,
-                     /*IncludeTopLevel=*/false, Loc);
+  lookupVisibleDecls(AccessFilteringConsumer, Loc, CurrDeclContext,
+                     /*IncludeTopLevel=*/false);
 
   CodeCompletionFilter filter{CodeCompletionFilterFlag::Type};
   if (ModuleQualifier) {
@@ -3446,8 +3446,8 @@ void CompletionLookup::getOptionalBindingCompletions(SourceLoc Loc) {
   // modules. For suggesting top level results, we need a way to filter cached
   // results.
 
-  lookupVisibleDecls(FilteringConsumer, CurrDeclContext,
-                     /*IncludeTopLevel=*/false, Loc);
+  lookupVisibleDecls(FilteringConsumer, Loc, CurrDeclContext,
+                     /*IncludeTopLevel=*/false);
 }
 
 void CompletionLookup::addWithoutConstraintTypes() {

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -394,7 +394,7 @@ CompletionLookup::getSemanticContext(const Decl *D, DeclVisibilityKind Reason,
     return *ForcedSemanticContext;
 
   switch (Reason) {
-  case DeclVisibilityKind::LocalVariable:
+  case DeclVisibilityKind::LocalDecl:
   case DeclVisibilityKind::FunctionParameter:
   case DeclVisibilityKind::GenericParameter:
     return SemanticContextKind::Local;
@@ -2976,7 +2976,7 @@ void CompletionLookup::getGenericRequirementCompletions(
   // qualified by the current type. Thus also suggest current self type so the
   // user can do a memberwise lookup on it.
   if (auto SelfType = typeContext->getSelfNominalTypeDecl()) {
-    addNominalTypeRef(SelfType, DeclVisibilityKind::LocalVariable,
+    addNominalTypeRef(SelfType, DeclVisibilityKind::LocalDecl,
                       DynamicLookupInfo());
   }
 

--- a/lib/Refactoring/ExtractFunction.cpp
+++ b/lib/Refactoring/ExtractFunction.cpp
@@ -164,7 +164,7 @@ bool RefactoringActionExtractFunction::performChange() {
   }
 
   // Correct the given name if collision happens.
-  PreferredName = correctNewDeclName(InsertToDC, PreferredName);
+  PreferredName = correctNewDeclName(InsertLoc, InsertToDC, PreferredName);
 
   // Collect the parameters to pass down to the new function.
   std::vector<ReferencedDecl> Parameters;

--- a/lib/Refactoring/Utils.cpp
+++ b/lib/Refactoring/Utils.cpp
@@ -47,14 +47,15 @@ swift::refactoring::correctNameInternal(ASTContext &Ctx, StringRef Name,
   return Ctx.getIdentifier((llvm::Twine(Name) + SuffixToUse).str()).str();
 }
 
-llvm::StringRef swift::refactoring::correctNewDeclName(DeclContext *DC,
+llvm::StringRef swift::refactoring::correctNewDeclName(SourceLoc Loc,
+                                                       DeclContext *DC,
                                                        StringRef Name) {
 
   // Collect all visible decls in the decl context.
   llvm::SmallVector<ValueDecl *, 16> AllVisibles;
   VectorDeclConsumer Consumer(AllVisibles);
   ASTContext &Ctx = DC->getASTContext();
-  lookupVisibleDecls(Consumer, DC, true);
+  lookupVisibleDecls(Consumer, Loc, DC, /*IncludeTopLevel*/ true);
   return correctNameInternal(Ctx, Name, AllVisibles);
 }
 

--- a/lib/Refactoring/Utils.h
+++ b/lib/Refactoring/Utils.h
@@ -22,7 +22,7 @@ namespace refactoring {
 StringRef correctNameInternal(ASTContext &Ctx, StringRef Name,
                               ArrayRef<ValueDecl *> AllVisibles);
 
-StringRef correctNewDeclName(DeclContext *DC, StringRef Name);
+StringRef correctNewDeclName(SourceLoc Loc, DeclContext *DC, StringRef Name);
 
 /// If \p NTD is a protocol, return all the protocols it inherits from. If it's
 /// a type, return all the protocols it conforms to.

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -794,12 +794,12 @@ namespace llvm {
 
 template <> struct DenseMapInfo<FoundDeclTy> {
   static inline FoundDeclTy getEmptyKey() {
-    return FoundDeclTy{nullptr, DeclVisibilityKind::LocalVariable, {}};
+    return FoundDeclTy{nullptr, DeclVisibilityKind::LocalDecl, {}};
   }
 
   static inline FoundDeclTy getTombstoneKey() {
     return FoundDeclTy{reinterpret_cast<ValueDecl *>(0x1),
-                       DeclVisibilityKind::LocalVariable,
+                       DeclVisibilityKind::LocalDecl,
                        {}};
   }
 
@@ -988,7 +988,7 @@ public:
                 VD->getFormalAccess() > OtherVD->getFormalAccess());
             if (preferVD) {
               FilteredResults.remove(
-                  FoundDeclTy(OtherVD, DeclVisibilityKind::LocalVariable, {}));
+                  FoundDeclTy(OtherVD, DeclVisibilityKind::LocalDecl, {}));
               FilteredResults.insert(DeclAndReason);
               *I = VD;
             }

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -1171,167 +1171,129 @@ static void lookupVisibleMemberDecls(
   overrideConsumer.filterDecls(Consumer);
 }
 
-static void lookupVisibleDeclsImpl(VisibleDeclConsumer &Consumer,
-                                   const DeclContext *DC,
-                                   bool IncludeTopLevel, SourceLoc Loc) {
-  const SourceManager &SM = DC->getASTContext().SourceMgr;
-  auto MemberReason = DeclVisibilityKind::MemberOfCurrentNominal;
+namespace {
+class ASTScopeVisibleDeclConsumer
+    : public swift::namelookup::AbstractASTScopeDeclConsumer {
+  SourceLoc LookupLoc;
+  VisibleDeclConsumer &BaseConsumer;
 
-  // If we are inside of a method, check to see if there are any ivars in scope,
-  // and if so, whether this is a reference to one of them.
-  while (!DC->isModuleScopeContext()) {
-    GenericParamList *GenericParams = nullptr;
-    Type ExtendedType;
+  const DeclContext *const InnermostTypeDC;
+  DeclContext *SelfDC = nullptr;
+
+public:
+  ASTScopeVisibleDeclConsumer(SourceLoc Loc, const DeclContext *DC,
+                              VisibleDeclConsumer &BaseConsumer)
+      : LookupLoc(Loc), BaseConsumer(BaseConsumer),
+        InnermostTypeDC(DC->getInnermostTypeContext()) {}
+
+private:
+  void foundDecl(ValueDecl *VD) {
+    auto Kind = DeclVisibilityKind::LocalDecl;
+    if (isa<ParamDecl>(VD))
+      Kind = DeclVisibilityKind::FunctionParameter;
+    if (auto *GP = dyn_cast<GenericTypeParamDecl>(VD)) {
+      Kind = DeclVisibilityKind::GenericParameter;
+      // Generic param for 'some' parameter type is not "visible".
+      if (GP->isOpaqueType())
+        return;
+    }
+    BaseConsumer.foundDecl(VD, Kind);
+  }
+
+  bool consume(ArrayRef<ValueDecl *> values,
+               NullablePtr<DeclContext> baseDC) override {
+    for (auto *VD : values) {
+      if (auto *var = dyn_cast<VarDecl>(VD)) {
+        // If we have the 'self' parameter, make a note of the DeclContext
+        // where it exists.
+        if (var->isSelfParameter())
+          SelfDC = var->getDeclContext();
+
+        if (var->getPropertyWrapperBackingProperty()) {
+          // FIXME: This is currently required to set the interface type of the
+          // auxiliary variables (unless 'var' is a closure param).
+          (void)var->getPropertyWrapperBackingPropertyType();
+        }
+        var->visitAuxiliaryDecls(
+            [&](VarDecl *auxVar) { foundDecl(auxVar); });
+      }
+      // NOTE: We don't call Decl::visitAuxiliaryDecls here since peer decls of
+      // local decls should not show up in lookup results.
+      foundDecl(VD);
+    }
+    return false;
+  }
+
+  bool lookInMembers(const DeclContext *DC) const override {
     auto LS = LookupState::makeUnqualified();
     LS = LS.withIncludeProtocolExtensionMembers();
 
-    // Skip initializer contexts, we will not find any declarations there.
-    if (isa<Initializer>(DC)) {
-      // For non-'lazy' decls, lookup on the meta type.
-      if (!isa<PatternBindingInitializer>(DC) ||
-          !cast<PatternBindingInitializer>(DC)->getInitializedLazyVar())
-        LS = LS.withOnMetatype();
-      DC = DC->getParentForLookup();
-    }
+    auto canAccessInstanceMembers = [&]() {
+      // No 'self' available.
+      if (!SelfDC)
+        return false;
 
-    // We don't look for generic parameters if we are in the context of a
-    // nominal type: they will be looked up anyways via `lookupVisibleMemberDecls`.
-    if (DC && !isa<NominalTypeDecl>(DC)) {
-      if (auto *decl = DC->getAsDecl()) {
-        if (auto GC = decl->getAsGenericContext()) {
-          auto params = GC->getGenericParams();
-          namelookup::FindLocalVal(SM, Loc, Consumer).checkGenericParams(params);
-        }
+      // The 'self' we have is for a different type context than we're in.
+      if (InnermostTypeDC != DC || SelfDC->getInnermostTypeContext() != DC)
+        return false;
+
+      // If the 'self' decl is for a static member, we can't access instance
+      // members.
+      if (auto *VD = dyn_cast_or_null<ValueDecl>(SelfDC->getAsDecl())) {
+        if (VD->isStatic())
+          return false;
       }
-    }
+      return true;
+    };
 
-    if (auto *SE = dyn_cast<SubscriptDecl>(DC)) {
-      ExtendedType = SE->getDeclContext()->getSelfTypeInContext();
-      DC = DC->getParentForLookup();
-      if (SE->isStatic())
-        LS = LS.withOnMetatype();
-    } else if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC)) {
+    if (!canAccessInstanceMembers())
+      LS = LS.withOnMetatype();
 
-      // Look for local variables; normally, the parser resolves these
-      // for us, but it can't do the right thing inside local types.
-      // FIXME: when we can parse and typecheck the function body partially for
-      // code completion, AFD->getBody() check can be removed.
-      if (Loc.isValid() &&
-          AFD->getBodySourceRange().isValid() &&
-          SM.rangeContainsTokenLoc(AFD->getBodySourceRange(), Loc) &&
-          AFD->getBody()) {
-        namelookup::FindLocalVal(SM, Loc, Consumer).visit(AFD->getBody());
-      }
+    auto MemberKind = InnermostTypeDC == DC
+                          ? DeclVisibilityKind::MemberOfCurrentNominal
+                          : DeclVisibilityKind::MemberOfOutsideNominal;
 
-      if (auto *P = AFD->getImplicitSelfDecl()) {
-        namelookup::FindLocalVal(SM, Loc, Consumer).checkValueDecl(
-          const_cast<ParamDecl *>(P), DeclVisibilityKind::FunctionParameter);
-      }
-
-      namelookup::FindLocalVal(SM, Loc, Consumer).checkParameterList(
-        AFD->getParameters());
-
-      GenericParams = AFD->getGenericParams();
-
-      if (AFD->getDeclContext()->isTypeContext()) {
-        ExtendedType = AFD->getDeclContext()->getSelfTypeInContext();
-        DC = DC->getParentForLookup();
-
-        if (auto *FD = dyn_cast<FuncDecl>(AFD))
-          if (FD->isStatic())
-            LS = LS.withOnMetatype();
-      }
-    } else if (auto CE = dyn_cast<ClosureExpr>(DC)) {
-      if (Loc.isValid()) {
-        namelookup::FindLocalVal(SM, Loc, Consumer).visit(CE->getBody());
-        if (auto P = CE->getParameters()) {
-          namelookup::FindLocalVal(SM, Loc, Consumer).checkParameterList(P);
-        }
-      }
-    } else if (auto ED = dyn_cast<ExtensionDecl>(DC)) {
-      ExtendedType = ED->getSelfTypeInContext();
-    } else if (auto ND = dyn_cast<NominalTypeDecl>(DC)) {
-      ExtendedType = ND->getSelfTypeInContext();
-    }
-
-    // If we're inside a function context, we've already moved to
-    // the parent DC, so we have to check the function's generic
-    // parameters first.
-    if (GenericParams) {
-      namelookup::FindLocalVal localVal(SM, Loc, Consumer);
-      localVal.checkGenericParams(GenericParams);
-    }
-
-    // Check the generic parameters of our context.
-    GenericParamList *dcGenericParams = nullptr;
-    if (auto nominal = dyn_cast<NominalTypeDecl>(DC))
-      dcGenericParams = nominal->getGenericParams();
-    else if (auto ext = dyn_cast<ExtensionDecl>(DC))
-      dcGenericParams = ext->getGenericParams();
-    else if (auto subscript = dyn_cast<SubscriptDecl>(DC))
-      dcGenericParams = subscript->getGenericParams();
-
-    while (dcGenericParams) {
-      namelookup::FindLocalVal localVal(SM, Loc, Consumer);
-      localVal.checkGenericParams(dcGenericParams);
-      dcGenericParams = dcGenericParams->getOuterParameters();
-    }
-
-    if (ExtendedType) {
-      ::lookupVisibleMemberDecls(ExtendedType, Loc, Consumer, DC, LS,
-                                 MemberReason);
-
-      // Going outside the current type context.
-      MemberReason = DeclVisibilityKind::MemberOfOutsideNominal;
-    }
-
-    DC = DC->getParentForLookup();
+    lookupVisibleMemberDecls(DC->getSelfTypeInContext(), LookupLoc,
+                             BaseConsumer, DC, LS, MemberKind);
+    return false;
   }
+};
+} // end anonymous namespace
 
-  if (auto SF = dyn_cast<SourceFile>(DC)) {
-    if (Loc.isValid()) {
-      // Look for local variables in top-level code; normally, the parser
-      // resolves these for us, but it can't do the right thing for
-      // local types.
-      namelookup::FindLocalVal(SM, Loc, Consumer).checkSourceFile(*SF);
-    }
-
-    if (IncludeTopLevel) {
-      auto &cached = SF->getCachedVisibleDecls();
-      if (!cached.empty()) {
-        for (auto result : cached)
-          Consumer.foundDecl(result, DeclVisibilityKind::VisibleAtTopLevel);
-        return;
-      }
-    }
-  }
-
-  if (IncludeTopLevel) {
-    using namespace namelookup;
-    SmallVector<ValueDecl *, 0> moduleResults;
-    lookupVisibleDeclsInModule(DC, {}, moduleResults,
-                               NLKind::UnqualifiedLookup,
-                               ResolutionKind::Overloadable,
-                               DC);
-    for (auto result : moduleResults)
+static void lookupVisibleDeclsInModule(const SourceFile *SF,
+                                       VisibleDeclConsumer &Consumer) {
+  auto &cached = SF->getCachedVisibleDecls();
+  if (!cached.empty()) {
+    for (auto result : cached)
       Consumer.foundDecl(result, DeclVisibilityKind::VisibleAtTopLevel);
-
-    if (auto SF = dyn_cast<SourceFile>(DC))
-      SF->cacheVisibleDecls(std::move(moduleResults));
-  }
-}
-
-void swift::lookupVisibleDecls(VisibleDeclConsumer &Consumer,
-                               const DeclContext *DC,
-                               bool IncludeTopLevel,
-                               SourceLoc Loc) {
-  if (Loc.isInvalid()) {
-    lookupVisibleDeclsImpl(Consumer, DC, IncludeTopLevel, Loc);
     return;
   }
-  UsableFilteringDeclConsumer FilteringConsumer(DC->getASTContext().SourceMgr,
-                                                DC, Loc, Consumer);
-  lookupVisibleDeclsImpl(FilteringConsumer, DC, IncludeTopLevel, Loc);
+  using namespace namelookup;
+  SmallVector<ValueDecl *, 0> moduleResults;
+  namelookup::lookupVisibleDeclsInModule(SF, {}, moduleResults,
+                                         NLKind::UnqualifiedLookup,
+                                         ResolutionKind::Overloadable, SF);
+  for (auto result : moduleResults)
+    Consumer.foundDecl(result, DeclVisibilityKind::VisibleAtTopLevel);
+
+  SF->cacheVisibleDecls(std::move(moduleResults));
+}
+
+void swift::lookupVisibleDecls(VisibleDeclConsumer &ParentConsumer,
+                               SourceLoc Loc, const DeclContext *DC,
+                               bool IncludeTopLevel) {
+  auto *SF = DC->getParentSourceFile();
+  assert(SF);
+  assert(Loc.isValid());
+
+  UsableFilteringDeclConsumer Consumer(SF->getASTContext().SourceMgr, DC, Loc,
+                                       ParentConsumer);
+  {
+    ASTScopeVisibleDeclConsumer ASTScopeDeclConsumer(Loc, DC, Consumer);
+    ASTScope::unqualifiedLookup(SF, Loc, ASTScopeDeclConsumer);
+  }
+  if (IncludeTopLevel)
+    ::lookupVisibleDeclsInModule(SF, Consumer);
 }
 
 void swift::lookupVisibleMemberDecls(VisibleDeclConsumer &Consumer, Type BaseTy,

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -630,8 +630,8 @@ void TypeChecker::performTypoCorrection(DeclContext *DC, DeclRefKind refKind,
                              /*includeProtocolExtensionMembers*/true,
                              genericSig);
   } else {
-    lookupVisibleDecls(consumer, DC, /*top level*/ true,
-                       corrections.Loc.getBaseNameLoc());
+    lookupVisibleDecls(consumer, corrections.Loc.getBaseNameLoc(), DC,
+                       /*top level*/ true);
   }
 
   // Impose a maximum distance from the best score.

--- a/test/IDE/complete_exception.swift
+++ b/test/IDE/complete_exception.swift
@@ -98,9 +98,9 @@ func test002() {
 // starting from these, we could remove them.  But that may be infeasible in
 // the presence of overloaded operators.
 // THROW1-DAG: Decl[Class]/CurrModule:             NoneError1[#NoneError1#]; name=NoneError1{{$}}
-// THROW1-LOCAL: Decl[LocalVar]/Local:               text[#String#]; name=text{{$}}
-// THROW1-LOCAL: Decl[LocalVar]/Local/TypeRelation[Convertible]:               e1[#Error1#]; name=e1{{$}}
-// THROW1-LOCAL: Decl[LocalVar]/Local/TypeRelation[Convertible]:               e2[#Error2#]; name=e2{{$}}
+// THROW1-LOCAL-DAG: Decl[LocalVar]/Local:                           text[#String#]; name=text{{$}}
+// THROW1-LOCAL-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: e1[#Error1#]; name=e1{{$}}
+// THROW1-LOCAL-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: e2[#Error2#]; name=e2{{$}}
 }
 
 func test003() {

--- a/test/IDE/complete_generic_param.swift
+++ b/test/IDE/complete_generic_param.swift
@@ -53,3 +53,7 @@ func someFunction() {
 }
 
 // GENERIC_PARAM_ON_NESTED_TYPE-DAG: Decl[Struct]/CurrModule:            S2[#S2#];
+
+func testGenericWithImplicitSome<T>(_ x: some P1) -> #^GENERIC_WITH_IMPLICIT_SOME^# {}
+
+// GENERIC_WITH_IMPLICIT_SOME-DAG: Decl[GenericTypeParam]/Local:       T[#T#]; name=T

--- a/test/IDE/complete_if_switch_expr.swift
+++ b/test/IDE/complete_if_switch_expr.swift
@@ -115,15 +115,17 @@ func switchExprBinding() -> E {
   return x
 }
 
-// Triggering interface type computation of this will cause an assert to fire,
-// ensuring we don't attempt to type-check any references to it.
-let NOTYPECHECK = FORBIDDEN
+struct NO {
+  // Triggering interface type computation of this will cause an assert to fire,
+  // ensuring we don't attempt to type-check any references to it.
+  static var TYPECHECK = FORBIDDEN
+}
 
 func testSkipTypechecking1() -> E {
   // Make sure we don't try to type-check the first branch, as it doesn't
   // contribute to the type.
   if .random() {
-    _ = NOTYPECHECK
+    _ = NO.TYPECHECK
     throw SomeError()
   } else {
     .#^DOT11?check=DOT^#
@@ -136,7 +138,7 @@ func testSkipTypechecking2() -> E {
   if .random() {
     .#^DOT12?check=DOT^#
   } else {
-    _ = NOTYPECHECK
+    _ = NO.TYPECHECK
     throw SomeError()
   }
 }
@@ -146,7 +148,7 @@ func testSkipTypechecking3() -> E {
   // contribute to the type.
   switch Bool.random() {
   case true:
-    _ = NOTYPECHECK
+    _ = NO.TYPECHECK
     throw SomeError()
   case false:
     .#^DOT13?check=DOT^#
@@ -160,7 +162,7 @@ func testSkipTypechecking4() -> E {
   case true:
     .#^DOT14?check=DOT^#
   case false:
-    _ = NOTYPECHECK
+    _ = NO.TYPECHECK
     throw SomeError()
   }
 }
@@ -171,12 +173,12 @@ func testSkipTypechecking5() throws -> E {
   // Make sure we only type-check the first branch.
   if .random() {
     // We can still skip type-checking this tho.
-    x = NOTYPECHECK
+    x = NO.TYPECHECK
 
     takesE(.#^DOT15?check=DOT^#)
     throw SomeError()
   } else {
-    NOTYPECHECK
+    NO.TYPECHECK
   }
 }
 
@@ -185,12 +187,12 @@ func testSkipTypechecking6() throws -> E {
   switch Bool.random() {
   case true:
     // We can still skip type-checking this tho.
-    x = NOTYPECHECK
+    x = NO.TYPECHECK
 
     takesE(.#^DOT16?check=DOT^#)
     throw SomeError()
   case false:
-    NOTYPECHECK
+    NO.TYPECHECK
   }
 }
 
@@ -217,9 +219,9 @@ func testSkipTypechecking7() throws -> E {
 func testSkipTypeChecking8() throws -> E {
   let e: E = if Bool.random() {
     takesE(.#^DOT18?check=DOT^#)
-    throw NOTYPECHECK
+    throw NO.TYPECHECK
   } else {
-    NOTYPECHECK
+    NO.TYPECHECK
   }
   return e
 }
@@ -230,9 +232,9 @@ func testSkipTypeChecking8() throws -> E {
     func localFunc() {
       takesE(.#^DOT19?check=DOT^#)
     }
-    throw NOTYPECHECK
+    throw NO.TYPECHECK
   } else {
-    NOTYPECHECK
+    NO.TYPECHECK
   }
   return e
 }
@@ -253,13 +255,13 @@ func testSkipTypeChecking9() -> E {
 func testSkipTypeChecking10() -> E {
   // We only need to type-check the inner-most function for this.
   if Bool.random() {
-    NOTYPECHECK
+    NO.TYPECHECK
   } else {
-    takesArgAndClosure(NOTYPECHECK) {
+    takesArgAndClosure(NO.TYPECHECK) {
       func foo() {
         takesE(.#^DOT21?check=DOT^#)
       }
-      return NOTYPECHECK
+      return NO.TYPECHECK
     }
   }
 }
@@ -267,15 +269,15 @@ func testSkipTypeChecking10() -> E {
 func testSkipTypeChecking11() -> E {
   // We only need to type-check the inner-most function for this.
   if Bool.random() {
-    NOTYPECHECK
+    NO.TYPECHECK
   } else {
-    if NOTYPECHECK {
+    if NO.TYPECHECK {
       func foo() {
         takesE(.#^DOT22?check=DOT^#)
       }
-      throw NOTYPECHECK
+      throw NO.TYPECHECK
     } else {
-      NOTYPECHECK
+      NO.TYPECHECK
     }
   }
 }
@@ -283,9 +285,9 @@ func testSkipTypeChecking11() -> E {
 func testSkipTypeChecking12() -> E {
   // Only need to type-check the condition here.
   if .#^DOT23?check=BOOL^# {
-    NOTYPECHECK
+    NO.TYPECHECK
   } else {
-    NOTYPECHECK
+    NO.TYPECHECK
   }
 }
 
@@ -308,13 +310,13 @@ func testSkipTypeChecking14() -> E {
   if Bool.random() {
     .#^DOT25?check=DOT^#
   } else if .random() {
-    let x = NOTYPECHECK
+    let x = NO.TYPECHECK
     throw x
   } else if .random() {
-    let x = NOTYPECHECK
+    let x = NO.TYPECHECK
     throw x
   } else {
-    let x = NOTYPECHECK
+    let x = NO.TYPECHECK
     throw x
   }
 }
@@ -324,13 +326,13 @@ func testSkipTypeChecking14() -> E {
   case true:
     .#^DOT26?check=DOT^#
   case _ where Bool.random():
-    let x = NOTYPECHECK
+    let x = NO.TYPECHECK
     throw x
   case _ where Bool.random():
-    let x = NOTYPECHECK
+    let x = NO.TYPECHECK
     throw x
   default:
-    let x = NOTYPECHECK
+    let x = NO.TYPECHECK
     throw x
   }
 }
@@ -347,3 +349,23 @@ func testSkipTypechecking15(_ x: inout Int) -> E {
 // DOT:     Begin completions, 2 items
 // DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: e[#E#]; name=e
 // DOT-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: f({#Int#})[#E#]; name=f()
+
+// https://github.com/apple/swift/issues/71384
+func testCompleteBinding1(_ e: E) -> Int {
+  switch e {
+  case .f(let foobar):
+    #^BINDING1?check=BINDING^#
+  case .e:
+    0
+  }
+}
+
+func testCompleteBinding2(_ x: Int?) -> Int {
+  if let foobar = x {
+    #^BINDING2?check=BINDING^#
+  } else {
+    0
+  }
+}
+
+// BINDING-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: foobar[#Int#]; name=foobar

--- a/test/IDE/complete_macros_expanded.swift
+++ b/test/IDE/complete_macros_expanded.swift
@@ -83,14 +83,14 @@ func testLocal() {
   @PeerWithSuffix func localFunc() {}
 
   do {
-    #^LOCAL?skip=FIXME^#
-// FIXME: macros in replace function bodies are not handled correclty.
-// FIXME: decls instroduced by #defineDeclsWithKnownNames are missing.
-// LOCAL-DAG: Decl[FreeFunction]/Local:           localFunc()[#Void#]; name=localFunc()
-// LOCAL-DAG: Decl[LocalVar]/Local:               localFunc_peer[#Int#]; name=localFunc_peer
-// LOCAL-DAG: Decl[Struct]/Local:            A[#A#]; name=A
-// LOCAL-DAG: Decl[Struct]/Local:            B[#B#]; name=B
-// LOCAL-DAG: Decl[LocalVar]/Local:         foo[#Int#]; name=foo
-// LOCAL-DAG: Decl[LocalVar]/Local:         addOne[#(Int) -> Int#]; name=addOne
+    #^LOCAL?check=LOCAL;check=LOCAL_MACRO^#
+// LOCAL-DAG:       Decl[FreeFunction]/Local: localFunc()[#Void#]; name=localFunc()
+
+// Local macros cannot introduce peer decls, so make sure they don't show up.
+// LOCAL_MACRO-NOT: Decl[LocalVar]/Local: localFunc_peer[#Int#]; name=localFunc_peer
+// LOCAL_MACRO-NOT: Decl[Struct]/Local:   A[#A#]; name=A
+// LOCAL_MACRO-NOT: Decl[Struct]/Local:   B[#B#]; name=B
+// LOCAL_MACRO-NOT: Decl[LocalVar]/Local: foo[#Int#]; name=foo
+// LOCAL_MACRO-NOT: Decl[LocalVar]/Local: addOne[#(Int) -> Int#]; name=addOne
   }
 }

--- a/test/IDE/complete_shadowing.swift
+++ b/test/IDE/complete_shadowing.swift
@@ -141,11 +141,7 @@ func test_Local_OutNominal() {
     static var testValue: String = ""
     struct Inner {
       static func test() {
-        // FIXME: Currently any 'testValue' is not suggested. But since this is
-        // in 'static', 'Outer.testValue' is visible and usable.
-        // Note that the local 'testValue: Int' is not usable because struct
-        // decl cannot close over local values in outer scope.
-        #^Local_OutNominal?check=OUTNOMINAL_STRING_TESTVALUE_STATIC;xfail=rdar92479209^#
+        #^Local_OutNominal?check=OUTNOMINAL_STRING_TESTVALUE_STATIC^#
       }
     }
   }
@@ -163,13 +159,11 @@ func test_Global_Local() {
 
 func test_GenericParam_Local<testValue>(_: testValue) {
   var testValue: String = ""
-  // FIXME: The generic parameter is suggested because lookupVisibleDeclsImpl() reports it first.
-  #^GenericParam_Local?check=LOCAL_STRING_TESTVALUE;xfail=FIXME^#
+  #^GenericParam_Local?check=LOCAL_STRING_TESTVALUE^#
 }
 
 func test_GenericParam_Param<testValue>(testValue: String, _: testValue) {
-  // FIXME: The generic parameter is suggested because lookupVisibleDeclsImpl() reports it first.
-  #^GenericParam_Param?check=LOCAL_STRING_TESTVALUE;xfail=FIXME^#
+  #^GenericParam_Param?check=LOCAL_STRING_TESTVALUE^#
 }
 
 func test_GenericParam_LocalClosure<testValue>(_: testValue) {
@@ -198,7 +192,6 @@ func test_LocalFunc_LocalVar() {
   var testValue: String = ""
   #^LocalFunc_LocalVar^#
 // LocalFunc_LocalVar-NOT: name=testValue
-// LocalFunc_LocalVar-DAG: Decl[FreeFunction]/Local:           testValue({#arg: Int#})[#Void#]; name=testValue(arg:)
 // LocalFunc_LocalVar-DAG: Decl[LocalVar]/Local:               testValue[#String#]; name=testValue
 // LocalFunc_LocalVar-NOT: name=testValue
 }

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -755,3 +755,14 @@ var _: HaveNested.#^IN_POSTFIX_BASE_MEMBER_5?check=POSTFIX_BASE_MEMBER^#.Type
 // POSTFIX_BASE_MEMBER: Begin completions, 2 items
 // POSTFIX_BASE_MEMBER-DAG: Decl[Struct]/CurrNominal:           Nested[#HaveNested.Nested#];
 // POSTFIX_BASE_MEMBER-DAG: Keyword/None:                       Type[#HaveNested.Type#];
+
+func testGenericResultCompletion1<T>() -> #^GENERIC_RESULT1?check=GENERIC_RESULT^# {}
+func testGenericResultCompletion2<T>() -> [#^GENERIC_RESULT2?check=GENERIC_RESULT^#] {}
+func testGenericResultCompletion3<T>() -> (#^GENERIC_RESULT3?check=GENERIC_RESULT^#) {}
+func testGenericResultCompletion4<T>() -> (Int, #^GENERIC_RESULT4?check=GENERIC_RESULT^#) {}
+func testGenericResultCompletion5<T>() -> FooProtocol & #^GENERIC_RESULT5?check=GENERIC_RESULT^# {}
+func testGenericResultCompletion6<T>() -> [[#^GENERIC_RESULT6?check=GENERIC_RESULT^#]] {}
+func testGenericResultCompletion7<T>() -> Array< #^GENERIC_RESULT7?check=GENERIC_RESULT^#> {}
+func testGenericResultCompletion8<T>() -> Array<(Int, #^GENERIC_RESULT8?check=GENERIC_RESULT^#)> {}
+
+// GENERIC_RESULT-DAG: Decl[GenericTypeParam]/Local: T[#T#]; name=T


### PR DESCRIPTION
Replace with an ASTScope lookup. This also lets us simplify UsableFilteringDeclConsumer, and fixes a couple of completion bugs.

Resolves #66925
Resolves #71384
rdar://92479209
rdar://108164277
rdar://122302481