### PR TITLE
[BitwiseCopyable] Verify only within module.

### DIFF
--- a/test/IRGen/bitwise_copyable.swift
+++ b/test/IRGen/bitwise_copyable.swift
@@ -6,9 +6,11 @@
 // RUN:     -enable-builtin-module
 
 // REQUIRES: asserts
+// REQUIRES: objc_interop
 
 // Force verification of TypeLowering's isTrivial.
 
+import Foundation
 import Builtin
 
 struct Box<T : _BitwiseCopyable> : _BitwiseCopyable {
@@ -32,3 +34,7 @@ func nameBuiltinBridgeObject(_ b: Builtin.BridgeObject) {}
 func nameBuiltinUnsafeValueBuffer(_ b: Builtin.UnsafeValueBuffer) {}
 func nameBuiltinDefaultActorStorage(_ b: Builtin.DefaultActorStorage) {}
 func nameBuiltinNonDefaultDistributedActorStorage(_ b: Builtin.NonDefaultDistributedActorStorage) {}
+
+struct MyObjCBool {
+  var value: ObjCBool
+}


### PR DESCRIPTION
Don't verify lowering in modules built from swiftinterface (which may not have been built with `-enable-experimental-feature BitwiseCopyable`)

Allow trivial types defined in other modules to lack conformance because those modules may not have been built with the feature enabled.
