### PR TITLE
[CodeCompletion] Always suggest call pattern for nested function calls

### DIFF
--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1407,3 +1407,38 @@ struct AtStartOfFunctionCallWithExistingParams {
     // AT_START_OF_CALL_ONE_EXISTING_ARGUMENT-DAG: Pattern/Local/Flair[ArgLabels]:     {#a: Int#}[#Int#]; name=a:
   }
 }
+
+struct NestedCallsWithoutClosingParen {
+  func foo(arg: Int, arg2: Int) -> Int { 1 }
+  func bar(arg: Int, option: Int) -> Int { 1 }
+
+  func test() {
+    bar(arg: foo(#^NESTED_CALL_AT_START^#, option: 1)
+    // NESTED_CALL_AT_START-DAG: Decl[InstanceMethod]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#arg: Int#}, {#arg2: Int#}[')'][#Int#];
+
+    bar(arg: 1 + foo(#^NESTED_CALL_IN_BINARY_OP?check=NESTED_CALL_AT_START^#, option: 1)
+
+    bar(arg: foo(#^NESTED_CALL_AFTER_MEMBER_ACCESS?check=NESTED_CALL_AT_START^#, option: 1)
+
+    bar(arg: foo(arg: 1, #^NESTED_CALL_AT_SECOND_ARG^#, option: 1)
+    // NESTED_CALL_AT_SECOND_ARG-DAG: Pattern/Local/Flair[ArgLabels]:     {#arg2: Int#}[#Int#];
+  }
+
+  func testInDictionaryLiteral() {
+    let a = 1
+    let b = 2
+    _ = [a: foo(#^IN_DICTIONARY_LITERAL?check=NESTED_CALL_AT_START^#, b: 1]
+  } 
+
+  func testInArrayLiteral() {
+    _ = [foo(#^IN_ARRAY_LITERAL?check=NESTED_CALL_AT_START^#, 1]
+  }
+
+  func testInParen() {
+    _ = (foo(#^IN_PAREN?check=NESTED_CALL_AT_START^#)
+  }
+
+  func testInTuple() {
+    _ = (foo(#^IN_TUPLE?check=NESTED_CALL_AT_START^#, 1)
+  }
+}

--- a/test/SourceKit/CodeComplete/complete_call_pattern.swift
+++ b/test/SourceKit/CodeComplete/complete_call_pattern.swift
@@ -9,7 +9,6 @@ func test() {
 
 // RUN: %sourcekitd-test -req=complete -pos=7:11 %s -- %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=complete.open -pos=7:11 %s -- %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=complete.open -pos=7:11 %s -- %s | %FileCheck %s
 
-// CHECK: key.kind: source.lang.swift.pattern
+// CHECK: key.kind: source.lang.swift.decl.function.constructor
 // CHECK-NEXT: key.name: "foo:"

--- a/validation-test/IDE/issues_fixed/issue-57149.swift
+++ b/validation-test/IDE/issues_fixed/issue-57149.swift
@@ -27,4 +27,4 @@ struct ContentView: View {
   }
 }
 
-// COMPLETE: Pattern/Local/Flair[ArgLabels]:     {#foo: Int#}[#Int#];
+// COMPLETE: Decl[InstanceMethod]/Super/Flair[ArgLabels]/TypeRelation[Convertible]: ['(']{#foo: Int#}[')'][#Never#]; name=foo:


### PR DESCRIPTION
When completing in cases like `bar(arg: foo(|, option: 1)`, we don’t know if `option` belongs to the call to `foo` or `bar`. Be defensive and also suggest the signature.
