### PR TITLE
[Availability] Lazily expand type refinement contexts for extensions.

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -551,6 +551,10 @@ private:
       return true;
     }
 
+    if (isa<ExtensionDecl>(D)) {
+      return true;
+    }
+
     return false;
   }
 

--- a/test/Macros/macro_expand_extensions.swift
+++ b/test/Macros/macro_expand_extensions.swift
@@ -256,3 +256,13 @@ final class SendableClass {
 @AddSendable
 class InvalidSendableClass {
 }
+
+@AddSendable
+struct HasNestedType {
+  struct Inner {}
+}
+
+// Make sure no circularity error is produced when resolving
+// extensions of nested types when the outer type has an
+// attached macro that can add other nested types.
+extension HasNestedType.Inner {}

--- a/test/Sema/availability_refinement_contexts.swift
+++ b/test/Sema/availability_refinement_contexts.swift
@@ -73,8 +73,9 @@ protocol SomeProtocol {
   var protoProperty: Int { get }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl versions=[10.52,+Inf) decl=someExtensionFunction()
+// CHECK-NEXT: {{^}}  (decl_implicit versions=[10.13,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl versions=[10.51,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someExtensionFunction()
 @available(OSX 10.51, *)
 extension SomeClass {
   @available(OSX 10.52, *)
@@ -207,15 +208,16 @@ func functionWithWhile() {
   }
 }
 
-// CHECK-NEXT: {{^}}  (decl versions=[10.51,+Inf) decl=extension.SomeClass
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyWithClosureInit
-// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someStaticPropertyWithClosureInit
-// CHECK-NEXT: {{^}}        (condition_following_availability versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}        (if_then versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}    (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyWithClosureInitInferred
-// CHECK-NEXT: {{^}}      (decl versions=[10.52,+Inf) decl=someStaticPropertyWithClosureInitInferred
-// CHECK-NEXT: {{^}}        (condition_following_availability versions=[10.54,+Inf)
-// CHECK-NEXT: {{^}}        (if_then versions=[10.54,+Inf)
+// CHECK-NEXT: {{^}}  (decl_implicit versions=[10.13,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}    (decl versions=[10.51,+Inf) decl=extension.SomeClass
+// CHECK-NEXT: {{^}}      (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}        (decl versions=[10.52,+Inf) decl=someStaticPropertyWithClosureInit
+// CHECK-NEXT: {{^}}          (condition_following_availability versions=[10.54,+Inf)
+// CHECK-NEXT: {{^}}          (if_then versions=[10.54,+Inf)
+// CHECK-NEXT: {{^}}      (decl_implicit versions=[10.51,+Inf) decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}        (decl versions=[10.52,+Inf) decl=someStaticPropertyWithClosureInitInferred
+// CHECK-NEXT: {{^}}          (condition_following_availability versions=[10.54,+Inf)
+// CHECK-NEXT: {{^}}          (if_then versions=[10.54,+Inf)
 @available(OSX 10.51, *)
 extension SomeClass {
   @available(OSX 10.52, *)

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -225,6 +225,12 @@ class GuardedAvailability {
   }()
 }
 
+@Observable class Parent {
+  class Nested {}
+}
+
+extension Parent.Nested {}
+
 struct CowContainer {
   final class Contents { }
   


### PR DESCRIPTION
When resolving an attached macro, the constraint system needs to check whether a potential macro candidate is available in the current context. That triggers building a type refinement context, and when the macro is applied at the top-level, building the type refinement context needs to resolve extensions because extensions get their availability from the extended type. However, if the extended type is nested inside another type that has attached macros, those macros must be expanded to produce any member types that might be added by the macro. This leads to circularity errors that cannot be resolved.

This change opts extension declarations into lazily building a TRC to avoid needing to resolve the extended type while building a type refinement context to check availability at an unrelated source location in the same file.

Resolves rdar://115851283, resolves #66450, resolves #70096