### PR TITLE
Support bypassing resilience checks for package decls at use site in a package

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2920,10 +2920,6 @@ public:
   /// if the base declaration is \c open, the override might have to be too.
   bool hasOpenAccess(const DeclContext *useDC) const;
 
-  /// Returns whether this declaration should be treated as having the \c
-  /// package access level.
-  bool hasPackageAccess() const;
-
   /// FIXME: This is deprecated.
   bool isRecursiveValidation() const;
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5842,13 +5842,6 @@ public:
                                    ModuleDecl *module,
                                    ResilienceExpansion expansion) const;
 
-  /// Should this declaration behave as if it must be accessed
-  /// resiliently, even when we're building a non-resilient module?
-  ///
-  /// This is used for diagnostics, because we do not want a behavior
-  /// change between builds with resilience enabled and disabled.
-  bool isFormallyResilient() const;
-
   /// Do we need to use resilient access patterns outside of this
   /// property's resilience domain?
   bool isResilient() const;

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -530,6 +530,13 @@ public:
   LLVM_READONLY
   PackageUnit *getPackageContext(bool lookupIfNotCurrent = false) const;
 
+  /// True if resilience checks can be bypassed within a package.
+  /// \p isForPackageDecl Bypassing only applies to package types
+  /// (possibly also public types later) if opted-in, client and defining module
+  /// are in the same package, and the defining module is a binary module.
+  LLVM_READONLY
+  bool allowBypassResilienceInPackage(bool isForPackageDecl) const;
+
   /// Returns the module context that contains this context.
   LLVM_READONLY
   ModuleDecl *getParentModule() const;

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -535,7 +535,7 @@ public:
   /// (possibly also public types later) if opted-in, client and defining module
   /// are in the same package, and the defining module is a binary module.
   LLVM_READONLY
-  bool allowBypassResilienceInPackage(bool isForPackageDecl) const;
+  bool bypassResilienceInPackage(bool isForPackageDecl) const;
 
   /// Returns the module context that contains this context.
   LLVM_READONLY

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -480,6 +480,10 @@ public:
     return Identifier();
   }
 
+  bool inPackage(std::string packageName) {
+    return !getPackageName().empty() && getPackageName().str() == packageName;
+  }
+
   /// Get the package associated with this module
   PackageUnit *getPackage() const { return Package; }
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -480,8 +480,8 @@ public:
     return Identifier();
   }
 
-  bool inPackage(std::string packageName) {
-    return !getPackageName().empty() && getPackageName().str() == packageName;
+  bool inSamePackage(ModuleDecl *other) {
+    return !getPackageName().empty() && getPackageName() == other->getPackageName();
   }
 
   /// Get the package associated with this module

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -186,6 +186,9 @@ namespace swift {
     /// Disable API availability checking.
     bool DisableAvailabilityChecking = false;
 
+    /// Enable optimization to bypass resilience checks in a package
+    bool EnableBypassResilienceInPackage = false;
+
     /// Optimization mode for unavailable declarations.
     llvm::Optional<UnavailableDeclOptimization> UnavailableDeclOptimizationMode;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -516,6 +516,10 @@ def unavailable_decl_optimization_EQ : Joined<["-"], "unavailable-decl-optimizat
            "value may be 'none' (no optimization) or 'complete' (code is not "
            "generated at all unavailable declarations)">;
 
+def package_bypass_resilience_optimization : Flag<["-"], "package-bypass-resilience-optimization">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable optimization to bypass resilience within a package">;
+
 def library_level : Separate<["-"], "library-level">,
   MetaVarName<"<level>">,
   Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2957,14 +2957,16 @@ bool AbstractStorageDecl::isResilient() const {
   if (getAttrs().hasAttribute<FixedLayoutAttr>())
     return false;
 
+  // If we're an instance property of a nominal type, query the type.
   if (!isStatic())
     if (auto *nominalDecl = getDeclContext()->getSelfNominalTypeDecl())
       return nominalDecl->isResilient();
 
   // Non-public global and static variables always have a
   // fixed layout.
-  if (!getFormalAccessScope(/*useDC=*/nullptr,
-                            /*treatUsableFromInlineAsPublic=*/true).isPublicOrPackage())
+  auto accessScope = getFormalAccessScope(/*useDC=*/nullptr,
+                                          /*treatUsableFromInlineAsPublic=*/true);
+  if (!accessScope.isPublicOrPackage())
     return false;
 
   if (!getModuleContext()->isResilient())
@@ -2973,8 +2975,7 @@ bool AbstractStorageDecl::isResilient() const {
   // Allows bypassing resilience checks for package decls
   // at use site within a package if opted in, whether the
   // loaded module was built resiliently or not.
-  return !getDeclContext()->bypassResilienceInPackage(getFormalAccessScope(/*useDC=*/nullptr,
-                                                                           /*treatUsableFromInlineAsPublic=*/true).isPackage());
+  return !getDeclContext()->bypassResilienceInPackage(accessScope.isPackage());
 }
 
 bool AbstractStorageDecl::isResilient(ModuleDecl *M,
@@ -5050,8 +5051,9 @@ bool NominalTypeDecl::isResilient() const {
   // Allows bypassing resilience checks for package decls
   // at use site within a package if opted in, whether the
   // loaded module was built resiliently or not.
-  return !getDeclContext()->bypassResilienceInPackage(getFormalAccessScope(/*useDC=*/nullptr,
-                                                                           /*treatUsableFromInlineAsPublic=*/true).isPackage());
+  auto accessScope = getFormalAccessScope(/*useDC=*/nullptr,
+                                          /*treatUsableFromInlineAsPublic=*/true);
+  return !getDeclContext()->bypassResilienceInPackage(accessScope.isPackage());
 }
 
 DestructorDecl *NominalTypeDecl::getValueTypeDestructor() {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2975,8 +2975,13 @@ bool AbstractStorageDecl::isFormallyResilient() const {
 bool AbstractStorageDecl::isResilient() const {
   if (!isFormallyResilient())
     return false;
-
-  return getModuleContext()->isResilient();
+  if (!getModuleContext()->isResilient())
+    return false;
+  // Allows bypassing resilience checks for package decls
+  // at use site within a package if opted in, whether the
+  // loaded module was built resiliently or not.
+  return !getDeclContext()->allowBypassResilienceInPackage(getFormalAccessScope(/*useDC=*/nullptr,
+                                                                                /*treatUsableFromInlineAsPublic=*/true).isPackage());
 }
 
 bool AbstractStorageDecl::isResilient(ModuleDecl *M,
@@ -4207,13 +4212,6 @@ bool ValueDecl::hasOpenAccess(const DeclContext *useDC) const {
   return access == AccessLevel::Open;
 }
 
-bool ValueDecl::hasPackageAccess() const {
-  AccessLevel access =
-      getAdjustedFormalAccess(this, /*useDC*/ nullptr,
-                              /*treatUsableFromInlineAsPublic*/ false);
-  return access == AccessLevel::Package;
-}
-
 /// Given the formal access level for using \p VD, compute the scope where
 /// \p VD may be accessed, taking \@usableFromInline, \@testable imports,
 /// \@_spi imports, and enclosing access levels into account.
@@ -5054,8 +5052,13 @@ bool NominalTypeDecl::isFormallyResilient() const {
 bool NominalTypeDecl::isResilient() const {
   if (!isFormallyResilient())
     return false;
-
-  return getModuleContext()->isResilient();
+  if (!getModuleContext()->isResilient())
+    return false;
+  // Allows bypassing resilience checks for package decls
+  // at use site within a package if opted in, whether the
+  // loaded module was built resiliently or not.
+  return !getDeclContext()->allowBypassResilienceInPackage(getFormalAccessScope(/*useDC=*/nullptr,
+                                                                                /*treatUsableFromInlineAsPublic=*/true).isPackage());
 }
 
 DestructorDecl *NominalTypeDecl::getValueTypeDestructor() {
@@ -6375,7 +6378,11 @@ bool EnumDecl::isFormallyExhaustive(const DeclContext *useDC) const {
   // Non-public, non-versioned enums are always exhaustive.
   AccessScope accessScope = getFormalAccessScope(/*useDC*/nullptr,
                                                  /*respectVersioned*/true);
-  if (!accessScope.isPublic())
+  // Both public and package enums should behave the same unless
+  // package enum is optimized with bypassing resilience checks.
+  if (!accessScope.isPublicOrPackage())
+    return true;
+  if (useDC && useDC->allowBypassResilienceInPackage(accessScope.isPackage()))
     return true;
 
   // All other checks are use-site specific; with no further information, the

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -302,12 +302,12 @@ PackageUnit *DeclContext::getPackageContext(bool lookupIfNotCurrent) const {
 
 bool DeclContext::bypassResilienceInPackage(bool isForPackageDecl) const {
   // Bypassing resilience checks only applies to package types (and possibly
-  // public types in a package in the future). Allowed only if opted-in for
-  // bypassing checks, client and defining module are in the same package,
-  // and defining module is a binary module.
+  // public types in the same package in the future). Allowed only if opted-in
+  // for bypassing optimization, client and defining module are in the same
+  // package, and defining module is a binary module.
   return isForPackageDecl &&
          getASTContext().LangOpts.EnableBypassResilienceInPackage &&
-         getParentModule()->inPackage(getASTContext().LangOpts.PackageName) &&
+         getParentModule()->inSamePackage(getASTContext().MainModule) &&
          !getParentModule()->isBuiltFromInterface();
 }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -349,6 +349,7 @@ bool NormalProtocolConformance::isResilient() const {
   // individual witnesses.
   if (!getDeclContext()->getSelfNominalTypeDecl()->isResilient())
     return false;
+
   return getDeclContext()->getParentModule()->isResilient();
 }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -349,7 +349,6 @@ bool NormalProtocolConformance::isResilient() const {
   // individual witnesses.
   if (!getDeclContext()->getSelfNominalTypeDecl()->isResilient())
     return false;
-
   return getDeclContext()->getParentModule()->isResilient();
 }
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -299,6 +299,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_Rpass_missed_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_suppress_warnings);
   inputArgs.AddLastArg(arguments, options::OPT_suppress_remarks);
+  inputArgs.AddLastArg(arguments, options::OPT_package_bypass_resilience_optimization);
   inputArgs.AddLastArg(arguments, options::OPT_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_profile_coverage_mapping);
@@ -551,7 +552,7 @@ ToolChain::constructInvocation(const CompileJobAction &job,
   if (context.Args.hasArg(options::OPT_CrossModuleOptimization)) {
     Arguments.push_back("-cross-module-optimization");
   }
-                                 
+
   if (context.Args.hasArg(options::OPT_ExperimentalPerformanceAnnotations)) {
     Arguments.push_back("-experimental-performance-annotations");
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -671,6 +671,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnablePackageInterfaceLoad = Args.hasArg(OPT_experimental_package_interface_load) ||
                                     ::getenv("SWIFT_ENABLE_PACKAGE_INTERFACE_LOAD");
 
+  Opts.EnableBypassResilienceInPackage = Args.hasArg(OPT_package_bypass_resilience_optimization);
+
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
   if (Args.hasArg(OPT_check_api_availability_only))

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1889,7 +1889,10 @@ static bool canStorageUseTrivialDescriptor(SILGenModule &SGM,
     if (SGM.canStorageUseStoredKeyPathComponent(decl, expansion)) {
       // External modules can't directly access storage, unless this is a
       // property in a fixed-layout type.
-      return !decl->isFormallyResilient();
+      // Assert here as key path component cannot refer to a static var.
+      assert(!decl->isStatic());
+      // By this point, decl is a fixed layout or its enclosing type is non-resilient.
+      return true;
     }
 
     // If the type is computed and doesn't have a setter that's hidden from

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -762,8 +762,7 @@ void UnboundImport::validateInterfaceWithPackageName(ModuleDecl *topLevelModule,
 
   // If source file is .swift or non-interface, show diags when importing an interface file
   ASTContext &ctx = topLevelModule->getASTContext();
-  if (!topLevelModule->getPackageName().empty() &&
-      topLevelModule->getPackageName().str() == ctx.LangOpts.PackageName &&
+  if (topLevelModule->inPackage(ctx.LangOpts.PackageName) &&
       topLevelModule->isBuiltFromInterface() &&
       !topLevelModule->getModuleSourceFilename().endswith(".package.swiftinterface")) {
       ctx.Diags.diagnose(import.module.getModulePath().front().Loc,

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -762,7 +762,7 @@ void UnboundImport::validateInterfaceWithPackageName(ModuleDecl *topLevelModule,
 
   // If source file is .swift or non-interface, show diags when importing an interface file
   ASTContext &ctx = topLevelModule->getASTContext();
-  if (topLevelModule->inPackage(ctx.LangOpts.PackageName) &&
+  if (topLevelModule->inSamePackage(ctx.MainModule) &&
       topLevelModule->isBuiltFromInterface() &&
       !topLevelModule->getModuleSourceFilename().endswith(".package.swiftinterface")) {
       ctx.Diags.diagnose(import.module.getModulePath().front().Loc,

--- a/test/IRGen/package_resilience.swift
+++ b/test/IRGen/package_resilience.swift
@@ -221,7 +221,7 @@ public func memoryLayoutDotSizeWithResilientStruct() -> Int {
 // CHECK-LABEL: define{{.*}} swiftcc {{i32|i64}} @"$s18package_resilience40memoryLayoutDotStrideWithResilientStructSiyF"()
 public func memoryLayoutDotStrideWithResilientStruct() -> Int {
   // CHECK: ret [[INT]] [[#WORDSIZE + WORDSIZE]]
-  return MemoryLayout<Size>.size
+  return MemoryLayout<Size>.stride
 }
 
 // CHECK-LABEL: define{{.*}} swiftcc {{i32|i64}} @"$s18package_resilience43memoryLayoutDotAlignmentWithResilientStructSiyF"()

--- a/test/IRGen/package_resilience.swift
+++ b/test/IRGen/package_resilience.swift
@@ -1,20 +1,18 @@
 //
 // Unlike its counterparts in the other *_resilience.swift files, the goal is
 // for the package's component modules to all be considered within the same
-// resilience domain. This file ensures that we use direct access as much as
-// possible.
+// resilience domain. This file ensures that we use direct access to package
+// decls at use site as much as possible with -package-bypass-resilience-optimization.
 //
-
-// REQUIRES: rdar118947451
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/package_resilience.swift
 // RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/Inputs/package_types/resilient_struct.swift
 // RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/Inputs/package_types/resilient_enum.swift
 // RUN: %target-swift-frontend -package-name MyPkg -emit-module -enable-library-evolution -emit-module-path=%t/resilient_class.swiftmodule -module-name=resilient_class -I %t %S/Inputs/package_types/resilient_class.swift
-// RUN: %target-swift-frontend -package-name MyPkg -enable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-%target-import-type-objc-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment
-// RUN: %target-swift-frontend -package-name MyPkg -disable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-native-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=4 -D#MDSIZE32=40 -D#MDSIZE64=56 -D#WORDSIZE=%target-alignment
-// RUN: %target-swift-frontend -package-name MyPkg -I %t -emit-ir -enable-library-evolution -O %t/package_resilience.swift -package-name MyPkg
+// RUN: %target-swift-frontend -package-name MyPkg -package-bypass-resilience-optimization -enable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-objc,CHECK-objc%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-%target-import-type-objc-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=7 -D#MDSIZE32=52 -D#MDSIZE64=80 -D#WORDSIZE=%target-alignment
+// RUN: %target-swift-frontend -package-name MyPkg -package-bypass-resilience-optimization -disable-objc-interop -I %t -emit-ir -enable-library-evolution %t/package_resilience.swift | %FileCheck %t/package_resilience.swift --check-prefixes=CHECK,CHECK-native,CHECK-native%target-ptrsize,CHECK-%target-ptrsize,CHECK-%target-cpu,CHECK-native-STABLE-ABI-%target-mandates-stable-abi,CHECK-%target-sdk-name -DINT=i%target-ptrsize -D#MDWORDS=4 -D#MDSIZE32=40 -D#MDSIZE64=56 -D#WORDSIZE=%target-alignment
+// RUN: %target-swift-frontend -package-name MyPkg -package-bypass-resilience-optimization -I %t -emit-ir -enable-library-evolution -O %t/package_resilience.swift -package-name MyPkg
 // REQUIRES: objc_codegen
 // REQUIRES: OS=macosx || OS=ios || OS=tvos || OS=watchos
 // REQUIRES: CPU=x86_64 || CPU=arm64

--- a/test/Sema/package_resilience_bypass_exhaustive_switch.swift
+++ b/test/Sema/package_resilience_bypass_exhaustive_switch.swift
@@ -1,5 +1,3 @@
-// REQUIRES: rdar118947451
-
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
@@ -9,69 +7,53 @@
 // RUN:   -enable-library-evolution \
 // RUN:   -emit-module -emit-module-path %t/Utils.swiftmodule
 
-// RUN: %target-swift-frontend -emit-sil %t/Client.swift -package-name mypkg -I %t > %t/Client.sil
-// RUN: %FileCheck %s < %t/Client.sil
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t -swift-version 5 -package-name mypkg -verify
+// RUN: %target-swift-frontend -typecheck %t/ClientDefault.swift -I %t -swift-version 5 -package-name mypkg -verify
+
+// RUN: %target-swift-frontend -typecheck %t/ClientOptimized.swift -I %t -swift-version 5 -package-name mypkg -package-bypass-resilience-optimization -verify
 
 //--- Utils.swift
 
-// Resilient; public.
-// Switch stmt requires @unknown default.
 public enum PublicEnum {
   case one
   case two(Int)
 }
 
-// Resilient; public.
-public struct PublicStruct {
-  public var publicVar: Int
-}
-
-// Non-resilient; frozen. Accessed directly.
-// Switch stmt does not require @unknown default.
 @frozen
 public enum FrozenPublicEnum {
   case one
   case two(Int)
 }
 
-// Non-resilient; non-public / associated value is also non-resilient (Int is @frozen public).
-// Accessed directly.
-// Switch stmt does not require @unknown default.
 package enum PkgEnum {
   case one
   case two(Int)
 }
 
-// Non-resilient but accessed indirectly since associated value is resilient.
-// Passed by address to func as @in_guaranteed in Silgen.
-// Switch stmt does not require @unknown default.
+public struct PublicStruct {
+  public var publicVar: Int
+}
+
 package enum PkgEnumWithPublicCase {
   case one
   case two(PublicStruct)
 }
 
-// Non-resilient but accessed indirectly since associated value is resilient (existential).
-// Passed by address to func as @in_guaranteed in Silgen.
-// Switch stmt does not require @unknown default.
 package enum PkgEnumWithExistentialCase {
   case one
   case two(any StringProtocol)
 }
 
-// Resilient since inlinable.
 @usableFromInline
 package enum UfiPkgEnum {
   case one
   case two(Int)
 }
 
-
-//--- Client.swift
+//--- ClientDefault.swift
 import Utils
 
-package func f(_ arg: PkgEnum) -> Int {
-  switch arg { // no-warning
+func f(_ arg: PkgEnum) -> Int {
+  switch arg { // expected-warning {{switch covers known cases, but 'PkgEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
   case .one:
     return 1
   case .two(let val):
@@ -79,72 +61,7 @@ package func f(_ arg: PkgEnum) -> Int {
   }
 }
 
-// CHECK: // f(_:)
-// CHECK-NEXT: sil @$s6Client1fySi5Utils7PkgEnumOF : $@convention(thin) (PkgEnum) -> Int {
-// CHECK-NEXT: // %0 "arg"
-// CHECK-NEXT: bb0(%0 : $PkgEnum):
-// CHECK-NEXT:   debug_value %0 : $PkgEnum, let, name "arg", argno 1
-// CHECK-NEXT:   switch_enum %0 : $PkgEnum, case #PkgEnum.one!enumelt: bb1, case #PkgEnum.two!enumelt: bb2
-
-package func g1(_ arg: PkgEnumWithPublicCase) -> Int {
-  switch arg { // no-warning
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val.publicVar
-  }
-}
-
-// CHECK: // g1(_:)
-// CHECK-NEXT: sil @$s6Client2g1ySi5Utils21PkgEnumWithPublicCaseOF : $@convention(thin) (@in_guaranteed PkgEnumWithPublicCase) -> Int {
-// CHECK-NEXT: // %0 "arg"
-// CHECK-NEXT: bb0(%0 : $*PkgEnumWithPublicCase):
-// CHECK-NEXT:   debug_value %0 : $*PkgEnumWithPublicCase, let, name "arg", argno 1, expr op_deref
-// CHECK-NEXT:   %2 = alloc_stack $PkgEnumWithPublicCase
-// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PkgEnumWithPublicCase
-// CHECK-NEXT:   switch_enum_addr %2 : $*PkgEnumWithPublicCase, case #PkgEnumWithPublicCase.one!enumelt: bb1, case #PkgEnumWithPublicCase.two!enumelt: bb2
-
-package func g2(_ arg: PkgEnumWithExistentialCase) -> any StringProtocol {
-  switch arg { // no-warning
-  case .one:
-    return "1"
-  case .two(let val):
-    return val
-  }
-}
-
-// CHECK: // g2(_:)
-// CHECK-NEXT: sil @$s6Client2g2ySy_p5Utils26PkgEnumWithExistentialCaseOF : $@convention(thin) (@in_guaranteed PkgEnumWithExistentialCase) -> @out any StringProtocol {
-// CHECK-NEXT: // %0 "$return_value"
-// CHECK-NEXT: // %1 "arg"
-// CHECK-NEXT: bb0(%0 : $*any StringProtocol, %1 : $*PkgEnumWithExistentialCase):
-// CHECK-NEXT:   debug_value %1 : $*PkgEnumWithExistentialCase, let, name "arg", argno 1, expr op_deref
-// CHECK-NEXT:   %3 = alloc_stack $PkgEnumWithExistentialCase
-// CHECK-NEXT:   copy_addr %1 to [init] %3 : $*PkgEnumWithExistentialCase
-// CHECK-NEXT:   switch_enum_addr %3 : $*PkgEnumWithExistentialCase, case #PkgEnumWithExistentialCase.one!enumelt: bb1, case #PkgEnumWithExistentialCase.two!enumelt: bb2
-
-
-@inlinable
-package func h(_ arg: UfiPkgEnum) -> Int {
-  switch arg { // expected-warning {{switch covers known cases, but 'UfiPkgEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val
-  }
-}
-
-// CHECK: // h(_:)
-// CHECK-NEXT: sil @$s6Client1hySi5Utils10UfiPkgEnumOF : $@convention(thin) (@in_guaranteed UfiPkgEnum) -> Int {
-// CHECK-NEXT: // %0 "arg"
-// CHECK-NEXT: bb0(%0 : $*UfiPkgEnum):
-// CHECK-NEXT:   debug_value %0 : $*UfiPkgEnum, let, name "arg", argno 1, expr op_deref
-// CHECK-NEXT:   %2 = alloc_stack $UfiPkgEnum
-// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*UfiPkgEnum
-// CHECK-NEXT:   %4 = value_metatype $@thick UfiPkgEnum.Type, %2 : $*UfiPkgEnum
-// CHECK-NEXT:   switch_enum_addr %2 : $*UfiPkgEnum, case #UfiPkgEnum.one!enumelt: bb1, case #UfiPkgEnum.two!enumelt: bb2, default bb3
-
-public func k(_ arg: PublicEnum) -> Int {
+public func g(_ arg: PublicEnum) -> Int {
   switch arg { // expected-warning {{switch covers known cases, but 'PublicEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
   case .one:
     return 1
@@ -152,17 +69,8 @@ public func k(_ arg: PublicEnum) -> Int {
     return 2 + val
   }
 }
-// CHECK: // k(_:)
-// CHECK-NEXT: sil @$s6Client1kySi5Utils10PublicEnumOF : $@convention(thin) (@in_guaranteed PublicEnum) -> Int {
-// CHECK-NEXT: // %0 "arg"
-// CHECK-NEXT: bb0(%0 : $*PublicEnum):
-// CHECK-NEXT:   debug_value %0 : $*PublicEnum, let, name "arg", argno 1, expr op_deref
-// CHECK-NEXT:   %2 = alloc_stack $PublicEnum
-// CHECK-NEXT:   copy_addr %0 to [init] %2 : $*PublicEnum
-// CHECK-NEXT:   %4 = value_metatype $@thick PublicEnum.Type, %2 : $*PublicEnum
-// CHECK-NEXT:   switch_enum_addr %2 : $*PublicEnum, case #PublicEnum.one!enumelt: bb1, case #PublicEnum.two!enumelt: bb2, default bb3
 
-public func m(_ arg: FrozenPublicEnum) -> Int {
+public func h(_ arg: FrozenPublicEnum) -> Int {
   switch arg { // no-warning
   case .one:
     return 1
@@ -171,11 +79,34 @@ public func m(_ arg: FrozenPublicEnum) -> Int {
   }
 }
 
-// CHECK: // m(_:)
-// CHECK-NEXT: sil @$s6Client1mySi5Utils16FrozenPublicEnumOF : $@convention(thin) (FrozenPublicEnum) -> Int {
-// CHECK-NEXT: // %0 "arg"
-// CHECK-NEXT: bb0(%0 : $FrozenPublicEnum):
-// CHECK-NEXT:   debug_value %0 : $FrozenPublicEnum, let, name "arg", argno 1
-// CHECK-NEXT:   switch_enum %0 : $FrozenPublicEnum, case #FrozenPublicEnum.one!enumelt: bb1, case #FrozenPublicEnum.two!enumelt: bb2
+//--- ClientOptimized.swift
+import Utils
 
+// No warning with optimization to bypass resilience checks for package enums.
+func f(_ arg: PkgEnum) -> Int {
+  switch arg {
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val
+  }
+}
 
+// Warning still shows up for public enum as the optimization is targeted for package types.
+public func g(_ arg: PublicEnum) -> Int {
+  switch arg { // expected-warning {{switch covers known cases, but 'PublicEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val
+  }
+}
+
+public func h(_ arg: FrozenPublicEnum) -> Int {
+  switch arg { // no-warning
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val
+  }
+}

--- a/test/Sema/package_resilience_bypass_exhaustive_switch.swift
+++ b/test/Sema/package_resilience_bypass_exhaustive_switch.swift
@@ -13,6 +13,17 @@
 
 //--- Utils.swift
 
+package enum PkgEnum {
+  case one
+  case two(Int)
+}
+
+@usableFromInline
+package enum UfiPkgEnum {
+  case one
+  case two(Int)
+}
+
 public enum PublicEnum {
   case one
   case two(Int)
@@ -20,31 +31,6 @@ public enum PublicEnum {
 
 @frozen
 public enum FrozenPublicEnum {
-  case one
-  case two(Int)
-}
-
-package enum PkgEnum {
-  case one
-  case two(Int)
-}
-
-public struct PublicStruct {
-  public var publicVar: Int
-}
-
-package enum PkgEnumWithPublicCase {
-  case one
-  case two(PublicStruct)
-}
-
-package enum PkgEnumWithExistentialCase {
-  case one
-  case two(any StringProtocol)
-}
-
-@usableFromInline
-package enum UfiPkgEnum {
   case one
   case two(Int)
 }
@@ -61,7 +47,16 @@ func f(_ arg: PkgEnum) -> Int {
   }
 }
 
-public func g(_ arg: PublicEnum) -> Int {
+func g(_ arg: UfiPkgEnum) -> Int {
+  switch arg { // expected-warning {{switch covers known cases, but 'UfiPkgEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val
+  }
+}
+
+public func h(_ arg: PublicEnum) -> Int {
   switch arg { // expected-warning {{switch covers known cases, but 'PublicEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
   case .one:
     return 1
@@ -70,7 +65,7 @@ public func g(_ arg: PublicEnum) -> Int {
   }
 }
 
-public func h(_ arg: FrozenPublicEnum) -> Int {
+public func k(_ arg: FrozenPublicEnum) -> Int {
   switch arg { // no-warning
   case .one:
     return 1
@@ -92,8 +87,19 @@ func f(_ arg: PkgEnum) -> Int {
   }
 }
 
+// Warning still shows up for usableFromInline package enum as the optimization is targeted for
+// decls with package access, not the elevated public access. This might be allowed later.
+func g(_ arg: UfiPkgEnum) -> Int {
+  switch arg { // expected-warning {{switch covers known cases, but 'UfiPkgEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
+  case .one:
+    return 1
+  case .two(let val):
+    return 2 + val
+  }
+}
+
 // Warning still shows up for public enum as the optimization is targeted for package types.
-public func g(_ arg: PublicEnum) -> Int {
+public func h(_ arg: PublicEnum) -> Int {
   switch arg { // expected-warning {{switch covers known cases, but 'PublicEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
   case .one:
     return 1
@@ -102,7 +108,7 @@ public func g(_ arg: PublicEnum) -> Int {
   }
 }
 
-public func h(_ arg: FrozenPublicEnum) -> Int {
+public func k(_ arg: FrozenPublicEnum) -> Int {
   switch arg { // no-warning
   case .one:
     return 1


### PR DESCRIPTION
By default package decls are treated as resilient, similar to public (non-frozen). This PR adds support to allow direct access to package decls at use site if opted-in. Requires the loaded module to be a binary module in the same package.

Resolves rdar://121626315
