### PR TITLE
Remove an old restriction on `_ObjectiveCBridgeable` conformances.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6310,10 +6310,6 @@ ERROR(objc_ambiguous_error_convention,none,
 NOTE(objc_ambiguous_error_convention_candidate,none,
      "%0 provides an error argument here", (const ValueDecl *))
 
-ERROR(nonlocal_bridged_to_objc,none,
-      "conformance of %0 to %1 can only be written in module %2",
-      (Identifier, Identifier, Identifier))
-
 ERROR(missing_bridging_function,Fatal,
       "missing '%select{_forceBridgeFromObjectiveC|"
       "_conditionallyBridgeFromObjectiveC}0'", (bool))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2389,29 +2389,6 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
     }
   }
 
-  // Except in specific hardcoded cases for Foundation/Swift
-  // standard library compatibility, an _ObjectiveCBridgeable
-  // conformance must appear in the same module as the definition of
-  // the conforming type.
-  //
-  // Note that we check the module name to smooth over the difference
-  // between an imported Objective-C module and its overlay.
-  if (Proto->isSpecificProtocol(KnownProtocolKind::ObjectiveCBridgeable)) {
-    auto nominal = DC->getSelfNominalTypeDecl();
-    if (!Context.isTypeBridgedInExternalModule(nominal)) {
-      auto clangLoader = Context.getClangModuleLoader();
-      if (nominal->getParentModule() != DC->getParentModule() &&
-          !(clangLoader &&
-            clangLoader->isInOverlayModuleForImportedModule(DC, nominal))) {
-        auto nominalModule = nominal->getParentModule();
-        Context.Diags.diagnose(conformance->getLoc(),
-                               diag::nonlocal_bridged_to_objc,
-                               nominal->getName(), Proto->getName(),
-                               nominalModule->getName());
-      }
-    }
-  }
-
   // Check that T conforms to all inherited protocols.
   for (auto InheritedProto : Proto->getInheritedProtocols()) {
     auto InheritedConformance =

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -13,9 +13,10 @@ public class BridgedClass : NSObject, NSCopying {
 
 public class BridgedClassSub : BridgedClass { }
 
-// Attempt to bridge to a type from another module. We only allow this for a
-// few specific types, like String.
-extension LazyFilterSequence.Iterator : @retroactive _ObjectiveCBridgeable { // expected-error{{conformance of 'Iterator' to '_ObjectiveCBridgeable' can only be written in module 'Swift'}}
+// Attempt to bridge to a type from another module.
+// We used to work hard to prevent this, but doing so was getting in the
+// way of layering for the swift-foundation project.
+extension LazyFilterSequence.Iterator : @retroactive _ObjectiveCBridgeable {
   public typealias _ObjectiveCType = BridgedClassSub
 
   public func _bridgeToObjectiveC() -> _ObjectiveCType {


### PR DESCRIPTION
Historically, we checked against a specific allowlist for a certain set of types that were allowed to introduce an `_ObjectiveCBridgeable` conformance in a different module that where the type was defined. This rigid allow-list isn't really buying us much, but it's getting in the way of some refactoring for swift-foundation that's changing the layering. Remove this diagnostic, since it really isn't buying us much nowadays, and we have the more general warnings about retroactive conformances to make folks think twice.
