### PR TITLE
Add deserialization support for section attribute

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6094,6 +6094,14 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::Section_DECL_ATTR: {
+        bool isImplicit;
+        serialization::decls_block::SectionDeclAttrLayout::readRecord(
+            scratch, isImplicit);
+        Attr = new (ctx) SectionAttr(blobData, isImplicit);
+        break;
+      }
+
       case decls_block::RawLayout_DECL_ATTR: {
         bool isImplicit;
         TypeID typeID;

--- a/test/Serialization/attr-section.swift
+++ b/test/Serialization/attr-section.swift
@@ -1,4 +1,4 @@
-// XFAIL: OS=windows-msvc
+// REQUIRES: swift_in_compiler
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature SymbolLinkageMarkers -emit-module-path %t/a.swiftmodule -module-name a %s

--- a/test/Serialization/attr-section.swift
+++ b/test/Serialization/attr-section.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature SymbolLinkageMarkers -emit-module-path %t/a.swiftmodule -module-name a %s
+// RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --check-prefix BC-CHECK --implicit-check-not UnknownCode %s
+// RUN: %target-swift-ide-test -print-module -module-to-print a -source-filename x -I %t | %FileCheck --check-prefix MODULE-CHECK %s
+
+// BC-CHECK: <Section_DECL_ATTR
+
+// MODULE-CHECK: @_section("SOME_SECT") let Constant: Int
+@_section("SOME_SECT")
+let Constant = 321

--- a/test/Serialization/attr-section.swift
+++ b/test/Serialization/attr-section.swift
@@ -1,3 +1,5 @@
+// XFAIL: OS=windows-msvc
+
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-as-library -enable-experimental-feature SymbolLinkageMarkers -emit-module-path %t/a.swiftmodule -module-name a %s
 // RUN: llvm-bcanalyzer -dump %t/a.swiftmodule | %FileCheck --check-prefix BC-CHECK --implicit-check-not UnknownCode %s


### PR DESCRIPTION
While working on #71425, I hit an assert indicating the `@_section` attribute was not handled in `DeclDeserializer::deserializeDeclCommon`. This change adds the missing deserialization for the `@_section` attribute.