### PR TITLE
[Concurrency] Diagnose invalid erasure of closure isolation when the isolation is not represented in the closure type.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4994,6 +4994,9 @@ NOTE(add_explicit_escaping,none,
 ERROR(converting_func_loses_global_actor,none,
       "converting function value of type %0 to %1 loses global actor %2",
       (Type, Type, Type))
+ERROR(sendable_isolated_function,none,
+      "%0 function cannot be converted to a synchronous '@Sendable' function type",
+      (ActorIsolation))
 ERROR(capture_across_type_decl,none,
       "%0 declaration cannot close over value %1 defined in outer scope",
       (DescriptiveDeclKind, Identifier))

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1719,3 +1719,27 @@ class InferIsolationViaOverride: SuperWithIsolatedMethod {
     // expected-error@-1 {{call to main actor-isolated instance method 'isolatedMethod()' in a synchronous nonisolated context}}
   }
 }
+
+func requireSendableInheritContext(@_inheritActorContext _: @Sendable () -> ()) {}
+
+actor InvalidInheritedActorIsolation {
+  func actorFunction() {}
+
+  func test() {
+    // expected-warning@+1 {{actor-isolated function cannot be converted to a synchronous '@Sendable' function type; this is an error in Swift 6}}
+    requireSendableInheritContext {
+      self.actorFunction()
+    }
+  }
+}
+
+@MainActor
+class InvalidInheritedGlobalActorIsolation {
+  func mainActorFunction() {}
+
+  func test() {
+    // expected-warning@+1 {{main actor-isolated function cannot be converted to a synchronous '@Sendable' function type; this is an error in Swift 6}}
+    requireSendableInheritContext {
+      self.mainActorFunction()
+    }
+}


### PR DESCRIPTION
There are cases where the isolation of a closure is not represented in the closure type, e.g. when `@_inheritActorContext` is used. However, the current diagnostics for invalid actor isolation erasure relied on a function conversion in the type checked AST. This change fixes an issue where invalid isolation erasure was not diagnosed when the isolation of a closure is not represented in the closure type.