### PR TITLE
[embedded] Switch dependency from posix_memalign to C11 standard aligned_alloc

### DIFF
--- a/docs/EmbeddedSwift/UserManual.md
+++ b/docs/EmbeddedSwift/UserManual.md
@@ -151,7 +151,7 @@ Embedded Swift minimizes external dependencies (i.e. functions that need to be a
 For (1), external dependencies are only used based on actual usage of the program under compilation:
 
 - instantiating a class, or using UnsafeMutablePointer.allocate()
-  - dependency: `int posix_memalign(void **, size_t, size_t);`
+  - dependency: `void *aligned_alloc(size_t alignment, size_t size);`
   - dependency: `void free(void *);`
 - using print()
   - dependency: `int putchar(int);`

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -48,8 +48,8 @@ public struct HeapObject {
 
 /// Forward declarations of C functions
 
-@_extern(c, "posix_memalign")
-func posix_memalign(_: UnsafeMutablePointer<UnsafeMutableRawPointer?>, _: Int, _: Int) -> CInt
+@_extern(c, "aligned_alloc")
+func aligned_alloc(_: Int, _: Int) -> Builtin.RawPointer
 
 @_extern(c, "free")
 func free(_ p: Builtin.RawPointer)
@@ -60,9 +60,8 @@ func free(_ p: Builtin.RawPointer)
 
 func alignedAlloc(size: Int, alignment: Int) -> UnsafeMutableRawPointer? {
   let alignment = max(alignment, MemoryLayout<UnsafeRawPointer>.size)
-  var r: UnsafeMutableRawPointer? = nil
-  _ = posix_memalign(&r, alignment, size)
-  return r
+  let size = (size + alignment - 1) & ~(alignment - 1)
+  return UnsafeMutableRawPointer(aligned_alloc(alignment, size))
 }
 
 @_cdecl("swift_slowAlloc")

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -14,10 +14,10 @@
 // DEP: ___stack_chk_fail
 // DEP: ___stack_chk_guard
 // DEP: _arc4random_buf
+// DEP: _aligned_alloc
 // DEP: _free
 // DEP: _memset
 // DEP: _putchar
-// DEP: _posix_memalign
 
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang -x c -c %S/Inputs/linux-rng-support.c -o %t/linux-rng-support.o

--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -13,10 +13,10 @@
 
 // DEP: ___stack_chk_fail
 // DEP: ___stack_chk_guard
+// DEP: _aligned_alloc
 // DEP: _free
 // DEP: _memset
 // DEP: _putchar
-// DEP: _posix_memalign
 
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out


### PR DESCRIPTION
Switch posix_memalign to aligned_alloc. The latter seems to be more standard, and more widespread in existing libc embedded implementations.