### PR TITLE
embedded: Fix a few problems with vtable specialization

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -1608,6 +1608,7 @@ VTables
 
   decl ::= sil-vtable
   sil-vtable ::= 'sil_vtable' identifier '{' sil-vtable-entry* '}'
+  sil-vtable ::= 'sil_vtable' sil-type '{' sil-vtable-entry* '}'
 
   sil-vtable-entry ::= sil-decl-ref ':' sil-linkage? sil-function-name
 
@@ -1669,6 +1670,13 @@ class (such as ``C.bas`` in ``C``'s vtable).
 
 In case the SIL function is a thunk, the function name is preceded with the
 linkage of the original implementing function.
+
+If the vtable refers to a specialized class, a SIL type specifies the bound
+generic class type::
+
+  sil_vtable $G<Int> {
+    // ...
+  }
 
 Witness Tables
 ~~~~~~~~~~~~~~

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -115,6 +115,7 @@ private:
   /// The ClassDecl mapped to this VTable.
   ClassDecl *Class;
 
+  /// The class type if this is a specialized vtable, otherwise null.
   SILType classType;
 
   /// Whether or not this vtable is serialized, which allows

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3988,7 +3988,12 @@ void SILVTable::print(llvm::raw_ostream &OS, bool Verbose) const {
   OS << "sil_vtable ";
   if (isSerialized())
     OS << "[serialized] ";
-  OS << getClass()->getName() << " {\n";
+  if (SILType classTy = getClassType()) {
+    OS << classTy;
+  } else {
+    OS << getClass()->getName();
+  }
+  OS << " {\n";
 
   for (auto &entry : getEntries()) {
     OS << "  ";

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -7452,27 +7452,39 @@ bool SILParserState::parseSILVTable(Parser &P) {
                            nullptr, nullptr, VTableState, M))
     return true;
 
-  // Parse the class name.
-  Identifier Name;
-  SourceLoc Loc;
-  if (VTableState.parseSILIdentifier(Name, Loc,
-                                     diag::expected_sil_value_name))
-    return true;
 
-  // Find the class decl.
-  llvm::PointerUnion<ValueDecl*, ModuleDecl *> Res =
-    lookupTopDecl(P, Name, /*typeLookup=*/true);
-  assert(Res.is<ValueDecl*>() && "Class look-up should return a Decl");
-  ValueDecl *VD = Res.get<ValueDecl*>();
-  if (!VD) {
-    P.diagnose(Loc, diag::sil_vtable_class_not_found, Name);
-    return true;
-  }
+  ClassDecl *theClass = nullptr;
+  SILType specializedClassTy;
+  if (P.Tok.isNot(tok::sil_dollar)) {
+    // Parse the class name.
+    Identifier Name;
+    SourceLoc Loc;
+    if (VTableState.parseSILIdentifier(Name, Loc,
+                                       diag::expected_sil_value_name))
+      return true;
 
-  auto *theClass = dyn_cast<ClassDecl>(VD);
-  if (!theClass) {
-    P.diagnose(Loc, diag::sil_vtable_class_not_found, Name);
-    return true;
+    // Find the class decl.
+    llvm::PointerUnion<ValueDecl*, ModuleDecl *> Res =
+      lookupTopDecl(P, Name, /*typeLookup=*/true);
+    assert(Res.is<ValueDecl*>() && "Class look-up should return a Decl");
+    ValueDecl *VD = Res.get<ValueDecl*>();
+    if (!VD) {
+      P.diagnose(Loc, diag::sil_vtable_class_not_found, Name);
+      return true;
+    }
+
+    theClass = dyn_cast<ClassDecl>(VD);
+    if (!theClass) {
+      P.diagnose(Loc, diag::sil_vtable_class_not_found, Name);
+      return true;
+    }
+  } else {
+    if (SILParser(P).parseSILType(specializedClassTy))
+      return true;
+    theClass = specializedClassTy.getClassOrBoundGenericClass();
+    if (!theClass) {
+      return true;
+    }
   }
 
   SourceLoc LBraceLoc = P.Tok.getLoc();
@@ -7540,7 +7552,7 @@ bool SILParserState::parseSILVTable(Parser &P) {
   P.parseMatchingToken(tok::r_brace, RBraceLoc, diag::expected_sil_rbrace,
                        LBraceLoc);
 
-  SILVTable::create(M, theClass, Serialized, vtableEntries);
+  SILVTable::create(M, theClass, specializedClassTy, Serialized, vtableEntries);
   return false;
 }
 

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -44,6 +44,13 @@ open class ManagedBuffer<Header, Element> {
   /// reading the `header` property during `ManagedBuffer.create` is undefined.
   public final var header: Header
 
+  #if $Embedded
+  // In embedded mode this initializer has to be public, otherwise derived
+  // classes cannot be specialized.
+  public init(_doNotCallMe: ()) {
+    _internalInvariantFailure("Only initialize these by calling create")
+  }
+  #else
   // This is really unfortunate. In Swift 5.0, the method descriptor for this
   // initializer was public and subclasses would "inherit" it, referencing its
   // method descriptor from their class override table.
@@ -51,6 +58,7 @@ open class ManagedBuffer<Header, Element> {
   internal init(_doNotCallMe: ()) {
     _internalInvariantFailure("Only initialize these by calling create")
   }
+  #endif
 
   @inlinable
   deinit {}

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -1807,3 +1807,14 @@ sil_vtable Foo2 {
   #Foo.subscript!getter: @Foo_subscript_getter [inherited] [nonoverridden]
   #Foo.subscript!setter: @Foo_subscript_setter [override]
 }
+
+class GenKlass<T> {}
+
+// CHECK-LABEL: sil_vtable GenKlass {
+sil_vtable GenKlass {
+}
+
+// CHECK-LABEL: sil_vtable $GenKlass<Int> {
+sil_vtable $GenKlass<Int> {
+}
+

--- a/test/embedded/classes-generic-no-stdlib.swift
+++ b/test/embedded/classes-generic-no-stdlib.swift
@@ -41,7 +41,7 @@ public func bar(t: T2) -> MyClass<T2> {
 // CHECK-SIL:   #MyClass.deinit!deallocator: @$s4main7MyClassCfDAA2T1V_Tg5  // specialized MyClass.__deallocating_deinit
 // CHECK-SIL: }
 
-// CHECK-SIL: sil_vtable MyClass {
+// CHECK-SIL: sil_vtable $MyClass<T2> {
 // CHECK-SIL:   #MyClass.t!getter: <T> (MyClass<T>) -> () -> T : @$s4main7MyClassC1txvgAA2T2V_Tg5 // specialized MyClass.t.getter
 // CHECK-SIL:   #MyClass.t!setter: <T> (MyClass<T>) -> (T) -> () : @$s4main7MyClassC1txvsAA2T2V_Tg5 // specialized MyClass.t.setter
 // CHECK-SIL:   #MyClass.t!modify: <T> (MyClass<T>) -> () -> () : @$s4main7MyClassC1txvMAA2T2V_Tg5  // specialized MyClass.t.modify

--- a/test/embedded/generic-classes.swift
+++ b/test/embedded/generic-classes.swift
@@ -22,6 +22,18 @@ func makeItFoo<F: Fooable>(f: F) {
   f.foo()
 }
 
+class BaseClass<A> {
+  func test() {}
+}
+
+class SubClass1<B>: BaseClass<Int> {
+  override func test() {}
+}
+
+class SubClass2 : SubClass1<Int> {
+  override func test() { print("SubClass2") }
+}
+
 @main
 struct Main {
   static func main() {
@@ -29,9 +41,12 @@ struct Main {
     makeItFoo(f: f)
     let g: GenericFooableClass = GenericFooableSubClass<Int>()
     makeItFoo(f: g)
+    let x = SubClass2()
+    x.test()
   }
 }
 
 // CHECK: GenericFooableClass<T>.foo
 // CHECK: GenericFooableSubClass<T>.foo
+// CHECK: SubClass2
 

--- a/test/embedded/managed-buffer.swift
+++ b/test/embedded/managed-buffer.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-emit-ir %s -module-name=main -enable-experimental-feature Embedded | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+// CHECK: @"$s4main8MyBufferCN" = {{.*global.*}} <{ ptr @"$ss13ManagedBufferCySis5UInt8VGN", ptr @"$s4main8MyBufferCfD", ptr @"$s4main8MyBufferC12_doNotCallMeACyt_tcfC" }>
+// CHECK: @"$ss13ManagedBufferCySis5UInt8VGN" = {{.*global.*}} <{ ptr null, ptr @"$ss13ManagedBufferCfDSi_s5UInt8VTg5", ptr @"$ss13ManagedBufferC12_doNotCallMeAByxq_Gyt_tcfCSi_s5UInt8VTg5" }>
+final public class MyBuffer: ManagedBuffer<Int, UInt8> {
+}
+


### PR DESCRIPTION
* Make sure to specialize tables of superclasses
Fixes an IRGen crash if a superclass of a class is generic and not used otherwise.
rdar://122405558

* make the ManagedBuffer initializer public in the embedded stdlib
Otherwise derived classes cannot be specialized.
Fixes a compile time error when using ManagedBuffer in embedded mode.
rdar://122414669

* support printing and parsing specialized vtables
