### PR TITLE
Teach the old associated type inference about AsyncSequence.Failure

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -300,7 +300,7 @@ static void recordTypeWitness(NormalProtocolConformance *conformance,
 
     // Construct the availability of the type witnesses based on the
     // availability of the enclosing type and the associated type.
-    const Decl * availabilitySources[2] = {dc->getAsDecl(), assocType };
+    const Decl *availabilitySources[2] = { dc->getAsDecl(), assocType };
     AvailabilityInference::applyInferredAvailableAttrs(
         aliasDecl, availabilitySources, ctx);
 

--- a/test/Concurrency/async_iterator_inference.swift
+++ b/test/Concurrency/async_iterator_inference.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -strict-concurrency=complete -emit-sil -o /dev/null %s -verify -disable-availability-checking
+// RUN: %target-swift-frontend -strict-concurrency=complete -emit-sil -o /dev/null %s -verify -disable-availability-checking -enable-experimental-associated-type-inference
+// RUN: %target-swift-frontend -strict-concurrency=complete -emit-sil -o /dev/null %s -verify -disable-availability-checking -disable-experimental-associated-type-inference
 // REQUIRES: concurrency
 
 @available(SwiftStdlib 5.1, *)


### PR DESCRIPTION
The new one is smart enough to figure out a type witness for
AsyncSequence.Failure from AsyncSequence.AsyncIterator.Failure, but the
old one doesn't have general logic to handle cases like these. Introduce
a bespoke rule to keep the old/new associated type inference logic in
sync for the newly-introduced Failure type.