### PR TITLE
Lower move-only wrapper types earlier to disable the TrivialMoveOnlyTypeEliminator pass.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -174,12 +174,21 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   if (EnableDeinitDevirtualizer)
     P.addDeinitDevirtualizer();
 
+  // FIXME: rdar://122701694 (`consuming` keyword causes verification error on
+  //        invalid SIL types)
+  //
   // Lower move only wrapped trivial types.
-  P.addTrivialMoveOnlyTypeEliminator();
+  //   P.addTrivialMoveOnlyTypeEliminator();
+
   // Check no uses after consume operator of a value in an address.
   P.addConsumeOperatorCopyableAddressesChecker();
   // No uses after consume operator of copyable value.
   P.addConsumeOperatorCopyableValuesChecker();
+
+  // As a temporary measure, we also eliminate move only for non-trivial types
+  // until we can audit the later part of the pipeline. Eventually, this should
+  // occur before IRGen.
+  P.addMoveOnlyTypeEliminator();
 
   //
   // End Ownership Optimizations
@@ -245,11 +254,6 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
 
   // Canonical swift requires all non cond_br critical edges to be split.
   P.addSplitNonCondBrCriticalEdges();
-
-  // As a temporary measure, we also eliminate move only for non-trivial types
-  // until we can audit the later part of the pipeline. Eventually, this should
-  // occur before IRGen.
-  P.addMoveOnlyTypeEliminator();
 
   // For embedded Swift: Specialize generic class vtables.
   P.addVTableSpecializer();

--- a/test/SILOptimizer/noimplicitcopy_consuming_parameters.swift
+++ b/test/SILOptimizer/noimplicitcopy_consuming_parameters.swift
@@ -9,6 +9,7 @@ public class Klass {
 
 public struct NonTrivialStruct {
     var k = Klass()
+    let i = 0
 
     func doSomethingDefault() {}
     borrowing func doSomethingBorrowing() {}
@@ -228,6 +229,10 @@ func testLoadableConsumingEnum2(_ x: consuming LoadableEnum) {
 
 func testLoadableConsumingCopyOperator(_ x: consuming NonTrivialStruct) {
     _ = copy x
+}
+
+func testLoadableConsumingTrivialLetField(_ x: consuming NonTrivialStruct) -> Int {
+    return x.i
 }
 
 //////////////////////////////////////////


### PR DESCRIPTION
This eliminates an in-between state where only some move-only wrapper types are removed. The long term fix is to teach SILGen to emit casts more precisely.

This fixes the `consuming` and `borrowing` keywords for some basic cases. In particular, if a nontrivial struct contains a trivial 'let' field, then this pass would result in invalid SIL types:

class C {}

struct BV {
  let p: UnsafeRawPointer
  let c: C
}

func getPointer(bv: consuming BV) -> UnsafeRawPointer {
  return bv.p
}

Ultimately, this pass makes sense, but there is something strange about the way move-only-ness propagates into fields of aggregates which needs to be fixed first. Until then, other features are blocked on basic support for these keywords.

Fixes rdar://122701694 (`consuming` keyword causes verification error on invalid SIL types)

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
