### PR TITLE
Allow rethrow-like typed throws functions as witnesses

### DIFF
--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -708,14 +708,9 @@ static Expr *removeErasureToExistentialError(Expr *expr) {
 
   return expr;
 }
+}
 
-/// Determine whether the given function uses typed throws in a manner
-/// than is structurally similar to 'rethrows', e.g.,
-///
-/// \code
-/// func map<T, E>(_ body: (Element) throws(E) -> T) throws(E) -> [T]
-/// \endcode
-static bool isRethrowLikeTypedThrows(AbstractFunctionDecl *func) {
+bool swift::isRethrowLikeTypedThrows(AbstractFunctionDecl *func) {
   // This notion is only for compatibility in Swift 5 and is disabled
   // when FullTypedThrows is enabled.
   ASTContext &ctx = func->getASTContext();
@@ -761,6 +756,8 @@ static bool isRethrowLikeTypedThrows(AbstractFunctionDecl *func) {
 
   return true;
 }
+
+namespace {
 
 /// Determine whether the given rethrows context is only allowed to be
 /// rethrowing because of the historically-rethrowing behavior of

--- a/lib/Sema/TypeCheckEffects.h
+++ b/lib/Sema/TypeCheckEffects.h
@@ -45,6 +45,14 @@ enum class ThrownErrorSubtyping {
 ThrownErrorSubtyping compareThrownErrorsForSubtyping(
     Type subThrownError, Type superThrownError, DeclContext *dc);
 
+/// Determine whether the given function uses typed throws in a manner
+/// that is structurally similar to 'rethrows', e.g.,
+///
+/// \code
+/// func map<T, E>(_ body: (Element) throws(E) -> T) throws(E) -> [T]
+/// \endcode
+bool isRethrowLikeTypedThrows(AbstractFunctionDecl *func);
+
 }
 
 #endif // SWIFT_SEMA_TYPECHECKEFFECTS_H

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -603,6 +603,11 @@ RequirementMatch swift::matchWitness(
       }
 
       case PolymorphicEffectKind::Always:
+        // If the witness is using typed throws in a manner that looks
+        // like rethrows, allow it.
+        if (isRethrowLikeTypedThrows(funcWitness))
+          break;
+
         return RequirementMatch(witness, MatchKind::RethrowsConflict);
       }
     }

--- a/test/decl/protocol/conforms/typed_throws.swift
+++ b/test/decl/protocol/conforms/typed_throws.swift
@@ -69,3 +69,10 @@ func testAssociatedTypes() {
 func assocFailureType<T: FailureAssociatedType>(_ value: T, _ error: T.Failure) throws(T.Failure) {
   throw error
 }
+
+// Allow a typed-throws version of a function to witness a rethrowing function.
+public protocol HasRethrowingMap: Sequence {
+  func map<T>(_ transform: (Element) throws -> T) rethrows -> [T]
+}
+
+extension Array: HasRethrowingMap {}


### PR DESCRIPTION
Extend an existing source compatibility hack that allows a typed throws-using function that *looks* like a rethrows function to be treated like a rethrows function. Here, do so when a typed-throws function is witnessing a rethrows requirement.

Fixes rdar://122588459.
