### PR TITLE
[stdlib] properly rename validatingUTF8 to validatingCString

### DIFF
--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -186,11 +186,16 @@ extension String {
   ///
   /// - Parameter nullTerminatedUTF8:
   ///     A pointer to a null-terminated sequence of UTF-8 code units.
-  @inlinable
-  @_alwaysEmitIntoClient
+  @_silgen_name("$sSS14validatingUTF8SSSgSPys4Int8VG_tcfC")
   public init?(validatingCString nullTerminatedUTF8: UnsafePointer<CChar>) {
-    // FIXME: https://github.com/apple/swift/issues/68433 (rdar://115296219)
-    self.init(validatingUTF8: nullTerminatedUTF8)
+    let len = UTF8._nullCodeUnitOffset(in: nullTerminatedUTF8)
+    let validated = nullTerminatedUTF8.withMemoryRebound(
+      to: UInt8.self,
+      capacity: len,
+      { String._tryFromUTF8(UnsafeBufferPointer(start: $0, count: len)) }
+    )
+    guard let validated else { return nil }
+    self = validated
   }
 
   /// Creates a new string by copying and validating the null-terminated UTF-8
@@ -223,15 +228,12 @@ extension String {
   ///
   /// - Parameter cString:
   ///     A pointer to a null-terminated sequence of UTF-8 code units.
+  @inlinable
+  @_alwaysEmitIntoClient
   @available(swift, deprecated: 6, renamed: "String.init(validatingCString:)")
+  @_silgen_name("_swift_se0405_String_validatingUTF8")
   public init?(validatingUTF8 cString: UnsafePointer<CChar>) {
-    let len = UTF8._nullCodeUnitOffset(in: cString)
-    guard let str = cString.withMemoryRebound(to: UInt8.self, capacity: len, {
-      String._tryFromUTF8(UnsafeBufferPointer(start: $0, count: len))
-    })
-    else { return nil }
-
-    self = str
+    self.init(validatingCString: cString)
   }
 
   /// Creates a new string by copying and validating the null-terminated UTF-8

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -152,6 +152,12 @@ Func UnsafeMutablePointer.moveUpdate(from:count:) is a new API without @availabl
 Func UnsafeMutableBufferPointer.initialize(from:) has mangled name changing from 'Swift.UnsafeMutableBufferPointer.initialize<A where A == A1.Element, A1: Swift.Sequence>(from: A1) -> (A1.Iterator, Swift.Int)' to 'Swift.UnsafeMutableBufferPointer.initialize<A where A == A1.Element, A1: Swift.Sequence>(from: A1) -> (unwritten: A1.Iterator, index: Swift.Int)'
 Func UnsafeMutableBufferPointer.initialize(from:) has return type change from (τ_1_0.Iterator, Swift.Int) to (unwritten: τ_1_0.Iterator, index: Swift.Int)
 
+// This hasn't actually been removed; it was renamed at the source level while
+// retaining its old mangled/silgen name. The old source-level name is preserved
+// as an @_alwaysEmitIntoClient function. The source break was accepted as part of se-0405.
+Constructor String.init(validatingCString:) is a new API without @available attribute
+Constructor String.init(validatingUTF8:) has been removed
+
 // These haven't actually been removed; they are simply marked unavailable.
 // This seems to be a false positive in the ABI checker. This is not an ABI
 // break because the symbols are still present.


### PR DESCRIPTION
This is the initializer renamed as part of SE-0405. I was [previously unable to do this rename "properly"](https://github.com/apple/swift/pull/68423), in that it emitted a warning while building the standard library. Thanks to @DougGregor's fix in commit d19f082665489d0a49ef3d201907bf7f68b3dae2, that warning can be eliminated.