### PR TITLE
Revert "[ClangImporter] Align callback with Clang change (#71475)"

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -117,10 +117,9 @@ namespace {
         clang::SourceLocation HashLoc, const clang::Token &IncludeTok,
         StringRef FileName, bool IsAngled, clang::CharSourceRange FilenameRange,
         clang::OptionalFileEntryRef File, StringRef SearchPath,
-        StringRef RelativePath, const clang::Module *SuggestedModule,
-        bool ModuleImported,
+        StringRef RelativePath, const clang::Module *Imported,
         clang::SrcMgr::CharacteristicKind FileType) override {
-      handleImport(ModuleImported ? SuggestedModule : nullptr);
+      handleImport(Imported);
     }
 
     void moduleImport(clang::SourceLocation ImportLoc,
@@ -294,19 +293,18 @@ private:
                           bool IsAngled, clang::CharSourceRange FilenameRange,
                           clang::OptionalFileEntryRef File,
                           StringRef SearchPath, StringRef RelativePath,
-                          const clang::Module *SuggestedModule,
-                          bool ModuleImported,
+                          const clang::Module *Imported,
                           clang::SrcMgr::CharacteristicKind FileType) override {
-    if (!ModuleImported) {
+    if (!Imported) {
       if (File)
         Impl.BridgeHeaderFiles.insert(*File);
       return;
     }
     // Synthesize identifier locations.
     SmallVector<clang::SourceLocation, 4> IdLocs;
-    for (unsigned I = 0, E = getNumModuleIdentifiers(SuggestedModule); I != E; ++I)
+    for (unsigned I = 0, E = getNumModuleIdentifiers(Imported); I != E; ++I)
       IdLocs.push_back(HashLoc);
-    handleImport(HashLoc, IdLocs, SuggestedModule);
+    handleImport(HashLoc, IdLocs, Imported);
   }
 
   void moduleImport(clang::SourceLocation ImportLoc,


### PR DESCRIPTION
The commit 757c50cd4b56723afaad048a06ad0141a51847dc causes a CI failure https://ci.swift.org/job/swift-PR-macos/13503/console. This PR reverts the commit.
