### PR TITLE
Infer availability for typealiases for inferred type witness

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -298,6 +298,12 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
       aliasDecl->getAttrs().add(attr);
     }
 
+    // Construct the availability of the type witnesses based on the
+    // availability of the enclosing type and the associated type.
+    const Decl * availabilitySources[2] = {dc->getAsDecl(), assocType };
+    AvailabilityInference::applyInferredAvailableAttrs(
+        aliasDecl, availabilitySources, ctx);
+
     if (nominal == dc) {
       nominal->addMember(aliasDecl);
     } else {

--- a/test/ModuleInterface/async_sequence_conformance.swift
+++ b/test/ModuleInterface/async_sequence_conformance.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name conformances
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name conformances
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// REQUIRES: concurrency, OS=macosx
+
+// CHECK: @available(
+// CHECK-NEXT: public struct SequenceAdapte
+@available(SwiftStdlib 5.1, *)
+public struct SequenceAdapter<Base: AsyncSequence>: AsyncSequence {
+  // CHECK-LABEL: public struct AsyncIterator
+  // CHECK: @available{{.*}}macOS 10.15
+  // CHECK-NEXT: public typealias Element = Base.Element
+  // CHECK: @available(
+  // CHECK-NEXT: public typealias Failure = Base.Failure
+  public typealias Element = Base.Element
+
+  public struct AsyncIterator: AsyncIteratorProtocol {
+    public mutating func next() async rethrows -> Base.Element? { nil }
+  }
+
+  // CHECK-LABEL: public func makeAsyncIterator
+  public func makeAsyncIterator() -> AsyncIterator { AsyncIterator() }
+
+  // CHECK: @available(
+  // CHECK-NEXT: public typealias Failure = Base.Failure
+}


### PR DESCRIPTION
Now that associated types can have availability, make sure that we infer availability attributes for any inferred type witnesses of said associated types based on both the enclosing context and the associated type itself. This eliminates failures in the emitted Swift interfaces.

Fixes rdar://122596219.
