### PR TITLE
[docs] Fix examples for TaskLocal

### DIFF
--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -26,7 +26,7 @@ import Swift
 ///
 ///     enum Example {
 ///         @TaskLocal
-///         static let traceID: TraceID?
+///         static var traceID: TraceID?
 ///     }
 ///
 /// ### Default values
@@ -37,7 +37,7 @@ import Swift
 ///
 ///     enum Example { 
 ///         @TaskLocal
-///         static let traceID: TraceID = TraceID.default
+///         static var traceID: TraceID = TraceID.default
 ///     }
 /// 
 /// The default value is returned whenever the task-local is read


### PR DESCRIPTION
<!-- What's in this pull request? -->
Although TaskLocal doesn't support `static let`, the syntax is shown as examples in the documents.
In this PR, I fixed the examples.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
