### PR TITLE
BuildScript: add ncgenerics preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -643,6 +643,12 @@ build-subdir=buildbot_incremental
 
 lto
 
+[preset: ncgenerics,smoketest=macosx]
+mixin-preset=buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx
+build-subdir=buildbot_incremental
+
+enable-experimental-noncopyable-generics=1
+
 [preset: buildbot_incremental,tools=RA,llvm-only]
 build-subdir=buildbot_incremental_llvmonly
 


### PR DESCRIPTION
This allows for simpler CI testing with NCGenerics enabled using this:

```
preset=ncgenerics,smoketest=macosx
@swift-ci Please test with preset macOS Platform
```
