### PR TITLE
[Dependency Scanning] Interface-scanning sub-invocations should not attempt to import `CxxShims`

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -336,6 +336,9 @@ public:
   /// for testing purposes only.
   bool DisableBuildingInterface = false;
 
+  /// Is this frontend configuration of an interface dependency scan sub-invocation
+  bool DependencyScanningSubInvocation = false;
+
   /// When performing a dependency scanning action, only identify and output all imports
   /// of the main Swift module's source files.
   bool ImportPrescan = false;

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1169,9 +1169,14 @@ bool CompilerInstance::canImportCxxShim() const {
   ImportPath::Module::Builder builder(
       getASTContext().getIdentifier(CXX_SHIM_NAME));
   auto modulePath = builder.get();
+  // Currently, Swift interfaces are not to expose their
+  // C++ dependencies. Which means that when scanning them we should not
+  // bring in such dependencies, including CxxShims.
   return getASTContext().testImportModule(modulePath) &&
          !Invocation.getFrontendOptions()
-              .InputsAndOutputs.hasModuleInterfaceOutputPath();
+              .InputsAndOutputs.hasModuleInterfaceOutputPath() &&
+         !Invocation.getFrontendOptions()
+              .DependencyScanningSubInvocation;
 }
 
 bool CompilerInstance::supportCaching() const {

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1803,6 +1803,8 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     // in the Swift compile commands, when different.
     inheritedParentContextClangArgs =
         clangImporterOpts.getReducedExtraArgsForSwiftModuleDependency();
+    genericSubInvocation.getFrontendOptions()
+        .DependencyScanningSubInvocation = true;
   } else if (LoaderOpts.strictImplicitModuleContext) {
     // If the compiler has been asked to be strict with ensuring downstream
     // dependencies get the parent invocation's context, inherit the extra Clang

--- a/test/ScanDependencies/test_no_indirect_cxx.swift
+++ b/test/ScanDependencies/test_no_indirect_cxx.swift
@@ -1,0 +1,18 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/deps)
+// RUN: split-file %s %t
+// RUN: mv %t/Foo.swiftinterface %t/deps/
+
+// RUN: %target-swift-frontend -scan-dependencies -o %t/deps.json %t/a.swift -I %t/deps -verify
+
+//--- Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foo -cxx-interoperability-mode=default
+public struct S1 {}
+
+//--- a.swift
+import Foo
+
+// RUN: cat %t/deps.json | %FileCheck %s
+// CHECK-NOT: "CxxShim"


### PR DESCRIPTION
Swift interfaces currently aren't meant to expose C++ in their API so we should not also bring in this C++-related module dependency which is not found when the ClangImporter is not configured for C++.

Resolves rdar://122965484