### PR TITLE
Fix ABI breakage caused by `ValueOwnership` order change.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -14,6 +14,10 @@
 // includes target-independent information which can be usefully shared
 // between them.
 //
+// This header ought not to include any compiler-specific headers (such as
+// those from `swift/AST`, `swift/SIL`, etc.) since doing so may introduce
+// accidental ABI dependencies on compiler internals.
+//
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_ABI_METADATAVALUES_H
@@ -21,7 +25,11 @@
 
 #include "swift/ABI/KeyPath.h"
 #include "swift/ABI/ProtocolDispatchStrategy.h"
+
+// FIXME: this include shouldn't be here, but removing it causes symbol
+// mangling mismatches on Windows for some reason?
 #include "swift/AST/Ownership.h"
+
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/FlagSet.h"
@@ -1248,10 +1256,25 @@ public:
 };
 using ExtendedFunctionTypeFlags = TargetExtendedFunctionTypeFlags<uint32_t>;
 
+/// Different kinds of value ownership supported by function types.
+enum class ParameterOwnership : uint8_t {
+  /// the context-dependent default ownership (sometimes shared,
+  /// sometimes owned)
+  Default,
+  /// an 'inout' exclusive, mutating borrow
+  InOut,
+  /// a 'borrowing' nonexclusive, usually nonmutating borrow
+  Shared,
+  /// a 'consuming' ownership transfer
+  Owned,
+
+  Last_Kind = Owned
+};
+
 template <typename int_type>
 class TargetParameterTypeFlags {
   enum : int_type {
-    ValueOwnershipMask    = 0x7F,
+    OwnershipMask         = 0x7F,
     VariadicMask          = 0x80,
     AutoClosureMask       = 0x100,
     NoDerivativeMask      = 0x200,
@@ -1266,8 +1289,8 @@ public:
   constexpr TargetParameterTypeFlags() : Data(0) {}
 
   constexpr TargetParameterTypeFlags<int_type>
-  withValueOwnership(ValueOwnership ownership) const {
-    return TargetParameterTypeFlags<int_type>((Data & ~ValueOwnershipMask) |
+  withOwnership(ParameterOwnership ownership) const {
+    return TargetParameterTypeFlags<int_type>((Data & ~OwnershipMask) |
                                               (int_type)ownership);
   }
 
@@ -1308,8 +1331,8 @@ public:
   bool isIsolated() const { return Data & IsolatedMask; }
   bool isTransferring() const { return Data & TransferringMask; }
 
-  ValueOwnership getValueOwnership() const {
-    return (ValueOwnership)(Data & ValueOwnershipMask);
+  ParameterOwnership getOwnership() const {
+    return (ParameterOwnership)(Data & OwnershipMask);
   }
 
   int_type getIntValue() const { return Data; }

--- a/include/swift/AST/Ownership.h
+++ b/include/swift/AST/Ownership.h
@@ -142,6 +142,14 @@ enum class ValueOwnership : uint8_t {
 enum : unsigned { NumValueOwnershipBits =
   countBitsUsed(static_cast<unsigned>(ValueOwnership::Last_Kind)) };
 
+enum class ParameterOwnership : uint8_t;
+
+/// Map a `ValueOwnership` to the corresponding ABI-stable constant used by
+/// runtime metadata.
+ParameterOwnership asParameterOwnership(ValueOwnership o);
+/// Map an ABI-stable ownership identifier to a `ValueOwnership`.
+ValueOwnership asValueOwnership(ParameterOwnership o);
+
 static inline llvm::StringRef getOwnershipSpelling(ValueOwnership ownership) {
   switch (ownership) {
   case ValueOwnership::Default:

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -73,8 +73,8 @@ public:
 
   void setVariadic() { Flags = Flags.withVariadic(true); }
   void setAutoClosure() { Flags = Flags.withAutoClosure(true); }
-  void setValueOwnership(ValueOwnership ownership) {
-    Flags = Flags.withValueOwnership(ownership);
+  void setOwnership(ParameterOwnership ownership) {
+    Flags = Flags.withOwnership(ownership);
   }
   void setNoDerivative() { Flags = Flags.withNoDerivative(true); }
   void setIsolated() { Flags = Flags.withIsolated(true); }
@@ -1701,19 +1701,19 @@ private:
       while (recurse) {
         switch (node->getKind()) {
         case NodeKind::InOut:
-          param.setValueOwnership(ValueOwnership::InOut);
+          param.setOwnership(ParameterOwnership::InOut);
           node = node->getFirstChild();
           hasParamFlags = true;
           break;
 
         case NodeKind::Shared:
-          param.setValueOwnership(ValueOwnership::Shared);
+          param.setOwnership(ParameterOwnership::Shared);
           node = node->getFirstChild();
           hasParamFlags = true;
           break;
 
         case NodeKind::Owned:
-          param.setValueOwnership(ValueOwnership::Owned);
+          param.setOwnership(ParameterOwnership::Owned);
           node = node->getFirstChild();
           hasParamFlags = true;
           break;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -18,6 +18,7 @@
 #include "ClangTypeConverter.h"
 #include "ForeignRepresentationInfo.h"
 #include "SubstitutionMapStorage.h"
+#include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ClangModuleLoader.h"
 #include "swift/AST/ConcreteDeclRef.h"
 #include "swift/AST/DiagnosticEngine.h"
@@ -6609,4 +6610,25 @@ Type ASTContext::getNamedSwiftType(ModuleDecl *module, StringRef name) {
   if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(decl))
     return nominalDecl->getDeclaredType();
   return decl->getDeclaredInterfaceType();
+}
+
+/// Map a `ValueOwnership` to the corresponding ABI-stable constant used by
+/// runtime metadata.
+ParameterOwnership swift::asParameterOwnership(ValueOwnership o) {
+  switch (o) {
+  case ValueOwnership::Default: return ParameterOwnership::Default;
+  case ValueOwnership::Shared:  return ParameterOwnership::Shared;
+  case ValueOwnership::InOut:   return ParameterOwnership::InOut;
+  case ValueOwnership::Owned:   return ParameterOwnership::Owned;
+  }
+  llvm_unreachable("exhaustive switch");
+}
+ValueOwnership swift::asValueOwnership(ParameterOwnership o) {
+  switch (o) {
+  case ParameterOwnership::Default: return ValueOwnership::Default;
+  case ParameterOwnership::Shared:  return ValueOwnership::Shared;
+  case ParameterOwnership::InOut:   return ValueOwnership::InOut;
+  case ParameterOwnership::Owned:   return ValueOwnership::Owned;
+  }
+  llvm_unreachable("exhaustive switch");
 }

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -408,7 +408,7 @@ Type ASTBuilder::createFunctionType(
     auto label = Ctx.getIdentifier(param.getLabel());
     auto flags = param.getFlags();
     auto ownership =
-      ParamDecl::getParameterSpecifierForValueOwnership(flags.getValueOwnership());
+      ParamDecl::getParameterSpecifierForValueOwnership(asValueOwnership(flags.getOwnership()));
     auto parameterFlags = ParameterTypeFlags()
                               .withOwnershipSpecifier(ownership)
                               .withVariadic(flags.isVariadic())

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1379,7 +1379,7 @@ static llvm::Value *getFunctionParameterRef(IRGenFunction &IGF,
 /// Mapping type-level parameter flags to ABI parameter flags.
 ParameterFlags irgen::getABIParameterFlags(ParameterTypeFlags flags) {
   return ParameterFlags()
-      .withValueOwnership(flags.getValueOwnership())
+      .withOwnership(asParameterOwnership(flags.getValueOwnership()))
       .withVariadic(flags.isVariadic())
       .withAutoClosure(flags.isAutoClosure())
       .withNoDerivative(flags.isNoDerivative())

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1180,7 +1180,7 @@ GenericParamList *ModuleFile::maybeReadGenericParams(DeclContext *DC) {
 static llvm::Optional<RequirementKind>
 getActualRequirementKind(uint64_t rawKind) {
 #define CASE(KIND)                   \
-  case GenericRequirementKind::KIND: \
+  case serialization::GenericRequirementKind::KIND: \
     return RequirementKind::KIND;
 
   switch (rawKind) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1461,7 +1461,7 @@ getRawStableMetatypeRepresentation(const AnyMetatypeType *metatype) {
 static uint8_t getRawStableRequirementKind(RequirementKind kind) {
 #define CASE(KIND)            \
   case RequirementKind::KIND: \
-    return GenericRequirementKind::KIND;
+    return serialization::GenericRequirementKind::KIND;
 
   switch (kind) {
   CASE(SameShape)

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -192,17 +192,17 @@ public:
         stream << "\n";
       }
 
-      switch (flags.getValueOwnership()) {
-      case ValueOwnership::Default:
+      switch (flags.getOwnership()) {
+      case ParameterOwnership::Default:
         /* nothing */
         break;
-      case ValueOwnership::InOut:
+      case ParameterOwnership::InOut:
         printHeader("inout");
         break;
-      case ValueOwnership::Shared:
+      case ParameterOwnership::Shared:
         printHeader("shared");
         break;
-      case ValueOwnership::Owned:
+      case ParameterOwnership::Owned:
         printHeader("owned");
         break;
       }
@@ -681,17 +681,17 @@ public:
       if (flags.isNoDerivative()) {
         wrapInput(Node::Kind::NoDerivative);
       }
-      switch (flags.getValueOwnership()) {
-      case ValueOwnership::Default:
+      switch (flags.getOwnership()) {
+      case ParameterOwnership::Default:
         /* nothing */
         break;
-      case ValueOwnership::InOut:
+      case ParameterOwnership::InOut:
         wrapInput(Node::Kind::InOut);
         break;
-      case ValueOwnership::Shared:
+      case ParameterOwnership::Shared:
         wrapInput(Node::Kind::Shared);
         break;
-      case ValueOwnership::Owned:
+      case ParameterOwnership::Owned:
         wrapInput(Node::Kind::Owned);
         break;
       }

--- a/stdlib/public/runtime/Demangle.cpp
+++ b/stdlib/public/runtime/Demangle.cpp
@@ -622,17 +622,17 @@ swift::_swift_buildDemanglingForMetadata(const Metadata *type,
       if (flags.isNoDerivative()) {
         wrapInput(Node::Kind::NoDerivative);
       }
-      switch (flags.getValueOwnership()) {
-      case ValueOwnership::Default:
+      switch (flags.getOwnership()) {
+      case ParameterOwnership::Default:
         /* nothing */
         break;
-      case ValueOwnership::InOut:
+      case ParameterOwnership::InOut:
         wrapInput(Node::Kind::InOut);
         break;
-      case ValueOwnership::Shared:
+      case ParameterOwnership::Shared:
         wrapInput(Node::Kind::Shared);
         break;
-      case ValueOwnership::Owned:
+      case ParameterOwnership::Owned:
         wrapInput(Node::Kind::Owned);
         break;
       }

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -160,10 +160,10 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 
   // Test parameter with and without inout/shared/variadic and/or label.
   ParameterFlags paramFlags;
-  auto inoutFlags = paramFlags.withValueOwnership(ValueOwnership::InOut);
+  auto inoutFlags = paramFlags.withOwnership(ParameterOwnership::InOut);
   auto variadicFlags = paramFlags.withVariadic(true);
-  auto sharedFlags = paramFlags.withValueOwnership(ValueOwnership::Shared);
-  auto ownedFlags = paramFlags.withValueOwnership(ValueOwnership::Owned);
+  auto sharedFlags = paramFlags.withOwnership(ParameterOwnership::Shared);
+  auto ownedFlags = paramFlags.withOwnership(ParameterOwnership::Owned);
 
   auto F6 = Builder.createFunctionType(
       {Param1.withFlags(inoutFlags)}, Result, FunctionTypeFlags(),


### PR DESCRIPTION
The `ABI` headers had accidentally grown an `#include` into compiler headers, allowing the enum constant values of the `ValueOwnership` enum to leak into the runtime ABI. Sever this inappropriate relationship by declaring a separate `ParameterOwnership` enum with ABI-stable values in the ABI headers, and explicitly converting between the AST and ABI representation where needed. Fixes rdar://122435628.