### PR TITLE
[Concurrency] Always diagnose invalid isolated parameter types in type resolution.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5528,10 +5528,8 @@ NOTE(protocol_isolated_to_global_actor_here,none,
      "%0 is isolated to global actor %1 here", (Type, Type))
 
 ERROR(isolated_parameter_not_actor,none,
-      "'isolated' parameter has non-actor type %0", (Type))
-ERROR(isolated_parameter_no_actor_conformance,none,
-      "'isolated' parameter %0 must conform to 'Actor' "
-      "or 'DistributedActor' protocol", (Type))
+      "'isolated' parameter type %0 does not conform to 'Actor' "
+      "or 'DistributedActor'", (Type))
 ERROR(isolated_parameter_duplicate,none,
       "cannot have more than one 'isolated' parameter", ())
 ERROR(isolated_parameter_duplicate_type,none,

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -20,7 +20,7 @@ extension Actor {
 func testA<T: Actor>(
   a: isolated A,  // expected-note{{previous 'isolated' parameter 'a'}}
   b: isolated T,  // expected-warning{{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
-  c: isolated Int // expected-error {{'isolated' parameter has non-actor type 'Int'}}
+  c: isolated Int // expected-error {{'isolated' parameter type 'Int' does not conform to 'Actor' or 'DistributedActor'}}
 ) {
   a.f()
   a.g()
@@ -350,14 +350,14 @@ func getValues(
 }
 
 func isolated_generic_bad_1<T>(_ t: isolated T) {}
-// expected-error@-1 {{'isolated' parameter 'T' must conform to 'Actor' or 'DistributedActor' protocol}}
+// expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
 func isolated_generic_bad_2<T: Equatable>(_ t: isolated T) {}
-// expected-error@-1 {{'isolated' parameter 'T' must conform to 'Actor' or 'DistributedActor' protocol}}
+// expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
 func isolated_generic_bad_3<T: AnyActor>(_ t: isolated T) {}
-// expected-error@-1 {{'isolated' parameter 'T' must conform to 'Actor' or 'DistributedActor' protocol}}
+// expected-error@-1 {{'isolated' parameter type 'T' does not conform to 'Actor' or 'DistributedActor'}}
 
 func isolated_generic_bad_4<T>(_ t: isolated Array<T>) {}
-// expected-error@-1 {{'isolated' parameter has non-actor type 'Array<T>'}}
+// expected-error@-1 {{'isolated' parameter type 'Array<T>' does not conform to 'Actor' or 'DistributedActor'}}
 
 func isolated_generic_ok_1<T: Actor>(_ t: isolated T) {}
 
@@ -473,3 +473,7 @@ func preciseIsolated(a: isolated MyActor) async {
 nonisolated func fromNonisolated(ns: NotSendable) async -> NotSendable {
   await pass(value: ns, isolation: nil)
 }
+
+func invalidIsolatedClosureParam<A: AnyActor> (
+  _: (isolated A) async throws -> Void // expected-error {{'isolated' parameter type 'A' does not conform to 'Actor' or 'DistributedActor'}}
+) {}


### PR DESCRIPTION
This fixes an issue where invalid isolated parameter types that contain type parameters were not diagnosed in structural position, for example:

```swift
func invalidIsolatedClosureParam<A: AnyActor> (
  _: (isolated A) async throws -> Void
) {}
```

This is because the conformance lookup for type parameters happened in `ActorIsolationRequest::evaluate`, which only diagnosed isolated parameters of function declarations, so the above code went undiagnosed. Diagnosing invalid isolated parameter types in one place also simplifies the code a bit.