### PR TITLE
Revert Disallow multi-line filenames and non-decimal line numbers in `#sourceLocation` directive in Swift 6 mode

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -88,8 +88,6 @@ WARNING(escaped_parameter_name,none,
 
 ERROR(forbidden_interpolated_string,none,
       "%0 cannot be an interpolated string literal", (StringRef))
-ERROR(forbidden_multiline_string,none,
-      "%0 cannot be a multi-line string literal", (StringRef))
 ERROR(forbidden_extended_escaping_string,none,
       "%0 cannot be an extended escaping string literal", (StringRef))
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -718,11 +718,8 @@ public:
   ///
   /// \param Loc where to diagnose.
   /// \param DiagText name for the string literal in the diagnostic.
-  /// \param AllowMultiline Whether the string literal can be a multiline string
-  ///        literal.
   std::optional<StringRef>
-  getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText,
-                                    bool AllowMultiline);
+  getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText);
 
   /// Returns true to indicate that experimental concurrency syntax should be
   /// parsed if the parser is generating only a syntax tree or if the user has

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -569,8 +569,7 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
       }
 
       auto Value = getStringLiteralIfNotInterpolated(
-          AttrLoc, ("'" + ArgumentKindStr + "'").str(),
-          /*AllowMultiline=*/true);
+          AttrLoc, ("'" + ArgumentKindStr + "'").str());
       consumeToken();
       if (!Value) {
         AnyArgumentInvalid = true;
@@ -1462,8 +1461,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
       return std::nullopt;
     }
     std::optional<StringRef> importModuleName =
-        getStringLiteralIfNotInterpolated(Loc, ("'" + AttrName + "'").str(),
-                                          /*AllowMultiline=*/false);
+        getStringLiteralIfNotInterpolated(Loc, ("'" + AttrName + "'").str());
     consumeToken(tok::string_literal);
 
     if (!importModuleName.has_value()) {
@@ -3240,8 +3238,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
 
-      AsmName = getStringLiteralIfNotInterpolated(
-          Loc, ("'" + AttrName + "'").str(), /*AllowMultiline=*/false);
+      AsmName =
+          getStringLiteralIfNotInterpolated(Loc, ("'" + AttrName + "'").str());
 
       consumeToken(tok::string_literal);
 
@@ -3311,7 +3309,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
 
     auto Name = getStringLiteralIfNotInterpolated(
-        Loc, ("'" + AttrName + "'").str(), /*AllowMultiline=*/false);
+        Loc, ("'" + AttrName + "'").str());
 
     consumeToken(tok::string_literal);
 
@@ -3398,7 +3396,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     }
 
     auto Value = getStringLiteralIfNotInterpolated(
-        Loc, ("'" + AttrName + "'").str(), /*AllowMultiline=*/false);
+        Loc, ("'" + AttrName + "'").str());
 
     consumeToken(tok::string_literal);
 
@@ -3461,8 +3459,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         // Parse the next string literal as the original module name.
         auto ModuleNameLoc = Tok.getLoc();
         if (Tok.is(tok::string_literal)) {
-          auto NameOp = getStringLiteralIfNotInterpolated(
-              Tok.getLoc(), "original module name", /*AllowMultiline=*/false);
+          auto NameOp = getStringLiteralIfNotInterpolated(Tok.getLoc(),
+                                                          "original module name");
           if (NameOp.has_value())
             OriginalModuleName = *NameOp;
           consumeToken();
@@ -3551,8 +3549,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         diagnose(ColonLoc, diag::attr_private_import_expected_sourcefile_name);
         return makeParserSuccess();
       }
-      filename = getStringLiteralIfNotInterpolated(Loc, "_private",
-                                                   /*AllowMultiline=*/false);
+      filename = getStringLiteralIfNotInterpolated(Loc, "_private");
       if (!filename.has_value()) {
         diagnose(ColonLoc, diag::attr_private_import_expected_sourcefile_name);
         return makeParserSuccess();
@@ -3829,8 +3826,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
         return makeParserSuccess();
       }
 
-      std::optional<StringRef> value = getStringLiteralIfNotInterpolated(
-          Tok.getLoc(), flag, /*AllowMultiline=*/false);
+      std::optional<StringRef> value =
+          getStringLiteralIfNotInterpolated(Tok.getLoc(), flag);
       if (!value)
         return makeParserSuccess();
       Token stringTok = Tok;
@@ -4569,8 +4566,7 @@ bool Parser::parseConventionAttributeInternal(SourceLoc atLoc, SourceLoc attrLoc
         diagnose(Tok, diag::convention_attribute_ctype_expected_string);
       return true;
     }
-    if (auto ty = getStringLiteralIfNotInterpolated(Tok.getLoc(), "(C type)",
-                                                    /*AllowMultiline=*/false)) {
+    if (auto ty = getStringLiteralIfNotInterpolated(Tok.getLoc(), "(C type)")) {
       cType = Located<StringRef>(ty.value(), Tok.getLoc());
     }
     consumeToken(tok::string_literal);
@@ -7276,8 +7272,8 @@ ParserStatus Parser::parseLineDirective(bool isLine) {
         return makeParserError();
       }
 
-      Filename = getStringLiteralIfNotInterpolated(Loc, "'#sourceLocation'",
-                                                   /*AllowMultiline=*/false);
+      Filename =
+          getStringLiteralIfNotInterpolated(Loc, "'#sourceLocation'");
       if (!Filename.has_value())
         return makeParserError();
       SourceLoc filenameLoc = consumeToken(tok::string_literal);
@@ -7295,11 +7291,6 @@ ParserStatus Parser::parseLineDirective(bool isLine) {
       }
       SmallString<16> buffer;
       auto text = stripUnderscoresIfNeeded(Tok.getText(), buffer);
-      if (text.find_first_not_of("0123456789") != StringRef::npos) {
-        // Disallow non-decimal line numbers in Swift 6.
-        diagnose(Tok, diag::expected_line_directive_number)
-            .warnUntilSwiftVersion(6);
-      }
       if (text.getAsInteger(0, StartLine)) {
         diagnose(Tok, diag::expected_line_directive_number);
         return makeParserError();
@@ -7347,9 +7338,8 @@ ParserStatus Parser::parseLineDirective(bool isLine) {
       diagnose(Tok, diag::expected_line_directive_name);
       return makeParserError();
     }
-
-    Filename = getStringLiteralIfNotInterpolated(Loc, "'#line'",
-                                                 /*AllowMultiline=*/false);
+    
+    Filename = getStringLiteralIfNotInterpolated(Loc, "'#line'");
     if (!Filename.has_value())
       return makeParserError();
   }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2773,9 +2773,8 @@ ParserResult<Stmt> Parser::parseStmtPoundAssert() {
       return makeParserError();
     }
 
-    auto messageOpt =
-        getStringLiteralIfNotInterpolated(Tok.getLoc(), "'#assert' message",
-                                          /*AllowMultiline=*/true);
+    auto messageOpt = getStringLiteralIfNotInterpolated(Tok.getLoc(),
+                                                        "'#assert' message");
     consumeToken();
     if (!messageOpt)
       return makeParserError();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1098,18 +1098,13 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
 }
 
 std::optional<StringRef>
-Parser::getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText,
-                                          bool AllowMultiline) {
+Parser::getStringLiteralIfNotInterpolated(SourceLoc Loc, StringRef DiagText) {
   assert(Tok.is(tok::string_literal));
 
   // FIXME: Support extended escaping string literal.
   if (Tok.getCustomDelimiterLen()) {
     diagnose(Loc, diag::forbidden_extended_escaping_string, DiagText);
     return std::nullopt;
-  }
-  if (!AllowMultiline && Tok.isMultilineString()) {
-    diagnose(Loc, diag::forbidden_multiline_string, DiagText)
-        .warnUntilSwiftVersion(6);
   }
 
   SmallVector<Lexer::StringSegment, 1> Segments;

--- a/test/Parse/line-directive.swift
+++ b/test/Parse/line-directive.swift
@@ -14,17 +14,6 @@ x // expected-error {{parameterless closing #sourceLocation() directive without 
 
 #sourceLocation(file: x.swift, line: 1) // expected-error{{expected filename string literal}}
 
-// expected-warning@+1 {{expected starting line number for #sourceLocation directive; this is an error in Swift 6}}
-#sourceLocation(file: "x.swift", line: 0xff)
-
-#sourceLocation()
-
-// expected-warning@+1 {{'#sourceLocation' cannot be a multi-line string literal; this is an error in Swift 6}}
-#sourceLocation(file: """
-x.swift
-y.swift
-""", line: 42)
-
 #sourceLocation(file: "x.swift", line: 42)
 x x ; // should be ignored by expected_error because it is in a different file
 x


### PR DESCRIPTION
Revert https://github.com/apple/swift/pull/71238

After looking at the SwiftParser implementation, I decided that it’s actually harder to diagnose these cases than to allow them, so let’s just continue allowing them.