### PR TITLE
[Concurrency] Make `#isolation` macro expansions explicit.

### DIFF
--- a/test/Concurrency/isolation_macro.swift
+++ b/test/Concurrency/isolation_macro.swift
@@ -33,7 +33,7 @@ extension A {
     // CHECK: rewritten=current_context_isolation_expr
     // CHECK-NEXT: inject_into_optional
     // CHECK-NEXT: erasure_expr
-    // CHECK: declref_expr implicit type="A"{{.*}}self@
+    // CHECK: declref_expr type="A"{{.*}}self@
     _ = #isolation
   }
 }
@@ -45,7 +45,7 @@ func actorIsolationToParam(_ isolatedParam: isolated A) {
   // CHECK: rewritten=current_context_isolation_expr
   // CHECK-NEXT: inject_into_optional
   // CHECK-NEXT: erasure_expr
-  // CHECK: declref_expr implicit type="A"{{.*}}isolatedParam@
+  // CHECK: declref_expr type="A"{{.*}}isolatedParam@
   _ = #isolation
 }
 
@@ -57,8 +57,8 @@ func mainActorIsolated() {
   // CHECK: rewritten=current_context_isolation_expr
   // CHECK-NEXT: inject_into_optional
   // CHECK-NEXT: erasure_expr
-  // CHECK: member_ref_expr implicit type="MainActor" decl="_Concurrency.(file).MainActor.shared"
-  // CHECK-NEXT: type_expr implicit type="MainActor.Type"
+  // CHECK: member_ref_expr type="MainActor" location=@__swiftmacro_{{.*}} decl="_Concurrency.(file).MainActor.shared"
+  // CHECK-NEXT: type_expr type="MainActor.Type"
   _ = #isolation
 }
 
@@ -72,9 +72,24 @@ func closureIsolatedToOuterParam(_ isolatedParam: isolated A) {
   // CHECK: rewritten=current_context_isolation_expr
   // CHECK-NEXT: inject_into_optional
   // CHECK-NEXT: erasure_expr
-  // CHECK: declref_expr implicit type="A"{{.*}}isolatedParam@
+  // CHECK: declref_expr type="A"{{.*}}isolatedParam@
   acceptClosure {
     _ = #isolation
     print(isolatedParam)
   }
+}
+
+func acceptEscapingClosure(_ fn: @escaping () -> Void) { }
+
+@available(SwiftStdlib 5.1, *)
+extension A {
+  func f() {
+    // Make sure this doesn't diagnose a use of implicit 'self'
+    acceptEscapingClosure {
+      _ = #isolation
+      self.g()
+    }
+  }
+
+  func g() {}
 }

--- a/test/Distributed/isolation_macro.swift
+++ b/test/Distributed/isolation_macro.swift
@@ -16,7 +16,7 @@ extension DistributedActor {
     // CHECK: rewritten=current_context_isolation_expr
     // CHECK-NEXT: inject_into_optional
     // CHECK: member_ref_expr{{.*}}asLocalActor
-    // CHECK: declref_expr implicit type="Self"
+    // CHECK: declref_expr type="Self"
     _ = #isolation
   }
 }


### PR DESCRIPTION
Macro expansions are never considered implicit. They have valid source locations in their macro expansion buffer, they do not cause implicit `self` capture diagnostics, etc.

This fixes an issue where existing code that iterates over an async sequence in an escaping closure in an actor-instance-isolated context would diagnose a use of implicit `self` via the `#isolation` argument to `next()`.

Resolves rdar://122578942
