### PR TITLE
Update to WiX 4.0.4 to pick up a security fix

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -432,21 +432,21 @@ function Ensure-WindowsSDK {
 }
 
 function Ensure-SwiftToolchain($Arch) {
-  if (-not (Test-Path $BinaryCache\wix-4.0.1.zip)) {
+  if (-not (Test-Path $BinaryCache\wix-4.0.4.zip)) {
     Write-Output "WiX not found. Downloading from nuget.org..."
-    Invoke-Program curl.exe -sL https://www.nuget.org/api/v2/package/wix/4.0.1 --output $BinaryCache\wix-4.0.1.zip --create-dirs
+    Invoke-Program curl.exe -sL https://www.nuget.org/api/v2/package/wix/4.0.4 --output $BinaryCache\wix-4.0.4.zip --create-dirs
   }
 
   if (-not $ToBatch) {
-    $SHA256 = Get-FileHash -Path "$BinaryCache\wix-4.0.1.zip" -Algorithm SHA256
-    if ($SHA256.Hash -ne "756AD3115F0CE808313266F4E401C0F520D319211DE0B9D8D7E7697020E0C461") {
-      throw "WiX SHA256 mismatch ($($SHA256.Hash) vs 756AD3115F0CE808313266F4E401C0F520D319211DE0B9D8D7E7697020E0C461)"
+    $SHA256 = Get-FileHash -Path "$BinaryCache\wix-4.0.4.zip" -Algorithm SHA256
+    if ($SHA256.Hash -ne "A9CA12214E61BB49430A8C6E5E48AC5AE6F27DC82573B5306955C4D35F2D34E2") {
+      throw "WiX SHA256 mismatch ($($SHA256.Hash) vs A9CA12214E61BB49430A8C6E5E48AC5AE6F27DC82573B5306955C4D35F2D34E2)"
     }
   }
 
-  New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache\wix-4.0.1 | Out-Null
+  New-Item -ItemType Directory -ErrorAction Ignore $BinaryCache\wix-4.0.4 | Out-Null
   Write-Output "Extracting WiX..."
-  Expand-Archive -Path $BinaryCache\wix-4.0.1.zip -Destination $BinaryCache\wix-4.0.1 -Force
+  Expand-Archive -Path $BinaryCache\wix-4.0.4.zip -Destination $BinaryCache\wix-4.0.4 -Force
 
   if (-not (Test-Path "$BinaryCache\${PinnedToolchain}.exe")) {
     Write-Output "Swift toolchain not found. Downloading from swift.org..."
@@ -463,7 +463,7 @@ function Ensure-SwiftToolchain($Arch) {
 
   New-Item -ItemType Directory -ErrorAction Ignore "$BinaryCache\toolchains" | Out-Null
   Write-Output "Extracting Swift toolchain..."
-  Invoke-Program "$BinaryCache\wix-4.0.1\tools\net6.0\any\wix.exe" -- burn extract "$BinaryCache\${PinnedToolchain}.exe" -out "$BinaryCache\toolchains\"
+  Invoke-Program "$BinaryCache\wix-4.0.4\tools\net6.0\any\wix.exe" -- burn extract "$BinaryCache\${PinnedToolchain}.exe" -out "$BinaryCache\toolchains\"
   Invoke-Program -OutNull msiexec.exe /qn /a "$BinaryCache\toolchains\a0" TARGETDIR="$BinaryCache\toolchains\${PinnedToolchain}"
   Invoke-Program -OutNull msiexec.exe /qn /a "$BinaryCache\toolchains\a1" TARGETDIR="$BinaryCache\toolchains\${PinnedToolchain}"
   Invoke-Program -OutNull msiexec.exe /qn /a "$BinaryCache\toolchains\a2" TARGETDIR="$BinaryCache\toolchains\${PinnedToolchain}"
@@ -1684,7 +1684,7 @@ function Stage-BuildArtifacts($Arch) {
   } else {
     New-Item -Type Directory -Path "$($Arch.BinaryCache)\installer\$($Arch.VSName)\" -ErrorAction Ignore | Out-Null
   }
-  Invoke-Program "$BinaryCache\wix-4.0.1\tools\net6.0\any\wix.exe" -- burn detach "$($Arch.BinaryCache)\installer\Release\$($Arch.VSName)\installer.exe" -engine "$Stage\installer-engine.exe" -intermediateFolder "$($Arch.BinaryCache)\installer\$($Arch.VSName)\"
+  Invoke-Program "$BinaryCache\wix-4.0.4\tools\net6.0\any\wix.exe" -- burn detach "$($Arch.BinaryCache)\installer\Release\$($Arch.VSName)\installer.exe" -engine "$Stage\installer-engine.exe" -intermediateFolder "$($Arch.BinaryCache)\installer\$($Arch.VSName)\"
 }
 
 #-------------------------------------------------------------------


### PR DESCRIPTION
Replicates https://github.com/apple/swift/pull/71482 on 5.10

> There is a Windows behavior that an attacker could use to escalate privileges using a Burn bundle. All versions of WiX < 4.0.4 are affected by this vulnerability.