### PR TITLE
[BitwiseCopyable] Use TypeInfo for conforming resilient types.

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -7198,6 +7198,14 @@ ResilientEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
                                                   EnumDecl *theEnum,
                                                   llvm::StructType *enumTy) {
   auto abiAccessible = IsABIAccessible_t(TC.IGM.isTypeABIAccessible(Type));
+  auto *bitwiseCopyableProtocol =
+      IGM.getSwiftModule()->getASTContext().getProtocol(
+          KnownProtocolKind::BitwiseCopyable);
+  if (bitwiseCopyableProtocol &&
+      IGM.getSwiftModule()->lookupConformance(
+          theEnum->getDeclaredInterfaceType(), bitwiseCopyableProtocol)) {
+    return BitwiseCopyableTypeInfo::create(enumTy, abiAccessible);
+  }
   auto copyable = !theEnum->canBeCopyable()
     ? IsNotCopyable : IsCopyable;
   return registerEnumTypeInfo(

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -1690,6 +1690,14 @@ const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
       ? IsNotCopyable : IsCopyable;
     auto structAccessible =
       IsABIAccessible_t(IGM.getSILModule().isTypeMetadataAccessible(type));
+    auto *bitwiseCopyableProtocol =
+        IGM.getSwiftModule()->getASTContext().getProtocol(
+            KnownProtocolKind::BitwiseCopyable);
+    if (bitwiseCopyableProtocol &&
+        IGM.getSwiftModule()->lookupConformance(D->getDeclaredInterfaceType(),
+                                                bitwiseCopyableProtocol)) {
+      return BitwiseCopyableTypeInfo::create(IGM.OpaqueTy, structAccessible);
+    }
     return &getResilientStructTypeInfo(copyable, structAccessible);
   }
 

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -520,6 +520,13 @@ namespace {
 
 const TypeInfo *TypeConverter::convertTupleType(TupleType *tuple) {
   if (tuple->containsPackExpansionType()) {
+    auto *bitwiseCopyableProtocol =
+        IGM.getSwiftModule()->getASTContext().getProtocol(
+            KnownProtocolKind::BitwiseCopyable);
+    if (bitwiseCopyableProtocol && IGM.getSwiftModule()->lookupConformance(
+                                       tuple, bitwiseCopyableProtocol)) {
+      return BitwiseCopyableTypeInfo::create(IGM.OpaqueTy, IsABIAccessible);
+    }
     // FIXME: Figure out if its copyable at least
     return &getDynamicTupleTypeInfo(IsCopyable);
   }

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -26,6 +26,7 @@
 #include "Address.h"
 #include "GenOpaque.h"
 #include "IndirectTypeInfo.h"
+#include "Outlining.h"
 
 namespace swift {
 namespace irgen {
@@ -128,6 +129,77 @@ public:
   }
   llvm::Constant *getStaticStride(IRGenModule &IGM) const override {
     return nullptr;
+  }
+};
+
+class BitwiseCopyableTypeInfo
+    : public WitnessSizedTypeInfo<BitwiseCopyableTypeInfo> {
+  using Self = BitwiseCopyableTypeInfo;
+  using Super = WitnessSizedTypeInfo<Self>;
+  BitwiseCopyableTypeInfo(llvm::Type *type,
+                                   IsABIAccessible_t abiAccessible)
+      : Super(type, Alignment(1), IsNotTriviallyDestroyable,
+              IsNotBitwiseTakable, IsCopyable, abiAccessible) {}
+
+public:
+  static const BitwiseCopyableTypeInfo *
+  create(llvm::Type *type, IsABIAccessible_t abiAccessible) {
+    return new Self(type, abiAccessible);
+  }
+
+  void bitwiseCopy(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                   SILType T, bool isOutlined) const {
+    IGF.Builder.CreateMemCpy(destAddr, srcAddr, getSize(IGF, T));
+  }
+
+  void initializeWithTake(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                          SILType T, bool isOutlined) const override {
+    bitwiseCopy(IGF, destAddr, srcAddr, T, isOutlined);
+  }
+
+  void initializeWithCopy(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                          SILType T, bool isOutlined) const override {
+    bitwiseCopy(IGF, destAddr, srcAddr, T, isOutlined);
+  }
+
+  void assignWithCopy(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                      SILType T, bool isOutlined) const override {
+    bitwiseCopy(IGF, destAddr, srcAddr, T, isOutlined);
+  }
+
+  void assignWithTake(IRGenFunction &IGF, Address destAddr, Address srcAddr,
+                      SILType T, bool isOutlined) const override {
+    bitwiseCopy(IGF, destAddr, srcAddr, T, isOutlined);
+  }
+
+  void destroy(IRGenFunction &IGF, Address address, SILType T,
+               bool isOutlined) const override {
+    // BitwiseCopyable types are trivial, so destroy is a no-op.
+  }
+
+  llvm::Value *getEnumTagSinglePayload(IRGenFunction &IGF,
+                                       llvm::Value *numEmptyCases,
+                                       Address enumAddr, SILType T,
+                                       bool isOutlined) const override {
+    return emitGetEnumTagSinglePayloadCall(IGF, T, numEmptyCases, enumAddr);
+  }
+
+  void storeEnumTagSinglePayload(IRGenFunction &IGF, llvm::Value *whichCase,
+                                 llvm::Value *numEmptyCases, Address enumAddr,
+                                 SILType T, bool isOutlined) const override {
+    emitStoreEnumTagSinglePayloadCall(IGF, T, whichCase, numEmptyCases,
+                                      enumAddr);
+  }
+
+  void collectMetadataForOutlining(OutliningMetadataCollector &collector,
+                                   SILType T) const override {
+    // We'll need formal type metadata for this archetype.
+    collector.collectTypeMetadataForLayout(T);
+  }
+
+  TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, SILType T,
+                                        bool useStructLayouts) const override {
+    return IGM.typeLayoutCache.getOrCreateArchetypeEntry(T.getObjectType());
   }
 };
 }

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -136,14 +136,13 @@ class BitwiseCopyableTypeInfo
     : public WitnessSizedTypeInfo<BitwiseCopyableTypeInfo> {
   using Self = BitwiseCopyableTypeInfo;
   using Super = WitnessSizedTypeInfo<Self>;
-  BitwiseCopyableTypeInfo(llvm::Type *type,
-                                   IsABIAccessible_t abiAccessible)
+  BitwiseCopyableTypeInfo(llvm::Type *type, IsABIAccessible_t abiAccessible)
       : Super(type, Alignment(1), IsNotTriviallyDestroyable,
               IsNotBitwiseTakable, IsCopyable, abiAccessible) {}
 
 public:
-  static const BitwiseCopyableTypeInfo *
-  create(llvm::Type *type, IsABIAccessible_t abiAccessible) {
+  static BitwiseCopyableTypeInfo *create(llvm::Type *type,
+                                         IsABIAccessible_t abiAccessible) {
     return new Self(type, abiAccessible);
   }
 


### PR DESCRIPTION
Move the conforming archetype type info to a header and use it as the type info for all resilient types that conform.
