### PR TITLE
Serialization: Apply the SDK build version as part of the swiftmodule cache hash

### DIFF
--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -209,6 +209,7 @@ public:
 struct InterfaceSubContextDelegate {
   virtual std::error_code runInSubContext(StringRef moduleName,
                                           StringRef interfacePath,
+                                          StringRef sdkPath,
                                           StringRef outputPath,
                                           SourceLoc diagLoc,
     llvm::function_ref<std::error_code(ASTContext&, ModuleDecl*,
@@ -216,6 +217,7 @@ struct InterfaceSubContextDelegate {
                                        ArrayRef<StringRef>, StringRef)> action) = 0;
   virtual std::error_code runInSubCompilerInstance(StringRef moduleName,
                                                    StringRef interfacePath,
+                                                   StringRef sdkPath,
                                                    StringRef outputPath,
                                                    SourceLoc diagLoc,
                                                    bool silenceErrors,

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -693,6 +693,7 @@ public:
 
   std::error_code runInSubContext(StringRef moduleName,
                                   StringRef interfacePath,
+                                  StringRef sdkPath,
                                   StringRef outputPath,
                                   SourceLoc diagLoc,
     llvm::function_ref<std::error_code(ASTContext&, ModuleDecl*,
@@ -700,6 +701,7 @@ public:
                                        StringRef)> action) override;
   std::error_code runInSubCompilerInstance(StringRef moduleName,
                                            StringRef interfacePath,
+                                           StringRef sdkPath,
                                            StringRef outputPath,
                                            SourceLoc diagLoc,
                                            bool silenceErrors,
@@ -710,9 +712,10 @@ public:
   /// includes a hash of relevant key data.
   StringRef computeCachedOutputPath(StringRef moduleName,
                                     StringRef UseInterfacePath,
+                                    StringRef sdkPath,
                                     llvm::SmallString<256> &OutPath,
                                     StringRef &CacheHash);
-  std::string getCacheHash(StringRef useInterfacePath);
+  std::string getCacheHash(StringRef useInterfacePath, StringRef sdkPath);
 };
 }
 

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -345,7 +345,7 @@ bool ImplicitModuleInterfaceBuilder::buildSwiftModuleInternal(
     }
 
     SubError = (bool)subASTDelegate.runInSubCompilerInstance(
-        moduleName, interfacePath, OutPath, diagnosticLoc,
+        moduleName, interfacePath, sdkPath, OutPath, diagnosticLoc,
         silenceInterfaceDiagnostics,
         [&](SubCompilerInstanceInfo &info) {
           auto EBuilder = ExplicitModuleInterfaceBuilder(

--- a/lib/Frontend/ModuleInterfaceBuilder.h
+++ b/lib/Frontend/ModuleInterfaceBuilder.h
@@ -41,6 +41,7 @@ class ImplicitModuleInterfaceBuilder {
   DiagnosticEngine *diags;
   InterfaceSubContextDelegate &subASTDelegate;
   const StringRef interfacePath;
+  const StringRef sdkPath;
   const StringRef moduleName;
   const StringRef moduleCachePath;
   const StringRef prebuiltCachePath;
@@ -84,7 +85,8 @@ private:
 public:
   ImplicitModuleInterfaceBuilder(
       SourceManager &sourceMgr, DiagnosticEngine *diags,
-      InterfaceSubContextDelegate &subASTDelegate, StringRef interfacePath,
+      InterfaceSubContextDelegate &subASTDelegate,
+      StringRef interfacePath, StringRef sdkPath,
       StringRef moduleName, StringRef moduleCachePath,
       StringRef backupInterfaceDir, StringRef prebuiltCachePath,
       StringRef ABIDescriptorPath, bool disableInterfaceFileLock = false,
@@ -92,7 +94,7 @@ public:
       SourceLoc diagnosticLoc = SourceLoc(),
       DependencyTracker *tracker = nullptr)
       : sourceMgr(sourceMgr), diags(diags), subASTDelegate(subASTDelegate),
-        interfacePath(interfacePath), moduleName(moduleName),
+        interfacePath(interfacePath), sdkPath(sdkPath), moduleName(moduleName),
         moduleCachePath(moduleCachePath), prebuiltCachePath(prebuiltCachePath),
         backupInterfaceDir(backupInterfaceDir),
         ABIDescriptorPath(ABIDescriptorPath),

--- a/lib/Serialization/ScanningLoaders.cpp
+++ b/lib/Serialization/ScanningLoaders.cpp
@@ -154,11 +154,13 @@ SwiftModuleScanner::scanInterfaceFile(Twine moduleInterfacePath,
   // name for the module, which includes an appropriate hash.
   auto newExt = file_types::getExtension(file_types::TY_SwiftModuleFile);
   auto realModuleName = Ctx.getRealModuleName(moduleName);
+  StringRef sdkPath = Ctx.SearchPathOpts.getSDKPath();
   llvm::SmallString<32> modulePath = realModuleName.str();
   llvm::sys::path::replace_extension(modulePath, newExt);
   llvm::Optional<ModuleDependencyInfo> Result;
   std::error_code code = astDelegate.runInSubContext(
-      realModuleName.str(), moduleInterfacePath.str(), StringRef(), SourceLoc(),
+      realModuleName.str(), moduleInterfacePath.str(), sdkPath,
+      StringRef(), SourceLoc(),
       [&](ASTContext &Ctx, ModuleDecl *mainMod, ArrayRef<StringRef> BaseArgs,
           ArrayRef<StringRef> PCMArgs, StringRef Hash) {
         assert(mainMod);

--- a/test/ModuleInterface/ModuleCache/module-cache-sdk-build-version.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-sdk-build-version.swift
@@ -1,0 +1,71 @@
+/// ProductBuildVersion of the SDK is tracked as part of the module cache hash.
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/ModuleCache)
+// RUN: %empty-directory(%t/sdk/System/Library/CoreServices/)
+// RUN: split-file %s %t
+
+/// Setup an "old" SDK.
+// RUN: cp %t/SystemVersion.plist.old %t/sdk/System/Library/CoreServices/SystemVersion.plist
+
+/// Build Lib against the old SDK.
+// RUN: %target-swift-frontend -emit-module -sdk %t/sdk %t/Lib.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-path %t/Lib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Lib.swiftinterface
+
+/// Baseline check, we should read the adjacent swiftmodule.
+// RUN: %target-swift-frontend -typecheck -verify -sdk %t/sdk -I %t \
+// RUN:   %t/Client_NoRebuild.swift \
+// RUN:   -Rmodule-interface-rebuild -module-cache-path %t/ModuleCache
+
+/// Keep only the swiftinterface.
+// RUN: rm %t/Lib.swiftmodule
+
+/// Build client, which should trigger a build from swiftinterface.
+// RUN: %target-swift-frontend -typecheck -verify -sdk %t/sdk -I %t \
+// RUN:   %t/Client.swift \
+// RUN:   -Rmodule-interface-rebuild -module-cache-path %t/ModuleCache
+
+/// Update SDK.
+// RUN: cp %t/SystemVersion.plist.new %t/sdk/System/Library/CoreServices/SystemVersion.plist
+
+/// Build client, which should trigger a build from swiftinterface.
+// RUN: %target-swift-frontend -typecheck -verify -sdk %t/sdk -I %t \
+// RUN:   %t/Client.swift \
+// RUN:   -Rmodule-interface-rebuild -module-cache-path %t/ModuleCache
+
+/// Baseline check, we should reused the newly cached swiftmodule.
+// RUN: %target-swift-frontend -typecheck -verify -sdk %t/sdk -I %t \
+// RUN:   %t/Client_NoRebuild.swift \
+// RUN:   -Rmodule-interface-rebuild -module-cache-path %t/ModuleCache
+
+//--- SystemVersion.plist.old
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ProductBuildVersion</key>
+	<string>10A100</string>
+</dict>
+</plist>
+
+//--- SystemVersion.plist.new
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ProductBuildVersion</key>
+	<string>10A200</string>
+</dict>
+</plist>
+
+//--- Lib.swift
+public func foo() {}
+
+//--- Client.swift
+import Lib // expected-remark {{rebuilding module 'Lib' from interface}}
+
+//--- Client_NoRebuild.swift
+import Lib
+


### PR DESCRIPTION
The SDK build version is a decent heuristic for expected changes in the SDK. Any change in SDK, to clang modules and headers in particular, can break references from cached swiftmodules.

Track the SDK build version as part of the swiftmodule cache hash. This will ensure we rebuild from swiftinterfaces on SDK updates.

rdar://122655978