### PR TITLE
[Distributed] Handle DA declared inside a generic type

### DIFF
--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -355,7 +355,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
             C, recordGenericSubstitutionDecl->getName());
 
     for (auto genParamType : genEnv->getGenericParams()) {
-      auto tyExpr = TypeExpr::createImplicit(thunk->mapTypeIntoContext(genParamType), C);
+      auto tyExpr = TypeExpr::createImplicit(genEnv->mapTypeIntoContext(genParamType), C);
       auto subTypeExpr = new (C) DotSelfExpr(
           tyExpr,
           sloc, sloc, tyExpr->getType());

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -346,7 +346,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
 
   // --- Recording invocation details
   // -- recordGenericSubstitution(s)
-  if (thunk->isGeneric() || nominal->isGeneric()) {
+  if (auto genEnv = thunk->getGenericEnvironment()) {
     auto recordGenericSubstitutionDecl =
         C.getRecordGenericSubstitutionOnDistributedInvocationEncoder(invocationEncoderDecl);
     assert(recordGenericSubstitutionDecl);
@@ -354,9 +354,7 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
         UnresolvedDeclRefExpr::createImplicit(
             C, recordGenericSubstitutionDecl->getName());
 
-    auto signature = thunk->getGenericSignature();
-    for (auto genParamType : signature.getGenericParams()) {
-
+    for (auto genParamType : genEnv->getGenericParams()) {
       auto tyExpr = TypeExpr::createImplicit(thunk->mapTypeIntoContext(genParamType), C);
       auto subTypeExpr = new (C) DotSelfExpr(
           tyExpr,

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_da_in_generic_type.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_da_in_generic_type.swift
@@ -1,0 +1,69 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main  -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// UNSUPPORTED: OS=windows-msvc
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+struct Outer: Sendable, Codable {
+  distributed actor Greeter<Element> where Element: Sendable & Codable {
+    distributed func hello() -> String {
+      return "Hello, \(Element.self)!"
+    }
+  }
+}
+
+struct OuterGeneric<Element>: Sendable, Codable where Element: Sendable & Codable {
+  distributed actor Greeter {
+    distributed func hello() -> String {
+      return "Hello, \(Element.self)!"
+    }
+  }
+}
+
+func test() async throws {
+  let system = DefaultDistributedActorSystem()
+
+  do {
+    let local = Outer.Greeter<String>(actorSystem: system)
+    let ref = try Outer.Greeter<String>.resolve(id: local.id, using: system)
+    let response = try await ref.hello()
+    // CHECK: > encode generic sub: Swift.String
+    // CHECK: >> remoteCall: on:main.Outer.Greeter<Swift.String>, target:Greeter.hello(), invocation:FakeInvocationEncoder(genericSubs: [Swift.String], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    print("response 1: \(response)")
+    // CHECK: response 1: Hello, String!
+  }
+
+  do {
+    let local = OuterGeneric<String>.Greeter(actorSystem: system)
+    let ref = try OuterGeneric<String>.Greeter.resolve(id: local.id, using: system)
+    let response = try await ref.hello()
+    // CHECK: > encode generic sub: Swift.String
+    // CHECK: >> remoteCall: on:main.OuterGeneric<Swift.String>.Greeter, target:Greeter.hello(), invocation:FakeInvocationEncoder(genericSubs: [Swift.String], arguments: [], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    print("response 2: \(response)")
+    // CHECK: response 2: Hello, String!
+  }
+
+
+
+}
+
+@main struct Main {
+  static func main() async {
+    try! await test()
+  }
+}


### PR DESCRIPTION
We were not considering the outer scope when forwarding generic substitutions.

Such nesting would not get the generic sub on the distributed call recorded, and thus the call would not be able to be executed on the remote peer:

```swift
struct OuterGeneric<Element>: Sendable, Codable where Element: Sendable & Codable {
  distributed actor Greeter {
    distributed func hello() -> String {
    }
  }
}
```

Resolves rdar://122596546
