### PR TITLE
Initialize `ErasedIsolation` in the `ImplFunctionTypeFlags` constructor

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -286,7 +286,7 @@ class ImplFunctionTypeFlags {
 public:
   ImplFunctionTypeFlags()
       : Rep(0), Pseudogeneric(0), Escaping(0), Concurrent(0), Async(0),
-        DifferentiabilityKind(0) {}
+        ErasedIsolation(0), DifferentiabilityKind(0) {}
 
   ImplFunctionTypeFlags(ImplFunctionRepresentation rep, bool pseudogeneric,
                         bool noescape, bool concurrent, bool async,


### PR DESCRIPTION
Unfortunately, I can't see any easy way to test this — we already have tests for demangling function types in general which obviously didn't catch it reliably, and whether the bug is even detectable is very sensitive to Clang's code generation.