### PR TITLE
[IRGen] Mask extra tag bits in getEnumTag function for CVW

### DIFF
--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -259,17 +259,17 @@ public:
   
   /// Return the enum case tag for the given value. Payload cases come first,
   /// followed by non-payload cases. Used for the getEnumTag value witness.
-  virtual llvm::Value *emitGetEnumTag(IRGenFunction &IGF,
-                                      SILType T,
-                                      Address enumAddr) const = 0;
+  virtual llvm::Value *emitGetEnumTag(IRGenFunction &IGF, SILType T,
+                                      Address enumAddr,
+                                      bool maskExtraTagBits = false) const = 0;
 
   /// Return the enum case tag for the given value. Payload cases come first,
   /// followed by non-payload cases. Used for the getEnumTag value witness.
   ///
   /// Only ever called for fixed types.
-  virtual llvm::Value *emitFixedGetEnumTag(IRGenFunction &IGF,
-                                           SILType T,
-                                           Address enumAddr) const;
+  virtual llvm::Value *emitFixedGetEnumTag(IRGenFunction &IGF, SILType T,
+                                           Address enumAddr,
+                                           bool maskExtraTagBits = false) const;
   llvm::Value *emitOutlinedGetEnumTag(IRGenFunction &IGF, SILType T,
                                            Address enumAddr) const;
 

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -517,7 +517,8 @@ llvm::Function *createFixedEnumLoadTag(IRGenModule &IGM,
         auto enumAddr = typeInfo->getAddressForPointer(castEnumPtr);
 
         auto &strategy = getEnumImplStrategy(IGM, entry.ty);
-        auto tag = strategy.emitFixedGetEnumTag(IGF, entry.ty, enumAddr);
+        auto tag = strategy.emitFixedGetEnumTag(IGF, entry.ty, enumAddr,
+                                                /*maskExtraTagBits*/ true);
         IGF.Builder.CreateRet(tag);
       });
 

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -576,6 +576,18 @@ public struct TupleLargeAlignment<T> {
     }
 }
 
+public enum NestedMultiPayloadInner {
+    case a(UInt)
+    case b(AnyObject)
+    case c(AnyObject)
+}
+
+public enum NestedMultiPayloadOuter {
+    case a(NestedMultiPayloadInner)
+    case b(NestedMultiPayloadInner)
+    case c(NestedMultiPayloadInner)
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1103,6 +1103,35 @@ func testNotBitwiseTakableBridge() {
 
 testNotBitwiseTakableBridge()
 
+// Regression test for rdar://121868127
+func testMultiPayloadEnumNested() {
+    let ptr = UnsafeMutablePointer<NestedMultiPayloadOuter>.allocate(capacity: 1)
+
+    do {
+        testInit(ptr, to: .b(.b(SimpleClass(x: 23))))
+    }
+
+    do {
+        let y = NestedMultiPayloadOuter.b(.b(SimpleClass(x: 23)))
+
+        // CHECK: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testMultiPayloadEnumNested()
+
 #if os(macOS)
 func testObjc() {
     let ptr = UnsafeMutablePointer<ObjcWrapper>.allocate(capacity: 1)


### PR DESCRIPTION
rdar://121868127

In compact value witnesses we need to mask the extra tag bits in case they are used to store tag bits of outer enums, so we only read the ones we are interested in.
