### PR TITLE
[Macros] Expand nested macros in qualified name lookup.

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -2091,6 +2091,35 @@ public struct SendableMacro: ExtensionMacro {
   }
 }
 
+public struct GenerateStubMemberMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["#generateMemberStubs"]
+  }
+}
+
+public struct GenerateStubsFreestandingMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["#generateMember"]
+  }
+}
+
+public struct SingleMemberStubMacro: DeclarationMacro {
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return ["static func member() {}"]
+  }
+}
+
 public struct FakeCodeItemMacro: DeclarationMacro, PeerMacro {
   public static func expansion(
     of node: some FreestandingMacroExpansionSyntax,

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -141,3 +141,19 @@ func testC2() {
   // CHECK: deinit was called
 }
 testC2()
+
+@attached(member, names: arbitrary)
+macro GenerateStubs() = #externalMacro(module: "MacroDefinition", type: "GenerateStubMemberMacro")
+
+@freestanding(declaration, names: arbitrary)
+macro generateMemberStubs() = #externalMacro(module: "MacroDefinition", type: "GenerateStubsFreestandingMacro")
+
+@freestanding(declaration, names: named(member()))
+macro generateMember() = #externalMacro(module: "MacroDefinition", type: "SingleMemberStubMacro")
+
+@GenerateStubs
+struct NestedMacroExpansion {}
+
+func callNestedExpansionMember() {
+  NestedMacroExpansion.member()
+}


### PR DESCRIPTION
`populateLookupTableEntryFromMacroExpansions` expands macros that can introduce a given name into the type or extension that we're performing qualified lookup into. However, it only handled one level of macro expansion; it failed to expand any nested macros that can introduce the given name. This change applies the same logic to nested macros to ensure that qualified name lookup doesn't fail when the declaration is produced through several levels of macro expansion.

Resolves rdar://121882362