### PR TITLE
[Debugging] Disable DebugDescriptionMacro for windows targets

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DebugDescriptionMacro.swift
@@ -213,9 +213,8 @@ extension _DebugDescriptionPropertyMacro: PeerMacro {
 
     // Serialize the type summary into a global record, in a custom section, for LLDB to load.
     let decl: DeclSyntax = """
+        #if !os(Windows)
         #if os(Linux)
-        @_section(".lldbsummaries")
-        #elseif os(Windows)
         @_section(".lldbsummaries")
         #else
         @_section("__TEXT,__lldbsummaries")
@@ -224,6 +223,7 @@ extension _DebugDescriptionPropertyMacro: PeerMacro {
         static let _lldb_summary = (
             \(raw: encodeTypeSummaryRecord(typeIdentifier, summaryString))
         )
+        #endif
         """
 
     return [decl]

--- a/test/Macros/DebugDescription/linkage.swift
+++ b/test/Macros/DebugDescription/linkage.swift
@@ -8,13 +8,18 @@
 struct MyStruct: CustomDebugStringConvertible {
   var debugDescription: String { "thirty" }
 }
+// CHECK: #if !os(Windows)
 // CHECK: #if os(Linux)
-// CHECK: @_section(".lldbsummaries")
-// CHECK: #elseif os(Windows)
 // CHECK: @_section(".lldbsummaries")
 // CHECK: #else
 // CHECK: @_section("__TEXT,__lldbsummaries")
 // CHECK: #endif
 // CHECK: @_used
 // CHECK: static let _lldb_summary = (
+// CHECK:     /* version */ 1 as UInt8,
+// CHECK:     /* record size */ 23 as UInt8,
+// CHECK:     /* "main.MyStruct" */ 14 as UInt8, 109 as UInt8, 97 as UInt8, 105 as UInt8, 110 as UInt8, 46 as UInt8, 77 as UInt8, 121 as UInt8, 83 as UInt8, 116 as UInt8, 114 as UInt8, 117 as UInt8, 99 as UInt8, 116 as UInt8, 0 as UInt8,
+// CHECK:     /* "thirty" */ 7 as UInt8, 116 as UInt8, 104 as UInt8, 105 as UInt8, 114 as UInt8, 116 as UInt8, 121 as UInt8, 0 as UInt8
+// CHECK: )
+// CHECK: #endif
 


### PR DESCRIPTION
On windows (PECOFF), the `static let` properties produced by `DebugDescriptionMacro` are not constants, and as a result the `@_section` macro cannot be applied. The error message is:

> global variable must be a compile-time constant to use `@_section` attribute

Until this issue is addressed, DebugDescriptionMacro is disabled for windows targets.