### PR TITLE
[CSRanking] Adjust `isDeclMoreConstrainedThan` to account for inverti…

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -344,9 +344,16 @@ static bool isDeclMoreConstrainedThan(ValueDecl *decl1, ValueDecl *decl2) {
       for (size_t i = 0; i < params1.size(); i++) {
         auto p1 = params1[i];
         auto p2 = params2[i];
-          
-        int np1 = static_cast<int>(sig1->getRequiredProtocols(p1).size());
-        int np2 = static_cast<int>(sig2->getRequiredProtocols(p2).size());
+
+        int np1 =
+            llvm::count_if(sig1->getRequiredProtocols(p1), [](const auto *P) {
+              return !P->getInvertibleProtocolKind();
+            });
+        int np2 =
+            llvm::count_if(sig2->getRequiredProtocols(p2), [](const auto *P) {
+              return !P->getInvertibleProtocolKind();
+            });
+
         int aDelta = np1 - np2;
           
         if (aDelta)

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -329,3 +329,23 @@ func fn63834_3() -> String {} // expected-note {{found candidate with type 'Stri
 func fn63834_3() -> Double {} // expected-note {{found candidate with type 'Double'}}
 
 fn63834_3() as Int // expected-error {{no exact matches in call to global function 'fn63834_3'}}
+
+// Make sure that Copyable and/or Escapable don't change overloading behavior
+do {
+  struct S {
+    var v: Int
+  }
+
+  func test(data: [S]) {
+    let transformed = data.flatMap { e in
+      if true {
+        return Array<S>()
+      }
+      return Array(arrayLiteral: e)
+    }
+
+    _ = transformed.map {
+      _ = $0.v // Ok
+    }
+  }
+}


### PR DESCRIPTION
…ble protocols

Use of invertible protocols doesn't make type parameter more constrained.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
