### PR TITLE
LifetimeDependenceInsertion: do not emit inherited dependencies.

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -115,37 +115,6 @@ public struct StringRef : CustomStringConvertible, NoReflectionChildren {
 }
 
 //===----------------------------------------------------------------------===//
-//                      Single-Element Inline Array
-//===----------------------------------------------------------------------===//
-
-public struct SingleInlineArray<Element>: RandomAccessCollection {
-  private var singleElement: Element? = nil
-  private var multipleElements: [Element] = []
-
-  public init() {}
-
-  public var startIndex: Int { 0 }
-  public var endIndex: Int {
-    singleElement == nil ? 0 : multipleElements.count + 1
-  }
-
-  public subscript(_ index: Int) -> Element {
-    if index == 0 {
-      return singleElement!
-    }
-    return multipleElements[index - 1]
-  }
-
-  public mutating func push(_ element: Element) {
-    guard singleElement != nil else {
-      singleElement = element
-      return
-    }
-    multipleElements.append(element)
-  }
-}
-
-//===----------------------------------------------------------------------===//
 //                            Bridging Utilities
 //===----------------------------------------------------------------------===//
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -131,6 +131,14 @@ private struct DiagnoseDependence {
     if function.hasUnsafeNonEscapableResult {
       return .continueWalk
     }
+    // FIXME: remove this condition once we have a Builtin.dependence,
+    // which developers should use to model the unsafe
+    // dependence. Builtin.lifetime_dependence will be lowered to
+    // mark_dependence [unresolved], which will be checked
+    // independently. Instead, of this function result check, allow
+    // isUnsafeApplyResult to be used be mark_dependence [unresolved]
+    // without checking its dependents.
+    //
     // Allow returning an apply result (@_unsafeNonescapableResult) if
     // the calling function has a dependence. This implicitly makes
     // the unsafe nonescapable result dependent on the calling

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -66,11 +66,12 @@ import SIL
 /// Value.enclosingAccess iteratively to find to AccessBase. This
 /// walker is useful for finding the innermost access, which may also
 /// be relevant for diagnostics.
-func gatherVariableIntroducers(for value: Value, _ context: Context) -> [Value]
+func gatherVariableIntroducers(for value: Value, _ context: Context)
+  -> SingleInlineArray<Value>
 {
-  var introducers: [Value] = []
+  var introducers = SingleInlineArray<Value>()
   var useDefVisitor = VariableIntroducerUseDefWalker(context) {
-    introducers.append($0)
+    introducers.push($0)
     return .continueWalk
   }
   defer { useDefVisitor.deinitialize() }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -1053,10 +1053,32 @@ extension LifetimeDependenceDefUseWalker {
     if let conv = apply.convention(of: operand), conv.isIndirectOut {
       return leafUse(of: operand)
     }
-
     if apply.isCallee(operand: operand) {
       return leafUse(of: operand)
     }
+    if let dep = apply.resultDependence(on: operand),
+       dep == .inherit {
+      // Operand is nonescapable and passed as a call argument. If the
+      // result inherits its lifetime, then consider any nonescapable
+      // result value to be a dependent use.
+      //
+      // If the lifetime dependence is scoped, then we can ignore it
+      // because a mark_dependence [nonescaping] represents the
+      // dependence.
+      if let result = apply.singleDirectResult, !result.type.isEscapable {
+        if dependentUse(of: operand, into: result) == .abortWalk {
+          return .abortWalk
+        }
+      }
+      for resultAddr in apply.indirectResultOperands
+          where !resultAddr.value.type.isEscapable {
+        if visitStoredUses(of: operand, into: resultAddr.value) == .abortWalk {
+          return .abortWalk
+        }
+      }
+    }
+    // Regardless of lifetime dependencies, consider the operand to be
+    // use for the duration of the call.
     if apply is BeginApplyInst {
       return scopedAddressUse(of: operand)
     }

--- a/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
@@ -117,3 +117,34 @@ extension LazyMapSequence : CollectionLikeSequence,
 extension LazyFilterSequence : CollectionLikeSequence,
                                FormattedLikeArray, CustomStringConvertible, CustomReflectable
                                where Base: CollectionLikeSequence {}
+
+//===----------------------------------------------------------------------===//
+//                      Single-Element Inline Array
+//===----------------------------------------------------------------------===//
+
+public struct SingleInlineArray<Element>: RandomAccessCollection, FormattedLikeArray {
+  private var singleElement: Element? = nil
+  private var multipleElements: [Element] = []
+
+  public init() {}
+
+  public var startIndex: Int { 0 }
+  public var endIndex: Int {
+    singleElement == nil ? 0 : multipleElements.count + 1
+  }
+
+  public subscript(_ index: Int) -> Element {
+    if index == 0 {
+      return singleElement!
+    }
+    return multipleElements[index - 1]
+  }
+
+  public mutating func push(_ element: Element) {
+    guard singleElement != nil else {
+      singleElement = element
+      return
+    }
+    multipleElements.append(element)
+  }
+}

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -69,6 +69,13 @@ llvm::cl::opt<bool>
     EnableDeinitDevirtualizer("enable-deinit-devirtualizer", llvm::cl::init(false),
                           llvm::cl::desc("Enable the DestroyHoisting pass."));
 
+// Temporary flag until the stdlib builds with ~Escapable
+llvm::cl::opt<bool>
+EnableLifetimeDependenceInsertion(
+  "enable-lifetime-dependence-insertion", llvm::cl::init(false),
+  llvm::cl::desc("Enable lifetime dependence insertion."));
+
+// Temporary flag until the stdlib builds with ~Escapable
 llvm::cl::opt<bool>
 EnableLifetimeDependenceDiagnostics(
   "enable-lifetime-dependence-diagnostics", llvm::cl::init(false),
@@ -291,7 +298,7 @@ SILPassPipelinePlan::getSILGenPassPipeline(const SILOptions &Options) {
   P.startPipeline("SILGen Passes");
 
   P.addSILGenCleanup();
-  if (EnableLifetimeDependenceDiagnostics) {
+  if (EnableLifetimeDependenceDiagnostics || EnableLifetimeDependenceInsertion) {
     P.addLifetimeDependenceInsertion();
   }
   if (SILViewSILGenCFG) {

--- a/test/SILOptimizer/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics.swift
@@ -18,14 +18,26 @@ func bv_copy(_ bv: borrowing BV) -> _copy(bv) BV {
   copy bv
 }
 
-// Diagnostics resolves mark_dependence [nonescaping].
+// No mark_dependence is needed for a inherited scope.
 //
-// CHECK-LABEL: sil hidden @$s4test14bv_borrow_copy0B0AA2BVVAE_tF : $@convention(thin) (@guaranteed BV) -> _scope(1) @owned BV {
-// CHECK: bb0(%0 : @noImplicitCopy $BV):
-// CHECK:   [[R:%.*]] = apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _inherit(1) @owned BV
-// CHECK:   [[MD:%.*]] = mark_dependence [nonescaping] [[R]] : $BV on %0 : $BV
-// CHECK:   return [[MD]] : $BV
-// CHECK-LABEL: } // end sil function '$s4test14bv_borrow_copy0B0AA2BVVAE_tF'
-func bv_borrow_copy(bv: borrowing BV) -> _borrow(bv) BV {
+// CHECK-LABEL: sil hidden @$s4test14bv_borrow_copyyAA2BVVADF : $@convention(thin) (@guaranteed BV) -> _scope(1) @owned BV {
+// CHECK:      bb0(%0 : @noImplicitCopy $BV):
+// CHECK:        apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _inherit(1) @owned BV // user: %4
+// CHECK-NEXT:   return %3 : $BV
+// CHECK-LABEL: } // end sil function '$s4test14bv_borrow_copyyAA2BVVADF'
+func bv_borrow_copy(_ bv: borrowing BV) -> _borrow(bv) BV {
   bv_copy(bv) 
+}
+
+// The mark_dependence for the borrow scope should be marked
+// [nonescaping] after diagnostics.
+//
+// CHECK-LABEL: sil hidden @$s4test010bv_borrow_C00B0AA2BVVAE_tF : $@convention(thin) (@guaranteed BV) -> _scope(1) @owned BV {
+// CHECK:       bb0(%0 : @noImplicitCopy $BV):
+// CHECK:         [[R:%.*]] = apply %{{.*}}(%0) : $@convention(thin) (@guaranteed BV) -> _scope(1) @owned BV
+// CHECK:         %{{.*}} = mark_dependence [nonescaping] [[R]] : $BV on %0 : $BV
+// CHECK-NEXT:    return %{{.*}} : $BV
+// CHECK-LABEL: } // end sil function '$s4test010bv_borrow_C00B0AA2BVVAE_tF'
+func bv_borrow_borrow(bv: borrowing BV) -> _borrow(bv) BV {
+  bv_borrow_copy(bv)
 }

--- a/test/SILOptimizer/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit.swift
@@ -37,3 +37,10 @@ struct NE {
     return self
   }
 }
+
+// Test lifetime inheritance through chained consumes.
+//
+// This requires an inherit_lifetime marker on the argument.
+func bv_derive(bv: consuming BV) -> _consume(bv) BV {
+  bv.derive()
+}

--- a/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
@@ -36,10 +36,3 @@ struct NE {
     return self
   }
 }
-
-func bv_derive_local(bv: consuming BV) -> _consume(bv) BV {
-  let bv2 = BV(bv.p, bv.i)
-  return bv2.derive() // expected-error {{lifetime-dependent value escapes its scope}}
-  // expected-note @-2 {{it depends on the lifetime of variable 'bv2'}}
-  // expected-note @-2 {{this use causes the lifetime-dependent value to escape}}
-}

--- a/test/SILOptimizer/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence_insertion.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -disable-experimental-parser-round-trip \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -Xllvm -enable-lifetime-dependence-insertion \
+// RUN:   2>&1 | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+@_nonescapable
+struct BV {
+  let p: UnsafeRawPointer
+  let i: Int
+
+  @_unsafeNonescapableResult
+  init(_ p: UnsafeRawPointer, _ i: Int) {
+    self.p = p
+    self.i = i
+  }
+}
+
+struct NC : ~Copyable {
+  let p: UnsafeRawPointer
+  let i: Int
+
+  // Requires a borrow.
+  borrowing func getBV() -> _borrow(self) BV {
+    BV(p, i)
+  }
+}
+
+@_silgen_name("use")
+func use(_ o : borrowing BV)
+
+// CHECK-LABEL: sil hidden @$s4test13bv_borrow_var1p1iySV_SitF : $@convention(thin) (UnsafeRawPointer, Int) -> () {
+// CHECK: [[A:%.*]] = begin_access [read] [static] %{{.*}} : $*NC
+// CHECK: [[L:%.*]] = load [[A]] : $*NC
+// CHECK:   [[R:%.*]] = apply %{{.*}}([[L]]) : $@convention(method) (@guaranteed NC) -> _scope(0) @owned BV
+// CHECK:   [[M:%.*]] = mark_dependence [unresolved] [[R]] : $BV on [[A]] : $*NC
+// CHECK:   end_access [[A]] : $*NC
+// CHECK:   %{{.*}} = apply %{{.*}}([[M]]) : $@convention(thin) (@guaranteed BV) -> ()
+// CHECK-LABEL: } // end sil function '$s4test13bv_borrow_var1p1iySV_SitF'
+func bv_borrow_var(p: UnsafeRawPointer, i: Int) {
+  var nc = NC(p: p, i: i)
+  let bv = nc.getBV()
+  use(bv)
+}

--- a/test/SILOptimizer/lifetime_dependence_todo.swift
+++ b/test/SILOptimizer/lifetime_dependence_todo.swift
@@ -19,11 +19,16 @@ func bv_get_mutate(container: inout NC) -> _mutate(container) BV {
   container.getBV()
 }
 
-// Test lifetime inheritance through chained consumes.
+// =============================================================================
+// Diagnostics that should fail.
+
+// Test that an unsafe dependence requires Builtin.lifetime_dependence.
 //
-// This requires an inherit_lifetime marker on the argument.
-func bv_derive(bv: consuming BV) -> _consume(bv) BV {
-  bv.derive()
+func bv_derive_local(bv: consuming BV) -> _consume(bv) BV {
+  let bv2 = BV(bv.p, bv.i)
+  return bv2.derive() // expected-error {{lifetime-dependent value escapes its scope}}
+  // expected-note @-2 {{it depends on the lifetime of variable 'bv2'}}
+  // expected-note @-2 {{this use causes the lifetime-dependent value to escape}}
 }
 
 // =============================================================================


### PR DESCRIPTION
These were always redundant. And there is no way to emit them
correctly for valid OSA when the original dependence scope is in the
caller.

LifetimeDefUseWalker handles inherited dependencies instead.

NFC without:
    -enable-experimental-feature NonescapableTypes
    -enable-lifetime-dependence-diagnostics