### PR TITLE
Add a couple missing Optional includes

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -25,6 +25,7 @@
 #include "swift/Basic/OptimizationMode.h"
 #include "swift/Config.h"
 #include "clang/Basic/PointerAuthOptions.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/IR/CallingConv.h"
 // FIXME: This include is just for llvm::SanitizerCoverageOptions. We should
 // split the header upstream so we don't include so much.

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -25,6 +25,7 @@
 #include "swift/Basic/Sanitizers.h"
 #include "swift/Driver/Util.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 
 #include <functional>


### PR DESCRIPTION
To avoid synced PRs, add some temporary `Optional.h` includes so that the move from `llvm::Optional` -> `std::optional` in LLVM can be merged.

Once the LLVM change is in we can merge the Swift move. Then we'll need one final PR to fully remove `Optional.h` and `None.h` (this will likely have to be a synced PR since optional references keep being added).