### PR TITLE
Eliminate pointer auth overhead in interposable refcount support

### DIFF
--- a/include/swift/Runtime/InstrumentsSupport.h
+++ b/include/swift/Runtime/InstrumentsSupport.h
@@ -42,6 +42,8 @@ void (*SWIFT_RT_DECLARE_ENTRY _swift_release)(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 void (*SWIFT_RT_DECLARE_ENTRY _swift_release_n)(HeapObject *object, uint32_t n);
 SWIFT_RUNTIME_EXPORT
+std::atomic<bool> _swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstrumentsOnly;
+SWIFT_RUNTIME_EXPORT
 size_t swift_retainCount(HeapObject *object);
 
 // liboainject tries to patch the function pointers and call the functions below

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -255,3 +255,4 @@ Added: __swift_pod_direct_initializeBufferWithCopyOfBuffer
 Added: __swift_pod_indirect_initializeBufferWithCopyOfBuffer
 Added: __swift_validatePrespecializedMetadata
 Added: _swift_willThrowTypedImpl
+Added: __swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstrumentsOnly

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -255,3 +255,4 @@ Added: __swift_pod_direct_initializeBufferWithCopyOfBuffer
 Added: __swift_pod_indirect_initializeBufferWithCopyOfBuffer
 Added: __swift_validatePrespecializedMetadata
 Added: _swift_willThrowTypedImpl
+Added: __swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstrumentsOnly


### PR DESCRIPTION
Fixes rdar://122595662