### PR TITLE
[Dependency Scanning] Improve the cycle-detection diagnostic for Swift overlay dependencies

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -199,7 +199,10 @@ WARNING(cross_imported_by_both_modules, none,
 //------------------------------------------------------------------------------
 
 ERROR(scanner_find_cycle, none,
-      "dependency scanner detected dependency cycle: '%0'", (StringRef))
+      "module dependency cycle: '%0'", (StringRef))
+
+NOTE(scanner_find_cycle_swift_overlay_path, none,
+     "Swift Overlay dependency of '%0' on '%1' via Clang module dependency: '%2'", (StringRef, StringRef, StringRef))
 
 ERROR(scanner_arguments_invalid, none,
       "dependencies scanner cannot be configured with arguments: '%0'", (StringRef))

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -1036,6 +1036,14 @@ public:
   std::vector<ModuleDependencyID>
   getAllDependencies(const ModuleDependencyID &moduleID) const;
 
+  /// Query only direct import dependencies
+  llvm::ArrayRef<ModuleDependencyID>
+  getOnlyDirectDependencies(const ModuleDependencyID &moduleID) const;
+
+  /// Query only Swift overlay dependencies
+  llvm::ArrayRef<ModuleDependencyID>
+  getOnlyOverlayDependencies(const ModuleDependencyID &moduleID) const;
+
   /// Look for module dependencies for a module with the given ID
   ///
   /// \returns the cached result, or \c None if there is no cached entry.

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -795,16 +795,30 @@ void ModuleDependenciesCache::setSwiftOverlayDependencies(ModuleDependencyID mod
 
 std::vector<ModuleDependencyID>
 ModuleDependenciesCache::getAllDependencies(const ModuleDependencyID &moduleID) const {
-  const auto &optionalModuleInfo = findDependency(moduleID);
-  assert(optionalModuleInfo.has_value());
+  const auto &moduleInfo = findDependency(moduleID);
+  assert(moduleInfo.has_value());
   auto directDependenciesRef =
-      optionalModuleInfo.value()->getDirectModuleDependencies();
+      moduleInfo.value()->getDirectModuleDependencies();
   auto overlayDependenciesRef =
-      optionalModuleInfo.value()->getSwiftOverlayDependencies();
+      moduleInfo.value()->getSwiftOverlayDependencies();
   std::vector<ModuleDependencyID> result;
   result.insert(std::end(result), directDependenciesRef.begin(),
                 directDependenciesRef.end());
   result.insert(std::end(result), overlayDependenciesRef.begin(),
                 overlayDependenciesRef.end());
   return result;
+}
+
+ArrayRef<ModuleDependencyID>
+ModuleDependenciesCache::getOnlyOverlayDependencies(const ModuleDependencyID &moduleID) const {
+  const auto &moduleInfo = findDependency(moduleID);
+  assert(moduleInfo.has_value());
+  return moduleInfo.value()->getSwiftOverlayDependencies();
+}
+
+ArrayRef<ModuleDependencyID>
+ModuleDependenciesCache::getOnlyDirectDependencies(const ModuleDependencyID &moduleID) const {
+  const auto &moduleInfo = findDependency(moduleID);
+  assert(moduleInfo.has_value());
+  return moduleInfo.value()->getDirectModuleDependencies();
 }

--- a/test/ScanDependencies/Inputs/CHeaders/CycleClangMiddle.h
+++ b/test/ScanDependencies/Inputs/CHeaders/CycleClangMiddle.h
@@ -1,0 +1,1 @@
+#include "CycleOverlay.h"

--- a/test/ScanDependencies/Inputs/CHeaders/CycleOverlay.h
+++ b/test/ScanDependencies/Inputs/CHeaders/CycleOverlay.h
@@ -1,0 +1,1 @@
+void funcOverlay(void);

--- a/test/ScanDependencies/Inputs/CHeaders/module.modulemap
+++ b/test/ScanDependencies/Inputs/CHeaders/module.modulemap
@@ -57,3 +57,11 @@ module ClangModuleWithOverlayedDep {
   header "ClangModuleWithOverlayedDep.h"
   export *
 }
+module CycleClangMiddle {
+  header "CycleClangMiddle.h"
+  export *
+}
+module CycleOverlay {
+  header "CycleOverlay.h"
+  export *
+}

--- a/test/ScanDependencies/Inputs/Swift/CycleOverlay.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/CycleOverlay.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name CycleOverlay
+import Swift
+import CycleSwiftMiddle

--- a/test/ScanDependencies/Inputs/Swift/CycleSwiftMiddle.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/CycleSwiftMiddle.swiftinterface
@@ -1,0 +1,4 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name CycleSwiftMiddle
+import Swift
+import CycleClangMiddle

--- a/test/ScanDependencies/diagnose_dependency_cycle.swift
+++ b/test/ScanDependencies/diagnose_dependency_cycle.swift
@@ -5,6 +5,6 @@
 
 // RUN: %FileCheck %s < %t/out.txt
 
-// CHECK: dependency scanner detected dependency cycle: 'CycleOne.swiftmodule -> CycleTwo.swiftmodule -> CycleThree.swiftmodule -> CycleOne.swiftmodule'
+// CHECK: module dependency cycle: 'CycleOne.swiftinterface -> CycleTwo.swiftinterface -> CycleThree.swiftinterface -> CycleOne.swiftinterface'
 
 import CycleOne

--- a/test/ScanDependencies/diagnose_dependency_cycle_overlay.swift
+++ b/test/ScanDependencies/diagnose_dependency_cycle_overlay.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift &> %t/out.txt
+// RUN: %FileCheck %s < %t/out.txt
+
+// CHECK: error: module dependency cycle: 'CycleOverlay.swiftinterface -> CycleSwiftMiddle.swiftinterface -> CycleOverlay.swiftinterface'
+// CHECK: note: Swift Overlay dependency of 'CycleSwiftMiddle' on 'CycleOverlay' via Clang module dependency: 'CycleSwiftMiddle.swiftinterface -> CycleClangMiddle.pcm -> CycleOverlay.pcm'
+
+import CycleOverlay


### PR DESCRIPTION
Add tracing of the underlying Clang module for an overlay dependency if said overlay dependency forms a cycle