### PR TITLE
Add REQUIRES: asserts to lifetime_dependence lit tests.

### DIFF
--- a/test/SILOptimizer/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow.swift
@@ -8,10 +8,10 @@
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
 
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
 // REQUIRES: swift_in_compiler
 
-struct BV : ~Escapable {
+@_nonescapable
+struct BV {
   let p: UnsafeRawPointer
   let c: Int
 
@@ -24,7 +24,8 @@ struct BV : ~Escapable {
   }
 }
 
-struct NCNE : ~Copyable, ~Escapable {
+@_nonescapable
+struct NCNE : ~Copyable {
   let p: UnsafeRawPointer
   let c: Int
 

--- a/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
@@ -9,10 +9,10 @@
 // RUN:   -enable-experimental-lifetime-dependence-inference
 
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
 // REQUIRES: swift_in_compiler
 
-struct BV : ~Escapable {
+@_nonescapable
+struct BV {
   let p: UnsafeRawPointer
   let i: Int
 
@@ -37,7 +37,8 @@ struct NC : ~Copyable {
   }
 }
 
-struct NE : ~Escapable {
+@_nonescapable
+struct NE {
   let p: UnsafeRawPointer
   let i: Int
 

--- a/test/SILOptimizer/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics.swift
@@ -6,6 +6,7 @@
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics \
 // RUN:   2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 @_nonescapable

--- a/test/SILOptimizer/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence_generic.swift
@@ -9,6 +9,7 @@
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics \
 // RUN:   -parse-stdlib -module-name Swift
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 @_marker public protocol Escapable {}

--- a/test/SILOptimizer/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit.swift
@@ -7,6 +7,7 @@
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 @_nonescapable

--- a/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
@@ -7,6 +7,7 @@
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 @_nonescapable

--- a/test/SILOptimizer/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence_insertion.swift
@@ -6,6 +6,7 @@
 // RUN:   -Xllvm -enable-lifetime-dependence-insertion \
 // RUN:   2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 @_nonescapable

--- a/test/SILOptimizer/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence_mutate.swift
@@ -7,6 +7,7 @@
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 @_nonescapable

--- a/test/SILOptimizer/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence_param.swift
@@ -7,6 +7,7 @@
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 @_nonescapable

--- a/test/SILOptimizer/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_param_fail.swift
@@ -7,6 +7,7 @@
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 @_nonescapable

--- a/test/SILOptimizer/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope.swift
@@ -6,6 +6,7 @@
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics \
 // RUN:   2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 // Test LifetimeDependenceScopeFixup.

--- a/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
@@ -5,6 +5,7 @@
 // RUN: -enable-experimental-feature NoncopyableGenerics \
 // RUN: -enable-experimental-lifetime-dependence-inference \
 // RUN:  -Xllvm -enable-lifetime-dependence-diagnostics=true
+
 // REQUIRES: asserts
 // REQUIRES: noncopyable_generics
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_todo.swift
+++ b/test/SILOptimizer/lifetime_dependence_todo.swift
@@ -5,6 +5,7 @@
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 // Future tests for LifetimeDependenceDiagnostics.

--- a/test/SILOptimizer/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence_util.sil
@@ -2,6 +2,7 @@
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o /dev/null 2>&1 | %FileCheck %s
 
+// REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
 sil_stage canonical


### PR DESCRIPTION
These tests use a bunch of rapidly changing feature flags. I'm not sure if they are all supported in non-asserts builds.