### PR TITLE
SILGen: Improve handling of copyable subpatterns in borrowing switches.

### DIFF
--- a/test/SILOptimizer/moveonly_borrowing_switch_copyable_subpattern.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_copyable_subpattern.swift
@@ -1,0 +1,55 @@
+// RUN: %target-swift-frontend -emit-sil -verify -enable-experimental-feature BorrowingSwitch -disable-experimental-parser-round-trip %s
+
+struct Payload: ~Copyable {
+    var x: Int
+    var y: String
+}
+
+enum Foo: ~Copyable {
+    case nonCopyablePayload(Payload)
+    case copyablePayload(String)
+}
+
+func hungryCondition(_: consuming String) -> Bool { fatalError() }
+func condition(_: borrowing String) -> Bool { fatalError() }
+
+func eat(_: consuming String) {}
+func nibble(_: borrowing String) {}
+
+func test(borrowing foo: borrowing Foo) {
+    switch foo {
+    case .nonCopyablePayload(_borrowing x): // expected-warning{{}}
+        break
+
+    // OK to form a normal `let` binding when the payload is copyable.
+    // Then it's OK to consume copies of it in the condition clause
+    // and in the body.
+    case .copyablePayload(let x) where hungryCondition(x):
+        eat(x)
+        nibble(x)
+    case .copyablePayload(let x) where condition(x):
+        eat(x)
+        nibble(x)
+
+    // `_borrowing` match variables impose the no-implicit-copy constraint
+    // like `borrowing` parameters do.
+    case .copyablePayload(_borrowing x) // expected-error{{'x' is borrowed and cannot be consumed}}
+      where hungryCondition(x): // expected-note{{consumed here}}
+        eat(x) // expected-note{{consumed here}}
+        nibble(x)
+
+    case .copyablePayload(_borrowing x) // expected-error{{'x' is borrowed and cannot be consumed}}
+      where condition(x):
+        eat(x) // expected-note{{consumed here}}
+        nibble(x)
+
+    // Explicit copies are OK.
+    case .copyablePayload(_borrowing x)
+      where hungryCondition(copy x):
+        eat(copy x)
+        nibble(x)
+
+    case .copyablePayload(_borrowing x):
+        nibble(x)
+    }
+}

--- a/test/Sema/switch-ownership.swift
+++ b/test/Sema/switch-ownership.swift
@@ -31,7 +31,7 @@ func test(value: A) {
     case C():
         break
     // CHECK: (case_stmt
-    // CHECK:   (case_label_item ownership=consuming
+    // CHECK:   (case_label_item ownership=borrowing
     // CHECK:     (pattern_expr type="A" ownership=consuming
     case D():
         break
@@ -46,7 +46,7 @@ func test(value: A) {
     case F():
         break
     // CHECK: (case_stmt
-    // CHECK:   (case_label_item ownership=consuming
+    // CHECK:   (case_label_item ownership=borrowing
     // CHECK:     (pattern_expr type="A" ownership=consuming
     case G():
         break


### PR DESCRIPTION
A `let` binding of a copyable subpattern can create an independent variable which should be copyable and consumable without affecting a borrowed move-only base. In the same way that `borrowing` parameters are no-implicit-copy, though, explicitly `_borrowing` subpatterns of copyable type should be no-implicit-copy as well.