### PR TITLE
FlattenSequence/distance(from:to:) enhancements.

### DIFF
--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -303,7 +303,7 @@ extension FlattenCollection: Collection {
     }
     
     // The following combines the distance of three sections.
-    let range = start <= end ? start ... end : end ... start
+    let range = start <= end ? start ..< end : end ..< start
     var outer = range.lowerBound._outer
     var count = 0 as Int // 0...Int.max
     


### PR DESCRIPTION
I was looking through Swift's issues tab and found this issue (#57496), which points out the poor performance of `FlattenSequence/count`. The current `count` implementation calls `distance(from:to:)`, which iterates through the entire collection, so I thought I'd improve that method. The new version computes the distance as the sum of three parts, with a fast path when both indices belong to the same underlying collection. Note that it does this by calling either `count` or `distance(from:to:)` on each underlying collection, which makes `[repeatElement(0, count: Int.max)].joined().count` instant, for example.

<details>
<summary>Here's some code I've used to test it...</summary>

```swift
/// Loops through every index pair for some random instances.
func testFlattenSequenceDistanceFromTo() {
  for _ in 0 ..< 10000 {
    let joined = (0 ..< Int.random(in: 0 ..< 10)).map({ Array(repeating: $0, count: Int.random(in: 0 ..< 10)) }).joined()
          
    var index0 = joined.startIndex; var offset0 = 0; loop0: while index0 <= joined.endIndex {
    var index1 = joined.startIndex; var offset1 = 0; loop1: while index1 <= joined.endIndex {
      
      precondition(joined.distance(from: index0, to: index1) == offset1 - offset0)
      precondition(joined.distance(from: index1, to: index0) == offset0 - offset1)
      
      if index1 < joined.endIndex { joined.formIndex(after: &index1); offset1 += 1 } else { break loop1 }
    };if index0 < joined.endIndex { joined.formIndex(after: &index0); offset0 += 1 } else { break loop0 }
    }
  }
}
```

</details>