### PR TITLE
[Debug] Fix regex type names in DebugDescriptionMacro

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
@@ -71,15 +71,19 @@ extension DebugDescriptionMacro: MemberAttributeMacro {
       return []
     }
 
+    // Warning: To use a backslash escape in `typeIdentifier`, it needs to be double escaped. This is because
+    // the string is serialized to a String literal (an argument to `@_DebugDescriptionProperty`), which
+    // effectively "consumes" one level of escaping. To avoid mistakes, dots are matched with `[.]` instead
+    // of the more conventional `\.`.
     var typeIdentifier: String
     if let typeParameters = declaration.asProtocol(WithGenericParametersSyntax.self)?.genericParameterClause?.parameters, typeParameters.count > 0 {
       let typePatterns = Array(repeating: ".+", count: typeParameters.count).joined(separator: ",")
       // A regex matching that matches the generic type.
-      typeIdentifier = "^\(moduleName)\\.\(typeName)<\(typePatterns)>"
+      typeIdentifier = "^\(moduleName)[.]\(typeName)<\(typePatterns)>"
     } else if declaration.is(ExtensionDeclSyntax.self) {
       // When attached to an extension, the type may or may not be a generic type.
       // This regular expression handles both cases.
-      typeIdentifier = "^\(moduleName)\\.\(typeName)(<.+>)?$"
+      typeIdentifier = "^\(moduleName)[.]\(typeName)(<.+>)?$"
     } else {
       typeIdentifier = "\(moduleName).\(typeName)"
     }
@@ -249,7 +253,7 @@ fileprivate let ENCODING_VERSION: UInt = 1
 
 /// Construct an LLDB type summary record.
 ///
-/// The record is serializeed as a tuple of `UInt8` bytes.
+/// The record is serialized as a tuple of `UInt8` bytes.
 ///
 /// The record contains the following:
 ///   * Version number of the record format
@@ -352,7 +356,7 @@ extension DeclGroupSyntax {
     case .actorDecl, .classDecl, .enumDecl, .structDecl:
       return self.asProtocol(NamedDeclSyntax.self)?.name.text
     case .extensionDecl:
-      return self.as(ExtensionDeclSyntax.self)?.extendedType.description
+      return self.as(ExtensionDeclSyntax.self)?.extendedType.trimmedDescription
     default:
       // New types of decls are not presumed to be valid.
       return nil

--- a/test/Macros/DebugDescription/extension.swift
+++ b/test/Macros/DebugDescription/extension.swift
@@ -1,0 +1,26 @@
+// REQUIRES: swift_swift_parser
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -swift-version 5 -module-name main -disable-availability-checking -typecheck -enable-experimental-feature SymbolLinkageMarkers -plugin-path %swift-plugin-dir -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %FileCheck %s < %t/expansions-dump.txt
+
+struct MyStruct {}
+
+@_DebugDescription
+extension MyStruct {
+  var debugDescription: String { "thirty" }
+}
+// CHECK: #if os(Linux)
+// CHECK: @_section(".lldbsummaries")
+// CHECK: #elseif os(Windows)
+// CHECK: @_section(".lldbsummaries")
+// CHECK: #else
+// CHECK: @_section("__DATA_CONST,__lldbsummaries")
+// CHECK: #endif
+// CHECK: @_used
+// CHECK: static let _lldb_summary = (
+// CHECK:     /* version */ 1 as UInt8,
+// CHECK:     /* record size */ 34 as UInt8,
+// CHECK:     /* "^main[.]MyStruct(<.+>)?$" */ 25 as UInt8, 94 as UInt8, 109 as UInt8, 97 as UInt8, 105 as UInt8, 110 as UInt8, 91 as UInt8, 46 as UInt8, 93 as UInt8, 77 as UInt8, 121 as UInt8, 83 as UInt8, 116 as UInt8, 114 as UInt8, 117 as UInt8, 99 as UInt8, 116 as UInt8, 40 as UInt8, 60 as UInt8, 46 as UInt8, 43 as UInt8, 62 as UInt8, 41 as UInt8, 63 as UInt8, 36 as UInt8, 0 as UInt8,
+// CHECK:     /* "thirty" */ 7 as UInt8, 116 as UInt8, 104 as UInt8, 105 as UInt8, 114 as UInt8, 116 as UInt8, 121 as UInt8, 0 as UInt8
+// CHECK: )


### PR DESCRIPTION
Fixes the way `DebugDescriptionMacro` produces a regex type name.

The problem was use of backslash escapes that weren't sufficiently escaped. They needed to be double escaped. To avoid this trap, the regexes now use `[.]` to match a dot, instead of the more conventional `\.` syntax.