### PR TITLE
[Caching] Do not mix swift modules built from CAS vs. from FileSystem

### DIFF
--- a/include/swift/Basic/CASOptions.h
+++ b/include/swift/Basic/CASOptions.h
@@ -19,6 +19,7 @@
 #define SWIFT_BASIC_CASOPTIONS_H
 
 #include "clang/CAS/CASOptions.h"
+#include "llvm/ADT/Hashing.h"
 
 namespace swift {
 
@@ -57,6 +58,21 @@ public:
     return EnableCaching &&
            (!CASFSRootIDs.empty() || !ClangIncludeTrees.empty() ||
             !InputFileKey.empty() || !BridgingHeaderPCHCacheKey.empty());
+  }
+
+  /// Return a hash code of any components from these options that should
+  /// contribute to a Swift Bridging PCH hash.
+  llvm::hash_code getPCHHashComponents() const {
+    // The CASIDs are generated from scanner, thus not part of the hash since
+    // they will always be empty when requested.
+    // TODO: Add frozen clang::CASOptions to the hash.
+    return llvm::hash_combine(EnableCaching);
+  }
+
+  /// Return a hash code of any components from these options that should
+  /// contribute to a Swift Dependency Scanning hash.
+  llvm::hash_code getModuleScanningHashComponents() const {
+    return getPCHHashComponents();
   }
 };
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -71,7 +71,8 @@ std::string CompilerInvocation::getPCHHash() const {
                            SearchPathOpts.getPCHHashComponents(),
                            DiagnosticOpts.getPCHHashComponents(),
                            SILOpts.getPCHHashComponents(),
-                           IRGenOpts.getPCHHashComponents());
+                           IRGenOpts.getPCHHashComponents(),
+                           CASOpts.getPCHHashComponents());
 
   return llvm::toString(llvm::APInt(64, Code), 36, /*Signed=*/false);
 }
@@ -85,7 +86,8 @@ std::string CompilerInvocation::getModuleScanningHash() const {
                            SearchPathOpts.getModuleScanningHashComponents(),
                            DiagnosticOpts.getModuleScanningHashComponents(),
                            SILOpts.getModuleScanningHashComponents(),
-                           IRGenOpts.getModuleScanningHashComponents());
+                           IRGenOpts.getModuleScanningHashComponents(),
+                           CASOpts.getModuleScanningHashComponents());
 
   return llvm::toString(llvm::APInt(64, Code), 36, /*Signed=*/false);
 }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1922,6 +1922,10 @@ InterfaceSubContextDelegateImpl::getCacheHash(StringRef useInterfacePath,
       // invalidation behavior of this cache item.
       genericSubInvocation.getFrontendOptions().shouldTrackSystemDependencies(),
 
+      // Whether or not caching is enabled affects if the instance is able to
+      // correctly load the dependencies.
+      genericSubInvocation.getCASOptions().getModuleScanningHashComponents(),
+
       // Whether or not OSSA modules are enabled.
       //
       // If OSSA modules are enabled, we use a separate namespace of modules to

--- a/test/CAS/module_hash.swift
+++ b/test/CAS/module_hash.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -module-name Test
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps_cache.json -module-name Test \
+// RUN:    -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json Swift modulePath > %t/path1
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps_cache.json Swift modulePath > %t/path2
+// RUN: not diff %t/path1 %t/path2
+
+func test() {}


### PR DESCRIPTION
Use a different context hash for modules built from caching using CAS vs. normal swift modules. They should not be mixed since those cannot be loaded as a dependencies for a module which is setup to build with a different method.

rdar://122814823

