### PR TITLE
SILGen: Emit borrowing switch subjects under a formal access.

### DIFF
--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -222,12 +222,6 @@ public:
     return Storage.get<LValueStorage>(StoredKind).Loc;
   }
 
-  /// The kind of operation under which we are querying a storage reference.
-  enum class StorageReferenceOperationKind {
-    Borrow,
-    Consume
-  };
-
   Expr *findStorageReferenceExprForBorrow() &&;
   Expr *findStorageReferenceExprForMoveOnly(SILGenFunction &SGF,
                                       StorageReferenceOperationKind refKind) &&;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3193,13 +3193,8 @@ static StorageRefResult findStorageReferenceExprForBorrow(Expr *e) {
   return StorageRefResult();
 }
 
-Expr *ArgumentSource::findStorageReferenceExprForMoveOnly(
-    SILGenFunction &SGF, StorageReferenceOperationKind kind) && {
-  if (!isExpr())
-    return nullptr;
-
-  auto argExpr = asKnownExpr();
-
+Expr *SILGenFunction::findStorageReferenceExprForMoveOnly(Expr *argExpr,
+                                           StorageReferenceOperationKind kind) {
   // If there's a load around the outer part of this arg expr, look past it.
   bool sawLoad = false;
   if (auto *li = dyn_cast<LoadExpr>(argExpr)) {
@@ -3267,7 +3262,7 @@ Expr *ArgumentSource::findStorageReferenceExprForMoveOnly(
   assert(type);
 
   SILType ty =
-      SGF.getLoweredType(type->getWithoutSpecifierType()->getCanonicalType());
+      getLoweredType(type->getWithoutSpecifierType()->getCanonicalType());
   bool isMoveOnly = ty.isMoveOnly(/*orWrapped=*/false);
   if (auto *pd = dyn_cast<ParamDecl>(storage)) {
     isMoveOnly |= pd->getSpecifier() == ParamSpecifier::Borrowing;
@@ -3275,10 +3270,6 @@ Expr *ArgumentSource::findStorageReferenceExprForMoveOnly(
   }
   if (!isMoveOnly)
     return nullptr;
-
-  // Claim the value of this argument since we found a storage reference that
-  // has a move only base.
-  (void)std::move(*this).asKnownExpr();
 
   // If we saw a subscript expr and the base of the subscript expr passed our
   // tests above, we can emit the call to the subscript directly as a borrowed
@@ -3289,11 +3280,22 @@ Expr *ArgumentSource::findStorageReferenceExprForMoveOnly(
   return result.getTransitiveRoot();
 }
 
-Expr *
-ArgumentSource::findStorageReferenceExprForBorrowExpr(SILGenFunction &SGF) && {
+Expr *ArgumentSource::findStorageReferenceExprForMoveOnly(
+    SILGenFunction &SGF, StorageReferenceOperationKind kind) && {
   if (!isExpr())
     return nullptr;
 
+  auto lvExpr = SGF.findStorageReferenceExprForMoveOnly(asKnownExpr(), kind);
+  if (lvExpr) {
+    // Claim the value of this argument since we found a storage reference that
+    // has a move only base.
+    (void)std::move(*this).asKnownExpr();
+  }
+  return lvExpr;
+}
+
+Expr *
+SILGenFunction::findStorageReferenceExprForBorrowExpr(Expr *argExpr) {
   // We support two patterns:
   //
   // (load_expr (borrow_expr))
@@ -3302,8 +3304,6 @@ ArgumentSource::findStorageReferenceExprForBorrowExpr(SILGenFunction &SGF) && {
   //
   // The first happens if a borrow is used on a non-self argument. The second
   // happens if we pass self as a borrow.
-  auto *argExpr = asKnownExpr();
-
   if (auto *parenExpr = dyn_cast<ParenExpr>(argExpr))
     argExpr = parenExpr->getSubExpr();
 
@@ -3314,14 +3314,21 @@ ArgumentSource::findStorageReferenceExprForBorrowExpr(SILGenFunction &SGF) && {
   if (!borrowExpr)
     return nullptr;
 
-  Expr *lvExpr = ::findStorageReferenceExprForBorrow(borrowExpr->getSubExpr())
+  return ::findStorageReferenceExprForBorrow(borrowExpr->getSubExpr())
                      .getTransitiveRoot();
+}
 
+Expr *
+ArgumentSource::findStorageReferenceExprForBorrowExpr(SILGenFunction &SGF) && {
+  if (!isExpr())
+    return nullptr;
+
+  auto lvExpr = SGF.findStorageReferenceExprForBorrowExpr(asKnownExpr());
   // Claim the value of this argument.
   if (lvExpr) {
     (void)std::move(*this).asKnownExpr();
   }
-
+  
   return lvExpr;
 }
 
@@ -3683,7 +3690,7 @@ private:
 
     // Try to find an expression we can emit as a borrowed l-value.
     auto lvExpr = std::move(arg).findStorageReferenceExprForMoveOnly(
-        SGF, ArgumentSource::StorageReferenceOperationKind::Borrow);
+        SGF, StorageReferenceOperationKind::Borrow);
     if (!lvExpr)
       return false;
 
@@ -3757,7 +3764,7 @@ private:
 
     // Try to find an expression we can emit as a consumed l-value.
     auto lvExpr = std::move(arg).findStorageReferenceExprForMoveOnly(
-        SGF, ArgumentSource::StorageReferenceOperationKind::Consume);
+                                  SGF, StorageReferenceOperationKind::Consume);
     if (!lvExpr)
       return false;
 
@@ -3788,7 +3795,7 @@ private:
   void
   emitDirect(ArgumentSource &&arg, SILType loweredSubstArgType,
              AbstractionPattern origParamType, SILParameterInfo param,
-             llvm::Optional<AnyFunctionType::Param> origParam = llvm::None) {
+             llvm::Optional<AnyFunctionType::Param> origParam = llvm::None) {             
     ManagedValue value;
     auto loc = arg.getLocation();
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -272,6 +272,12 @@ struct MaterializedLValue {
       callbackStorage(callbackStorage) {}
 };
 
+/// The kind of operation under which we are querying a storage reference.
+enum class StorageReferenceOperationKind {
+  Borrow,
+  Consume
+};
+
 /// SILGenFunction - an ASTVisitor for producing SIL from function bodies.
 class LLVM_LIBRARY_VISIBILITY SILGenFunction
   : public ASTVisitor<SILGenFunction>
@@ -1510,6 +1516,12 @@ public:
 
   /// Emit the given expression as an r-value.
   RValue emitRValue(Expr *E, SGFContext C = SGFContext());
+
+  /// Given an expression, find the subexpression that can be emitted as a borrow formal access, if
+  /// any.
+  Expr *findStorageReferenceExprForMoveOnly(Expr *argExpr,
+                                            StorageReferenceOperationKind kind);
+  Expr *findStorageReferenceExprForBorrowExpr(Expr *argExpr);
 
   /// Emit the given expression as a +1 r-value.
   ///

--- a/test/SILGen/borrowing_switch_subjects.swift
+++ b/test/SILGen/borrowing_switch_subjects.swift
@@ -1,0 +1,75 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature BorrowingSwitch -disable-experimental-parser-round-trip %s | %FileCheck %s
+
+struct Inner: ~Copyable {}
+
+struct Outer: ~Copyable {
+    var storedInner: Inner
+
+    var readInner: Inner {
+        _read { fatalError() }
+    }
+
+    var getInner: Inner {
+        get { fatalError() }
+    }
+}
+
+func use(_: borrowing Outer) {}
+func use(_: borrowing Inner) {}
+
+func temporary() -> Outer { fatalError() }
+
+// CHECK-LABEL: sil {{.*}}@{{.*}}11borrowParam
+// CHECK:  = mark_unresolved_non_copyable_value [no_consume_or_assign]
+func borrowParam(x: borrowing Outer) {
+    // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign]
+    // CHECK: [[BORROW:%.*]] = begin_borrow [[MARK]]
+    switch x {
+    case _borrowing y:
+        // CHECK: apply {{.*}}([[BORROW]])
+        use(y)
+    }
+    // CHECK: end_borrow [[BORROW]]
+
+    
+    // CHECK: [[BORROW_OUTER:%.*]] = begin_borrow {{.*}} : $Outer
+    // CHECK: [[BORROW_INNER:%.*]] = struct_extract [[BORROW_OUTER]]
+    // CHECK: [[COPY_INNER:%.*]] = copy_value [[BORROW_INNER]]
+    // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_INNER]]
+    // CHECK: [[BORROW:%.*]] = begin_borrow [[MARK]]
+    switch x.storedInner {
+    case _borrowing y:
+        // CHECK: apply {{.*}}([[BORROW]])
+        use(y)
+    }
+    // CHECK: end_borrow [[BORROW]]
+    // CHECK: end_borrow [[BORROW_OUTER]]
+
+    // CHECK: [[BORROW_OUTER:%.*]] = begin_borrow {{.*}} : $Outer
+    // CHECK: ([[BORROW_INNER:%.*]], [[TOKEN:%.*]]) = begin_apply {{.*}}([[BORROW_OUTER]]
+    // CHECK: [[COPY_INNER:%.*]] = copy_value [[BORROW_INNER]]
+    // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY_INNER]]
+    // CHECK: [[BORROW:%.*]] = begin_borrow [[MARK]]
+    // CHECK: [[COPY2:%.*]] = copy_value [[BORROW]]
+    // CHECK: [[MARK2:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY2]]
+    // CHECK: [[BORROW2:%.*]] = begin_borrow [[MARK2]]
+    switch x.readInner {
+    case _borrowing y:
+        // CHECK: apply {{.*}}([[BORROW2]])
+        use(y)
+    }
+    // CHECK: end_apply [[TOKEN]]
+    // CHECK: end_borrow [[BORROW_OUTER]]
+
+    // CHECK: [[FN:%.*]] = function_ref @{{.*}}9temporary
+    // CHECK: [[TMP:%.*]] = apply [[FN]]()
+    // CHECK: [[BORROW_OUTER:%.*]] = begin_borrow [[TMP]]
+    // CHECK: [[COPY:%.*]] = copy_value [[BORROW_OUTER]]
+    // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[COPY]]
+    // CHECK: [[BORROW:%.*]] = begin_borrow [[MARK]]
+    switch temporary() {
+    case _borrowing y:
+        // CHECK: apply {{.*}}([[BORROW]])
+        use(y)
+    }
+}

--- a/test/SILOptimizer/moveonly_borrowing_switch.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch.swift
@@ -1,0 +1,102 @@
+// RUN: %target-swift-frontend -emit-sil -verify -enable-experimental-feature BorrowingSwitch -disable-experimental-parser-round-trip %s
+
+struct Payload: ~Copyable {
+    var x: Int
+    var y: String
+}
+
+enum Foo: ~Copyable {
+    case payload(Payload)
+    case noPayload
+}
+
+enum Bar: ~Copyable {
+    case payload(Foo)
+    case noPayload
+}
+
+enum Bas: ~Copyable {
+    case loadablePayload(Foo)
+    case aoPayload(Any)
+}
+
+@_silgen_name("condition")
+func condition(_: borrowing Payload) -> Bool
+
+@_silgen_name("hungryCondition")
+func hungryCondition(_: consuming Payload) -> Bool
+
+func eat(payload: consuming Payload) {}
+func nibble(payload: borrowing Payload) {}
+
+func test(consuming foo: consuming Bar) { // expected-error{{'foo' used after consume}}
+    switch foo {
+    case .payload(.payload(_borrowing x))
+      where condition(x):
+        nibble(payload: x)
+    // can't consume _borrowing bindings in either `where` condition 
+    // or body
+    case .payload(.payload(_borrowing x)) // expected-error{{cannot be consumed}}
+      where hungryCondition(x): // expected-note{{consumed here}}
+        eat(payload: x) // expected-note{{consumed here}}
+    case .payload(.payload(_borrowing x)): // expected-warning{{}}
+        break
+    case .payload(.noPayload):
+        ()
+    case .noPayload:
+        ()
+    }
+
+    switch foo { // expected-note{{consumed here}}
+    case .payload(.payload(let x))
+      where condition(x):
+        nibble(payload: x)
+    // can't consume in a `where` condition even if binding is consumable
+    case .payload(.payload(let x)) // expected-error{{cannot be consumed}}
+      where hungryCondition(x): // expected-note{{consumed here}}
+        // consuming in the case block is OK though
+        eat(payload: x)
+    case .payload(.payload(let x)): // expected-warning{{}}
+        break
+    case .payload(.noPayload):
+        ()
+    case .noPayload:
+        ()
+    }
+
+    switch foo { // expected-note{{used here}}
+    case _borrowing x: // expected-warning{{}}
+        break
+    }
+}
+
+@_silgen_name("nibble_bar")
+func nibble(bar: borrowing Bar) 
+
+func test(borrowing foo: borrowing Bar) { // expected-error{{'foo' is borrowed and cannot be consumed}}
+    // can't use consuming patterns on a borrow
+    // TODO: improve diagnostic
+    switch foo {
+    case .payload(.payload(let x)): // expected-note{{consumed here}} expected-warning{{}}
+        break
+    case .payload(.noPayload): // expected-note{{consumed here}}
+        ()
+    case .noPayload:
+        ()
+    }
+
+    switch foo {
+    case .payload(.payload(_borrowing x))
+      where condition(x):
+        nibble(payload: x)
+    case .payload(.payload(_borrowing x)) // expected-error{{'x' is borrowed and cannot be consumed}}
+      where hungryCondition(x): // expected-note{{consumed here}}
+        eat(payload: x) // expected-note{{consumed here}}
+    case .payload(.payload(_borrowing x)): // expected-warning{{}}
+        break
+    case .payload(.noPayload):
+        ()
+    case .noPayload:
+        ()
+    }
+}


### PR DESCRIPTION
Ensure that dependent accesses are properly nested when a subject isn't directly a borrowed parameter binding.
