### PR TITLE
[libSwiftScan] Fix a use-after-free in replay instance creation

### DIFF
--- a/tools/libSwiftScan/SwiftCaching.cpp
+++ b/tools/libSwiftScan/SwiftCaching.cpp
@@ -253,7 +253,7 @@ expandSwiftInvocation(int argc, const char **argv, llvm::StringSaver &Saver,
                       llvm::SmallVectorImpl<const char *> &ArgsStorage) {
   ArgsStorage.reserve(argc);
   for (int i = 0; i < argc; ++i)
-    ArgsStorage.push_back(argv[i]);
+    ArgsStorage.push_back(Saver.save(argv[i]).data());
   swift::driver::ExpandResponseFilesWithRetry(Saver, ArgsStorage);
 
   // Drop the `-frontend` option if it is passed.


### PR DESCRIPTION
The response file expansion function doesn't return all the arguments allocated using StringSaver produced. It only use the StringSaver to save the newly expanded arguments. Need to make sure all the original arguments are saved so they can be used later during replay.

rdar://121808135
