### PR TITLE
SILGen: Handle emitting borrowed lvalues from value bindings.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1193,9 +1193,11 @@ namespace {
 
     ManagedValue project(SILGenFunction &SGF, SILLocation loc,
                          ManagedValue base) && override {
-      assert(base
-             && base.getType().isAddress()
-             && "should have an address base to borrow from");
+      // If the base is already loaded, we just need to borrow it.
+      if (!base.getType().isAddress()) {
+        return base.formalAccessBorrow(SGF, loc);
+      }
+
       // If the base value is address-only then we can borrow from the
       // address in-place.
       if (!base.getType().isLoadable(SGF.F)) {
@@ -3384,9 +3386,15 @@ void LValue::addNonMemberVarComponent(
                "local var should not be actor isolated!");
       }
 
-      assert(address.isLValue() &&
-             "Must have a physical copyable lvalue decl ref that "
-             "evaluates to an address");
+      if (!address.isLValue()) {
+        assert((AccessKind == SGFAccessKind::BorrowedObjectRead
+                || AccessKind == SGFAccessKind::BorrowedAddressRead)
+               && "non-borrow component requires an address base");
+        LV.add<ValueComponent>(address, std::nullopt, typeData,
+                               /*rvalue*/ true);
+        LV.add<BorrowValueComponent>(typeData);
+        return;
+      }
 
       llvm::Optional<SILAccessEnforcement> enforcement;
       if (!Storage->isLet()) {

--- a/test/SILGen/read_yield_local_variable.swift
+++ b/test/SILGen/read_yield_local_variable.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+func foo(x: borrowing String) {}
+
+var last:String
+{
+    // CHECK-LABEL: sil{{.*}} @{{.*}}4lastSSvr :
+    _read
+    {
+        // CHECK: [[X:%.*]] = move_value
+        let x:String = ""
+        // CHECK:   [[BORROW1:%.*]] = begin_borrow [[X]]
+        // CHECK:   apply {{.*}}([[BORROW1]])
+        // CHECK:   end_borrow [[BORROW1]]
+        foo(x: x)
+        // CHECK:   [[BORROW2:%.*]] = begin_borrow [[X]]
+        // CHECK:   yield [[BORROW2]] : {{.*}}, resume [[RESUME:bb[0-9]+]],
+        // CHECK: [[RESUME]]:
+        // CHECK:   end_borrow [[BORROW2]]
+        yield x
+    }
+
+    _modify {
+        var x: String = ""
+        yield &x
+    }
+}


### PR DESCRIPTION
Replace the "must be an address" assertion with an implementation that emits and borrows the base value. Fixes #71598.