### PR TITLE
SIL: Adjust `isTypeMetadataForLayoutAccessible()` to visit more lowered positions

### DIFF
--- a/lib/SIL/IR/SIL.cpp
+++ b/lib/SIL/IR/SIL.cpp
@@ -249,6 +249,24 @@ static bool isTypeMetadataForLayoutAccessible(SILModule &M, SILType type) {
   if (type.is<AnyMetatypeType>())
     return true;
 
+  //   - pack expansion types
+  if (auto expansionType = type.getAs<PackExpansionType>()) {
+    auto patternType = SILType::getPrimitiveType(expansionType.getPatternType(),
+                                                 type.getCategory());
+    return isTypeMetadataForLayoutAccessible(M, patternType);
+  }
+
+  //   - lowered pack types
+  if (auto packType = type.getAs<SILPackType>()) {
+    for (auto eltType : packType.getElementTypes()) {
+      if (!isTypeMetadataForLayoutAccessible(
+              M, SILType::getPrimitiveAddressType(eltType)))
+        return false;
+    }
+
+    return true;
+  }
+
   // Otherwise, check that we can fetch the type metadata.
   return M.isTypeMetadataAccessible(type.getASTType());
 }

--- a/test/IRGen/variadic_generic_captures.swift
+++ b/test/IRGen/variadic_generic_captures.swift
@@ -65,3 +65,8 @@ public func has_witness_table_pack2<each T: Sequence>(t: repeat each T) -> () ->
     where repeat (each T).Element: Sequence {
   return { _ = (repeat (each T).Element.Element).self }
 }
+
+// https://github.com/apple/swift/issues/71455
+func f<each T>(t: (repeat each T)) {
+  let tup = (repeat ((each T).self, each t))
+}


### PR DESCRIPTION
Fixes #71455, rdar://119267393
- [x] Add a test case
