### PR TITLE
[Concurrency] Don't allow non-`Sendable`, isolated closures to capture non-`Sendable` values that may be isolated to a different actor.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5436,6 +5436,10 @@ ERROR(non_sendable_capture,none,
       "capture of %1 with non-sendable type %0 in a `@Sendable` "
       "%select{local function|closure}2",
       (Type, DeclName, bool))
+ERROR(non_sendable_isolated_capture,none,
+      "capture of %1 with non-sendable type %0 in an isolated "
+      "%select{local function|closure}2",
+      (Type, DeclName, bool))
 ERROR(implicit_async_let_non_sendable_capture,none,
       "capture of %1 with non-sendable type %0 in 'async let' binding",
       (Type, DeclName))

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -1,0 +1,98 @@
+// RUN: %target-swift-frontend -verify -disable-availability-checking -strict-concurrency=complete -verify-additional-prefix complete- -emit-sil -o /dev/null %s
+// RUN: %target-swift-frontend -verify -disable-availability-checking -strict-concurrency=complete -verify-additional-prefix region-isolation- -emit-sil -o /dev/null %s -enable-experimental-feature RegionBasedIsolation
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+@globalActor
+actor MyActor {
+  static let shared = MyActor()
+  @MyActor static var ns: NotSendable?
+  @MyActor static func ohNo() { ns!.x += 1 }
+}
+
+@globalActor
+actor YourActor {
+  static let shared = YourActor()
+  @YourActor static var ns: NotSendable?
+  @YourActor static func ohNo() { ns!.x += 1 }
+}
+
+// expected-complete-note@+1 3{{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+class NotSendable {
+  var x: Int = 0
+
+  @MyActor init() {
+    MyActor.ns = self
+  }
+
+  init(x: Int) {
+    self.x = x
+  }
+
+  @MyActor func stash() {
+    MyActor.ns = self
+  }
+}
+
+@MyActor func exhibitRace1() async {
+  let ns = NotSendable(x: 0)
+  MyActor.ns = ns
+
+  // expected-region-isolation-warning@+1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller; this is an error in Swift 6}}
+  await { @YourActor in
+    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in Swift 6}}
+    YourActor.ns = ns
+  }()
+
+  await withTaskGroup(of: Void.self) {
+    $0.addTask {
+      await MyActor.ohNo()
+    }
+
+    $0.addTask {
+      await YourActor.ohNo()
+    }
+  }
+}
+
+@MyActor func exhibitRace2() async {
+  let ns = NotSendable(x: 0)
+  ns.stash()
+
+  // FIXME: Region isolation should diagnose this (https://github.com/apple/swift/issues/71533)
+  await { @YourActor in
+    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in Swift 6}}
+    YourActor.ns = ns
+  }()
+
+  await withTaskGroup(of: Void.self) {
+    $0.addTask {
+      await MyActor.ohNo()
+    }
+
+    $0.addTask {
+      await YourActor.ohNo()
+    }
+  }
+}
+
+@MyActor func exhibitRace3() async {
+  let ns = NotSendable()
+
+  // FIXME: Region isolation should diagnose this (https://github.com/apple/swift/issues/71533)
+  await { @YourActor in
+    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in Swift 6}}
+    YourActor.ns = ns
+  }()
+
+  await withTaskGroup(of: Void.self) {
+    $0.addTask {
+      await MyActor.ohNo()
+    }
+
+    $0.addTask {
+      await YourActor.ohNo()
+    }
+  }
+}


### PR DESCRIPTION
If a closure is not `Sendable`, its isolation differs from its enclosing context, and both contexts are actor isolated, treat the closure as if it may execute concurrently. Otherwise, the closure may capture non-`Sendable` state from the outer context and stash it into isolated state on a different actor, allowing for concurrent access later on.

See https://forums.swift.org/t/should-global-actor-isolated-functions-be-implicitly-sendable/60553/9 for more details.