### PR TITLE
Fix another bug with type reconstruction of `@isolated(any)` types

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -293,7 +293,7 @@ public:
                         bool erasedIsolation,
                         ImplFunctionDifferentiabilityKind diffKind)
       : Rep(unsigned(rep)), Pseudogeneric(pseudogeneric), Escaping(noescape),
-        Concurrent(concurrent), Async(async),
+        Concurrent(concurrent), Async(async), ErasedIsolation(erasedIsolation),
         DifferentiabilityKind(unsigned(diffKind)) {}
 
   ImplFunctionTypeFlags


### PR DESCRIPTION
The fix in #71591 was not complete; there's another place where I wasn't initializing the field.  Perils of late-night coding, unsafe programming languages, and difficult-to-test code paths.