### PR TITLE
Windows: include SDDL conversion headers

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -315,6 +315,8 @@ module WinSDK [system] {
   }
 
   module Security {
+    header "../shared/sddl.h"
+
     module AuthZ {
       header "AuthZ.h"
       export *


### PR DESCRIPTION
This is allows us to use `ConvertSidToStringSidW`.