### PR TITLE
Fix an IRGenDebugInfo type reconstruction error

### DIFF
--- a/test/IRGen/round-trip-debug-types-isolated.swift
+++ b/test/IRGen/round-trip-debug-types-isolated.swift
@@ -1,0 +1,51 @@
+// RUN: %target-build-swift -g %s -emit-ir | %FileCheck %s
+
+// Check that the IRGenDebugInfo type reconstruction
+// (round-trip-debug-types) doesn't crash.
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$sSWxs5Error_pIgyrzo_D"
+
+class __DataStorage {
+    public init(bytes: UnsafeRawPointer, count: Int) {
+        _representation = _Representation(UnsafeRawBufferPointer(start: bytes, count: count))
+    }
+
+    struct InlineData {
+        typealias Buffer = (UInt8, UInt8, UInt8)
+        var bytes: Buffer
+        var length: UInt8
+
+        init(count: Int = 0) {
+            bytes = (UInt8(0), UInt8(0), UInt8(0))
+            length = UInt8(count)
+        }
+        
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            let count = Int(length)
+            return try Swift.withUnsafeBytes(of: bytes) { (rawBuffer) throws -> Result in
+                return try apply(UnsafeRawBufferPointer(start: rawBuffer.baseAddress, count: count))
+            }
+        }
+    }
+
+    enum _Representation {
+        case empty
+        case inline(InlineData)
+
+        init(_ buffer: UnsafeRawBufferPointer) {
+            self = .empty
+        }
+
+        func withUnsafeBytes<Result>(_ apply: (UnsafeRawBufferPointer) throws -> Result) rethrows -> Result {
+            switch self {
+            case .empty:
+                let empty = InlineData()
+                return try empty.withUnsafeBytes(apply)
+            case .inline(let inline):
+                return try inline.withUnsafeBytes(apply)
+            }
+        }
+    }
+
+    var _representation: _Representation
+}
+    


### PR DESCRIPTION
This is the error:

Incorrect reconstructed type for $sSWxs5Error_pIgyrzo_D Original type:
(sil_function_type type="@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out \xCF\x84_0_0, @error any Error)"
  (input=struct_type decl="Swift.(file).UnsafeRawBufferPointer")
  (result=generic_type_param_type depth=0 index=0)
  (error=existential_type
    (protocol_type decl="Swift.(file).Error"))
  (substitution_map null_generic_signature)
  (substitution_map null_generic_signature))
Reconstructed type:
(sil_function_type type="@isolated(any) @noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out \xCF\x84_0_0, @error Error)"
  (input=struct_type decl="Swift.(file).UnsafeRawBufferPointer")
  (result=generic_type_param_type depth=0 index=0)
  (error=protocol_type decl="Swift.(file).Error")
  (substitution_map null_generic_signature)
  (substitution_map null_generic_signature))

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
