### PR TITLE
Add `swift5_tests` to `MetadataSections`.

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/MetadataSections.h
+++ b/stdlib/public/SwiftShims/swift/shims/MetadataSections.h
@@ -98,6 +98,7 @@ struct MetadataSections {
   MetadataSectionRange swift5_mpenum;
   MetadataSectionRange swift5_accessible_functions;
   MetadataSectionRange swift5_runtime_attributes;
+  MetadataSectionRange swift5_tests;
 };
 
 #ifdef __cplusplus

--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -51,7 +51,7 @@
 
 namespace swift {
 struct MetadataSections;
-static constexpr const uintptr_t CurrentSectionMetadataVersion = 3;
+static constexpr const uintptr_t CurrentSectionMetadataVersion = 4;
 }
 
 struct SectionInfo {

--- a/stdlib/public/runtime/SwiftRT-COFF.cpp
+++ b/stdlib/public/runtime/SwiftRT-COFF.cpp
@@ -55,6 +55,7 @@ DECLARE_SWIFT_SECTION(sw5cptr)
 DECLARE_SWIFT_SECTION(sw5mpen)
 DECLARE_SWIFT_SECTION(sw5acfn)
 DECLARE_SWIFT_SECTION(sw5ratt)
+DECLARE_SWIFT_SECTION(sw5test)
 }
 
 namespace {
@@ -88,6 +89,7 @@ static void swift_image_constructor() {
       SWIFT_SECTION_RANGE(sw5mpen),
       SWIFT_SECTION_RANGE(sw5acfn),
       SWIFT_SECTION_RANGE(sw5ratt),
+      SWIFT_SECTION_RANGE(sw5test),
   };
 
 #undef SWIFT_SECTION_RANGE

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -62,6 +62,7 @@ DECLARE_SWIFT_SECTION(swift5_capture)
 DECLARE_SWIFT_SECTION(swift5_mpenum)
 DECLARE_SWIFT_SECTION(swift5_accessible_functions)
 DECLARE_SWIFT_SECTION(swift5_runtime_attributes)
+DECLARE_SWIFT_SECTION(swift5_tests)
 }
 
 #undef DECLARE_SWIFT_SECTION
@@ -98,6 +99,7 @@ static void swift_image_constructor() {
       SWIFT_SECTION_RANGE(swift5_mpenum),
       SWIFT_SECTION_RANGE(swift5_accessible_functions),
       SWIFT_SECTION_RANGE(swift5_runtime_attributes),
+      SWIFT_SECTION_RANGE(swift5_tests),
   };
 
 #undef SWIFT_SECTION_RANGE


### PR DESCRIPTION
This PR adds a `swift5_tests` property to `MetadataSections` and populates it in the static constructors used on Linux and Windows. This section will be used by swift-testing to store test metadata for discovery at runtime (see https://github.com/apple/swift-testing/pull/210.)

This change is necessary because on Linux and Windows, section boundaries are not discoverable at runtime and so must be noted on a per-image basis at compile time. (This is also why `MetadataSections` and the static constructors are present in the first place.)

There are no compiler changes needed here. The compiler does not need special knowledge of the tests section emitted by swift-testing. The compiler does not itself need to emit anything into this section.

This change does not affect platforms that use the Mach-O binary format (i.e. Darwin) because on those platforms, there is API to find sections and segments at runtime.