### PR TITLE
[Dependency Scanning] Only omit Clang VFS overlays from Swift dependencies if unused by their Clang dependencies

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -697,7 +697,7 @@ DiagnosticBehavior LangOptions::getAccessNoteFailureLimit() const {
 }
 
 namespace {
-  static constexpr std::array<std::string_view, 16> knownSearchPathPrefiexes =
+  constexpr std::array<std::string_view, 16> knownSearchPathPrefiexes =
        {"-I",
         "-F",
         "-fmodule-map-file=",
@@ -714,6 +714,23 @@ namespace {
         "-ivfsoverlay",
         "-working-directory=",
         "-working-directory"};
+
+constexpr std::array<std::string_view, 15> knownClangDependencyIgnorablePrefiexes =
+     {"-I",
+      "-F",
+      "-fmodule-map-file=",
+      "-iquote",
+      "-idirafter",
+      "-iframeworkwithsysroot",
+      "-iframework",
+      "-iprefix",
+      "-iwithprefixbefore",
+      "-iwithprefix",
+      "-isystemafter",
+      "-isystem",
+      "-isysroot",
+      "-working-directory=",
+      "-working-directory"};
 }
 
 std::vector<std::string> ClangImporterOptions::getRemappedExtraArgs(
@@ -756,7 +773,7 @@ std::vector<std::string> ClangImporterOptions::getRemappedExtraArgs(
 std::vector<std::string>
 ClangImporterOptions::getReducedExtraArgsForSwiftModuleDependency() const {
   auto matchIncludeOption = [](StringRef &arg) {
-    for (const auto &option : knownSearchPathPrefiexes)
+    for (const auto &option : knownClangDependencyIgnorablePrefiexes)
       if (arg.consume_front(option))
         return true;
     return false;

--- a/test/ScanDependencies/eliminate_unused_vfs.swift
+++ b/test/ScanDependencies/eliminate_unused_vfs.swift
@@ -1,0 +1,62 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/redirects)
+// RUN: split-file %s %t
+
+// RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%S/Inputs/CHeaders|g" %t/overlay_template.yaml > %t/overlay.yaml
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -Xcc -ivfsoverlay -Xcc %t/overlay.yaml
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+//--- overlay_template.yaml
+{
+  'version': 0,
+  'use-external-names': false,
+  'roots': [
+    {
+      'name': 'IN_DIR', 'type': 'directory',
+      'contents': [
+      ]
+    },
+  ]
+}
+
+//--- test.swift
+import F
+
+// CHECK: "mainModuleName": "deps"
+/// --------Main module
+// CHECK-LABEL: "modulePath": "deps.swiftmodule",
+// CHECK-NEXT: sourceFiles
+// CHECK-NEXT: test.swift
+// CHECK-NEXT: ],
+// CHECK-NEXT: "directDependencies": [
+// CHECK-DAG:     "swift": "F"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK: ],
+
+// Ensure that the VFS overlay command-line flag is pruned on the Swift module dependency
+// that uses a Clang module which has optimized it away as un-used.
+/// --------Swift module F
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
+
+// CHECK: "directDependencies": [
+// CHECK-NEXT:   {
+// CHECK-DAG:     "clang": "F"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ],
+
+// CHECK: "commandLine": [
+// CHECK: "-compile-module-from-interface"
+// CHECK-NOT: "-ivfsoverlay",
+// CHECK-NOT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK: ],
+
+/// --------Clang module F
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.pcm",
+// CHECK-NOT: "-ivfsoverlay",
+// CHECK-NOT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",

--- a/test/ScanDependencies/preserve_used_vfs.swift
+++ b/test/ScanDependencies/preserve_used_vfs.swift
@@ -1,0 +1,67 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+// RUN: %empty-directory(%t/redirects)
+// RUN: split-file %s %t
+
+// RUN: sed -e "s|OUT_DIR|%t/redirects|g"  -e "s|IN_DIR|%S/Inputs/CHeaders|g" %t/overlay_template.yaml > %t/overlay.yaml
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/module-cache %t/test.swift -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -Xcc -ivfsoverlay -Xcc %t/overlay.yaml
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+//--- redirects/RedirectedF.h
+void funcRedirectedF(void);
+
+//--- overlay_template.yaml
+{
+  'version': 0,
+  'use-external-names': false,
+  'roots': [
+    {
+      'name': 'IN_DIR', 'type': 'directory',
+      'contents': [
+        { 'name': 'F.h', 'type': 'file',
+          'external-contents': 'OUT_DIR/RedirectedF.h'
+        }
+      ]
+    },
+  ]
+}
+
+//--- test.swift
+import F
+
+// CHECK: "mainModuleName": "deps"
+/// --------Main module
+// CHECK-LABEL: "modulePath": "deps.swiftmodule",
+// CHECK-NEXT: sourceFiles
+// CHECK-NEXT: test.swift
+// CHECK-NEXT: ],
+// CHECK-NEXT: "directDependencies": [
+// CHECK-DAG:     "swift": "F"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK: ],
+
+// Ensure that the VFS overlay command-line flag is preserved on the Swift module dependency
+// that uses a Clang module affected by this overlay
+/// --------Swift module F
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
+
+// CHECK: "directDependencies": [
+// CHECK-NEXT:   {
+// CHECK-DAG:     "clang": "F"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ],
+
+// CHECK: "commandLine": [
+// CHECK: "-compile-module-from-interface"
+// CHECK: "-ivfsoverlay",
+// CHECK-NEXT: "-Xcc",
+// CHECK-NEXT: "{{.*}}{{/|\\}}preserve_used_vfs.swift.tmp{{/|\\}}overlay.yaml",
+// CHECK: ],
+
+/// --------Clang module F
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.pcm",


### PR DESCRIPTION
We previously blanket omitted `-Xcc -vfsoverlay` flags from Swift module dependencies' command-line recipes. This is incorrect as the Swift module must have an exact matching VFS overlay that its Clang dependencies use, in order to load said Clang dependnecies successfully and resolve their headers as expected and as was done during the scan.

Resolves rdar://122667530
