### PR TITLE
Treat `@rethrows` protocols inheriting AsyncSequence like AsyncSequence

### DIFF
--- a/test/Concurrency/async_sequence_rethrows.swift
+++ b/test/Concurrency/async_sequence_rethrows.swift
@@ -40,3 +40,14 @@ func testCalls(x: some AsyncSequence<Int, Never>, y: any AsyncSequence<Int, any 
   await f3(x, x)
   try await f3(x, y)
 }
+
+// Treat @rethrows protocols that inherit AsyncSequence like they are
+// AsyncSequence for the purpose of rethrowing methods.
+@rethrows
+protocol InheritsAsyncSequence: AsyncSequence { }
+
+extension InheritsAsyncSequence {
+  func blah() async rethrows -> [Element] {
+    try await self.reduce(into: [Element]()) { $0.append($1) }
+  }
+}


### PR DESCRIPTION
This is a source compatibility hack for such protocols. Fixes rdar://122577080.
