### PR TITLE
[BitwiseCopyable] Require conformance in same module as declaration.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7629,6 +7629,9 @@ NOTE(add_nominal_bitwise_copyable_conformance,none,
 NOTE(add_generic_parameter_non_bitwise_copyable_conformance,none,
      "consider making generic parameter %0 conform to the 'BitwiseCopyable' protocol",
      (Type))
+ERROR(bitwise_copyable_outside_module,none,
+      "conformance to 'BitwiseCopyable' must occur in the same module as %kind0",
+      (const ValueDecl *))
 
 // -- older ones below --
 

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -373,6 +373,13 @@ bool swift::checkBitwiseCopyableConformance(ProtocolConformance *conformance,
       return false;
   }
 
+  // BitwiseCopyable must be added in the same source file.
+  auto conformanceDecl = conformanceDC->getAsDecl();
+  if (conformanceDecl->getModuleContext() != nominal->getModuleContext()) {
+    conformanceDecl->diagnose(diag::bitwise_copyable_outside_module, nominal);
+    return true;
+  }
+
   auto check = isImplicit ? BitwiseCopyableCheck::Implicit
                           : BitwiseCopyableCheck::Explicit;
 

--- a/test/Sema/bitwise_copyable_resilience.swift
+++ b/test/Sema/bitwise_copyable_resilience.swift
@@ -27,6 +27,10 @@ case somebody(T)
 case noone
 }
 
+public struct Integer {
+  var value: Int
+}
+
 //--- Downstream.swift
 import Library
 
@@ -47,3 +51,4 @@ struct S_Explicit_With_Woopsional<T> : _BitwiseCopyable {
 func passWoopsional<T>(_ t: Woopsional<T>) { take(t) } // expected-error    {{type_does_not_conform_decl_owner}}
                                                        // expected-note@-15 {{where_requirement_failure_one_subst}}
 
+extension Integer : @retroactive _BitwiseCopyable {} // expected-error {{bitwise_copyable_outside_module}}


### PR DESCRIPTION
Don't allow conformances to `BitwiseCopyable` to be declared in other modules.
