### PR TITLE
[SILGen] Look through loads for storage.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3188,6 +3188,9 @@ static StorageRefResult findStorageReferenceExprForBorrow(Expr *e) {
   } else if (auto ioe = dyn_cast<InOutExpr>(e)) {
     if (auto result = findStorageReferenceExprForBorrow(ioe->getSubExpr()))
       return result.withTransitiveRoot(ioe);
+  } else if (auto le = dyn_cast<LoadExpr>(e)) {
+    if (auto result = findStorageReferenceExprForBorrow(le->getSubExpr()))
+      return result.withTransitiveRoot(le);
   }
 
   return StorageRefResult();

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -342,6 +342,8 @@ public:
 
   // Expressions that wrap lvalues
   
+  LValue visitLoadExpr(LoadExpr *e, SGFAccessKind accessKind,
+                        LValueOptions options);
   LValue visitInOutExpr(InOutExpr *e, SGFAccessKind accessKind,
                         LValueOptions options);
   LValue visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *e,
@@ -4326,6 +4328,11 @@ LValue SILGenLValue::visitBindOptionalExpr(BindOptionalExpr *e,
 LValue SILGenLValue::visitInOutExpr(InOutExpr *e, SGFAccessKind accessKind,
                                     LValueOptions options) {
   return visitRec(e->getSubExpr(), accessKind, options);
+}
+
+LValue SILGenLValue::visitLoadExpr(LoadExpr *e, SGFAccessKind accessKind,
+                               LValueOptions options) {
+  return visit(e->getSubExpr(), accessKind, options);
 }
 
 LValue SILGenLValue::visitConsumeExpr(ConsumeExpr *e, SGFAccessKind accessKind,

--- a/test/SILGen/borrow_from_load_expr.swift
+++ b/test/SILGen/borrow_from_load_expr.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend                           \
+// RUN:     %s                                           \
+// RUN:     -emit-silgen                                 \
+// RUN:     -debug-diagnostic-names                      \
+// RUN:     -I %t                                        \
+// RUN: |                                                \
+// RUN: %FileCheck %s
+
+public struct FA<T> {
+  public subscript(_ int: Int) -> T {
+// CHECK-LABEL: sil [ossa] @read : {{.*}} {
+                  // function_ref UnsafeMutablePointer.subscript.unsafeAddressor
+// CHECK:         [[ADDRESSOR:%[^,]+]] = function_ref @$sSpyxSicilu
+// CHECK:         [[POINTER:%[^,]+]] = apply [[ADDRESSOR]]
+// CHECK:         [[RAW_POINTER:%[^,]+]] = struct_extract [[POINTER]]
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[RAW_POINTER]]
+// CHECK:         [[ACCESS:%[^,]+]] = begin_access [read] [unsafe] [[ADDR]]
+// Verify that no spurious temporary is emitted.
+// CHECK-NOT:     alloc_stack
+// CHECK:         yield [[ACCESS]] : $*T, resume [[SUCCESS:bb[0-9]+]], unwind [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         end_access [[ACCESS]]
+// CHECK:       [[FAILURE]]:
+// CHECK:         end_access [[ACCESS]]
+// CHECK:         unwind
+// CHECK-LABEL: } // end sil function 'read'
+    @_silgen_name("read")
+    _read {
+      yield ump[int]
+    }
+  }
+  var ump: UnsafeMutablePointer<T>
+}
+


### PR DESCRIPTION
When emitting an indirect guaranteed argument, such as a yield, a search is made for storage which can be borrowed.  Look through LoadExprs during this search.
