### PR TITLE
[DNM][Distributed] Handle generic actors and Codable better

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7458,6 +7458,9 @@ public:
            getSILSynthesizeKind() == SILSynthesizeKind::DistributedActorFactory;
   }
 
+  /// Determines whether this function is `DistributedActorSystem::remoteCall{Void}`.
+  bool isDistributedActorSystemRemoteCallRequirement(bool withResult) const;
+
   /// Determines whether this function is a 'remoteCall' function,
   /// which is used as ad-hoc protocol requirement by the
   /// 'DistributedActorSystem' protocol.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1653,11 +1653,15 @@ public:
   /// Compute the set of substitutions for a generic signature opened at the
   /// given locator.
   ///
+  /// \param decl The underlying declaration for which the substitutions are
+  /// computed.
+  ///
   /// \param sig The generic signature.
   ///
   /// \param locator The locator that describes where the substitutions came
   /// from.
-  SubstitutionMap computeSubstitutions(GenericSignature sig,
+  SubstitutionMap computeSubstitutions(NullablePtr<ValueDecl> decl,
+                                       GenericSignature sig,
                                        ConstraintLocator *locator) const;
 
   /// Resolves the contextual substitutions for a reference to a declaration

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -104,6 +104,7 @@ Solution::computeSubstitutions(NullablePtr<ValueDecl> decl,
     subs[opened.first] = type;
   }
 
+  auto *DC = constraintSystem->DC;
   auto lookupConformanceFn =
       [&](CanType original, Type replacement,
           ProtocolDecl *protoType) -> ProtocolConformanceRef {
@@ -114,8 +115,24 @@ Solution::computeSubstitutions(NullablePtr<ValueDecl> decl,
     }
 
     // FIXME: Retrieve the conformance from the solution itself.
-    return getConstraintSystem().DC->getParentModule()->checkConformance(
-        replacement, protoType);
+    auto conformance =
+        DC->getParentModule()->checkConformance(replacement, protoType);
+
+    if (conformance.isInvalid()) {
+      if (auto *funcDecl = dyn_cast<FuncDecl>(decl.getPtrOrNull())) {
+        if (funcDecl->isDistributedActorSystemRemoteCall(
+                /*isVoidResult=*/false)) {
+          // `Res` conformances would be looked by at runtime but are
+          // guaranteed to be there by Sema because all distributed
+          // methods and accessors are checked to conform to
+          // `SerializationRequirement` of `DistributedActorSystem`.
+          if (original->isEqual(funcDecl->getResultInterfaceType()))
+            return ProtocolConformanceRef(protoType);
+        }
+      }
+    }
+
+    return conformance;
   };
 
   return SubstitutionMap::get(sig,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -82,7 +82,8 @@ static bool isOpenedAnyObject(Type type) {
 }
 
 SubstitutionMap
-Solution::computeSubstitutions(GenericSignature sig,
+Solution::computeSubstitutions(NullablePtr<ValueDecl> decl,
+                               GenericSignature sig,
                                ConstraintLocator *locator) const {
   if (sig.isNull())
     return SubstitutionMap();
@@ -147,7 +148,7 @@ Solution::resolveConcreteDeclRef(ValueDecl *decl,
 
   // Get the generic signature of the decl and compute the substitutions.
   auto sig = decl->getInnermostDeclContext()->getGenericSignatureOfContext();
-  auto subst = computeSubstitutions(sig, locator);
+  auto subst = computeSubstitutions(decl, sig, locator);
 
   maybeInstantiateCXXMethodDefinition(decl);
 
@@ -7121,7 +7122,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     auto opaqueLocator = solution.getConstraintSystem().getOpenOpaqueLocator(
         locator, opaqueDecl);
     SubstitutionMap substitutions = solution.computeSubstitutions(
-        opaqueDecl->getOpaqueInterfaceGenericSignature(), opaqueLocator);
+        opaqueDecl, opaqueDecl->getOpaqueInterfaceGenericSignature(),
+        opaqueLocator);
 
     // If we don't have substitutions, this is an opaque archetype from
     // another declaration being manipulated, and not an erasure of a

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -751,9 +751,8 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
 /*********************** CODABLE CONFORMANCE **********************************/
 /******************************************************************************/
 
-static NormalProtocolConformance*
-addDistributedActorCodableConformance(
-    ClassDecl *actor, ProtocolDecl *proto) {
+static NormalProtocolConformance *
+addDistributedActorCodableConformance(ClassDecl *actor, ProtocolDecl *proto) {
   auto &C = actor->getASTContext();
   auto module = actor->getParentModule();
 
@@ -763,7 +762,8 @@ addDistributedActorCodableConformance(
   }
 
   if (actor->isGeneric()) {
-    auto idTy = C.getAssociatedTypeOfDistributedSystemOfActor(actor, C.Id_ActorID);
+    auto idTy =
+        C.getAssociatedTypeOfDistributedSystemOfActor(actor, C.Id_ActorID);
     if (idTy->hasError()) {
       return nullptr;
     }
@@ -774,7 +774,8 @@ addDistributedActorCodableConformance(
         idTy, C.getProtocol(swift::KnownProtocolKind::Decodable),
         /*allowMissing=*/true);
 
-    // the system's ID is not codable, thus the actor isn't as well -- don't add the conformance.
+    // the system's ID is not codable, thus the actor isn't as well -- don't add
+    // the conformance.
     if (encodableConf.isInvalid()) {
       return nullptr;
     }
@@ -981,8 +982,7 @@ VarDecl *GetDistributedActorSystemPropertyRequest::evaluate(
   return addImplicitDistributedActorActorSystemProperty(classDecl);
 }
 
-NormalProtocolConformance *
-GetDistributedActorImplicitCodableRequest::evaluate(
+NormalProtocolConformance *GetDistributedActorImplicitCodableRequest::evaluate(
     Evaluator &evaluator, NominalTypeDecl *nominal,
     KnownProtocolKind protoKind) const {
   assert(nominal->isDistributedActor());

--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -516,6 +516,19 @@ deriveDistributedActorType_ActorSystem(
   assert(derived.Nominal->isDistributedActor());
   auto &C = derived.Context;
 
+
+  // If the actor is generic over ActorSystem,
+  // we don't need to synthesize the typealias.
+  if (derived.Nominal->getGenericSignature()) {
+    auto genSig = derived.Nominal->getGenericSignature();
+    for (auto param : genSig.getGenericParams()) {
+      if (param->getName() == C.Id_ActorSystem) {
+        return nullptr;
+      }
+    }
+  }
+
+
   // Look for a type DefaultDistributedActorSystem within the parent context.
   auto defaultDistributedActorSystemLookup = TypeChecker::lookupUnqualified(
       derived.getConformanceContext()->getModuleScopeContext(),

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1195,13 +1195,52 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     }
     bool requiresNonSendable = false;
     if (!solution || solution->Fixes.size()) {
-      /// If the *only* problems are that `@Sendable` attributes are missing,
-      /// allow the match in some circumstances.
-      requiresNonSendable = solution
-          && llvm::all_of(solution->Fixes, [](constraints::ConstraintFix *fix) {
-            return fix->getKind() == constraints::FixKind::AddSendableAttribute;
-          });
-      if (!requiresNonSendable)
+      auto isMatchedAllowed = [&](const constraints::Solution &solution) {
+        /// If the *only* problems are that `@Sendable` attributes are missing,
+        /// allow the match in some circumstances.
+        if (llvm::all_of(solution.Fixes, [](constraints::ConstraintFix *fix) {
+              return fix->getKind() ==
+                     constraints::FixKind::AddSendableAttribute;
+            }))
+          return true;
+
+        auto *funcDecl = dyn_cast<AbstractFunctionDecl>(req);
+        // Conformance requirement between on `Res` and `SerializationRequirement`
+        // of `DistributedActorSystem.remoteCall` are not expressible at the moment
+        // but they are verified by Sema so it's okay to omit them here and lookup
+        // dynamically during IRGen.
+        if (funcDecl && funcDecl->isDistributedActorSystemRemoteCallRequirement(
+                            /*withResult=*/true)) {
+          if (llvm::all_of(solution.Fixes, [&witness](constraints::ConstraintFix
+                                                          *fix) {
+                auto conformance = dyn_cast<MissingConformance>(fix);
+                if (!conformance)
+                  return false;
+
+                auto *locator = fix->getLocator();
+                auto requirement = locator->getLastElementAs<
+                    LocatorPathElt::TypeParameterRequirement>();
+                if (!requirement)
+                  return false;
+
+                auto signature =
+                    locator->findLast<LocatorPathElt::OpenedGeneric>()
+                        ->getSignature();
+
+                auto subject =
+                    signature.getRequirements()[requirement->getIndex()]
+                        .getFirstType();
+                // `Res` is the result type so we can check against that.
+                return subject->isEqual(
+                    cast<FuncDecl>(witness)->getResultInterfaceType());
+              }))
+            return true;
+        }
+        // In all other cases - disallow the match.
+        return false;
+      };
+
+      if (!solution || !isMatchedAllowed(*solution))
         return RequirementMatch(witness, MatchKind::TypeConflict,
                                 witnessType);
     }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1231,8 +1231,8 @@ swift::matchWitness(WitnessChecker::RequirementEnvironmentCache &reqEnvCache,
     auto witnessSig =
       witness->getInnermostDeclContext()->getGenericSignatureOfContext();
     result.WitnessSubstitutions =
-      solution->computeSubstitutions(witnessSig, witnessLocator);
-    
+        solution->computeSubstitutions(witness, witnessSig, witnessLocator);
+
     return result;
   };
 

--- a/stdlib/public/Distributed/DistributedActorSystem.swift
+++ b/stdlib/public/Distributed/DistributedActorSystem.swift
@@ -249,7 +249,7 @@ import _Concurrency
 /// - [SE-0336: Distributed Actor Isolation](https://github.com/apple/swift-evolution/blob/main/proposals/0336-distributed-actor-isolation.md)
 /// - [SE-0344: Distributed Actor Runtime](https://github.com/apple/swift-evolution/blob/main/proposals/0344-distributed-actor-runtime.md)
 @available(SwiftStdlib 5.7, *)
-public protocol DistributedActorSystem: Sendable {
+public protocol DistributedActorSystem<SerializationRequirement>: Sendable {
   /// The type ID that will be assigned to any distributed actor managed by this actor system.
   ///
   /// ### A note on Codable IDs
@@ -375,47 +375,47 @@ public protocol DistributedActorSystem: Sendable {
   /// that are associated with this specific invocation.
   func makeInvocationEncoder() -> InvocationEncoder
 
-//  /// Invoked by the Swift runtime when making a remote call.
-//  ///
-//  /// The `arguments` are the arguments container that was previously created
-//  /// by `makeInvocationEncoder` and has been populated with all arguments.
-//  ///
-//  /// This method should perform the actual remote function call, and await for its response.
-//  ///
-//  /// ## Errors
-//  /// This method is allowed to throw because of underlying transport or serialization errors,
-//  /// as well as by re-throwing the error received from the remote callee (if able to).
-//  func remoteCall<Act, Err, Res>(
-//      on actor: Act,
-//      target: RemoteCallTarget,
-//      invocation: inout InvocationEncoder,
-//      throwing: Err.Type,
-//      returning: Res.Type
-//  ) async throws -> Res
-//      where Act: DistributedActor,
-//            Act.ID == ActorID,
-//            Err: Error,
-//            Res: SerializationRequirement
+  /// Invoked by the Swift runtime when making a remote call.
+  ///
+  /// The `arguments` are the arguments container that was previously created
+  /// by `makeInvocationEncoder` and has been populated with all arguments.
+  ///
+  /// This method should perform the actual remote function call, and await for its response.
+  ///
+  /// ## Errors
+  /// This method is allowed to throw because of underlying transport or serialization errors,
+  /// as well as by re-throwing the error received from the remote callee (if able to).
+  func remoteCall<Act, Err, Res>(
+      on actor: Act,
+      target: RemoteCallTarget,
+      invocation: inout InvocationEncoder,
+      throwing: Err.Type,
+      returning: Res.Type
+  ) async throws -> Res
+      where Act: DistributedActor,
+            Act.ID == ActorID,
+            Err: Error
+//          Res: SerializationRequirement
 
-//  /// Invoked by the Swift runtime when making a remote call.
-//  ///
-//  /// The `arguments` are the arguments container that was previously created
-//  /// by `makeInvocationEncoder` and has been populated with all arguments.
-//  ///
-//  /// This method should perform the actual remote function call, and await for its response.
-//  ///
-//  /// ## Errors
-//  /// This method is allowed to throw because of underlying transport or serialization errors,
-//  /// as well as by re-throwing the error received from the remote callee (if able to).
-//  func remoteCallVoid<Act, Err>(
-//      on actor: Act,
-//      target: RemoteCallTarget,
-//      invocation: inout InvocationEncoder,
-//      throwing: Err.Type
-//  ) async throws -> Res
-//      where Act: DistributedActor,
-//            Act.ID == ActorID,
-//            Err: Error
+  /// Invoked by the Swift runtime when making a remote call.
+  ///
+  /// The `arguments` are the arguments container that was previously created
+  /// by `makeInvocationEncoder` and has been populated with all arguments.
+  ///
+  /// This method should perform the actual remote function call, and await for its response.
+  ///
+  /// ## Errors
+  /// This method is allowed to throw because of underlying transport or serialization errors,
+  /// as well as by re-throwing the error received from the remote callee (if able to).
+  func remoteCallVoid<Act, Err>(
+      on actor: Act,
+      target: RemoteCallTarget,
+      invocation: inout InvocationEncoder,
+      throwing: Err.Type
+  ) async throws
+      where Act: DistributedActor,
+            Act.ID == ActorID,
+            Err: Error
 
   // Implementation notes:
   // The `metatype` must be the type of `Value`, and it must conform to

--- a/test/Distributed/Runtime/distributed_actor_generic_codable_da_conformance.swift
+++ b/test/Distributed/Runtime/distributed_actor_generic_codable_da_conformance.swift
@@ -1,0 +1,165 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main  -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import Foundation
+import Distributed
+
+final class LocalActorSystem : DistributedActorSystem {
+  typealias ActorID = LocalTestingActorID
+  typealias ResultHandler = LocalTestingInvocationResultHandler
+  typealias InvocationEncoder = LocalTestingInvocationEncoder
+  typealias InvocationDecoder = LocalTestingInvocationDecoder
+  typealias SerializationRequirement = any Codable
+
+  func makeInvocationEncoder() -> InvocationEncoder { LocalTestingDistributedActorSystem().makeInvocationEncoder() }
+
+  func resolve<Act>(id: ActorID, as actorType: Act.Type) throws -> Act? where Act: DistributedActor {
+    nil
+  }
+
+  func actorReady<Act>(_ actor: Act) where Act: DistributedActor, Act.ID == ActorID {
+  }
+
+  func resignID(_ id: ActorID) {}
+
+  func assignID<Act>(_ actorType: Act.Type) -> ActorID
+    where Act: DistributedActor {
+    .init(id: "42")
+  }
+
+  func remoteCall<Act, Err, Res>(on actor: Act,
+                                 target: RemoteCallTarget,
+                                 invocation: inout InvocationEncoder,
+                                 throwing: Err.Type,
+                                 returning: Res.Type) async throws -> Res
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error,
+          Res: Codable {
+    let decoder = JSONDecoder()
+    return try! decoder.decode(Res.self, from: await fetchData())
+  }
+
+  func remoteCallVoid<Act, Err>(on actor: Act,
+                                target: RemoteCallTarget,
+                                invocation: inout InvocationEncoder,
+                                throwing errorType: Err.Type) async throws
+    where Act: DistributedActor,
+          Act.ID == ActorID,
+          Err: Error {
+    fatalError("not implemented: \(#function)")
+  }
+
+  func fetchData() async -> Data {
+    "42".data(using: .ascii)!
+  }
+}
+
+distributed actor NotCodableDA<ActorSystem>
+  where ActorSystem: DistributedActorSystem<any Codable> {
+
+  init(actorSystem: ActorSystem) async {
+    self.actorSystem = actorSystem
+
+    print(try! await self.request())
+  }
+
+  func request() async throws -> Int {
+    let target = RemoteCallTarget("test.request")
+    var encoder = actorSystem.makeInvocationEncoder()
+    return try await actorSystem.remoteCall(on: self,
+      target: target,
+      invocation: &encoder,
+      throwing: Error.self,
+      returning: Int.self)
+  }
+}
+
+distributed actor CodableDA<ActorSystem>: Codable
+  where ActorSystem: DistributedActorSystem<any Codable>,
+        ActorSystem.ActorID: Codable {
+
+  init(actorSystem: ActorSystem) async {
+    self.actorSystem = actorSystem
+
+    print(try! await self.request())
+  }
+
+  func request() async throws -> Int {
+    let target = RemoteCallTarget("test.request")
+    var encoder = actorSystem.makeInvocationEncoder()
+    return try await actorSystem.remoteCall(on: self,
+      target: target,
+      invocation: &encoder,
+      throwing: Error.self,
+      returning: Int.self)
+  }
+}
+
+distributed actor CodableIDDA<ActorSystem>
+  where ActorSystem: DistributedActorSystem<any Codable>,
+        ActorSystem.ActorID: Codable {
+
+  init(actorSystem: ActorSystem) async {
+    self.actorSystem = actorSystem
+
+    print(try! await self.request())
+  }
+
+  func request() async throws -> Int {
+    let target = RemoteCallTarget("test.request")
+    var encoder = actorSystem.makeInvocationEncoder()
+    return try await actorSystem.remoteCall(on: self,
+      target: target,
+      invocation: &encoder,
+      throwing: Error.self,
+      returning: Int.self)
+  }
+}
+
+@main struct Main {
+  static func main() async throws {
+    if #available(SwiftStdlib 5.9, *) {
+      let system = LocalActorSystem()
+      let ncda = await NotCodableDA(actorSystem: system)
+      let cidda = await CodableIDDA(actorSystem: system)
+      let cda = await CodableDA(actorSystem: system)
+
+      try await ncda.whenLocal {
+        let got = try await $0.request()
+
+        // CHECK: got = 42
+        print("got = \(got)")
+      }
+
+      try await cidda.whenLocal {
+        let got = try await $0.request()
+
+        // CHECK: got = 42
+        print("got = \(got)")
+      }
+
+      let c: any (DistributedActor & Codable) = cda
+      try await cda.whenLocal {
+        let got = try await $0.request()
+
+        // CHECK: got = 42
+        print("got = \(got)")
+      }
+
+      // CHECK: OK
+      print("OK")
+    }
+  }
+}

--- a/test/Distributed/distributed_actor_implicit_codable.swift
+++ b/test/Distributed/distributed_actor_implicit_codable.swift
@@ -9,11 +9,47 @@ import FakeDistributedActorSystems
 
 typealias DefaultDistributedActorSystem = FakeActorSystem
 
+func takeCodable<A: Codable>(actor: A) {}
+
+// ====
+
 distributed actor DA {
 }
 
-func take<A: Codable>(actor: A) {}
+func test_DA(actorSystem: FakeActorSystem) {
+  takeCodable(actor: DA(actorSystem: actorSystem)) // ok
+}
 
-func test(actorSystem: FakeActorSystem) {
-  take(actor: DA(actorSystem: actorSystem)) // ok
+// ==== Generic actors
+
+distributed actor DAG<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable> {
+}
+func test_DAG(actorSystem: FakeActorSystem) {
+  takeCodable(actor: DAG<FakeActorSystem>(actorSystem: actorSystem)) // ok
+}
+
+distributed actor DAG_ID<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable>,
+  ID: Codable { // expected-error{{cannot find type 'ID' in scope}}
+}
+func test_DAG_ID(actorSystem: FakeActorSystem) {
+  takeCodable(actor: DAG_ID<FakeActorSystem>(actorSystem: actorSystem)) // ok
+}
+
+distributed actor DAG_ActorSystem_ActorID<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable>,
+  ActorSystem.ActorID: Codable {
+}
+func test_DAG_ActorSystem_ActorID(actorSystem: FakeActorSystem) {
+  takeCodable(actor: DAG_ActorSystem_ActorID<FakeActorSystem>(actorSystem: actorSystem)) // ok
+}
+
+// ==== Not codable cases
+
+protocol SerializableButNotCodable {}
+
+distributed actor DAG_ActorSystem_ActorID_Custom<ActorSystem>
+    where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
+  ActorSystem.ActorID: SerializableButNotCodable {
+}
+func test_DAG_ActorSystem_ActorID_Custom(actorSystem: FakeActorSystem) {
+  takeCodable(actor: DAG_ActorSystem_ActorID<FakeActorSystem>(actorSystem: actorSystem)) // bad
 }

--- a/test/Distributed/distributed_actor_implicit_codable.swift
+++ b/test/Distributed/distributed_actor_implicit_codable.swift
@@ -7,49 +7,97 @@
 import Distributed
 import FakeDistributedActorSystems
 
-typealias DefaultDistributedActorSystem = FakeActorSystem
+
+// FIXME: handle this; don't add the typealias
+// typealias DefaultDistributedActorSystem = FakeActorSystem
 
 func takeCodable<A: Codable>(actor: A) {}
+// expected-note@-1{{where 'A' = 'DAG<FakeActorSystem>'}}
+// expected-note@-2{{where 'A' = 'DAG<FakeActorSystem>'}}
+// expected-note@-3{{where 'A' = 'DAG_ActorSystem_ActorID_Custom<ActorSystem>'}}
+// expected-note@-4{{where 'A' = 'DAG_ActorSystem_ActorID<FakeActorSystem>'}}
+// expected-note@-5{{where 'A' = 'DAG_ID<FakeActorSystem>'}}
+// expected-note@-6{{where 'A' = 'DAG_ActorSystem_ActorID_Custom<ActorSystem>'}}
+// expected-note@-7{{where 'A' = 'DAG_ActorSystem_ActorID<FakeActorSystem>'}}
+// expected-note@-8{{where 'A' = 'DAG_ID<FakeActorSystem>'}}
 
-// ====
+// ==== ------------------------------------------------------------------------
 
 distributed actor DA {
+  typealias ActorSystem = FakeActorSystem
 }
 
 func test_DA(actorSystem: FakeActorSystem) {
   takeCodable(actor: DA(actorSystem: actorSystem)) // ok
 }
 
-// ==== Generic actors
+// ==== Generic actors ---------------------------------------------------------
 
-distributed actor DAG<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable> {
+// --- Not codable cases -------------------------------------------------------
+
+distributed actor DAG<ActorSystem>
+  where ActorSystem: DistributedActorSystem<any Codable> {
 }
 func test_DAG(actorSystem: FakeActorSystem) {
-  takeCodable(actor: DAG<FakeActorSystem>(actorSystem: actorSystem)) // ok
+  // expected-error@+2{{global function 'takeCodable(actor:)' requires that 'DAG<FakeActorSystem>' conform to 'Decodable'}}
+  // expected-error@+1{{global function 'takeCodable(actor:)' requires that 'DAG<FakeActorSystem>' conform to 'Encodable'}}
+  takeCodable(actor: DAG<FakeActorSystem>(actorSystem: actorSystem))
 }
 
-distributed actor DAG_ID<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable>,
-  ID: Codable { // expected-error{{cannot find type 'ID' in scope}}
+distributed actor DAG_ID<ActorSystem>
+  where ActorSystem: DistributedActorSystem<any Codable>,
+        ID: Codable { // expected-error{{cannot find type 'ID' in scope}}
 }
 func test_DAG_ID(actorSystem: FakeActorSystem) {
-  takeCodable(actor: DAG_ID<FakeActorSystem>(actorSystem: actorSystem)) // ok
+  // expected-error@+2{{global function 'takeCodable(actor:)' requires that 'DAG_ID<FakeActorSystem>' conform to 'Decodable'}}
+  // expected-error@+1{{global function 'takeCodable(actor:)' requires that 'DAG_ID<FakeActorSystem>' conform to 'Encodable'}}
+  takeCodable(actor: DAG_ID<FakeActorSystem>(actorSystem: actorSystem))
 }
 
 distributed actor DAG_ActorSystem_ActorID<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable>,
   ActorSystem.ActorID: Codable {
 }
 func test_DAG_ActorSystem_ActorID(actorSystem: FakeActorSystem) {
-  takeCodable(actor: DAG_ActorSystem_ActorID<FakeActorSystem>(actorSystem: actorSystem)) // ok
+  // expected-error@+2{{global function 'takeCodable(actor:)' requires that 'DAG_ActorSystem_ActorID<FakeActorSystem>' conform to 'Decodable'}}
+  // expected-error@+1{{global function 'takeCodable(actor:)' requires that 'DAG_ActorSystem_ActorID<FakeActorSystem>' conform to 'Encodable'}}
+  takeCodable(actor: DAG_ActorSystem_ActorID<FakeActorSystem>(actorSystem: actorSystem))
 }
 
-// ==== Not codable cases
+protocol SerializableButNotCodable {
+  func serialize()
+}
+extension DistributedActor where ActorSystem.ActorID: SerializableButNotCodable {
+  nonisolated func serialize() {
+    // get id and serialize it
+  }
+}
 
-protocol SerializableButNotCodable {}
+func takeSerializableButNotCodable<A: SerializableButNotCodable>(actor: A) {}
 
 distributed actor DAG_ActorSystem_ActorID_Custom<ActorSystem>
     where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
   ActorSystem.ActorID: SerializableButNotCodable {
 }
-func test_DAG_ActorSystem_ActorID_Custom(actorSystem: FakeActorSystem) {
-  takeCodable(actor: DAG_ActorSystem_ActorID<FakeActorSystem>(actorSystem: actorSystem)) // bad
+func test_DAG_ActorSystem_ActorID_Custom<ActorSystem>(actorSystem: ActorSystem)
+    where ActorSystem: DistributedActorSystem<any SerializableButNotCodable> {
+  // expected-error@+1{{type 'ActorSystem.ActorID' does not conform to protocol 'SerializableButNotCodable'}}
+  takeCodable(actor: DAG_ActorSystem_ActorID_Custom<ActorSystem>(actorSystem: actorSystem))
+}
+
+func test_DAG_ActorSystem_ActorID_Custom<ActorSystem>(actorSystem: ActorSystem)
+    where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
+          ActorSystem.ActorID: SerializableButNotCodable {
+  // expected-error@+2{{global function 'takeCodable(actor:)' requires that 'DAG_ActorSystem_ActorID_Custom<ActorSystem>' conform to 'Decodable'}}
+  // expected-error@+1{{global function 'takeCodable(actor:)' requires that 'DAG_ActorSystem_ActorID_Custom<ActorSystem>' conform to 'Encodable'}}
+  takeCodable(actor: DAG_ActorSystem_ActorID_Custom<ActorSystem>(actorSystem: actorSystem))
+}
+
+distributed actor DAG_ActorSystem_ActorID_SerializableButNotCodable_Explicitly<ActorSystem>: SerializableButNotCodable
+  where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
+  ActorSystem.ActorID: SerializableButNotCodable {
+}
+func test_DAG_ActorSystem_ActorID_SerializableButNotCodable_Explicitly<ActorSystem>(actorSystem: ActorSystem)
+    where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
+          ActorSystem.ActorID: SerializableButNotCodable {
+  takeSerializableButNotCodable(actor: DAG_ActorSystem_ActorID_SerializableButNotCodable_Explicitly<ActorSystem>(actorSystem: actorSystem))
 }

--- a/test/Distributed/distributed_actor_implicit_codable.swift
+++ b/test/Distributed/distributed_actor_implicit_codable.swift
@@ -7,10 +7,6 @@
 import Distributed
 import FakeDistributedActorSystems
 
-
-// FIXME: handle this; don't add the typealias
-// typealias DefaultDistributedActorSystem = FakeActorSystem
-
 func takeCodable<A: Codable>(actor: A) {}
 // expected-note@-1{{where 'A' = 'DAG<FakeActorSystem>'}}
 // expected-note@-2{{where 'A' = 'DAG<FakeActorSystem>'}}
@@ -21,10 +17,15 @@ func takeCodable<A: Codable>(actor: A) {}
 // expected-note@-7{{where 'A' = 'DAG_ActorSystem_ActorID<FakeActorSystem>'}}
 // expected-note@-8{{where 'A' = 'DAG_ID<FakeActorSystem>'}}
 
-// ==== ------------------------------------------------------------------------
+// ==== Actors -----------------------------------------------------------------
 
 distributed actor DA {
   typealias ActorSystem = FakeActorSystem
+}
+
+distributed actor DAG_ActorSystem_ActorID_SerializableButNotCodable_Explicitly<ActorSystem>: SerializableButNotCodable
+  where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
+  ActorSystem.ActorID: SerializableButNotCodable {
 }
 
 func test_DA(actorSystem: FakeActorSystem) {
@@ -92,10 +93,6 @@ func test_DAG_ActorSystem_ActorID_Custom<ActorSystem>(actorSystem: ActorSystem)
   takeCodable(actor: DAG_ActorSystem_ActorID_Custom<ActorSystem>(actorSystem: actorSystem))
 }
 
-distributed actor DAG_ActorSystem_ActorID_SerializableButNotCodable_Explicitly<ActorSystem>: SerializableButNotCodable
-  where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
-  ActorSystem.ActorID: SerializableButNotCodable {
-}
 func test_DAG_ActorSystem_ActorID_SerializableButNotCodable_Explicitly<ActorSystem>(actorSystem: ActorSystem)
     where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
           ActorSystem.ActorID: SerializableButNotCodable {

--- a/test/Distributed/distributed_actor_implicit_codable_default_actor_system_conflict.swift
+++ b/test/Distributed/distributed_actor_implicit_codable_default_actor_system_conflict.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -enable-experimental-distributed -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+protocol SerializableButNotCodable {}
+func takeSerializableButNotCodable<A: SerializableButNotCodable>(actor: A) {}
+
+// ==== ------------------------------------------------------------------------
+
+distributed actor DAG_ActorSystem_ActorID_SerializableButNotCodable_Explicitly<ActorSystem>: SerializableButNotCodable
+  where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
+        ActorSystem.ActorID: SerializableButNotCodable {
+}
+
+func test_DAG_ActorSystem_ActorID_SerializableButNotCodable_Explicitly<ActorSystem>(actorSystem: ActorSystem)
+    where ActorSystem: DistributedActorSystem<any SerializableButNotCodable>,
+          ActorSystem.ActorID: SerializableButNotCodable {
+  takeSerializableButNotCodable(actor: DAG_ActorSystem_ActorID_SerializableButNotCodable_Explicitly<ActorSystem>(actorSystem: actorSystem))
+}


### PR DESCRIPTION
This builds on top of https://github.com/apple/swift/pull/71435

And adds the last commit which cleans up our "implicit codable" logic.
I think this is probably good enough tbh -- see test cases @xedin 

The commit: https://github.com/apple/swift/pull/71467/commits/5f669bb611dc63dcefcd4726813d34fdfca04960