### PR TITLE
[TaskExecutor] Remove un-necessary nonisolated(unsafe)

### DIFF
--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -31,8 +31,7 @@ import Swift
 /// detailed discussion of task executor preferences.
 ///
 /// Customizing the global concurrent executor is currently not supported.
-@available(SwiftStdlib 9999, *)
-nonisolated(unsafe)
+@available(SwiftStdlib 5.11, *)
 public var globalConcurrentExecutor: any TaskExecutor {
   get {
     _DefaultGlobalConcurrentExecutor.shared
@@ -44,7 +43,7 @@ public var globalConcurrentExecutor: any TaskExecutor {
 /// A task executor which enqueues all work on the default global concurrent
 /// thread pool that is used as the default executor for Swift concurrency
 /// tasks.
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.11, *)
 internal final class _DefaultGlobalConcurrentExecutor: TaskExecutor {
   public static let shared: _DefaultGlobalConcurrentExecutor = .init()
 

--- a/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
+++ b/stdlib/public/Concurrency/GlobalConcurrentExecutor.swift
@@ -31,7 +31,7 @@ import Swift
 /// detailed discussion of task executor preferences.
 ///
 /// Customizing the global concurrent executor is currently not supported.
-@available(SwiftStdlib 5.11, *)
+@available(SwiftStdlib 9999, *)
 public var globalConcurrentExecutor: any TaskExecutor {
   get {
     _DefaultGlobalConcurrentExecutor.shared
@@ -43,7 +43,7 @@ public var globalConcurrentExecutor: any TaskExecutor {
 /// A task executor which enqueues all work on the default global concurrent
 /// thread pool that is used as the default executor for Swift concurrency
 /// tasks.
-@available(SwiftStdlib 5.11, *)
+@available(SwiftStdlib 9999, *)
 internal final class _DefaultGlobalConcurrentExecutor: TaskExecutor {
   public static let shared: _DefaultGlobalConcurrentExecutor = .init()
 


### PR DESCRIPTION
This could lead to compatibility issues between compilers/sdks, so remove the un-necessary `nonisolated(unsafe)` attribute
