### PR TITLE
Add xrOS to silence -Wswitch violations

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -180,6 +180,7 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::CloudABI:
   case llvm::Triple::DragonFly:
   case llvm::Triple::DriverKit:
+  case llvm::Triple::XROS:
   case llvm::Triple::Emscripten:
   case llvm::Triple::Fuchsia:
   case llvm::Triple::KFreeBSD:


### PR DESCRIPTION
To commit the necessary llvm-project changes to land xrOS support,  xrOS as a triple must be understood to swift. Add minimal support such that CI passes.