### PR TITLE
PerformanceDiagnostics: print an error in embedded swift if a value type deinit cannot be devirtualized

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -365,6 +365,8 @@ ERROR(perf_diag_existential_type,none,
       "cannot use a value of protocol type %0 in @_noExistential function", (Type))
 ERROR(perf_diag_existential,none,
       "cannot use a value of protocol type in @_noExistential function", ())
+ERROR(embedded_swift_value_deinit,none,
+      "cannot de-virtualize deinit of type %0", (Type))
 ERROR(embedded_swift_metatype_type,none,
       "cannot use metatype of type %0 in embedded Swift", (Type))
 ERROR(embedded_swift_metatype,none,

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -870,6 +870,12 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
     impactType = inst->getOperand(0)->getType();
     if (impactType.isBlockPointerCompatible())
       return RuntimeEffect::ObjectiveC | RuntimeEffect::Releasing;
+    if (impactType.isMoveOnly() &&
+        !isa<DropDeinitInst>(lookThroughOwnershipInsts(inst->getOperand(0)))) {
+      // Not de-virtualized value type deinits can require metatype in case the
+      // deinit needs to be called via the value witness table.
+      return RuntimeEffect::MetaData | RuntimeEffect::Releasing;
+    }
     return ifNonTrivial(inst->getOperand(0)->getType(),
                         RuntimeEffect::Releasing);
 

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -514,6 +514,11 @@ bool PerformanceDiagnostics::visitInst(SILInstruction *inst,
     }
 
     if (impact & RuntimeEffect::MetaData) {
+      if (isa<ReleaseValueInst>(inst)) {
+        // Move-only value types for which the deinit is not de-virtualized.
+        diagnose(loc, diag::embedded_swift_value_deinit, impactType.getASTType());
+        return true;
+      }
       if (!allowedMetadataUseInEmbeddedSwift(inst)) {
         PrettyStackTracePerformanceDiagnostics stackTrace("metatype", inst);
         if (impactType) {


### PR DESCRIPTION
Not de-virtualized value type deinits can require metatype in case the deinit needs to be called via the value witness table. Usually this does not happen because deinits are mandatory de-virtualized. But it can show up if e.g. wrong build options are used.

rdar://122651706
