### PR TITLE
[Concurrency] SILGenModule::emitEntryPoint crashes when `exit` hasn't been imported

### DIFF
--- a/test/Concurrency/async_main_no_exit.swift
+++ b/test/Concurrency/async_main_no_exit.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library -disable-availability-checking -parse-stdlib
+// expect-no-diagnostics
+
+import _Concurrency
+
+@main struct Main {
+  static func main() async {
+  }
+}

--- a/test/Concurrency/async_top_level_no_exit.swift
+++ b/test/Concurrency/async_top_level_no_exit.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -parse-stdlib
+// expect-no-diagnostics
+
+import _Concurrency
+
+func foo() async {
+}
+
+await foo()


### PR DESCRIPTION
If `exit` hasn't been imported, SILGenModule::emitEntryPoint crashes because it doesn't synthesize an exit function like SILGenFunction::emitCallToMain does. Make it do so.

rdar://122413238