### PR TITLE
[Debugging] Use __TEXT segment for DebugDescription macro

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
@@ -218,7 +218,7 @@ extension _DebugDescriptionPropertyMacro: PeerMacro {
         #elseif os(Windows)
         @_section(".lldbsummaries")
         #else
-        @_section("__DATA_CONST,__lldbsummaries")
+        @_section("__TEXT,__lldbsummaries")
         #endif
         @_used
         static let _lldb_summary = (

--- a/test/Macros/DebugDescription/extension.swift
+++ b/test/Macros/DebugDescription/extension.swift
@@ -10,14 +10,6 @@ struct MyStruct {}
 extension MyStruct {
   var debugDescription: String { "thirty" }
 }
-// CHECK: #if os(Linux)
-// CHECK: @_section(".lldbsummaries")
-// CHECK: #elseif os(Windows)
-// CHECK: @_section(".lldbsummaries")
-// CHECK: #else
-// CHECK: @_section("__DATA_CONST,__lldbsummaries")
-// CHECK: #endif
-// CHECK: @_used
 // CHECK: static let _lldb_summary = (
 // CHECK:     /* version */ 1 as UInt8,
 // CHECK:     /* record size */ 34 as UInt8,

--- a/test/Macros/DebugDescription/linkage.swift
+++ b/test/Macros/DebugDescription/linkage.swift
@@ -13,7 +13,7 @@ struct MyStruct: CustomDebugStringConvertible {
 // CHECK: #elseif os(Windows)
 // CHECK: @_section(".lldbsummaries")
 // CHECK: #else
-// CHECK: @_section("__DATA_CONST,__lldbsummaries")
+// CHECK: @_section("__TEXT,__lldbsummaries")
 // CHECK: #endif
 // CHECK: @_used
 // CHECK: static let _lldb_summary = (


### PR DESCRIPTION
The data emitted by `DebugDescriptionMacro` is constant. For that reason, it was placed in `__DATA_CONST`. However, this causes a problem with the linker, which emits an error  if the `__DATA_CONST` segment is _not_ marked `SG_READ_ONLY`.

After discussion, it was pointed out that if the constant data has no fixups, then it can and should be in the the `__TEXT` segment. The `__DATA_CONST` segment is for data that is essentially constant but contains dyld fixups.