### PR TITLE
BinaryInteger advanced(by:) fixes

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1624,17 +1624,15 @@ extension BinaryInteger {
   @inlinable
   @inline(__always)
   public func advanced(by n: Int) -> Self {
-    if !Self.isSigned {
+    if Self.isSigned {
+      return self.bitWidth < n.bitWidth
+        ? Self(Int(truncatingIfNeeded: self) + n)
+        : self + Self(truncatingIfNeeded: n)
+    } else {
       return n < (0 as Int)
-        ? self - Self(-n)
-        : self + Self(n)
+        ? self - Self(n.magnitude)
+        : self + Self(n.magnitude)
     }
-    if (self < (0 as Self)) == (n < (0 as Self)) {
-      return self + Self(n)
-    }
-    return self.magnitude < n.magnitude
-      ? Self(Int(self) + n)
-      : self + Self(n)
   }
 }
 

--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1630,8 +1630,8 @@ extension BinaryInteger {
         : self + Self(truncatingIfNeeded: n)
     } else {
       return n < (0 as Int)
-        ? self - Self(n.magnitude)
-        : self + Self(n.magnitude)
+        ? self - Self(UInt(bitPattern: ~n &+ 1))
+        : self + Self(UInt(bitPattern: n))
     }
   }
 }

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -853,7 +853,7 @@ tests.test("Strideable") {
   expectEqual(dist(Int8.min, Int8.max), 255)
   expectEqual(dist(Int8.max, Int8.min), -255)
   
-  expectEqual(Int8.min.advanced(by: 128), 0)
+  expectEqual(Int8.min.advanced(by: Int(Int8.max)+1), 0)
   expectEqual(UInt.max.advanced(by: Int.min), UInt.max / 2)
 }
 

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -852,6 +852,9 @@ tests.test("Strideable") {
   expectEqual(dist(UInt8.max, UInt8.min), -255)
   expectEqual(dist(Int8.min, Int8.max), 255)
   expectEqual(dist(Int8.max, Int8.min), -255)
+  
+  expectEqual(Int8.min.advanced(by: 128), 0)
+  expectEqual(UInt.max.advanced(by: Int.min), UInt.max / 2)
 }
 
 tests.test("signum/generic") {


### PR DESCRIPTION
This patch fixes two unnecessary traps in BinaryInteger's advanced(by:) method. 

- `Int8.min.advanced(by: 128)`, etc.
- `UInt.max.advanced(by: Int.min)`, etc.

The first one is also mentioned in (https://github.com/apple/swift/issues/53747), w.r.t. `range.index(_:offsetBy:)`.

#### Before

```swift
if !Self.isSigned {
  return n < (0 as Int)
    ? self - Self(-n) // ------------------------ (1) crashes on UInt.max.advanced(by: Int.min)
    : self + Self(n)
}
if (self < (0 as Self)) == (n < (0 as Self)) {
  return self + Self(n) // ---------------------- (2) bit width comparison makes this unneccessary :tm:
}
return self.magnitude < n.magnitude
  ? Self(Int(self) + n)
  : self + Self(n) // --------------------------- (3) crashes on Int8.min.advanced(by: 128)
```

#### After

```swift
if Self.isSigned {
  return self.bitWidth < n.bitWidth // ---------- (2) constant-foldable when fixed-width (probably)
    ? Self(Int(truncatingIfNeeded: self) + n)
    : self + Self(truncatingIfNeeded: n) // ----- (3) can represent n because bit width is [>=]
} else {
  return n < (0 as Int)
    ? self - Self(UInt(bitPattern: ~n &+ 1)) // - (1) n.magnitude can represent all -n where n < 0
    : self + Self(UInt(bitPattern: n))
}
```