### PR TITLE
Sema: Only diagnose retroactive conformances once

### DIFF
--- a/test/Sema/extension_retroactive_conformances.swift
+++ b/test/Sema/extension_retroactive_conformances.swift
@@ -6,9 +6,16 @@
 // Define a couple protocols with no requirements that're easy to conform to
 public protocol SampleProtocol1 {}
 public protocol SampleProtocol2 {}
+public protocol SampleProtocol1a: SampleProtocol1 {}
+public protocol SampleProtocol1b: SampleProtocol1 {}
 
 public struct Sample1 {}
 public struct Sample2 {}
+public struct Sample2a {}
+public struct Sample2b {}
+public struct Sample2c {}
+public struct Sample2d {}
+public struct Sample2e {}
 public struct Sample3 {}
 public struct Sample4 {}
 public struct Sample5 {}
@@ -35,6 +42,19 @@ extension Sample2: InheritsSampleProtocol {} // expected-warning {{extension dec
 // expected-note @-1 {{add '@retroactive' to silence this warning}} {{1-1=extension Sample2: @retroactive SampleProtocol1 {\}\n}}
 
 extension SampleAlreadyConforms: InheritsSampleProtocol {} // ok, SampleAlreadyConforms already conforms in the source module
+
+extension Sample2a: @retroactive SampleProtocol1, InheritsSampleProtocol {} // ok, the concrete conformance to SampleProtocol1 has been declared retroactive
+
+extension Sample2b: InheritsSampleProtocol, @retroactive SampleProtocol1 {} // ok, same as above but in the opposite order
+
+// FIXME: It would be better to only suggest marking SampleProtocol1a @retroactive here
+extension Sample2c: SampleProtocol1a {} // expected-warning {{extension declares a conformance of imported type 'Sample2c' to imported protocols 'SampleProtocol1a', 'SampleProtocol1'}}
+// expected-note @-1 {{add '@retroactive' to silence this warning}} {{21-37=@retroactive SampleProtocol1a}} {{1-1=extension Sample2c: @retroactive SampleProtocol1 {\}\n}}
+
+extension Sample2d: @retroactive SampleProtocol1a {} // ok, retroactive conformance to SampleProtocol1a covers conformance to SampleProtocol1
+
+extension Sample2e: SampleProtocol1a, @retroactive SampleProtocol1b {} // expected-warning {{extension declares a conformance of imported type 'Sample2e' to imported protocol 'SampleProtocol1a'}}
+// expected-note @-1 {{add '@retroactive' to silence this warning}} {{21-37=@retroactive SampleProtocol1a}}
 
 extension Sample3: NestedInheritsSampleProtocol {} // expected-warning {{extension declares a conformance of imported type 'Sample3' to imported protocol 'SampleProtocol1'}}
 // expected-note @-1 {{add '@retroactive' to silence this warning}} {{1-1=extension Sample3: @retroactive SampleProtocol1 {\}\n}}


### PR DESCRIPTION
A type may conform to a single protocol via multiple inheritance clauses on the same extension. When this occurs, we must be careful to only diagnose that conformance as needing `@retroactive` once, or not at all if one of those clauses is marked `@retroactive`.

Resolves rdar://121479047
