### PR TITLE
[cxx-interop] Allow initializing `std::function` from Swift closures

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.h
+++ b/lib/ClangImporter/ClangDerivedConformances.h
@@ -71,6 +71,12 @@ void conformToCxxVectorIfNeeded(ClangImporter::Implementation &impl,
                                 NominalTypeDecl *decl,
                                 const clang::CXXRecordDecl *clangDecl);
 
+/// If the decl is an instantiation of C++ `std::function`, synthesize a
+/// conformance to CxxFunction, which is defined in the Cxx module.
+void conformToCxxFunctionIfNeeded(ClangImporter::Implementation &impl,
+                                  NominalTypeDecl *decl,
+                                  const clang::CXXRecordDecl *clangDecl);
+
 } // namespace swift
 
 #endif // SWIFT_CLANG_DERIVED_CONFORMANCES_H

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2815,6 +2815,7 @@ namespace {
           conformToCxxPairIfNeeded(Impl, nominalDecl, decl);
           conformToCxxOptionalIfNeeded(Impl, nominalDecl, decl);
           conformToCxxVectorIfNeeded(Impl, nominalDecl, decl);
+          conformToCxxFunctionIfNeeded(Impl, nominalDecl, decl);
         }
       }
 

--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -263,6 +263,10 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
     // Unfortunately, implicitly defined CXXDestructorDecls don't have a real
     // body, so we need to traverse these manually.
     if (auto *dtor = dyn_cast<clang::CXXDestructorDecl>(next)) {
+      if (dtor->isImplicit() && dtor->isDefaulted() && !dtor->isDeleted() &&
+          !dtor->doesThisDeclarationHaveABody())
+        clangSema.DefineImplicitDestructor(dtor->getLocation(), dtor);
+
       if (dtor->isImplicit() || dtor->hasBody()) {
         auto cxxRecord = dtor->getParent();
 

--- a/test/Interop/Cxx/stdlib/Inputs/std-function.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-function.h
@@ -2,8 +2,10 @@
 #define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_FUNCTION_H
 
 #include <functional>
+#include <string>
 
 using FunctionIntToInt = std::function<int(int)>;
+using FunctionStringToString = std::function<std::string(const std::string&)>;
 
 inline FunctionIntToInt getIdentityFunction() {
   return [](int x) { return x; };
@@ -12,5 +14,9 @@ inline FunctionIntToInt getIdentityFunction() {
 inline bool isEmptyFunction(FunctionIntToInt f) { return !(bool)f; }
 
 inline int invokeFunction(FunctionIntToInt f, int x) { return f(x); }
+
+std::string invokeFunctionTwice(FunctionStringToString f, std::string s) {
+  return f(f(s));
+}
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_FUNCTION_H

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -9,10 +9,11 @@
 
 import StdlibUnittest
 import StdFunction
+import CxxStdlib
 
 var StdFunctionTestSuite = TestSuite("StdFunction")
 
-StdFunctionTestSuite.test("init empty") {
+StdFunctionTestSuite.test("FunctionIntToInt.init()") {
   let f = FunctionIntToInt()
   expectTrue(isEmptyFunction(f))
 
@@ -20,14 +21,40 @@ StdFunctionTestSuite.test("init empty") {
   expectTrue(isEmptyFunction(copied))
 }
 
-StdFunctionTestSuite.test("call") {
+StdFunctionTestSuite.test("FunctionIntToInt.callAsFunction") {
   let f = getIdentityFunction()
   expectEqual(123, f(123))
 }
 
-StdFunctionTestSuite.test("retrieve and pass back as parameter") {
+StdFunctionTestSuite.test("FunctionIntToInt retrieve and pass back as parameter") {
   let res = invokeFunction(getIdentityFunction(), 456)
   expectEqual(456, res)
 }
+
+#if !os(Windows) // FIXME: rdar://103979602
+StdFunctionTestSuite.test("FunctionIntToInt init from closure and call") {
+  let cClosure: @convention(c) (Int32) -> Int32 = { $0 + 1 }
+  let f = FunctionIntToInt(cClosure)
+  expectEqual(1, f(0))
+  expectEqual(124, f(123))
+  expectEqual(0, f(-1))
+
+  let f2 = FunctionIntToInt({ $0 * 2 })
+  expectEqual(0, f2(0))
+  expectEqual(246, f2(123))
+}
+
+StdFunctionTestSuite.test("FunctionIntToInt init from closure and pass as parameter") {
+  let res = invokeFunction(.init({ $0 * 2 }), 111)
+  expectEqual(222, res)
+}
+
+// FIXME: assertion for address-only closure params (rdar://124501345)
+//StdFunctionTestSuite.test("FunctionStringToString init from closure and pass as parameter") {
+//  let res = invokeFunctionTwice(.init({ $0 + std.string("abc") }),
+//                                std.string("prefix"))
+//  expectEqual(std.string("prefixabcabc"), res)
+//}
+#endif
 
 runAllTests()


### PR DESCRIPTION
This adds a Swift initializer to instantiations of `std::function` that accepts a Swift closure with `@convention(c)`.

rdar://103979602