### PR TITLE
Sema: Restore old behavior of generic parameters with associated type inference

### DIFF
--- a/test/decl/protocol/req/associated_type_generic_param.swift
+++ b/test/decl/protocol/req/associated_type_generic_param.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
-// RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 protocol P {
   associatedtype A = Int
@@ -7,4 +7,5 @@ protocol P {
 
 struct S<A>: P {}
 
-let x: String.Type = S<String>.A.self
+// This is unfortunate but it is the behavior of Swift 5.10.
+let x: Int.Type = S<String>.A.self

--- a/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference_fixed_type_experimental_inference.swift
@@ -214,7 +214,7 @@ do {
   // CHECK-NEXT: }
   struct Conformer1: P17a {} // expected-error {{type 'Conformer1' does not conform to protocol 'P17a'}}
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer2<A> to P17b: {
-  // CHECK-NEXT: A => A (preferred), [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: A => (unresolved), [[EQUIV_CLASS:0x[0-9a-f]+]]
   // CHECK-NEXT: B => (unresolved)
   // CHECK-NEXT: }
   struct Conformer2<A>: P17b {} // expected-error {{type 'Conformer2<A>' does not conform to protocol 'P17b'}}
@@ -223,7 +223,7 @@ do {
   // CHECK-NEXT: }
   struct Conformer3: P17c {}
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer4<A> to P17d: {
-  // CHECK-NEXT: A => A (preferred), [[EQUIV_CLASS:0x[0-9a-f]+]]
+  // CHECK-NEXT: A => Int (preferred), [[EQUIV_CLASS:0x[0-9a-f]+]]
   // CHECK-NEXT: B => Int (preferred), [[EQUIV_CLASS:0x[0-9a-f]+]]
   // CHECK-NEXT: }
   struct Conformer4<A>: P17d {}
@@ -645,7 +645,7 @@ protocol P37b {
 }
 do {
   // CHECK-LABEL: Abstract type witness system for conformance of Conformer1<C> to P37b: {
-  // CHECK-NEXT: C => C (preferred),
+  // CHECK-NEXT: C => Self.B.A (preferred),
   // CHECK-NEXT: }
   struct Conformer1<C>: P37b {
     struct Inner: P37a { typealias A = C }

--- a/test/decl/protocol/req/associated_type_inference_stdlib_3.swift
+++ b/test/decl/protocol/req/associated_type_inference_stdlib_3.swift
@@ -1,5 +1,7 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-typecheck-verify-swift -enable-experimental-associated-type-inference
 // RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+
+// FIXME: Get this passing with -enable-experimental-associated-type-inference again.
 
 struct FooIterator<T: Sequence>: IteratorProtocol {
   typealias Element = T.Element

--- a/test/decl/protocol/req/rdar122587432.swift
+++ b/test/decl/protocol/req/rdar122587432.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+
+public struct S<Element: Hashable> {
+  public typealias A = [Element: Int]
+}
+
+extension S: Sequence {
+  public func makeIterator() -> A.Iterator {
+    fatalError()
+  }
+}
+
+let x: (key: String, value: Int).Type = S<String>.Element.self


### PR DESCRIPTION
This effectively reverts https://github.com/apple/swift/commit/d0bd026077c8154da710e77389f8d06d0539e5a1, so
we now look for abstract type witnesses before generic parameters.

In particular, this means we again prefer the default type witness
over a generic parameter if nothing else forces it to be a generic
parameter:

    protocol P { associatedtype A = Int }
    struct S<T>: P {}
    // S.T is always Int

Fixing this properly requires modeling generic parameter bindings as
disjunctions, which is a more disruptive change than I want to take
for now.

Fixes rdar://problem/122587432.