### PR TITLE
NCGenerics: rebuild stdlib from its interface

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -869,9 +869,6 @@ ERROR(serialization_target_too_new_repl,none,
       "deployment target of %0 %3: %4",
       (StringRef, llvm::VersionTuple, Identifier, llvm::VersionTuple,
        StringRef))
-ERROR(serialization_noncopyable_generics_mismatch,none,
-      "module %0 was not compiled with NoncopyableGenerics",
-      (Identifier))
 
 ERROR(serialization_fatal,Fatal,
       "fatal error encountered while reading from module '%0'; "

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -84,9 +84,9 @@ enum class Status {
   /// to build the client.
   SDKMismatch,
 
-  /// The module file was not built with support for NoncopyableGenerics,
-  /// yet that is required to by this compiler.
-  NotUsingNoncopyableGenerics,
+  /// The module file was built with a different NoncopyableGenerics feature
+  /// mode than the compiler loading it.
+  NoncopyableGenericsMismatch,
 };
 
 /// Returns the string for the Status enum.

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -299,8 +299,7 @@ struct CollectGenericParams {
     // If it's an invertible protocol and NoncopyableGenerics is disabled
     // then skip the requirement.
     if (req.getProtocolDecl()->getInvertibleProtocolKind())
-      if (!(SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS ||
-          SC.Context.LangOpts.hasFeature(Feature::NoncopyableGenerics)))
+      if (!SC.Context.LangOpts.hasFeature(Feature::NoncopyableGenerics))
         return;
 
     AddedRequirements.push_back(req);
@@ -736,8 +735,7 @@ namespace {
       // If it's an invertible protocol and NoncopyableGenerics is disabled
       // then skip the requirement.
       if (req.getProtocolDecl()->getInvertibleProtocolKind())
-        if (!(SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS ||
-            Context.LangOpts.hasFeature(Feature::NoncopyableGenerics)))
+        if (!Context.LangOpts.hasFeature(Feature::NoncopyableGenerics))
           return;
 
       addedRequirements.push_back(req);

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -714,8 +714,7 @@ Type GenericSignatureImpl::getUpperBound(Type type,
   // we didn't have a superclass or require AnyObject.
   InvertibleProtocolSet inverses;
 
-  if (SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS ||
-      ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
     if (!superclass && !hasExplicitAnyObject) {
       for (auto ip : InvertibleProtocolSet::full()) {
         auto *kp = ctx.getProtocol(::getKnownProtocolKind(ip));
@@ -726,8 +725,7 @@ Type GenericSignatureImpl::getUpperBound(Type type,
   }
 
   for (auto *proto : getRequiredProtocols(type)) {
-    if (SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS ||
-      ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+    if (ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
       // Don't add invertible protocols to the composition, because we recorded
       // their absence above.
       if (proto->getInvertibleProtocolKind())
@@ -1298,8 +1296,7 @@ void GenericSignatureImpl::getRequirementsWithInverses(
     SmallVector<InverseRequirement, 2> &inverses) const {
   auto &ctx = getASTContext();
 
-  if (!SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS &&
-      !ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
     reqs.append(getRequirements().begin(), getRequirements().end());
     return;
   }
@@ -1342,8 +1339,7 @@ void RequirementSignature::getRequirementsWithInverses(
     SmallVector<InverseRequirement, 2> &inverses) const {
   auto &ctx = owner->getASTContext();
 
-  if (!SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS &&
-      !ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
+  if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
     reqs.append(getRequirements().begin(), getRequirements().end());
     return;
   }

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -318,8 +318,8 @@ struct ModuleRebuildInfo {
       return "compiled with a different version of the compiler";
     case Status::NotInOSSA:
       return "module was not built with OSSA";
-    case Status::NotUsingNoncopyableGenerics:
-      return "module was not built with NoncopyableGenerics";
+    case Status::NoncopyableGenericsMismatch:
+      return "module was not built with matching NoncopyableGenerics feature";
     case Status::MissingDependency:
       return "missing dependency";
     case Status::MissingUnderlyingModule:
@@ -869,7 +869,10 @@ class ModuleInterfaceLoaderImpl {
                    loadMode == ModuleLoadingMode::PreferSerialized &&
                    !version::isCurrentCompilerTagged() &&
                    rebuildInfo.getOrInsertCandidateModule(adjacentMod).serializationStatus !=
-                     serialization::Status::SDKMismatch) {
+                     serialization::Status::SDKMismatch &&
+                     // FIXME(kavon): temporary while we bootstrap NoncopyableGenerics.
+                   rebuildInfo.getOrInsertCandidateModule(adjacentMod).serializationStatus !=
+                     serialization::Status::NoncopyableGenericsMismatch) {
           // Special-case here: If we're loading a .swiftmodule from the resource
           // dir adjacent to the compiler, defer to the serialized loader instead
           // of falling back. This is to support local development of Swift,
@@ -1933,7 +1936,13 @@ InterfaceSubContextDelegateImpl::getCacheHash(StringRef useInterfacePath,
       //
       // If OSSA modules are enabled, we use a separate namespace of modules to
       // ensure that we compile all swift interface files with the option set.
-      unsigned(genericSubInvocation.getSILOptions().EnableOSSAModules));
+      unsigned(genericSubInvocation.getSILOptions().EnableOSSAModules),
+
+      // Whether or not NoncopyableGenerics are enabled, as that influences
+      // many things like generic signatures and conformances.
+      unsigned(genericSubInvocation.getLangOptions()
+               .hasFeature(Feature::NoncopyableGenerics))
+      );
 
   return llvm::toString(llvm::APInt(64, H), 36, /*Signed=*/false);
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3985,7 +3985,7 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
     return getTypeMatchAmbiguous();
   }
 
-  if (!SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS) {
+  if (!getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
     // move-only types (and their metatypes) cannot match with existential types.
     if (type1->getMetatypeInstanceType()->isNoncopyable()) {
       // tailor error message
@@ -8494,7 +8494,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
 
   // FIXME: This is already handled by tuple conformance lookup path and
   // should be removed once non-copyable generics are enabled by default.
-  if (!SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS) {
+  if (!getASTContext().LangOpts.hasFeature(Feature::NoncopyableGenerics)) {
     // Copyable is checked structurally, so for better performance, split apart
     // this constraint into individual Copyable constraints on each tuple
     // element.

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -426,8 +426,8 @@ static ValidationInfo validateControlBlock(
     }
     case control_block::HAS_NONCOPYABLE_GENERICS: {
       auto hasNoncopyableGenerics = scratch[0];
-      if (requiresNoncopyableGenerics && !hasNoncopyableGenerics)
-        result.status = Status::NotUsingNoncopyableGenerics;
+      if (requiresNoncopyableGenerics != hasNoncopyableGenerics)
+        result.status = Status::NoncopyableGenericsMismatch;
       break;
     }
     default:
@@ -533,8 +533,8 @@ std::string serialization::StatusToString(Status S) {
   case Status::FormatTooNew: return "FormatTooNew";
   case Status::RevisionIncompatible: return "RevisionIncompatible";
   case Status::NotInOSSA: return "NotInOSSA";
-  case Status::NotUsingNoncopyableGenerics:
-    return "NotUsingNoncopyableGenerics";
+  case Status::NoncopyableGenericsMismatch:
+    return "NoncopyableGenericsMismatch";
   case Status::MissingDependency: return "MissingDependency";
   case Status::MissingUnderlyingModule: return "MissingUnderlyingModule";
   case Status::CircularDependency: return "CircularDependency";

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1064,10 +1064,8 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
     Ctx.Diags.diagnose(diagLoc, diag::serialization_module_too_old, ModuleName,
                        moduleBufferID);
     break;
-  case serialization::Status::NotUsingNoncopyableGenerics:
-    Ctx.Diags.diagnose(diagLoc,
-                       diag::serialization_noncopyable_generics_mismatch,
-                       ModuleName);
+  case serialization::Status::NoncopyableGenericsMismatch:
+    // Ignore; the module should get rebuilt from its interface.
     break;
   case serialization::Status::NotInOSSA:
     // soft reject, silently ignore.
@@ -1161,7 +1159,7 @@ void swift::serialization::diagnoseSerializedASTLoadFailureTransitive(
   case serialization::Status::FormatTooNew:
   case serialization::Status::FormatTooOld:
   case serialization::Status::NotInOSSA:
-  case serialization::Status::NotUsingNoncopyableGenerics:
+  case serialization::Status::NoncopyableGenericsMismatch:
   case serialization::Status::RevisionIncompatible:
   case serialization::Status::Malformed:
   case serialization::Status::MalformedDocumentation:

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes
 
-// REQUIRES: noncopyable_generics
+
 
 // Check support for explicit conditional conformance
 public struct ExplicitCond<T: ~Copyable>: ~Copyable {}

--- a/test/Generics/inverse_generics_stdlib.swift
+++ b/test/Generics/inverse_generics_stdlib.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -parse-stdlib -module-name Swift -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes
 
-// REQUIRES: noncopyable_generics
+
 
 /// This test specifically covers constructs that are only valid in the stdlib.
 

--- a/test/Generics/inverse_protocols.swift
+++ b/test/Generics/inverse_protocols.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
 
-// REQUIRES: noncopyable_generics
+
 
 protocol Eq: ~Copyable {
   func same(as: borrowing Self) -> Bool

--- a/test/Generics/inverse_protocols_errors.swift
+++ b/test/Generics/inverse_protocols_errors.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
 
-// REQUIRES: noncopyable_generics
+
 
 protocol RegularProto {}
 protocol NCProto: RegularProto

--- a/test/Generics/inverse_rdar119950540.swift
+++ b/test/Generics/inverse_rdar119950540.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-silgen -enable-experimental-feature NoncopyableGenerics > /dev/null
 
-// REQUIRES: noncopyable_generics
+
 
 public protocol MyIteratorProtocol<Element> {
   associatedtype Element

--- a/test/Generics/inverse_scoping.swift
+++ b/test/Generics/inverse_scoping.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes
 
-// REQUIRES: noncopyable_generics
+
 
 protocol NoCopyReq: ~Copyable {}
 

--- a/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
+++ b/test/Interop/Cxx/class/move-only/move-only-cxx-value-type-generics.swift
@@ -4,7 +4,7 @@
 // REQUIRES: executable_test
 // REQUIRES: GH_ISSUE_70246
 
-// REQUIRES: noncopyable_generics
+
 
 import MoveOnlyCxxValueType
 import StdlibUnittest

--- a/test/Interpreter/moveonly_generics.swift
+++ b/test/Interpreter/moveonly_generics.swift
@@ -3,7 +3,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
+
 
 // Needed due to limitations of autoclosures and noncopyable types.
 func eagerAssert(_ b: Bool, _ line: Int = #line) {

--- a/test/Interpreter/moveonly_generics_associatedtype.swift
+++ b/test/Interpreter/moveonly_generics_associatedtype.swift
@@ -4,7 +4,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
+
 
 class Backend {
     private var data: [String: String] = [:]

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -35,7 +35,7 @@
 // RUN:    -enable-experimental-feature NoncopyableGenerics \
 // RUN:    -enable-experimental-feature NonescapableTypes
 
-// REQUIRES: noncopyable_generics
+
 
 import NoncopyableGenerics_Misc
 

--- a/test/Parse/explicit_lifetime_dependence_specifiers.swift
+++ b/test/Parse/explicit_lifetime_dependence_specifiers.swift
@@ -1,6 +1,5 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip   -enable-experimental-feature NoncopyableGenerics -enable-builtin-module -enable-experimental-lifetime-dependence-inference 
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
 
 import Builtin
 

--- a/test/Parse/inverse_escapable_feature.swift
+++ b/test/Parse/inverse_escapable_feature.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
 
-// REQUIRES: noncopyable_generics
+
 
 struct S: ~Escapable {} // expected-error {{type '~Escapable' requires -enable-experimental-feature NonescapableTypes}}

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
 
-// REQUIRES: noncopyable_generics
+
 
 protocol U {}
 

--- a/test/SIL/Parser/basic2_noncopyable_generics.sil
+++ b/test/SIL/Parser/basic2_noncopyable_generics.sil
@@ -10,7 +10,7 @@
 // RUN: %FileCheck %s
 
 // For -enable-experimental-feature NoncopyableGenerics/NonescapableTypes
-// REQUIRES: noncopyable_generics
+
 // REQUIRES: asserts
 // TODO: Once NoncopyableGenerics/NonescapableTypes is no longer behind a feature flag, merge this into basic2.
 

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -5,7 +5,7 @@
 // RUN: -disable-experimental-parser-round-trip \
 // RUN: -enable-experimental-feature NoncopyableGenerics \
 // RUN: -enable-experimental-lifetime-dependence-inference | %FileCheck %s
-// REQUIRES: noncopyable_generics
+
 
 import Builtin
 

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -6,7 +6,7 @@
 // RUN: -enable-experimental-feature NoncopyableGenerics \
 // RUN: -enable-experimental-lifetime-dependence-inference | %FileCheck %s
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
+
 
 import Builtin
 

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -3,7 +3,7 @@
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-lifetime-dependence-inference | %FileCheck %s
-// REQUIRES: noncopyable_generics
+
 
 protocol P {
   associatedtype E: ~Escapable

--- a/test/SILGen/moveonly_basics.swift
+++ b/test/SILGen/moveonly_basics.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature NoncopyableGenerics -module-name test %s | %FileCheck %s --enable-var-scope
 
 // For -enable-experimental-feature NoncopyableGenerics
-// REQUIRES: noncopyable_generics
+
 
 class Retainable {}
 

--- a/test/SILGen/typelowering_inverses.swift
+++ b/test/SILGen/typelowering_inverses.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -disable-availability-checking -module-name main %s | %FileCheck %s
 
-// REQUIRES: noncopyable_generics
+
 
 struct NC: ~Copyable {}
 

--- a/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
@@ -7,7 +7,7 @@
 // RUN:  -Xllvm -enable-lifetime-dependence-diagnostics=true
 
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
+
 // REQUIRES: swift_in_compiler
 
 struct NCContainer : ~Copyable {

--- a/test/SILOptimizer/moveonly_addressors.swift
+++ b/test/SILOptimizer/moveonly_addressors.swift
@@ -4,7 +4,7 @@
 // RUN: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DEMPTY -emit-sil -verify %s
 
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
+
 
 // TODO: Use the real stdlib types once `UnsafePointer` supports noncopyable
 // types.

--- a/test/SILOptimizer/moveonly_computed_property.swift
+++ b/test/SILOptimizer/moveonly_computed_property.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s > /dev/null
 // RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -emit-sil -verify %s > /dev/null
 
-// REQUIRES: noncopyable_generics
+
 
 // Applying a computed property to a move-only field in a class should occur
 // entirely within a formal access to the class property. rdar://105794506

--- a/test/SILOptimizer/moveonly_generics_basic.swift
+++ b/test/SILOptimizer/moveonly_generics_basic.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend %s -sil-verify-all -verify -emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoncopyableGenerics
 
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
+
 
 /// MARK: types
 

--- a/test/Sema/invertible_no_stdlib.swift
+++ b/test/Sema/invertible_no_stdlib.swift
@@ -2,7 +2,7 @@
 // RUN:   -parse-stdlib -module-name Ghost \
 // RUN:   -enable-experimental-feature NoncopyableGenerics
 
-// REQUIRES: noncopyable_generics
+
 
 // This test covers only rudimentary typechecking when only the Builtin module
 // is available. It's not a fully-supported configuration!

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -11,7 +11,7 @@
 // RUN: -disable-experimental-parser-round-trip \
 // RUN: -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
 
-// REQUIRES: noncopyable_generics
+
 
 import def_explicit_lifetime_dependence
 

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -12,7 +12,7 @@
 // RUN: -enable-experimental-feature NoncopyableGenerics \
 // RUN: -enable-experimental-lifetime-dependence-inference | %FileCheck %s
 
-// REQUIRES: noncopyable_generics
+
 
 import def_implicit_lifetime_dependence
 


### PR DESCRIPTION
When a NoncopyableGenericsMismatch happens between the compiler and stdlib, allow the compiler to rebuild the stdlib from its interface instead of exiting with an error.
