### PR TITLE
[Associated type inference] Limit `Failure` inference to rethrows next()

### DIFF
--- a/test/Concurrency/async_iterator_inference.swift
+++ b/test/Concurrency/async_iterator_inference.swift
@@ -22,6 +22,18 @@ struct TS: AsyncSequence {
 }
 
 @available(SwiftStdlib 5.1, *)
+struct SpecificTS<F: Error>: AsyncSequence {
+  typealias Element = Int
+  typealias Failure = F
+  struct AsyncIterator: AsyncIteratorProtocol {
+    typealias Failure = F
+    mutating func next() async throws -> Int? { nil }
+  }
+
+  func makeAsyncIterator() -> AsyncIterator { AsyncIterator() }
+}
+
+@available(SwiftStdlib 5.1, *)
 struct GenericTS<Failure: Error>: AsyncSequence {
   typealias Element = Int
   struct AsyncIterator: AsyncIteratorProtocol {
@@ -42,16 +54,33 @@ struct SequenceAdapter<Base: AsyncSequence>: AsyncSequence {
   func makeAsyncIterator() -> AsyncIterator { AsyncIterator() }
 }
 
+public struct NormalThrowingAsyncSequence<Element, Failure>: AsyncSequence {
+  private let iteratorMaker: () -> AsyncIterator
+
+  public struct AsyncIterator: AsyncIteratorProtocol {
+    let nextMaker: () async throws -> Element?
+    public mutating func next() async throws -> Element? {
+      try await nextMaker()
+    }
+  }
+
+  public func makeAsyncIterator() -> AsyncIterator {
+    iteratorMaker()
+  }
+}
+
+
 enum MyError: Error {
 case fail
 }
 
 @available(SwiftStdlib 5.1, *)
-func testAssocTypeInference(sf: S.Failure, tsf: TS.Failure, gtsf1: GenericTS<MyError>.Failure, adapter: SequenceAdapter<GenericTS<MyError>>.Failure) {
+func testAssocTypeInference(sf: S.Failure, tsf: TS.Failure, gtsf1: GenericTS<MyError>.Failure, adapter: SequenceAdapter<SpecificTS<MyError>>.Failure, ntas: NormalThrowingAsyncSequence<String, MyError>.Failure) {
   let _: Int = sf // expected-error{{cannot convert value of type 'S.Failure' (aka 'Never') to specified type 'Int'}}
   let _: Int = tsf // expected-error{{cannot convert value of type 'TS.Failure' (aka 'any Error') to specified type 'Int'}}
-  let _: Int = gtsf1 // expected-error{{cannot convert value of type 'GenericTS<MyError>.Failure' (aka 'MyError') to specified type 'Int'}}
-  let _: Int = adapter // expected-error{{cannot convert value of type 'SequenceAdapter<GenericTS<MyError>>.Failure' (aka 'MyError') to specified type 'Int'}}
+  let _: Int = gtsf1 // expected-error{{cannot convert value of type 'GenericTS<MyError>.Failure' (aka 'any Error') to specified type 'Int'}}
+  let _: Int = adapter // expected-error{{cannot convert value of type 'SequenceAdapter<SpecificTS<MyError>>.Failure' (aka 'MyError') to specified type 'Int'}}
+  let _: Int = ntas // expected-error{{cannot convert value of type 'NormalThrowingAsyncSequence<String, MyError>.Failure' (aka 'any Error') to specified type 'Int'}}
 }
 
 
@@ -66,9 +95,9 @@ case boom
 
 
 @available(SwiftStdlib 5.1, *)
-func testMyError(s: GenericTS<MyError>, so: GenericTS<OtherError>) async throws(MyError) {
+func testMyError(s: SpecificTS<MyError>, so: SpecificTS<OtherError>) async throws(MyError) {
   for try await x in s { _ = x }
 
   for try await x in so { _ = x }
-  // expected-error@-1{{thrown expression type 'OtherError' cannot be converted to error type 'MyError'}}
+  // expected-error@-1{{thrown expression type 'SpecificTS<OtherError>.AsyncIterator.Failure' (aka 'OtherError') cannot be converted to error type 'MyError'}}
 }


### PR DESCRIPTION
When inferring a type witness for `AsyncIteratorProtocol` or `AsyncSequence`'s `Failure` associated type, don't infer from a generic parameter named `Failure`. Instead, use `next()` as a cue: if it `rethrows`, use `Failure` from one of the conformances; if it `throws`, use `any Error`. This is a more conservative inference rule, and addresses a failure to infer a `Failure` type witness for some fairly-obvious cases.

Fixes rdar://122514816.
