### PR TITLE
[BitwiseCopyable] Don't diagnose implicit checks.

### DIFF
--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -224,12 +224,16 @@ static bool checkBitwiseCopyableInstanceStorage(NominalTypeDecl *nominal,
       KnownProtocolKind::BitwiseCopyable));
 
   if (dc->mapTypeIntoContext(nominal->getDeclaredInterfaceType())->isNoncopyable()) {
-    nominal->diagnose(diag::non_bitwise_copyable_type_noncopyable);
+    if (!isImplicit(check)) {
+      nominal->diagnose(diag::non_bitwise_copyable_type_noncopyable);
+    }
     return true;
   }
 
   if (!dc->mapTypeIntoContext(nominal->getDeclaredInterfaceType())->isEscapable()) {
-    nominal->diagnose(diag::non_bitwise_copyable_type_nonescapable);
+    if (!isImplicit(check)) {
+      nominal->diagnose(diag::non_bitwise_copyable_type_nonescapable);
+    }
     return true;
   }
 

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -193,6 +193,11 @@ struct S_Explicit_Nonescapable : ~Escapable, _BitwiseCopyable {} // expected-err
 
 struct S_Explicit_Noncopyable : ~Copyable, _BitwiseCopyable {} // expected-error{{non_bitwise_copyable_type_noncopyable}}
 
+struct S_Implicit_Nonescapable : ~Escapable {}
+
+struct S_Implicit_Noncopyable : ~Copyable {}
+
+
 func passUnmanaged<T : AnyObject>(_ u: Unmanaged<T>) { take3(u) }
 
 struct S_Explicit_With_Unmanaged<T : AnyObject> : _BitwiseCopyable {

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift                       \
+// RUN:     -disable-availability-checking                   \
+// RUN:     -enable-experimental-feature NonescapableTypes   \
+// RUN:     -enable-experimental-feature BitwiseCopyable     \
+// RUN:     -enable-builtin-module                           \
+// RUN:     -debug-diagnostic-names
+
+// This test file only exists in order to test without noncopyable_generics and can be deleted once that is always enabled.
+
+@_nonescapable
+struct S_Implicit_Nonescapable {}
+
+struct S_Implicit_Noncopyable : ~Copyable {}


### PR DESCRIPTION
Previously, the diagnostics for conforming a non-escaping or non-copyable type to `_BitwiseCopyable` were emitted even in the case of an implicit check for conformance.  Here this is fixed to suppress the diagnostics in the case of an implicit check as is done for other diagnostics.
