### PR TITLE
AST: Don't optimize decls that are unavailable in extensions

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2655,7 +2655,8 @@ public:
   /// Finds the most-specific platform-specific attribute that is
   /// active for the current platform.
   const AvailableAttr *
-  findMostSpecificActivePlatform(const ASTContext &ctx) const;
+  findMostSpecificActivePlatform(const ASTContext &ctx,
+                                 bool ignoreAppExtensions = false) const;
 
   /// Returns the first @available attribute that indicates
   /// a declaration is unavailable, or the first one that indicates it's
@@ -2664,7 +2665,8 @@ public:
 
   /// Returns the first @available attribute that indicates
   /// a declaration is unavailable, or null otherwise.
-  const AvailableAttr *getUnavailable(const ASTContext &ctx) const;
+  const AvailableAttr *getUnavailable(const ASTContext &ctx,
+                                      bool ignoreAppExtensions = false) const;
 
   /// Returns the first @available attribute that indicates
   /// a declaration is deprecated on all deployment targets, or null otherwise.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1286,7 +1286,8 @@ public:
   getSemanticAvailableRangeAttr() const;
 
   /// Retrieve the @available attribute that makes this declaration unavailable,
-  /// if any.
+  /// if any. If \p ignoreAppExtensions is true then attributes for app
+  /// extension platforms are ignored.
   ///
   /// This attribute may come from an enclosing decl since availability is
   /// inherited. The second member of the returned pair is the decl that owns
@@ -1295,7 +1296,7 @@ public:
   /// Note that this notion of unavailability is broader than that which is
   /// checked by \c AvailableAttr::isUnavailable.
   llvm::Optional<std::pair<const AvailableAttr *, const Decl *>>
-  getSemanticUnavailableAttr() const;
+  getSemanticUnavailableAttr(bool ignoreAppExtensions = false) const;
 
   /// Returns true if this declaration should be considered available during
   /// SIL/IR lowering. A declaration would not be available during lowering if,

--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -57,6 +57,12 @@ StringRef prettyPlatformString(PlatformKind platform);
 llvm::Optional<PlatformKind>
 basePlatformForExtensionPlatform(PlatformKind Platform);
 
+/// Returns true if \p Platform represents and application extension platform,
+/// e.g. `iOSApplicationExtension`.
+inline bool isApplicationExtensionPlatform(PlatformKind Platform) {
+  return basePlatformForExtensionPlatform(Platform).has_value();
+}
+
 /// Returns whether the passed-in platform is active, given the language
 /// options. A platform is active if either it is the target platform or its
 /// AppExtension variant is the target platform. For example, OS X is

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3985,7 +3985,8 @@ public:
 
 class SemanticUnavailableAttrRequest
     : public SimpleRequest<SemanticUnavailableAttrRequest,
-                           llvm::Optional<AvailableAttrDeclPair>(const Decl *),
+                           llvm::Optional<AvailableAttrDeclPair>(
+                               const Decl *decl, bool ignoreAppExtensions),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3993,8 +3994,9 @@ public:
 private:
   friend SimpleRequest;
 
-  llvm::Optional<AvailableAttrDeclPair> evaluate(Evaluator &evaluator,
-                                                 const Decl *decl) const;
+  llvm::Optional<AvailableAttrDeclPair>
+  evaluate(Evaluator &evaluator, const Decl *decl,
+           bool ignoreAppExtensions) const;
 
 public:
   bool isCached() const { return true; }

--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -109,10 +109,6 @@ swift::basePlatformForExtensionPlatform(PlatformKind Platform) {
   llvm_unreachable("bad PlatformKind");
 }
 
-static bool isApplicationExtensionPlatform(PlatformKind Platform) {
-  return basePlatformForExtensionPlatform(Platform).has_value();
-}
-
 static bool isPlatformActiveForTarget(PlatformKind Platform,
                                       const llvm::Triple &Target,
                                       bool EnableAppExtensionRestrictions) {

--- a/test/SILGen/unavailable_decl_optimization_stub_macos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos.swift
@@ -1,5 +1,7 @@
-// RUN: %target-swift-emit-silgen -target %target-swift-abi-5.8-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK-SWIFT5_8
-// RUN: %target-swift-emit-silgen -target %target-swift-abi-5.9-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK-SWIFT5_9
+// RUN: %target-swift-emit-silgen -target %target-swift-abi-5.8-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_8
+// RUN: %target-swift-emit-silgen -target %target-swift-abi-5.8-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -application-extension | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_8
+// RUN: %target-swift-emit-silgen -target %target-swift-abi-5.9-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_9
+// RUN: %target-swift-emit-silgen -target %target-swift-abi-5.9-triple -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub -application-extension | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_9
 
 // REQUIRES: OS=macosx
 
@@ -19,3 +21,22 @@ public func unavailableFunc() {}
 @available(*, unavailable)
 @inlinable public func unavailableInlinableFunc() {}
 
+// CHECK-LABEL:     sil{{.*}}@$s4Test22unavailableOnMacOSFuncyyF
+// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF : $@convention(thin) () -> Never
+// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test22unavailableOnMacOSFuncyyF'
+@available(macOS, unavailable)
+public func unavailableOnMacOSFunc() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test31unavailableOnMacOSExtensionFuncyyF
+// CHECK-NOT:         function_ref @$ss36_diagnoseUnavailableCodeReached{{.*}} : $@convention(thin) () -> Never
+// CHECK:           } // end sil function '$s4Test31unavailableOnMacOSExtensionFuncyyF'
+@available(macOSApplicationExtension, unavailable)
+public func unavailableOnMacOSExtensionFunc() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test20unavailableOniOSFuncyyF
+// CHECK-NOT:         function_ref @$ss36_diagnoseUnavailableCodeReached{{.*}} : $@convention(thin) () -> Never
+// CHECK:           } // end sil function '$s4Test20unavailableOniOSFuncyyF'
+@available(iOS, unavailable)
+public func unavailableOniOSFunc() {}

--- a/test/SILGen/unavailable_decl_optimization_stub_macos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos.swift
@@ -35,6 +35,15 @@ public func unavailableOnMacOSFunc() {}
 @available(macOSApplicationExtension, unavailable)
 public func unavailableOnMacOSExtensionFunc() {}
 
+// CHECK-LABEL:     sil{{.*}}@$s4Test021unavailableOnMacOSAndD15OSExtensionFuncyyF
+// CHECK-SWIFT5_8:    [[FNREF:%.*]] = function_ref @$ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF : $@convention(thin) () -> Never
+// CHECK-SWIFT5_9:    [[FNREF:%.*]] = function_ref @$ss31_diagnoseUnavailableCodeReacheds5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test021unavailableOnMacOSAndD15OSExtensionFuncyyF'
+@available(macOS, unavailable)
+@available(macOSApplicationExtension, unavailable) // FIXME: Seems like this should be diagnosed as redundant
+public func unavailableOnMacOSAndMacOSExtensionFunc() {}
+
 // CHECK-LABEL:     sil{{.*}}@$s4Test20unavailableOniOSFuncyyF
 // CHECK-NOT:         function_ref @$ss36_diagnoseUnavailableCodeReached{{.*}} : $@convention(thin) () -> Never
 // CHECK:           } // end sil function '$s4Test20unavailableOniOSFuncyyF'


### PR DESCRIPTION
Unavailable decl optimization is meant to optimize declarations that are unreachable at runtime. A declaration that is marked unavailable in app extensions (e.g. `@available(macOSApplicationExtension, unavailable)`) may be reachable by non-extension processes so it cannot be safely optimized.

Resolves rdar://122924862
