### PR TITLE
Add mark_dependence [unresolved]

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Builder.swift
+++ b/SwiftCompilerSources/Sources/SIL/Builder.swift
@@ -414,8 +414,8 @@ public struct Builder {
     return notifyNew(endMutation.getAs(EndCOWMutationInst.self))
   }
 
-  public func createMarkDependence(value: Value, base: Value, isNonEscaping: Bool) -> MarkDependenceInst {
-    let markDependence = bridged.createMarkDependence(value.bridged, base.bridged, isNonEscaping)
+  public func createMarkDependence(value: Value, base: Value, kind: MarkDependenceInst.Kind) -> MarkDependenceInst {
+    let markDependence = bridged.createMarkDependence(value.bridged, base.bridged, kind)
     return notifyNew(markDependence.getAs(MarkDependenceInst.self))
   }
 }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -923,11 +923,15 @@ class GetAsyncContinuationAddrInst : SingleValueInstruction, UnaryInstruction {}
 
 final public
 class MarkDependenceInst : SingleValueInstruction, ForwardingInstruction {
+  public typealias Kind = BridgedInstruction.MarkDependenceKind
+
   public var valueOperand: Operand { operands[0] }
   public var baseOperand: Operand { operands[1] }
   public var value: Value { return valueOperand.value }
   public var base: Value { return baseOperand.value }
-  public var isNonEscaping: Bool { bridged.MarkDependenceInst_isNonEscaping() }
+  public var dependenceKind: Kind { bridged.MarkDependenceInst_dependenceKind() }
+  public var isNonEscaping: Bool { dependenceKind == .NonEscaping }
+  public var isUnresolved: Bool { dependenceKind == .Unresolved }
 }
 
 final public class RefToBridgeObjectInst : SingleValueInstruction, ForwardingInstruction {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -798,6 +798,10 @@ struct BridgedInstruction {
     Deinit
   };
 
+  enum class MarkDependenceKind {
+    Unresolved, Escaping, NonEscaping
+  };
+
   struct KeyPathFunctionResults {
     enum { maxFunctions = 5 };
     BridgedFunction functions[maxFunctions];
@@ -861,7 +865,7 @@ struct BridgedInstruction {
   BRIDGED_INLINE SwiftInt SwitchEnumInst_getCaseIndex(SwiftInt idx) const;
   BRIDGED_INLINE SwiftInt StoreInst_getStoreOwnership() const;
   BRIDGED_INLINE SwiftInt AssignInst_getAssignOwnership() const;
-  BRIDGED_INLINE bool MarkDependenceInst_isNonEscaping() const;
+  BRIDGED_INLINE MarkDependenceKind MarkDependenceInst_dependenceKind() const;
   BRIDGED_INLINE AccessKind BeginAccessInst_getAccessKind() const;
   BRIDGED_INLINE bool BeginAccessInst_isStatic() const;
   BRIDGED_INLINE bool CopyAddrInst_isTakeOfSrc() const;
@@ -1203,7 +1207,8 @@ struct BridgedBuilder{
                                           BridgedType::MetatypeRepresentation representation) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createEndCOWMutation(BridgedValue instance,
                                                                              bool keepUnique) const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMarkDependence(BridgedValue value, BridgedValue base, bool isNonEscaping) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedInstruction createMarkDependence(
+    BridgedValue value, BridgedValue base, BridgedInstruction::MarkDependenceKind dependenceKind) const;
 };
 
 // Passmanager and Context

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1098,8 +1098,8 @@ SwiftInt BridgedInstruction::AssignInst_getAssignOwnership() const {
   return (SwiftInt)getAs<swift::AssignInst>()->getOwnershipQualifier();
 }
 
-bool BridgedInstruction::MarkDependenceInst_isNonEscaping() const {
-  return getAs<swift::MarkDependenceInst>()->isNonEscaping();
+BridgedInstruction::MarkDependenceKind BridgedInstruction::MarkDependenceInst_dependenceKind() const {
+  return (MarkDependenceKind)getAs<swift::MarkDependenceInst>()->dependenceKind();
 }
 
 BridgedInstruction::AccessKind BridgedInstruction::BeginAccessInst_getAccessKind() const {
@@ -1709,8 +1709,8 @@ BridgedInstruction BridgedBuilder::createEndCOWMutation(BridgedValue instance, b
                                            keepUnique)};
 }
 
-BridgedInstruction BridgedBuilder::createMarkDependence(BridgedValue value, BridgedValue base, bool isNonEscaping) const {
-  return {unbridged().createMarkDependence(regularLoc(), value.getSILValue(), base.getSILValue(), isNonEscaping)};
+BridgedInstruction BridgedBuilder::createMarkDependence(BridgedValue value, BridgedValue base, BridgedInstruction::MarkDependenceKind kind) const {
+  return {unbridged().createMarkDependence(regularLoc(), value.getSILValue(), base.getSILValue(), swift::MarkDependenceKind(kind))};
 }
 
 SWIFT_END_NULLABILITY_ANNOTATIONS

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2282,18 +2282,19 @@ public:
                                                        SILValue value);
 
   MarkDependenceInst *createMarkDependence(SILLocation Loc, SILValue value,
-                                           SILValue base, bool isNonEscaping) {
+                                           SILValue base,
+                                           MarkDependenceKind dependenceKind) {
     return createMarkDependence(Loc, value, base, value->getOwnershipKind(),
-                                isNonEscaping);
+                                dependenceKind);
   }
 
   MarkDependenceInst *
   createMarkDependence(SILLocation Loc, SILValue value, SILValue base,
                        ValueOwnershipKind forwardingOwnershipKind,
-                       bool isNonEscaping) {
+                       MarkDependenceKind dependenceKind) {
     return insert(new (getModule()) MarkDependenceInst(
                     getSILDebugLocation(Loc), value, base,
-                    forwardingOwnershipKind, isNonEscaping));
+                    forwardingOwnershipKind, dependenceKind));
   }
 
   IsUniqueInst *createIsUnique(SILLocation Loc, SILValue operand) {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2955,7 +2955,7 @@ void SILCloner<ImplClass>::visitMarkDependenceInst(MarkDependenceInst *Inst) {
                 getBuilder().hasOwnership()
                 ? Inst->getForwardingOwnershipKind()
                 : ValueOwnershipKind(OwnershipKind::None),
-                /*isNonEscaping*/false));
+                Inst->dependenceKind()));
 }
 
 template<typename ImplClass>

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8353,6 +8353,11 @@ public:
   }
 };
 
+enum class MarkDependenceKind {
+  Unresolved, Escaping, NonEscaping
+};
+static_assert(2 == SILNode::NumMarkDependenceKindBits, "Size mismatch");
+
 /// Indicates that the validity of the first operand ("the value") depends on
 /// the value of the second operand ("the base").  Operations that would destroy
 /// the base must not be moved before any instructions which depend on the
@@ -8397,12 +8402,10 @@ class MarkDependenceInst
 
   MarkDependenceInst(SILDebugLocation DebugLoc, SILValue value, SILValue base,
                      ValueOwnershipKind forwardingOwnershipKind,
-                     bool isNonEscaping)
+                     MarkDependenceKind dependenceKind)
       : InstructionBase(DebugLoc, value->getType(), forwardingOwnershipKind),
         Operands{this, value, base} {
-    if (isNonEscaping) {
-      sharedUInt8().MarkDependenceInst.nonEscaping = true;
-    }
+    sharedUInt8().MarkDependenceInst.dependenceKind = uint8_t(dependenceKind);
   }
 
 public:
@@ -8422,8 +8425,19 @@ public:
   ArrayRef<Operand> getAllOperands() const { return Operands.asArray(); }
   MutableArrayRef<Operand> getAllOperands() { return Operands.asArray(); }
 
+  MarkDependenceKind dependenceKind() const {
+    return MarkDependenceKind(sharedUInt8().MarkDependenceInst.dependenceKind);
+  }
+
   bool isNonEscaping() const {
-    return sharedUInt8().MarkDependenceInst.nonEscaping;
+    return dependenceKind() == MarkDependenceKind::NonEscaping;
+  }
+
+  /// An unresolved escape is semantically an escaping dependence, but this
+  /// form is only valid prior to lifetime dependence diagnostics which will
+  /// convert it to NonEscaping if the program is valid.
+  bool hasUnresolvedEscape() const {
+    return dependenceKind() == MarkDependenceKind::Unresolved;
   }
 
   /// Visit the instructions that end the lifetime of an OSSA on-stack closure.

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -124,6 +124,7 @@ public:
   enum { NumSILAccessKindBits = 2 };
   enum { NumSILAccessEnforcementBits = 3 };
   enum { NumAllocRefTailTypesBits = 4 };
+  enum { NumMarkDependenceKindBits = 2 };
 
 protected:
   friend class SILInstruction;
@@ -277,7 +278,7 @@ protected:
                  fromVarDecl : 1);
 
     SHARED_FIELD(MarkDependenceInst, uint8_t
-                 nonEscaping : 1);
+                 dependenceKind : NumMarkDependenceKindBits);
 
   // Do not use `_sharedUInt8_private` outside of SILNode.
   } _sharedUInt8_private;

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2854,7 +2854,7 @@ bool LoadableByAddress::recreateConvInstr(SILInstruction &I,
     auto instr = cast<MarkDependenceInst>(convInstr);
     newInstr = convBuilder.createMarkDependence(
       instr->getLoc(), instr->getValue(), instr->getBase(),
-      instr->isNonEscaping());
+      instr->dependenceKind());
     break;
   }
   case SILInstructionKind::DifferentiableFunctionInst: {
@@ -3885,7 +3885,7 @@ protected:
     auto builder = assignment.getBuilder(m->getIterator());
     auto opdAddr = assignment.getAddressForValue(m->getBase());
     auto newValue = builder.createMarkDependence(m->getLoc(), m->getValue(),
-                                                 opdAddr, m->isNonEscaping());
+                                                 opdAddr, m->dependenceKind());
     m->replaceAllUsesWith(newValue);
     assignment.markForDeletion(m);
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2530,7 +2530,12 @@ public:
     *this << getIDAndType(CBOI->getOperand());
   }
   void visitMarkDependenceInst(MarkDependenceInst *MDI) {
-    if (MDI->isNonEscaping()) {
+    switch (MDI->dependenceKind()) {
+    case MarkDependenceKind::Unresolved:
+      *this << "[unresolved] ";
+    case MarkDependenceKind::Escaping:
+      break;
+    case MarkDependenceKind::NonEscaping:
       *this << "[nonescaping] ";
     }
     *this << getIDAndType(MDI->getValue()) << " on "

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2948,7 +2948,8 @@ private:
       if (valueTL.isTrivial()) {
         SILValue dependentValue =
           SGF.B.createMarkDependence(eval, value.forward(SGF),
-                                     owner.getValue(), /*isNonEscaping*/false);
+                                     owner.getValue(),
+                                     MarkDependenceKind::Escaping);
         value = SGF.emitManagedRValueWithCleanup(dependentValue, valueTL);
       }
     }
@@ -6437,7 +6438,7 @@ SILGenFunction::emitUninitializedArrayAllocation(Type ArrayTy,
   // Add a mark_dependence between the interior pointer and the array value
   auto dependentValue = B.createMarkDependence(Loc, resultElts[1].getValue(),
                                                resultElts[0].getValue(),
-                                               /*isNonEscaping*/false);
+                                               MarkDependenceKind::Escaping);
   return {resultElts[0], dependentValue};
 }
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -1022,14 +1022,15 @@ ManagedValue SILGenBuilder::createProjectBox(SILLocation loc, ManagedValue mv,
   return ManagedValue::forBorrowedAddressRValue(pbi);
 }
 
-ManagedValue SILGenBuilder::createMarkDependence(SILLocation loc,
-                                                 ManagedValue value,
-                                                 ManagedValue base,
-                                                 bool isNonEscaping) {
+ManagedValue SILGenBuilder::createMarkDependence(
+  SILLocation loc,
+  ManagedValue value,
+  ManagedValue base,
+  MarkDependenceKind dependenceKind) {
   CleanupCloner cloner(*this, value);
   auto *mdi = createMarkDependence(loc, value.forward(getSILGenFunction()),
                                    base.forward(getSILGenFunction()),
-                                   isNonEscaping);
+                                   dependenceKind);
   return cloner.clone(mdi);
 }
 

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -461,7 +461,8 @@ public:
 
   using SILBuilder::createMarkDependence;
   ManagedValue createMarkDependence(SILLocation loc, ManagedValue value,
-                                    ManagedValue base, bool isNonEscaping);
+                                    ManagedValue base,
+                                    MarkDependenceKind dependencekind);
 
   using SILBuilder::createBeginBorrow;
   ManagedValue createBeginBorrow(SILLocation loc, ManagedValue value,

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1446,7 +1446,7 @@ static ManagedValue emitBuiltinConvertUnownedUnsafeToGuaranteed(
       SGF.emitManagedBorrowedRValueWithCleanup(guaranteedNonTrivialRef);
   // Now create a mark dependence on our base and return the result.
   return SGF.B.createMarkDependence(loc, guaranteedNonTrivialRefMV, baseMV,
-                                    /*isNonEscaping*/false);
+                                    MarkDependenceKind::Escaping);
 }
 
 // Emit SIL for the named builtin: getCurrentAsyncTask.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5903,7 +5903,7 @@ public:
     // above the retain. We are doing unmanaged things here so we need to be
     // extra careful.
     ownedMV = SGF.B.createMarkDependence(loc, ownedMV, base,
-                                         /*isNonEscaping*/false);
+                                         MarkDependenceKind::Escaping);
 
     // Then reassign the mark dependence into the +1 storage.
     ownedMV.assignInto(SGF, loc, base.getUnmanagedValue());
@@ -6219,7 +6219,7 @@ SILGenFunction::emitArrayToPointer(SILLocation loc, ManagedValue array,
   auto owner = resultScalars[0];
   auto pointer = resultScalars[1].forward(*this);
   pointer = B.createMarkDependence(loc, pointer, owner.getValue(),
-                                   /*isNonEscaping*/false);
+                                   MarkDependenceKind::Escaping);
 
   // The owner's already in its own cleanup.  Return the pointer.
   return {ManagedValue::forObjectRValueWithoutOwnership(pointer), owner};
@@ -6255,7 +6255,7 @@ SILGenFunction::emitStringToPointer(SILLocation loc, ManagedValue stringValue,
   auto owner = results[0];
   auto pointer = results[1].forward(*this);
   pointer = B.createMarkDependence(loc, pointer, owner.getValue(),
-                                   /*isNonEscaping*/false);
+                                   MarkDependenceKind::Escaping);
 
   return {ManagedValue::forObjectRValueWithoutOwnership(pointer), owner};
 }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -5701,7 +5701,7 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
   thunkedFn = emitManagedRValueWithCleanup(
     B.createMarkDependence(loc, thunkedFn.forward(*this),
                            noEscapingFunctionValue.getValue(),
-                           /*isNonEscaping*/false));
+                           MarkDependenceKind::Escaping));
 
   return thunkedFn;
 }

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -784,7 +784,7 @@ SILValue ClosureSpecCloner::cloneCalleeConversion(
         origCalleeValue,
         Builder.createMarkDependence(CallSiteDesc.getLoc(), calleeValue,
                                      CapturedMap[MD->getBase()],
-                                     /*isNonEscaping*/false));
+                                     MarkDependenceKind::Escaping));
   }
 
 

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -279,7 +279,7 @@ static void extendLifetimeToEndOfFunction(SILFunction &fn,
   auto *borrow = lifetimeExtendBuilder.createBeginBorrow(loc, optionalSome);
   auto *mdi =
     lifetimeExtendBuilder.createMarkDependence(loc, cvt, borrow,
-                                               /*isNonEscaping*/false);
+                                               MarkDependenceKind::Escaping);
 
   // Replace all uses of the non escaping closure with mark_dependence
   SmallVector<Operand *, 4> convertUses;
@@ -405,7 +405,7 @@ static SILValue insertMarkDependenceForCapturedArguments(PartialApplyInst *pai,
       if (m->hasGuaranteedInitialKind())
         continue;
     curr = b.createMarkDependence(pai->getLoc(), curr, arg.get(),
-                                  /*isNonEscaping*/false);
+                                  MarkDependenceKind::Escaping);
   }
 
   return curr;

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -323,7 +323,7 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
   // Mark the dependence of the resulting value on the actor value to
   // force the actor to stay alive.
   SILValue executor = B.createMarkDependence(loc, unmarkedExecutor, actor,
-                                             /*isNonEscaping*/false);
+                                             MarkDependenceKind::Escaping);
 
   return executor;
 }

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -451,7 +451,7 @@ bool OwnershipModelEliminatorVisitor::visitPartialApplyInst(
       
       // If this is a nontrivial value argument, insert the mark_dependence.
       auto mdi = b.createMarkDependence(loc, newValue, op,
-                                        /*isNonEscaping*/false);
+                                        MarkDependenceKind::Escaping);
       if (!firstNewMDI)
         firstNewMDI = mdi;
       newValue = mdi;

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -849,7 +849,7 @@ TempRValueOptPass::tryOptimizeStoreIntoTemp(StoreInst *si) {
       auto newInst = builder.createMarkDependence(user->getLoc(),
                                                   mdi->getValue(),
                                                   si->getSrc(),
-                                                  mdi->isNonEscaping());
+                                                  mdi->dependenceKind());
       mdi->replaceAllUsesWith(newInst);
       toDelete.push_back(mdi);
       break;

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2006,7 +2006,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         getLocalValue(ValID2,
                       getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)),
-        /*nonEscaping*/Attr);
+        MarkDependenceKind(Attr));
     break;
   }
   case SILInstructionKind::BeginDeallocRefInst: {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 849; // update LifetimeDependence
+const uint16_t SWIFTMODULE_VERSION_MINOR = 850; // MarkDependenceKind
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1694,7 +1694,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       const MarkDependenceInst *MDI = cast<MarkDependenceInst>(&SI);
       operand = MDI->getValue();
       operand2 = MDI->getBase();
-      Attr = (MDI->isNonEscaping() ? 1 : 0);
+      Attr = unsigned(MDI->dependenceKind());
     } else {
       const IndexAddrInst *IAI = cast<IndexAddrInst>(&SI);
       operand = IAI->getBase();

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -296,13 +296,15 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
 
 // CHECK-LABEL: sil [ossa] @test_mark_dependence : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: [[MD1:%.*]] = mark_dependence %1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
-// CHECK: mark_dependence [nonescaping] [[MD1]] : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+// CHECK: [[MD2:%.*]] = mark_dependence [nonescaping] [[MD1]] : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+// CHECK: mark_dependence [unresolved] [[MD2]] : $Builtin.NativeObject on %0 : $Builtin.NativeObject
 // CHECK: } // end sil function 'test_mark_dependence'
 sil [ossa] @test_mark_dependence : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   %md1 = mark_dependence %1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
   %md2 = mark_dependence [nonescaping] %md1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
-  destroy_value %md2 : $Builtin.NativeObject
+  %md3 = mark_dependence [unresolved] %md2 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+  destroy_value %md3 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()

--- a/test/SIL/Serialization/basic2.sil
+++ b/test/SIL/Serialization/basic2.sil
@@ -91,13 +91,15 @@ bb0(%0 : @owned $Builtin.NativeObject):
 
 // CHECK-LABEL: sil [ossa] @test_mark_dependence : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: [[MD1:%.*]] = mark_dependence %1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
-// CHECK: mark_dependence [nonescaping] [[MD1]] : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+// CHECK: [[MD2:%.*]] = mark_dependence [nonescaping] [[MD1]] : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+// CHECK: mark_dependence [unresolved] [[MD2]] : $Builtin.NativeObject on %0 : $Builtin.NativeObject
 // CHECK: } // end sil function 'test_mark_dependence'
 sil [ossa] @test_mark_dependence : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   %md1 = mark_dependence %1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
   %md2 = mark_dependence [nonescaping] %md1 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
-  destroy_value %md2 : $Builtin.NativeObject
+  %md3 = mark_dependence [unresolved] %md2 : $Builtin.NativeObject on %0 : $Builtin.NativeObject
+  destroy_value %md3 : $Builtin.NativeObject
   destroy_value %0 : $Builtin.NativeObject
   %9999 = tuple()
   return %9999 : $()


### PR DESCRIPTION
In preparation for inserting mark_dependence instructions for lifetime dependencies early, immediately after SILGen. That will simplify the implementation of borrowed arguments.

Marking them unresolved is needed to make OSSA verification conservative until lifetime dependence diagnostics runs.