### PR TITLE
[IRGen] Allow inlining into thunks for -Osize

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3407,7 +3407,7 @@ static std::unique_ptr<CallEmission> getCallEmissionForLoweredValue(
   }
 
   auto callEmission = getCallEmission(IGF, selfValue, std::move(callee));
-  if (IGF.CurSILFn->isThunk())
+  if (IGF.CurSILFn->isThunk() && !IGF.getOptions().optimizeForSize())
     callEmission->addFnAttribute(llvm::Attribute::NoInline);
 
   return callEmission;


### PR DESCRIPTION
Allowing LLVM to inline calls into thunks seems to provide fairly significant size wins, with mixed performance results.

If compiling under -Osize, allow inlining prioritizing binary size.