### PR TITLE
[Concurrency] Don't skip conformance derivation for types with isolated stored properties.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5564,6 +5564,9 @@ ERROR(isolation_macro_experimental,none,
 NOTE(in_derived_conformance, none,
      "in derived conformance to %0",
      (Type))
+NOTE(in_derived_witness, none,
+     "in %0 %1 for derived conformance to %2",
+     (DescriptiveDeclKind, DeclName, Type))
 ERROR(non_sendable_param_type,none,
       "non-sendable type %0 %select{passed in call to %3 %kind2|"
       "exiting %3 context in call to non-isolated %kind2|"

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -2086,12 +2086,6 @@ static bool canDeriveCodable(NominalTypeDecl *NTD,
     return false;
   }
 
-  // Actor-isolated structs and classes cannot derive encodable/decodable
-  // unless all of their stored properties are immutable.
-  if ((isa<StructDecl>(NTD) || isa<ClassDecl>(NTD)) &&
-      memberwiseAccessorsRequireActorIsolation(NTD))
-    return false;
-
   return true;
 }
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -50,11 +50,6 @@ static bool canDeriveConformance(DeclContext *DC,
                DC, structDecl, protocol).empty())
       return false;
 
-    // If the struct is actor-isolated, we cannot derive Equatable/Hashable
-    // conformance if any of the stored properties are mutable.
-    if (memberwiseAccessorsRequireActorIsolation(structDecl))
-      return false;
-
     return true;
   }
 


### PR DESCRIPTION
Otherwise, types that rely on derived conformances to `Equatable` and friends will fail to compile if a library adds a `@preconcurrency @MainActor` annotation that starts getting inferred on the type. 

There is no need to prevent conformance derivation, because the actor isolation checker still runs on derived witnesses and will diagnose any concurrency violations (with appropriate downgrading behavior for `@preconcurrency`).

Resolves rdar://122891639