### PR TITLE
[SILGen] Don't peephole closures with abstraction differences in the thrown error

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3246,6 +3246,13 @@ TypeConverter::computeLoweredRValueType(TypeExpansionContext forExpansion,
       AnyFunctionType::ExtInfo baseExtInfo;
       if (auto origFnType = origType.getAs<AnyFunctionType>()) {
         baseExtInfo = origFnType->getExtInfo();
+
+        if (baseExtInfo.getThrownError()) {
+          if (auto substThrownError = substFnType->getEffectiveThrownErrorType())
+            baseExtInfo = baseExtInfo.withThrows(true, *substThrownError);
+          else
+            baseExtInfo = baseExtInfo.withThrows(false, Type());
+        }
       } else {
         baseExtInfo = substFnType->getExtInfo();
       }


### PR DESCRIPTION
The prolog and epilog code in SILGen is not set up to deal with abstraction differences in the thrown error type of closures, so disable the peephole optimization for closure literals.

Fixes https://github.com/apple/swift/issues/71401 / rdar://122366566, which I've stared at for waaaaay too many hours.
