### PR TITLE
[Runtime] Add an option to produce non-symbolicated backtraces.

### DIFF
--- a/docs/Backtracing.rst
+++ b/docs/Backtracing.rst
@@ -100,6 +100,9 @@ follows:
 |                 |         | standard error instead of standard output.  This |
 |                 |         | may be useful in some CI systems.                |
 +-----------------+---------+--------------------------------------------------+
+| symbolicate     | yes     | Set to ``no`` to disable symbolication.  This    |
+|                 |         | will also disable inline frame lookup.           |
++-----------------+---------+--------------------------------------------------+
 | swift-backtrace |         | If specified, gives the full path to the         |
 |                 |         | swift-backtrace binary to use for crashes.       |
 |                 |         | Otherwise, Swift will locate the binary relative |

--- a/docs/Backtracing.rst
+++ b/docs/Backtracing.rst
@@ -100,8 +100,9 @@ follows:
 |                 |         | standard error instead of standard output.  This |
 |                 |         | may be useful in some CI systems.                |
 +-----------------+---------+--------------------------------------------------+
-| symbolicate     | yes     | Set to ``no`` to disable symbolication.  This    |
-|                 |         | will also disable inline frame lookup.           |
+| symbolicate     | full    | Options are ``full``, ``fast``, or ``off``.      |
+|                 |         | Full means to look up source locations and       |
+|                 |         | inline frames.  Fast just does symbol lookup.    |
 +-----------------+---------+--------------------------------------------------+
 | swift-backtrace |         | If specified, gives the full path to the         |
 |                 |         | swift-backtrace binary to use for crashes.       |

--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -6,6 +6,7 @@ Contents
 .. toctree::
    :maxdepth: 1
 
+   Backtracing
    Generics
    StoredAndComputedVariables
    SIL

--- a/stdlib/public/Backtracing/Backtrace.swift
+++ b/stdlib/public/Backtracing/Backtrace.swift
@@ -613,6 +613,9 @@ public struct Backtrace: CustomStringConvertible, Sendable {
   ///                         running on, add virtual frames to show inline
   ///                         function calls.
   ///
+  /// @param showSourceLocation If `true`, look up the source location for
+  ///                           each address.
+  ///
   /// @param useSymbolCache   If the system we are on has a symbol cache,
   ///                         says whether or not to use it.
   ///
@@ -620,13 +623,17 @@ public struct Backtrace: CustomStringConvertible, Sendable {
   public func symbolicated(with images: [Image]? = nil,
                            sharedCacheInfo: SharedCacheInfo? = nil,
                            showInlineFrames: Bool = true,
+                           showSourceLocations: Bool = true,
                            useSymbolCache: Bool = true)
     -> SymbolicatedBacktrace? {
-    return SymbolicatedBacktrace.symbolicate(backtrace: self,
-                                             images: images,
-                                             sharedCacheInfo: sharedCacheInfo,
-                                             showInlineFrames: showInlineFrames,
-                                             useSymbolCache: useSymbolCache)
+    return SymbolicatedBacktrace.symbolicate(
+      backtrace: self,
+      images: images,
+      sharedCacheInfo: sharedCacheInfo,
+      showInlineFrames: showInlineFrames,
+      showSourceLocations: showSourceLocations,
+      useSymbolCache: useSymbolCache
+    )
   }
 
   /// Provide a textual version of the backtrace.

--- a/stdlib/public/Backtracing/BacktraceFormatter.swift
+++ b/stdlib/public/Backtracing/BacktraceFormatter.swift
@@ -545,12 +545,12 @@ public struct BacktraceFormatter {
     if let index = index {
       columns.append(options._theme.frameIndex("\(index)"))
     }
-    columns.append(options._theme.programCounter(pc))
     if options._showFrameAttributes {
       columns.append(attrs.map(
                        options._theme.frameAttribute
                      ).joined(separator: " "))
     }
+    columns.append(options._theme.programCounter(pc))
 
     return columns
   }

--- a/stdlib/public/Backtracing/SymbolicatedBacktrace.swift
+++ b/stdlib/public/Backtracing/SymbolicatedBacktrace.swift
@@ -336,7 +336,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
                                  with owner: CSSymbolOwnerRef,
                                  isInline: Bool,
                                  symbol: CSSymbolRef,
-                                 sourceInfo: CSSourceInfoRef,
+                                 sourceInfo: CSSourceInfoRef?,
                                  images: [Backtrace.Image]) -> Frame {
     if CSIsNull(symbol) {
       return Frame(captured: capturedFrame, symbol: nil)
@@ -349,7 +349,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
 
     let location: SourceLocation?
 
-    if !CSIsNull(sourceInfo) {
+    if let sourceInfo = sourceInfo, !CSIsNull(sourceInfo) {
       let path = CSSourceInfoGetPath(sourceInfo) ?? "<unknown>"
       let line = CSSourceInfoGetLineNumber(sourceInfo)
       let column = CSSourceInfoGetColumn(sourceInfo)
@@ -390,6 +390,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
                                    images: [Backtrace.Image]?,
                                    sharedCacheInfo: Backtrace.SharedCacheInfo?,
                                    showInlineFrames: Bool,
+                                   showSourceLocations: Bool,
                                    useSymbolCache: Bool)
     -> SymbolicatedBacktrace? {
 
@@ -449,7 +450,7 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
 
                 first = false
               }
-            } else {
+            } else if showSourceLocations {
               let symbol = CSSymbolOwnerGetSymbolWithAddress(owner, address)
               let sourceInfo = CSSymbolOwnerGetSourceInfoWithAddress(owner,
                                                                      address)
@@ -459,6 +460,15 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
                                        isInline: false,
                                        symbol: symbol,
                                        sourceInfo: sourceInfo,
+                                       images: theImages))
+            } else {
+              let symbol = CSSymbolOwnerGetSymbolWithAddress(owner, address)
+
+              frames.append(buildFrame(from: frame,
+                                       with: owner,
+                                       isInline: false,
+                                       symbol: symbol,
+                                       sourceInfo: nil,
                                        images: theImages))
             }
         }
@@ -500,21 +510,29 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
         }
 
         if let theSymbol = elf32Image?.lookupSymbol(address: relativeAddress) {
-          var location = try? elf32Image!.sourceLocation(for: relativeAddress)
+          var location: SourceLocation?
 
-          for inline in elf32Image!.inlineCallSites(at: relativeAddress) {
-            let fakeSymbol = Symbol(imageIndex: imageNdx,
-                                    imageName: theImages[imageNdx].name,
-                                    rawName: inline.rawName ?? "<unknown>",
-                                    offset: 0,
-                                    sourceLocation: location)
-            frames.append(Frame(captured: frame,
-                                symbol: fakeSymbol,
-                                inlined: true))
+          if showSourceLocations || showInlineFrames {
+            location = try? elf32Image!.sourceLocation(for: relativeAddress)
+          } else {
+            location = nil
+          }
 
-            location = SourceLocation(path: inline.filename,
-                                      line: inline.line,
-                                      column: inline.column)
+          if showInlineFrames {
+            for inline in elf32Image!.inlineCallSites(at: relativeAddress) {
+              let fakeSymbol = Symbol(imageIndex: imageNdx,
+                                      imageName: theImages[imageNdx].name,
+                                      rawName: inline.rawName ?? "<unknown>",
+                                      offset: 0,
+                                      sourceLocation: location)
+              frames.append(Frame(captured: frame,
+                                  symbol: fakeSymbol,
+                                  inlined: true))
+
+              location = SourceLocation(path: inline.filename,
+                                        line: inline.line,
+                                        column: inline.column)
+            }
           }
 
           symbol = Symbol(imageIndex: imageNdx,
@@ -523,21 +541,29 @@ public struct SymbolicatedBacktrace: CustomStringConvertible {
                           offset: theSymbol.offset,
                           sourceLocation: location)
         } else if let theSymbol = elf64Image?.lookupSymbol(address: relativeAddress) {
-          var location = try? elf64Image!.sourceLocation(for: relativeAddress)
+          var location: SourceLocation?
 
-          for inline in elf64Image!.inlineCallSites(at: relativeAddress) {
-            let fakeSymbol = Symbol(imageIndex: imageNdx,
-                                    imageName: theImages[imageNdx].name,
-                                    rawName: inline.rawName ?? "<unknown>",
-                                    offset: 0,
-                                    sourceLocation: location)
-            frames.append(Frame(captured: frame,
-                                symbol: fakeSymbol,
-                                inlined: true))
+          if showSourceLocations || showInlineFrames {
+            location = try? elf64Image!.sourceLocation(for: relativeAddress)
+          } else {
+            location = nil
+          }
 
-            location = SourceLocation(path: inline.filename,
-                                      line: inline.line,
-                                      column: inline.column)
+          if showInlineFrames {
+            for inline in elf64Image!.inlineCallSites(at: relativeAddress) {
+              let fakeSymbol = Symbol(imageIndex: imageNdx,
+                                      imageName: theImages[imageNdx].name,
+                                      rawName: inline.rawName ?? "<unknown>",
+                                      offset: 0,
+                                      sourceLocation: location)
+              frames.append(Frame(captured: frame,
+                                  symbol: fakeSymbol,
+                                  inlined: true))
+
+              location = SourceLocation(path: inline.filename,
+                                        line: inline.line,
+                                        column: inline.column)
+            }
           }
 
           symbol = Symbol(imageIndex: imageNdx,

--- a/stdlib/public/libexec/swift-backtrace/TargetLinux.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetLinux.swift
@@ -27,13 +27,18 @@ import _Backtracing
 
 @_implementationOnly import Runtime
 
+enum SomeBacktrace {
+  case raw(Backtrace)
+  case symbolicated(SymbolicatedBacktrace)
+}
+
 struct TargetThread {
   typealias ThreadID = pid_t
 
   var id: ThreadID
   var context: HostContext?
   var name: String
-  var backtrace: SymbolicatedBacktrace
+  var backtrace: SomeBacktrace
 }
 
 class Target {
@@ -105,7 +110,8 @@ class Target {
     return trimmed
   }
 
-  init(crashInfoAddr: UInt64, limit: Int?, top: Int, cache: Bool) {
+  init(crashInfoAddr: UInt64, limit: Int?, top: Int, cache: Bool,
+       symbolicate: Bool) {
     // fd #4 is reserved for the memory server
     let memserverFd: CInt = 4
 
@@ -130,7 +136,8 @@ class Target {
 
     do {
       try fetchThreads(threadListHead: Address(crashInfo.thread_list),
-                       limit: limit, top: top, cache: cache)
+                       limit: limit, top: top, cache: cache,
+                       symbolicate: symbolicate)
     } catch {
       print("swift-backtrace: failed to fetch thread information: \(error)")
       exit(1)
@@ -143,7 +150,7 @@ class Target {
   /// uninterruptible wait, we won't have a ucontext for it.
   func fetchThreads(
     threadListHead: Address,
-    limit: Int?, top: Int, cache: Bool
+    limit: Int?, top: Int, cache: Bool, symbolicate: Bool
   ) throws {
     var next = threadListHead
 
@@ -164,18 +171,26 @@ class Target {
                                             images: images,
                                             limit: limit,
                                             top: top)
-      guard let symbolicated
-              = backtrace.symbolicated(with: images,
-                                       sharedCacheInfo: nil,
-                                       useSymbolCache: cache) else {
-        print("unable to symbolicate backtrace for thread \(t.tid)")
-        exit(1)
-      }
 
-      threads.append(TargetThread(id: TargetThread.ThreadID(t.tid),
-                                  context: context,
-                                  name: getThreadName(tid: t.tid),
-                                  backtrace: symbolicated))
+      if symbolicate {
+        guard let symbolicated
+                = backtrace.symbolicated(with: images,
+                                         sharedCacheInfo: nil,
+                                         useSymbolCache: cache) else {
+          print("unable to symbolicate backtrace for thread \(t.tid)")
+          exit(1)
+        }
+
+        threads.append(TargetThread(id: TargetThread.ThreadID(t.tid),
+                                    context: context,
+                                    name: getThreadName(tid: t.tid),
+                                    backtrace: .symbolicated(symbolicated)))
+      } else {
+        threads.append(TargetThread(id: TargetThread.ThreadID(t.tid),
+                                    context: context,
+                                    name: getThreadName(tid: t.tid),
+                                    backtrace: .raw(backtrace)))
+      }
     }
 
     // Sort the threads by thread ID; the main thread always sorts
@@ -193,7 +208,7 @@ class Target {
     }
   }
 
-  func redoBacktraces(limit: Int?, top: Int, cache: Bool) {
+  func redoBacktraces(limit: Int?, top: Int, cache: Bool, symbolicate: Bool) {
     for (ndx, thread) in threads.enumerated() {
       guard let context = thread.context else {
         continue
@@ -208,14 +223,18 @@ class Target {
         continue
       }
 
-      guard let symbolicated = backtrace.symbolicated(with: images,
-                                                      sharedCacheInfo: nil,
-                                                      useSymbolCache: cache) else {
-        print("unable to symbolicate backtrace from context for thread \(ndx)")
-        continue
-      }
+      if symbolicate {
+        guard let symbolicated = backtrace.symbolicated(with: images,
+                                                        sharedCacheInfo: nil,
+                                                        useSymbolCache: cache) else {
+          print("unable to symbolicate backtrace from context for thread \(ndx)")
+          continue
+        }
 
-      threads[ndx].backtrace = symbolicated
+        threads[ndx].backtrace = .symbolicated(symbolicated)
+      } else {
+        threads[ndx].backtrace = .raw(backtrace)
+      }
     }
   }
 

--- a/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
+++ b/stdlib/public/libexec/swift-backtrace/TargetMacOS.swift
@@ -46,13 +46,18 @@ extension thread_extended_info {
   }
 }
 
+enum SomeBacktrace {
+  case raw(Backtrace)
+  case symbolicated(SymbolicatedBacktrace)
+}
+
 struct TargetThread {
   typealias ThreadID = UInt64
 
   var id: ThreadID
   var context: HostContext?
   var name: String
-  var backtrace: SymbolicatedBacktrace
+  var backtrace: SomeBacktrace
 }
 
 class Target {
@@ -134,7 +139,8 @@ class Target {
       (flags & UInt32(CS_PLATFORM_BINARY | CS_PLATFORM_PATH)) != 0
   }
 
-  init(crashInfoAddr: UInt64, limit: Int?, top: Int, cache: Bool) {
+  init(crashInfoAddr: UInt64, limit: Int?, top: Int, cache: Bool,
+       symbolicate: Bool) {
     pid = getppid()
 
     if Self.isPlatformBinary(pid: pid) {
@@ -185,10 +191,10 @@ class Target {
     images = Backtrace.captureImages(for: task)
     sharedCacheInfo = Backtrace.captureSharedCacheInfo(for: task)
 
-    fetchThreads(limit: limit, top: top, cache: cache)
+    fetchThreads(limit: limit, top: top, cache: cache, symbolicate: symbolicate)
   }
 
-  func fetchThreads(limit: Int?, top: Int, cache: Bool) {
+  func fetchThreads(limit: Int?, top: Int, cache: Bool, symbolicate: Bool) {
     var threadPorts: thread_act_array_t? = nil
     var threadCount: mach_msg_type_number_t = 0
     let kr = task_threads(task,
@@ -260,24 +266,32 @@ class Target {
         exit(1)
       }
 
-      guard let symbolicated = backtrace.symbolicated(with: images,
-                                                      sharedCacheInfo: sharedCacheInfo,
-                                                      useSymbolCache: cache) else {
-        print("unable to symbolicate backtrace from context for thread \(ndx)",
-              to: &standardError)
-        exit(1)
-      }
+      if symbolicate {
+        guard let symbolicated = backtrace.symbolicated(with: images,
+                                                        sharedCacheInfo: sharedCacheInfo,
+                                                        useSymbolCache: cache) else {
+          print("unable to symbolicate backtrace from context for thread \(ndx)",
+                to: &standardError)
+          exit(1)
+        }
 
-      threads.append(TargetThread(id: info.thread_id,
-                                  context: ctx,
-                                  name: threadName,
-                                  backtrace: symbolicated))
+        threads.append(TargetThread(id: info.thread_id,
+                                    context: ctx,
+                                    name: threadName,
+                                    backtrace: .symbolicated(symbolicated)))
+      } else {
+        threads.append(TargetThread(id: info.thread_id,
+                                    context: ctx,
+                                    name: threadName,
+                                    backtrace: .raw(backtrace)))
+      }
 
       mach_port_deallocate(mach_task_self_, ports[Int(ndx)])
     }
   }
 
-  public func redoBacktraces(limit: Int?, top: Int, cache: Bool) {
+  public func redoBacktraces(limit: Int?, top: Int,
+                             cache: Bool, symbolicate: Bool) {
     for (ndx, thread) in threads.enumerated() {
       guard let context = thread.context else {
         continue
@@ -293,15 +307,19 @@ class Target {
         continue
       }
 
-      guard let symbolicated = backtrace.symbolicated(with: images,
-                                                      sharedCacheInfo: sharedCacheInfo,
-                                                      useSymbolCache: cache) else {
-        print("swift-backtrace: unable to symbolicate backtrace from context for thread \(ndx)",
-              to: &standardError)
-        continue
-      }
+      if symbolicate {
+        guard let symbolicated = backtrace.symbolicated(with: images,
+                                                        sharedCacheInfo: sharedCacheInfo,
+                                                        useSymbolCache: cache) else {
+          print("swift-backtrace: unable to symbolicate backtrace from context for thread \(ndx)",
+                to: &standardError)
+          continue
+        }
 
-      threads[ndx].backtrace = symbolicated
+        threads[ndx].backtrace = .symbolicated(symbolicated)
+      } else {
+        threads[ndx].backtrace = .raw(backtrace)
+      }
     }
   }
 

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -56,6 +56,12 @@ internal struct SwiftBacktrace {
     case stderr
   }
 
+  enum Symbolication {
+    case off
+    case fast
+    case full
+  }
+
   struct Arguments {
     var unwindAlgorithm: UnwindAlgorithm = .precise
     var demangle = false
@@ -72,7 +78,7 @@ internal struct SwiftBacktrace {
     var sanitize: Bool? = nil
     var cache = true
     var outputTo: OutputTo = .stdout
-    var symbolicate = true
+    var symbolicate: Symbolication = .full
   }
 
   static var args = Arguments()
@@ -204,9 +210,9 @@ Generate a backtrace for the parent process.
 -a <addr>               Provide a pointer to a platform specific CrashInfo
                         structure.  <addr> should be in hexadecimal.
 
---symbolicate [<bool>]  Set whether or not to resolve addresses into symbols.
-                        Also controls whether or not we look for inline frame
-                        data.
+--symbolicate [<mode>]  Set to "full" to fully symbolicate, including inline
+                        frames and source locations; "fast" to just do symbol
+                        lookup, of "off" to disable.  The default is "full".
 """, to: &standardError)
   }
 
@@ -426,9 +432,19 @@ Generate a backtrace for the parent process.
         }
       case "--symbolicate":
         if let v = value {
-          args.symbolicate = parseBool(v)
+          switch v.lowercased() {
+            case "off":
+              args.symbolicate = .off
+            case "fast":
+              args.symbolicate = .fast
+            case "full":
+              args.symbolicate = .full
+            default:
+              print("swift-backtrace: unknown symbolicate setting '\(v)'",
+                    to: &standardError)
+          }
         } else {
-          args.symbolicate = true
+          args.symbolicate = .full
         }
       default:
         print("swift-backtrace: unknown argument '\(arg)'",
@@ -1122,7 +1138,16 @@ Generate a backtrace for the parent process.
                   case "symbolicate":
                     let oldSymbolicate = args.symbolicate
 
-                    args.symbolicate = parseBool(value)
+                    switch value.lowercased() {
+                      case "off":
+                        args.symbolicate = .off
+                      case "fast":
+                        args.symbolicate = .fast
+                      case "full":
+                        args.symbolicate = .full
+                      default:
+                        writeln(theme.error("bad symbolicate value '\(value)'"))
+                    }
 
                     if args.symbolicate != oldSymbolicate {
                       changedBacktrace = true

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -72,6 +72,7 @@ internal struct SwiftBacktrace {
     var sanitize: Bool? = nil
     var cache = true
     var outputTo: OutputTo = .stdout
+    var symbolicate = true
   }
 
   static var args = Arguments()
@@ -202,6 +203,10 @@ Generate a backtrace for the parent process.
 --crashinfo <addr>
 -a <addr>               Provide a pointer to a platform specific CrashInfo
                         structure.  <addr> should be in hexadecimal.
+
+--symbolicate [<bool>]  Set whether or not to resolve addresses into symbols.
+                        Also controls whether or not we look for inline frame
+                        data.
 """, to: &standardError)
   }
 
@@ -419,6 +424,12 @@ Generate a backtrace for the parent process.
           usage()
           exit(1)
         }
+      case "--symbolicate":
+        if let v = value {
+          args.symbolicate = parseBool(v)
+        } else {
+          args.symbolicate = true
+        }
       default:
         print("swift-backtrace: unknown argument '\(arg)'",
               to: &standardError)
@@ -497,7 +508,8 @@ Generate a backtrace for the parent process.
     let duration = measureDuration {
       target = Target(crashInfoAddr: crashInfoAddr,
                       limit: args.limit, top: args.top,
-                      cache: args.cache)
+                      cache: args.cache,
+                      symbolicate: args.symbolicate)
 
       currentThread = target!.crashingThreadNdx
     }
@@ -646,7 +658,8 @@ Generate a backtrace for the parent process.
 
     let description: String
 
-    if let failure = crashingThread.backtrace.swiftRuntimeFailure {
+    if case let .symbolicated(symbolicated) = crashingThread.backtrace,
+       let failure = symbolicated.swiftRuntimeFailure {
       description = failure
     } else {
       description = "Program crashed: \(target.signalDescription) at \(hex(target.faultAddress))"
@@ -678,18 +691,37 @@ Generate a backtrace for the parent process.
         writeln("")
       }
 
-      let formatted = formatter.format(backtrace: thread.backtrace)
+      let formatted: String
+      switch thread.backtrace {
+        case let .raw(backtrace):
+          formatted = formatter.format(backtrace: backtrace)
+        case let .symbolicated(backtrace):
+          formatted = formatter.format(backtrace: backtrace)
+      }
 
       writeln(formatted)
 
       if args.showImages! == .mentioned {
-        for frame in thread.backtrace.frames {
-          if formatter.shouldSkip(frame) {
-            continue
-          }
-          if let symbol = frame.symbol, symbol.imageIndex >= 0 {
-            mentionedImages.insert(symbol.imageIndex)
-          }
+        switch thread.backtrace {
+          case let .raw(backtrace):
+            for frame in backtrace.frames {
+              let address = frame.adjustedProgramCounter
+              if let imageNdx = target.images.firstIndex(
+                   where: { address >= $0.baseAddress
+                              && address < $0.endOfText }
+                 ) {
+                mentionedImages.insert(imageNdx)
+              }
+            }
+          case let .symbolicated(backtrace):
+            for frame in backtrace.frames {
+              if formatter.shouldSkip(frame) {
+                continue
+              }
+              if let symbol = frame.symbol, symbol.imageIndex >= 0 {
+                mentionedImages.insert(symbol.imageIndex)
+              }
+            }
         }
       }
     }
@@ -712,7 +744,13 @@ Generate a backtrace for the parent process.
       }
     }
 
-    let addressWidthInChars = (crashingThread.backtrace.addressWidth + 3) / 4
+    let addressWidthInChars: Int
+    switch crashingThread.backtrace {
+      case let .raw(backtrace):
+        addressWidthInChars = (backtrace.addressWidth + 3) / 4
+      case let .symbolicated(backtrace):
+        addressWidthInChars = (backtrace.addressWidth + 3) / 4
+    }
     switch args.showImages! {
       case .none:
         break
@@ -778,9 +816,13 @@ Generate a backtrace for the parent process.
           startDebugger()
         case "bt", "backtrace":
           let formatter = backtraceFormatter()
-          let backtrace = target.threads[currentThread].backtrace
-          let formatted = formatter.format(backtrace: backtrace)
-
+          let formatted: String
+          switch target.threads[currentThread].backtrace {
+            case let .raw(backtrace):
+              formatted = formatter.format(backtrace: backtrace)
+            case let .symbolicated(backtrace):
+              formatted = formatter.format(backtrace: backtrace)
+          }
           writeln(formatted)
         case "thread":
           if cmd.count >= 2 {
@@ -801,19 +843,28 @@ Generate a backtrace for the parent process.
           }
 
           let thread = target.threads[currentThread]
-          let backtrace = thread.backtrace
           let name = thread.name.isEmpty ? "" : " \(thread.name)"
           writeln("Thread \(currentThread) id=\(thread.id)\(name)\(crashed)\n")
 
-          let addressWidthInChars = (backtrace.addressWidth + 3) / 4
+          let formatter = backtraceFormatter()
+          switch thread.backtrace {
+            case let .raw(backtrace):
+              let addressWidthInChars = (backtrace.addressWidth + 3) / 4
+              if let frame = backtrace.frames.first {
+                let formatted = formatter.format(frame: frame,
+                                                 addressWidth: addressWidthInChars)
+                writeln("\(formatted)")
+              }
+            case let .symbolicated(backtrace):
+              let addressWidthInChars = (backtrace.addressWidth + 3) / 4
 
-          if let frame = backtrace.frames.drop(while: {
-            $0.isSwiftRuntimeFailure
-          }).first {
-            let formatter = backtraceFormatter()
-            let formatted = formatter.format(frame: frame,
-                                             addressWidth: addressWidthInChars)
-            writeln("\(formatted)")
+              if let frame = backtrace.frames.drop(while: {
+                $0.isSwiftRuntimeFailure
+              }).first {
+                let formatted = formatter.format(frame: frame,
+                                                 addressWidth: addressWidthInChars)
+                writeln("\(formatted)")
+              }
           }
           break
         case "reg", "registers":
@@ -866,9 +917,6 @@ Generate a backtrace for the parent process.
 
           var rows: [BacktraceFormatter.TableRow] = []
           for (n, thread) in target.threads.enumerated() {
-            let backtrace = thread.backtrace
-            let addressWidthInChars = (backtrace.addressWidth + 3) / 4
-
             let crashed: String
             if n == target.crashingThreadNdx {
               crashed = " (crashed)"
@@ -882,21 +930,42 @@ Generate a backtrace for the parent process.
             rows.append(.columns([ selected,
                                    "\(n)",
                                    "id=\(thread.id)\(name)\(crashed)" ]))
-            if let frame = backtrace.frames.drop(while: {
-              $0.isSwiftRuntimeFailure
-            }).first {
 
-              rows += formatter.formatRows(
-                frame: frame,
-                addressWidth: addressWidthInChars).map{ row in
+            switch thread.backtrace {
+              case let .raw(backtrace):
+                let addressWidthInChars = (backtrace.addressWidth + 3) / 4
 
-                switch row {
-                  case let .columns(columns):
-                    return .columns([ "", "" ] + columns)
-                  default:
-                    return row
+                if let frame = backtrace.frames.first {
+                  rows += formatter.formatRows(
+                    frame: frame,
+                    addressWidth: addressWidthInChars).map{ row in
+
+                    switch row {
+                      case let .columns(columns):
+                        return .columns([ "", "" ] + columns)
+                      default:
+                        return row
+                    }
+                  }
                 }
-              }
+              case let .symbolicated(backtrace):
+                let addressWidthInChars = (backtrace.addressWidth + 3) / 4
+
+                if let frame = backtrace.frames.drop(while: {
+                  $0.isSwiftRuntimeFailure
+                }).first {
+                  rows += formatter.formatRows(
+                    frame: frame,
+                    addressWidth: addressWidthInChars).map{ row in
+
+                    switch row {
+                      case let .columns(columns):
+                        return .columns([ "", "" ] + columns)
+                      default:
+                        return row
+                    }
+                  }
+                }
             }
           }
 
@@ -908,9 +977,14 @@ Generate a backtrace for the parent process.
           writeln(output)
         case "images":
           let formatter = backtraceFormatter()
-          let backtrace = target.threads[currentThread].backtrace
-          let images = backtrace.images
-          let addressWidthInChars = (backtrace.addressWidth + 3) / 4
+          let images = target.images
+          let addressWidthInChars: Int
+          switch target.threads[currentThread].backtrace {
+            case let .raw(backtrace):
+              addressWidthInChars = (backtrace.addressWidth + 3) / 4
+            case let .symbolicated(backtrace):
+              addressWidthInChars = (backtrace.addressWidth + 3) / 4
+          }
           let output = formatter.format(images: images,
                                         addressWidth: addressWidthInChars)
 
@@ -937,6 +1011,7 @@ Generate a backtrace for the parent process.
                     system-frames  = \(!formattingOptions.shouldSkipSystemFrames)
                     thunks         = \(!formattingOptions.shouldSkipThunkFunctions)
                     top            = \(top)
+                    symbolicate    = \(args.symbolicate)
                     """)
           } else {
             for optval in cmd[1...] {
@@ -972,7 +1047,8 @@ Generate a backtrace for the parent process.
                     writeln("thunks = \(!formattingOptions.shouldSkipThunkFunctions)")
                   case "top":
                     writeln("top = \(args.top)")
-
+                  case "symbolicate":
+                    writeln("symbolicate = \(args.symbolicate)")
                   default:
                     writeln(theme.error("unknown option '\(option)'"))
                 }
@@ -1043,6 +1119,14 @@ Generate a backtrace for the parent process.
                     formattingOptions =
                       formattingOptions.showImageNames(parseBool(value))
 
+                  case "symbolicate":
+                    let oldSymbolicate = args.symbolicate
+
+                    args.symbolicate = parseBool(value)
+
+                    if args.symbolicate != oldSymbolicate {
+                      changedBacktrace = true
+                    }
                   default:
                     writeln(theme.error("unknown option '\(option)'"))
                 }
@@ -1050,7 +1134,8 @@ Generate a backtrace for the parent process.
                 if changedBacktrace {
                   target.redoBacktraces(limit: args.limit,
                                         top: args.top,
-                                        cache: args.cache)
+                                        cache: args.cache,
+                                        symbolicate: args.symbolicate)
                 }
               }
             }

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -121,6 +121,9 @@ SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings = {
   // outputTo,
   OutputTo::Auto,
 
+  // symbolicate
+  true,
+
   // swiftBacktracePath
   NULL,
 };
@@ -673,6 +676,8 @@ _swift_processBacktracingSetting(llvm::StringRef key,
                      "swift runtime: unknown output-to setting '%.*s'\n",
                      static_cast<int>(value.size()), value.data());
     }
+  } else if (key.equals_insensitive("symbolicate")) {
+    _swift_backtraceSettings.symbolicate = parseBoolean(value);
 #if !defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
   } else if (key.equals_insensitive("swift-backtrace")) {
     size_t len = value.size();

--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -122,7 +122,7 @@ SWIFT_RUNTIME_STDLIB_INTERNAL BacktraceSettings _swift_backtraceSettings = {
   OutputTo::Auto,
 
   // symbolicate
-  true,
+  Symbolication::Full,
 
   // swiftBacktracePath
   NULL,
@@ -532,6 +532,22 @@ parseBoolean(llvm::StringRef value)
           || value.equals_insensitive("1"));
 }
 
+Symbolication
+parseSymbolication(llvm::StringRef value)
+{
+  if (value.equals_insensitive("on")
+      || value.equals_insensitive("true")
+      || value.equals_insensitive("yes")
+      || value.equals_insensitive("y")
+      || value.equals_insensitive("t")
+      || value.equals_insensitive("1")
+      || value.equals_insensitive("full"))
+    return Symbolication::Full;
+  if (value.equals_insensitive("fast"))
+    return Symbolication::Fast;
+  return Symbolication::Off;
+}
+
 void
 _swift_processBacktracingSetting(llvm::StringRef key,
                                  llvm::StringRef value)
@@ -677,7 +693,7 @@ _swift_processBacktracingSetting(llvm::StringRef key,
                      static_cast<int>(value.size()), value.data());
     }
   } else if (key.equals_insensitive("symbolicate")) {
-    _swift_backtraceSettings.symbolicate = parseBoolean(value);
+    _swift_backtraceSettings.symbolicate = parseSymbolication(value);
 #if !defined(SWIFT_RUNTIME_FIXED_BACKTRACER_PATH)
   } else if (key.equals_insensitive("swift-backtrace")) {
     size_t len = value.size();

--- a/stdlib/public/runtime/BacktracePrivate.h
+++ b/stdlib/public/runtime/BacktracePrivate.h
@@ -96,6 +96,12 @@ enum class OutputTo {
   Stderr = 2,
 };
 
+enum class Symbolication {
+  Off = 0,
+  Fast = 1,
+  Full = 2,
+};
+
 struct BacktraceSettings {
   UnwindAlgorithm  algorithm;
   OnOffTty         enabled;
@@ -112,7 +118,7 @@ struct BacktraceSettings {
   Preset           preset;
   bool             cache;
   OutputTo         outputTo;
-  bool             symbolicate;
+  Symbolication    symbolicate;
   const char      *swiftBacktracePath;
 };
 

--- a/stdlib/public/runtime/BacktracePrivate.h
+++ b/stdlib/public/runtime/BacktracePrivate.h
@@ -112,6 +112,7 @@ struct BacktraceSettings {
   Preset           preset;
   bool             cache;
   OutputTo         outputTo;
+  bool             symbolicate;
   const char      *swiftBacktracePath;
 };
 

--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -814,7 +814,7 @@ const char *backtracer_argv[] = {
   "--output-to",                // 29
   "stdout",                     // 30
   "--symbolicate",              // 31
-  "true",                       // 32
+  "full",                       // 32
   NULL
 };
 
@@ -924,7 +924,18 @@ run_backtracer(int memserver_fd)
   }
 
   backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
-  backtracer_argv[32] = trueOrFalse(_swift_backtraceSettings.symbolicate);
+
+  switch (_swift_backtraceSettings.symbolicate) {
+  case Symbolication::Off:
+    backtracer_argv[32] = "off";
+    break;
+  case Symbolication::Fast:
+    backtracer_argv[32] = "fast";
+    break;
+  case Symbolication::Full:
+    backtracer_argv[32] = "full";
+    break;
+  }
 
   _swift_formatUnsigned(_swift_backtraceSettings.timeout, timeout_buf);
 

--- a/stdlib/public/runtime/CrashHandlerLinux.cpp
+++ b/stdlib/public/runtime/CrashHandlerLinux.cpp
@@ -813,6 +813,8 @@ const char *backtracer_argv[] = {
   "true",                       // 28
   "--output-to",                // 29
   "stdout",                     // 30
+  "--symbolicate",              // 31
+  "true",                       // 32
   NULL
 };
 
@@ -922,6 +924,7 @@ run_backtracer(int memserver_fd)
   }
 
   backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
+  backtracer_argv[32] = trueOrFalse(_swift_backtraceSettings.symbolicate);
 
   _swift_formatUnsigned(_swift_backtraceSettings.timeout, timeout_buf);
 

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -307,6 +307,8 @@ const char *backtracer_argv[] = {
   "true",                       // 28
   "--output-to",                // 29
   "stdout",                     // 30
+  "--symbolicate",              // 31
+  "true",                       // 32
   NULL
 };
 
@@ -416,6 +418,7 @@ run_backtracer()
   }
 
   backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
+  backtracer_argv[32] = trueOrFalse(_swift_backtraceSettings.symbolicate);
 
   _swift_formatUnsigned(_swift_backtraceSettings.timeout, timeout_buf);
 

--- a/stdlib/public/runtime/CrashHandlerMacOS.cpp
+++ b/stdlib/public/runtime/CrashHandlerMacOS.cpp
@@ -418,7 +418,18 @@ run_backtracer()
   }
 
   backtracer_argv[28] = trueOrFalse(_swift_backtraceSettings.cache);
-  backtracer_argv[32] = trueOrFalse(_swift_backtraceSettings.symbolicate);
+
+  switch (_swift_backtraceSettings.symbolicate) {
+  case Symbolication::Off:
+    backtracer_argv[32] = "off";
+    break;
+  case Symbolication::Fast:
+    backtracer_argv[32] = "fast";
+    break;
+  case Symbolication::Full:
+    backtracer_argv[32] = "full";
+    break;
+  }
 
   _swift_formatUnsigned(_swift_backtraceSettings.timeout, timeout_buf);
 


### PR DESCRIPTION
Symbolication can take some time, depending on the binaries involved. In certain contexts it's better for the backtrace to finish quickly, and then symbolication could be done offline.

rdar://122302117