### PR TITLE
[region-isolation] Fixes that enable the stdlib to build with region based isolation

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -940,13 +940,13 @@ NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
 //
 
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
-      "transferring non-Sendable binding %0 could yield races with later accesses",
+      "transferring non-Sendable value %0 could yield races with later accesses",
       (Identifier))
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
      "%0 is transferred from %1 caller to %2 callee. Later uses in caller could race with potential uses in callee",
      (Identifier, ActorIsolation, ActorIsolation))
 NOTE(regionbasedisolation_named_info_isolated_capture, none,
-     "%1 binding %0 is captured by %2 closure. Later local uses could race",
+     "%1 value %0 is captured by %2 closure. Later local uses could race",
      (Identifier, ActorIsolation, ActorIsolation))
 NOTE(regionbasedisolation_named_arg_info, none,
      "Transferring task isolated function argument %0 could yield races with caller uses",

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -894,8 +894,20 @@ NOTE(sil_referencebinding_inout_binding_here, none,
       "inout binding here",
       ())
 
-// Warnings arising from the flow-sensitive checking of Sendability of
-// non-Sendable values
+//===----------------------------------------------------------------------===//
+//                  MARK: Region Based Isolation Diagnostics
+//===----------------------------------------------------------------------===//
+
+NOTE(regionbasedisolation_maybe_race, none,
+     "access here could race", ())
+ERROR(regionbasedisolation_unknown_pattern, none,
+      "pattern that the region based isolation checker does not understand how to check. Please file a bug",
+      ())
+
+//===---
+// Old Transfer Non Sendable Diagnostics
+//
+
 ERROR(regionbasedisolation_selforargtransferred, none,
       "call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller", ())
 ERROR(regionbasedisolation_transfer_yields_race_no_isolation, none,
@@ -919,14 +931,28 @@ ERROR(regionbasedisolation_arg_transferred, none,
 ERROR(regionbasedisolation_arg_passed_to_strongly_transferred_param, none,
       "task isolated value of type %0 passed as a strongly transferred parameter; later accesses could race",
       (Type))
-NOTE(regionbasedisolation_maybe_race, none,
-     "access here could race", ())
 NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
      "value is %0 since it is in the same region as %1",
      (StringRef, DeclBaseName))
-ERROR(regionbasedisolation_unknown_pattern, none,
-      "pattern that the region based isolation checker does not understand how to check. Please file a bug",
-      ())
+
+//===---
+// New Transfer Non Sendable Diagnostics
+//
+
+ERROR(regionbasedisolation_named_transfer_yields_race, none,
+      "transferring non-Sendable binding %0 could yield races with later accesses",
+      (Identifier))
+NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
+     "%0 is transferred from %1 caller to %2 callee. Later uses in caller could race with potential uses in callee",
+     (Identifier, ActorIsolation, ActorIsolation))
+NOTE(regionbasedisolation_named_info_isolated_capture, none,
+     "%1 binding %0 is captured by %2 closure. Later local uses could race",
+     (Identifier, ActorIsolation, ActorIsolation))
+NOTE(regionbasedisolation_named_arg_info, none,
+     "Transferring task isolated function argument %0 could yield races with caller uses",
+     (Identifier))
+NOTE(regionbasedisolation_named_stronglytransferred_binding, none,
+     "Cannot access a transferring parameter after the parameter has been transferred", ())
 
 // TODO: print the name of the nominal type
 ERROR(deinit_not_visible, none,

--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -531,6 +531,19 @@ struct DebugVarCarryingInst : VarDeclCarryingInst {
     return varName;
   }
 
+  std::optional<StringRef> maybeGetName() const {
+    assert(getKind() != Kind::Invalid);
+    if (auto varInfo = getVarInfo()) {
+      return varInfo->Name;
+    }
+
+    if (auto *decl = getDecl()) {
+      return decl->getBaseName().userFacingName();
+    }
+
+    return {};
+  }
+
   /// Take in \p inst, a potentially invalid DebugVarCarryingInst, and returns a
   /// name for it. If we have an invalid value or don't find var info or a decl,
   /// return "unknown".

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -1,0 +1,111 @@
+//===--- VariableNameUtils.h ----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// Utilities for inferring the name of a value.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_VARIABLENAMEUTILS_H
+#define SWIFT_SILOPTIMIZER_UTILS_VARIABLENAMEUTILS_H
+
+#include "swift/SIL/ApplySite.h"
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/StackList.h"
+
+namespace swift {
+
+class VariableNameInferrer {
+  /// The stacklist that we use to process from use->
+  StackList<PointerUnion<SILInstruction *, SILValue>> variableNamePath;
+
+  /// The root value of our string.
+  ///
+  /// If set, a diagnostic should do a 'root' is defined here error.
+  SILValue rootValue;
+
+  /// The final string we computed.
+  SmallString<64> &resultingString;
+
+public:
+  VariableNameInferrer(SILFunction *fn, SmallString<64> &resultingString)
+      : variableNamePath(fn), resultingString(resultingString) {}
+
+  /// Attempts to infer a name from just uses of \p searchValue.
+  ///
+  /// Returns true if we found a name.
+  bool tryInferNameFromUses(SILValue searchValue) {
+    auto *use = getAnyDebugUse(searchValue);
+    if (!use)
+      return false;
+
+    auto debugVar = DebugVarCarryingInst(use->getUser());
+    if (!debugVar)
+      return false;
+
+    assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
+    resultingString += debugVar.getName();
+    return true;
+  }
+
+  /// See if \p searchValue or one of its defs (walking use->def) has a name
+  /// that we can use.
+  ///
+  /// \p failInsteadOfEmittingUnknown set to true if we should return false
+  /// rather than emitting unknown (and always succeeding).
+  ///
+  /// \returns true if we inferred anything. Returns false otherwise.
+  bool inferByWalkingUsesToDefs(SILValue searchValue) {
+    // Look up our root value while adding to the variable name path list.
+    auto rootValue = findDebugInfoProvidingValue(searchValue);
+    if (!rootValue) {
+      // If we do not pattern match successfully, just set resulting string to
+      // unknown and return early.
+      resultingString += "unknown";
+      return true;
+    }
+
+    drainVariableNamePath();
+    return true;
+  }
+
+  /// Infers the value that provides the debug info. This can be something like
+  /// an alloc_stack that provides the information directly or a value that has
+  /// a debug_value as a user.
+  ///
+  /// \returns SILValue() if we did not find anything.
+  SILValue inferByWalkingUsesToDefsReturningRoot(SILValue searchValue) {
+    // Look up our root value while adding to the variable name path list.
+    auto rootValue = findDebugInfoProvidingValue(searchValue);
+    if (!rootValue) {
+      // If we do not pattern match successfully, return SILValue() early.
+      return SILValue();
+    }
+
+    drainVariableNamePath();
+    return rootValue;
+  }
+
+  StringRef getName() const { return resultingString; }
+
+private:
+  void drainVariableNamePath();
+
+  /// Finds the SILValue that either provides the direct debug information or
+  /// that has a debug_value user that provides the name of the value.
+  SILValue findDebugInfoProvidingValue(SILValue searchValue);
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -104,6 +104,11 @@ private:
   /// Finds the SILValue that either provides the direct debug information or
   /// that has a debug_value user that provides the name of the value.
   SILValue findDebugInfoProvidingValue(SILValue searchValue);
+
+  /// Given an initialized once allocation inst without a ValueDecl or a
+  /// DebugVariable provided name, attempt to find a root value from its
+  /// initialization.
+  SILValue getRootValueForTemporaryAllocation(AllocationInst *allocInst);
 };
 
 } // namespace swift

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1289,8 +1289,7 @@ class PartitionOpTranslator {
               continue;
             }
             if (auto *pbi = dyn_cast<ProjectBoxInst>(val)) {
-              if (isNonSendableType(
-                      pbi->getType().getSILBoxFieldType(function))) {
+              if (isNonSendableType(pbi->getType())) {
                 auto trackVal = getTrackableValue(val, true);
                 (void)trackVal;
                 continue;

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2304,7 +2304,6 @@ CONSTANT_TRANSLATION(TupleInst, Assign)
 CONSTANT_TRANSLATION(BeginAccessInst, LookThrough)
 CONSTANT_TRANSLATION(BeginBorrowInst, LookThrough)
 CONSTANT_TRANSLATION(BeginDeallocRefInst, LookThrough)
-CONSTANT_TRANSLATION(RefToBridgeObjectInst, LookThrough)
 CONSTANT_TRANSLATION(BridgeObjectToRefInst, LookThrough)
 CONSTANT_TRANSLATION(CopyValueInst, LookThrough)
 CONSTANT_TRANSLATION(ExplicitCopyValueInst, LookThrough)
@@ -2613,6 +2612,13 @@ CAST_WITH_MAYBE_SENDABLE_NONSENDABLE_OP_AND_RESULT(UncheckedValueCastInst)
 //===---
 // Custom Handling
 //
+
+TranslationSemantics
+PartitionOpTranslator::visitRefToBridgeObjectInst(RefToBridgeObjectInst *r) {
+  translateSILLookThrough(
+      SILValue(r), r->getOperand(RefToBridgeObjectInst::ConvertedOperand));
+  return TranslationSemantics::Special;
+}
 
 TranslationSemantics
 PartitionOpTranslator::visitPackElementGetInst(PackElementGetInst *r) {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2109,6 +2109,7 @@ public:
     }
 
     case TranslationSemantics::Asserting:
+      llvm::errs() << "BannedInst: " << *inst;
       llvm::report_fatal_error(
           "transfer-non-sendable: Found banned instruction?!");
       return;
@@ -2119,6 +2120,7 @@ public:
             return ::isNonSendableType(value->getType(), inst->getFunction());
           }))
         return;
+      llvm::errs() << "BadInst: " << *inst;
       llvm::report_fatal_error(
           "transfer-non-sendable: Found instruction that is not allowed to "
           "have non-Sendable parameters with such parameters?!");

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1434,8 +1434,12 @@ public:
 
     if (auto tryApplyInst = dyn_cast<TryApplyInst>(inst)) {
       foundResults.emplace_back(tryApplyInst->getNormalBB()->getArgument(0));
-      if (tryApplyInst->getErrorBB()->getNumArguments() > 0)
+      if (tryApplyInst->getErrorBB()->getNumArguments() > 0) {
         foundResults.emplace_back(tryApplyInst->getErrorBB()->getArgument(0));
+      }
+      for (auto indirectResults : tryApplyInst->getIndirectSILResults()) {
+        foundResults.emplace_back(indirectResults);
+      }
       return;
     }
 
@@ -1800,10 +1804,10 @@ public:
     };
 
     if (applySite.hasSelfArgument()) {
-      handleSILOperands(applySite.getOperandsWithoutSelf());
+      handleSILOperands(applySite.getOperandsWithoutIndirectResultsOrSelf());
       handleSILSelf(&applySite.getSelfArgumentOperand());
     } else {
-      handleSILOperands(applySite->getAllOperands());
+      handleSILOperands(applySite.getOperandsWithoutIndirectResults());
     }
 
     // non-sendable results can't be returned from cross-isolation calls without

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2415,6 +2415,8 @@ CONSTANT_TRANSLATION(BeginUnpairedAccessInst, Require)
 CONSTANT_TRANSLATION(ValueMetatypeInst, Require)
 // Require of the value we extract the metatype from.
 CONSTANT_TRANSLATION(ExistentialMetatypeInst, Require)
+// These can take a parameter. If it is non-Sendable, use a require.
+CONSTANT_TRANSLATION(GetAsyncContinuationAddrInst, Require)
 
 //===---
 // Asserting If Non Sendable Parameter
@@ -2455,7 +2457,6 @@ CONSTANT_TRANSLATION(DynamicMethodBranchInst, TerminatorPhi)
 // (UnsafeContinuation and UnsafeThrowingContinuation).
 CONSTANT_TRANSLATION(AwaitAsyncContinuationInst, AssertingIfNonSendable)
 CONSTANT_TRANSLATION(GetAsyncContinuationInst, AssertingIfNonSendable)
-CONSTANT_TRANSLATION(GetAsyncContinuationAddrInst, AssertingIfNonSendable)
 CONSTANT_TRANSLATION(ExtractExecutorInst, AssertingIfNonSendable)
 
 //===---

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -126,13 +126,17 @@ struct UseDefChainVisitor
     // do not want to treat this as a merge.
     if (auto p = Projection(inst)) {
       switch (p.getKind()) {
+      // Currently if we load and then project_box from a memory location,
+      // we treat that as a projection. This follows the semantics/notes in
+      // getAccessProjectionOperand.
+      case ProjectionKind::Box:
+        return cast<ProjectBoxInst>(inst)->getOperand();
       case ProjectionKind::Upcast:
       case ProjectionKind::RefCast:
       case ProjectionKind::BlockStorageCast:
       case ProjectionKind::BitwiseCast:
-      case ProjectionKind::TailElems:
-      case ProjectionKind::Box:
       case ProjectionKind::Class:
+      case ProjectionKind::TailElems:
         llvm_unreachable("Shouldn't see this here");
       case ProjectionKind::Index:
         // Index is always a merge.

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -23,6 +23,7 @@
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/FieldSensitivePrunedLiveness.h"
 #include "swift/SIL/SILArgument.h"
+#include "swift/SILOptimizer/Utils/VariableNameUtils.h"
 #include "llvm/Support/Debug.h"
 
 #include "MoveOnlyTypeUtils.h"
@@ -73,181 +74,12 @@ static void diagnose(ASTContext &context, SourceLoc loc, Diag<T...> diag,
   context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
 }
 
-/// Helper function that actually implements getVariableNameForValue. Do not
-/// call it directly! Call the unary variants instead.
-static void getVariableNameForValue(SILValue value2,
-                                    SILValue searchValue,
-                                    SmallString<64> &resultingString) {
-  // Before we do anything, lets see if we have an exact debug_value on our
-  // mmci. In such a case, we can end early and are done.
-  if (auto *use = getAnyDebugUse(value2)) {
-    if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
-      assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
-      resultingString += debugVar.getName();
-      return;
-    }
-  }
-
-  // Otherwise, we need to look at our mark_unresolved_non_copyable_value's
-  // operand.
-  StackList<llvm::PointerUnion<SILInstruction *, SILValue>> variableNamePath(
-      value2->getFunction());
-  while (searchValue) {
-    if (auto *allocInst = dyn_cast<AllocationInst>(searchValue)) {
-      // If the instruction itself doesn't carry any variable info, see whether
-      // it's copied from another place that does.
-      if (!allocInst->getDecl()) {
-        if (auto copy = allocInst->getSingleUserOfType<CopyAddrInst>()) {
-          if (copy->getDest() == allocInst
-              && !copy->isTakeOfSrc()
-              && copy->isInitializationOfDest()) {
-            searchValue = copy->getSrc();
-            continue;
-          }
-        }
-      }
-    
-      variableNamePath.push_back(allocInst);
-      break;
-    }
-
-    if (auto *globalAddrInst = dyn_cast<GlobalAddrInst>(searchValue)) {
-      variableNamePath.push_back(globalAddrInst);
-      break;
-    }
-
-    if (auto *oeInst = dyn_cast<OpenExistentialAddrInst>(searchValue)) {
-      searchValue = oeInst->getOperand();
-      continue;
-    }
-
-    if (auto *rei = dyn_cast<RefElementAddrInst>(searchValue)) {
-      variableNamePath.push_back(rei);
-      searchValue = rei->getOperand();
-      continue;
-    }
-
-    if (auto *fArg = dyn_cast<SILFunctionArgument>(searchValue)) {
-      variableNamePath.push_back({fArg});
-      break;
-    }
-    
-    auto getNamePathComponentFromCallee = [&](FullApplySite call) -> llvm::Optional<SILValue> {
-      // Use the name of the property being accessed if we can get to it.
-      if (isa<FunctionRefBaseInst>(call.getCallee())
-          || isa<MethodInst>(call.getCallee())) {
-        variableNamePath.push_back(call.getCallee()->getDefiningInstruction());
-        // Try to name the base of the property if this is a method.
-        if (call.getSubstCalleeType()->hasSelfParam()) {
-          return call.getSelfArgument();
-        } else {
-          return SILValue();
-        }
-      }
-      return llvm::None;
-    };
-
-    // Read or modify accessor.
-    if (auto bai = dyn_cast_or_null<BeginApplyInst>(searchValue->getDefiningInstruction())) {
-      if (auto selfParam = getNamePathComponentFromCallee(bai)) {
-        searchValue = *selfParam;
-        continue;
-      }
-    }
-    
-    // Addressor accessor.
-    if (auto ptrToAddr = dyn_cast<PointerToAddressInst>(stripAccessMarkers(searchValue))) {
-      // The addressor can either produce the raw pointer itself or an `UnsafePointer` stdlib type wrapping it.
-      ApplyInst *addressorInvocation;
-      if (auto structExtract = dyn_cast<StructExtractInst>(ptrToAddr->getOperand())) {
-        addressorInvocation = dyn_cast<ApplyInst>(structExtract->getOperand());
-      } else {
-        addressorInvocation = dyn_cast<ApplyInst>(ptrToAddr->getOperand());
-      }
-      
-      if (addressorInvocation) {
-        if (auto selfParam = getNamePathComponentFromCallee(addressorInvocation)) {
-          searchValue = *selfParam;
-          continue;
-        }
-      }
-    }
-
-    // If we do not do an exact match, see if we can find a debug_var inst. If
-    // we do, we always break since we have a root value.
-    if (auto *use = getAnyDebugUse(searchValue)) {
-      if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
-        assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
-        variableNamePath.push_back(use->getUser());
-        break;
-      }
-    }
-
-    // Otherwise, try to see if we have a single value instruction we can look
-    // through.
-    if (isa<BeginBorrowInst>(searchValue) || isa<LoadInst>(searchValue) ||
-        isa<LoadBorrowInst>(searchValue) || isa<BeginAccessInst>(searchValue) ||
-        isa<MarkUnresolvedNonCopyableValueInst>(searchValue) ||
-        isa<ProjectBoxInst>(searchValue) || isa<CopyValueInst>(searchValue)) {
-      searchValue = cast<SingleValueInstruction>(searchValue)->getOperand(0);
-      continue;
-    }
-    
-    // If we do not pattern match successfully, just set resulting string to
-    // unknown and return early.
-    resultingString += "unknown";
-    return;
-  }
-  
-  auto nameFromDecl = [&](Decl *d) -> StringRef {
-    if (d) {
-      if (auto accessor = dyn_cast<AccessorDecl>(d)) {
-        return accessor->getStorage()->getBaseName().userFacingName();
-      }
-      if (auto vd = dyn_cast<ValueDecl>(d)) {
-        return vd->getBaseName().userFacingName();
-      }
-    }
-    
-    return "<unknown decl>";
-  };
-
-  // Walk backwards, constructing our string.
-  while (true) {
-    auto next = variableNamePath.pop_back_val();
-
-    if (auto *inst = next.dyn_cast<SILInstruction *>()) {
-      if (auto i = DebugVarCarryingInst(inst)) {
-        resultingString += i.getName();
-      } else if (auto i = VarDeclCarryingInst(inst)) {
-        resultingString += i.getName();
-      } else if (auto f = dyn_cast<FunctionRefBaseInst>(inst)) {
-        if (auto dc = f->getInitiallyReferencedFunction()->getDeclContext()) {
-          resultingString += nameFromDecl(dc->getAsDecl());
-        } else {
-          resultingString += "<unknown decl>";
-        }
-      } else if (auto m = dyn_cast<MethodInst>(inst)) {
-        resultingString += nameFromDecl(m->getMember().getDecl());
-      } else {
-        resultingString += "<unknown decl>";      
-      }
-    } else {
-      auto value = next.get<SILValue>();
-      if (auto *fArg = dyn_cast<SILFunctionArgument>(value))
-        resultingString += fArg->getDecl()->getBaseName().userFacingName();
-    }
-
-    if (variableNamePath.empty())
-      return;
-
-    resultingString += '.';
-  }
-}
-
 static void getVariableNameForValue(MarkUnresolvedNonCopyableValueInst *mmci,
                                     SmallString<64> &resultingString) {
-  return getVariableNameForValue(mmci, mmci->getOperand(), resultingString);
+  VariableNameInferrer inferrer(mmci->getFunction(), resultingString);
+  if (inferrer.tryInferNameFromUses(mmci))
+    return;
+  inferrer.inferByWalkingUsesToDefs(mmci->getOperand());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Utils/CMakeLists.txt
+++ b/lib/SILOptimizer/Utils/CMakeLists.txt
@@ -31,4 +31,5 @@ target_sources(swiftSILOptimizer PRIVATE
   SpecializationMangler.cpp
   StackNesting.cpp
   ValueLifetime.cpp
+  VariableNameUtils.cpp
   OwnershipOptUtils.cpp)

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -57,6 +57,13 @@ SILValue VariableNameInferrer::getRootValueForTemporaryAllocation(
       }
     }
 
+    if (auto *si = dyn_cast<StoreInst>(&inst)) {
+      if (si->getDest() == allocInst &&
+          si->getOwnershipQualifier() != StoreOwnershipQualifier::Assign) {
+        return si->getSrc();
+      }
+    }
+
     // If we do not identify the write... return SILValue(). We weren't able to
     // understand the write.
     return SILValue();

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -1,0 +1,193 @@
+//===--- VariableNameUtils.cpp --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Utils/VariableNameUtils.h"
+
+using namespace swift;
+
+SILValue
+VariableNameInferrer::findDebugInfoProvidingValue(SILValue searchValue) {
+  if (!searchValue)
+    return SILValue();
+
+  while (true) {
+    assert(searchValue);
+    if (auto *allocInst = dyn_cast<AllocationInst>(searchValue)) {
+      // If the instruction itself doesn't carry any variable info, see
+      // whether it's copied from another place that does.
+      auto allocInstHasInfo = [](AllocationInst *allocInst) {
+        if (allocInst->getDecl())
+          return true;
+        auto debugVar = DebugVarCarryingInst(allocInst);
+        return debugVar && debugVar.maybeGetName().has_value();
+      };
+
+      if (!allocInstHasInfo(allocInst)) {
+        if (auto copy = allocInst->getSingleUserOfType<CopyAddrInst>()) {
+          if (copy->getDest() == allocInst && !copy->isTakeOfSrc() &&
+              copy->isInitializationOfDest()) {
+            searchValue = copy->getSrc();
+            continue;
+          }
+        }
+
+        // If we didn't find anything and did not have a decl, return SILValue()
+        // so that we fail.
+        return SILValue();
+      }
+
+      variableNamePath.push_back(allocInst);
+      return allocInst;
+    }
+
+    if (auto *globalAddrInst = dyn_cast<GlobalAddrInst>(searchValue)) {
+      variableNamePath.push_back(globalAddrInst);
+      return globalAddrInst;
+    }
+
+    if (auto *oeInst = dyn_cast<OpenExistentialAddrInst>(searchValue)) {
+      searchValue = oeInst->getOperand();
+      continue;
+    }
+
+    if (auto *rei = dyn_cast<RefElementAddrInst>(searchValue)) {
+      variableNamePath.push_back(rei);
+      searchValue = rei->getOperand();
+      continue;
+    }
+
+    if (auto *fArg = dyn_cast<SILFunctionArgument>(searchValue)) {
+      variableNamePath.push_back({fArg});
+      return fArg;
+    }
+
+    auto getNamePathComponentFromCallee =
+        [&](FullApplySite call) -> std::optional<SILValue> {
+      // Use the name of the property being accessed if we can get to it.
+      if (isa<FunctionRefBaseInst>(call.getCallee()) ||
+          isa<MethodInst>(call.getCallee())) {
+        variableNamePath.push_back(call.getCallee()->getDefiningInstruction());
+        // Try to name the base of the property if this is a method.
+        if (call.getSubstCalleeType()->hasSelfParam()) {
+          return call.getSelfArgument();
+        }
+
+        return SILValue();
+      }
+      return {};
+    };
+
+    // Read or modify accessor.
+    if (auto bai = dyn_cast_or_null<BeginApplyInst>(
+            searchValue->getDefiningInstruction())) {
+      if (auto selfParam = getNamePathComponentFromCallee(bai)) {
+        searchValue = *selfParam;
+        continue;
+      }
+    }
+
+    // Addressor accessor.
+    if (auto ptrToAddr =
+            dyn_cast<PointerToAddressInst>(stripAccessMarkers(searchValue))) {
+      // The addressor can either produce the raw pointer itself or an
+      // `UnsafePointer` stdlib type wrapping it.
+      ApplyInst *addressorInvocation;
+      if (auto structExtract =
+              dyn_cast<StructExtractInst>(ptrToAddr->getOperand())) {
+        addressorInvocation = dyn_cast<ApplyInst>(structExtract->getOperand());
+      } else {
+        addressorInvocation = dyn_cast<ApplyInst>(ptrToAddr->getOperand());
+      }
+
+      if (addressorInvocation) {
+        if (auto selfParam =
+                getNamePathComponentFromCallee(addressorInvocation)) {
+          searchValue = *selfParam;
+          continue;
+        }
+      }
+    }
+
+    // If we do not do an exact match, see if we can find a debug_var inst. If
+    // we do, we always break since we have a root value.
+    if (auto *use = getAnyDebugUse(searchValue)) {
+      if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
+        assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
+        variableNamePath.push_back(use->getUser());
+
+        // We return the value, not the debug_info.
+        return searchValue;
+      }
+    }
+
+    // Otherwise, try to see if we have a single value instruction we can look
+    // through.
+    if (isa<BeginBorrowInst>(searchValue) || isa<LoadInst>(searchValue) ||
+        isa<LoadBorrowInst>(searchValue) || isa<BeginAccessInst>(searchValue) ||
+        isa<MarkUnresolvedNonCopyableValueInst>(searchValue) ||
+        isa<ProjectBoxInst>(searchValue) || isa<CopyValueInst>(searchValue)) {
+      searchValue = cast<SingleValueInstruction>(searchValue)->getOperand(0);
+      continue;
+    }
+
+    // Return SILValue() if we ever get to the bottom to signal we failed to
+    // find anything.
+    return SILValue();
+  }
+}
+
+static StringRef getNameFromDecl(Decl *d) {
+  if (d) {
+    if (auto accessor = dyn_cast<AccessorDecl>(d)) {
+      return accessor->getStorage()->getBaseName().userFacingName();
+    }
+    if (auto vd = dyn_cast<ValueDecl>(d)) {
+      return vd->getBaseName().userFacingName();
+    }
+  }
+
+  return "<unknown decl>";
+}
+
+void VariableNameInferrer::drainVariableNamePath() {
+  // Walk backwards, constructing our string.
+  while (true) {
+    auto next = variableNamePath.pop_back_val();
+
+    if (auto *inst = next.dyn_cast<SILInstruction *>()) {
+      if (auto i = DebugVarCarryingInst(inst)) {
+        resultingString += i.getName();
+      } else if (auto i = VarDeclCarryingInst(inst)) {
+        resultingString += i.getName();
+      } else if (auto f = dyn_cast<FunctionRefBaseInst>(inst)) {
+        if (auto dc = f->getInitiallyReferencedFunction()->getDeclContext()) {
+          resultingString += getNameFromDecl(dc->getAsDecl());
+        } else {
+          resultingString += "<unknown decl>";
+        }
+      } else if (auto m = dyn_cast<MethodInst>(inst)) {
+        resultingString += getNameFromDecl(m->getMember().getDecl());
+      } else {
+        resultingString += "<unknown decl>";
+      }
+    } else {
+      auto value = next.get<SILValue>();
+      if (auto *fArg = dyn_cast<SILFunctionArgument>(value))
+        resultingString += fArg->getDecl()->getBaseName().userFacingName();
+    }
+
+    if (variableNamePath.empty())
+      return;
+
+    resultingString += '.';
+  }
+}

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SILOptimizer/Utils/VariableNameUtils.h"
+#include "swift/SIL/Test.h"
 
 using namespace swift;
 
@@ -191,3 +192,30 @@ void VariableNameInferrer::drainVariableNamePath() {
     resultingString += '.';
   }
 }
+
+//===----------------------------------------------------------------------===//
+//                                MARK: Tests
+//===----------------------------------------------------------------------===//
+
+namespace swift::test {
+
+// Arguments:
+// - SILValue: value to emit a name for.
+// Dumps:
+// - The inferred name
+// - The inferred value.
+static FunctionTest VariableNameInferrerTests(
+    "variable-name-inference", [](auto &function, auto &arguments, auto &test) {
+      auto value = arguments.takeValue();
+      SmallString<64> finalString;
+      VariableNameInferrer inferrer(&function, finalString);
+      SILValue rootValue =
+          inferrer.inferByWalkingUsesToDefsReturningRoot(value);
+      llvm::outs() << "Input Value: " << *value;
+      if (!rootValue) {
+        llvm::outs() << "Name: 'unknown'\nRoot: 'unknown'\n";
+        return;
+      }
+      llvm::outs() << "Name: '" << finalString << "'\nRoot: " << rootValue;
+    });
+} // namespace swift::test

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -31,7 +31,7 @@ func iterate(stream: AsyncStream<Int>) async {
   // FIXME: Region isolation should consider a value from a 'nonisolated(unsafe)'
   // declaration to be in a disconnected region
 
-  // expected-region-isolation-warning @+3 {{transferring non-Sendable binding 'it' could yield races with later accesses}}
+  // expected-region-isolation-warning @+3 {{transferring non-Sendable value 'it' could yield races with later accesses}}
   // expected-region-isolation-note @+2 {{'it' is transferred from main actor-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-region-isolation-note @+1 {{access here could race}}
   while let element = await it.next() {

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -27,12 +27,13 @@ struct Test2: TestProtocol { // expected-warning{{conformance of 'C2' to 'Sendab
 
 @MainActor
 func iterate(stream: AsyncStream<Int>) async {
-  nonisolated(unsafe) var it = stream.makeAsyncIterator()
+  nonisolated(unsafe) var it = stream.makeAsyncIterator() // expected-region-isolation-note {{variable defined here}}
   // FIXME: Region isolation should consider a value from a 'nonisolated(unsafe)'
   // declaration to be in a disconnected region
 
-  // expected-region-isolation-warning@+2 {{transferring value of non-Sendable type 'AsyncStream<Int>.Iterator' from main actor-isolated context to nonisolated context; later accesses could race}}
-  // expected-region-isolation-note@+1 {{access here could race}}
+  // expected-region-isolation-warning @+3 {{transferring non-Sendable binding 'it' could yield races with later accesses}}
+  // expected-region-isolation-note @+2 {{'it' is transferred from main actor-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-region-isolation-note @+1 {{access here could race}}
   while let element = await it.next() {
     print(element)
   }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -270,10 +270,11 @@ final class NonSendable {
 
 @available(SwiftStdlib 5.1, *)
 func testNonSendableBaseArg() async {
-  let t = NonSendable()
+  let t = NonSendable() // expected-tns-note {{variable defined here}}
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-  // expected-tns-warning@-2 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-2 {{transferring non-Sendable binding 't' could yield races with later accesses}}
+  // expected-tns-note @-3 {{'t' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -288,13 +288,12 @@ func globalSendable(_ ns: NonSendable) async {}
 @available(SwiftStdlib 5.1, *)
 @MainActor
 func callNonisolatedAsyncClosure(
-  ns: NonSendable, // expected-tns-note {{value is task isolated since it is in the same region as 'ns'}}
+  ns: NonSendable,
   g: (NonSendable) async -> Void
 ) async {
   await g(ns)
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{task isolated value of type 'NonSendable' transferred to nonisolated context; later accesses to value could race}}
-  // expected-tns-warning @-3 {{task isolated value of type '@noescape @async @callee_guaranteed (@guaranteed NonSendable) -> ()' transferred to nonisolated context; later accesses to value could race}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -273,7 +273,7 @@ func testNonSendableBaseArg() async {
   let t = NonSendable() // expected-tns-note {{variable defined here}}
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring non-Sendable binding 't' could yield races with later accesses}}
+  // expected-tns-warning @-2 {{transferring non-Sendable value 't' could yield races with later accesses}}
   // expected-tns-note @-3 {{'t' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   _ = await t.x

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -1,0 +1,94 @@
+// RUN: %target-sil-opt -transfer-non-sendable -enable-experimental-feature RegionBasedIsolation -strict-concurrency=complete %s -o /dev/null -verify
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// PLEASE READ THIS!
+//
+// This test is specifically meant for small test cases that come from bugs that
+// do not categorize by a specific category. If this gets too big, please split
+// sections of tests out if possible.
+
+sil_stage raw
+
+import Swift
+import Builtin
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+sil @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+sil @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+sil @useUnmanagedNonSendableKlass : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> ()
+
+final class SendableKlass : Sendable {}
+
+sil @transferSendableKlass : $@convention(thin) @async (@guaranteed SendableKlass) -> ()
+sil @constructSendableKlass : $@convention(thin) () -> @owned SendableKlass
+
+final class KlassContainingKlasses {
+  let nsImmutable : NonSendableKlass
+  var nsMutable : NonSendableKlass
+  let sImmutable : SendableKlass
+  var sMutable : SendableKlass
+}
+
+sil @transferKlassContainingKlasses : $@convention(thin) @async (@guaranteed KlassContainingKlasses) -> ()
+sil @useKlassContainingKlasses : $@convention(thin) (@guaranteed KlassContainingKlasses) -> ()
+sil @constructKlassContainingKlasses : $@convention(thin) () -> @owned KlassContainingKlasses
+
+@_moveOnly
+struct NonSendableMoveOnlyStruct {
+  var ns: NonSendableKlass
+
+  deinit
+}
+
+sil @constructMoveOnlyStruct : $@convention(thin) () -> @owned NonSendableMoveOnlyStruct
+sil @transferMoveOnlyStruct : $@convention(thin) @async (@guaranteed NonSendableMoveOnlyStruct) -> ()
+
+struct NonSendableStruct {
+  var ns: NonSendableKlass
+}
+
+sil @constructStruct : $@convention(thin) () -> @owned NonSendableStruct
+sil @transferStruct : $@convention(thin) @async (@guaranteed NonSendableStruct) -> ()
+
+sil @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
+sil @useRawPointer : $@convention(thin) (Builtin.RawPointer) -> ()
+sil @initRawPointer : $@convention(thin) () -> Builtin.RawPointer
+
+sil @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+sil @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+sil @initIndirect : $@convention(thin) <T> () -> @out T
+sil @initIndirectTransferring : $@convention(thin) @async <T> () -> @out T
+sil @initIndirectTransferringError : $@convention(thin) @async <T> () -> (@out Optional<T>, @error any Error)
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+// This goes through the access projection code differently from normal
+// project_box since we do not see the alloc_box.
+sil [ossa] @project_box_loadable_test_case : $@convention(thin) @async (@in { var NonSendableKlass }) -> () {
+bb0(%0 : $*{ var NonSendableKlass }):
+  %1 = load [take] %0 : $*{ var NonSendableKlass }
+  %3 = project_box %1 : ${ var NonSendableKlass }, 0
+
+  %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  destroy_value %1 : ${ var NonSendableKlass }
+
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -63,6 +63,7 @@ sil @useRawPointer : $@convention(thin) (Builtin.RawPointer) -> ()
 sil @initRawPointer : $@convention(thin) () -> Builtin.RawPointer
 
 sil @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+sil @transferIndirectWithOutResult : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
 sil @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 sil @initIndirect : $@convention(thin) <T> () -> @out T
 sil @initIndirectTransferring : $@convention(thin) @async <T> () -> @out T
@@ -88,6 +89,58 @@ bb0(%0 : $*{ var NonSendableKlass }):
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
   destroy_value %1 : ${ var NonSendableKlass }
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// This doesn't error since the @out parameter is not transferred when it is initialized.
+//
+// DISCUSSION: The frontend prevents us from using such a value. But we
+// shouldn't crash on such values.
+sil [ossa] @transfer_does_not_transfer_out_parameters_1 : $@convention(thin) @async () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableKlass
+  %init = function_ref @initIndirect : $@convention(thin) <T> () -> @out T
+  apply %init<NonSendableKlass>(%0) : $@convention(thin) <T> () -> @out T
+
+  %1 = alloc_stack $NonSendableKlass
+  %f = function_ref @transferIndirectWithOutResult : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%1, %0) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
+
+  %useIndirect = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply %useIndirect<NonSendableKlass>(%1) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+
+  destroy_addr %1 : $*NonSendableKlass
+  dealloc_stack %1 : $*NonSendableKlass
+  destroy_addr %0 : $*NonSendableKlass
+  dealloc_stack %0 : $*NonSendableKlass
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @transfer_does_not_transfer_out_parameters_2 : $@convention(thin) @async () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableKlass
+  %init = function_ref @initIndirect : $@convention(thin) <T> () -> @out T
+  apply %init<NonSendableKlass>(%0) : $@convention(thin) <T> () -> @out T
+
+  %1 = alloc_stack $NonSendableKlass
+  %f = function_ref @transferIndirectWithOutResult : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%1, %0) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
+
+  %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%1) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+  %useIndirect = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply %useIndirect<NonSendableKlass>(%1) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  // expected-note @-1 {{access here could race}}
+
+  destroy_addr %1 : $*NonSendableKlass
+  dealloc_stack %1 : $*NonSendableKlass
+  destroy_addr %0 : $*NonSendableKlass
+  dealloc_stack %0 : $*NonSendableKlass
 
   %9999 = tuple ()
   return %9999 : $()

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -123,7 +123,7 @@ func closureInOut(_ a: Actor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{transferring non-Sendable binding 'ns0' could yield races with later accesses}}
+  // expected-tns-warning @-2 {{transferring non-Sendable value 'ns0' could yield races with later accesses}}
   // expected-tns-note @-3 {{'ns0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // We only emit a warning on the first use we see, so make sure we do both
@@ -146,13 +146,13 @@ func closureInOut2(_ a: Actor) async {
 
   var closure = {}
 
-  await a.useKlass(ns0) // expected-tns-warning {{transferring non-Sendable binding 'ns0' could yield races with later accesses}}
+  await a.useKlass(ns0) // expected-tns-warning {{transferring non-Sendable value 'ns0' could yield races with later accesses}}
   // expected-tns-note @-1 {{'ns0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure = { useInOut(&contents) } // expected-tns-note {{access here could race}}
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring non-Sendable binding 'ns1' could yield races with later accesses}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring non-Sendable value 'ns1' could yield races with later accesses}}
   // expected-tns-note @-1 {{'ns1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
@@ -174,7 +174,7 @@ func closureNonInOut(_ a: Actor) async {
 
   closure = { useValue(contents) }
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring non-Sendable binding 'ns1' could yield races with later accesses}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring non-Sendable value 'ns1' could yield races with later accesses}}
   // expected-tns-note @-1 {{'ns1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -112,7 +112,7 @@ func formClosureWithoutCrashing() {
 // treat assignments into contents as a merge operation rather than an assign.
 func closureInOut(_ a: Actor) async {
   var contents = NonSendableKlass()
-  let ns0 = NonSendableKlass()
+  let ns0 = NonSendableKlass() // expected-tns-note {{variable defined here}}
   let ns1 = NonSendableKlass()
 
   contents = ns0
@@ -123,7 +123,8 @@ func closureInOut(_ a: Actor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-2 {{transferring non-Sendable binding 'ns0' could yield races with later accesses}}
+  // expected-tns-note @-3 {{'ns0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // We only emit a warning on the first use we see, so make sure we do both
   // klass and the closure.
@@ -137,21 +138,23 @@ func closureInOut(_ a: Actor) async {
 
 func closureInOut2(_ a: Actor) async {
   var contents = NonSendableKlass()
-  let ns0 = NonSendableKlass()
-  let ns1 = NonSendableKlass()
+  let ns0 = NonSendableKlass() // expected-tns-note {{variable defined here}}
+  let ns1 = NonSendableKlass() // expected-tns-note {{variable defined here}}
 
   contents = ns0
   contents = ns1
 
   var closure = {}
 
-  await a.useKlass(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  await a.useKlass(ns0) // expected-tns-warning {{transferring non-Sendable binding 'ns0' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'ns0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure = { useInOut(&contents) } // expected-tns-note {{access here could race}}
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring non-Sendable binding 'ns1' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'ns1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{access here could race}}
 }
@@ -159,7 +162,7 @@ func closureInOut2(_ a: Actor) async {
 func closureNonInOut(_ a: Actor) async {
   var contents = NonSendableKlass()
   let ns0 = NonSendableKlass()
-  let ns1 = NonSendableKlass()
+  let ns1 = NonSendableKlass() // expected-tns-note {{variable defined here}}
 
   contents = ns0
   contents = ns1
@@ -171,8 +174,9 @@ func closureNonInOut(_ a: Actor) async {
 
   closure = { useValue(contents) }
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring non-Sendable binding 'ns1' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'ns1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure() // expected-tns-note {{access here could race}}
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -543,7 +543,7 @@ func testSendableClosureCapturesNonSendable2(a: MainActorIsolatedKlass) {
 /////////////////////////////////////////////////////
 
 func singleFieldVarMergeTest() async {
-  var box = SingleFieldKlassBox()
+  var box = SingleFieldKlassBox() // expected-tns-note {{variable defined here}}
   box = SingleFieldKlassBox()
 
   // This transfers the entire region.
@@ -565,8 +565,9 @@ func singleFieldVarMergeTest() async {
   useValue(box)
   useValue(box.k)
 
-  await transferToMain(box) // expected-tns-warning {{transferring value of non-Sendable type 'SingleFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
+  await transferToMain(box) // expected-tns-warning {{transferring non-Sendable value 'box' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'box' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
   
 
   // But if we use box.k here, we emit an error since we didn't reinitialize at
@@ -818,28 +819,31 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
 }
 
 func letSendableTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() 
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func letSendableNonTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() 
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func letNonSendableNonTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() 
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
   useValue(test)
@@ -892,28 +896,31 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
 }
 
 func varSendableTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() 
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func varSendableNonTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() 
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func varNonSendableNonTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() 
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
   useValue(test)
@@ -921,135 +928,144 @@ func varNonSendableNonTrivialVarStructFieldTest() async {
 
 // vars cannot access sendable let/var if captured in a closure.
 func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   let cls = {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
   useValue(test)
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   let cls = {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
   useValue(test)
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   let cls = {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 // vars cannot access sendable let/var if captured in a closure.
 func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
   cls = {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
   useValue(test)
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
   cls = {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
   useValue(test)
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
   cls = {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
   cls = {
     test.varSendableNonTrivial = SendableKlass()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
   cls = {
     useInOut(&test)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
   cls = {
     useInOut(&test.varSendableNonTrivial)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
 
@@ -1059,8 +1075,9 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
     test.varSendableNonTrivial = SendableKlass()
   }
@@ -1069,7 +1086,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
 
@@ -1079,8 +1096,9 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
     }
     _ = cls
 
-    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1090,7 +1108,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
 // We do not error when accessing the sendable field in this example since the
 // transfer is not reachable from the closure. Instead we emit an error on test.
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
 
@@ -1100,8 +1118,9 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
   test.varSendableNonTrivial = SendableKlass()
@@ -1109,13 +1128,14 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
   var cls = {}
 
   for _ in 0..<1024 {
-    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests() // expected-tns-note {{access here could race}}
     cls = {
       useInOut(&test.varSendableNonTrivial)
@@ -1128,7 +1148,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
 
   // The reason why we error here is that even though we reassign at the end of
@@ -1139,9 +1159,10 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   // this. This is a case where we are going to need to be able to have the
   // compiler explain the regions well.
   for _ in 0..<1024 {
-    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-tns-note @-1 {{access here could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-tns-note @-2 {{access here could race}}
+    // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests()
   }
 
@@ -1150,7 +1171,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note 2{{variable defined here}}
   test = StructFieldTests()
   var cls = {}
 
@@ -1162,11 +1183,13 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1176,20 +1199,22 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
 // In this case since we are tracking the transfer from the else statement, we
 // track the closure.
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
-  var test = StructFieldTests()
+  var test = StructFieldTests() // expected-tns-note 2{{variable defined here}}
   test = StructFieldTests()
   var cls = {}
 
   if await booleanFlag {
-    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
     cls = {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1285,12 +1310,13 @@ func controlFlowTest1() async {
 // as well afterwards since if we exit from the loop header, we have that large
 // merge region leave the for loop.
 func controlFlowTest2() async {
-  var x = NonSendableKlass()
+  var x = NonSendableKlass() // expected-tns-note {{variable defined here}}
 
   for _ in 0..<1024 {
-    await transferToMain(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-tns-note @-1 {{access here could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    await transferToMain(x) // expected-tns-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+    // expected-tns-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-tns-note @-2 {{access here could race}}
+    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     x = NonSendableKlass()
   }

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -101,11 +101,12 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 }
 
 @GlobalActor func useGlobalActor6() async {
-  var x = StructContainingValue()
+  var x = StructContainingValue() // expected-tns-note {{variable defined here}}
   x = StructContainingValue()
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring value of non-Sendable type 'StructContainingValue' from global actor 'GlobalActor'-isolated context to nonisolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  // expected-tns-note @-1 {{'x' is transferred from global actor 'GlobalActor'-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
   useValue(x) // expected-tns-note {{access here could race}}
 }

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -1627,3 +1627,23 @@ bb0:
   %9999 = tuple ()
   return %9999 : $()
 }
+
+sil @use_bridge_object : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
+
+// ref_to_bridge_object is lookthrough in its first parameter. So we should
+// error on the use, not that instruction.
+sil [ossa] @ref_to_bridge_object_test : $@convention(thin) @async (Builtin.Word) -> () {
+bb0(%arg : $Builtin.Word):
+  %constructFn = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+  %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
+
+  %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+
+  %b = ref_to_bridge_object %value : $NonSendableKlass, %arg : $Builtin.Word
+  %bridgeUse = function_ref @use_bridge_object : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
+  apply %bridgeUse(%b) : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> () // expected-note {{access here could race}}
+  destroy_value %b : $Builtin.BridgeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -353,7 +353,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns5_0) // expected-tns-warning {{transferring non-Sendable binding 'ns5_0' could yield races with later accesses}}
+        await a.foo(ns5_0) // expected-tns-warning {{transferring non-Sendable value 'ns5_0' could yield races with later accesses}}
         // expected-tns-note @-1 {{'ns5_0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
@@ -363,7 +363,7 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns5_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns5_1) // expected-tns-warning {{transferring non-Sendable binding 'ns5_1' could yield races with later accesses}}
+        await a.foo(ns5_1) // expected-tns-warning {{transferring non-Sendable value 'ns5_1' could yield races with later accesses}}
         // expected-tns-note @-1 {{'ns5_1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -247,8 +247,8 @@ func test_indirect_regions(a : A, b : Bool) async {
 
     // same aux value points to both 0 and 1
     let ns5_aux = NonSendable();
-    let ns5_0 = ns5_aux.x;
-    let ns5_1 = ns5_aux.y;
+    let ns5_0 = ns5_aux.x; // expected-tns-note {{variable defined here}}
+    let ns5_1 = ns5_aux.y; // expected-tns-note {{variable defined here}}
 
     // now check for each pair that consuming half of it consumed the other half
 
@@ -353,8 +353,9 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns5_0) // expected-tns-warning {{transferring value of non-Sendable type 'Any' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
+        await a.foo(ns5_0) // expected-tns-warning {{transferring non-Sendable binding 'ns5_0' could yield races with later accesses}}
+        // expected-tns-note @-1 {{'ns5_0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+        // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
         if b {
           print(ns5_0) // expected-tns-note {{access here could race}}
@@ -362,8 +363,9 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns5_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns5_1) // expected-tns-warning {{transferring value of non-Sendable type 'Any' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
+        await a.foo(ns5_1) // expected-tns-warning {{transferring non-Sendable binding 'ns5_1' could yield races with later accesses}}
+        // expected-tns-note @-1 {{'ns5_1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+        // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
         if b {
           print(ns5_0) // expected-tns-note {{access here could race}}

--- a/test/Concurrency/transfernonsendable_strong_transferring.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring.swift
@@ -214,7 +214,7 @@ func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
   x = y
 
   // TODO: This should refer to the transferring parameter.
-  await transferToMain(x) // expected-warning {{transferring non-Sendable binding 'x' could yield races with later accesses}}
+  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   useValue(x) // expected-note {{access here could race}}

--- a/test/Concurrency/transfernonsendable_strong_transferring.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring.swift
@@ -90,12 +90,16 @@ func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) 
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
-  await transferToMain(x) // expected-warning {{transferring value of non-Sendable type 'Klass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-note @-1:54 {{variable defined here}}
+  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   await transferToMain(x) // expected-note {{access here could race}}
 }
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
-  await transferToMain(x) // expected-warning {{transferring value of non-Sendable type 'Klass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-note @-1 {{variable defined here}}
+  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   useValue(x) // expected-note {{access here could race}}
 }
 
@@ -109,12 +113,16 @@ actor MyActor {
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
-    await transferToMain(x) // expected-warning {{transferring value of non-Sendable type 'Klass' from actor-isolated context to main actor-isolated context; later accesses could race}}
+    // expected-note @-1 {{variable defined here}}
+    await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+    // expected-note @-1 {{'x' is transferred from actor-isolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     await transferToMain(x) // expected-note {{access here could race}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
-    await transferToMain(x)  // expected-warning {{transferring value of non-Sendable type 'Klass' from actor-isolated context to main actor-isolated context; later accesses could race}}
+    // expected-note @-1 {{variable defined here}}
+    await transferToMain(x)  // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  // expected-note @-1 {{'x' is transferred from actor-isolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     useValue(x) // expected-note {{access here could race}}
   }
 
@@ -151,8 +159,10 @@ func canTransferAssigningIntoLocal(_ x: transferring Klass) async {
 }
 
 func canTransferAssigningIntoLocal2(_ x: transferring Klass) async {
+  // expected-note @-1 {{variable defined here}}
   let _ = x
-  await transferToMain(x) // expected-warning {{transferring value of non-Sendable type 'Klass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   let _ = x // expected-note {{access here could race}}
 }
 
@@ -236,13 +246,16 @@ func assignToEntireValueEliminatesEarlierTransfer(_ x: transferring Any) async {
 }
 
 func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) async {
+  // expected-note @-1 {{variable defined here}}
+
   // Ok, this is disconnected.
   let y = Klass()
 
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring value of non-Sendable type 'NonSendableStruct' from nonisolated context to main actor-isolated context; later accesses could race}}
+  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // y is assigned into a field of x, so we treat this like a merge.
   x.first = y
@@ -251,13 +264,16 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
 }
 
 func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) async {
+  // expected-note @-1 {{variable defined here}}
+
   // Ok, this is disconnected.
   let y = Klass()
 
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring value of non-Sendable type 'NonSendableStruct' from nonisolated context to main actor-isolated context; later accesses could race}}
+  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // y is assigned into a field of x, so we treat this like a merge.
   x.first = y // expected-warning {{transferring value of non-Sendable type 'Klass' into transferring parameter; later accesses could race}}

--- a/test/Concurrency/transfernonsendable_strong_transferring.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring.swift
@@ -205,14 +205,17 @@ func canTransferAfterAssign(_ x: transferring Any) async {
 }
 
 func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
+  // expected-note @-1:44 {{variable defined here}}
+
   // Ok, this is disconnected.
   let y = getAny()
 
   // y is transferred into x.
   x = y
 
-  // TODO: Change this to refer to task context? Or to transferring parameter?
-  await transferToMain(x) // expected-warning {{transferring value of non-Sendable type 'Any' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // TODO: This should refer to the transferring parameter.
+  await transferToMain(x) // expected-warning {{transferring non-Sendable binding 'x' could yield races with later accesses}}
+  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   useValue(x) // expected-note {{access here could race}}
 }

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -1,0 +1,52 @@
+// RUN: %target-sil-opt -test-runner %s 2>&1 | %FileCheck %s
+
+import Builtin
+
+class Klass {}
+
+sil @getKlass : $@convention(thin) () -> @owned Klass
+sil @useIndirect : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on simple_test_case: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK: Name: 'MyName'
+// CHECK: Root:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on simple_test_case: variable-name-inference with: @trace[0]
+sil [ossa] @simple_test_case : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  debug_value [trace] %1 : $Klass
+  debug_value %1 : $Klass, let, name "MyName"
+  destroy_value %1 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_copy_addr: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %4 = alloc_stack $Klass
+// CHECK: Name: 'MyName'
+// CHECK: Root:   %2 = alloc_stack $Klass, var, name "MyName"
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_copy_addr: variable-name-inference with: @trace[0]
+sil [ossa] @temporary_init_with_copy_addr : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  %2 = alloc_stack $Klass, name "MyName"
+  store %1 to [init] %2 : $*Klass
+
+  %temp = alloc_stack $Klass
+  copy_addr %2 to [init] %temp : $*Klass
+  debug_value [trace] %temp : $*Klass
+  %use = function_ref @useIndirect : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  apply %use<Klass>(%temp) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+  destroy_addr %temp : $*Klass
+  dealloc_stack %temp : $*Klass
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -50,3 +50,27 @@ bb0:
   %9999 = tuple ()
   return %9999 : $()
 }
+
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_store: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %3 = alloc_stack $Klass
+// CHECK: Name: 'MyName'
+// CHECK: Root:   %1 = apply %0()
+// CHECK: end running test {{[0-9]+}} of {{[0-9]+}} on temporary_init_with_store: variable-name-inference with: @trace[0]
+sil [ossa] @temporary_init_with_store : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  debug_value %1 : $Klass, name "MyName", let
+
+  %temp = alloc_stack $Klass
+  store %1 to [init] %temp : $*Klass
+  debug_value [trace] %temp : $*Klass
+  %use = function_ref @useIndirect : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  apply %use<Klass>(%temp) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+  destroy_addr %temp : $*Klass
+  dealloc_stack %temp : $*Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}


### PR DESCRIPTION
Decided to use the stdlib to test out region based isolation. Found some issues. They are:

1. I discovered in a bunch of cases, we cannot rely on the AST in a real way to determine argument locations around for in loops. Rather than fix that AST, I just did the right thing and made it so that in those cases we emit a diagnostic that infers the name of the value from SIL rather than a type from the AST. I refactored code from the MoveChecker for this purpose and I also added the ability to test the VariableNameInferrer (the utilities name) independently of both by using specify_test.
2. I found I was not handling a few instructions correctly. I updated them.
3. We were transferring @out parameters in certain cases rather than treating them as initializing a value. Of course in cases where it is illegal to use such a value Sema will error. But we should handle it correctly.
4. There is a part of MemAccessUtils that as a hack until we have opaque values treat (project_box (load %boxAddr)) as a projection. I assumed we would never see a project_box as a projection and asserted. We hit that assert in the stdlib.

