### PR TITLE
 [ClangImporter] Import NSNotificationName constants as `nonisolated`

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -590,6 +590,13 @@ bool importer::isNSString(clang::QualType qt) {
   return qt.getTypePtrOrNull() && isNSString(qt.getTypePtrOrNull());
 }
 
+bool importer::isNSNotificationName(clang::QualType type) {
+  if (auto *typealias = type->getAs<clang::TypedefType>()) {
+    return typealias->getDecl()->getName() == "NSNotificationName";
+  }
+  return false;
+}
+
 bool importer::isNSNotificationGlobal(const clang::NamedDecl *decl) {
   // Looking for: extern NSString *fooNotification;
 

--- a/lib/ClangImporter/ClangAdapter.h
+++ b/lib/ClangImporter/ClangAdapter.h
@@ -129,6 +129,9 @@ clang::TypedefNameDecl *findSwiftNewtype(const clang::NamedDecl *decl,
 bool isNSString(const clang::Type *);
 bool isNSString(clang::QualType);
 
+/// Wehther the passed type is `NSNotificationName` typealias
+bool isNSNotificationName(clang::QualType);
+
 /// Whether the given declaration was exported from Swift.
 ///
 /// Note that this only checks the immediate declaration being passed.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8138,6 +8138,23 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
                                   /*isUnchecked=*/true);
     }
   }
+
+  // Special handling of `NSNotificationName` static immutable properties.
+  //
+  // These constants could be used with observer APIs from a different isolation
+  // context, so it's more convenient to import them as `nonisolated` unless
+  // they are explicitly isolated to a MainActor.
+  if (!seenMainActorAttr) {
+    auto *DC = MappedDecl->getDeclContext();
+    if (DC->isTypeContext() && isa<VarDecl>(MappedDecl)) {
+      auto *mappedVar = cast<VarDecl>(MappedDecl);
+      if (mappedVar->isStatic() && mappedVar->isLet() &&
+          isNSNotificationName(cast<clang::ValueDecl>(ClangDecl)->getType())) {
+        MappedDecl->getAttrs().add(new (SwiftContext) NonisolatedAttr(
+            /*unsafe=*/false, /*implicit=*/true));
+      }
+    }
+  }
 }
 
 static bool isUsingMacroName(clang::SourceManager &SM,

--- a/test/Concurrency/import_nsnotificationname_constants_as_nonisolated.swift
+++ b/test/Concurrency/import_nsnotificationname_constants_as_nonisolated.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t/src)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -strict-concurrency=complete \
+// RUN:   -disable-availability-checking \
+// RUN:   -module-name main -I %t -verify
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+//--- Test.h
+#define SWIFT_MAIN_ACTOR __attribute__((swift_attr("@MainActor")))
+
+#pragma clang assume_nonnull begin
+
+@import Foundation;
+
+SWIFT_MAIN_ACTOR
+@interface Test : NSObject
+@end
+
+extern NSNotificationName const TestDidTrigger __attribute__((swift_name("Test.didTrigger")));
+
+SWIFT_MAIN_ACTOR
+extern NSNotificationName const TestIsolatedTrigger __attribute__((swift_name("Test.isolatedTrigger")));
+
+#pragma clang assume_nonnull end
+
+//--- main.swift
+
+func testAsync() async {
+  print(Test.didTrigger) // Ok (property is nonisolated)
+  print(Test.isolatedTrigger)
+  // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-note@-2 {{property access is 'async'}}
+}
+
+@MainActor
+func testMainActor() {
+  print(Test.didTrigger) // Ok
+  print(Test.isolatedTrigger) // Ok
+}


### PR DESCRIPTION
These constants could be used with observer APIs from a different isolation
context, so it's more convenient to import them as `nonisolated` unless
they are explicitly isolated to a MainActor.

Resolves: rdar://114052705

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
