### PR TITLE
[BitwiseCopyable] Ban non-trivial C++ types.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7619,6 +7619,8 @@ ERROR(non_bitwise_copyable_type_noncopyable,none,
       "noncopyable type cannot conform to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_type_nonescapable,none,
       "nonescapable type cannot conform to 'BitwiseCopyable'", ())
+ERROR(non_bitwise_copyable_type_cxx_nontrivial,none,
+      "non-trivial C++ type cannot conform to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_type_member,none,
       "%select{stored property %2|associated value %2}1 of "
       "'BitwiseCopyable'-conforming %kind3 has non-bitwise-copyable type %0",

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -262,6 +262,14 @@ static bool checkBitwiseCopyableInstanceStorage(NominalTypeDecl *nominal,
     return true;
   }
 
+  auto *sd = dyn_cast<StructDecl>(nominal);
+  if (sd && sd->isCxxNonTrivial()) {
+    if (!isImplicit(check)) {
+      nominal->diagnose(diag::non_bitwise_copyable_type_cxx_nontrivial);
+    }
+    return true;
+  }
+
   BitwiseCopyableStorageVisitor visitor(nominal, dc, check);
 
   return visitor.visit(nominal, dc) || visitor.invalid;


### PR DESCRIPTION
Such types can't be copied bit-by-bit.
