### PR TITLE
Deserializer: better error message if types of referenced functions don't match

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -126,6 +126,10 @@ ERROR(function_type_mismatch,none,
 NOTE(function_declared_here,none,
      "function declared here", ())
 
+ERROR(deserialize_function_type_mismatch,Fatal,
+      "type mismatch of function '%0', declared as %1 but used in a swift module as %2",
+      (StringRef, Type, Type))
+
 // Capture before declaration diagnostics.
 ERROR(capture_before_declaration,none,
       "closure captures %0 before it is declared", (Identifier))

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -142,7 +142,7 @@ namespace swift {
     SILDifferentiabilityWitness *
     getSILDifferentiabilityWitnessForReference(StringRef mangledKey);
 
-    SILFunction *getFuncForReference(StringRef Name, SILType Ty);
+    SILFunction *getFuncForReference(StringRef Name, SILType Ty, TypeExpansionContext context);
     SILFunction *getFuncForReference(StringRef Name);
     SILVTable *readVTable(serialization::DeclID);
     SILMoveOnlyDeinit *readMoveOnlyDeinit(serialization::DeclID);


### PR DESCRIPTION
So far this resulted in an assert (in best case). Now a readable error is printed.
