### PR TITLE
Sema: Try not to let protocol type aliases leak into inferred type witnesses

### DIFF
--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -986,7 +986,6 @@ private:
 
   /// Infer associated type witnesses for the given associated type.
   InferredAssociatedTypesByWitnesses inferTypeWitnessesViaAssociatedType(
-                   const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
                    AssociatedTypeDecl *assocType);
 
   /// Infer associated type witnesses for all relevant value requirements.
@@ -1790,8 +1789,7 @@ AssociatedTypeInference::inferTypeWitnessesViaValueWitnesses(
       if (assocTypes.count(assocType) == 0)
         continue;
 
-      auto reqInferred = inferTypeWitnessesViaAssociatedType(assocTypes,
-                                                             assocType);
+      auto reqInferred = inferTypeWitnessesViaAssociatedType(assocType);
       if (!reqInferred.empty())
         result.push_back({req, std::move(reqInferred)});
 
@@ -1998,7 +1996,6 @@ static Type removeSelfParam(ValueDecl *value, Type type) {
 
 InferredAssociatedTypesByWitnesses
 AssociatedTypeInference::inferTypeWitnessesViaAssociatedType(
-                   const llvm::SetVector<AssociatedTypeDecl *> &allUnresolved,
                    AssociatedTypeDecl *assocType) {
   InferredAssociatedTypesByWitnesses result;
 

--- a/test/ModuleInterface/protocol_extension_type_witness.swift
+++ b/test/ModuleInterface/protocol_extension_type_witness.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name protocol_extension_type_witness -enable-experimental-associated-type-inference
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name protocol_extension_type_witness
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name protocol_extension_type_witness -disable-experimental-associated-type-inference
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name protocol_extension_type_witness
+// RUN: %FileCheck %s < %t.swiftinterface
+
+public protocol P {
+  associatedtype A
+  associatedtype B
+  associatedtype C
+  associatedtype D
+
+  func b(_: B)
+  func c(_: C)
+  func d(_: D)
+}
+
+extension P {
+  public typealias _Default_A = B
+  public typealias Alias = D
+
+  public func c(_: Alias) {}
+}
+
+public struct S<B>: P {
+  public func b(_: B) {}
+  public func d(_: String) {}
+}
+
+// CHECK-LABEL: public struct S<B> : protocol_extension_type_witness.P {
+// CHECK-NEXT:    public func b(_: B)
+// CHECK-NEXT:    public func d(_: Swift.String)
+// CHECK-NEXT:    public typealias A = B
+// CHECK-NEXT:    public typealias C = Swift.String
+// CHECK-NEXT:    public typealias D = Swift.String
+// CHECK-NEXT:  }

--- a/test/decl/protocol/req/associated_type_inference_distributed.swift
+++ b/test/decl/protocol/req/associated_type_inference_distributed.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: not %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+
+// Reduced from the distributed actors implementation. This didn't type check in 5.10
+// but works now.
+
+protocol DistributedActorSystem<SerializationRequirement> {
+  associatedtype SerializationRequirement
+}
+
+protocol DistributedActor where SerializationRequirement == ActorSystem.SerializationRequirement {
+  associatedtype ActorSystem: DistributedActorSystem
+  associatedtype SerializationRequirement
+}
+
+class Worker<ActorSystem>: DistributedActor where ActorSystem: DistributedActorSystem, ActorSystem.SerializationRequirement == Int {}
+
+struct FakeActorSystem: DistributedActorSystem {
+  typealias SerializationRequirement = Int
+}
+
+print(Worker<FakeActorSystem>.SerializationRequirement.self)


### PR DESCRIPTION
They don't always round-trip through a module interface, because of
request cycles in type resolution.

Fixes rdar://problem/122957148.