### PR TITLE
[Caching] Use subInvocation to verify interface

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -27,6 +27,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/CASOptions.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/Located.h"
 #include "swift/Basic/Malloc.h"
@@ -239,10 +240,9 @@ class ASTContext final {
       LangOptions &langOpts, TypeCheckerOptions &typecheckOpts,
       SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
       ClangImporterOptions &ClangImporterOpts,
-      symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
+      symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
       SourceManager &SourceMgr, DiagnosticEngine &Diags,
-      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr
-      );
+      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr);
 
 public:
   // Members that should only be used by ASTContext.cpp.
@@ -257,10 +257,9 @@ public:
   get(LangOptions &langOpts, TypeCheckerOptions &typecheckOpts,
       SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
       ClangImporterOptions &ClangImporterOpts,
-      symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
+      symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
       SourceManager &SourceMgr, DiagnosticEngine &Diags,
-      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr
-      );
+      llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend = nullptr);
   ~ASTContext();
 
   /// Optional table of counters to report, nullptr when not collecting.
@@ -286,6 +285,9 @@ public:
 
   /// The symbol graph generation options used by this AST context.
   symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts;
+
+  /// The CAS options used by this AST context.
+  const CASOptions &CASOpts;
 
   /// The source manager object.
   SourceManager &SourceMgr;

--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -1,0 +1,65 @@
+//===--- CASOptions.h - CAS & caching options -------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the CASOptions class, which provides various
+//  CAS and caching flags.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_CASOPTIONS_H
+#define SWIFT_BASIC_CASOPTIONS_H
+
+#include "clang/CAS/CASOptions.h"
+
+namespace swift {
+
+class CASOptions final {
+public:
+  /// Enable compiler caching.
+  bool EnableCaching = false;
+
+  /// Enable compiler caching remarks.
+  bool EnableCachingRemarks = false;
+
+  /// Skip replaying outputs from cache.
+  bool CacheSkipReplay = false;
+
+  /// CASOptions
+  clang::CASOptions CASOpts;
+
+  /// CASFS Root.
+  std::vector<std::string> CASFSRootIDs;
+
+  /// Clang Include Trees.
+  std::vector<std::string> ClangIncludeTrees;
+
+  /// CacheKey for input file.
+  std::string InputFileKey;
+
+  /// Cache key for imported bridging header.
+  std::string BridgingHeaderPCHCacheKey;
+
+  /// Get the CAS configuration flags.
+  void enumerateCASConfigurationFlags(
+      llvm::function_ref<void(llvm::StringRef)> Callback) const;
+
+  /// Check to see if a CASFileSystem is required.
+  bool requireCASFS() const {
+    return EnableCaching &&
+           (!CASFSRootIDs.empty() || !ClangIncludeTrees.empty() ||
+            !InputFileKey.empty() || !BridgingHeaderPCHCacheKey.empty());
+  }
+};
+
+} // namespace swift
+
+#endif // SWIFT_BASIC_CASOPTIONS_H

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -884,12 +884,6 @@ namespace swift {
     /// import, but it can affect Clang's IR generation of static functions.
     std::string Optimization;
 
-    /// clang CASOptions.
-    llvm::Optional<clang::CASOptions> CASOpts;
-
-    /// Cache key for imported bridging header.
-    std::string BridgingHeaderPCHCacheKey;
-
     /// Disable validating the persistent PCH.
     bool PCHDisableValidation = false;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -26,6 +26,7 @@
 #include "swift/AST/SILOptions.h"
 #include "swift/AST/SearchPathOptions.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/Basic/CASOptions.h"
 #include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Basic/SourceManager.h"
@@ -102,6 +103,7 @@ class CompilerInvocation {
   IRGenOptions IRGenOpts;
   TBDGenOptions TBDGenOpts;
   ModuleInterfaceOptions ModuleInterfaceOpts;
+  CASOptions CASOpts;
   llvm::MemoryBuffer *IDEInspectionTargetBuffer = nullptr;
 
   /// The offset that IDEInspection wants to further examine in offset of bytes
@@ -166,7 +168,7 @@ public:
   }
 
   bool requiresCAS() const {
-    return FrontendOpts.EnableCaching || FrontendOpts.UseCASBackend;
+    return CASOpts.EnableCaching || IRGenOpts.UseCASBackend;
   }
 
   void setClangModuleCachePath(StringRef Path) {
@@ -273,6 +275,9 @@ public:
 
   FrontendOptions &getFrontendOptions() { return FrontendOpts; }
   const FrontendOptions &getFrontendOptions() const { return FrontendOpts; }
+
+  CASOptions &getCASOptions() { return CASOpts; }
+  const CASOptions &getCASOptions() const { return CASOpts; }
 
   TBDGenOptions &getTBDGenOptions() { return TBDGenOpts; }
   const TBDGenOptions &getTBDGenOptions() const { return TBDGenOpts; }

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -129,33 +129,6 @@ public:
   /// The module for which we should verify all of the generic signatures.
   std::string VerifyGenericSignaturesInModule;
 
-  /// Enable compiler caching.
-  bool EnableCaching = false;
-
-  /// Enable compiler caching remarks.
-  bool EnableCachingRemarks = false;
-
-  /// Skip replaying outputs from cache.
-  bool CacheSkipReplay = false;
-
-  /// CASOptions
-  clang::CASOptions CASOpts;
-
-  /// CASFS Root.
-  std::vector<std::string> CASFSRootIDs;
-
-  /// Clang Include Trees.
-  std::vector<std::string> ClangIncludeTrees;
-
-  /// CacheKey for input file.
-  std::string InputFileKey;
-
-  /// Enable using the LLVM MCCAS backend for object file output.
-  bool UseCASBackend = false;
-
-  /// The output mode for the CAS Backend.
-  llvm::CASBackendMode CASObjMode;
-
   /// Emit a .casid file next to the object file if CAS Backend is used.
   bool EmitCASIDFile = false;
 

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -596,12 +596,12 @@ public:
   static bool buildSwiftModuleFromSwiftInterface(
       SourceManager &SourceMgr, DiagnosticEngine &Diags,
       const SearchPathOptions &SearchPathOpts, const LangOptions &LangOpts,
-      const ClangImporterOptions &ClangOpts, StringRef CacheDir,
-      StringRef PrebuiltCacheDir, StringRef BackupInterfaceDir,
-      StringRef ModuleName, StringRef InPath,
+      const ClangImporterOptions &ClangOpts, const CASOptions &CASOpts,
+      StringRef CacheDir, StringRef PrebuiltCacheDir,
+      StringRef BackupInterfaceDir, StringRef ModuleName, StringRef InPath,
       StringRef OutPath, StringRef ABIOutputPath,
-      bool SerializeDependencyHashes,
-      bool TrackSystemDependencies, ModuleInterfaceLoaderOptions Opts,
+      bool SerializeDependencyHashes, bool TrackSystemDependencies,
+      ModuleInterfaceLoaderOptions Opts,
       RequireOSSAModules_t RequireOSSAModules,
       RequireNoncopyableGenerics_t RequireNCGenerics,
       bool silenceInterfaceDiagnostics);
@@ -657,6 +657,7 @@ private:
   inheritOptionsForBuildingInterface(const SearchPathOptions &SearchPathOpts,
                                      const LangOptions &LangOpts,
                                      const ClangImporterOptions &clangImporterOpts,
+                                     const CASOptions &casOpts,
                                      bool suppressRemarks,
                                      RequireOSSAModules_t requireOSSAModules,
                                      RequireNoncopyableGenerics_t requireNCGenerics);
@@ -668,12 +669,11 @@ public:
   InterfaceSubContextDelegateImpl(
       SourceManager &SM, DiagnosticEngine *Diags,
       const SearchPathOptions &searchPathOpts, const LangOptions &langOpts,
-      const ClangImporterOptions &clangImporterOpts,
+      const ClangImporterOptions &clangImporterOpts, const CASOptions &casOpts,
       ModuleInterfaceLoaderOptions LoaderOpts, bool buildModuleCacheDirIfAbsent,
       StringRef moduleCachePath, StringRef prebuiltCachePath,
-      StringRef backupModuleInterfaceDir,
-      bool serializeDependencyHashes, bool trackSystemDependencies,
-      RequireOSSAModules_t requireOSSAModules,
+      StringRef backupModuleInterfaceDir, bool serializeDependencyHashes,
+      bool trackSystemDependencies, RequireOSSAModules_t requireOSSAModules,
       RequireNoncopyableGenerics_t requireNCGenerics);
 
   template<typename ...ArgTypes>

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -677,7 +677,7 @@ ASTContext *ASTContext::get(
     LangOptions &langOpts, TypeCheckerOptions &typecheckOpts,
     SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
     ClangImporterOptions &ClangImporterOpts,
-    symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
+    symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
     SourceManager &SourceMgr, DiagnosticEngine &Diags,
     llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutputBackend) {
   // If more than two data structures are concatentated, then the aggregate
@@ -692,7 +692,7 @@ ASTContext *ASTContext::get(
   new (impl) Implementation();
   return new (mem)
       ASTContext(langOpts, typecheckOpts, silOpts, SearchPathOpts,
-                 ClangImporterOpts, SymbolGraphOpts, SourceMgr, Diags,
+                 ClangImporterOpts, SymbolGraphOpts, casOpts, SourceMgr, Diags,
                  std::move(OutputBackend));
 }
 
@@ -700,15 +700,14 @@ ASTContext::ASTContext(
     LangOptions &langOpts, TypeCheckerOptions &typecheckOpts,
     SILOptions &silOpts, SearchPathOptions &SearchPathOpts,
     ClangImporterOptions &ClangImporterOpts,
-    symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts,
+    symbolgraphgen::SymbolGraphOptions &SymbolGraphOpts, CASOptions &casOpts,
     SourceManager &SourceMgr, DiagnosticEngine &Diags,
-    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend
-    )
+    llvm::IntrusiveRefCntPtr<llvm::vfs::OutputBackend> OutBackend)
     : LangOpts(langOpts), TypeCheckerOpts(typecheckOpts), SILOpts(silOpts),
       SearchPathOpts(SearchPathOpts), ClangImporterOpts(ClangImporterOpts),
-      SymbolGraphOpts(SymbolGraphOpts), SourceMgr(SourceMgr), Diags(Diags),
-      OutputBackend(std::move(OutBackend)), evaluator(Diags, langOpts),
-      TheBuiltinModule(createBuiltinModule(*this)),
+      SymbolGraphOpts(SymbolGraphOpts), CASOpts(casOpts), SourceMgr(SourceMgr),
+      Diags(Diags), OutputBackend(std::move(OutBackend)),
+      evaluator(Diags, langOpts), TheBuiltinModule(createBuiltinModule(*this)),
       StdlibModuleName(getIdentifier(STDLIB_NAME)),
       SwiftShimsModuleName(getIdentifier(SWIFT_SHIMS_NAME)),
       TheErrorType(new (*this, AllocationArena::Permanent) ErrorType(

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -480,12 +480,12 @@ SwiftDependencyTracker::createTreeFromDependencies() {
 
 bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
     CompilerInstance &Instance) {
-  if (!Instance.getInvocation().getFrontendOptions().EnableCaching)
+  if (!Instance.getInvocation().getCASOptions().EnableCaching)
     return false;
 
   if (CASOpts) {
     // If CASOption matches, the service is initialized already.
-    if (*CASOpts == Instance.getInvocation().getFrontendOptions().CASOpts)
+    if (*CASOpts == Instance.getInvocation().getCASOptions().CASOpts)
       return false;
 
     // CASOption mismatch, return error.
@@ -496,7 +496,7 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   }
 
   // Setup CAS.
-  CASOpts = Instance.getInvocation().getFrontendOptions().CASOpts;
+  CASOpts = Instance.getInvocation().getCASOptions().CASOpts;
   CAS = Instance.getSharedCASInstance();
 
   // Add SDKSetting file.
@@ -552,7 +552,7 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
   ClangScanningService.emplace(
       clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
       ClangScanningFormat,
-      Instance.getInvocation().getFrontendOptions().CASOpts,
+      Instance.getInvocation().getCASOptions().CASOpts,
       Instance.getSharedCASInstance(), Instance.getSharedCacheInstance(),
       UseClangIncludeTree ? nullptr : CacheFS);
 

--- a/lib/Basic/CASOptions.cpp
+++ b/lib/Basic/CASOptions.cpp
@@ -1,0 +1,39 @@
+//===--- CASOptions.cpp - CAS & caching options ---------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the CASOptions class, which provides various
+//  CAS and caching flags.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/CASOptions.h"
+
+using namespace swift;
+
+void CASOptions::enumerateCASConfigurationFlags(
+      llvm::function_ref<void(llvm::StringRef)> Callback) const {
+  if (EnableCaching) {
+    Callback("-cache-compile-job");
+    if (!CASOpts.CASPath.empty()) {
+      Callback("-cas-path");
+      Callback(CASOpts.CASPath);
+    }
+    if (!CASOpts.PluginPath.empty()) {
+      Callback("-cas-plugin-path");
+      Callback(CASOpts.PluginPath);
+      for (auto Opt : CASOpts.PluginOptions) {
+        Callback("-cas-plugin-option");
+        Callback((llvm::Twine(Opt.first) + "=" + Opt.second).str());
+      }
+    }
+  }
+}

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -45,6 +45,7 @@ add_swift_host_library(swiftBasic STATIC
   BasicBridging.cpp
   BasicSourceInfo.cpp
   Cache.cpp
+  CASOptions.cpp
   ClusteredBitVector.cpp
   DiverseStack.cpp
   Edit.cpp

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -716,21 +716,22 @@ importer::getNormalInvocationArguments(
                                llvm::sys::path::get_separator() +
                                "apinotes").str());
 
-  if (importerOpts.CASOpts) {
+  auto CASOpts = ctx.CASOpts;
+  if (CASOpts.EnableCaching) {
     invocationArgStrs.push_back("-Xclang");
     invocationArgStrs.push_back("-fno-pch-timestamp");
-    if (!importerOpts.CASOpts->CASPath.empty()) {
+    if (!CASOpts.CASOpts.CASPath.empty()) {
       invocationArgStrs.push_back("-Xclang");
       invocationArgStrs.push_back("-fcas-path");
       invocationArgStrs.push_back("-Xclang");
-      invocationArgStrs.push_back(importerOpts.CASOpts->CASPath);
+      invocationArgStrs.push_back(CASOpts.CASOpts.CASPath);
     }
-    if (!importerOpts.CASOpts->PluginPath.empty()) {
+    if (!CASOpts.CASOpts.PluginPath.empty()) {
       invocationArgStrs.push_back("-Xclang");
       invocationArgStrs.push_back("-fcas-plugin-path");
       invocationArgStrs.push_back("-Xclang");
-      invocationArgStrs.push_back(importerOpts.CASOpts->PluginPath);
-      for (auto Opt : importerOpts.CASOpts->PluginOptions) {
+      invocationArgStrs.push_back(CASOpts.CASOpts.PluginPath);
+      for (auto Opt : CASOpts.CASOpts.PluginOptions) {
         invocationArgStrs.push_back("-Xclang");
         invocationArgStrs.push_back("-fcas-plugin-option");
         invocationArgStrs.push_back("-Xclang");

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -237,22 +237,8 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
     std::string IncludeTree =
         clangModuleDep.IncludeTreeID ? *clangModuleDep.IncludeTreeID : "";
 
-    if (ctx.ClangImporterOpts.CASOpts) {
-      swiftArgs.push_back("-cache-compile-job");
-      if (!ctx.ClangImporterOpts.CASOpts->CASPath.empty()) {
-        swiftArgs.push_back("-cas-path");
-        swiftArgs.push_back(ctx.ClangImporterOpts.CASOpts->CASPath);
-      }
-      if (!ctx.ClangImporterOpts.CASOpts->PluginPath.empty()) {
-        swiftArgs.push_back("-cas-plugin-path");
-        swiftArgs.push_back(ctx.ClangImporterOpts.CASOpts->PluginPath);
-        for (auto Opt : ctx.ClangImporterOpts.CASOpts->PluginOptions) {
-          swiftArgs.push_back("-cas-plugin-option");
-          swiftArgs.push_back(
-              (llvm::Twine(Opt.first) + "=" + Opt.second).str());
-        }
-      }
-    }
+    ctx.CASOpts.enumerateCASConfigurationFlags(
+        [&](StringRef Arg) { swiftArgs.push_back(Arg.str()); });
 
     if (!RootID.empty()) {
       swiftArgs.push_back("-no-clang-include-tree");
@@ -343,21 +329,8 @@ void ClangImporter::recordBridgingHeaderOptions(
 
   llvm::for_each(clangArgs, addClangArg);
 
-  if (ctx.ClangImporterOpts.CASOpts) {
-    swiftArgs.push_back("-cache-compile-job");
-    if (!ctx.ClangImporterOpts.CASOpts->CASPath.empty()) {
-      swiftArgs.push_back("-cas-path");
-      swiftArgs.push_back(ctx.ClangImporterOpts.CASOpts->CASPath);
-    }
-    if (!ctx.ClangImporterOpts.CASOpts->PluginPath.empty()) {
-      swiftArgs.push_back("-cas-plugin-path");
-      swiftArgs.push_back(ctx.ClangImporterOpts.CASOpts->PluginPath);
-      for (auto Opt : ctx.ClangImporterOpts.CASOpts->PluginOptions) {
-        swiftArgs.push_back("-cas-plugin-option");
-        swiftArgs.push_back((llvm::Twine(Opt.first) + "=" + Opt.second).str());
-      }
-    }
-  }
+  ctx.CASOpts.enumerateCASConfigurationFlags(
+      [&](StringRef Arg) { swiftArgs.push_back(Arg.str()); });
 
   if (auto Tree = deps.IncludeTreeID) {
     swiftArgs.push_back("-clang-include-tree-root");

--- a/lib/DependencyScan/ModuleDependencyScanner.cpp
+++ b/lib/DependencyScan/ModuleDependencyScanner.cpp
@@ -157,7 +157,7 @@ ModuleDependencyScanningWorker::ModuleDependencyScanningWorker(
   ScanningASTDelegate = std::make_unique<InterfaceSubContextDelegateImpl>(
       ScanASTContext.SourceMgr, &ScanASTContext.Diags,
       ScanASTContext.SearchPathOpts, ScanASTContext.LangOpts,
-      ScanASTContext.ClangImporterOpts, LoaderOpts,
+      ScanASTContext.ClangImporterOpts, ScanASTContext.CASOpts, LoaderOpts,
       /*buildModuleCacheDirIfAbsent*/ false, ClangModuleCachePath,
       FEOpts.PrebuiltModuleCachePath, FEOpts.BackupModuleInterfaceDir,
       FEOpts.SerializeModuleInterfaceDependencyHashes,

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -335,7 +335,7 @@ static llvm::Error resolveExplicitModuleInputs(
   }
 
   // Handle CAS options.
-  if (instance.getInvocation().getFrontendOptions().EnableCaching) {
+  if (instance.getInvocation().getCASOptions().EnableCaching) {
     // Merge CASFS from clang dependency.
     auto &CASFS = cache.getScanService().getSharedCachingFS();
     auto &CAS = CASFS.getCAS();

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -182,10 +182,11 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   LangOptions LangOpts;
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
+  CASOptions CASOpts;
   LangOpts.Target = Invocation.getTargetTriple();
   ASTContext &ASTCtx = *ASTContext::get(
       LangOpts, TypeCheckOpts, SILOpts, SearchPathOpts, ClangImporterOpts,
-      SymbolGraphOpts, SrcMgr, Instance.getDiags(),
+      SymbolGraphOpts, CASOpts, SrcMgr, Instance.getDiags(),
       llvm::makeIntrusiveRefCnt<llvm::vfs::OnDiskOutputBackend>());
   registerParseRequestFunctions(ASTCtx.evaluator);
   registerTypeCheckerRequestFunctions(ASTCtx.evaluator);

--- a/lib/DriverTool/swift_cache_tool_main.cpp
+++ b/lib/DriverTool/swift_cache_tool_main.cpp
@@ -220,7 +220,7 @@ private:
                              MainExecutablePath))
       return true;
 
-    if (!Invocation.getFrontendOptions().EnableCaching) {
+    if (!Invocation.getCASOptions().EnableCaching) {
       llvm::errs() << "Requested command-line arguments do not enable CAS\n";
       return true;
     }

--- a/lib/DriverTool/swift_parse_test_main.cpp
+++ b/lib/DriverTool/swift_parse_test_main.cpp
@@ -81,9 +81,10 @@ struct LibParseExecutor {
     SearchPathOptions searchPathOpts;
     ClangImporterOptions clangOpts;
     symbolgraphgen::SymbolGraphOptions symbolOpts;
+    CASOptions casOpts;
     std::unique_ptr<ASTContext> ctx(
         ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
-                        clangOpts, symbolOpts, SM, diagEngine));
+                        clangOpts, symbolOpts, casOpts, SM, diagEngine));
 
     SourceFile::ParsingOptions parseOpts;
     parseOpts |= SourceFile::ParsingFlags::DisablePoundIfEvaluation;
@@ -150,6 +151,7 @@ struct ASTGenExecutor {
     SILOptions silOpts;
     SearchPathOptions searchPathOpts;
     ClangImporterOptions clangOpts;
+    CASOptions casOpts;
     symbolgraphgen::SymbolGraphOptions symbolOpts;
 
     // Enable ASTGen.
@@ -157,7 +159,7 @@ struct ASTGenExecutor {
 
     std::unique_ptr<ASTContext> ctx(
         ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
-                        clangOpts, symbolOpts, SM, diagEngine));
+                        clangOpts, symbolOpts, casOpts, SM, diagEngine));
     registerParseRequestFunctions(ctx->evaluator);
     registerTypeCheckerRequestFunctions(ctx->evaluator);
 

--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -752,7 +752,7 @@ CachingDiagnosticsProcessor::CachingDiagnosticsProcessor(
     : Impl(*new Implementation(Instance)) {
   Impl.serializedOutputCallback = [&](StringRef Output) {
     LLVM_DEBUG(llvm::dbgs() << Output << "\n";);
-    if (!Instance.getInvocation().getFrontendOptions().EnableCaching)
+    if (!Instance.getInvocation().getCASOptions().EnableCaching)
       return false;
 
     // compress the YAML file.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -270,10 +270,6 @@ setIRGenOutputOptsFromFrontendOptions(IRGenOptions &IRGenOpts,
     }
   }(FrontendOpts.RequestedAction);
 
-  IRGenOpts.UseCASBackend = FrontendOpts.UseCASBackend;
-  IRGenOpts.CASObjMode = FrontendOpts.CASObjMode;
-  IRGenOpts.EmitCASIDFile = FrontendOpts.EmitCASIDFile;
-
   // If we're in JIT mode, set the requisite flags.
   if (FrontendOpts.RequestedAction == FrontendOptions::ActionType::Immediate) {
     IRGenOpts.UseJIT = true;
@@ -529,6 +525,50 @@ parseStrictConcurrency(StringRef value) {
       .Case("targeted", swift::StrictConcurrency::Targeted)
       .Case("complete", swift::StrictConcurrency::Complete)
       .Default(llvm::None);
+}
+
+static bool ParseCASArgs(CASOptions &Opts, ArgList &Args,
+                         DiagnosticEngine &Diags,
+                         const FrontendOptions &FrontendOpts) {
+  using namespace options;
+  Opts.EnableCaching |= Args.hasArg(OPT_cache_compile_job);
+  Opts.EnableCachingRemarks |= Args.hasArg(OPT_cache_remarks);
+  Opts.CacheSkipReplay |= Args.hasArg(OPT_cache_disable_replay);
+  if (const Arg *A = Args.getLastArg(OPT_cas_path))
+    Opts.CASOpts.CASPath = A->getValue();
+  else if (Opts.CASOpts.CASPath.empty())
+    Opts.CASOpts.CASPath = llvm::cas::getDefaultOnDiskCASPath();
+
+  if (const Arg *A = Args.getLastArg(OPT_cas_plugin_path))
+    Opts.CASOpts.PluginPath = A->getValue();
+
+  for (StringRef Opt : Args.getAllArgValues(OPT_cas_plugin_option)) {
+    StringRef Name, Value;
+    std::tie(Name, Value) = Opt.split('=');
+    Opts.CASOpts.PluginOptions.emplace_back(std::string(Name),
+                                            std::string(Value));
+  }
+
+  for (const auto &A : Args.getAllArgValues(OPT_cas_fs))
+    Opts.CASFSRootIDs.emplace_back(A);
+  for (const auto &A : Args.getAllArgValues(OPT_clang_include_tree_root))
+    Opts.ClangIncludeTrees.emplace_back(A);
+
+  if (const Arg *A = Args.getLastArg(OPT_input_file_key))
+    Opts.InputFileKey = A->getValue();
+
+  if (const Arg*A = Args.getLastArg(OPT_bridging_header_pch_key))
+    Opts.BridgingHeaderPCHCacheKey = A->getValue();
+
+  if (Opts.EnableCaching && Opts.CASFSRootIDs.empty() &&
+      Opts.ClangIncludeTrees.empty() &&
+      FrontendOptions::supportCompilationCaching(
+          FrontendOpts.RequestedAction)) {
+    Diags.diagnose(SourceLoc(), diag::error_caching_no_cas_fs);
+    return true;
+  }
+
+  return false;
 }
 
 static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
@@ -1565,7 +1605,8 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
                                    DiagnosticEngine &Diags,
                                    StringRef workingDirectory,
                                    const LangOptions &LangOpts,
-                                   const FrontendOptions &FrontendOpts) {
+                                   const FrontendOptions &FrontendOpts,
+                                   const CASOptions &CASOpts) {
   using namespace options;
 
   if (const Arg *a = Args.getLastArg(OPT_tools_directory)) {
@@ -1633,8 +1674,8 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
     Opts.ExtraArgs.push_back("-ffile-compilation-dir=" + Val);
   }
 
-  if (FrontendOpts.CASFSRootIDs.empty() &&
-      FrontendOpts.ClangIncludeTrees.empty()) {
+  if (CASOpts.CASFSRootIDs.empty() &&
+      CASOpts.ClangIncludeTrees.empty()) {
     if (!workingDirectory.empty()) {
       // Provide a working directory to Clang as well if there are any -Xcc
       // options, in case some of them are search-related. But do it at the
@@ -1661,8 +1702,6 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
 
   if (auto *A = Args.getLastArg(OPT_import_objc_header))
     Opts.BridgingHeader = A->getValue();
-  Opts.BridgingHeaderPCHCacheKey =
-      Args.getLastArgValue(OPT_bridging_header_pch_key);
   Opts.DisableSwiftBridgeAttr |= Args.hasArg(OPT_disable_swift_bridge_attr);
 
   Opts.DisableOverlayModules |= Args.hasArg(OPT_emit_imported_modules);
@@ -1698,12 +1737,11 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
 
   // Forward the FrontendOptions to clang importer option so it can be
   // accessed when creating clang module compilation invocation.
-  if (FrontendOpts.EnableCaching) {
-    Opts.CASOpts = FrontendOpts.CASOpts;
+  if (CASOpts.EnableCaching) {
     // Only set UseClangIncludeTree when caching is enabled since it is not
     // useful in non-caching context.
-    Opts.UseClangIncludeTree = !Args.hasArg(OPT_no_clang_include_tree);
-    Opts.HasClangIncludeTreeRoot = Args.hasArg(OPT_clang_include_tree_root);
+    Opts.UseClangIncludeTree |= !Args.hasArg(OPT_no_clang_include_tree);
+    Opts.HasClangIncludeTreeRoot |= Args.hasArg(OPT_clang_include_tree_root);
   }
 
   return false;
@@ -3026,6 +3064,17 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
         .Default(llvm::CallingConv::C);
   }
 
+  if (Arg *A = Args.getLastArg(OPT_cas_backend_mode)) {
+    Opts.CASObjMode = llvm::StringSwitch<llvm::CASBackendMode>(A->getValue())
+                          .Case("native", llvm::CASBackendMode::Native)
+                          .Case("casid", llvm::CASBackendMode::CASID)
+                          .Case("verify", llvm::CASBackendMode::Verify)
+                          .Default(llvm::CASBackendMode::Native);
+  }
+
+  Opts.UseCASBackend |= Args.hasArg(OPT_cas_backend);
+  Opts.EmitCASIDFile |= Args.hasArg(OPT_cas_emit_casid_file);
+
   return false;
 }
 
@@ -3160,6 +3209,10 @@ bool CompilerInvocation::parseArgs(
   ParseModuleInterfaceArgs(ModuleInterfaceOpts, ParsedArgs);
   SaveModuleInterfaceArgs(ModuleInterfaceOpts, FrontendOpts, ParsedArgs, Diags);
 
+  if (ParseCASArgs(CASOpts, ParsedArgs, Diags, FrontendOpts)) {
+    return true;
+  }
+
   if (ParseLangArgs(LangOpts, ParsedArgs, Diags, FrontendOpts)) {
     return true;
   }
@@ -3169,7 +3222,8 @@ bool CompilerInvocation::parseArgs(
   }
 
   if (ParseClangImporterArgs(ClangImporterOpts, ParsedArgs, Diags,
-                             workingDirectory, LangOpts, FrontendOpts)) {
+                             workingDirectory, LangOpts, FrontendOpts,
+                             CASOpts)) {
     return true;
   }
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -419,18 +419,19 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
   // in the .swiftinterface file itself. Instead, creation of that
   // job should incorporate those flags.
   if (FEOpts.ExplicitInterfaceBuild &&
-      !(FEOpts.isTypeCheckAction() && !FEOpts.EnableCaching))
+      !(FEOpts.isTypeCheckAction() &&
+        !Invocation.getCASOptions().EnableCaching))
     return ModuleInterfaceLoader::buildExplicitSwiftModuleFromSwiftInterface(
         Instance, Invocation.getClangModuleCachePath(),
         FEOpts.BackupModuleInterfaceDir, PrebuiltCachePath, ABIPath, InputPath,
         Invocation.getOutputFilename(),
         /* shouldSerializeDeps */ true,
         Invocation.getSearchPathOptions().CandidateCompiledModules);
-  else
-    return ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
+
+  return ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
       Instance.getSourceMgr(), Instance.getDiags(),
       Invocation.getSearchPathOptions(), Invocation.getLangOptions(),
-      Invocation.getClangImporterOptions(),
+      Invocation.getClangImporterOptions(), Invocation.getCASOptions(),
       Invocation.getClangModuleCachePath(), PrebuiltCachePath,
       FEOpts.BackupModuleInterfaceDir, Invocation.getModuleName(), InputPath,
       Invocation.getOutputFilename(), ABIPath,
@@ -1455,7 +1456,7 @@ static bool performAction(CompilerInstance &Instance,
 /// false and will not replay any output.
 static bool tryReplayCompilerResults(CompilerInstance &Instance) {
   if (!Instance.supportCaching() ||
-      Instance.getInvocation().getFrontendOptions().CacheSkipReplay)
+      Instance.getInvocation().getCASOptions().CacheSkipReplay)
     return false;
 
   assert(Instance.getCompilerBaseKey() &&
@@ -1471,7 +1472,7 @@ static bool tryReplayCompilerResults(CompilerInstance &Instance) {
       Instance.getObjectStore(), Instance.getActionCache(),
       *Instance.getCompilerBaseKey(), Instance.getDiags(),
       Instance.getInvocation().getFrontendOptions().InputsAndOutputs, *CDP,
-      Instance.getInvocation().getFrontendOptions().EnableCachingRemarks);
+      Instance.getInvocation().getCASOptions().EnableCachingRemarks);
 
   // If we didn't replay successfully, re-start capture.
   if (!replayed)

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -418,9 +418,7 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
   // currently we need to ensure it still reads the flags written out
   // in the .swiftinterface file itself. Instead, creation of that
   // job should incorporate those flags.
-  if (FEOpts.ExplicitInterfaceBuild &&
-      !(FEOpts.isTypeCheckAction() &&
-        !Invocation.getCASOptions().EnableCaching))
+  if (FEOpts.ExplicitInterfaceBuild && !(FEOpts.isTypeCheckAction()))
     return ModuleInterfaceLoader::buildExplicitSwiftModuleFromSwiftInterface(
         Instance, Invocation.getClangModuleCachePath(),
         FEOpts.BackupModuleInterfaceDir, PrebuiltCachePath, ABIPath, InputPath,

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -125,11 +125,13 @@ getModifiedFunctionDeclList(const SourceFile &SF, SourceManager &tmpSM,
   SearchPathOptions searchPathOpts = ctx.SearchPathOpts;
   ClangImporterOptions clangOpts = ctx.ClangImporterOpts;
   SILOptions silOpts = ctx.SILOpts;
+  CASOptions casOpts = ctx.CASOpts;
   symbolgraphgen::SymbolGraphOptions symbolOpts = ctx.SymbolGraphOpts;
 
   DiagnosticEngine tmpDiags(tmpSM);
-  auto &tmpCtx = *ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts,
-                                  clangOpts, symbolOpts, tmpSM, tmpDiags);
+  auto &tmpCtx =
+      *ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts,
+                       symbolOpts, casOpts, tmpSM, tmpDiags);
   registerParseRequestFunctions(tmpCtx.evaluator);
   registerTypeCheckerRequestFunctions(tmpCtx.evaluator);
 

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -240,9 +240,10 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
   DiagnosticEngine tmpDiags(tmpSM);
   ClangImporterOptions clangOpts;
   symbolgraphgen::SymbolGraphOptions symbolOpts;
+  CASOptions casOpts;
   std::unique_ptr<ASTContext> tmpCtx(
       ASTContext::get(langOpts, typeckOpts, silOpts, searchPathOpts, clangOpts,
-                      symbolOpts, tmpSM, tmpDiags));
+                      symbolOpts, casOpts, tmpSM, tmpDiags));
   tmpCtx->CancellationFlag = CancellationFlag;
   registerParseRequestFunctions(tmpCtx->evaluator);
   registerIDERequestFunctions(tmpCtx->evaluator);

--- a/lib/IDETool/SyntacticMacroExpansion.cpp
+++ b/lib/IDETool/SyntacticMacroExpansion.cpp
@@ -62,7 +62,7 @@ bool SyntacticMacroExpansionInstance::setup(
       invocation.getLangOptions(), invocation.getTypeCheckerOptions(),
       invocation.getSILOptions(), invocation.getSearchPathOptions(),
       invocation.getClangImporterOptions(), invocation.getSymbolGraphOptions(),
-      SourceMgr, Diags));
+      invocation.getCASOptions(), SourceMgr, Diags));
   registerParseRequestFunctions(Ctx->evaluator);
   registerTypeCheckerRequestFunctions(Ctx->evaluator);
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1130,6 +1130,7 @@ struct ParserUnit::Implementation {
   SearchPathOptions SearchPathOpts;
   ClangImporterOptions clangImporterOpts;
   symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
+  CASOptions CASOpts;
   DiagnosticEngine Diags;
   ASTContext &Ctx;
   SourceFile *SF;
@@ -1138,10 +1139,10 @@ struct ParserUnit::Implementation {
   Implementation(SourceManager &SM, SourceFileKind SFKind, unsigned BufferID,
                  const LangOptions &Opts, const TypeCheckerOptions &TyOpts,
                  const SILOptions &silOpts, StringRef ModuleName)
-      : LangOpts(Opts),
-        TypeCheckerOpts(TyOpts), SILOpts(silOpts), Diags(SM),
+      : LangOpts(Opts), TypeCheckerOpts(TyOpts), SILOpts(silOpts), Diags(SM),
         Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
-                             clangImporterOpts, symbolGraphOpts, SM, Diags)) {
+                             clangImporterOpts, symbolGraphOpts, CASOpts, SM,
+                             Diags)) {
     registerParseRequestFunctions(Ctx.evaluator);
 
     auto parsingOpts = SourceFile::getDefaultParsingOptions(LangOpts);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -486,7 +486,7 @@ SerializedModuleLoaderBase::scanModuleFile(Twine modulePath, bool isFramework) {
   // of binary module dependencies. In the meantime, in non-CAS mode
   // loading clients will consume the `.h` files encoded in the `.swiftmodules`
   // directly.
-  if (Ctx.ClangImporterOpts.CASOpts) {
+  if (Ctx.CASOpts.EnableCaching) {
     importedHeaders.reserve(importedHeaderSet.size());
     llvm::transform(importedHeaderSet.keys(),
                     std::back_inserter(importedHeaders),

--- a/test/CAS/cas-explicit-module-map.swift
+++ b/test/CAS/cas-explicit-module-map.swift
@@ -36,13 +36,13 @@
 // RUN:   -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-library-evolution \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -explicit-interface-module-build -Rcache-compile-job @%t/MyApp.cmd -input-file-key @%t/key 2>&1 \
-// RUN:   | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-MISS
+// RUN:   | %FileCheck %s --check-prefix=CACHE-MISS
 // RUN: %target-swift-frontend -typecheck-module-from-interface %t/Foo.swiftinterface -disable-implicit-swift-modules \
 // RUN:   -module-cache-path %t.module-cache -explicit-swift-module-map-file @%t/map.casid  \
 // RUN:   -cache-compile-job -cas-path %t/cas -swift-version 5 -enable-library-evolution \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
 // RUN:   -explicit-interface-module-build -Rcache-compile-job @%t/MyApp.cmd -input-file-key @%t/key 2>&1 \
-// RUN:   | %FileCheck %s --check-prefix=VERIFY-OUTPUT --check-prefix=CACHE-HIT
+// RUN:   | %FileCheck %s --check-prefix=CACHE-HIT
 
 // CACHE-MISS: remark: cache miss for input
 // VERIFY-OUTPUT: warning: module 'B' was not compiled with library evolution support

--- a/tools/libSwiftScan/SwiftCaching.cpp
+++ b/tools/libSwiftScan/SwiftCaching.cpp
@@ -835,7 +835,7 @@ swiftscan_cache_replay_instance_create(int argc, const char **argv,
     return nullptr;
   }
 
-  if (!Instance->Invocation.getFrontendOptions().EnableCaching) {
+  if (!Instance->Invocation.getCASOptions().EnableCaching) {
     delete Instance;
     *error = swift::c_string_utils::create_clone(
         "caching is not enabled from command-line");
@@ -955,7 +955,7 @@ static llvm::Error replayCompilation(SwiftScanReplayInstance &Instance,
   Outputs.try_emplace(file_types::TY_CachedDiagnostics, "<cached-diagnostics>");
 
   // Load all the output buffer.
-  bool Remarks = Instance.Invocation.getFrontendOptions().EnableCachingRemarks;
+  bool Remarks = Instance.Invocation.getCASOptions().EnableCachingRemarks;
   struct OutputEntry {
     std::string Path;
     llvm::cas::ObjectProxy Proxy;

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -35,8 +35,8 @@ static Decl *createOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
 
 TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
     : Ctx(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts, SearchPathOpts,
-                           ClangImporterOpts, SymbolGraphOpts, SourceMgr,
-                           Diags)) {
+                           ClangImporterOpts, SymbolGraphOpts, CASOpts,
+                           SourceMgr, Diags)) {
   registerParseRequestFunctions(Ctx.evaluator);
   registerTypeCheckerRequestFunctions(Ctx.evaluator);
   registerClangImporterRequestFunctions(Ctx.evaluator);

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -35,6 +35,7 @@ public:
   SearchPathOptions SearchPathOpts;
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
+  CASOptions CASOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
 

--- a/unittests/ClangImporter/ClangImporterTests.cpp
+++ b/unittests/ClangImporter/ClangImporterTests.cpp
@@ -1,6 +1,7 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/SearchPathOptions.h"
+#include "swift/Basic/CASOptions.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "swift/Basic/LangOptions.h"
@@ -78,11 +79,12 @@ TEST(ClangImporterTest, emitPCHInMemory) {
   INITIALIZE_LLVM();
   swift::SearchPathOptions searchPathOpts;
   swift::symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
+  swift::CASOptions casOpts;
   swift::SourceManager sourceMgr;
   swift::DiagnosticEngine diags(sourceMgr);
   std::unique_ptr<ASTContext> context(
       ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts, options,
-                      symbolGraphOpts, sourceMgr, diags));
+                      symbolGraphOpts, casOpts, sourceMgr, diags));
   auto importer = ClangImporter::create(*context);
 
   std::string PCH = createFilename(cache, "bridging.h.pch");
@@ -192,6 +194,7 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
   swift::SourceManager sourceMgr;
   swift::DiagnosticEngine diags(sourceMgr);
   ClangImporterOptions options;
+  CASOptions casOpts;
   options.clangPath = "/usr/bin/clang";
   options.ExtraArgs.push_back(
       (llvm::Twine("--gcc-toolchain=") + "/opt/rh/devtoolset-9/root/usr")
@@ -199,7 +202,7 @@ TEST(ClangImporterTest, libStdCxxInjectionTest) {
   options.ExtraArgs.push_back("--gcc-toolchain");
   std::unique_ptr<ASTContext> context(
       ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts, options,
-                      symbolGraphOpts, sourceMgr, diags));
+                      symbolGraphOpts, casOpts, sourceMgr, diags));
 
   {
     LibStdCxxInjectionVFS vfs;

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -103,8 +103,10 @@ protected:
     ClangImporterOptions clangImpOpts;
     symbolgraphgen::SymbolGraphOptions symbolGraphOpts;
     SILOptions silOpts;
+    CASOptions casOpts;
     auto ctx = ASTContext::get(langOpts, typecheckOpts, silOpts, searchPathOpts,
-                               clangImpOpts, symbolGraphOpts, sourceMgr, diags);
+                               clangImpOpts, symbolGraphOpts, casOpts,
+                               sourceMgr, diags);
 
     ctx->addModuleInterfaceChecker(
       std::make_unique<ModuleInterfaceCheckerImpl>(*ctx, cacheDir,

--- a/unittests/Sema/SemaFixture.cpp
+++ b/unittests/Sema/SemaFixture.cpp
@@ -31,7 +31,7 @@ using namespace swift::constraints::inference;
 SemaTest::SemaTest()
     : Context(*ASTContext::get(LangOpts, TypeCheckerOpts, SILOpts,
                                SearchPathOpts, ClangImporterOpts,
-                               SymbolGraphOpts, SourceMgr, Diags)) {
+                               SymbolGraphOpts, CASOpts, SourceMgr, Diags)) {
   INITIALIZE_LLVM();
 
   registerParseRequestFunctions(Context.evaluator);

--- a/unittests/Sema/SemaFixture.h
+++ b/unittests/Sema/SemaFixture.h
@@ -42,6 +42,7 @@ public:
   SearchPathOptions SearchPathOpts;
   ClangImporterOptions ClangImporterOpts;
   symbolgraphgen::SymbolGraphOptions SymbolGraphOpts;
+  CASOptions CASOpts;
   SourceManager SourceMgr;
   DiagnosticEngine Diags;
 


### PR DESCRIPTION
The interface verification needs to read some command-line from the interface file so it needs to be built inside sub-invocation.

rdar://122423965
