### PR TITLE
Fix crash checking objcImpl block property

### DIFF
--- a/test/decl/ext/Inputs/objc_implementation.h
+++ b/test/decl/ext/Inputs/objc_implementation.h
@@ -57,6 +57,9 @@
 - (void)instanceMethod1:(int)param;
 - (void)instanceMethod2:(int)param;
 
+// rdar://122280735 - crash when the parameter of a block property needs @escaping
+@property (nonatomic, readonly) void (^ _Nonnull rdar122280735)(void (^_Nonnull completion)());
+
 @end
 
 @interface ObjCClass () <NSCopying>

--- a/test/decl/ext/objc_implementation.swift
+++ b/test/decl/ext/objc_implementation.swift
@@ -225,6 +225,10 @@ protocol EmptySwiftProto {}
     // OK
     return self
   }
+
+  // rdar://122280735 - crash when the parameter of a block property needs @escaping
+  let rdar122280735: (() -> ()) -> Void = { _ in }
+  // expected-warning@-1 {{property 'rdar122280735' of type '(() -> ()) -> Void' does not match type '(@escaping () -> Void) -> Void' declared by the header}}
 }
 
 @_objcImplementation(PresentAdditions) extension ObjCClass {

--- a/test/decl/ext/objc_implementation_conflicts.swift
+++ b/test/decl/ext/objc_implementation_conflicts.swift
@@ -175,6 +175,8 @@ import objc_implementation_private
   @objc func extensionMethod(fromHeader2: CInt) {}
 
   @objc(copyWithZone:) func copy(with zone: NSZone?) -> Any { self }
+
+  let rdar122280735: (@escaping () -> ()) -> Void = { _ in }
 }
 
 @_objcImplementation(PresentAdditions) extension ObjCClass {


### PR DESCRIPTION
`ObjCImplementationChecker::matchTypes()` implicitly assumed that if it was comparing function types, it must be working on an `AbstractFunctionDecl`. This isn’t true for a property of block type, which could cause crashes when checking their parameter types. Fix this oversight.

Fixes rdar://122280735.