### PR TITLE
[region-analysis] Add a pass that explicitly invalidates RegionAnalysis.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -481,6 +481,8 @@ PASS(DebugInfoCanonicalizer, "sil-onone-debuginfo-canonicalizer",
      "Canonicalize debug info at -Onone by propagating debug info into coroutine funclets")
 PASS(PartialApplySimplification, "partial-apply-simplification",
      "Transform partial_apply instructions into explicit closure box constructions")
+PASS(RegionAnalysisInvalidationTransform, "region-analysis-invalidation-transform",
+     "Delete the analysis state associated with region analysis")
 PASS(MovedAsyncVarDebugInfoPropagator, "sil-moved-async-var-dbginfo-propagator",
      "Propagate debug info from moved async vars after coroutine funclet boundaries")
 PASS(MoveOnlyBorrowToDestructureTransform,

--- a/include/swift/SILOptimizer/Transforms/AnalysisInvalidationTransform.h
+++ b/include/swift/SILOptimizer/Transforms/AnalysisInvalidationTransform.h
@@ -1,0 +1,43 @@
+//===--- AnalysisInvalidationTransform.h ----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This file defines a transform that can be used to explicitly invalidate an
+/// analysis in the pass pipeline. It is intended to be used in a situation
+/// where passes are reusing state from an analysis and one wants to explicitly
+/// placed into the pass pipeline that it is expected that the analysis be
+/// invalidated after the series of passes complete. If we were to just place
+/// the invalidation in the last run of the passes, it is possible for a
+/// programmer later to add another pass to the end of the pipeline. This would
+/// then force recomputation and may prevent invalidation from happening. So by
+/// doing this, it is clear to someone adding a new pass that this needs to
+/// happen last.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_UTILS_ANALYSISINVALIDATIONTRANSFORM_H
+#define SWIFT_SILOPTIMIZER_UTILS_ANALYSISINVALIDATIONTRANSFORM_H
+
+#include "swift/SILOptimizer/Analysis/Analysis.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+namespace swift {
+
+template <typename AnalysisTy>
+struct AnalysisInvalidationTransform : public SILFunctionTransform {
+  void run() override {
+    getAnalysis<AnalysisTy>()->invalidate();
+  }
+};
+
+} // namespace swift
+
+#endif

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -48,4 +48,5 @@ target_sources(swiftSILOptimizer PRIVATE
   YieldOnceCheck.cpp
   OSLogOptimization.cpp
   MoveOnlyWrappedTypeEliminator.cpp
+  RegionAnalysisInvalidationTransform.cpp
   OwnershipModelEliminator.cpp)

--- a/lib/SILOptimizer/Mandatory/RegionAnalysisInvalidationTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/RegionAnalysisInvalidationTransform.cpp
@@ -1,0 +1,20 @@
+//===--- RegionAnalysisInvalidationTransform.cpp --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Analysis/RegionAnalysis.h"
+#include "swift/SILOptimizer/Transforms/AnalysisInvalidationTransform.h"
+
+using namespace swift;
+
+SILTransform *swift::createRegionAnalysisInvalidationTransform() {
+  return new AnalysisInvalidationTransform<RegionAnalysis>();
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -137,7 +137,16 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addAddressLowering();
 
   P.addFlowIsolation();
+
+  //===---
+  // Passes that depend on region analysis information
+  //
+
   P.addTransferNonSendable();
+
+  // Now that we have completed running passes that use region analysis, clear
+  // region analysis.
+  P.addRegionAnalysisInvalidationTransform();
   // Lower tuple addr constructor. Eventually this can be merged into later
   // passes. This ensures we do not need to update later passes for something
   // that is only needed by TransferNonSendable().


### PR DESCRIPTION
Over time I am going to be using RegionAnalysis for a series of passes that all use that same information since I am worried about RegionAnalysis computation time. With that being said, we want to make sure to eliminate the memory that RegionAnalysis uses once this series of passes have completed. What this commit does is create a pass that explicitly invalidates region analysis and explicitly places it in the pass pipeline after the series of passes. This will ensure that even if we add an additional pass, there is a strong "rattlesnake" signal to the new code author that the code needs to be placed before the region analysis invalidation and will prevent mistakes such as having to recompute the region analysis in that later pass or the later pass forgeting to invalidate the analysis.
