### PR TITLE
[CSBindings] Don't allow leading-dot base inference from Escapable pr…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -625,14 +625,15 @@ bool BindingSet::finalize(
           for (auto *constraint : *TransitiveProtocols) {
             Type protocolTy = constraint->getSecondType();
 
-            // The Copyable protocol can't have members, yet will be a
+            // The Copyable/Escapable protocols can't have members, yet will be a
             // constraint of basically all type variables, so don't suggest it.
             //
             // NOTE: worth considering for all marker protocols, but keep in
             // mind that you're allowed to extend them with members!
             if (auto p = protocolTy->getAs<ProtocolType>()) {
               if (ProtocolDecl *decl = p->getDecl())
-                if (decl->isSpecificProtocol(KnownProtocolKind::Copyable))
+                if (decl->isSpecificProtocol(KnownProtocolKind::Copyable) ||
+                    decl->isSpecificProtocol(KnownProtocolKind::Escapable))
                   continue;
             }
 

--- a/test/Constraints/static_members_on_protocol_in_generic_context.swift
+++ b/test/Constraints/static_members_on_protocol_in_generic_context.swift
@@ -349,3 +349,22 @@ func test_leading_dot_syntax_with_typelias() {
   test(.box) // expected-error {{type 'Box<T>.Type' cannot conform to 'Container'}} expected-note {{only concrete types such as structs, enums and classes can conform to protocols}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
 }
+
+extension Copyable where Self == Int {
+  static func answer() -> Int { 42 }
+}
+
+extension Escapable where Self == String {
+  static func question() -> String { "" }
+}
+
+do {
+  func testCopyable<T: Copyable>(_: T) {}
+  func testEscapable<T: Escapable>(_: T) {}
+
+  testCopyable(.answer())
+  // expected-error@-1 {{cannot infer contextual base in reference to member 'answer'}}
+
+  testEscapable(.question())
+  // expected-error@-1 {{cannot infer contextual base in reference to member 'question'}}
+}


### PR DESCRIPTION
…otocol

Similarly to `Copyable`, `Escapable` shouldn't have any members declared and 
as a result shouldn't be considered for leading-dot base type inference.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
