### PR TITLE
[NFC] Remove accidental comment in TypeCheckType.cpp

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4891,7 +4891,6 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
   if (auto dynamicSelfType = dyn_cast<DynamicSelfType>(unwrappedType)) {
     unwrappedType = dynamicSelfType->getSelfType();
   }
-  // here
 
   if (inStage(TypeResolutionStage::Interface)) {
     if (auto *env = resolution.getGenericSignature().getGenericEnvironment())


### PR DESCRIPTION
I left myself a comment when I found the code I needed to change in https://github.com/apple/swift/pull/71503, and then I forgot to remove it after I made the change!