### PR TITLE
[Sema] Diagnose @_staticExclusiveOnly in clients without the feature flag

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2497,8 +2497,7 @@ public:
 
     // @_staticExclusiveOnly types cannot be put into 'var's, only 'let'.
     if (auto SD = VD->getInterfaceType()->getStructOrBoundGenericStruct()) {
-      if (Ctx.LangOpts.hasFeature(Feature::StaticExclusiveOnly) &&
-          SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
+      if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
           !VD->isLet()) {
         Ctx.Diags.diagnoseWithNotes(
           VD->diagnose(diag::attr_static_exclusive_only_let_only,
@@ -4214,8 +4213,7 @@ void TypeChecker::checkParameterList(ParameterList *params,
     // @_staticExclusiveOnly types cannot be passed as 'inout', only as either
     // a borrow or as consuming.
     if (auto SD = param->getInterfaceType()->getStructOrBoundGenericStruct()) {
-      if (SD->getASTContext().LangOpts.hasFeature(Feature::StaticExclusiveOnly) &&
-          SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
+      if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
           param->isInOut()) {
         SD->getASTContext().Diags.diagnoseWithNotes(
           param->diagnose(diag::attr_static_exclusive_only_let_only_param,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3771,8 +3771,7 @@ TypeResolver::resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
       // @_staticExclusiveOnly types cannot be passed as 'inout' in function
       // types.
       if (auto SD = ty->getStructOrBoundGenericStruct()) {
-        if (getASTContext().LangOpts.hasFeature(Feature::StaticExclusiveOnly) &&
-            SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
+        if (SD->getAttrs().hasAttribute<StaticExclusiveOnlyAttr>() &&
             ownership == ParamSpecifier::InOut) {
           diagnose(eltTypeRepr->getLoc(),
                    diag::attr_static_exclusive_only_let_only_param,

--- a/test/Sema/atomic-diagnose-var.swift
+++ b/test/Sema/atomic-diagnose-var.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking
+// REQUIRES: synchronization
+
+import Synchronization
+
+var a = Atomic(0) // expected-error {{variable of type 'Atomic<Int>' must be declared with a 'let'}}
+
+let b = Atomic(0) // OK
+
+class C {
+  var d = Atomic(0) // expected-error {{variable of type 'Atomic<Int>' must be declared with a 'let'}}
+  let e = Atomic(0) // OK
+}
+
+struct F: ~Copyable {
+  var g = Atomic(0) // expected-error {{variable of type 'Atomic<Int>' must be declared with a 'let'}}
+  let h = Atomic(0) // OK
+}
+
+func i(_: borrowing Atomic<Int>) {} // OK
+
+func j(_: inout Atomic<Int>) {} // expected-error {{parameter of type 'Atomic<Int>' must be declared as either 'borrowing' or 'consuming'}}
+
+func k(_: (inout Atomic<Int>) -> ()) {} // expected-error {{parameter of type 'Atomic<Int>' must be declared as either 'borrowing' or 'consuming'}}
+
+func l(_: (borrowing Atomic<Int>) -> ()) {} // OK
+
+func m() {
+  let _: (Int, Int) -> Int = {
+    var n = Atomic(0) // expected-error {{variable of type 'Atomic<Int>' must be declared with a 'let'}}
+                 // expected-warning@-1 {{initialization of variable 'n' was never used; consider replacing with assignment to '_' or removing it}}
+
+    return $0 + $1
+  }
+}
+
+func o(_: consuming Atomic<Int>) {} // OK
+
+func p(_: (consuming Atomic<Int>) -> ()) {} // OK

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -155,6 +155,8 @@ if "@SWIFT_ENABLE_EXPERIMENTAL_OBSERVATION@" == "TRUE":
     config.available_features.add('observation')
 if "@SWIFT_STDLIB_ENABLE_DEBUG_PRECONDITIONS_IN_RELEASE@" == "TRUE":
     config.available_features.add('swift_stdlib_debug_preconditions_in_release')
+if "@SWIFT_ENABLE_SYNCHRONIZATION@" == "TRUE":
+    config.available_features.add('synchronization')
 
 config.swift_freestanding_is_darwin = "@SWIFT_FREESTANDING_IS_DARWIN@" == "TRUE"
 config.swift_stdlib_use_relative_protocol_witness_tables = "@SWIFT_STDLIB_USE_RELATIVE_PROTOCOL_WITNESS_TABLES@" == "TRUE"

--- a/test/stdlib/Atomics/LockFreeSingleConsumerStack.swift
+++ b/test/stdlib/Atomics/LockFreeSingleConsumerStack.swift
@@ -17,8 +17,8 @@ class LockFreeSingleConsumerStack<Element> {
   }
   typealias NodePtr = UnsafeMutablePointer<Node>
 
-  private var _last = Atomic<NodePtr?>(nil)
-  private var _consumerCount = Atomic<Int>(0)
+  private let _last = Atomic<NodePtr?>(nil)
+  private let _consumerCount = Atomic<Int>(0)
   private var foo = 0
 
   deinit {


### PR DESCRIPTION
We were incorrectly guarding this condition on the fact that the client has the feature flag. The intent is that you cannot use `@_staticExclusiveOnly` in a module unless this flag is present. Modules who don't have the flag should still diagnose incorrect attempts to use types who were compiled with this attribute.