### PR TITLE
[BitwiseCopyable] Remove existential conformance.

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -688,8 +688,16 @@ bool
 ExistentialConformsToSelfRequest::evaluate(Evaluator &evaluator,
                                            ProtocolDecl *decl) const {
   // Marker protocols always self-conform.
-  if (decl->isMarkerProtocol())
+  if (decl->isMarkerProtocol()) {
+    // Except for BitwiseCopyable an existential of which is non-trivial.
+    auto *bitwiseCopyableProtocol =
+        decl->getASTContext().getProtocol(KnownProtocolKind::BitwiseCopyable);
+    if (decl->getASTContext().LangOpts.hasFeature(Feature::BitwiseCopyable) &&
+        decl == bitwiseCopyableProtocol) {
+      return false;
+    }
     return true;
+  }
 
   // Otherwise, if it's not @objc, it conforms to itself only if it has a
   // self-conformance witness table.

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -11,3 +11,7 @@
 struct S_Implicit_Nonescapable {}
 
 struct S_Implicit_Noncopyable : ~Copyable {}
+
+struct S_Explicit_With_Any_BitwiseCopyable : _BitwiseCopyable {
+  var a: any _BitwiseCopyable // expected-error {{non_bitwise_copyable_type_member}}
+}


### PR DESCRIPTION
It makes sense to form an existential of a type that conforms to `BitwiseCopyable` but such an existential is not itself trivial and consequently not `BitwiseCopyable`.
