### PR TITLE
Sema: Associated type inference regressions, round 4

### DIFF
--- a/test/Generics/associated_type_where_clause.swift
+++ b/test/Generics/associated_type_where_clause.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -swift-version 4 -disable-experimental-associated-type-inference
 
 func needsSameType<T>(_: T.Type, _: T.Type) {}
 

--- a/test/Sema/where_clause_across_module_boundaries.swift
+++ b/test/Sema/where_clause_across_module_boundaries.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t/ModuleA.swiftmodule %S/Inputs/where_clause_across_module_boundaries_module.swift
-// RUN: %target-typecheck-verify-swift -I %t
+// RUN: %target-typecheck-verify-swift -I %t -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -I %t -disable-experimental-associated-type-inference
 
 // https://github.com/apple/swift/issues/58084
 // Associated Type Inference fails across module boundaries

--- a/test/decl/protocol/req/associated_type_inference_abstract.swift
+++ b/test/decl/protocol/req/associated_type_inference_abstract.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 protocol Q {}
 

--- a/test/decl/protocol/req/associated_type_inference_stdlib_4a.swift
+++ b/test/decl/protocol/req/associated_type_inference_stdlib_4a.swift
@@ -30,78 +30,77 @@
 
 #if A1
 
-for x in S() { _ = x }
+for x in G<String>() { _ = x }
 
 #elseif A2
 
 func f<T: Sequence>(_: T.Type) -> T.Element.Type { fatalError() }
-let x: String.Type = f(S.self)
+let x: String.Type = f(G<String>.self)
 
 #elseif A3
 
 func f<T: Sequence>(_: T.Type) -> T.Iterator.Type { fatalError() }
-let x: IndexingIterator<S>.Type = f(S.self)
+let x: IndexingIterator<G<String>>.Type = f(G<String>.self)
 
 #elseif A4
 
 func f<T: Sequence>(_: T.Type) -> T.Iterator.Element.Type { fatalError() }
-let x: String.Type = f(S.self)
+let x: String.Type = f(G<String>.self)
 
 #elseif A5
 
 func f<T: Collection>(_: T.Type) -> T.Element.Type { fatalError() }
-let x: String.Type = f(S.self)
+let x: String.Type = f(G<String>.self)
 
 #elseif A6
 
 func f<T: Collection>(_: T.Type) -> T.Index.Type { fatalError() }
-let x: Int.Type = f(S.self)
+let x: Int.Type = f(G<String>.self)
 
 #elseif A7
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Type { fatalError() }
-let x: Slice<S>.Type = f(S.self)
+let x: Slice<G<String>>.Type = f(G<String>.self)
 
 #elseif A8
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Element.Type { fatalError() }
-let x: String.Type = f(S.self)
+let x: String.Type = f(G<String>.self)
 
 #elseif A9
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Index.Type { fatalError() }
-let x: Int.Type = f(S.self)
+let x: Int.Type = f(G<String>.self)
 
 #elseif A10
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Iterator.Type { fatalError() }
-let x: IndexingIterator<Slice<S>>.Type = f(S.self)
+let x: IndexingIterator<Slice<G<String>>>.Type = f(G<String>.self)
 
 #elseif A11
 
 func f<T: Collection>(_: T.Type) -> T.Indices.Type { fatalError() }
-let x: Range<Int>.Type = f(S.self)
+let x: Range<Int>.Type = f(G<String>.self)
 
 #elseif A12
 
 func f<T: Collection>(_: T.Type) -> T.Indices.Element.Type { fatalError() }
-let x: Int.Type = f(S.self)
+let x: Int.Type = f(G<String>.self)
 
 #elseif A13
 
 func f<T: Collection>(_: T.Type) -> T.Indices.SubSequence.Type { fatalError() }
-let x: Range<Int>.Type = f(S.self)
+let x: Range<Int>.Type = f(G<String>.self)
 
 #elseif A14
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Indices.Type { fatalError() }
-let x: Range<Int>.Type = f(S.self)
+let x: Range<Int>.Type = f(G<String>.self)
 
 #endif
 
-struct S: RandomAccessCollection {
+struct G<Element>: RandomAccessCollection {
   public var startIndex: Int { 0 }
   public var endIndex: Int { 0 }
-  public subscript(position: Int) -> String { "" }
+  public subscript(position: Int) -> Element { fatalError() }
 }
-

--- a/test/decl/protocol/req/issue-10831.swift
+++ b/test/decl/protocol/req/issue-10831.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
 
 struct G<T> {}
   

--- a/test/decl/protocol/req/rdar122587920.swift
+++ b/test/decl/protocol/req/rdar122587920.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
-// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference -DNEW
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference -DOLD
 
 struct S<Element> {}
 
@@ -27,4 +27,10 @@ extension S: Collection {
   }
 }
 
+// The old behavior didn't make much sense.
+
+#if NEW
 let x: S<Int>.Type = S<Int>.Iterator.self
+#elseif OLD
+let x: IndexingIterator<S<Int>>.Type = S<Int>.Iterator.self
+#endif

--- a/test/decl/protocol/req/rdar122589094.swift
+++ b/test/decl/protocol/req/rdar122589094.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+
+protocol P1 {
+  associatedtype A
+
+  func f1(_: C) -> A
+  func f2(_: A, _: C)
+
+  typealias C = S1<Self>
+}
+
+struct S1<T> {}
+
+protocol P2: P1 where A == B {
+  associatedtype B
+
+  func g1(_: C) -> B
+  func g2(_: B, _: C)
+}
+
+extension P2 {
+  func f1(_: C) -> B { fatalError() }
+  func f2(_: B, _: C) { fatalError() }
+}
+
+extension P2 {
+  func g2(_: B, _: C) {}
+}
+
+struct S2: P2 {
+  func g1(_: C) -> Int {
+    fatalError()
+  }
+}

--- a/test/decl/protocol/req/rdar122596633-1.swift
+++ b/test/decl/protocol/req/rdar122596633-1.swift
@@ -1,0 +1,49 @@
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+
+public protocol P1 {
+    associatedtype A = Void
+
+    func makeA() -> A
+    func consumeA(a: inout A)
+}
+
+extension P1 where A == Void {
+    // Don't consider this witness in the 'S2: P1' conformance below.
+    public func makeA() -> A { fatalError() }
+}
+
+public struct S1: P1 {}
+
+public protocol P2: P1 where A == B.A {
+    associatedtype B: P1
+    var base: B { get }
+}
+
+extension P2 {
+    public func makeA() -> B.A { fatalError() }
+    public func consumeA(a: inout B.A) {}
+}
+
+extension S1: P2 {
+    public var base: S2 { fatalError() }
+}
+
+public struct S2 {}
+
+public struct S3 {}
+
+extension S2: P1 {
+    public typealias A = S3
+}
+
+public protocol P3: P1 where A == S3 {}
+
+extension P3 {
+    public func makeA() -> A { fatalError() }
+    public func consumeA(a: inout A) {}
+}
+
+extension S2: P3 {}
+
+let x: S3.Type = S2.A.self

--- a/test/decl/protocol/req/rdar122596633-2.swift
+++ b/test/decl/protocol/req/rdar122596633-2.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference -disable-availability-checking
+
+public protocol P<A> {
+    associatedtype A
+    associatedtype B: P
+
+    func makeA() -> A
+    var b: B { get }
+}
+
+extension P where A == B.A {
+    public func makeA() -> B.A {
+        fatalError()
+    }
+}
+
+public struct S: P {
+    public var b: some P<Int> {
+        return G<Int>()
+    }
+}
+
+public struct G<A>: P {
+    public func makeA() -> A { fatalError() }
+    public var b: Never { fatalError() }
+}
+
+extension Never: P {
+    public func makeA() -> Never { fatalError() }
+    public var b: Never { fatalError() }
+}


### PR DESCRIPTION
Fixes rdar://problem/122589094, rdar://problem/122596633, and rdar://problem/122810266.

There is a bunch of new code in `AssociatedTypeInference.cpp` conditionalized on the new flag. Also to minimize breakage with the flag off I restored some old code behind the negation of the flag. The file looks messy right now but the structure will become apparent once the old code is gone.