### PR TITLE
Improve performance of bridge to the new diagnostics formatter

### DIFF
--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -94,7 +94,8 @@ public:
 
 private:
   /// Retrieve the SourceFileSyntax for the given buffer.
-  void *getSourceFileSyntax(SourceManager &SM, unsigned bufferID);
+  void *getSourceFileSyntax(SourceManager &SM, unsigned bufferID,
+                            StringRef displayName);
 
   void queueBuffer(SourceManager &sourceMgr, unsigned bufferID);
   void printDiagnostic(SourceManager &SM, const DiagnosticInfo &Info);

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -51,6 +51,9 @@ class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   void *queuedDiagnostics = nullptr;
   llvm::DenseMap<unsigned, QueuedBuffer> queuedBuffers;
 
+  /// Source file syntax nodes cached by { source manager, buffer ID }.
+  llvm::DenseMap<std::pair<SourceManager *, unsigned>, void *> sourceFileSyntax;
+
 public:
   PrintingDiagnosticConsumer(llvm::raw_ostream &stream = llvm::errs());
   ~PrintingDiagnosticConsumer();
@@ -90,6 +93,9 @@ public:
   }
 
 private:
+  /// Retrieve the SourceFileSyntax for the given buffer.
+  void *getSourceFileSyntax(SourceManager &SM, unsigned bufferID);
+
   void queueBuffer(SourceManager &sourceMgr, unsigned bufferID);
   void printDiagnostic(SourceManager &SM, const DiagnosticInfo &Info);
 };

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -361,6 +361,7 @@ public func addQueuedSourceFile(
   let sourceFile = sourceFilePtr.assumingMemoryBound(to: ExportedSourceFile.self)
   let sourceFileID = queuedDiagnostics.pointee.grouped.addSourceFile(
     tree: sourceFile.pointee.syntax,
+    sourceLocationConverter: sourceFile.pointee.sourceLocationConverter,
     displayName: displayName,
     parent: parent
   )

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -304,16 +304,26 @@ static SmallVector<unsigned, 1> getSourceBufferStack(
   }
 }
 
-void PrintingDiagnosticConsumer::queueBuffer(
+void *PrintingDiagnosticConsumer::getSourceFileSyntax(
     SourceManager &sourceMgr, unsigned bufferID) {
-  QueuedBuffer knownSourceFile = queuedBuffers[bufferID];
-  if (knownSourceFile)
-    return;
+  auto known = sourceFileSyntax.find({&sourceMgr, bufferID});
+  if (known != sourceFileSyntax.end())
+    return known->second;
 
   auto bufferContents = sourceMgr.getEntireTextForBuffer(bufferID);
   auto sourceFile = swift_ASTGen_parseSourceFile(
       bufferContents.data(), bufferContents.size(),
       "module", "file.swift", /*ctx*/ nullptr);
+
+  sourceFileSyntax[{&sourceMgr, bufferID}] = sourceFile;
+  return sourceFile;
+}
+
+void PrintingDiagnosticConsumer::queueBuffer(
+    SourceManager &sourceMgr, unsigned bufferID) {
+  QueuedBuffer knownSourceFile = queuedBuffers[bufferID];
+  if (knownSourceFile)
+    return;
 
   // Find the parent and position in parent, if there is one.
   int parentID = -1;
@@ -345,6 +355,7 @@ void PrintingDiagnosticConsumer::queueBuffer(
         sourceMgr.getLocForBufferStart(bufferID)).str();
   }
 
+  auto sourceFile = getSourceFileSyntax(sourceMgr, bufferID);
   swift_ASTGen_addQueuedSourceFile(
       queuedDiagnostics, bufferID, sourceFile,
       (const uint8_t*)displayName.data(), displayName.size(),
@@ -423,9 +434,6 @@ void PrintingDiagnosticConsumer::flush(bool includeTrailingBreak) {
     }
     swift_ASTGen_destroyQueuedDiagnostics(queuedDiagnostics);
     queuedDiagnostics = nullptr;
-    for (const auto &buffer : queuedBuffers) {
-      swift_ASTGen_destroySourceFile(buffer.second);
-    }
     queuedBuffers.clear();
 
     if (includeTrailingBreak)
@@ -566,4 +574,9 @@ SourceManager::GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
 PrintingDiagnosticConsumer::PrintingDiagnosticConsumer(
     llvm::raw_ostream &stream)
     : Stream(stream) {}
-PrintingDiagnosticConsumer::~PrintingDiagnosticConsumer() = default;
+
+PrintingDiagnosticConsumer::~PrintingDiagnosticConsumer() {
+  for (const auto &sourceFileSyntax : sourceFileSyntax) {
+    swift_ASTGen_destroySourceFile(sourceFileSyntax.second);
+  }
+}

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -305,7 +305,7 @@ static SmallVector<unsigned, 1> getSourceBufferStack(
 }
 
 void *PrintingDiagnosticConsumer::getSourceFileSyntax(
-    SourceManager &sourceMgr, unsigned bufferID) {
+    SourceManager &sourceMgr, unsigned bufferID, StringRef displayName) {
   auto known = sourceFileSyntax.find({&sourceMgr, bufferID});
   if (known != sourceFileSyntax.end())
     return known->second;
@@ -313,7 +313,7 @@ void *PrintingDiagnosticConsumer::getSourceFileSyntax(
   auto bufferContents = sourceMgr.getEntireTextForBuffer(bufferID);
   auto sourceFile = swift_ASTGen_parseSourceFile(
       bufferContents.data(), bufferContents.size(),
-      "module", "file.swift", /*ctx*/ nullptr);
+      "module", displayName.str().c_str(), /*ctx*/ nullptr);
 
   sourceFileSyntax[{&sourceMgr, bufferID}] = sourceFile;
   return sourceFile;
@@ -355,7 +355,7 @@ void PrintingDiagnosticConsumer::queueBuffer(
         sourceMgr.getLocForBufferStart(bufferID)).str();
   }
 
-  auto sourceFile = getSourceFileSyntax(sourceMgr, bufferID);
+  auto sourceFile = getSourceFileSyntax(sourceMgr, bufferID, displayName);
   swift_ASTGen_addQueuedSourceFile(
       queuedDiagnostics, bufferID, sourceFile,
       (const uint8_t*)displayName.data(), displayName.size(),


### PR DESCRIPTION
The bridge to the new diagnostics formatter was performing a lot of extra computation to re-parse source files and build up the line table. Cache those so we don't rebuild them from one diagnostic to the next.