### PR TITLE
[CMake] Add broader support for cross-compiling the portions of the compiler that are written in Swift to non-Darwin Unix

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -148,10 +148,9 @@ function(add_swift_compiler_modules_library name)
       list(APPEND sdk_option "-resource-dir" "${swift_exec_bin_dir}/../bootstrapping0/lib/swift")
     endif()
   elseif(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
-    get_filename_component(swift_exec_bin_dir ${ALS_SWIFT_EXEC} DIRECTORY)
     # NOTE: prepending allows SWIFT_COMPILER_SOURCES_SDK_FLAGS to override the
     # resource directory if needed.
-    list(PREPEND sdk_option "-resource-dir" "${swift_exec_bin_dir}/../lib/swift")
+    list(PREPEND sdk_option "-resource-dir" "${SWIFTLIB_DIR}")
   endif()
   get_versioned_target_triple(target ${SWIFT_HOST_VARIANT_SDK}
       ${SWIFT_HOST_VARIANT_ARCH} "${deployment_version}")
@@ -225,6 +224,9 @@ function(add_swift_compiler_modules_library name)
         importedHeaderDependencies
       COMMENT "Building swift module ${module}")
 
+    if(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
+      add_dependencies(${dep_target} swift-stdlib-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+    endif()
     set("${module}_dep_target" ${dep_target})
     set(all_module_targets ${all_module_targets} ${dep_target})
   endforeach()

--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -60,6 +60,16 @@ function(_add_host_swift_compile_options name)
     $<$<COMPILE_LANGUAGE:Swift>:none>)
 
   target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-target;${SWIFT_HOST_TRIPLE}>)
+  if(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
+    add_dependencies(${name} swift-stdlib-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+    target_compile_options(${name} PRIVATE
+      $<$<COMPILE_LANGUAGE:Swift>:-sdk;${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_PATH};>
+      $<$<COMPILE_LANGUAGE:Swift>:-resource-dir;${SWIFTLIB_DIR};>)
+    if(SWIFT_HOST_VARIANT_SDK STREQUAL "ANDROID" AND NOT "${SWIFT_ANDROID_NDK_PATH}" STREQUAL "")
+      swift_android_tools_path(${SWIFT_HOST_VARIANT_ARCH} tools_path)
+      target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-tools-directory;${tools_path};>)
+    endif()
+  endif()
   _add_host_variant_swift_sanitizer_flags(${name})
 
   target_compile_options(${name} PRIVATE

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -529,15 +529,19 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
   elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD|FREEBSD|WINDOWS")
     set(swiftrt "swiftImageRegistrationObject${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
     if(ASRLF_BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|CROSSCOMPILE")
-      # At build time and run time, link against the swift libraries in the
-      # installed host toolchain.
-      if(SWIFT_PATH_TO_SWIFT_SDK)
-        set(swift_dir "${SWIFT_PATH_TO_SWIFT_SDK}/usr")
+      if(ASRLF_BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
+        # At build time and run time, link against the swift libraries in the
+        # installed host toolchain.
+        if(SWIFT_PATH_TO_SWIFT_SDK)
+          set(swift_dir "${SWIFT_PATH_TO_SWIFT_SDK}/usr")
+        else()
+          get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
+          get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
+        endif()
+        set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
       else()
-        get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
-        get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
+        set(host_lib_dir "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
       endif()
-      set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
       set(host_lib_arch_dir "${host_lib_dir}/${SWIFT_HOST_VARIANT_ARCH}")
 
       set(swiftrt "${host_lib_arch_dir}/swiftrt${CMAKE_C_OUTPUT_EXTENSION}")

--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -71,6 +71,10 @@ endif()
 add_dependencies(swift-syntax-lib
   ${SWIFT_SYNTAX_MODULES})
 
+if(BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
+    add_dependencies(swift-syntax-lib swift-stdlib-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
+endif()
+
 # Install Swift module interface files.
 foreach(module ${SWIFT_SYNTAX_MODULES})
   set(module_dir "${module}.swiftmodule")

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -836,8 +836,9 @@ function(_compile_swift_files
   endif()
 
   set(swift_compiler_tool_dep)
-  if(SWIFT_INCLUDE_TOOLS)
-    # Depend on the binary itself, in addition to the symlink.
+  if(SWIFT_INCLUDE_TOOLS AND NOT BOOTSTRAPPING_MODE STREQUAL "CROSSCOMPILE")
+    # Depend on the binary itself, in addition to the symlink, unless
+    # cross-compiling the compiler.
     set(swift_compiler_tool_dep "swift-frontend${target_suffix}")
   endif()
 

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -106,11 +106,15 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
   elseif(SWIFT_HOST_VARIANT_SDK MATCHES "LINUX|ANDROID|OPENBSD" AND HAS_SWIFT_MODULES AND ASKD_BOOTSTRAPPING_MODE)
     set(swiftrt "swiftImageRegistrationObject${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_OBJECT_FORMAT}-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}")
     if(ASKD_BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS|CROSSCOMPILE")
-      # At build time and run time, link against the swift libraries in the
-      # installed host toolchain.
-      get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
-      get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
-      set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+      if(ASKD_BOOTSTRAPPING_MODE MATCHES "HOSTTOOLS")
+        # At build time and run time, link against the swift libraries in the
+        # installed host toolchain.
+        get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
+        get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
+        set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+      else()
+        set(host_lib_dir "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+      endif()
 
       target_link_libraries(${target} PRIVATE ${swiftrt})
       target_link_libraries(${target} PRIVATE "swiftCore")


### PR DESCRIPTION
Add cross-compilation flags for the newly added Swift source in `lib/ASTGen/`, similar to how `SwiftCompilerSources/` is already cross-compiled for other platforms. Make sure the Swift source in the compiler builds and links against `SWIFTLIB_DIR` in this cross-compilation build directory, not the one that comes with the native host compiler.

This requires changing the dependency chain in `CROSSCOMPILE` mode, as normally the Swift compiler is built first when building natively for the host, then it's used to build the stdlib. However, when cross-compiling the toolchain, the stdlib must be cross-compiled first by the host compiler, then the portions of the Swift compiler written in Swift must be cross-compiled with that new stdlib. All these dependency changes simply change that compilation order when cross-compiling, including removing the dependency that the Swift compiler is built before the stdlib when cross-compiling the Swift compiler.

All changes in this pull are gated on the `CROSSCOMPILE` mode, so they will not affect any of the existing CI or build presets.

This implements 1. of #71507, generalizing my Android patch from late last year to more non-Darwin platforms. @compnerd, let me know what you think, could be useful for Windows too. @rintaro and @bnbarham, you added some of this CMake support for linux that I'm now modifying for cross-compilation, input appreciated.

@drodriguez, you may be the only person other than me using this `CROSSCOMPILE` mode, considering the slight modifications you added in #70134 a couple months ago. What platforms are you building for? Let me know what you think of this pull, and if you need me to pull out the `SWIFT_COMPILER_SOURCES_SDK_FLAGS` override you added there and apply it to _all_ this Swift source that is now built into the compiler.