### PR TITLE
[Distributed] whenLocal adoption of typed throws

### DIFF
--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -362,9 +362,9 @@ extension DistributedActor {
   /// state.
   ///
   /// When the actor is remote, the closure won't be executed and this function will return nil.
-  public nonisolated func whenLocal<T: Sendable>(
-    _ body: @Sendable (isolated Self) async throws -> T
-  ) async rethrows -> T? {
+  public nonisolated func whenLocal<T: Sendable, E>(
+    _ body: @Sendable (isolated Self) async throws(E) -> T
+  ) async throws(E) -> T? {
     if __isLocalActor(self) {
        _local let localSelf = self
        return try await body(localSelf)

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -372,6 +372,15 @@ extension DistributedActor {
       return nil
     }
   }
+
+  // ABI: Historical whenLocal, rethrows was changed to typed throws `throws(E)`
+  @_silgen_name("$s11Distributed0A5ActorPAAE9whenLocalyqd__Sgqd__xYiYaYbKXEYaKs8SendableRd__lF")
+  @usableFromInline
+  nonisolated func __abi_whenLocal<T: Sendable>(
+    _ body: @Sendable (isolated Self) async throws -> T
+  ) async rethrows -> T? {
+    try await whenLocal(body)
+  }
 }
 
 /// Supports the operation to produce an any Actor instance from a local


### PR DESCRIPTION
whenLocal is a "rethrows" and can be expressed using a typed throw now.

resolves rdar://122464127