### PR TITLE
[stdlib] Do a fast NFC check over the slice instead of guts

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1169,7 +1169,7 @@ extension _StringGutsSlice {
   }
 
   internal func _fastNFCCheck(_ isNFCQC: inout Bool, _ prevCCC: inout UInt8) {
-    _guts.withFastUTF8 { utf8 in
+    withFastUTF8 { utf8 in
       var position = 0
 
       while position < utf8.count {


### PR DESCRIPTION
When hashing strings/substrings, we do a fast nfc check over the slice to determine if we can skip normalization. Unfortunately this was asking the entire guts for its UTF8 buffer, instead of asking for its own UTF8 buffer. This caused us to iterate the entire base string instead of just searching the slice.

Resolves: rdar://122490088