### PR TITLE
[Test] Disable availability checking when building ExternalGenericMetadataBuilder tests.

### DIFF
--- a/test/ExternalGenericMetadataBuilder/ExternalGenericMetadataBuilder.swift
+++ b/test/ExternalGenericMetadataBuilder/ExternalGenericMetadataBuilder.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -I %swift-lib-dir -I %swift_src_root/lib/ExternalGenericMetadataBuilder -L%swift-lib-dir -lswiftGenericMetadataBuilder -enable-experimental-feature Extern %s -o %t/ExternalMetadataBuilderTest
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-lib-dir -I %swift_src_root/lib/ExternalGenericMetadataBuilder -L%swift-lib-dir -lswiftGenericMetadataBuilder -enable-experimental-feature Extern %s -o %t/ExternalMetadataBuilderTest
 // RUN: %target-codesign %t/ExternalMetadataBuilderTest
 // RUN: %target-run %t/ExternalMetadataBuilderTest
 

--- a/test/ExternalGenericMetadataBuilder/VerifyExternalMetadata.swift
+++ b/test/ExternalGenericMetadataBuilder/VerifyExternalMetadata.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -I %swift-lib-dir -I %swift_src_root/lib/ExternalGenericMetadataBuilder -L%swift-lib-dir -lswiftGenericMetadataBuilder -enable-experimental-feature Extern %s -o %t/VerifyExternalMetadata
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-lib-dir -I %swift_src_root/lib/ExternalGenericMetadataBuilder -L%swift-lib-dir -lswiftGenericMetadataBuilder -enable-experimental-feature Extern %s -o %t/VerifyExternalMetadata
 // RUN: %target-codesign %t/VerifyExternalMetadata
 //
 // RUN: %target-build-swift -I %swift-lib-dir -I %swift_src_root/lib/ExternalGenericMetadataBuilder -L%swift-lib-dir -lswiftGenericMetadataBuilder -enable-experimental-feature Extern %S/Inputs/buildMetadataJSON.swift -o %t/buildMetadataJSON


### PR DESCRIPTION
The compiler can end up thinking that _mangledTypeName isn't available, but we're always going to be running against a just-built runtime which has it.