### PR TITLE
lit: add space after -color-diagnostics

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1957,7 +1957,7 @@ subst_target_swift_frontend_mock_sdk += " -typo-correction-limit 10 "
 
 # Enable colors if we have them.
 if config.color_output:
-    config.target_swift_frontend += " -color-diagnostics"
+    config.target_swift_frontend += " -color-diagnostics "
 
 config.substitutions.append(('%module-target-triple',
                              target_specific_module_triple))


### PR DESCRIPTION
Some tests put no space after `%target-swift-frontend` and the flag that follows it, so we can end up with `-color-diagnostics-emit-module`.