### PR TITLE
Remove special case for stdlib in IsNonUserModuleRequest

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3906,10 +3906,6 @@ FrontendStatsTracer::getTraceFormatter<const SourceFile *>() {
 }
 
 bool IsNonUserModuleRequest::evaluate(Evaluator &evaluator, ModuleDecl *mod) const {
-  // stdlib is non-user by definition
-  if (mod->isStdlibModule())
-    return true;
-  
   // If there's no SDK path, fallback to checking whether the module was
   // in the system search path or a clang system module
   SearchPathOptions &searchPathOpts = mod->getASTContext().SearchPathOpts;

--- a/test/IDE/complete_diagnostics.swift
+++ b/test/IDE/complete_diagnostics.swift
@@ -77,7 +77,7 @@ import MyModule
 import #^IMPORT^#;
 // IMPORT-DAG: Decl[Module]/None/NotRecommended:   MyModule[#Module#]; name=MyModule; diagnostics=warning:module 'MyModule' is already imported{{$}}
 // IMPORT-DAG: Decl[Module]/None/NotRecommended:   OtherModule[#Module#]; name=OtherModule; diagnostics=note:module 'OtherModule' is already imported via another module import{{$}}
-// IMPORT-DAG: Decl[Module]/None/NotRecommended/IsSystem:   Swift[#Module#]; name=Swift; diagnostics=warning:module 'Swift' is already imported{{$}}
+// IMPORT-DAG: Decl[Module]/None/NotRecommended:   Swift[#Module#]; name=Swift; diagnostics=warning:module 'Swift' is already imported{{$}}
 
 func test(foo: Foo) {
   foo.#^MEMBER^#

--- a/test/SourceKit/CursorInfo/cursor_stdlib_local.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib_local.swift
@@ -1,0 +1,42 @@
+// This test ensures that we don't consider the stdlib as a system library if
+// it's a module that we're building outside of the resource path.
+
+//--- Swift.swift
+public enum E {
+  case a, b, c
+}
+
+//--- Client.swift
+func test(_ x: E) {
+  if case .a = x {}
+}
+
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %empty-directory(%t/modules)
+// RUN: %empty-directory(%t/modulecache)
+
+// RUN: %target-swift-frontend -emit-module -module-name Swift -parse-stdlib -swift-version 5 -enable-library-evolution -emit-module-interface-path %t/modules/Swift.swiftinterface -emit-module-source-info-path %t/modules/Swift.swiftsourceinfo %t/Swift.swift -o /dev/null
+
+// RUN: %sourcekitd-test -req=cursor -pos=10:16 %t/Client.swift -- -I %t/modules -module-cache-path %t/modulecache -target %target-triple %t/Client.swift | %FileCheck %s -check-prefix=CHECK1
+// CHECK1:      source.lang.swift.ref.enum ({{.*}}Swift.swift:5:13-5:14)
+// CHECK1-NEXT: E
+// CHECK1-NEXT: s:s1EO
+// CHECK1-NOT:  SYSTEM
+
+// RUN: %sourcekitd-test -req=cursor -pos=11:12 %t/Client.swift -- -I %t/modules -module-cache-path %t/modulecache -target %target-triple %t/Client.swift | %FileCheck %s -check-prefix=CHECK2
+// CHECK2:      source.lang.swift.ref.enumelement ({{.*}}Swift.swift:6:8-6:9)
+// CHECK2-NEXT: a
+// CHECK2-NEXT: s:s1EO1ayA2BmF
+// CHECK2-NOT:  SYSTEM
+
+// Now try again with a swiftmodule.
+
+// RUN: %empty-directory(%t/modules)
+// RUN: %empty-directory(%t/modulecache)
+
+// RUN: %target-swift-frontend -emit-module -module-name Swift -parse-stdlib -swift-version 5 -enable-library-evolution %t/Swift.swift -emit-module-path %t/modules/Swift.swiftmodule -emit-module-source-info-path %t/modules/Swift.swiftsourceinfo
+
+// RUN: %sourcekitd-test -req=cursor -pos=10:16 %t/Client.swift -- -I %t/modules -target %target-triple %t/Client.swift | %FileCheck %s -check-prefix=CHECK1
+// RUN: %sourcekitd-test -req=cursor -pos=11:12 %t/Client.swift -- -I %t/modules -target %target-triple %t/Client.swift | %FileCheck %s -check-prefix=CHECK2


### PR DESCRIPTION
It's possible this may be the main module, or a "local" dependency within the same project, and should be treated as a user module in such cases.