### PR TITLE
[BitwiseCopyable] Don't infer for packages types.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3056,7 +3056,7 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
 
   if (lowering.isTrivial() && !conformance) {
     // A trivial type can lack a conformance in a few cases:
-    // (1) containing or being a public, non-frozen type
+    // (1) containing or being a exported, non-frozen type
     // (2) containing or being a generic type which doesn't conform
     //     unconditionally but in this particular instantiation is trivial
     // (3) being a special type that's not worth forming a conformance for
@@ -3089,11 +3089,11 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
             return true;
           }
 
-          // Public, non-frozen trivial types may not conform (case (1)).
+          // Exported, non-frozen trivial types may not conform (case (1)).
           if (nominal
                   ->getFormalAccessScope(/*useDC=*/nullptr,
                                          /*treatUsableFromInlineAsPublic=*/true)
-                  .isPublic())
+                  .isPublicOrPackage())
             return true;
 
           auto *module = nominal->getModuleContext();
@@ -3159,11 +3159,11 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
             return false;
           }
 
-          // Public, non-frozen trivial types may not conform (case (1)).
+          // Exported, non-frozen trivial types may not conform (case (1)).
           if (nominal
                   ->getFormalAccessScope(/*useDC=*/nullptr,
                                          /*treatUsableFromInlineAsPublic=*/true)
-                  .isPublic())
+                  .isPublicOrPackage())
             return false;
 
           auto *module = nominal->getModuleContext();

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3074,6 +3074,7 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
     // (6) being defined in a module built from interface
     // (7) being or containing a variadic generic type which doesn't conform
     //     unconditionally but does in this case
+    // (8) being or containing the error type
     bool hasNoNonconformingNode = visitAggregateLeaves(
         origType, substType, forExpansion,
         /*isLeafAggregate=*/
@@ -3119,6 +3120,10 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
           // being trivial but not conforming to BitwiseCopyable.
 
           auto isTopLevel = !field;
+
+          // The error type doesn't conform but is trivial (case (8)).
+          if (isa<ErrorType>(ty))
+            return false;
 
           // These show up in the context of non-conforming variadic generics
           // which may lack a conformance (case (7)).

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -57,7 +57,7 @@ getImplicitCheckForNominal(NominalTypeDecl *nominal) {
   if (!nominal
            ->getFormalAccessScope(
                /*useDC=*/nullptr, /*treatUsableFromInlineAsPublic=*/true)
-           .isPublic())
+           .isPublicOrPackage())
     return {BitwiseCopyableCheck::Implicit};
 
   if (nominal->hasClangNode() ||

--- a/test/Sema/bitwise_copyable_package_resilience.swift
+++ b/test/Sema/bitwise_copyable_package_resilience.swift
@@ -21,12 +21,12 @@
 
 //--- Library.swift
 
-// !public => conforms
+// package => exported => !inferred
 package struct PackageStruct {
   package var int: Int
 }
 
-// Public => !conforms
+// public => exported => !inferred
 public struct PublicStruct {
   public var int: Int
 }
@@ -36,7 +36,8 @@ import Library
 
 func take<T : _BitwiseCopyable>(_ t: T) {}
 
-func passPackageStruct(_ s: PackageStruct) { take(s) }
+func passPackageStruct(_ s: PackageStruct) { take(s) } // expected-error{{type_does_not_conform_decl_owner}}
+                                                       // expected-note@-3{{where_requirement_failure_one_subst}}
 
 func passPublicStruct(_ s: PublicStruct) { take(s) } // expected-error{{type_does_not_conform_decl_owner}}
-                                                     // expected-note@-5{{where_requirement_failure_one_subst}}
+                                                     // expected-note@-6{{where_requirement_failure_one_subst}}


### PR DESCRIPTION
Like `public` and `@usableFromInline` types, package types too are exported. In the case of a module built with library evolution, they may cease to conform in the future.  Apply the same rule regardless of that build configuration.
