### PR TITLE
EscapeUtils: fix escape result in case an address is stored

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -239,6 +239,13 @@ struct EscapeUtilityTypes {
     ///
     let followStores: Bool
 
+    /// Set to true if an address is stored.
+    /// This unusual situation can happen if an address is converted to a raw pointer and that pointer
+    /// is stored to a memory location.
+    /// In this case the walkers need to follow load instructions even if the visitor and current projection
+    /// path don't say so.
+    let addressIsStored: Bool
+
     /// Not nil, if the exact type of the current value is know.
     ///
     /// This is used for destructor analysis.
@@ -251,20 +258,29 @@ struct EscapeUtilityTypes {
     let knownType: Type?
 
     func with(projectionPath: SmallProjectionPath) -> Self {
-      return Self(projectionPath: projectionPath, followStores: self.followStores, knownType: self.knownType)
+      return Self(projectionPath: projectionPath, followStores: self.followStores,
+                  addressIsStored: self.addressIsStored, knownType: self.knownType)
     }
 
     func with(followStores: Bool) -> Self {
-      return Self(projectionPath: self.projectionPath, followStores: followStores, knownType: self.knownType)
+      return Self(projectionPath: self.projectionPath, followStores: followStores,
+                  addressIsStored: self.addressIsStored, knownType: self.knownType)
     }
     
+    func with(addressStored: Bool) -> Self {
+      return Self(projectionPath: self.projectionPath, followStores: self.followStores, addressIsStored: addressStored,
+                  knownType: self.knownType)
+    }
+
     func with(knownType: Type?) -> Self {
-      return Self(projectionPath: self.projectionPath, followStores: self.followStores, knownType: knownType)
+      return Self(projectionPath: self.projectionPath, followStores: self.followStores,
+                  addressIsStored: self.addressIsStored, knownType: knownType)
     }
     
     func merge(with other: EscapePath) -> EscapePath {
       let mergedPath = self.projectionPath.merge(with: other.projectionPath)
       let mergedFollowStores = self.followStores || other.followStores
+      let mergedAddrStored = self.addressIsStored || other.addressIsStored
       let mergedKnownType: Type?
       if let ty = self.knownType {
         if let otherTy = other.knownType, ty != otherTy {
@@ -275,7 +291,8 @@ struct EscapeUtilityTypes {
       } else {
         mergedKnownType = other.knownType
       }
-      return EscapePath(projectionPath: mergedPath, followStores: mergedFollowStores, knownType: mergedKnownType)
+      return EscapePath(projectionPath: mergedPath, followStores: mergedFollowStores,
+                        addressIsStored: mergedAddrStored, knownType: mergedKnownType)
     }
   }
   
@@ -362,7 +379,10 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       }
     case is StoreInst, is StoreWeakInst, is StoreUnownedInst:
       let store = instruction as! StoringInstruction
-      assert(operand == store.sourceOperand )
+      assert(operand == store.sourceOperand)
+      if !followLoads(at: path) {
+        return walkUp(address: store.destination, path: path.with(addressStored: true))
+      }
       return walkUp(address: store.destination, path: path)
     case is DestroyValueInst, is ReleaseValueInst, is StrongReleaseInst:
       if handleDestroy(of: operand.value, path: path) == .abortWalk {
@@ -456,7 +476,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
         return walkUp(value: store.source, path: path)
       }
     case let copyAddr as CopyAddrInst:
-      if !followLoads(at: path.projectionPath) {
+      if !followLoads(at: path) {
         return .continueWalk
       }
       if operand == copyAddr.sourceOperand {
@@ -491,7 +511,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       // 2. something can escape in a destructor when the context is destroyed
       return walkDownUses(ofValue: pai, path: path.with(knownType: nil))
     case is LoadInst, is LoadWeakInst, is LoadUnownedInst, is LoadBorrowInst:
-      if !followLoads(at: path.projectionPath) {
+      if !followLoads(at: path) {
         return .continueWalk
       }
       let svi = instruction as! SingleValueInstruction
@@ -561,7 +581,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
     }
 
     // Indirect arguments cannot escape the function, but loaded values from such can.
-    if !followLoads(at: path.projectionPath) &&
+    if !followLoads(at: path) &&
        // Except for begin_apply: it can yield an address value.
        !apply.isBeginApplyWithIndirectResults {
       return .continueWalk
@@ -622,7 +642,8 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
           // Continue at the destination of an arg-to-arg escape.
           let arg = argOp.value
           
-          let p = Path(projectionPath: toPath, followStores: false, knownType: nil)
+          let p = Path(projectionPath: toPath, followStores: false, addressIsStored: argPath.addressIsStored,
+                       knownType: nil)
           if walkUp(addressOrValue: arg, path: p) == .abortWalk {
             return .abortWalk
           }
@@ -634,8 +655,9 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
             return isEscaping
           }
 
-          let p = Path(projectionPath: toPath, followStores: false, knownType: exclusive ? argPath.knownType : nil)
-          
+          let p = Path(projectionPath: toPath, followStores: false, addressIsStored: argPath.addressIsStored,
+                       knownType: exclusive ? argPath.knownType : nil)
+
           if walkDownUses(ofValue: result, path: p) == .abortWalk {
             return .abortWalk
           }
@@ -700,7 +722,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
     case let ap as ApplyInst:
       return walkUpApplyResult(apply: ap, path: path.with(knownType: nil))
     case is LoadInst, is LoadWeakInst, is LoadUnownedInst, is LoadBorrowInst:
-      if !followLoads(at: path.projectionPath) {
+      if !followLoads(at: path) {
         // When walking up we shouldn't end up at a load where followLoads is false,
         // because going from a (non-followLoads) address to a load always involves a class indirection.
         // There is one exception: loading a raw pointer, e.g.
@@ -743,7 +765,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
     case is AllocStackInst:
       return cachedWalkDown(addressOrValue: def, path: path.with(knownType: nil))
     case let arg as FunctionArgument:
-      if !followLoads(at: path.projectionPath) && arg.convention.isExclusiveIndirect && !path.followStores {
+      if !followLoads(at: path) && arg.convention.isExclusiveIndirect && !path.followStores {
         return cachedWalkDown(addressOrValue: def, path: path.with(knownType: nil))
       } else {
         return isEscaping
@@ -781,7 +803,8 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
             }
             let arg = argOp.value
             
-            let p = Path(projectionPath: effect.pathPattern, followStores: path.followStores, knownType: nil)
+            let p = Path(projectionPath: effect.pathPattern, followStores: path.followStores,
+                         addressIsStored: path.addressIsStored, knownType: nil)
             if walkUp(addressOrValue: arg, path: p) == .abortWalk {
               return .abortWalk
             }
@@ -840,10 +863,11 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
     return false
   }
 
-  private func followLoads(at path: SmallProjectionPath) -> Bool {
+  private func followLoads(at path: Path) -> Bool {
     return visitor.followLoads ||
            // When part of a class field we have to follow loads.
-           path.mayHaveClassProjection
+           path.projectionPath.mayHaveClassProjection ||
+           path.addressIsStored
   }
 
   private func pathForArgumentEscapeChecking(_ path: SmallProjectionPath) -> SmallProjectionPath {
@@ -867,7 +891,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
 
 private extension SmallProjectionPath {
   var escapePath: EscapeUtilityTypes.EscapePath {
-    EscapeUtilityTypes.EscapePath(projectionPath: self, followStores: false, knownType: nil)
+    EscapeUtilityTypes.EscapePath(projectionPath: self, followStores: false, addressIsStored: false, knownType: nil)
   }
 }
 

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -48,6 +48,9 @@ sil @inout_class_argument : $@convention(thin) (@inout X) -> () {
 }
 sil @container_argument : $@convention(thin) (@guaranteed Container) -> ()
 sil @take_closure_as_addr : $@convention(thin) (@in @callee_guaranteed () -> ()) -> ()
+sil @take_closure_as_addr_noescape : $@convention(thin) (@in @callee_guaranteed () -> ()) -> () {
+[%0: noescape **]
+}
 sil @closure_with_inout : $@convention(thin) (@inout Str) -> () {
 [%0: noescape **]
 }
@@ -56,6 +59,7 @@ sil @initX : $@convention(method) (@owned X) -> @owned X {
 }
 sil @modifyStr : $@convention(method) (@inout Str) -> ()
 sil @guaranteed_yield_coroutine : $@yield_once @convention(thin) (@inout X) -> @yields @inout X
+sil @in_ptr : $@convention(thin) (@in Builtin.RawPointer) -> ()
 
 // CHECK-LABEL: Address escape information for test_simple:
 // CHECK:       value:  %1 = struct_element_addr %0 : $*Str, #Str.a
@@ -406,7 +410,7 @@ bb0:
 // CHECK-LABEL: Address escape information for partial_apply_with_inout:
 // CHECK:       value:  %0 = alloc_stack $Str
 // CHECK-NEXT:    ==>   %7 = apply %6(%4) : $@convention(thin) (@in @callee_guaranteed () -> ()) -> ()
-// CHECK-NEXT:    -     %9 = apply %8() : $@convention(thin) () -> ()
+// CHECK-NEXT:    ==>   %9 = apply %8() : $@convention(thin) () -> ()
 // CHECK:       End function partial_apply_with_inout
 sil @partial_apply_with_inout : $@convention(thin) () -> () {
 bb0:
@@ -417,6 +421,29 @@ bb0:
   %4 = alloc_stack $@callee_guaranteed () -> ()
   store %3 to %4 : $*@callee_guaranteed () -> ()
   %6 = function_ref @take_closure_as_addr : $@convention(thin) (@in @callee_guaranteed () -> ()) -> ()
+  %7 = apply %6(%4) : $@convention(thin) (@in @callee_guaranteed () -> ()) -> ()
+  %8 = function_ref @no_arguments : $@convention(thin) () -> ()
+  %9 = apply %8() : $@convention(thin) () -> ()
+  dealloc_stack %4 : $*@callee_guaranteed () -> ()
+  dealloc_stack %0 : $*Str
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// CHECK-LABEL: Address escape information for partial_apply_with_inout_noescape:
+// CHECK:       value:  %0 = alloc_stack $Str
+// CHECK-NEXT:    ==>   %7 = apply %6(%4) : $@convention(thin) (@in @callee_guaranteed () -> ()) -> ()
+// CHECK-NEXT:    -     %9 = apply %8() : $@convention(thin) () -> ()
+// CHECK:       End function partial_apply_with_inout_noescape
+sil @partial_apply_with_inout_noescape : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Str
+  fix_lifetime %0 : $*Str
+  %2 = function_ref @closure_with_inout : $@convention(thin) (@inout Str) -> ()
+  %3 = partial_apply [callee_guaranteed] %2(%0) : $@convention(thin) (@inout Str) -> ()
+  %4 = alloc_stack $@callee_guaranteed () -> ()
+  store %3 to %4 : $*@callee_guaranteed () -> ()
+  %6 = function_ref @take_closure_as_addr_noescape : $@convention(thin) (@in @callee_guaranteed () -> ()) -> ()
   %7 = apply %6(%4) : $@convention(thin) (@in @callee_guaranteed () -> ()) -> ()
   %8 = function_ref @no_arguments : $@convention(thin) () -> ()
   %9 = apply %8() : $@convention(thin) () -> ()
@@ -707,5 +734,24 @@ bb0(%0 : $Int):
   dealloc_stack %1 : $*P
   %r = tuple ()
   return %r : $()
+}
+
+// CHECK-LABEL: Address escape information for test_stored_pointer:
+// CHECK:       value:  %0 = alloc_stack $Int
+// CHECK-NEXT:    ==>   %5 = apply %4(%2) : $@convention(thin) (@in Builtin.RawPointer) -> ()
+// CHECK:      End function test_stored_pointer
+sil @test_stored_pointer : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Int
+  %1 = address_to_pointer %0 : $*Int to $Builtin.RawPointer
+  %2 = alloc_stack $Builtin.RawPointer
+  store %1 to %2 : $*Builtin.RawPointer
+  %4 = function_ref @in_ptr : $@convention(thin) (@in Builtin.RawPointer) -> ()
+  %5 = apply %4(%2) : $@convention(thin) (@in Builtin.RawPointer) -> ()
+  dealloc_stack %2 : $*Builtin.RawPointer
+  fix_lifetime %0 : $*Int
+  dealloc_stack %0 : $*Int
+  %8 = tuple ()
+  return %8 : $()
 }
 

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -30,6 +30,7 @@ sil @single_indirect_arg_coroutine : $@yield_once @convention(thin) (@in Int32) 
 sil @indirect_arg_and_ptr : $@convention(thin) (@in Int32, Builtin.RawPointer) -> Int32
 sil @single_reference : $@convention(thin) (@guaranteed X) -> Int32
 sil @nouser_func : $@convention(thin) () -> ()
+sil @in_ptr : $@convention(thin) (@in Builtin.RawPointer) -> ()
 
 sil @store_to_int : $@convention(thin) (Int32, @inout Int32) -> () {
 [%1: write v**]
@@ -1097,4 +1098,23 @@ bb0:
   dealloc_stack %0 : $*C
   %4 = tuple ()
   return %4 : $()
+}
+
+// CHECK-LABEL: @test_stored_pointer
+// CHECK:       PAIR #3.
+// CHECK-NEXT:      %5 = apply %4(%2) : $@convention(thin) (@in Builtin.RawPointer) -> ()
+// CHECK-NEXT:      %0 = alloc_stack $Int                           // users: %7, %1
+// CHECK-NEXT:    r=1,w=1
+sil @test_stored_pointer : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Int
+  %1 = address_to_pointer %0 : $*Int to $Builtin.RawPointer
+  %2 = alloc_stack $Builtin.RawPointer
+  store %1 to %2 : $*Builtin.RawPointer
+  %4 = function_ref @in_ptr : $@convention(thin) (@in Builtin.RawPointer) -> ()
+  %5 = apply %4(%2) : $@convention(thin) (@in Builtin.RawPointer) -> ()
+  dealloc_stack %2 : $*Builtin.RawPointer
+  dealloc_stack %0 : $*Int
+  %8 = tuple ()
+  return %8 : $()
 }

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -134,6 +134,7 @@ sil @use_twofield : $@convention(thin) (TwoField) -> ()
 sil @escaped_a_ptr : $@convention(thin) () -> @out A
 sil @escaped_a : $@convention(thin) () -> Builtin.RawPointer
 sil @init_twofield : $@convention(thin) (@thin TwoField.Type) -> TwoField
+sil @in_ptr : $@convention(thin) (@in Builtin.RawPointer) -> ()
 
 
 // We have a bug in the old projection code which this test case exposes.
@@ -1294,4 +1295,23 @@ bb0:
   end_apply %3
   %7 = tuple (%4 : $String, %5 : $Int64)
   return %7 : $(String, Int64)
+}
+
+// CHECK-LABEL: sil @dont_remove_load_from_stored_pointer :
+// CHECK:         [[L:%[0-9]+]] = load
+// CHECK:         return [[L]]
+// CHECK-LABEL: } // end sil function 'dont_remove_load_from_stored_pointer'
+sil @dont_remove_load_from_stored_pointer : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = alloc_stack $Int
+  store %0 to %1 : $*Int
+  %5 = address_to_pointer %1 : $*Int to $Builtin.RawPointer
+  %32 = alloc_stack $Builtin.RawPointer
+  store %5 to %32 : $*Builtin.RawPointer
+  %34 = function_ref @in_ptr : $@convention(thin) (@in Builtin.RawPointer) -> ()
+  %35 = apply %34(%32) : $@convention(thin) (@in Builtin.RawPointer) -> ()
+  dealloc_stack %32 : $*Builtin.RawPointer
+  %53 = load %1 : $*Int
+  dealloc_stack %1 : $*Int
+  return %53 : $Int
 }


### PR DESCRIPTION
This unusual situation can happen if an address is converted to a raw pointer and that pointer is stored to a memory location. In this case the walkers need to follow load instructions even if the visitor and current projection path don't say so.

Fixes a miscompile
rdar://122805546
