### PR TITLE
[BitwiseCopyable] Don't ever infer for public.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -54,6 +54,10 @@ llvm::cl::opt<bool> TypeLoweringForceOpaqueValueLowering(
     llvm::cl::desc("Force TypeLowering to behave as if building with opaque "
                    "values enabled"));
 
+llvm::cl::opt<bool> TypeLoweringDisableVerification(
+    "type-lowering-disable-verification", llvm::cl::init(false),
+    llvm::cl::desc("Disable the asserts-only verification of lowerings"));
+
 namespace {
   /// A CRTP type visitor for deciding whether the metatype for a type
   /// is a singleton type, i.e. whether there can only ever be one
@@ -2945,6 +2949,9 @@ void TypeConverter::verifyLowering(const TypeLowering &lowering,
                                    AbstractionPattern origType,
                                    CanType substType,
                                    TypeExpansionContext forExpansion) {
+  if (TypeLoweringDisableVerification) {
+    return;
+  }
   verifyLexicalLowering(lowering, origType, substType, forExpansion);
   verifyTrivialLowering(lowering, origType, substType, forExpansion);
 }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3049,7 +3049,7 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
 
   if (lowering.isTrivial() && !conformance) {
     // A trivial type can lack a conformance in a few cases:
-    // (1) containing or being a resilient type
+    // (1) containing or being a public, non-frozen type
     // (2) containing or being a generic type which doesn't conform
     //     unconditionally but in this particular instantiation is trivial
     // (3) being a special type that's not worth forming a conformance for
@@ -3082,8 +3082,11 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
             return true;
           }
 
-          // Resilient trivial types may not conform (case (1)).
-          if (nominal->isResilient())
+          // Public, non-frozen trivial types may not conform (case (1)).
+          if (nominal
+                  ->getFormalAccessScope(/*useDC=*/nullptr,
+                                         /*treatUsableFromInlineAsPublic=*/true)
+                  .isPublic())
             return true;
 
           auto *module = nominal->getModuleContext();
@@ -3149,8 +3152,11 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
             return false;
           }
 
-          // Resilient trivial types may not conform (case (1)).
-          if (nominal->isResilient())
+          // Public, non-frozen trivial types may not conform (case (1)).
+          if (nominal
+                  ->getFormalAccessScope(/*useDC=*/nullptr,
+                                         /*treatUsableFromInlineAsPublic=*/true)
+                  .isPublic())
             return false;
 
           auto *module = nominal->getModuleContext();

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -57,8 +57,7 @@ getImplicitCheckForNominal(NominalTypeDecl *nominal) {
   if (!nominal
            ->getFormalAccessScope(
                /*useDC=*/nullptr, /*treatUsableFromInlineAsPublic=*/true)
-           .isPublic() ||
-      !nominal->isResilient())
+           .isPublic())
     return {BitwiseCopyableCheck::Implicit};
 
   if (nominal->hasClangNode() ||

--- a/test/IRGen/bitwise_copyable_resilient.swift
+++ b/test/IRGen/bitwise_copyable_resilient.swift
@@ -1,0 +1,55 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                           \
+// RUN:     %t/Library.swift                             \
+// RUN:     -emit-module                                 \
+// RUN:     -enable-library-evolution                    \
+// RUN:     -enable-experimental-feature BitwiseCopyable \
+// RUN:     -module-name Library                         \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-swift-frontend                           \
+// RUN:     %t/Downstream.swift                          \
+// RUN:     -typecheck -verify                           \
+// RUN:     -debug-diagnostic-names                      \
+// RUN:     -enable-experimental-feature BitwiseCopyable \
+// RUN:     -I %t
+
+//--- Library.swift
+public enum Oopsional<T> {
+case someone(T)
+case nobody
+}
+
+@frozen public enum Woopsional<T> {
+case somebody(T)
+case noone
+}
+
+public struct Integer {
+  var value: Int
+}
+
+//--- Downstream.swift
+import Library
+
+func take<T: _BitwiseCopyable>(_ t: T) {}
+
+struct S_Explicit_With_Oopsional<T> : _BitwiseCopyable {
+  var o: Oopsional<T> // expected-error{{non_bitwise_copyable_type_member}}
+}
+
+func passOopsional<T>(_ t: Oopsional<T>) { take(t) } // expected-error   {{type_does_not_conform_decl_owner}}
+                                                     // expected-note@-7 {{where_requirement_failure_one_subst}}
+
+
+struct S_Explicit_With_Woopsional<T> : _BitwiseCopyable {
+  var o: Woopsional<T> // expected-error{{non_bitwise_copyable_type_member}}
+}
+
+func passWoopsional<T>(_ t: Woopsional<T>) { take(t) } // expected-error    {{type_does_not_conform_decl_owner}}
+                                                       // expected-note@-15 {{where_requirement_failure_one_subst}}
+
+extension Integer : @retroactive _BitwiseCopyable {} // expected-error {{bitwise_copyable_outside_module}}
+

--- a/test/SILGen/bitwise_copyable.swift
+++ b/test/SILGen/bitwise_copyable.swift
@@ -40,7 +40,7 @@ enum Context<T> {
 
 func doit() -> Context<Int>.Here { .init(t: 0) }
 
-public enum E {
+public enum E : _BitwiseCopyable {
   case a
 }
 

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -62,7 +62,8 @@ struct S_Explicit_With_Function_C : _BitwiseCopyable {
 public struct S_Public {}
 
 struct S_Explicit_With_S_Public : _BitwiseCopyable {
-  var s: S_Public
+  var s: S_Public // expected-error   {{non_bitwise_copyable_type_member}}
+                  // expected-note@-4 {{add_nominal_bitwise_copyable_conformance}}
 }
 
 struct S_Explicit_With_Generic<T> : _BitwiseCopyable {

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -25,3 +25,13 @@ indirect enum E_Explicit_Indirect : _BitwiseCopyable { // expected-error {{non_b
 enum E_Explicit_Indirect_Case : _BitwiseCopyable { // expected-error {{non_bitwise_copyable_type_indirect_enum_element}}
   indirect case s(S) // expected-note {{note_non_bitwise_copyable_type_indirect_enum_element}}
 }
+
+func take<T : _BitwiseCopyable>(_ t: T) {}
+
+// public (effectively) => !conforms
+@usableFromInline internal struct InternalUsableStruct {
+  public var int: Int
+}
+
+func passInternalUsableStruct(_ s: InternalUsableStruct) { take(s) } // expected-error{{type_does_not_conform_decl_owner}}
+                                                                     // expected-note@-8{{where_requirement_failure_one_subst}}

--- a/test/Sema/bitwise_copyable_nonresilient.swift
+++ b/test/Sema/bitwise_copyable_nonresilient.swift
@@ -32,15 +32,17 @@ import Library
 func take<T: _BitwiseCopyable>(_ t: T) {}
 
 struct S_Explicit_With_Oopsional<T> : _BitwiseCopyable {
-  var o: Oopsional<T>
+  var o: Oopsional<T> // expected-error{{non_bitwise_copyable_type_member}}
 }
 
-func passOopsional<T>(_ t: Oopsional<T>) { take(t) }
+func passOopsional<T>(_ t: Oopsional<T>) { take(t) } // expected-error{{type_does_not_conform_decl_owner}}
+                                                     // expected-note@-7{{where_requirement_failure_one_subst}}
 
 
 struct S_Explicit_With_Woopsional<T> : _BitwiseCopyable {
-  var o: Woopsional<T>
+  var o: Woopsional<T> // expected-error{{non_bitwise_copyable_type_member}}
 }
 
-func passWoopsional<T>(_ t: Woopsional<T>) { take(t) }
+func passWoopsional<T>(_ t: Woopsional<T>) { take(t) } // expected-error{{type_does_not_conform_decl_owner}}
+                                                       // expected-note@-15{{where_requirement_failure_one_subst}}
 

--- a/test/Sema/bitwise_copyable_package_resilience.swift
+++ b/test/Sema/bitwise_copyable_package_resilience.swift
@@ -1,0 +1,42 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                           \
+// RUN:     %t/Library.swift                             \
+// RUN:     -emit-module                                 \
+// RUN:     -package-name Package                        \
+// RUN:     -enable-library-evolution                    \
+// RUN:     -enable-experimental-feature BitwiseCopyable \
+// RUN:     -module-name Library                         \
+// RUN:     -emit-module-path %t/Library.swiftmodule     \
+// RUN:     -emit-module-interface-path %t/Library.swiftinterface
+
+// RUN: %target-swift-frontend                           \
+// RUN:     %t/Downstream.swift                          \
+// RUN:     -typecheck -verify                           \
+// RUN:     -package-name Package                        \
+// RUN:     -debug-diagnostic-names                      \
+// RUN:     -enable-experimental-feature BitwiseCopyable \
+// RUN:     -I %t
+
+//--- Library.swift
+
+// !public => conforms
+package struct PackageStruct {
+  package var int: Int
+}
+
+// Public => !conforms
+public struct PublicStruct {
+  public var int: Int
+}
+
+//--- Downstream.swift
+import Library
+
+func take<T : _BitwiseCopyable>(_ t: T) {}
+
+func passPackageStruct(_ s: PackageStruct) { take(s) }
+
+func passPublicStruct(_ s: PublicStruct) { take(s) } // expected-error{{type_does_not_conform_decl_owner}}
+                                                     // expected-note@-5{{where_requirement_failure_one_subst}}


### PR DESCRIPTION
Don't key inference behavior off of library evolution mode.
