### PR TITLE
[embedded] Print function name + class name when missing loc in 'non-final generic fuctions' diagnostic

### DIFF
--- a/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/VTableSpecializer.cpp
@@ -98,6 +98,14 @@ bool VTableSpecializer::specializeVTables(SILModule &module) {
       ValueDecl *decl = entry.getMethod().getDecl();
       module.getASTContext().Diags.diagnose(
           decl->getLoc(), diag::non_final_generic_class_function);
+
+      if (decl->getLoc().isInvalid()) {
+        auto demangledName = Demangle::demangleSymbolAsString(
+            method->getName(),
+            Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
+        llvm::errs() << "in function " << demangledName << "\n";
+        llvm::errs() << "in class " << vtable->getClass()->getName() << "\n";
+      }
     }
   }
 


### PR DESCRIPTION
Just adding a fallback in case we're missing source location when printing this diagnostic:
```
<unknown>:0: error: classes cannot have non-final generic fuctions in embedded Swift
```
