### PR TITLE
[MoveChecker] Ban exported partial consumption.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -831,12 +831,24 @@ ERROR(sil_movechecking_notconsumable_but_assignable_was_consumed, none,
 ERROR(sil_movechecking_cannot_destructure_has_deinit, none,
       "cannot partially consume '%0' when it has a deinitializer",
       (StringRef))
+ERROR(sil_movechecking_cannot_destructure_imported_nonfrozen, none,
+      "cannot partially consume '%0' of non-frozen type %1 imported from %2",
+      (StringRef, Type, const ModuleDecl*))
+ERROR(sil_movechecking_cannot_destructure_exported_usableFromInline_alwaysEmitIntoClient, none,
+      "cannot partially consume '%0' of non-frozen usableFromInline type %1 within a function annotated @_alwaysEmitIntoClient",
+      (StringRef, Type))
 ERROR(sil_movechecking_cannot_destructure, none,
       "cannot partially consume '%0'",
       (StringRef))
 ERROR(sil_movechecking_cannot_partially_reinit_has_deinit, none,
       "cannot partially reinitialize '%0' when it has a deinitializer; only full reinitialization is allowed",
       (StringRef))
+ERROR(sil_movechecking_cannot_partially_reinit_nonfrozen, none,
+      "cannot partially reinitialize '%0' of non-frozen type %1 imported from %2; only full reinitialization is allowed",
+      (StringRef, Type, const ModuleDecl*))
+ERROR(sil_movechecking_cannot_partially_reinit_exported_usableFromInline_alwaysEmitIntoClient, none,
+      "cannot partially reinitialize '%0' of non-frozen usableFromInline type %1 within a function annotated @_alwaysEmitIntoClient",
+      (StringRef, Type))
 ERROR(sil_movechecking_cannot_partially_reinit, none,
       "cannot partially reinitialize '%0' after it has been consumed; only full reinitialization is allowed",
       (StringRef))

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -824,17 +824,15 @@ void DiagnosticEmitter::emitCannotPartiallyMutateError(
         astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption) ||
         astContext.LangOpts.hasFeature(
             Feature::MoveOnlyPartialReinitialization));
-    switch (kind) {
-    case PartialMutation::Kind::Consume:
-      diagnose(astContext, user,
-               diag::sil_movechecking_cannot_destructure_has_deinit, varName);
-      break;
-    case PartialMutation::Kind::Reinit:
-      diagnose(astContext, user,
-               diag::sil_movechecking_cannot_partially_reinit_has_deinit,
-               varName);
-      break;
-    }
+    auto diagnostic = [&]() {
+      switch (kind) {
+      case PartialMutation::Kind::Consume:
+        return diag::sil_movechecking_cannot_destructure_has_deinit;
+      case PartialMutation::Kind::Reinit:
+        return diag::sil_movechecking_cannot_partially_reinit_has_deinit;
+      }
+    }();
+    diagnose(astContext, user, diagnostic, varName);
     registerDiagnosticEmitted(address);
     auto deinitLoc = error.getNominal().getValueTypeDestructor()->getLoc(
         /*SerializedOK=*/false);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -834,11 +834,52 @@ void DiagnosticEmitter::emitCannotPartiallyMutateError(
     }();
     diagnose(astContext, user, diagnostic, varName);
     registerDiagnosticEmitted(address);
-    auto deinitLoc = error.getNominal().getValueTypeDestructor()->getLoc(
-        /*SerializedOK=*/false);
+    auto deinitLoc =
+        error.getDeinitingNominal().getValueTypeDestructor()->getLoc(
+            /*SerializedOK=*/false);
     if (!deinitLoc)
       return;
     astContext.Diags.diagnose(deinitLoc, diag::sil_movechecking_deinit_here);
+    return;
+  }
+  case PartialMutationError::Kind::NonfrozenImportedType: {
+    assert(
+        astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption) ||
+        astContext.LangOpts.hasFeature(
+            Feature::MoveOnlyPartialReinitialization));
+    auto &nominal = error.getNonfrozenImportedNominal();
+    auto diagnostic = [&]() {
+      switch (kind) {
+      case PartialMutation::Kind::Consume:
+        return diag::sil_movechecking_cannot_destructure_imported_nonfrozen;
+      case PartialMutation::Kind::Reinit:
+        return diag::sil_movechecking_cannot_partially_reinit_nonfrozen;
+      }
+    }();
+    diagnose(astContext, user, diagnostic, varName,
+             nominal.getDeclaredInterfaceType(), nominal.getModuleContext());
+    registerDiagnosticEmitted(address);
+    return;
+  }
+  case PartialMutationError::Kind::NonfrozenUsableFromInlineType: {
+    assert(
+        astContext.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption) ||
+        astContext.LangOpts.hasFeature(
+            Feature::MoveOnlyPartialReinitialization));
+    auto &nominal = error.getNonfrozenUsableFromInlineNominal();
+    auto diagnostic = [&]() {
+      switch (kind) {
+      case PartialMutation::Kind::Consume:
+        return diag::
+            sil_movechecking_cannot_destructure_exported_usableFromInline_alwaysEmitIntoClient;
+      case PartialMutation::Kind::Reinit:
+        return diag::
+            sil_movechecking_cannot_partially_reinit_exported_usableFromInline_alwaysEmitIntoClient;
+      }
+    }();
+    diagnose(astContext, user, diagnostic, varName,
+             nominal.getDeclaredInterfaceType());
+    registerDiagnosticEmitted(address);
     return;
   }
   }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.h
@@ -141,9 +141,12 @@ inline Feature partialMutationFeature(PartialMutation::Kind kind) {
 ///
 /// Emulates the following enum with associated value:
 ///
-/// enum class PartialMutationError {
-/// case featureDisabled(SILType)
-/// case hasDeinit(SILType, NominalTypeDecl)
+/// struct PartialMutationError {
+///   let type: SILType
+///   enum Kind {
+///     case featureDisabled
+///     case hasDeinit(NominalTypeDecl)
+///   }
 /// }
 class PartialMutationError {
   struct FeatureDisabled {
@@ -154,9 +157,8 @@ class PartialMutationError {
   };
   TaggedUnion<FeatureDisabled, HasDeinit> kind;
 
-  PartialMutationError(SILType type, FeatureDisabled fd)
-      : kind({fd}), type(type) {}
-  PartialMutationError(SILType type, HasDeinit r) : kind({r}), type(type) {}
+  PartialMutationError(SILType type, Payload payload)
+      : payload(payload), type(type) {}
 
 public:
   /// The type within the aggregate responsible for the error.

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_ufi.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume_ufi.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend                                      \
+// RUN:     %s                                                      \
+// RUN:     -emit-sil -verify -verify-additional-prefix fragile-    \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -module-name Library
+// RUN: %target-swift-frontend                                      \
+// RUN:     %s                                                      \
+// RUN:     -emit-sil -verify -verify-additional-prefix resilient-  \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -enable-library-evolution                               \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -module-name Library
+
+public func take(_ u: consuming Ur) {}
+
+public struct Ur : ~Copyable {
+  @usableFromInline init() {}
+  deinit {}
+}
+
+@usableFromInline
+internal struct Agg_Internal_UFI : ~Copyable {
+  @usableFromInline
+  init(u1: consuming Ur, u2: consuming Ur) {
+    self.u1 = u1
+    self.u2 = u2
+  }
+
+  @usableFromInline
+  internal var u1: Ur
+  @usableFromInline
+  internal var u2: Ur
+}
+
+@_alwaysEmitIntoClient
+func piecewise_Agg_Internal_UFI(_ a: consuming Agg_Internal_UFI) {
+  take(a.u1) // expected-fragile-error{{cannot partially consume 'a' of non-frozen usableFromInline type 'Agg_Internal_UFI' within a function annotated @_alwaysEmitIntoClient}}
+             // expected-resilient-error@-1{{field 'a.u1' was consumed but not reinitialized; the field must be reinitialized during the access}}
+             // expected-resilient-note@-2{{consumed here}}
+  take(a.u2) // expected-fragile-error{{cannot partially consume 'a' of non-frozen usableFromInline type 'Agg_Internal_UFI' within a function annotated @_alwaysEmitIntoClient}}
+             // expected-resilient-error@-1{{field 'a.u2' was consumed but not reinitialized; the field must be reinitialized during the access}}
+             // expected-resilient-note@-2{{consumed here}}
+}
+
+@_alwaysEmitIntoClient
+func get_Agg_Internal_UFI() -> Agg_Internal_UFI {
+  return Agg_Internal_UFI(u1: Ur(), u2: Ur())
+}
+
+@_alwaysEmitIntoClient
+public func call_piecewise_Agg_Internal_UFI() {
+  let a = get_Agg_Internal_UFI()
+  piecewise_Agg_Internal_UFI(a)
+}
+

--- a/test/SILOptimizer/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume.swift
+++ b/test/SILOptimizer/test/SILOptimizer/moveonly_addresschecker_diagnostics_partial_consume.swift
@@ -1,0 +1,158 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Library.swift                                        \
+// RUN:     -emit-module                                            \
+// RUN:     -package-name Package                                   \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -module-name Library                                    \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Downstream.swift                                     \
+// RUN:     -emit-sil -verify  -verify-additional-prefix fragile-   \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -package-name Package                                   \
+// RUN:     -debug-diagnostic-names                                 \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -I %t
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Library.swift                                        \
+// RUN:     -emit-module                                            \
+// RUN:     -package-name Package                                   \
+// RUN:     -enable-library-evolution                               \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -module-name Library                                    \
+// RUN:     -emit-module-path %t/Library.swiftmodule
+
+// RUN: %target-swift-frontend                                      \
+// RUN:     %t/Downstream.swift                                     \
+// RUN:     -emit-sil -verify  -verify-additional-prefix resilient- \
+// RUN:     -sil-verify-all                                         \
+// RUN:     -package-name Package                                   \
+// RUN:     -debug-diagnostic-names                                 \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -I %t
+
+//--- Library.swift
+
+public func take(_ u: consuming Ur) {}
+
+public struct Ur : ~Copyable {
+  @usableFromInline init() {}
+  deinit {}
+}
+
+// =====BEGIN======================= Agg_Public =============================={{
+
+public struct Agg_Public : ~Copyable {
+  public var u1: Ur
+  public var u2: Ur
+}
+
+// =====END========================= Agg_Public ==============================}}
+
+// =====BEGIN==================== Agg_Public_Frozen =========================={{
+
+@frozen public struct Agg_Public_Frozen : ~Copyable {
+  public var u1: Ur
+  public var u2: Ur
+}
+
+// =====END====================== Agg_Public_Frozen ==========================}}
+
+// =====BEGIN====================== Agg_Package =============================={{
+
+package struct Agg_Package : ~Copyable {
+  package var u1: Ur
+  package var u2: Ur
+}
+
+// =====END======================== Agg_Package ==============================}}
+
+// =====BEGIN=================== Agg_Package_Frozen =========================={{
+// TODO: Uncomment when package decls can be marked @frozen.
+//
+// @frozen package struct Agg_Package_Frozen : ~Copyable {
+//   package var u1: Ur
+//   package var u2: Ur
+// }
+// 
+// =====END===================== Agg_Package_Frozen ==========================}}
+
+// =====BEGIN================ Agg_Internal_UFI_Frozen ========================{{
+
+@usableFromInline
+@frozen internal struct Agg_Internal_UFI_Frozen : ~Copyable {
+  @usableFromInline
+  init(u1: consuming Ur, u2: consuming Ur) {
+    self.u1 = u1
+    self.u2 = u2
+  }
+
+  @usableFromInline
+  internal var u1: Ur
+  @usableFromInline
+  internal var u2: Ur
+}
+
+@_alwaysEmitIntoClient
+func piecewise_Agg_Internal_UFI_Frozen(_ a: consuming Agg_Internal_UFI_Frozen) {
+  take(a.u1)
+  take(a.u2)
+}
+
+@_alwaysEmitIntoClient
+func get_Agg_Internal_UFI_Frozen() -> Agg_Internal_UFI_Frozen {
+  return Agg_Internal_UFI_Frozen(u1: Ur(), u2: Ur())
+}
+
+@_alwaysEmitIntoClient
+public func call_piecewise_Agg_Internal_UFI_Frozen() {
+  let a = get_Agg_Internal_UFI_Frozen()
+  piecewise_Agg_Internal_UFI_Frozen(a)
+}
+
+// =====END================== Agg_Internal_UFI_Frozen ========================}}
+
+//--- Downstream.swift
+
+import Library
+
+func piecewise_Agg_Public(_ a: consuming Agg_Public) {
+  take(a.u1) // expected-fragile-error{{cannot partially consume 'a' of non-frozen type 'Agg_Public' imported from 'Library'}}
+             // expected-resilient-error@-1{{field 'a.u1' was consumed but not reinitialized; the field must be reinitialized during the access}}
+             // expected-resilient-note@-2{{consumed here}}
+  take(a.u2) // expected-fragile-error{{cannot partially consume 'a' of non-frozen type 'Agg_Public' imported from 'Library'}}
+             // expected-resilient-error@-1{{field 'a.u2' was consumed but not reinitialized; the field must be reinitialized during the access}}
+             // expected-resilient-note@-2{{consumed here}}
+}
+
+func piecewise_Agg_Public_Frozen(_ a: consuming Agg_Public_Frozen) {
+  take(a.u1)
+  take(a.u2)
+}
+
+func piecewise_Agg_Package(_ a: consuming Agg_Package) {
+  take(a.u1) // expected-fragile-error{{cannot partially consume 'a' of non-frozen type 'Agg_Package' imported from 'Library'}}
+             // expected-resilient-error@-1{{field 'a.u1' was consumed but not reinitialized; the field must be reinitialized during the access}}
+             // expected-resilient-note@-2{{consumed here}}
+  take(a.u2) // expected-fragile-error{{cannot partially consume 'a' of non-frozen type 'Agg_Package' imported from 'Library'}}
+             // expected-resilient-error@-1{{field 'a.u2' was consumed but not reinitialized; the field must be reinitialized during the access}}
+             // expected-resilient-note@-2{{consumed here}}
+}
+
+// TODO: Uncomment when package decls can be marked @frozen.
+// func piecewise_Agg_Package_Frozen(_ a: consuming Agg_Package_Frozen) {
+//   take(a.u1)
+//   take(a.u2)
+// }
+
+func call_call_piecewise_Agg_Internal_UFI_Frozen() {
+  call_piecewise_Agg_Internal_UFI_Frozen()
+}


### PR DESCRIPTION
To avoid dialecticization based on compilation mode, ban for non-resilient modules partial consumption of aggregates which would be illegal were those modules instead resilient.
