### PR TITLE
[stdlib] BitwiseCopyable storeBytes overload.

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -1814,15 +1814,14 @@ internal struct RawKeyPathComponent {
   }
 }
 
-internal func _pop<T>(from: inout UnsafeRawBufferPointer,
+internal func _pop<T : _BitwiseCopyable>(from: inout UnsafeRawBufferPointer,
                       as type: T.Type) -> T {
   let buffer = _pop(from: &from, as: type, count: 1)
   return buffer.baseAddress.unsafelyUnwrapped.pointee
 }
-internal func _pop<T>(from: inout UnsafeRawBufferPointer,
+internal func _pop<T : _BitwiseCopyable>(from: inout UnsafeRawBufferPointer,
                       as: T.Type,
                       count: Int) -> UnsafeBufferPointer<T> {
-  _internalInvariant(_isPOD(T.self), "should be POD")
   from = MemoryLayout<T>._roundingUpBaseToAlignment(from)
   let byteCount = MemoryLayout<T>.stride * count
   let result = UnsafeBufferPointer(
@@ -3414,8 +3413,7 @@ internal struct InstantiateKeyPathBuffer: KeyPathPatternVisitor {
     }
     return (baseAddress, misalign)
   }
-  mutating func pushDest<T>(_ value: T) {
-    _internalInvariant(_isPOD(T.self))
+  mutating func pushDest<T : _BitwiseCopyable>(_ value: T) {
     let size = MemoryLayout<T>.size
     let (baseAddress, misalign) = adjustDestForAlignment(of: T.self)
     _withUnprotectedUnsafeBytes(of: value) {

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1310,6 +1310,20 @@ public struct UnsafeMutableRawPointer: _Pointer {
   ///   - offset: The offset from this pointer, in bytes. `offset` must be
   ///     nonnegative. The default is zero.
   ///   - type: The type of `value`.
+#if $BitwiseCopyable
+  @inlinable
+  @_alwaysEmitIntoClient
+  public func storeBytes<T : _BitwiseCopyable>(
+    of value: T, toByteOffset offset: Int = 0, as type: T.Type
+  ) {
+    withUnsafePointer(to: value) { source in
+      _memcpy(
+        dest: (self + offset), 
+        src: source, 
+        size: UInt(MemoryLayout<T>.size))
+    }
+  }
+#endif
   @inlinable
   @_alwaysEmitIntoClient
   // This custom silgen name is chosen to not interfere with the old ABI


### PR DESCRIPTION
The new overload is constrained to `BitwiseCopyable` and so enjoys the use of `BitwiseCopyableArchetypeTypeInfo`.

Also promote some isPOD checks in KeyPath.swift to `BitwiseCopyable` constraints.
