### PR TITLE
[Concurrency] Synchronous witness of an async isolated requirement sh…

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3126,6 +3126,12 @@ ConformanceChecker::checkActorIsolation(ValueDecl *requirement,
       break;
     }
 
+    // Witnessing `async` requirement with an isolated synchronous
+    // declaration is done via async witness thunk which requires
+    // a hop to the expected concurrency domain.
+    if (isAsyncDecl(requirement) && !isAsyncDecl(witness))
+      return refResult.isolation;
+
     // Otherwise, we're done.
     return llvm::None;
 

--- a/test/Concurrency/issue62394.swift
+++ b/test/Concurrency/issue62394.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -disable-availability-checking -emit-silgen -verify -strict-concurrency=complete %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+
+@MainActor
+protocol P {
+  func test() async
+}
+
+struct S : P {
+  func test() {}
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s10issue623941SVAA1PA2aDP4testyyYaFTW : $@convention(witness_method: P) @async (@in_guaranteed S) -> ()
+// CHECK: [[MAIN_ACTOR:%.*]] = begin_borrow {{.*}} : $MainActor
+// CHECK-NEXT: hop_to_executor [[MAIN_ACTOR]] : $MainActor
+// CHECK: [[SELF:%.*]] = load [trivial] %0 : $*S
+// CHECK: [[TEST_FN:%.*]] = function_ref @$s10issue623941SV4testyyF : $@convention(method) (S) -> ()
+// CHECK-NEXT: {{.*}} = apply [[TEST_FN]]([[SELF]]) : $@convention(method) (S) -> ()


### PR DESCRIPTION
…ould hop

The witness thunk is async which means that it needs a hop to the expected concurrency domain imposed by the requirement otherwise it says in the caller's domain.

Resolves: https://github.com/apple/swift/issues/62394
Resolves: rdar://121415906

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
