### PR TITLE
Stop emitting conditions for Swift 5.5-era features into textual interfaces

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -34,6 +34,10 @@
 // imply the existence of earlier features.  (This only needs to apply to
 // suppressible features.)
 //
+// BASELINE_LANGUAGE_FEATURE is the same as LANGUAGE_FEATURE, but is used
+// for features that can be assumed to be available in any Swift compiler that
+// will be used to process the textual interface files produced by this
+// Swift compiler.
 //===----------------------------------------------------------------------===//
 
 #ifndef LANGUAGE_FEATURE
@@ -62,29 +66,34 @@
      EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
 #endif
 
-LANGUAGE_FEATURE(AsyncAwait, 296, "async/await")
-LANGUAGE_FEATURE(EffectfulProp, 310, "Effectful properties")
-LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol")
-LANGUAGE_FEATURE(Actors, 0, "actors")
-LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions")
+#ifndef BASELINE_LANGUAGE_FEATURE
+#  define BASELINE_LANGUAGE_FEATURE(FeatureName, SENumber, Description) \
+  LANGUAGE_FEATURE(FeatureName, SENumber, Description)
+#endif
+
+BASELINE_LANGUAGE_FEATURE(AsyncAwait, 296, "async/await")
+BASELINE_LANGUAGE_FEATURE(EffectfulProp, 310, "Effectful properties")
+BASELINE_LANGUAGE_FEATURE(MarkerProtocol, 0, "@_marker protocol")
+BASELINE_LANGUAGE_FEATURE(Actors, 0, "actors")
+BASELINE_LANGUAGE_FEATURE(ConcurrentFunctions, 0, "@concurrent functions")
 LANGUAGE_FEATURE(RethrowsProtocol, 0, "@rethrows protocol")
-LANGUAGE_FEATURE(GlobalActors, 316, "Global actors")
-LANGUAGE_FEATURE(BuiltinJob, 0, "Builtin.Job type")
-LANGUAGE_FEATURE(Sendable, 0, "Sendable and @Sendable")
-LANGUAGE_FEATURE(BuiltinExecutor, 0, "Builtin.Executor type")
-LANGUAGE_FEATURE(BuiltinContinuation, 0, "Continuation builtins")
-LANGUAGE_FEATURE(BuiltinHopToActor, 0, "Builtin.HopToActor")
-LANGUAGE_FEATURE(BuiltinTaskGroupWithArgument, 0, "TaskGroup builtins")
-LANGUAGE_FEATURE(InheritActorContext, 0, "@_inheritActorContext attribute")
-LANGUAGE_FEATURE(ImplicitSelfCapture, 0, "@_implicitSelfCapture attribute")
+BASELINE_LANGUAGE_FEATURE(GlobalActors, 316, "Global actors")
+BASELINE_LANGUAGE_FEATURE(BuiltinJob, 0, "Builtin.Job type")
+BASELINE_LANGUAGE_FEATURE(Sendable, 0, "Sendable and @Sendable")
+BASELINE_LANGUAGE_FEATURE(BuiltinExecutor, 0, "Builtin.Executor type")
+BASELINE_LANGUAGE_FEATURE(BuiltinContinuation, 0, "Continuation builtins")
+BASELINE_LANGUAGE_FEATURE(BuiltinHopToActor, 0, "Builtin.HopToActor")
+BASELINE_LANGUAGE_FEATURE(BuiltinTaskGroupWithArgument, 0, "TaskGroup builtins")
+BASELINE_LANGUAGE_FEATURE(InheritActorContext, 0, "@_inheritActorContext attribute")
+BASELINE_LANGUAGE_FEATURE(ImplicitSelfCapture, 0, "@_implicitSelfCapture attribute")
 LANGUAGE_FEATURE(BuiltinBuildTaskExecutorRef, 0, "TaskExecutor-building builtins")
 LANGUAGE_FEATURE(BuiltinBuildExecutor, 0, "Executor-building builtins")
 LANGUAGE_FEATURE(BuiltinBuildComplexEqualityExecutor, 0, "Executor-building for 'complexEquality executor' builtins")
-LANGUAGE_FEATURE(BuiltinBuildMainExecutor, 0, "MainActor executor building builtin")
-LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroup, 0, "Task create in task group builtin with extra flags")
+BASELINE_LANGUAGE_FEATURE(BuiltinBuildMainExecutor, 0, "MainActor executor building builtin")
+BASELINE_LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroup, 0, "Task create in task group builtin with extra flags")
 LANGUAGE_FEATURE(BuiltinCreateAsyncTaskInGroupWithExecutor, 0, "Task create in task group builtin with extra flags")
 LANGUAGE_FEATURE(BuiltinCreateAsyncDiscardingTaskInGroup, 0, "Task create in discarding task group builtin, accounting for the Void return type")
-LANGUAGE_FEATURE(BuiltinCreateAsyncTaskWithExecutor, 0, "Task create builtin with extra executor preference")
+BASELINE_LANGUAGE_FEATURE(BuiltinCreateAsyncTaskWithExecutor, 0, "Task create builtin with extra executor preference")
 LANGUAGE_FEATURE(BuiltinCreateAsyncDiscardingTaskInGroupWithExecutor, 0, "Task create in discarding task group with extra executor preference")
 LANGUAGE_FEATURE(BuiltinCopy, 0, "Builtin.copy()")
 LANGUAGE_FEATURE(BuiltinStackAlloc, 0, "Builtin.stackAlloc")
@@ -287,5 +296,6 @@ EXPERIMENTAL_FEATURE(IsolatedAny, false)
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
+#undef BASELINE_LANGUAGE_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE
 #undef LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2964,34 +2964,10 @@ static bool usesFeatureStaticAssert(Decl *decl) {
 }
 
 static bool usesFeatureEffectfulProp(Decl *decl) {
-  if (auto asd = dyn_cast<AbstractStorageDecl>(decl))
-    return asd->getEffectfulGetAccessor() != nullptr;
   return false;
 }
 
 static bool usesFeatureAsyncAwait(Decl *decl) {
-  if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-    if (func->hasAsync())
-      return true;
-  }
-
-  // Check for async functions in the types of declarations.
-  if (auto value = dyn_cast<ValueDecl>(decl)) {
-    if (Type type = value->getInterfaceType()) {
-      bool hasAsync = type.findIf([](Type type) {
-        if (auto fnType = type->getAs<AnyFunctionType>()) {
-          if (fnType->isAsync())
-            return true;
-        }
-
-        return false;
-      });
-
-      if (hasAsync)
-        return true;
-    }
-  }
-
   return false;
 }
 
@@ -3000,34 +2976,6 @@ static bool usesFeatureMarkerProtocol(Decl *decl) {
 }
 
 static bool usesFeatureActors(Decl *decl) {
-  if (auto classDecl = dyn_cast<ClassDecl>(decl)) {
-    if (classDecl->isActor())
-      return true;
-  }
-
-  if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
-    if (auto classDecl = ext->getSelfClassDecl())
-      if (classDecl->isActor())
-        return true;
-  }
-
-  // Check for actors in the types of declarations.
-  if (auto value = dyn_cast<ValueDecl>(decl)) {
-    if (Type type = value->getInterfaceType()) {
-      bool hasActor = type.findIf([](Type type) {
-        if (auto classDecl = type->getClassOrBoundGenericClass()) {
-          if (classDecl->isActor())
-            return true;
-        }
-
-        return false;
-      });
-
-      if (hasActor)
-        return true;
-    }
-  }
-
   return false;
 }
 
@@ -3100,28 +3048,6 @@ static bool usesFeatureConcurrentFunctions(Decl *decl) {
 }
 
 static bool usesFeatureSendable(Decl *decl) {
-  if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-    if (func->isSendable())
-      return true;
-  }
-
-  // Check for sendable functions in the types of declarations.
-  if (auto value = dyn_cast<ValueDecl>(decl)) {
-    if (Type type = value->getInterfaceType()) {
-      bool hasSendable = type.findIf([](Type type) {
-        if (auto fnType = type->getAs<AnyFunctionType>()) {
-          if (fnType->isSendable())
-            return true;
-        }
-
-        return false;
-      });
-
-      if (hasSendable)
-        return true;
-    }
-  }
-
   return false;
 }
 
@@ -3226,20 +3152,12 @@ static bool usesTypeMatching(Decl *decl, llvm::function_ref<bool(Type)> fn) {
   return false;
 }
 
-static bool usesBuiltinType(Decl *decl, BuiltinTypeKind kind) {
-  return usesTypeMatching(decl, [=](Type type) {
-    if (auto builtinTy = type->getAs<BuiltinType>())
-      return builtinTy->getBuiltinTypeKind() == kind;
-    return false;
-  });
-}
-
 static bool usesFeatureBuiltinJob(Decl *decl) {
-  return usesBuiltinType(decl, BuiltinTypeKind::BuiltinJob);
+  return false;
 }
 
 static bool usesFeatureBuiltinExecutor(Decl *decl) {
-  return usesBuiltinType(decl, BuiltinTypeKind::BuiltinExecutor);
+  return false;
 }
 
 static bool usesFeatureBuiltinBuildTaskExecutorRef(Decl *decl) { return false; }
@@ -3330,24 +3248,10 @@ static void suppressingFeatureSpecializeAttributeWithAvailability(
 }
 
 static bool usesFeatureInheritActorContext(Decl *decl) {
-  if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-    for (auto param : *func->getParameters()) {
-      if (param->getAttrs().hasAttribute<InheritActorContextAttr>())
-        return true;
-    }
-  }
-
   return false;
 }
 
 static bool usesFeatureImplicitSelfCapture(Decl *decl) {
-  if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
-    for (auto param : *func->getParameters()) {
-      if (param->getAttrs().hasAttribute<ImplicitSelfCaptureAttr>())
-        return true;
-    }
-  }
-
   return false;
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2963,21 +2963,12 @@ static bool usesFeatureStaticAssert(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureEffectfulProp(Decl *decl) {
-  return false;
+#define BASELINE_LANGUAGE_FEATURE(FeatureName, SENumber, Description) \
+static bool usesFeature##FeatureName(Decl *decl) { \
+  return false; \
 }
-
-static bool usesFeatureAsyncAwait(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureMarkerProtocol(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureActors(Decl *decl) {
-  return false;
-}
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)
+#include "swift/Basic/Features.def"
 
 static bool usesFeatureMacros(Decl *decl) {
   return isa<MacroDecl>(decl);
@@ -3041,14 +3032,6 @@ static bool usesFeatureAttachedMacros(Decl *decl) {
     return false;
 
   return static_cast<bool>(macro->getMacroRoles() & getAttachedMacroRoles());
-}
-
-static bool usesFeatureConcurrentFunctions(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureSendable(Decl *decl) {
-  return false;
 }
 
 static bool usesFeatureRethrowsProtocol(
@@ -3126,10 +3109,6 @@ static bool usesFeatureRethrowsProtocol(Decl *decl) {
   return usesFeatureRethrowsProtocol(decl, checked);
 }
 
-static bool usesFeatureGlobalActors(Decl *decl) {
-  return false;
-}
-
 static bool usesFeatureRetroactiveAttribute(Decl *decl) {
   auto ext = dyn_cast<ExtensionDecl>(decl);
   if (!ext)
@@ -3152,14 +3131,6 @@ static bool usesTypeMatching(Decl *decl, llvm::function_ref<bool(Type)> fn) {
   return false;
 }
 
-static bool usesFeatureBuiltinJob(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureBuiltinExecutor(Decl *decl) {
-  return false;
-}
-
 static bool usesFeatureBuiltinBuildTaskExecutorRef(Decl *decl) { return false; }
 
 static bool usesFeatureBuiltinBuildExecutor(Decl *decl) {
@@ -3170,35 +3141,11 @@ static bool usesFeatureBuiltinBuildComplexEqualityExecutor(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureBuiltinBuildMainExecutor(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureBuiltinContinuation(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureBuiltinHopToActor(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureBuiltinTaskGroupWithArgument(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureBuiltinCreateAsyncTaskInGroup(Decl *decl) {
-  return false;
-}
-
 static bool usesFeatureBuiltinCreateAsyncTaskInGroupWithExecutor(Decl *decl) {
   return false;
 }
 
 static bool usesFeatureBuiltinCreateAsyncDiscardingTaskInGroup(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureBuiltinCreateAsyncTaskWithExecutor(Decl *decl) {
   return false;
 }
 
@@ -3245,14 +3192,6 @@ static void suppressingFeatureSpecializeAttributeWithAvailability(
   llvm::SaveAndRestore<bool> scope(
     options.PrintSpecializeAttributeWithAvailability, false);
   action();
-}
-
-static bool usesFeatureInheritActorContext(Decl *decl) {
-  return false;
-}
-
-static bool usesFeatureImplicitSelfCapture(Decl *decl) {
-  return false;
 }
 
 static bool usesFeatureBuiltinStackAlloc(Decl *decl) {

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -7,18 +7,17 @@
 
 // REQUIRES: VENDOR=apple
 
-// CHECK: #if compiler(>=5.3) && $Actors
-// CHECK-NEXT: public actor ActorWithImplicitAvailability {
+// CHECK-NOT: #if compiler(>=5.3) && $Actors
+// CHECK: public actor ActorWithImplicitAvailability {
 public actor ActorWithImplicitAvailability {
   // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
   // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
 }
-// CHECK: #endif
 
-// CHECK: #if compiler(>=5.3) && $Actors
-// CHECK-NEXT: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+// CHECK-NOT: #if compiler(>=5.3) && $Actors
+// CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
 // CHECK-NEXT: public actor ActorWithExplicitAvailability {
 @available(SwiftStdlib 5.2, *)
 public actor ActorWithExplicitAvailability {
@@ -27,10 +26,9 @@ public actor ActorWithExplicitAvailability {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
 }
-// CHECK: #endif
 
-// CHECK: #if compiler(>=5.3) && $Actors
-// CHECK-NEXT: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
+// CHECK-NOT: #if compiler(>=5.3) && $Actors
+// CHECK: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
 // CHECK-NEXT: public actor UnavailableActor {
 @available(macOS, unavailable)
 public actor UnavailableActor {
@@ -40,27 +38,25 @@ public actor UnavailableActor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
 }
-// CHECK: #endif
 
 // CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
 // CHECK-NEXT: public enum Enum {
 @available(SwiftStdlib 5.2, *)
 public enum Enum {
-  // CHECK:   #if compiler(>=5.3) && $Actors
-  // CHECK-NEXT: @_hasMissingDesignatedInitializers public actor NestedActor {
+  // CHECK-NOT:   #if compiler(>=5.3) && $Actors
+  // CHECK: @_hasMissingDesignatedInitializers public actor NestedActor {
   public actor NestedActor {
     // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
   }
-  // CHECK: #endif
 }
 
 // CHECK: extension Library.Enum {
 extension Enum {
-  // CHECK: #if compiler(>=5.3) && $Actors
-  // CHECK-NEXT: @_hasMissingDesignatedInitializers public actor ExtensionNestedActor {
+  // CHECK-NOT: #if compiler(>=5.3) && $Actors
+  // CHECK: @_hasMissingDesignatedInitializers public actor ExtensionNestedActor {
   public actor ExtensionNestedActor {
     // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
@@ -68,8 +64,8 @@ extension Enum {
     // CHECK-NEXT: }
   }
 
-  // CHECK: #if compiler(>=5.3) && $Actors
-  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
+  // CHECK-NOT: #if compiler(>=5.3) && $Actors
+  // CHECK: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
   // CHECK-NEXT: public actor UnavailableExtensionNestedActor {
   @available(macOS, unavailable)
   public actor UnavailableExtensionNestedActor {
@@ -93,8 +89,8 @@ extension Enum {
 // CHECK-PRIVATE-NEXT: public struct SPIAvailableStruct
 @_spi_available(SwiftStdlib 5.2, *)
 public struct SPIAvailableStruct {
-  // CHECK: #if compiler(>=5.3) && $Actors
-  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
+  // CHECK-NOT: #if compiler(>=5.3) && $Actors
+  // CHECK: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
   // CHECK-NEXT: public actor UnavailableNestedActor
   @available(macOS, unavailable)
   public actor UnavailableNestedActor {
@@ -115,15 +111,15 @@ public struct SPIAvailableStruct {
 // CHECK-NEXT: public class MacCatalystAvailableClass
 @available(macCatalyst 13.1, *)
 public class MacCatalystAvailableClass {
-  // CHECK: #if compiler(>=5.3) && $Actors
-  // CHECK-NEXT: @_hasMissingDesignatedInitializers public actor NestedActor
+  // CHECK-NOT: #if compiler(>=5.3) && $Actors
+  // CHECK: @_hasMissingDesignatedInitializers public actor NestedActor
   public actor NestedActor {
     // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 13.1, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }
 
-  // CHECK: #if compiler(>=5.3) && $Actors
-  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(macCatalyst 14, *)
+  // CHECK-NOT: #if compiler(>=5.3) && $Actors
+  // CHECK: @_hasMissingDesignatedInitializers @available(macCatalyst 14, *)
   // CHECK-NEXT: public actor LessAvailableMacCatalystActor
   @available(macCatalyst 14, *)
   public actor LessAvailableMacCatalystActor {
@@ -131,8 +127,8 @@ public class MacCatalystAvailableClass {
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }
 
-  // CHECK: #if compiler(>=5.3) && $Actors
-  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(iOS 15.0, macOS 12.0, *)
+  // CHECK-NOT: #if compiler(>=5.3) && $Actors
+  // CHECK: @_hasMissingDesignatedInitializers @available(iOS 15.0, macOS 12.0, *)
   // CHECK-NEXT: public actor AvailableiOSAndMacOSNestedActor {
   @available(iOS 15.0, macOS 12.0, *)
   public actor AvailableiOSAndMacOSNestedActor {
@@ -140,8 +136,8 @@ public class MacCatalystAvailableClass {
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }
 
-  // CHECK: #if compiler(>=5.3) && $Actors
-  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(iOS, unavailable)
+  // CHECK-NOT: #if compiler(>=5.3) && $Actors
+  // CHECK: @_hasMissingDesignatedInitializers @available(iOS, unavailable)
   // CHECK-NEXT: public actor UnavailableiOSNestedActor
   @available(iOS, unavailable)
   public actor UnavailableiOSNestedActor {

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -8,31 +8,31 @@
 // REQUIRES: VENDOR=apple
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
-// CHECK: public actor ActorWithImplicitAvailability {
+// CHECK:     public actor ActorWithImplicitAvailability {
 public actor ActorWithImplicitAvailability {
-  // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
   // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
 }
 
-// CHECK-NOT: #if compiler(>=5.3) && $Actors
-// CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+// CHECK-NOT:  #if compiler(>=5.3) && $Actors
+// CHECK:      @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
 // CHECK-NEXT: public actor ActorWithExplicitAvailability {
 @available(SwiftStdlib 5.2, *)
 public actor ActorWithExplicitAvailability {
-  // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+  // CHECK:      @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
   // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
 }
 
-// CHECK-NOT: #if compiler(>=5.3) && $Actors
-// CHECK: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
+// CHECK-NOT:  #if compiler(>=5.3) && $Actors
+// CHECK:      @_hasMissingDesignatedInitializers @available(macOS, unavailable)
 // CHECK-NEXT: public actor UnavailableActor {
 @available(macOS, unavailable)
 public actor UnavailableActor {
-  // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   // CHECK-NEXT: @available(macOS, unavailable, introduced: 10.15)
   // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
   // CHECK-NEXT:   get
@@ -44,7 +44,7 @@ public actor UnavailableActor {
 @available(SwiftStdlib 5.2, *)
 public enum Enum {
   // CHECK-NOT:   #if compiler(>=5.3) && $Actors
-  // CHECK: @_hasMissingDesignatedInitializers public actor NestedActor {
+  // CHECK:       @_hasMissingDesignatedInitializers public actor NestedActor {
   public actor NestedActor {
     // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
@@ -56,20 +56,20 @@ public enum Enum {
 // CHECK: extension Library.Enum {
 extension Enum {
   // CHECK-NOT: #if compiler(>=5.3) && $Actors
-  // CHECK: @_hasMissingDesignatedInitializers public actor ExtensionNestedActor {
+  // CHECK:     @_hasMissingDesignatedInitializers public actor ExtensionNestedActor {
   public actor ExtensionNestedActor {
-    // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+    // CHECK:      @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
   }
 
-  // CHECK-NOT: #if compiler(>=5.3) && $Actors
-  // CHECK: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
+  // CHECK-NOT:  #if compiler(>=5.3) && $Actors
+  // CHECK:      @_hasMissingDesignatedInitializers @available(macOS, unavailable)
   // CHECK-NEXT: public actor UnavailableExtensionNestedActor {
   @available(macOS, unavailable)
   public actor UnavailableExtensionNestedActor {
-    // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+    // CHECK:      @available(iOS 13.4, tvOS 13.4, watchOS 6.2, *)
     // CHECK-NEXT: @available(macOS, unavailable, introduced: 10.15.4)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
     // CHECK-NEXT:   get
@@ -77,7 +77,7 @@ extension Enum {
   }
 }
 
-// CHECK-PUBLIC: @available(macOS, unavailable)
+// CHECK-PUBLIC:      @available(macOS, unavailable)
 // CHECK-PUBLIC-NEXT: @available(iOS, unavailable)
 // CHECK-PUBLIC-NEXT: @available(watchOS, unavailable)
 // CHECK-PUBLIC-NEXT: @available(tvOS, unavailable)
@@ -89,12 +89,12 @@ extension Enum {
 // CHECK-PRIVATE-NEXT: public struct SPIAvailableStruct
 @_spi_available(SwiftStdlib 5.2, *)
 public struct SPIAvailableStruct {
-  // CHECK-NOT: #if compiler(>=5.3) && $Actors
-  // CHECK: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
+  // CHECK-NOT:  #if compiler(>=5.3) && $Actors
+  // CHECK:      @_hasMissingDesignatedInitializers @available(macOS, unavailable)
   // CHECK-NEXT: public actor UnavailableNestedActor
   @available(macOS, unavailable)
   public actor UnavailableNestedActor {
-    // CHECK-PUBLIC: @available(iOS, unavailable)
+    // CHECK-PUBLIC:      @available(iOS, unavailable)
     // CHECK-PUBLIC-NEXT: @available(tvOS, unavailable)
     // CHECK-PUBLIC-NEXT: @available(watchOS, unavailable)
     // CHECK-PUBLIC-NEXT: @available(macOS, unavailable)
@@ -107,41 +107,41 @@ public struct SPIAvailableStruct {
   }
 }
 
-// CHECK: @_hasMissingDesignatedInitializers @available(macCatalyst 13.1, *)
+// CHECK:      @_hasMissingDesignatedInitializers @available(macCatalyst 13.1, *)
 // CHECK-NEXT: public class MacCatalystAvailableClass
 @available(macCatalyst 13.1, *)
 public class MacCatalystAvailableClass {
   // CHECK-NOT: #if compiler(>=5.3) && $Actors
-  // CHECK: @_hasMissingDesignatedInitializers public actor NestedActor
+  // CHECK:     @_hasMissingDesignatedInitializers public actor NestedActor
   public actor NestedActor {
-    // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 13.1, *)
+    // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 13.1, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }
 
-  // CHECK-NOT: #if compiler(>=5.3) && $Actors
-  // CHECK: @_hasMissingDesignatedInitializers @available(macCatalyst 14, *)
+  // CHECK-NOT:  #if compiler(>=5.3) && $Actors
+  // CHECK:      @_hasMissingDesignatedInitializers @available(macCatalyst 14, *)
   // CHECK-NEXT: public actor LessAvailableMacCatalystActor
   @available(macCatalyst 14, *)
   public actor LessAvailableMacCatalystActor {
-    // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 14, *)
+    // CHECK:      @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, macCatalyst 14, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }
 
   // CHECK-NOT: #if compiler(>=5.3) && $Actors
-  // CHECK: @_hasMissingDesignatedInitializers @available(iOS 15.0, macOS 12.0, *)
+  // CHECK:     @_hasMissingDesignatedInitializers @available(iOS 15.0, macOS 12.0, *)
   // CHECK-NEXT: public actor AvailableiOSAndMacOSNestedActor {
   @available(iOS 15.0, macOS 12.0, *)
   public actor AvailableiOSAndMacOSNestedActor {
-    // CHECK: @available(iOS 15.0, tvOS 13.0, watchOS 6.0, macOS 12.0, *)
+    // CHECK:      @available(iOS 15.0, tvOS 13.0, watchOS 6.0, macOS 12.0, *)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }
 
-  // CHECK-NOT: #if compiler(>=5.3) && $Actors
-  // CHECK: @_hasMissingDesignatedInitializers @available(iOS, unavailable)
+  // CHECK-NOT:  #if compiler(>=5.3) && $Actors
+  // CHECK:      @_hasMissingDesignatedInitializers @available(iOS, unavailable)
   // CHECK-NEXT: public actor UnavailableiOSNestedActor
   @available(iOS, unavailable)
   public actor UnavailableiOSNestedActor {
-    // CHECK: @available(tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+    // CHECK:      @available(tvOS 13.0, watchOS 6.0, macOS 10.15, *)
     // CHECK-NEXT: @available(iOS, unavailable, introduced: 13.0)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }

--- a/test/ModuleInterface/distributed-actor.swift
+++ b/test/ModuleInterface/distributed-actor.swift
@@ -7,8 +7,8 @@
 
 import Distributed
 
-// CHECK-NOT:      #if compiler(>=5.3) && $Actors
-// CHECK: @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NOT:  #if compiler(>=5.3) && $Actors
+// CHECK:      @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 // CHECK-NEXT: distributed public actor DA {
 @available(SwiftStdlib 5.7, *)
 public distributed actor DA {
@@ -32,12 +32,12 @@ public distributed actor DA {
 }
 
 
-// CHECK-NOT:       #if compiler(>=5.3) && $Actors
-// CHECK:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-// CHECK-NEXT:  extension Library.DA : Distributed.DistributedActor {}
-// CHECK-NOT:       #if compiler(>=5.3) && $Actors
-// CHECK:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-// CHECK-NEXT:  extension Library.DA : Swift.Encodable {}
-// CHECK-NOT:       #if compiler(>=5.3) && $Actors
-// CHECK:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
-// CHECK-NEXT:  extension Library.DA : Swift.Decodable {}
+// CHECK-NOT: #if compiler(>=5.3) && $Actors
+// CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NEXT:extension Library.DA : Distributed.DistributedActor {}
+// CHECK-NOT: #if compiler(>=5.3) && $Actors
+// CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NEXT:extension Library.DA : Swift.Encodable {}
+// CHECK-NOT: #if compiler(>=5.3) && $Actors
+// CHECK:     @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NEXT:extension Library.DA : Swift.Decodable {}

--- a/test/ModuleInterface/distributed-actor.swift
+++ b/test/ModuleInterface/distributed-actor.swift
@@ -7,8 +7,8 @@
 
 import Distributed
 
-// CHECK:      #if compiler(>=5.3) && $Actors
-// CHECK-NEXT: @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NOT:      #if compiler(>=5.3) && $Actors
+// CHECK: @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 // CHECK-NEXT: distributed public actor DA {
 @available(SwiftStdlib 5.7, *)
 public distributed actor DA {
@@ -30,18 +30,14 @@ public distributed actor DA {
   // CHECK-NEXT:    get
   // CHECK-NEXT:  }
 }
-// CHECK: #endif
 
 
-// CHECK:       #if compiler(>=5.3) && $Actors
-// CHECK-NEXT:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NOT:       #if compiler(>=5.3) && $Actors
+// CHECK:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 // CHECK-NEXT:  extension Library.DA : Distributed.DistributedActor {}
-// CHECK-NEXT:  #endif
-// CHECK:       #if compiler(>=5.3) && $Actors
-// CHECK-NEXT:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NOT:       #if compiler(>=5.3) && $Actors
+// CHECK:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 // CHECK-NEXT:  extension Library.DA : Swift.Encodable {}
-// CHECK-NEXT:  #endif
-// CHECK:       #if compiler(>=5.3) && $Actors
-// CHECK-NEXT:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
+// CHECK-NOT:       #if compiler(>=5.3) && $Actors
+// CHECK:  @available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *)
 // CHECK-NEXT:  extension Library.DA : Swift.Decodable {}
-// CHECK-NEXT:  #endif

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -4,7 +4,7 @@
 
 public struct MyStruct {}
 
-// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        public var status: Swift.Bool {
 // CHECK:          get async throws
 // CHECK:        }
@@ -15,13 +15,13 @@ public extension MyStruct {
     }
 }
 
-// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        public var hello: Swift.Int {
 // CHECK:            get async
 // CHECK:          }
 
 
-// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        public subscript(x: Swift.Int) -> Swift.Void {
 // CHECK:            get async throws
 // CHECK:          }
@@ -34,7 +34,7 @@ public class C {
   }
 }
 
-// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        public var world: Swift.Int {
 // CHECK:          get throws
 // CHECK:        }
@@ -43,11 +43,11 @@ public enum E {
   public var world: Int { get throws { 0 } }
 }
 
-// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        var books: Swift.Int { get async }
 
 
-// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:    #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        subscript(x: Swift.Int) -> Swift.Int { get throws }
 
 public protocol P {

--- a/test/ModuleInterface/effectful_properties.swift
+++ b/test/ModuleInterface/effectful_properties.swift
@@ -4,11 +4,10 @@
 
 public struct MyStruct {}
 
-// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        public var status: Swift.Bool {
 // CHECK:          get async throws
 // CHECK:        }
-// CHECK:        #endif
 
 public extension MyStruct {
   struct InnerStruct {
@@ -16,18 +15,16 @@ public extension MyStruct {
     }
 }
 
-// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        public var hello: Swift.Int {
 // CHECK:            get async
 // CHECK:          }
-// CHECK:        #endif
 
 
-// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        public subscript(x: Swift.Int) -> Swift.Void {
 // CHECK:            get async throws
 // CHECK:          }
-// CHECK:        #endif
 
 public class C {
   public var hello: Int { get async { 0 } }
@@ -37,24 +34,21 @@ public class C {
   }
 }
 
-// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        public var world: Swift.Int {
 // CHECK:          get throws
 // CHECK:        }
-// CHECK:        #endif
 
 public enum E {
   public var world: Int { get throws { 0 } }
 }
 
-// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        var books: Swift.Int { get async }
-// CHECK:        #endif
 
 
-// CHECK-LABEL:  #if compiler(>=5.3) && $EffectfulProp
+// CHECK-NOT:  #if compiler(>=5.3) && $EffectfulProp
 // CHECK:        subscript(x: Swift.Int) -> Swift.Int { get throws }
-// CHECK:        #endif
 
 public protocol P {
   var books: Int { get async }

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -21,7 +21,7 @@ public func specializeWithAvailability<T>(_ t: T) {
 }
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
-// CHECK: public actor MyActor
+// CHECK:      public actor MyActor
 // CHECK:        @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
 // CHECK-NEXT:     get
 // CHECK-NEXT:   }
@@ -30,32 +30,32 @@ public actor MyActor {
 }
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
-// CHECK: extension FeatureTest.MyActor
+// CHECK:     extension FeatureTest.MyActor
 public extension MyActor {
   // CHECK-NOT: $Actors
-  // CHECK: testFunc
+  // CHECK:     testFunc
   func testFunc() async { }
   // CHECK: }
 }
 
 // CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
-// CHECK: globalAsync
+// CHECK:     globalAsync
 public func globalAsync() async { }
 
-// CHECK: @_marker public protocol MP {
+// CHECK:      @_marker public protocol MP {
 // CHECK-NEXT: }
 @_marker public protocol MP { }
 
-// CHECK: @_marker public protocol MP2 : FeatureTest.MP {
+// CHECK:      @_marker public protocol MP2 : FeatureTest.MP {
 // CHECK-NEXT: }
 @_marker public protocol MP2: MP { }
 
 // CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK: public protocol MP3 : AnyObject, FeatureTest.MP {
+// CHECK:      public protocol MP3 : AnyObject, FeatureTest.MP {
 // CHECK-NEXT: }
 public protocol MP3: AnyObject, MP { }
 
-// CHECK: extension FeatureTest.MP2 {
+// CHECK:      extension FeatureTest.MP2 {
 // CHECK-NEXT: func inMP2
 extension MP2 {
   public func inMP2() { }
@@ -64,18 +64,18 @@ extension MP2 {
 // CHECK: class OldSchool : FeatureTest.MP {
 public class OldSchool: MP {
   // CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
-  // CHECK: takeClass()
+  // CHECK:     takeClass()
   public func takeClass() async { }
 }
 
 // CHECK: class OldSchool2 : FeatureTest.MP {
 public class OldSchool2: MP {
   // CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
-  // CHECK: takeClass()
+  // CHECK:     takeClass()
   public func takeClass() async { }
 }
 
-// CHECK: #if compiler(>=5.3) && $RethrowsProtocol
+// CHECK:      #if compiler(>=5.3) && $RethrowsProtocol
 // CHECK-NEXT: @rethrows public protocol RP
 @rethrows public protocol RP {
   func f() throws -> Bool
@@ -83,24 +83,24 @@ public class OldSchool2: MP {
 
 // CHECK: public struct UsesRP {
 public struct UsesRP {
-  // CHECK: #if compiler(>=5.3) && $RethrowsProtocol
+  // CHECK:     #if compiler(>=5.3) && $RethrowsProtocol
   // CHECK-NEXT:  public var value: (any FeatureTest.RP)? {
   // CHECK-NOT: #if compiler(>=5.3) && $RethrowsProtocol
-  // CHECK: get
+  // CHECK:         get
   public var value: RP? {
     nil
   }
 }
 
-// CHECK: #if compiler(>=5.3) && $RethrowsProtocol
+// CHECK:      #if compiler(>=5.3) && $RethrowsProtocol
 // CHECK-NEXT: public struct IsRP
 public struct IsRP: RP {
   // CHECK-NEXT: public func f()
   public func f() -> Bool { }
 
   // CHECK-NOT: $RethrowsProtocol
-  // CHECK-NEXT: public var isF: 
-  // CHECK-NEXT: get
+  // CHECK-NEXT: public var isF:
+  // CHECK-NEXT:   get
   public var isF: Bool {
     f()
   }
@@ -111,43 +111,43 @@ public struct IsRP: RP {
 public func acceptsRP<T: RP>(_: T) { }
 
 // CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK: extension Swift.Array : FeatureTest.MP where Element : FeatureTest.MP {
+// CHECK:     extension Swift.Array : FeatureTest.MP where Element : FeatureTest.MP {
 extension Array: FeatureTest.MP where Element : FeatureTest.MP { }
 // CHECK: }
 
 // CHECK-NOT: #if compiler(>=5.3) && $MarkerProtocol
-// CHECK: extension FeatureTest.OldSchool : Swift.UnsafeSendable {
+// CHECK:     extension FeatureTest.OldSchool : Swift.UnsafeSendable {
 extension OldSchool: UnsafeSendable { }
 // CHECK-NEXT: }
 
 
 // CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
-// CHECK: func runSomethingSomewhere
+// CHECK:     func runSomethingSomewhere
 public func runSomethingSomewhere(body: () async -> Void) { }
 
 // CHECK-NOT: #if compiler(>=5.3) && $Sendable
-// CHECK: func runSomethingConcurrently(body: @Sendable () -> 
+// CHECK:     func runSomethingConcurrently(body: @Sendable () -> 
 public func runSomethingConcurrently(body: @Sendable () -> Void) { }
 
 // CHECK-NOT: #if compiler(>=5.3) && $Actors
-// CHECK: func stage
+// CHECK:     func stage
 public func stage(with actor: MyActor) { }
 
 // CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait && $Sendable && $InheritActorContext
-// CHECK: func asyncIsh
+// CHECK:     func asyncIsh
 public func asyncIsh(@_inheritActorContext operation: @Sendable @escaping () async -> Void) { }
 
-// CHECK-NOT:      #if compiler(>=5.3) && $AsyncAwait
-// CHECK: #if compiler(>=5.3) && $UnsafeInheritExecutor
-// CHECK: @_unsafeInheritExecutor public func unsafeInheritExecutor() async
+// CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
+// CHECK:     #if compiler(>=5.3) && $UnsafeInheritExecutor
+// CHECK:     @_unsafeInheritExecutor public func unsafeInheritExecutor() async
 @_unsafeInheritExecutor
 public func unsafeInheritExecutor() async {}
 
-// CHECK-NOT:      #if compiler(>=5.3) && $AsyncAwait
+// CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
 // CHECK-NOT: #if $UnsafeInheritExecutor
-// CHECK: #elseif compiler(>=5.3) && $SpecializeAttributeWithAvailability
-// CHECK: @_specialize{{.*}}
-// CHECK: public func multipleSuppressible<T>(value: T) async
+// CHECK:     #elseif compiler(>=5.3) && $SpecializeAttributeWithAvailability
+// CHECK:     @_specialize{{.*}}
+// CHECK:     public func multipleSuppressible<T>(value: T) async
 @_unsafeInheritExecutor
 @_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
 public func multipleSuppressible<T>(value: T) async {}

--- a/test/ModuleInterface/features.swift
+++ b/test/ModuleInterface/features.swift
@@ -20,29 +20,26 @@
 public func specializeWithAvailability<T>(_ t: T) {
 }
 
-// CHECK: #if compiler(>=5.3) && $Actors
-// CHECK-NEXT: public actor MyActor
+// CHECK-NOT: #if compiler(>=5.3) && $Actors
+// CHECK: public actor MyActor
 // CHECK:        @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
 // CHECK-NEXT:     get
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
-// CHECK-NEXT: #endif
 public actor MyActor {
 }
 
-// CHECK: #if compiler(>=5.3) && $Actors
-// CHECK-NEXT: extension FeatureTest.MyActor
+// CHECK-NOT: #if compiler(>=5.3) && $Actors
+// CHECK: extension FeatureTest.MyActor
 public extension MyActor {
   // CHECK-NOT: $Actors
   // CHECK: testFunc
   func testFunc() async { }
   // CHECK: }
-  // CHECK-NEXT: #endif
 }
 
-// CHECK: #if compiler(>=5.3) && $AsyncAwait
-// CHECK-NEXT: globalAsync
-// CHECK-NEXT: #endif
+// CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
+// CHECK: globalAsync
 public func globalAsync() async { }
 
 // CHECK: @_marker public protocol MP {
@@ -66,17 +63,15 @@ extension MP2 {
 
 // CHECK: class OldSchool : FeatureTest.MP {
 public class OldSchool: MP {
-  // CHECK: #if compiler(>=5.3) && $AsyncAwait
-  // CHECK-NEXT: takeClass()
-  // CHECK-NEXT: #endif
+  // CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
+  // CHECK: takeClass()
   public func takeClass() async { }
 }
 
 // CHECK: class OldSchool2 : FeatureTest.MP {
 public class OldSchool2: MP {
-  // CHECK: #if compiler(>=5.3) && $AsyncAwait
-  // CHECK-NEXT: takeClass()
-  // CHECK-NEXT: #endif
+  // CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
+  // CHECK: takeClass()
   public func takeClass() async { }
 }
 
@@ -126,47 +121,33 @@ extension OldSchool: UnsafeSendable { }
 // CHECK-NEXT: }
 
 
-// CHECK: #if compiler(>=5.3) && $AsyncAwait
-// CHECK-NEXT: func runSomethingSomewhere
-// CHECK-NEXT: #endif
+// CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait
+// CHECK: func runSomethingSomewhere
 public func runSomethingSomewhere(body: () async -> Void) { }
 
-// CHECK: #if compiler(>=5.3) && $Sendable
-// CHECK-NEXT: func runSomethingConcurrently(body: @Sendable () -> 
-// CHECK-NEXT: #endif
+// CHECK-NOT: #if compiler(>=5.3) && $Sendable
+// CHECK: func runSomethingConcurrently(body: @Sendable () -> 
 public func runSomethingConcurrently(body: @Sendable () -> Void) { }
 
-// CHECK: #if compiler(>=5.3) && $Actors
-// CHECK-NEXT: func stage
-// CHECK-NEXT: #endif
+// CHECK-NOT: #if compiler(>=5.3) && $Actors
+// CHECK: func stage
 public func stage(with actor: MyActor) { }
 
-// CHECK: #if compiler(>=5.3) && $AsyncAwait && $Sendable && $InheritActorContext
-// CHECK-NEXT: func asyncIsh
-// CHECK-NEXT: #endif
+// CHECK-NOT: #if compiler(>=5.3) && $AsyncAwait && $Sendable && $InheritActorContext
+// CHECK: func asyncIsh
 public func asyncIsh(@_inheritActorContext operation: @Sendable @escaping () async -> Void) { }
 
-// CHECK:      #if compiler(>=5.3) && $AsyncAwait
-// CHECK-NEXT: #if $UnsafeInheritExecutor
-// CHECK-NEXT: @_unsafeInheritExecutor public func unsafeInheritExecutor() async
-// CHECK-NEXT: #else
-// CHECK-NEXT: public func unsafeInheritExecutor() async
-// CHECK-NEXT: #endif
-// CHECK-NEXT: #endif
+// CHECK-NOT:      #if compiler(>=5.3) && $AsyncAwait
+// CHECK: #if compiler(>=5.3) && $UnsafeInheritExecutor
+// CHECK: @_unsafeInheritExecutor public func unsafeInheritExecutor() async
 @_unsafeInheritExecutor
 public func unsafeInheritExecutor() async {}
 
-// CHECK:      #if compiler(>=5.3) && $AsyncAwait
-// CHECK-NEXT: #if $UnsafeInheritExecutor
-// CHECK-NEXT: @_specialize{{.*}}
-// CHECK-NEXT: @_unsafeInheritExecutor public func multipleSuppressible<T>(value: T) async
-// CHECK-NEXT: #elseif $SpecializeAttributeWithAvailability
-// CHECK-NEXT: @_specialize{{.*}}
-// CHECK-NEXT: public func multipleSuppressible<T>(value: T) async
-// CHECK-NEXT: #else
-// CHECK-NEXT: public func multipleSuppressible<T>(value: T) async
-// CHECK-NEXT: #endif
-// CHECK-NEXT: #endif
+// CHECK-NOT:      #if compiler(>=5.3) && $AsyncAwait
+// CHECK-NOT: #if $UnsafeInheritExecutor
+// CHECK: #elseif compiler(>=5.3) && $SpecializeAttributeWithAvailability
+// CHECK: @_specialize{{.*}}
+// CHECK: public func multipleSuppressible<T>(value: T) async
 @_unsafeInheritExecutor
 @_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
 public func multipleSuppressible<T>(value: T) async {}


### PR DESCRIPTION
The "#if compiler(>=5.3) && $AsyncAwait" checks were necessary for staging in concurrency in Swift 5.5. At this point, it's safe to assume that any compiler that tries to read a generated Swift interface file will support concurrency, so we can stop emitting these guards.
