### PR TITLE
[DNM] Revert "IRGen: Use llvm.compiler.used instead of llvm.used on ELF"

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -214,17 +214,6 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
 #else
     Arguments.push_back(context.Args.MakeArgString("-fuse-ld=" + Linker));
 #endif
-    // Starting with lld 13, Swift stopped working with the lld --gc-sections
-    // implementation for ELF, unless -z nostart-stop-gc is also passed to lld:
-    //
-    // https://reviews.llvm.org/D96914
-    if (Linker == "lld" || (Linker.length() > 5 &&
-                            Linker.substr(Linker.length() - 6) == "ld.lld")) {
-      Arguments.push_back("-Xlinker");
-      Arguments.push_back("-z");
-      Arguments.push_back("-Xlinker");
-      Arguments.push_back("nostart-stop-gc");
-    }
   }
 
   // Configure the toolchain.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1030,15 +1030,6 @@ bool LinkInfo::isUsed(IRLinkage IRL) {
 ///
 /// This value must have a definition by the time the module is finalized.
 void IRGenModule::addUsedGlobal(llvm::GlobalValue *global) {
-
-  // As of reviews.llvm.org/D97448 "ELF: Create unique SHF_GNU_RETAIN sections
-  // for llvm.used global objects" LLVM creates separate sections for globals in
-  // llvm.used on ELF.  Therefore we use llvm.compiler.used on ELF instead.
-  if (TargetInfo.OutputObjectFormat == llvm::Triple::ELF) {
-    addCompilerUsedGlobal(global);
-    return;
-  }
-
   LLVMUsed.push_back(global);
 }
 

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -36,31 +36,40 @@ static const void *__backtraceRef __attribute__((used))
 // by the linker.  Otherwise, we may end up with undefined symbol references as
 // the linker table section was never constructed.
 #if defined(__ELF__)
-# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"aR\"\n");
+# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"a\"\n");
+# define DECLARE_EMPTY_RETAINED_METADATA_SECTION(name) __asm__("\t.section " #name ",\"aR\"\n");
 #elif defined(__wasm__)
 # define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"\",@\n");
+# define DECLARE_EMPTY_RETAINED_METADATA_SECTION(name) DECLAREDECLARE_EMPTY_METADATA_SECTION(name)
 #endif
 
-#define DECLARE_SWIFT_SECTION(name)                                                          \
-  DECLARE_EMPTY_METADATA_SECTION(name)                                                                \
+#define DECLARE_SWIFT_ENCAPSULATION_SYMBOLS(name) \
   __attribute__((__visibility__("hidden"),__aligned__(1))) extern const char __start_##name; \
   __attribute__((__visibility__("hidden"),__aligned__(1))) extern const char __stop_##name;
 
+#define DECLARE_SWIFT_SECTION(name) \
+  DECLARE_EMPTY_METADATA_SECTION(name) \
+  DECLARE_SWIFT_ENCAPSULATION_SYMBOLS(name)
+
+#define DECLARE_SWIFT_RETAINED_SECTION(name) \
+  DECLARE_EMPTY_RETAINED_METADATA_SECTION(name) \
+  DECLARE_SWIFT_ENCAPSULATION_SYMBOLS(name)
+
 extern "C" {
-DECLARE_SWIFT_SECTION(swift5_protocols)
-DECLARE_SWIFT_SECTION(swift5_protocol_conformances)
-DECLARE_SWIFT_SECTION(swift5_type_metadata)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_protocols)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_protocol_conformances)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_type_metadata)
 
 DECLARE_SWIFT_SECTION(swift5_typeref)
 DECLARE_SWIFT_SECTION(swift5_reflstr)
-DECLARE_SWIFT_SECTION(swift5_fieldmd)
-DECLARE_SWIFT_SECTION(swift5_assocty)
-DECLARE_SWIFT_SECTION(swift5_replace)
-DECLARE_SWIFT_SECTION(swift5_replac2)
-DECLARE_SWIFT_SECTION(swift5_builtin)
-DECLARE_SWIFT_SECTION(swift5_capture)
-DECLARE_SWIFT_SECTION(swift5_mpenum)
-DECLARE_SWIFT_SECTION(swift5_accessible_functions)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_fieldmd)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_assocty)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_replace)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_replac2)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_builtin)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_capture)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_mpenum)
+DECLARE_SWIFT_RETAINED_SECTION(swift5_accessible_functions)
 DECLARE_SWIFT_SECTION(swift5_runtime_attributes)
 }
 

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -36,7 +36,7 @@ static const void *__backtraceRef __attribute__((used))
 // by the linker.  Otherwise, we may end up with undefined symbol references as
 // the linker table section was never constructed.
 #if defined(__ELF__)
-# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"a\"\n");
+# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"aR\"\n");
 #elif defined(__wasm__)
 # define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"\",@\n");
 #endif

--- a/test/Driver/link-time-opt.swift
+++ b/test/Driver/link-time-opt.swift
@@ -14,7 +14,6 @@
 // CHECK-SIMPLE-THIN-linux-gnu: clang
 // CHECK-SIMPLE-THIN-linux-gnu-DAG: -flto=thin
 // CHECK-SIMPLE-THIN-linux-gnu-DAG: -fuse-ld=lld
-// CHECK-SIMPLE-THIN-linux-gnu-DAG: -Xlinker -z -Xlinker nostart-stop-gc
 // CHECK-SIMPLE-THIN-linux-gnu-DAG: [[BITCODEFILE]]
 // CHECK-SIMPLE-THIN-linux-gnu-NOT: swift-autolink-extract
 
@@ -36,7 +35,6 @@
 // CHECK-SIMPLE-FULL-linux-gnu: clang
 // CHECK-SIMPLE-FULL-linux-gnu-DAG: -flto=full
 // CHECK-SIMPLE-FULL-linux-gnu-DAG: -fuse-ld=lld
-// CHECK-SIMPLE-FULL-linux-gnu-DAG: -Xlinker -z -Xlinker nostart-stop-gc
 // CHECK-SIMPLE-FULL-linux-gnu-DAG: [[BITCODEFILE]]
 // CHECK-SIMPLE-FULL-linux-gnu-NOT: swift-autolink-extract
 


### PR DESCRIPTION
This reverts commit 2bbea54dc0bf95d2622f71ecc3e100eff3a19183 to see what multiple sections for each global broke.

The use of `llvm.compiler.used` as a replacement for `llvm.used` changes the semantics of symbol requirements at link time, and it loses `SHF_GNU_RETAIN` for generated `swift5` metadata sections.

I'm not sure why multiple same name sections were problem here 🤔 