### PR TITLE
[IRGen] Fix a bug where an argument wasn't annotated with sret

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3511,7 +3511,10 @@ llvm::Constant *swift::irgen::emitCXXConstructorThunkIfNeeded(
       emitCXXConstructorCall(subIGF, ctor, ctorFnType, ctorAddress, Args);
   if (isa<llvm::InvokeInst>(call))
     IGM.emittedForeignFunctionThunksWithExceptionTraps.insert(thunk);
-  subIGF.Builder.CreateRetVoid();
+  if (ctorFnType->getReturnType()->isVoidTy())
+    subIGF.Builder.CreateRetVoid();
+  else
+    subIGF.Builder.CreateRet(call);
 
   return thunk;
 }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3583,8 +3583,7 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
     }
 
     if (cxxCtor) {
-      Signature signature = getSignature(f->getLoweredFunctionType(),
-                                         /*isCXXConstructorCall*/ true);
+      Signature signature = getSignature(f->getLoweredFunctionType(), cxxCtor);
 
       // The thunk has private linkage, so it doesn't need to have a predictable
       // mangled name -- we just need to make sure the name is unique.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3583,7 +3583,8 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
     }
 
     if (cxxCtor) {
-      Signature signature = getSignature(f->getLoweredFunctionType());
+      Signature signature = getSignature(f->getLoweredFunctionType(),
+                                         /*isCXXConstructorCall*/ true);
 
       // The thunk has private linkage, so it doesn't need to have a predictable
       // mangled name -- we just need to make sure the name is unique.

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -620,7 +620,7 @@ namespace {
       auto clangFnAddr =
           IGF.IGM.getAddrOfClangGlobalDecl(globalDecl, NotForDefinition);
       auto callee = cast<llvm::Function>(clangFnAddr->stripPointerCasts());
-      Signature signature = IGF.IGM.getSignature(fnType);
+      Signature signature = IGF.IGM.getSignature(fnType, copyConstructor);
       std::string name = "__swift_cxx_copy_ctor" + callee->getName().str();
       auto *origClangFnAddr = clangFnAddr;
       clangFnAddr = emitCXXConstructorThunkIfNeeded(

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1574,11 +1574,13 @@ public:
   void finalizeClangCodeGen();
   void finishEmitAfterTopLevel();
 
-  Signature getSignature(CanSILFunctionType fnType,
-                         bool isCXXConstructorCall = false);
-  Signature getSignature(CanSILFunctionType fnType, FunctionPointerKind kind,
-                         bool forStaticCall = false,
-                         bool isCXXConstructorCall = false);
+  Signature
+  getSignature(CanSILFunctionType fnType,
+               const clang::CXXConstructorDecl *cxxCtorDecl = nullptr);
+  Signature
+  getSignature(CanSILFunctionType fnType, FunctionPointerKind kind,
+               bool forStaticCall = false,
+               const clang::CXXConstructorDecl *cxxCtorDecl = nullptr);
   llvm::FunctionType *getFunctionType(CanSILFunctionType type,
                                       llvm::AttributeList &attrs,
                                       ForeignFunctionInfo *foreignInfo=nullptr);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1574,10 +1574,11 @@ public:
   void finalizeClangCodeGen();
   void finishEmitAfterTopLevel();
 
-  Signature getSignature(CanSILFunctionType fnType);
   Signature getSignature(CanSILFunctionType fnType,
-                         FunctionPointerKind kind,
-                         bool forStaticCall = false);
+                         bool isCXXConstructorCall = false);
+  Signature getSignature(CanSILFunctionType fnType, FunctionPointerKind kind,
+                         bool forStaticCall = false,
+                         bool isCXXConstructorCall = false);
   llvm::FunctionType *getFunctionType(CanSILFunctionType type,
                                       llvm::AttributeList &attrs,
                                       ForeignFunctionInfo *foreignInfo=nullptr);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2969,8 +2969,13 @@ void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
   auto fnType = fn->getLoweredFunctionType();
 
   auto fpKind = irgen::classifyFunctionPointerKind(fn);
+  bool isCXXConstructor = false;
 
-  auto sig = IGM.getSignature(fnType, fpKind, true /*forStaticCall*/);
+  if (auto *clangFnDecl = fn->getClangDecl())
+    isCXXConstructor = isa<clang::CXXConstructorDecl>(clangFnDecl);
+
+  auto sig = IGM.getSignature(fnType, fpKind, true /*forStaticCall*/,
+                              isCXXConstructor);
 
   // Note that the pointer value returned by getAddrOfSILFunction doesn't
   // necessarily have element type sig.getType(), e.g. if it's imported.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2969,13 +2969,13 @@ void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
   auto fnType = fn->getLoweredFunctionType();
 
   auto fpKind = irgen::classifyFunctionPointerKind(fn);
-  bool isCXXConstructor = false;
+  const clang::CXXConstructorDecl *cxxCtorDecl = nullptr;
 
   if (auto *clangFnDecl = fn->getClangDecl())
-    isCXXConstructor = isa<clang::CXXConstructorDecl>(clangFnDecl);
+    cxxCtorDecl = dyn_cast<clang::CXXConstructorDecl>(clangFnDecl);
 
-  auto sig = IGM.getSignature(fnType, fpKind, true /*forStaticCall*/,
-                              isCXXConstructor);
+  auto sig =
+      IGM.getSignature(fnType, fpKind, true /*forStaticCall*/, cxxCtorDecl);
 
   // Note that the pointer value returned by getAddrOfSILFunction doesn't
   // necessarily have element type sig.getType(), e.g. if it's imported.

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -31,6 +31,7 @@ namespace llvm {
 }
 
 namespace clang {
+  class CXXConstructorDecl;
   namespace CodeGen {
     class CGFunctionInfo;    
   }
@@ -202,10 +203,10 @@ public:
   /// This is a private detail of the implementation of
   /// IRGenModule::getSignature(CanSILFunctionType), which is what
   /// clients should generally be using.
-  static Signature getUncached(IRGenModule &IGM, CanSILFunctionType formalType,
-                               FunctionPointerKind kind,
-                               bool forStaticCall = false,
-                               bool forCXXConstructorCall = false);
+  static Signature
+  getUncached(IRGenModule &IGM, CanSILFunctionType formalType,
+              FunctionPointerKind kind, bool forStaticCall = false,
+              const clang::CXXConstructorDecl *cxxCtorDecl = nullptr);
 
   static SignatureExpansionABIDetails
   getUncachedABIDetails(IRGenModule &IGM, CanSILFunctionType formalType,

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -204,7 +204,8 @@ public:
   /// clients should generally be using.
   static Signature getUncached(IRGenModule &IGM, CanSILFunctionType formalType,
                                FunctionPointerKind kind,
-                               bool forStaticCall = false);
+                               bool forStaticCall = false,
+                               bool forCXXConstructorCall = false);
 
   static SignatureExpansionABIDetails
   getUncachedABIDetails(IRGenModule &IGM, CanSILFunctionType formalType,

--- a/test/IRGen/extern_c_abitypes.swift
+++ b/test/IRGen/extern_c_abitypes.swift
@@ -99,11 +99,11 @@ func test() {
 
   // assume %struct.c_struct and %TSo8c_structV have compatible layout
   //
-  // CHECK-x86_64: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK-x86_64: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
   // CHECK-x86_64: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
-  // CHECK-arm64:  call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK-arm64:  call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
   // CHECK-arm64:  call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
-  // CHECK-wasm32: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%struct.c_struct) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
+  // CHECK-wasm32: call void     @c_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV) {{.*}}, ptr{{( byval\(%struct.c_struct\))?}}[[ALIGN:(align [0-9]+)?]] {{.*}})
   // CHECK-wasm32: call void @swift_roundtrip_c_struct(ptr noalias nocapture sret(%TSo8c_structV)   {{.*}}, ptr{{( byval\(%TSo8c_structV\))?}}[[ALIGN]] {{.*}})
   // CHECK-armv7k: call [3 x i32]     @c_roundtrip_c_struct([3 x i32] {{.*}})
   // CHECK-armv7k: call [3 x i32] @swift_roundtrip_c_struct([3 x i32] {{.*}})

--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
@@ -12,6 +12,6 @@ public func use() -> CInt {
 
 // CHECK: %[[instance:.*]] = alloca %TSo10HasMethodsV
 // CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
-// CHECK: call void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr noalias nocapture sret(%struct.NonTrivialInWrapper) %[[result]], ptr %[[instance]], i32 42)
+// CHECK: call void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr noalias sret(%TSo19NonTrivialInWrapperV) %[[result]], ptr %[[instance]], i32 42)
 
 // CHECK: define {{.*}} void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, ptr {{.*}} %{{.*}}, i32 noundef %{{.*}})

--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-itanium.swift
@@ -12,6 +12,6 @@ public func use() -> CInt {
 
 // CHECK: %[[instance:.*]] = alloca %TSo10HasMethodsV
 // CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
-// CHECK: call void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr sret(%struct.NonTrivialInWrapper) %[[result]], ptr %[[instance]], i32 42)
+// CHECK: call void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr noalias nocapture sret(%struct.NonTrivialInWrapper) %[[result]], ptr %[[instance]], i32 42)
 
 // CHECK: define {{.*}} void @_ZN10HasMethods28nonConstPassThroughAsWrapperEi(ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, ptr {{.*}} %{{.*}}, i32 noundef %{{.*}})

--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
@@ -12,7 +12,7 @@ public func use() -> CInt {
 
 // CHECK: %[[instance:.*]] = alloca %TSo10HasMethodsV
 // CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
-// CHECK: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr sret(%struct.NonTrivialInWrapper) %[[result]], i32 42)
+// CHECK: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr noalias sret(%struct.NonTrivialInWrapper) %[[result]], i32 42)
 
 // CHECK-x86_64: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})
 // CHECK-aarch64: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr inreg noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})

--- a/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
+++ b/test/Interop/Cxx/class/method/methods-this-and-indirect-return-irgen-msvc.swift
@@ -12,7 +12,7 @@ public func use() -> CInt {
 
 // CHECK: %[[instance:.*]] = alloca %TSo10HasMethodsV
 // CHECK: %[[result:.*]] = alloca %TSo19NonTrivialInWrapperV
-// CHECK: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr noalias sret(%struct.NonTrivialInWrapper) %[[result]], i32 42)
+// CHECK: call void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr %[[instance]], ptr noalias sret(%TSo19NonTrivialInWrapperV) %[[result]], i32 42)
 
 // CHECK-x86_64: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})
 // CHECK-aarch64: define {{.*}} void @"?nonConstPassThroughAsWrapper@HasMethods@@QEAA?AUNonTrivialInWrapper@@H@Z"(ptr {{.*}} %{{.*}}, ptr inreg noalias sret(%struct.NonTrivialInWrapper) {{.*}} %{{.*}}, i32 noundef %{{.*}})

--- a/test/Interop/Cxx/objc-correctness/sret.swift
+++ b/test/Interop/Cxx/objc-correctness/sret.swift
@@ -1,0 +1,72 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-ir -I %t/Inputs -cxx-interoperability-mode=default %t/test.swift | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+//--- Inputs/header.h
+
+class S {
+public:
+  int a;
+  ~S();
+  S getS(int) const;
+  static S getSStatic(int);
+};
+
+S getS(int);
+
+@interface C
++(S)getS:(int)a;
+-(S)getS:(int)a;
+@end
+
+//--- Inputs/module.modulemap
+
+module SRet {
+  header "header.h"
+  requires cplusplus
+  export *
+}
+
+//--- test.swift
+
+import SRet
+
+func test(c : C, s : S) {
+  let _ : S = c.getS(1)
+  let _ : S = C.getS(1)
+  let _ : S = S()
+  let _ : S = getS(1)
+  let _ : S = s.getS(1)
+  let _ : S = S.getSStatic(1)
+}
+
+// CHECK: %[[TSO1SV:.*]] = type <{ %[[TS5INT32V:.*]] }>
+// CHECK: %[[TS5INT32V]] = type <{ i32 }>
+// CHECK: %[[SWIFT_OPAQUE:.*]] = type opaque
+// CHECK: %[[CLASS_S:.*]] = type { i32 }
+
+// CHECK: define hidden swiftcc void @"$s4testAA1c1sySo1CC_So1SVtF"(ptr %[[V0:.*]], ptr {{.*}}%[[V1:.*]])
+// CHECK: %[[V2:.*]] = alloca %[[TSO1SV]], align 4
+// CHECK: %[[V3:.*]] = alloca %[[TSO1SV]], align 4
+// CHECK: %[[V4:.*]] = alloca %[[TSO1SV]], align 4
+// CHECK: %[[V5:.*]] = alloca %[[TSO1SV]], align 4
+// CHECK: %[[V6:.*]] = alloca %[[TSO1SV]], align 4
+// CHECK: %[[V7:.*]] = alloca %[[TSO1SV]], align 4
+// CHECK: call void @llvm.lifetime.start.p0(i64 4, ptr %[[V2]])
+// CHECK: %[[V8:.*]] = load ptr, ptr @"\01L_selector(getS:)", align 8
+// CHECK: invoke void @objc_msgSend(ptr noalias nocapture sret(%[[SWIFT_OPAQUE]]) %[[V2]], ptr %[[V0]], ptr %[[V8]], i32 1)
+
+// CHECK: %[[V10:.*]] = load ptr, ptr @"OBJC_CLASS_REF_$_C", align 8
+// CHECK: %[[V11:.*]] = call ptr @objc_opt_self(ptr %[[V10]])
+// CHECK: %[[V12:.*]] = load ptr, ptr @"\01L_selector(getS:)", align 8
+// CHECK: invoke void @objc_msgSend(ptr noalias nocapture sret(%[[SWIFT_OPAQUE]]) %[[V3]], ptr %[[V11]], ptr %[[V12]], i32 1)
+
+// CHECK: %[[V14:.*]] = call ptr @_ZN1SC1Ev(ptr %[[V4]])
+// CHECK: invoke void @_Z4getSi(ptr noalias nocapture sret(%[[CLASS_S]]) %[[V5]], i32 1)
+
+// CHECK: invoke void @_ZNK1S4getSEi(ptr noalias nocapture sret(%[[CLASS_S]]) %[[V6]], ptr %[[V1]], i32 1)
+
+// CHECK: invoke void @_ZN1S10getSStaticEi(ptr noalias nocapture sret(%[[CLASS_S]]) %[[V7]], i32 1)

--- a/test/Interop/Cxx/objc-correctness/sret.swift
+++ b/test/Interop/Cxx/objc-correctness/sret.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-emit-ir -I %t/Inputs -cxx-interoperability-mode=default %t/test.swift | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %t/Inputs -cxx-interoperability-mode=default %t/test.swift -target arm64-apple-macos12 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Interop/Cxx/objc-correctness/sret.swift
+++ b/test/Interop/Cxx/objc-correctness/sret.swift
@@ -45,8 +45,6 @@ func test(c : C, s : S) {
 
 // CHECK: %[[TSO1SV:.*]] = type <{ %[[TS5INT32V:.*]] }>
 // CHECK: %[[TS5INT32V]] = type <{ i32 }>
-// CHECK: %[[SWIFT_OPAQUE:.*]] = type opaque
-// CHECK: %[[CLASS_S:.*]] = type { i32 }
 
 // CHECK: define hidden swiftcc void @"$s4testAA1c1sySo1CC_So1SVtF"(ptr %[[V0:.*]], ptr {{.*}}%[[V1:.*]])
 // CHECK: %[[V2:.*]] = alloca %[[TSO1SV]], align 4
@@ -57,16 +55,16 @@ func test(c : C, s : S) {
 // CHECK: %[[V7:.*]] = alloca %[[TSO1SV]], align 4
 // CHECK: call void @llvm.lifetime.start.p0(i64 4, ptr %[[V2]])
 // CHECK: %[[V8:.*]] = load ptr, ptr @"\01L_selector(getS:)", align 8
-// CHECK: invoke void @objc_msgSend(ptr noalias nocapture sret(%[[SWIFT_OPAQUE]]) %[[V2]], ptr %[[V0]], ptr %[[V8]], i32 1)
+// CHECK: invoke void @objc_msgSend(ptr noalias sret(%[[TSO1SV]]) %[[V2]], ptr %[[V0]], ptr %[[V8]], i32 1)
 
 // CHECK: %[[V10:.*]] = load ptr, ptr @"OBJC_CLASS_REF_$_C", align 8
 // CHECK: %[[V11:.*]] = call ptr @objc_opt_self(ptr %[[V10]])
 // CHECK: %[[V12:.*]] = load ptr, ptr @"\01L_selector(getS:)", align 8
-// CHECK: invoke void @objc_msgSend(ptr noalias nocapture sret(%[[SWIFT_OPAQUE]]) %[[V3]], ptr %[[V11]], ptr %[[V12]], i32 1)
+// CHECK: invoke void @objc_msgSend(ptr noalias sret(%[[TSO1SV]]) %[[V3]], ptr %[[V11]], ptr %[[V12]], i32 1)
 
 // CHECK: %[[V14:.*]] = call ptr @_ZN1SC1Ev(ptr %[[V4]])
-// CHECK: invoke void @_Z4getSi(ptr noalias nocapture sret(%[[CLASS_S]]) %[[V5]], i32 1)
+// CHECK: invoke void @_Z4getSi(ptr noalias sret(%[[TSO1SV]]) %[[V5]], i32 1)
 
-// CHECK: invoke void @_ZNK1S4getSEi(ptr noalias nocapture sret(%[[CLASS_S]]) %[[V6]], ptr %[[V1]], i32 1)
+// CHECK: invoke void @_ZNK1S4getSEi(ptr noalias sret(%[[TSO1SV]]) %[[V6]], ptr %[[V1]], i32 1)
 
-// CHECK: invoke void @_ZN1S10getSStaticEi(ptr noalias nocapture sret(%[[CLASS_S]]) %[[V7]], i32 1)
+// CHECK: invoke void @_ZN1S10getSStaticEi(ptr noalias sret(%[[TSO1SV]]) %[[V7]], i32 1)


### PR DESCRIPTION
Fix a bug in `expandExternalSignatureTypes` where it wasn't annotating a function call parameter type with `sret` when the result was being returned indirectly.

The bug was causing calls to ObjC methods that return their results indirectly to crash.

Additionally, fix the return type for C++ constructors computed in `expandExternalSignatureTypes`. Previously, the return type was always `void` even on targets that require constructors to return `this` (e.g., Apple arm64), which was causing C++ constructor thunks to be emitted needlessly.

Resolves rdar://121618707