### PR TITLE
Support class extensions in objcImpl

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -132,6 +132,12 @@ typedef llvm::PointerUnion<const clang::Decl *, const clang::MacroInfo *,
 class ClangImporter final : public ClangModuleLoader {
   friend class ClangModuleUnit;
 
+  // Make requests in the ClangImporter zone friends so they can access `Impl`.
+#define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \
+  friend class Name;
+#include "swift/ClangImporter/ClangImporterTypeIDZone.def"
+#undef SWIFT_REQUEST
+
 public:
   class Implementation;
 

--- a/include/swift/ClangImporter/ClangImporterTypeIDZone.def
+++ b/include/swift/ClangImporter/ClangImporterTypeIDZone.def
@@ -25,7 +25,7 @@ SWIFT_REQUEST(ClangImporter, ClangRecordMemberLookup,
               Decl *(ClangRecordMemberLookupDescriptor), Uncached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ClangCategoryLookupRequest,
-              IterableDeclContext *(ClangCategoryLookupDescriptor), Uncached,
+              llvm::TinyPtrVector<Decl *>(ClangCategoryLookupDescriptor), Uncached,
               NoLocationInfo)
 SWIFT_REQUEST(ClangImporter, ObjCInterfaceAndImplementationRequest,
               ObjCInterfaceAndImplementation(Decl *), SeparatelyCached,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1854,11 +1854,9 @@ bool Decl::isObjCImplementation() const {
 
 llvm::Optional<Identifier>
 ExtensionDecl::getCategoryNameForObjCImplementation() const {
-  assert(isObjCImplementation());
-
   auto attr = getAttrs()
                   .getAttribute<ObjCImplementationAttr>(/*AllowInvalid=*/true);
-  if (attr->isCategoryNameInvalid())
+  if (!attr || attr->isCategoryNameInvalid())
     return llvm::None;
 
   return attr->CategoryName;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5860,18 +5860,6 @@ struct OrderDecls {
 };
 }
 
-static llvm::TinyPtrVector<Decl *>
-findImplsGivenInterface(ClassDecl *classDecl, Identifier categoryName) {
-  llvm::TinyPtrVector<Decl *> impls;
-  for (ExtensionDecl *ext : classDecl->getExtensions()) {
-    if (ext->isObjCImplementation()
-        && ext->getCategoryNameForObjCImplementation() == categoryName)
-      impls.push_back(ext);
-  }
-
-  return impls;
-}
-
 Identifier ExtensionDecl::getObjCCategoryName() const {
   // Could it be an imported category?
   if (!hasClangNode())
@@ -5885,29 +5873,24 @@ Identifier ExtensionDecl::getObjCCategoryName() const {
 
   // We'll look for an implementation with this category name.
   auto clangCategoryName = category->getName();
+  if (clangCategoryName.empty())
+    // Class extension (has an empty name).
+    return Identifier();
+  
   return getASTContext().getIdentifier(clangCategoryName);
 }
 
-static IterableDeclContext *
-findInterfaceGivenImpl(ClassDecl *classDecl, ExtensionDecl *ext) {
-  assert(ext->isObjCImplementation());
-
-  if (auto name = ext->getCategoryNameForObjCImplementation())
-    return classDecl->getImportedObjCCategory(*name);
-
-  return nullptr;
-}
-
 static ObjCInterfaceAndImplementation
-constructResult(Decl *interface, llvm::TinyPtrVector<Decl *> &impls,
+constructResult(const llvm::TinyPtrVector<Decl *> &interfaces,
+                llvm::TinyPtrVector<Decl *> &impls,
                 Decl *diagnoseOn, Identifier categoryName) {
-  if (!interface || impls.empty())
+  if (interfaces.empty() || impls.empty())
     return ObjCInterfaceAndImplementation();
 
   if (impls.size() > 1) {
     llvm::sort(impls, OrderDecls());
 
-    auto &diags = interface->getASTContext().Diags;
+    auto &diags = interfaces.front()->getASTContext().Diags;
     for (auto extraImpl : llvm::ArrayRef<Decl *>(impls).drop_front()) {
       auto attr = extraImpl->getAttrs().getAttribute<ObjCImplementationAttr>();
       attr->setCategoryNameInvalid();
@@ -5919,7 +5902,7 @@ constructResult(Decl *interface, llvm::TinyPtrVector<Decl *> &impls,
     }
   }
 
-  return ObjCInterfaceAndImplementation(interface, impls.front());
+  return ObjCInterfaceAndImplementation(interfaces, impls.front());
 }
 
 static ObjCInterfaceAndImplementation
@@ -5932,42 +5915,38 @@ findContextInterfaceAndImplementation(DeclContext *dc) {
     // Only extensions of ObjC classes can have @_objcImplementations.
     return {};
 
-  // The name of the category to find implementations for, if `dc` turns out
-  // to be an interface.
+  // We know the class we're trying to work with. Next, the category name.
   Identifier categoryName;
 
-  // The interface, if we find one.
-  Decl *interfaceDecl;
-
   if (auto ext = dyn_cast<ExtensionDecl>(dc)) {
-    // Is this an `@_objcImplementation extension`? If so, find the interface
-    // and process that instead.
-    if (ext->isObjCImplementation()) {
-      if (auto interfaceDC = findInterfaceGivenImpl(classDecl, ext))
-        return findContextInterfaceAndImplementation(
-                                         interfaceDC->getAsGenericContext());
-      return {};
+    if (ext->hasClangNode()) {
+      // This is either an interface, or it's not objcImpl at all.
+      categoryName = ext->getObjCCategoryName();
+    } else {
+      // This is either the implementation, or it's not objcImpl at all.
+      if (auto name = ext->getCategoryNameForObjCImplementation())
+        categoryName = *name;
+      else
+        return {};
     }
-
-    // Is this an imported category? If so, extract its name so we can look for
-    // implementations of that category.
-    categoryName = ext->getObjCCategoryName();
-    if (categoryName.empty())
-      return {};
-
-    interfaceDecl = ext;
   } else {
     // Must be an imported class. Look for its main implementation.
     assert(isa_and_nonnull<ClassDecl>(dc));
-    categoryName = Identifier();    // technically a no-op
-    interfaceDecl = classDecl;
+    categoryName = Identifier();
   }
 
-  // If we reach here, we found an ObjC @interface of some kind and want to
-  // look for extensions implementing it.
+  // Now let's look up the interfaces for this...
+  auto interfaceDecls = classDecl->getImportedObjCCategory(categoryName);
 
-  auto implDecls = findImplsGivenInterface(classDecl, categoryName);
-  return constructResult(interfaceDecl, implDecls, classDecl, categoryName);
+  // And the implementations.
+  llvm::TinyPtrVector<Decl *> implDecls;
+  for (ExtensionDecl *ext : classDecl->getExtensions()) {
+    if (ext->isObjCImplementation()
+        && ext->getCategoryNameForObjCImplementation() == categoryName)
+      implDecls.push_back(ext);
+  }
+
+  return constructResult(interfaceDecls, implDecls, classDecl, categoryName);
 }
 
 static void lookupRelatedFuncs(AbstractFunctionDecl *func,
@@ -6047,7 +6026,7 @@ findFunctionInterfaceAndImplementation(AbstractFunctionDecl *func) {
   assert(interface == nullptr || impls.empty() ||
          interface == func || llvm::is_contained(impls, func));
 
-  return constructResult(interface, impls, interface,
+  return constructResult({ interface }, impls, interface,
                          /*categoryName=*/Identifier());
 }
 
@@ -6075,7 +6054,7 @@ void swift::simple_display(llvm::raw_ostream &out,
   }
 
   out << "clang interface ";
-  simple_display(out, pair.interfaceDecl);
+  simple_display(out, pair.interfaceDecls);
   out << " with @_objcImplementation ";
   simple_display(out, pair.implementationDecl);
 }
@@ -6087,14 +6066,13 @@ swift::extractNearestSourceLoc(const ObjCInterfaceAndImplementation &pair) {
   return extractNearestSourceLoc(pair.implementationDecl);
 }
 
-Decl *Decl::getImplementedObjCDecl() const {
+llvm::TinyPtrVector<Decl *> Decl::getAllImplementedObjCDecls() const {
   if (hasClangNode())
     // This *is* the interface, if there is one.
-    return nullptr;
+    return {};
 
   ObjCInterfaceAndImplementationRequest req{const_cast<Decl *>(this)};
-  return evaluateOrDefault(getASTContext().evaluator, req, {})
-             .interfaceDecl;
+  return evaluateOrDefault(getASTContext().evaluator, req, {}).interfaceDecls;
 }
 
 DeclContext *DeclContext::getImplementedObjCContext() const {
@@ -6114,36 +6092,49 @@ Decl *Decl::getObjCImplementationDecl() const {
              .implementationDecl;
 }
 
-IterableDeclContext *ClangCategoryLookupRequest::
-evaluate(Evaluator &evaluator, ClangCategoryLookupDescriptor desc) const {
+llvm::TinyPtrVector<Decl *>
+ClangCategoryLookupRequest::evaluate(Evaluator &evaluator,
+                                     ClangCategoryLookupDescriptor desc) const {
   const ClassDecl *CD = desc.classDecl;
   Identifier categoryName = desc.categoryName;
 
   auto clangClass =
       dyn_cast_or_null<clang::ObjCInterfaceDecl>(CD->getClangDecl());
   if (!clangClass)
-    return nullptr;
+    return {};
 
-  if (categoryName.empty())
+  auto importCategory = [&](const clang::ObjCCategoryDecl *clangCat) -> Decl * {
+    return CD->getASTContext().getClangModuleLoader()
+                  ->importDeclDirectly(clangCat);
+  };
+
+  if (categoryName.empty()) {
     // No category name, so we want the decl for the `@interface` in
-    // `clangClass`.
-    return const_cast<ClassDecl *>(CD);
+    // `clangClass`, as well as any class extensions.
+    llvm::TinyPtrVector<Decl *> results;
+    results.push_back(const_cast<ClassDecl *>(CD));
+
+    for (auto clangExt : clangClass->known_extensions()) {
+      results.push_back(importCategory(clangExt));
+    }
+
+    return results;
+  }
 
   auto ident = &clangClass->getASTContext().Idents.get(categoryName.str());
   auto clangCategory = clangClass->FindCategoryDeclaration(ident);
   if (!clangCategory)
-    return nullptr;
+    return {};
 
-  ASTContext &ctx = CD->getASTContext();
-  auto imported = ctx.getClangModuleLoader()->importDeclDirectly(clangCategory);
-  return cast_or_null<ExtensionDecl>(imported);
+  return { importCategory(clangCategory) };
 }
 
-IterableDeclContext *ClassDecl::getImportedObjCCategory(Identifier name) const {
+llvm::TinyPtrVector<Decl *>
+ClassDecl::getImportedObjCCategory(Identifier name) const {
   ClangCategoryLookupDescriptor desc{this, name};
   return evaluateOrDefault(getASTContext().evaluator,
                            ClangCategoryLookupRequest(desc),
-                           nullptr);
+                           {});
 }
 
 void swift::simple_display(llvm::raw_ostream &out,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -587,7 +587,7 @@ public:
 
   // Caches used by ObjCInterfaceAndImplementationRequest.
   llvm::DenseMap<Decl *, Decl *> ImplementationsByInterface;
-  llvm::DenseMap<Decl *, Decl *> InterfacesByImplementation;
+  llvm::DenseMap<Decl *, llvm::TinyPtrVector<Decl*>> InterfacesByImplementation;
 
   clang::CompilerInstance *getClangInstance() {
     return Instance.get();

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -585,6 +585,10 @@ public:
   // Mapping from imported types to their raw value types.
   llvm::DenseMap<const NominalTypeDecl *, Type> RawTypes;
 
+  // Caches used by ObjCInterfaceAndImplementationRequest.
+  llvm::DenseMap<Decl *, Decl *> ImplementationsByInterface;
+  llvm::DenseMap<Decl *, Decl *> InterfacesByImplementation;
+
   clang::CompilerInstance *getClangInstance() {
     return Instance.get();
   }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1242,7 +1242,7 @@ namespace {
         const ClassLayout &fieldLayout)
         : IGM(IGM), TheEntity(theUnion), TheExtension(nullptr),
           FieldLayout(&fieldLayout) {
-      visitConformances(getClass());
+      visitConformances(getClass()->getImplementationContext());
 
       if (getClass()->isRootDefaultActor()) {
         Ivars.push_back(Field::DefaultActorStorage);
@@ -1310,12 +1310,12 @@ namespace {
     /// Gather protocol records for all of the explicitly-specified Objective-C
     /// protocol conformances.
     void visitConformances(const IterableDeclContext *idc) {
-      auto dc = idc->getAsGenericContext();
-      if (dc->getImplementedObjCContext() != dc) {
-        // We want to use the conformance list imported from the ObjC header.
-        auto importedIDC = cast<IterableDeclContext>(
-                                 dc->getImplementedObjCContext()->getAsDecl());
-        visitConformances(importedIDC);
+      auto decl = idc->getDecl();
+      if (decl->getImplementedObjCDecl()) {
+        // We want to use the conformance lists imported from the ObjC header.
+        for (auto interface : decl->getAllImplementedObjCDecls()) {
+          visitConformances(cast<IterableDeclContext>(interface));
+        }
         return;
       }
 

--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2930,16 +2930,18 @@ public:
 
     // Did we actually match this extension to an interface? (In invalid code,
     // we might not have.)
-    auto interfaceDecl = ext->getImplementedObjCDecl();
-    if (!interfaceDecl)
+    auto interfaceDecls = ext->getAllImplementedObjCDecls();
+    if (interfaceDecls.empty())
       return;
 
     // Add the @_objcImplementation extension's members as candidates.
     addCandidates(ext);
 
     // Add its interface's members as requirements.
-    auto interface = cast<IterableDeclContext>(interfaceDecl);
-    addRequirements(interface);
+    for (auto interfaceDecl : interfaceDecls) {
+      auto interface = cast<IterableDeclContext>(interfaceDecl);
+      addRequirements(interface);
+    }
   }
 
 private:
@@ -3422,9 +3424,9 @@ private:
 
     // Check only applies to members of implementations, not implementations in
     // their own right.
-    if (!cand->isObjCImplementation()
-          && cand->getDeclContext()->getImplementedObjCContext()
-                 != req->getDeclContext())
+    if (!cand->isObjCImplementation() &&
+          getCategoryName(cand->getDeclContext()->getImplementedObjCContext())
+               != getCategoryName(req->getDeclContext()))
       return MatchOutcome::WrongCategory;
 
     if (cand->getKind() != req->getKind())

--- a/test/IRGen/Inputs/objc_implementation.h
+++ b/test/IRGen/Inputs/objc_implementation.h
@@ -10,6 +10,12 @@
 
 @end
 
+@interface ImplClass () <NSMutableCopying>
+
+- (void)extensionMethod:(int)param;
+
+@end
+
 
 @interface ImplClass (Category1)
 

--- a/test/IRGen/objc_implementation.swift
+++ b/test/IRGen/objc_implementation.swift
@@ -17,13 +17,13 @@
 
 // Metaclass
 // CHECK: @"OBJC_METACLASS_$_ImplClass" = global %objc_class { ptr @"OBJC_METACLASS_$_NSObject", ptr @"OBJC_METACLASS_$_NSObject", ptr @_objc_empty_cache, ptr null, {{.*}}ptr [[_METACLASS_DATA_ImplClass:@[^, ]+]]{{.*}}, align 8
-// CHECK: @_PROTOCOLS_ImplClass = internal constant { i64, [1 x ptr] } { i64 1, [1 x ptr] [ptr @_PROTOCOL_NSCopying] }, section "__DATA, __objc_const", align 8
+// CHECK: @_PROTOCOLS_ImplClass = internal constant { i64, [2 x ptr] } { i64 2, [2 x ptr] [ptr @_PROTOCOL_NSCopying, ptr @_PROTOCOL_NSMutableCopying] }, section "__DATA, __objc_const", align 8
 // CHECK: [[_METACLASS_DATA_ImplClass]] = internal constant { i32, i32, i32, i32, ptr, ptr, ptr, ptr, ptr, ptr, ptr } { i32 129, i32 40, i32 40, i32 0, ptr null, ptr @.str.9.ImplClass, ptr null, ptr @_PROTOCOLS_ImplClass, ptr null, ptr null, ptr null }, section "__DATA, __objc_const", align 8
 // TODO: Why the extra i32 field above?
 
 // Class
 // CHECK: [[selector_data__cxx_destruct:@[^, ]+]] = private global [14 x i8] c".cxx_destruct\00", section "__TEXT,__objc_methname,cstring_literals", align 1
-// CHECK: [[_INSTANCE_METHODS_ImplClass:@[^, ]+]] = internal constant { i32, i32, [7 x { ptr, ptr, ptr }] } { i32 24, i32 7, [7 x { ptr, ptr, ptr }] [{ ptr, ptr, ptr } { ptr @"\01L_selector_data(init)", ptr @".str.7.@16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEABycfcTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_implProperty]], ptr @".str.7.i16@0:8", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvgTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_setImplProperty_]], ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvsTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_mainMethod_]], ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE10mainMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(copyWithZone:)", ptr @".str.11.@24@0:8^v16", ptr @"$sSo9ImplClassC19objc_implementationE4copy4withypSg10ObjectiveC6NSZoneVSg_tFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(dealloc)", ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEfDTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data__cxx_destruct]], ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassCfETo{{(\.ptrauth)?}}" }] }, section "__DATA, __objc_data", align 8
+// CHECK: [[_INSTANCE_METHODS_ImplClass:@[^, ]+]] = internal constant { i32, i32, [9 x { ptr, ptr, ptr }] } { i32 24, i32 9, [9 x { ptr, ptr, ptr }] [{ ptr, ptr, ptr } { ptr @"\01L_selector_data(init)", ptr @".str.7.@16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEABycfcTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_implProperty]], ptr @".str.7.i16@0:8", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvgTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_setImplProperty_]], ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvsTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data_mainMethod_]], ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE10mainMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(extensionMethod:)", ptr @".str.10.v20@0:8i16", ptr @"$sSo9ImplClassC19objc_implementationE15extensionMethodyys5Int32VFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(copyWithZone:)", ptr @".str.11.@24@0:8^v16", ptr @"$sSo9ImplClassC19objc_implementationE4copy4withypSg10ObjectiveC6NSZoneVSg_tFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(mutableCopyWithZone:)", ptr @".str.11.@24@0:8^v16", ptr @"$sSo9ImplClassC19objc_implementationE11mutableCopy4withypSg10ObjectiveC6NSZoneVSg_tFTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr @"\01L_selector_data(dealloc)", ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassC19objc_implementationEfDTo{{(\.ptrauth)?}}" }, { ptr, ptr, ptr } { ptr [[selector_data__cxx_destruct]], ptr @".str.7.v16@0:8", ptr @"$sSo9ImplClassCfETo{{(\.ptrauth)?}}" }] }, section "__DATA, __objc_data", align 8
 // CHECK: [[_IVARS_ImplClass:@[^, ]+]] = internal constant { i32, i32, [2 x { ptr, ptr, ptr, i32, i32 }] } { i32 32, i32 2, [2 x { ptr, ptr, ptr, i32, i32 }] [{ ptr, ptr, ptr, i32, i32 } { ptr @"$sSo9ImplClassC19objc_implementationE12implPropertys5Int32VvpWvd", ptr @.str.12.implProperty, ptr @.str.0., i32 2, i32 4 }, { ptr, ptr, ptr, i32, i32 } { ptr @"$sSo9ImplClassC19objc_implementationE13implProperty2So8NSObjectCSgvpWvd", ptr @.str.13.implProperty2, ptr @.str.0., i32 3, i32 8 }] }, section "__DATA, __objc_const", align 8
 // CHECK: [[_PROPERTIES_ImplClass:@[^, ]+]] = internal constant { i32, i32, [1 x { ptr, ptr }] } { i32 16, i32 1, [1 x { ptr, ptr }] [{ ptr, ptr } { ptr @.str.12.implProperty, ptr @".str.18.Ti,N,VimplProperty" }] }, section "__DATA, __objc_const", align 8
 // FIXME: Should just be @_PROTOCOLS_ImplClass, but an IRGen bug causes the protocol list to be emitted twice.
@@ -50,6 +50,7 @@
   final var implProperty2: NSObject?
   
   @objc func mainMethod(_: Int32) { print(implProperty) }
+  @objc func extensionMethod(_: Int32) {}
 
   @objc(copyWithZone:)
   func copy(with zone: NSZone?) -> Any? {
@@ -59,6 +60,11 @@
     return copy
   }
   
+  @objc(mutableCopyWithZone:)
+  func mutableCopy(with zone: NSZone?) -> Any? {
+    return copy(with: zone)
+  }
+
   deinit { print(implProperty) }
 }
 
@@ -199,11 +205,23 @@ public func fn(impl: ImplClass, swiftSub: SwiftSubclass) {
 // ObjC calling convention -[ImplClass mainMethod:]
 // CHECK-LABEL: define internal void @"$sSo9ImplClassC19objc_implementationE10mainMethodyys5Int32VFTo"
 
+// Swift calling convention -[ImplClass extensionMethod:]
+// CHECK-LABEL: define hidden swiftcc void @"$sSo9ImplClassC19objc_implementationE15extensionMethodyys5Int32VF"
+
+// ObjC calling convention -[ImplClass extensionMethod:]
+// CHECK-LABEL: define internal void @"$sSo9ImplClassC19objc_implementationE15extensionMethodyys5Int32VFTo"
+
 // Swift calling convention -[ImplClass copyWithZone:]
 // CHECK-LABEL: define hidden swiftcc void @"$sSo9ImplClassC19objc_implementationE4copy4withypSg10ObjectiveC6NSZoneVSg_tF"
 
 // ObjC calling convention -[ImplClass copyWithZone:]
 // CHECK-LABEL: define internal ptr @"$sSo9ImplClassC19objc_implementationE4copy4withypSg10ObjectiveC6NSZoneVSg_tFTo"
+
+// Swift calling convention -[ImplClass mutableCopyWithZone:]
+// CHECK-LABEL: define hidden swiftcc void @"$sSo9ImplClassC19objc_implementationE11mutableCopy4withypSg10ObjectiveC6NSZoneVSg_tF"
+
+// ObjC calling convention -[ImplClass mutableCopyWithZone:]
+// CHECK-LABEL: define internal ptr @"$sSo9ImplClassC19objc_implementationE11mutableCopy4withypSg10ObjectiveC6NSZoneVSg_tFTo"
 
 // Swift calling convention -[ImplClass dealloc]
 // CHECK-LABEL: define linkonce_odr hidden swiftcc void @"$sSo9ImplClassC19objc_implementationEfD"

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -156,6 +156,10 @@ __attribute__((availability(ios,introduced=8.0)))
 - (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
+@protocol NSMutableCopying
+- (id)mutableCopyWithZone:(nullable NSZone *)zone;
+@end
+
 @interface NSDictionary<KeyType, ObjectType> : NSObject /*<NSCopying, NSMutableCopying, NSSecureCoding, NSFastEnumeration>*/
 @property (readonly) NSUInteger count;
 - (nullable ObjectType)objectForKey:(nonnull KeyType)aKey;

--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -59,6 +59,13 @@
 
 @end
 
+@interface ObjCClass () <NSCopying>
+
+- (void)extensionMethodFromHeader1:(int)param;
+- (void)extensionMethodFromHeader2:(int)param;
+
+@end
+
 @interface ObjCClass (PresentAdditions)
 
 - (void)categoryMethodFromHeader1:(int)param;

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -12,6 +12,7 @@ protocol EmptySwiftProto {}
   // FIXME: give better diagnostic expected-warning@-6 {{extension for main class interface should provide implementation for instance method 'method(fromHeader3:)'}}
   // expected-warning@-7 {{'@_objcImplementation' extension cannot add conformance to 'EmptySwiftProto'; add this conformance with an ordinary extension}}
   // expected-warning@-8 {{'@_objcImplementation' extension cannot add conformance to 'EmptyObjCProto'; add this conformance in the Objective-C header}}
+  // expected-warning@-9 {{extension for main class interface should provide implementation for instance method 'extensionMethod(fromHeader2:)'}}
 
   func method(fromHeader1: CInt) {
     // OK, provides an implementation for the header's method.
@@ -214,6 +215,15 @@ protocol EmptySwiftProto {}
 
   @nonobjc public convenience init(notFromHeader6: CInt) {
     // OK
+  }
+
+  @objc func extensionMethod(fromHeader1: CInt) {
+    // OK
+  }
+
+  @objc(copyWithZone:) func copy(with zone: NSZone?) -> Any {
+    // OK
+    return self
   }
 }
 

--- a/test/decl/ext/objc_implementation_conflicts.swift
+++ b/test/decl/ext/objc_implementation_conflicts.swift
@@ -170,6 +170,11 @@ import objc_implementation_private
 
   func instanceMethod1(_: CInt) {}
   func instanceMethod2(_: CInt) {}
+
+  @objc func extensionMethod(fromHeader1: CInt) {}
+  @objc func extensionMethod(fromHeader2: CInt) {}
+
+  @objc(copyWithZone:) func copy(with zone: NSZone?) -> Any { self }
 }
 
 @_objcImplementation(PresentAdditions) extension ObjCClass {


### PR DESCRIPTION
Their requirements are now included when typechecking the main body extension.

Fixes rdar://118535473.