### PR TITLE
[Runtime] Check for demangling failure when looking up prespecialized metadata.

### DIFF
--- a/stdlib/public/runtime/LibPrespecialized.cpp
+++ b/stdlib/public/runtime/LibPrespecialized.cpp
@@ -86,6 +86,16 @@ swift::getLibPrespecializedMetadata(const TypeContextDescriptor *description,
 
   Demangler dem;
   auto mangleNode = _buildDemanglingForGenericType(description, arguments, dem);
+  if (!mangleNode) {
+    if (SWIFT_UNLIKELY(runtime::environment::
+                           SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_LOGGING()))
+      fprintf(stderr,
+              "Prespecializations library: failed to build demangling with "
+              "descriptor %p.\n",
+              description);
+    return nullptr;
+  }
+
   if (mangleNode->getKind() != Node::Kind::Global) {
     auto wrapper = dem.createNode(Node::Kind::Global);
     wrapper->addChild(mangleNode, dem);


### PR DESCRIPTION
_buildDemanglingForGenericType can fail, so we need to check for NULL.