### PR TITLE
[Mem2Reg] When materializing an empty type projected from a non-empty aggregate, populate the non-empty fields of the aggregate with undef.

### DIFF
--- a/test/SILOptimizer/mem2reg.sil
+++ b/test/SILOptimizer/mem2reg.sil
@@ -531,3 +531,19 @@ sil @dont_canonicalize_undef : $@convention(thin) () -> () {
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: sil @undef_for_load_of_empty_type_from_nontrivial_aggregate : {{.*}} {
+// CHECK:         [[EMPTY:%[^,]+]] = tuple ()
+// CHECK:         [[AGGREGATE:%[^,]+]] = tuple (undef : $Builtin.BridgeObject, [[EMPTY]] : $())
+// CHECK:         tuple_extract [[AGGREGATE]] : $(Builtin.BridgeObject, ()), 1
+// CHECK-LABEL: } // end sil function 'undef_for_load_of_empty_type_from_nontrivial_aggregate'
+sil @undef_for_load_of_empty_type_from_nontrivial_aggregate : $@convention(thin) () -> () {
+bb0:
+  %11 = alloc_stack $(Builtin.BridgeObject, ())
+  %12 = tuple_element_addr %11 : $*(Builtin.BridgeObject, ()), 1
+  %13 = load %12 : $*()
+  %empty = tuple ()
+  %14 = tuple (%empty : $(), %13 : $())
+  dealloc_stack %11 : $*(Builtin.BridgeObject, ())
+  return undef : $()
+}


### PR DESCRIPTION
Mem2Reg may materialize the unique instance of empty types when promoting an address of that empty type.  Previously, it was required that the top-most type in the aggregate be empty.  This failed to handle the case where a projection of empty type from a non-empty aggregate was promoted.

For example:

```
%addr = alloc_stack $((), C)
%empty_addr = tuple_element_addr $addr : $*((), C), 0
%addr = load %empty_addr : $*()
```

where `C` is some non-empty type.

Here, that case is handled by using `undef` for each non-empty field in the projected-from aggregate.

In the example,

```
%empty = tuple ()
%tuple = tuple (%empty : $(), undef : $C)
%empty_again = tuple_extract %tuple : $((), C), 0
```

rdar://122417297