### PR TITLE
Sema: Fix recent regression with -disable-experimental-associated-type-inference

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -1902,6 +1902,13 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
     else
       continue;
 
+    if (result.empty()) {
+      // If we found at least one default candidate, we must allow for the
+      // possibility that no default is chosen by adding a tautological witness
+      // to our disjunction.
+      result.push_back(InferredAssociatedTypesByWitness());
+    }
+
     // Add this result.
     InferredAssociatedTypesByWitness inferred;
     inferred.Witness = typeDecl;
@@ -1909,12 +1916,6 @@ AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
     result.push_back(std::move(inferred));
   }
 
-  if (!result.empty()) {
-    // If we found at least one default candidate, we must allow for the
-    // possibility that no default is chosen by adding a tautological witness
-    // to our disjunction.
-    result.push_back(InferredAssociatedTypesByWitness());
-  }
   return result;
 }
 

--- a/test/decl/protocol/req/associated_type_inference_stdlib_4a.swift
+++ b/test/decl/protocol/req/associated_type_inference_stdlib_4a.swift
@@ -30,78 +30,77 @@
 
 #if A1
 
-for x in S() { _ = x }
+for x in G<String>() { _ = x }
 
 #elseif A2
 
 func f<T: Sequence>(_: T.Type) -> T.Element.Type { fatalError() }
-let x: String.Type = f(S.self)
+let x: String.Type = f(G<String>.self)
 
 #elseif A3
 
 func f<T: Sequence>(_: T.Type) -> T.Iterator.Type { fatalError() }
-let x: IndexingIterator<S>.Type = f(S.self)
+let x: IndexingIterator<G<String>>.Type = f(G<String>.self)
 
 #elseif A4
 
 func f<T: Sequence>(_: T.Type) -> T.Iterator.Element.Type { fatalError() }
-let x: String.Type = f(S.self)
+let x: String.Type = f(G<String>.self)
 
 #elseif A5
 
 func f<T: Collection>(_: T.Type) -> T.Element.Type { fatalError() }
-let x: String.Type = f(S.self)
+let x: String.Type = f(G<String>.self)
 
 #elseif A6
 
 func f<T: Collection>(_: T.Type) -> T.Index.Type { fatalError() }
-let x: Int.Type = f(S.self)
+let x: Int.Type = f(G<String>.self)
 
 #elseif A7
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Type { fatalError() }
-let x: Slice<S>.Type = f(S.self)
+let x: Slice<G<String>>.Type = f(G<String>.self)
 
 #elseif A8
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Element.Type { fatalError() }
-let x: String.Type = f(S.self)
+let x: String.Type = f(G<String>.self)
 
 #elseif A9
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Index.Type { fatalError() }
-let x: Int.Type = f(S.self)
+let x: Int.Type = f(G<String>.self)
 
 #elseif A10
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Iterator.Type { fatalError() }
-let x: IndexingIterator<Slice<S>>.Type = f(S.self)
+let x: IndexingIterator<Slice<G<String>>>.Type = f(G<String>.self)
 
 #elseif A11
 
 func f<T: Collection>(_: T.Type) -> T.Indices.Type { fatalError() }
-let x: Range<Int>.Type = f(S.self)
+let x: Range<Int>.Type = f(G<String>.self)
 
 #elseif A12
 
 func f<T: Collection>(_: T.Type) -> T.Indices.Element.Type { fatalError() }
-let x: Int.Type = f(S.self)
+let x: Int.Type = f(G<String>.self)
 
 #elseif A13
 
 func f<T: Collection>(_: T.Type) -> T.Indices.SubSequence.Type { fatalError() }
-let x: Range<Int>.Type = f(S.self)
+let x: Range<Int>.Type = f(G<String>.self)
 
 #elseif A14
 
 func f<T: Collection>(_: T.Type) -> T.SubSequence.Indices.Type { fatalError() }
-let x: Range<Int>.Type = f(S.self)
+let x: Range<Int>.Type = f(G<String>.self)
 
 #endif
 
-struct S: RandomAccessCollection {
+struct G<Element>: RandomAccessCollection {
   public var startIndex: Int { 0 }
   public var endIndex: Int { 0 }
-  public subscript(position: Int) -> String { "" }
+  public subscript(position: Int) -> Element { fatalError() }
 }
-


### PR DESCRIPTION
Change the order of bindings to exactly match what was going on before, because we seem to hit a request cycle via AssociatedConformanceRequest.

Of course the latter is lazier with -enable-experimental-associated-type-inference, and the staging flag will be ripped out completely soon, but we want to keep the old mode working a little while longer.

Fixes rdar://problem/122810266.