### PR TITLE
Bincompat hooks for revised hash/isEqual interop

### DIFF
--- a/include/swift/Runtime/Bincompat.h
+++ b/include/swift/Runtime/Bincompat.h
@@ -41,6 +41,12 @@ bool useLegacyObjCBoxingInCasting();
 /// Whether to use legacy semantics when unboxing __SwiftValue
 bool useLegacySwiftValueUnboxingInCasting();
 
+/// Legacy semantics use trivial implementations for -hashValue/-isEqual:
+/// requests from ObjC to Swift values.
+/// New semantics attempt to dispatch to Swift Hashable/Equatable conformances
+/// if present.
+bool useLegacySwiftObjCHashing();
+
 } // namespace bincompat
 
 } // namespace runtime

--- a/stdlib/public/runtime/Bincompat.cpp
+++ b/stdlib/public/runtime/Bincompat.cpp
@@ -228,6 +228,30 @@ bool useLegacySwiftValueUnboxingInCasting() {
 #endif
 }
 
+// Controls how ObjC -hashValue and -isEqual are handled
+// by Swift objects.
+// There are two basic semantics:
+// * pointer: -hashValue returns pointer, -isEqual: tests pointer equality
+// * proxy: -hashValue calls on Hashable conformance, -isEqual: calls Equatable conformance
+//
+// Legacy handling:
+// * Swift struct/enum values that implement Hashable: proxy -hashValue and -isEqual:
+// * Swift struct/enum values that implement Equatable but not Hashable: pointer semantics
+// * Swift class values regardless of hashable/Equatable support: pointer semantics
+//
+// New behavior:
+// * Swift struct/enum/class values that implement Hashable: proxy -hashValue and -isEqual:
+// * Swift struct/enum/class values that implement Equatable but not Hashable: proxy -isEqual:, constant -hashValue
+// * All other cases: pointer semantics
+//
+bool useLegacySwiftObjCHashing() {
+#if BINARY_COMPATIBILITY_APPLE
+  return true; // For now, legacy behavior on Apple OSes
+#else
+  return false; // Always use the new behavior on non-Apple OSes
+#endif
+}
+
 } // namespace bincompat
 
 } // namespace runtime

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -376,6 +376,11 @@ STANDARD_OBJC_METHOD_IMPLS_FOR_SWIFT_OBJECTS
 }
 
 - (NSUInteger)hash {
+  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
+    // Legacy behavior: Don't proxy to Swift Hashable
+    return (NSUInteger)self;
+  }
+
   auto selfMetadata = _swift_getClassOfAllocated(self);
 
   // If it's Hashable, use that
@@ -423,6 +428,11 @@ STANDARD_OBJC_METHOD_IMPLS_FOR_SWIFT_OBJECTS
   if (self == other) {
     return YES;
   }
+  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
+    // Legacy behavior: Don't proxy to Swift Hashable or Equatable
+    return NO; // We know the ids are different
+  }
+
 
   // Get Swift type for self and other
   auto selfMetadata = _swift_getClassOfAllocated(self);

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -24,6 +24,7 @@
 #include "SwiftObject.h"
 #include "SwiftValue.h"
 #include "swift/Basic/Lazy.h"
+#include "swift/Runtime/Bincompat.h"
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
@@ -429,6 +430,11 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
     }
   }
 
+  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
+    // Legacy behavior only proxies isEqual: for Hashable, not Equatable
+    return NO;
+  }
+
   if (auto equatableConformance = selfHeader->getEquatableConformance()) {
     if (auto selfEquatableBaseType = selfHeader->getEquatableBaseType()) {
       auto otherEquatableBaseType = otherHeader->getEquatableBaseType();
@@ -456,6 +462,11 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
 	    getSwiftValuePayload(self,
 				 getSwiftValuePayloadAlignMask(selfHeader->type)),
 	    selfHeader->type, hashableConformance);
+  }
+
+  if (!runtime::bincompat::useLegacySwiftObjCHashing()) {
+    // Legacy behavior doesn't honor Equatable conformance, only Hashable
+    return (NSUInteger)self;
   }
 
   // If Swift type is Equatable but not Hashable,

--- a/test/stdlib/Inputs/SwiftValueNSObject/SwiftValueNSObject.m
+++ b/test/stdlib/Inputs/SwiftValueNSObject/SwiftValueNSObject.m
@@ -102,9 +102,10 @@ void TestSwiftValueNSObjectNotEquals(id e1, id e2)
 
 void TestSwiftValueNSObjectHashValue(id e, NSUInteger hashValue)
 {
-  printf("NSObjectProtocol.hash: Expect [%s hashValue] == %lu\n",
+  printf("NSObjectProtocol.hash: Expect [%s hashValue] == %lu,  Got %lu\n",
 	 [[e description] UTF8String],
-	 (unsigned long)hashValue);
+	 (unsigned long)hashValue,
+	 [e hash]);
   expectTrue([e hash] == hashValue);
 }
 

--- a/test/stdlib/SwiftValueNSObject.swift
+++ b/test/stdlib/SwiftValueNSObject.swift
@@ -98,8 +98,14 @@ func TestHashable<T: Hashable>(_ h: T)
 // Test Obj-C hashValue for Swift types that are Equatable but not Hashable
 func TestEquatableHash<T: Equatable>(_ e: T)
 {
-  // These should have a constant hash value
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  // Legacy behavior used the pointer value, which is
+  // incompatible with user-defined equality.
+  TestSwiftValueNSObjectDefaultHashValue(e as AnyObject)
+#else
+  // New behavior uses a constant hash value in this case
   TestSwiftValueNSObjectHashValue(e as AnyObject, 1)
+#endif
 }
 
 func TestNonEquatableHash<T>(_ e: T)
@@ -112,10 +118,6 @@ func TestNonEquatableHash<T>(_ e: T)
 // CHECK: c ##This is C's debug description##
 // CHECK-NEXT: d ##This is D's description##
 // CHECK-NEXT: S ##{{.*}}__SwiftValue##
-
-// Full message is longer, but this is the essential part...
-// CHECK-NEXT: Obj-C `-hash` {{.*}} type `SwiftValueNSObject.E` {{.*}} Equatable but not Hashable
-// CHECK-NEXT: Obj-C `-hash` {{.*}} type `SwiftValueNSObject.E1` {{.*}} Equatable but not Hashable
 
 // Temporarily disable this test on older OSes until we have time to
 // look into why it's failing there. rdar://problem/47870743
@@ -156,6 +158,4 @@ if #available(OSX 10.12, iOS 10.0, *) {
   fputs("c ##This is C's debug description##\n", stderr)
   fputs("d ##This is D's description##\n", stderr)
   fputs("S ##__SwiftValue##\n", stderr)
-  fputs("Obj-C `-hash` ... type `SwiftValueNSObject.E` ... Equatable but not Hashable", stderr)
-  fputs("Obj-C `-hash` ... type `SwiftValueNSObject.E1` ... Equatable but not Hashable", stderr)
 }


### PR DESCRIPTION
This adds in hooks so that the new hash/isEqual interop (which bridges Obj-C hash/isEqual: calls to the corresponding Swift Hashable/Equatable conformances) can be selectively disabled based on the OS and/or client.

For now, enable the new semantics everywhere except Apple platforms (which have legacy apps that may be relying on the old semantics).

Resolves: rdar://121399248