### PR TITLE
[Runtime] Mask out reserved bits for SwiftError in BytecodeLayouts.cpp

### DIFF
--- a/stdlib/public/runtime/BytecodeLayouts.cpp
+++ b/stdlib/public/runtime/BytecodeLayouts.cpp
@@ -248,9 +248,12 @@ static void handleEnd(const Metadata *metadata,
 
 static void errorDestroy(const Metadata *metadata, LayoutStringReader1 &reader,
                          uintptr_t &addrOffset, uint8_t *addr) {
-  SwiftError *error = *(SwiftError**)(addr + addrOffset);
+  uintptr_t object = *(uintptr_t *)(addr + addrOffset);
+  if (object & _swift_abi_ObjCReservedBitsMask)
+    return;
+  object &= ~_swift_abi_SwiftSpareBitsMask;
   addrOffset += sizeof(SwiftError*);
-  swift_errorRelease(error);
+  swift_errorRelease((SwiftError *)object);
 }
 
 static void nativeStrongDestroy(const Metadata *metadata,
@@ -899,10 +902,13 @@ static void handleRefCountsInitWithCopy(const Metadata *metadata,
 static void errorRetain(const Metadata *metadata, LayoutStringReader1 &reader,
                         uintptr_t &addrOffset, uint8_t *dest, uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
-  SwiftError *object = *(SwiftError **)(src + _addrOffset);
+  uintptr_t object = *(uintptr_t *)(src + _addrOffset);
+  if (object & _swift_abi_ObjCReservedBitsMask)
+    return;
+  object &= ~_swift_abi_SwiftSpareBitsMask;
   memcpy(dest + addrOffset, &object, sizeof(SwiftError*));
   addrOffset = _addrOffset + sizeof(SwiftError *);
-  swift_errorRetain(object);
+  swift_errorRetain((SwiftError *)object);
 }
 
 static void nativeStrongRetain(const Metadata *metadata,
@@ -1286,12 +1292,21 @@ static void errorAssignWithCopy(const Metadata *metadata,
                                 uintptr_t &addrOffset, uint8_t *dest,
                                 uint8_t *src) {
   uintptr_t _addrOffset = addrOffset;
-  SwiftError *destObject = *(SwiftError **)(dest + _addrOffset);
-  SwiftError *srcObject = *(SwiftError **)(src + _addrOffset);
+  uintptr_t destObject = *(uintptr_t *)(dest + _addrOffset);
+  uintptr_t srcObject = *(uintptr_t *)(src + _addrOffset);
+
   memcpy(dest + _addrOffset, &srcObject, sizeof(SwiftError *));
   addrOffset = _addrOffset + sizeof(SwiftError *);
-  swift_errorRelease(destObject);
-  swift_errorRetain(srcObject);
+
+  if (!(destObject & _swift_abi_ObjCReservedBitsMask)) {
+    destObject &= ~_swift_abi_SwiftSpareBitsMask;
+    swift_errorRelease((SwiftError *)destObject);
+  }
+
+  if (!(srcObject & _swift_abi_ObjCReservedBitsMask)) {
+    srcObject &= ~_swift_abi_SwiftSpareBitsMask;
+    swift_errorRetain((SwiftError *)srcObject);
+  }
 }
 
 static void nativeStrongAssignWithCopy(const Metadata *metadata,

--- a/test/Interpreter/Inputs/layout_string_witnesses_types.swift
+++ b/test/Interpreter/Inputs/layout_string_witnesses_types.swift
@@ -588,6 +588,12 @@ public enum NestedMultiPayloadOuter {
     case c(NestedMultiPayloadInner)
 }
 
+public enum MultiPayloadError {
+    case empty
+    case error1(Int, Error)
+    case error2(Int, Error)
+}
+
 @inline(never)
 public func consume<T>(_ x: T.Type) {
     withExtendedLifetime(x) {}

--- a/test/Interpreter/layout_string_witnesses_static.swift
+++ b/test/Interpreter/layout_string_witnesses_static.swift
@@ -1132,6 +1132,54 @@ func testMultiPayloadEnumNested() {
 
 testMultiPayloadEnumNested()
 
+struct MyError: Error {
+    let x: SimpleClass
+}
+
+// Regression test for rdar://122911427
+func testMultiPayloadError() {
+    let ptr = UnsafeMutablePointer<MultiPayloadError>.allocate(capacity: 1)
+
+    // initWithTake
+    do {
+        let x = MultiPayloadError.error2(0, MyError(x: SimpleClass(x: 23)))
+        testInitTake(ptr, to: consume x)
+    }
+
+    // assignWithTake
+    do {
+        let y = MultiPayloadError.error2(1, MyError(x: SimpleClass(x: 32)))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssign(ptr, from: y)
+    }
+
+    // assignWithCopy
+    do {
+        var z = MultiPayloadError.error2(2, MyError(x: SimpleClass(x: 41)))
+
+        // CHECK-NEXT: Before deinit
+        print("Before deinit")
+
+        // CHECK-NEXT: SimpleClass deinitialized!
+        testAssignCopy(ptr, from: &z)
+    }
+
+    // CHECK-NEXT: Before deinit
+    print("Before deinit")
+
+    // destroy
+    // CHECK-NEXT: SimpleClass deinitialized!
+    testDestroy(ptr)
+
+    ptr.deallocate()
+}
+
+testMultiPayloadError()
+
 #if os(macOS)
 func testObjc() {
     let ptr = UnsafeMutablePointer<ObjcWrapper>.allocate(capacity: 1)


### PR DESCRIPTION
rdar://122911427

These bits can be used for storing multi payload enum tags and not masking them out can cause crashes an other unexpected behavior.