### PR TITLE
LifetimeDependenceDiagnostics: enable mutably borrowed lifetimes.

### DIFF
--- a/test/SILOptimizer/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence_mutate.swift
@@ -1,0 +1,48 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -disable-experimental-parser-round-trip \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
+
+// REQUIRES: swift_in_compiler
+
+@_nonescapable
+struct MBV : ~Copyable {
+  let p: UnsafeMutableRawPointer
+  let c: Int
+
+  @_unsafeNonescapableResult
+  init(_ p: UnsafeMutableRawPointer, _ c: Int) {
+    self.p = p
+    self.c = c
+  }
+
+  subscript(position: Int) -> Int {
+    get {
+      let offset = position * MemoryLayout<Int>.stride
+      return p.loadUnaligned(fromByteOffset: offset, as: Int.self)
+    }
+    nonmutating set(newValue) {
+      let offset = position * MemoryLayout<Int>.stride
+      p.storeBytes(of: newValue, toByteOffset: offset,
+                   as: Int.self)
+    }
+  }
+}
+
+struct NC : ~Copyable {
+  let p: UnsafeMutableRawPointer
+  let c: Int
+
+  // Requires a mutable borrow.
+  mutating func getMBV() -> _mutate(self) MBV {
+    MBV(p, c)
+  }
+}
+
+func mbv_set_element(nc: inout NC, e: Int) {
+  nc.getMBV()[3] = e
+}

--- a/test/SILOptimizer/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence_util.sil
@@ -75,8 +75,8 @@ entry(%0 : @owned $C):
   return %99 : $()
 }
 
-sil [ossa] @dependence_scope : $@convention(thin) (@owned C, @owned D, @guaranteed D, @in_guaranteed D) -> () {
-entry(%0 : @owned $C, %1 : @owned $D, %2 : @guaranteed $D, %3 : $*D):
+sil [ossa] @dependence_scope : $@convention(thin) (@owned C, @owned D, @guaranteed D, @in_guaranteed D, @inout D) -> () {
+entry(%0 : @owned $C, %1 : @owned $D, %2 : @guaranteed $D, %3 : $*D, %4 : $*D):
   %move = move_value %1 : $D
   %owned_mark = mark_dependence [nonescaping] %0 : $C on %move : $D
   specify_test "lifetime_dependence_scope %owned_mark"
@@ -93,7 +93,7 @@ entry(%0 : @owned $C, %1 : @owned $D, %2 : @guaranteed $D, %3 : $*D):
   %guaranteed_mark = mark_dependence [nonescaping] %owned_mark : $C on %pair : $PairC
   specify_test "lifetime_dependence_scope %guaranteed_mark"
 // CHECK-LABEL: dependence_scope: lifetime_dependence_scope with: %guaranteed_mark
-// CHECK-NEXT: Caller: %{{.*}} = argument of bb0 : $D
+// CHECK-NEXT: Caller:      %2 = argument of bb0 : $D
 // CHECK-NEXT: Dependent:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %{{.*}} : $PairC
 // CHECK-NEXT: Caller range
 // CHECK: dependence_scope: lifetime_dependence_scope with: %guaranteed_mark
@@ -130,21 +130,29 @@ entry(%0 : @owned $C, %1 : @owned $D, %2 : @guaranteed $D, %3 : $*D):
   %guaranteed_arg_mark = mark_dependence [nonescaping] %access_mark : $C on %2 : $D
   specify_test "lifetime_dependence_scope %guaranteed_arg_mark"
 // CHECK-LABEL: dependence_scope: lifetime_dependence_scope with: %guaranteed_arg_mark
-// CHECK-NEXT: Caller: %{{.*}} = argument of bb0 : $D
-// CHECK-NEXT: Dependent:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %{{.*}} : $D
+// CHECK-NEXT: Caller:      %2 = argument of bb0 : $D
+// CHECK-NEXT: Dependent:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %2 : $D
 // CHECK-NEXT: Caller range
 // CHECK: dependence_scope: lifetime_dependence_scope with: %guaranteed_arg_mark
 
   %inguaranteed_arg_mark = mark_dependence [nonescaping] %guaranteed_arg_mark : $C on %3 : $*D
   specify_test "lifetime_dependence_scope %inguaranteed_arg_mark"
 // CHECK-LABEL: dependence_scope: lifetime_dependence_scope with: %inguaranteed_arg_mark
-// CHECK-NEXT: Initialized: %{{.*}} = argument of bb0 : $*D
-// CHECK-NEXT: Dependent:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %{{.*}} : $*D
+// CHECK-NEXT: Initialized: %3 = argument of bb0 : $*D
+// CHECK-NEXT: Dependent:   %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %3 : $*D
 // CHECK-NEXT: begin:      %{{.*}} = move_value %{{.*}} : $D
 // CHECK-NEXT: ends:     
 // CHECK: dependence_scope: lifetime_dependence_scope with: %inguaranteed_arg_mark
   
-  destroy_value %inguaranteed_arg_mark : $C
+  %inout_arg_mark = mark_dependence [nonescaping] %inguaranteed_arg_mark : $C on %4 : $*D
+  specify_test "lifetime_dependence_scope %inout_arg_mark"
+// CHECK-LABEL: dependence_scope: lifetime_dependence_scope with: %inout_arg_mark
+// CHECK-NEXT: Caller:     %4 = argument of bb0 : $*D
+// CHECK-NEXT: Dependent:  %{{.*}} = mark_dependence [nonescaping] %{{.*}} : $C on %4 : $*D
+// CHECK-NEXT: Caller range
+// CHECK: dependence_scope: lifetime_dependence_scope with: %inout_arg_mark
+
+  destroy_value %inout_arg_mark : $C
   end_access %access : $*C
   end_apply %token
   end_borrow %borrow : $D


### PR DESCRIPTION
This allows basic prototyping. A separate analysis will ensure no mutation of the original value during the borrow.

NFC without -enable-experimental-feature NonescapableTypes