### PR TITLE
[ASTGen] Update for SPI in swift-syntax

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -12,7 +12,7 @@
 
 import ASTBridging
 import BasicBridging
-@_spi(ExperimentalLanguageFeature) import SwiftCompilerPluginMessageHandling
+@_spi(PluginMessage) @_spi(ExperimentalLanguageFeature) import SwiftCompilerPluginMessageHandling
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftSyntax

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -12,7 +12,7 @@
 
 import ASTBridging
 import BasicBridging
-import SwiftCompilerPluginMessageHandling
+@_spi(PluginMessage) import SwiftCompilerPluginMessageHandling
 import SwiftSyntax
 import swiftLLVMJSON
 

--- a/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
+++ b/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import SwiftCompilerPluginMessageHandling
+@_spi(PluginMessage) import SwiftCompilerPluginMessageHandling
 import SwiftSyntaxMacros
 import swiftLLVMJSON
 import CSwiftPluginServer


### PR DESCRIPTION
Update/preparation for https://github.com/apple/swift-syntax/pull/2489
All symbols in `SwiftCompilerPluginMessageHandling` are going to be SPI.
