### PR TITLE
Add interface for lookup of external MultiPayloadEnumDescriptor

### DIFF
--- a/include/swift/RemoteInspection/DescriptorFinder.h
+++ b/include/swift/RemoteInspection/DescriptorFinder.h
@@ -93,6 +93,26 @@ struct FieldDescriptorBase {
   getFieldRecords() = 0;
 };
 
+struct MultiPayloadEnumDescriptorBase {
+  virtual ~MultiPayloadEnumDescriptorBase(){};
+
+  virtual llvm::StringRef getMangledTypeName() = 0;
+
+  virtual uint32_t getContentsSizeInWords() const = 0;
+
+  virtual size_t getSizeInBytes() const = 0;
+
+  virtual uint32_t getFlags() const = 0;
+
+  virtual bool usesPayloadSpareBits() const = 0;
+
+  virtual uint32_t getPayloadSpareBitMaskByteOffset() const = 0;
+
+  virtual uint32_t getPayloadSpareBitMaskByteCount() const = 0;
+
+  virtual const uint8_t *getPayloadSpareBits() const = 0;
+
+};
 /// Interface for finding type descriptors. Implementors may provide descriptors
 /// that live inside or outside reflection metadata.
 struct DescriptorFinder {
@@ -104,6 +124,9 @@ struct DescriptorFinder {
 
   virtual std::unique_ptr<FieldDescriptorBase>
   getFieldDescriptor(const TypeRef *TR) = 0;
+
+  virtual std::unique_ptr<MultiPayloadEnumDescriptorBase>
+  getMultiPayloadEnumDescriptor(const TypeRef *TR) = 0;
 };
 
 } // namespace reflection

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -490,8 +490,8 @@ public:
     ClosureContextInfo getClosureContextInfo(RemoteRef<CaptureDescriptor> CD);
 
     /// Get the multipayload enum projection information for a given TR
-    RemoteRef<MultiPayloadEnumDescriptor>
-    getMultiPayloadEnumInfo(const TypeRef *TR);
+    std::unique_ptr<MultiPayloadEnumDescriptorBase>
+    getMultiPayloadEnumDescriptor(const TypeRef *TR) override;
 
     const TypeRef *lookupTypeWitness(const std::string &MangledTypeName,
                                      const std::string &Member,
@@ -514,6 +514,8 @@ public:
 
     /// Load unsubstituted field types for a nominal type.
     RemoteRef<FieldDescriptor> getFieldTypeInfo(const TypeRef *TR);
+
+    RemoteRef<MultiPayloadEnumDescriptor> getMultiPayloadEnumInfo(const TypeRef *TR);
 
     void populateFieldTypeInfoCacheWithReflectionAtIndex(size_t Index);
 
@@ -1563,14 +1565,15 @@ public:
   }
 
   /// Get the multipayload enum projection information for a given TR
-  RemoteRef<MultiPayloadEnumDescriptor>
-  getMultiPayloadEnumInfo(const TypeRef *TR) {
-    return RDF.getMultiPayloadEnumInfo(TR);
-  }
+  std::unique_ptr<MultiPayloadEnumDescriptorBase>
+  getMultiPayloadEnumDescriptor(const TypeRef *TR);
 
 private:
   /// Get the primitive type lowering for a builtin type.
   RemoteRef<BuiltinTypeDescriptor> getBuiltinTypeInfo(const TypeRef *TR);
+
+  RemoteRef<MultiPayloadEnumDescriptor>
+  getMultiPayloadEnumInfo(const TypeRef *TR);
 
   llvm::Optional<uint64_t> multiPayloadEnumPointerMask;
 

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2294,7 +2294,7 @@ public:
     // Uncomment the following line to dump the MPE section every time we come through here...
     //TC.getBuilder().dumpMultiPayloadEnumSection(std::cerr); // DEBUG helper
 
-    auto MPEDescriptor = TC.getBuilder().getMultiPayloadEnumInfo(TR);
+    auto MPEDescriptor = TC.getBuilder().getMultiPayloadEnumDescriptor(TR);
     if (MPEDescriptor && MPEDescriptor->usesPayloadSpareBits()) {
       auto PayloadSpareBitMaskByteCount = MPEDescriptor->getPayloadSpareBitMaskByteCount();
       auto PayloadSpareBitMaskByteOffset = MPEDescriptor->getPayloadSpareBitMaskByteOffset();


### PR DESCRIPTION
This is a follow up patch that allows for external DescriptorFinders to provide MultiPayloadEnumDescriptors (this is done to support embedded Swift debugging, which encodes the equivalent of Swift metadata as DWARF).
