### PR TITLE
[interop][SwiftToCxx] Skip emitting an accessor method if its name collides with an accessor method of another property

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -26,6 +26,7 @@ namespace clang {
 
 namespace swift {
 
+class AccessorDecl;
 class PrimitiveTypeMapping;
 class ValueDecl;
 class SwiftToClangInteropContext;
@@ -41,6 +42,7 @@ struct CxxDeclEmissionScope {
   /// lexical scope.
   llvm::StringMap<llvm::SmallVector<const AbstractFunctionDecl *, 2>>
       emittedFunctionOverloads;
+  llvm::StringMap<const AccessorDecl *> emittedAccessorMethodNames;
 };
 
 /// Responsible for printing a Swift Decl or Type in Objective-C, to be

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1471,6 +1471,27 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
   }
 }
 
+static bool checkDuplicatedMethodName(StringRef funcName,
+                                      const AccessorDecl *AD,
+                                      DeclAndTypePrinter &declAndTypePrinter,
+                                      raw_ostream &os) {
+  auto *&decl = declAndTypePrinter.getCxxDeclEmissionScope()
+                    .emittedAccessorMethodNames[funcName];
+
+  if (!decl) {
+    // This is the first time an accessor with this name has been emitted.
+    decl = AD;
+  } else if (decl != AD) {
+    // An accessor for another property had the same name.
+    os << "  // skip emitting accessor method for \'"
+       << AD->getStorage()->getBaseIdentifier().str() << "\'. \'" << funcName
+       << "\' already declared.\n";
+    return false;
+  }
+
+  return true;
+}
+
 void DeclAndTypeClangFunctionPrinter::printCxxMethod(
     DeclAndTypePrinter &declAndTypePrinter,
     const NominalTypeDecl *typeDeclContext, const AbstractFunctionDecl *FD,
@@ -1547,6 +1568,12 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
     Type resultTy, bool isStatic, bool isDefinition,
     llvm::Optional<IRABIDetailsProvider::MethodDispatchInfo> dispatchInfo) {
   assert(accessor->isSetter() || accessor->getParameters()->size() == 0);
+  std::string accessorName = remapPropertyName(accessor, resultTy);
+
+  if (!checkDuplicatedMethodName(accessorName, accessor, declAndTypePrinter,
+                                 os))
+    return;
+
   os << "  ";
 
   FunctionSignatureModifiers modifiers;
@@ -1558,9 +1585,9 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
       !isStatic && accessor->isGetter() && !isa<ClassDecl>(typeDeclContext);
   modifiers.hasSymbolUSR = !isDefinition;
   modifiers.symbolUSROverride = accessor->getStorage();
-  auto result = printFunctionSignature(
-      accessor, signature, remapPropertyName(accessor, resultTy), resultTy,
-      FunctionSignatureKind::CxxInlineThunk, modifiers);
+  auto result =
+      printFunctionSignature(accessor, signature, accessorName, resultTy,
+                             FunctionSignatureKind::CxxInlineThunk, modifiers);
   assert(!result.isUnsupported() && "C signature should be unsupported too!");
   declAndTypePrinter.printAvailability(os, accessor->getStorage());
   if (!isDefinition) {

--- a/test/Interop/SwiftToCxx/properties/name-collision.swift
+++ b/test/Interop/SwiftToCxx/properties/name-collision.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -clang-header-expose-decls=all-public -emit-clang-header-path %t/name-collision.h
+// RUN: %FileCheck %s < %t/name-collision.h
+
+public class C0 {
+  public static var description: String { "hello" }
+  public var description: String { "world" }
+}
+
+public class C1 {
+  public var feat: Int { 123 }
+  public var Feat: Int { 123 }
+}
+
+// CHECK: class SWIFT_SYMBOL("s:4main2C0C") C0 :
+// CHECK-NOT: getDescription()
+// CHECK: static SWIFT_INLINE_THUNK swift::String getDescription()
+// CHECK: skip emitting accessor method for 'description'. 'getDescription' already declared.
+// CHECK-NOT: getDescription()
+// CHECK:};
+
+// CHECK: class SWIFT_SYMBOL("s:4main2C1C") C1 :
+// CHECK-NOT: getFeat()
+// CHECK:   SWIFT_INLINE_THUNK swift::Int getFeat()
+// CHECK:   skip emitting accessor method for 'Feat'. 'getFeat' already declared.
+// CHECK-NOT: getFeat()
+// CHECK:};
+
+// CHECK: namespace main SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("main") {
+// CHECK-NOT: getDescription()
+// CHECK: SWIFT_INLINE_THUNK swift::String C0::getDescription() {
+// CHECK: skip emitting accessor method for 'description'. 'getDescription' already declared.
+// CHECK-NOT: getDescription()
+// CHECK-NOT: getFeat()
+// CHECK: SWIFT_INLINE_THUNK swift::Int C1::getFeat() {
+// CHECK: skip emitting accessor method for 'Feat'. 'getFeat' already declared.
+// CHECK-NOT: getFeat()


### PR DESCRIPTION
Resolves rdar://119835520 and rdar://119835571.