### PR TITLE
[Concurrency] Downgrade errors about actor-isolated witnesses to warnings until Swift 6 when the witness is a non-Sendable `let`.

### DIFF
--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -1543,6 +1543,15 @@ class OverridesNonsiolatedInit: SuperWithNonisolatedInit {
 // expected-note@+1 {{class 'NonSendable' does not conform to the 'Sendable' protocol}}
 class NonSendable {}
 
+protocol NonisolatedProtocol {
+  var ns: NonSendable { get } // expected-note {{'ns' declared here}}
+}
+
+actor ActorWithNonSendableLet: NonisolatedProtocol {
+  // expected-warning@+1 {{actor-isolated property 'ns' cannot be used to satisfy nonisolated protocol requirement; this is an error in Swift 6}}
+  let ns = NonSendable()
+}
+
 actor ProtectNonSendable {
   // expected-note@+1 2 {{property declared here}}
   let ns = NonSendable()


### PR DESCRIPTION
https://github.com/apple/swift/pull/70909 changed actor `let`s to only be considered `nonisolated` if the property type conforms to `Sendable`. This caused new witness checker errors if an actor isolated `let` witnesses a `nonisolated` protocol requirement, which breaks the following code:

```swift
class NotSendable {}

protocol P {
  var ns: NotSendable { get }
}

actor A: P {
  let ns = NotSendable() // error
}
```

Compiler versions <= 5.10 only diagnosed this as a Sendable violation under `-strict-concurrency=complete`, so the new witness checker diagnostic should only be diagnosed as a warning until Swift 6.