### PR TITLE
Sema: Don't warn on @_exported public imports that are not used in API

### DIFF
--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2472,6 +2472,10 @@ void swift::diagnoseUnnecessaryPublicImports(SourceFile &SF) {
     if (importedModule->getTopLevelModule() != importedModule)
       continue;
 
+    // Ignore @_exported as by themselves the import is meaningful.
+    if (import.options.contains(ImportFlags::Exported))
+      continue;
+
     AccessLevel levelUsed = SF.getMaxAccessLevelUsingImport(importedModule);
     if (import.accessLevel <= levelUsed)
       continue;

--- a/test/ModuleInterface/imports-swift6.swift
+++ b/test/ModuleInterface/imports-swift6.swift
@@ -18,7 +18,7 @@
 //--- empty.swift
 
 //--- main.swift
-@_exported public import resilient // expected-warning {{public import of 'resilient' was not used in public declarations or inlinable code}}
+@_exported public import resilient
 public import B.B2 // expected-warning {{public import of 'B' was not used in public declarations or inlinable code}}
 
 public import func C.c // expected-warning {{public import of 'C' was not used in public declarations or inlinable code}}
@@ -40,7 +40,6 @@ public import NotSoSecret // expected-warning {{'NotSoSecret' inconsistently imp
 @_implementationOnly import NotSoSecret2 // expected-note {{imported as implementation-only here}}
 //--- clientWithError.swift
 @_exported public import nonResilient // expected-error {{module 'nonResilient' was not compiled with library evolution support; using it means binary compatibility for 'clientWithError' can't be guaranteed}}
-// expected-warning @-1 {{public import of 'nonResilient' was not used in public declarations or inlinable code}}
 
 // CHECK-6-NOT: import
 // CHECK-6: {{^}}public import A{{$}}

--- a/test/Sema/conflicting-import-restrictions.swift
+++ b/test/Sema/conflicting-import-restrictions.swift
@@ -49,11 +49,10 @@
 // RUN:   -experimental-spi-only-imports -verify
 
 //--- Public_Exported.swift
-@_exported public import Lib // expected-warning {{public import of 'Lib' was not used in public declarations or inlinable code}}
+@_exported public import Lib
 
 //--- Package_Exported.swift
 @_exported package import Lib // expected-error {{'@_exported' is incompatible with 'package'; it can only be applied to public imports}}
-// expected-warning @-1 {{package import of 'Lib' was not used in package declarations}}
 
 //--- Internal_Exported.swift
 @_exported internal import Lib // expected-error {{'@_exported' is incompatible with 'internal'; it can only be applied to public imports}}

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -159,4 +159,3 @@ public import FullyPrivateClang // expected-error{{private module 'FullyPrivateC
 public import LocalClang // expected-error{{private module 'LocalClang' is imported publicly from the public module 'MainLib'}}
 // expected-warning @-1 {{public import of 'LocalClang' was not used in public declarations or inlinable code}}
 @_exported public import MainLib // expected-warning{{private module 'MainLib' is imported publicly from the public module 'MainLib'}}
-// expected-warning @-1 {{public import of 'MainLib' was not used in public declarations or inlinable code}}

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -20,6 +20,7 @@
 // RUN: %target-swift-frontend -emit-module %t/UnusedPackageImport.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ImportNotUseFromAPI.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ImportUsedInPackage.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/ExportedUnused.swift -o %t -I %t
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
@@ -102,6 +103,8 @@ public func notAnAPIFunc() -> NotAnAPIType { return NotAnAPIType() }
 public struct PackageType {}
 public func packageFunc() -> PackageType { return PackageType() }
 
+//--- ExportedUnused.swift
+
 //--- Client_Swift5.swift
 /// No diagnostics should be raised on the implicit access level.
 import UnusedImport // expected-error {{ambiguous implicit access level for import of 'UnusedImport'; it is imported as 'public' elsewhere}}
@@ -132,6 +135,8 @@ package import UnusedImport // expected-warning {{package import of 'UnusedImpor
 package import UnusedPackageImport // expected-warning {{package import of 'UnusedPackageImport' was not used in package declarations}} {{1-9=}}
 public import ImportNotUseFromAPI // expected-warning {{public import of 'ImportNotUseFromAPI' was not used in public declarations or inlinable code}} {{1-8=}}
 public import ImportUsedInPackage // expected-warning {{public import of 'ImportUsedInPackage' was not used in public declarations or inlinable code}} {{1-7=package}}
+
+@_exported public import ExportedUnused
 
 public func useInSignature(_ a: TypeUsedInSignature) {} // expected-remark {{struct 'TypeUsedInSignature' is imported via 'DepUsedInSignature'}}
 public func exportedTypeUseInSignature(_ a: ExportedType) {} // expected-remark {{struct 'ExportedType' is imported via 'Exporter', which reexports definition from 'Exportee'}}

--- a/test/Sema/superfluously-public-imports.swift
+++ b/test/Sema/superfluously-public-imports.swift
@@ -21,10 +21,12 @@
 // RUN: %target-swift-frontend -emit-module %t/ImportNotUseFromAPI.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ImportUsedInPackage.swift -o %t -I %t
 // RUN: %target-swift-frontend -emit-module %t/ExportedUnused.swift -o %t -I %t
+// RUN: %target-swift-frontend -emit-module %t/SPIOnlyUsedInSPI.swift -o %t -I %t
 
 /// Check diagnostics.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -package-name pkg -Rmodule-api-import -swift-version 6 -verify
+// RUN:   -package-name pkg -Rmodule-api-import -swift-version 6 -verify \
+// RUN:   -experimental-spi-only-imports
 // RUN: %target-swift-frontend -typecheck %t/ClientOfClangModules.swift -I %t \
 // RUN:   -package-name pkg -Rmodule-api-import -swift-version 6 -verify
 // RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
@@ -105,6 +107,9 @@ public func packageFunc() -> PackageType { return PackageType() }
 
 //--- ExportedUnused.swift
 
+//--- SPIOnlyUsedInSPI.swift
+public struct ToUseFromSPI {}
+
 //--- Client_Swift5.swift
 /// No diagnostics should be raised on the implicit access level.
 import UnusedImport // expected-error {{ambiguous implicit access level for import of 'UnusedImport'; it is imported as 'public' elsewhere}}
@@ -137,6 +142,7 @@ public import ImportNotUseFromAPI // expected-warning {{public import of 'Import
 public import ImportUsedInPackage // expected-warning {{public import of 'ImportUsedInPackage' was not used in public declarations or inlinable code}} {{1-7=package}}
 
 @_exported public import ExportedUnused
+@_spiOnly public import SPIOnlyUsedInSPI
 
 public func useInSignature(_ a: TypeUsedInSignature) {} // expected-remark {{struct 'TypeUsedInSignature' is imported via 'DepUsedInSignature'}}
 public func exportedTypeUseInSignature(_ a: ExportedType) {} // expected-remark {{struct 'ExportedType' is imported via 'Exporter', which reexports definition from 'Exportee'}}
@@ -218,6 +224,9 @@ func implicitlyInternalFunc(a: NotAnAPIType = notAnAPIFunc()) {}
 
 // For package decls we only remark on types used in signatures, not for inlinable code.
 package func packageFunc(a: PackageType = packageFunc()) {} // expected-remark {{struct 'PackageType' is imported via 'ImportUsedInPackage'}}
+
+@_spi(X)
+public func spiFunc(a: ToUseFromSPI) {} // expected-remark {{struct 'ToUseFromSPI' is imported via 'SPIOnlyUsedInSPI'}}
 
 /// Tests for imports of clang modules.
 //--- module.modulemap


### PR DESCRIPTION
An `@_export public import` is meaningful on its own as it declares a relationship between two modules and how clients see them. As such that import doesn't have to be referenced from API to be appropriate. Let's not report public import with an `@_export` attribute as being superfluous.

Also test the behavior of the same diagnostics with `@_spiOnly` imports without related logic changes.

rdar://122032960