### PR TITLE
[BitwiseCopyable] Ban indirect enums and cases.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7609,6 +7609,12 @@ ERROR(escapable_requires_feature_flag,none,
       ())
 ERROR(non_bitwise_copyable_type_class,none,
       "class cannot conform to 'BitwiseCopyable'", ())
+ERROR(non_bitwise_copyable_type_indirect_enum,none,
+      "indirect enum cannot conform to 'BitwiseCopyable'", ())
+ERROR(non_bitwise_copyable_type_indirect_enum_element,none,
+      "enum with indirect case cannot conform to 'BitwiseCopyable'", ())
+NOTE(note_non_bitwise_copyable_type_indirect_enum_element,none,
+     "indirect case is here", ())
 ERROR(non_bitwise_copyable_type_noncopyable,none,
       "noncopyable type cannot conform to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_type_nonescapable,none,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -688,8 +688,16 @@ bool
 ExistentialConformsToSelfRequest::evaluate(Evaluator &evaluator,
                                            ProtocolDecl *decl) const {
   // Marker protocols always self-conform.
-  if (decl->isMarkerProtocol())
+  if (decl->isMarkerProtocol()) {
+    // Except for BitwiseCopyable an existential of which is non-trivial.
+    auto *bitwiseCopyableProtocol =
+        decl->getASTContext().getProtocol(KnownProtocolKind::BitwiseCopyable);
+    if (decl->getASTContext().LangOpts.hasFeature(Feature::BitwiseCopyable) &&
+        decl == bitwiseCopyableProtocol) {
+      return false;
+    }
     return true;
+  }
 
   // Otherwise, if it's not @objc, it conforms to itself only if it has a
   // self-conformance witness table.

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -11,3 +11,7 @@
 struct S_Implicit_Nonescapable {}
 
 struct S_Implicit_Noncopyable : ~Copyable {}
+
+struct S_Explicit_With_Any_BitwiseCopyable : _BitwiseCopyable {
+  var a: any _BitwiseCopyable // expected-error {{non_bitwise_copyable_type_member}}
+}

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -15,3 +15,13 @@ struct S_Implicit_Noncopyable : ~Copyable {}
 struct S_Explicit_With_Any_BitwiseCopyable : _BitwiseCopyable {
   var a: any _BitwiseCopyable // expected-error {{non_bitwise_copyable_type_member}}
 }
+
+struct S {}
+
+indirect enum E_Explicit_Indirect : _BitwiseCopyable { // expected-error {{non_bitwise_copyable_type_indirect_enum}}
+  case s(S)
+}
+
+enum E_Explicit_Indirect_Case : _BitwiseCopyable { // expected-error {{non_bitwise_copyable_type_indirect_enum_element}}
+  indirect case s(S) // expected-note {{note_non_bitwise_copyable_type_indirect_enum_element}}
+}


### PR DESCRIPTION
Enums which are entirely indirect or which have indirect cases are never trivial and hence cannot conform to BitwiseCopyable.
