### PR TITLE
Add missing checks for nullptr.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -527,15 +527,26 @@ public:
         // Dig out the protocol from the protocol list.
         auto protocolList = readMangledName(resolved.getResolvedAddress(),
                                             MangledNameKind::Type, dem);
-        assert(protocolList->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getKind() == Node::Kind::Protocol);
-        auto protocol = protocolList->getFirstChild()
-                            ->getFirstChild()
-                            ->getFirstChild()
-                            ->getFirstChild();
+        assert(protocolList && protocolList->getNumChildren());
+        if (!protocolList || !protocolList->getNumChildren())
+          return nullptr;
+        auto child = protocolList->getFirstChild();
+        assert(child && child->getNumChildren());
+        if (!child || !child->getNumChildren())
+          return nullptr;
+        child = child->getFirstChild();
+        assert(child && child->getNumChildren());
+        if (!child || !child->getNumChildren())
+          return nullptr;
+        assert(child && child->getNumChildren());
+        child = child->getFirstChild();
+        if (!child || !child->getNumChildren())
+          return nullptr;
+        child = child->getFirstChild();
+        assert(child && child->getKind() == Node::Kind::Protocol);
+        if (!child || child->getKind() != Node::Kind::Protocol)
+          return nullptr;
+        auto protocol = child;
         auto protocolType = dem.createNode(Node::Kind::Type);
         protocolType->addChild(protocol, dem);
         return protocolType;


### PR DESCRIPTION
We got crash reports from LLDB where protocolList is a nullptr when demangling a symbolic reference. While we're also investigating the root cause of the issue, the code in MetadataReader should also not just crash with such input.

rdar://122698966

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
