### PR TITLE
Fix grouped actor errors for preconcurrency

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -254,10 +254,12 @@ struct IsolationError {
 
   SourceLoc loc;
 
+  bool preconcurrency;
+  
   Diagnostic diag;
 
 public:
-  IsolationError(SourceLoc loc, Diagnostic diag) : loc(loc), diag(diag) {}
+  IsolationError(SourceLoc loc, bool preconcurrency, Diagnostic diag) : loc(loc), preconcurrency(preconcurrency), diag(diag) {}
 
 };
 


### PR DESCRIPTION
The experimental feature that groups actor isolation errors should downgrade to a warning if `@preconcurrency` attribute is applied.
