### PR TITLE
[stdlib] Do not introduce any new ABI symbols for _get*RetainCount

### DIFF
--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -349,19 +349,19 @@ internal func _swift_unownedRetainCount(_: UnsafeMutableRawPointer) -> Int
 internal func _swift_weakRetainCount(_: UnsafeMutableRawPointer) -> Int
 
 // Utilities to get refcount(s) of class objects.
-@backDeployed(before: SwiftStdlib 6.0)
+@_alwaysEmitIntoClient
 public func _getRetainCount(_ object: AnyObject) -> UInt {
   let count = _withHeapObject(of: object) { _swift_retainCount($0) }
   return UInt(bitPattern: count)
 }
 
-@backDeployed(before: SwiftStdlib 6.0)
+@_alwaysEmitIntoClient
 public func _getUnownedRetainCount(_ object: AnyObject) -> UInt {
   let count = _withHeapObject(of: object) { _swift_unownedRetainCount($0) }
   return UInt(bitPattern: count)
 }
 
-@backDeployed(before: SwiftStdlib 6.0)
+@_alwaysEmitIntoClient
 public func _getWeakRetainCount(_ object: AnyObject) -> UInt {
   let count = _withHeapObject(of: object) { _swift_weakRetainCount($0) }
   return UInt(bitPattern: count)

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -36,15 +36,6 @@
 
 // Standard Library Symbols
 
-// Swift._getRetainCount(Swift.AnyObject) -> Swift.UInt
-Added: _$ss15_getRetainCountySuyXlF
-
-// Swift._getWeakRetainCount(Swift.AnyObject) -> Swift.UInt
-Added: _$ss19_getWeakRetainCountySuyXlF
-
-// Swift._getUnownedRetainCount(Swift.AnyObject) -> Swift.UInt
-Added: _$ss22_getUnownedRetainCountySuyXlF
-
 // Swift.String.init<A, B where A: Swift._UnicodeEncoding, B: Swift.Sequence, A.CodeUnit == B.Element>(validating: B, as: A.Type) -> Swift.String?
 Added: _$sSS10validating2asSSSgq__xmtcs16_UnicodeEncodingRzSTR_7ElementQy_8CodeUnitRtzr0_lufC
 

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -36,15 +36,6 @@
 
 // Standard Library Symbols
 
-// Swift._getRetainCount(Swift.AnyObject) -> Swift.UInt
-Added: _$ss15_getRetainCountySuyXlF
-
-// Swift._getWeakRetainCount(Swift.AnyObject) -> Swift.UInt
-Added: _$ss19_getWeakRetainCountySuyXlF
-
-// Swift._getUnownedRetainCount(Swift.AnyObject) -> Swift.UInt
-Added: _$ss22_getUnownedRetainCountySuyXlF
-
 // Swift.String.init<A, B where A: Swift._UnicodeEncoding, B: Swift.Sequence, A.CodeUnit == B.Element>(validating: B, as: A.Type) -> Swift.String?
 Added: _$sSS10validating2asSSSgq__xmtcs16_UnicodeEncodingRzSTR_7ElementQy_8CodeUnitRtzr0_lufC
 

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -59,6 +59,12 @@ Func _diagnoseUnavailableCodeReached() is a new API without @available attribute
 Func _swift_retainCount(_:) is a new API without @available attribute
 Func _swift_unownedRetainCount(_:) is a new API without @available attribute
 Func _swift_weakRetainCount(_:) is a new API without @available attribute
+// And these were temporarily added as ABI in https://github.com/apple/swift/pull/69352,
+// but then https://github.com/apple/swift/pull/71694 made them @_aeic before
+// they shipped anywhere, but not before they got into the ABI baseline. Fun!
+Func _getRetainCount(_:) has been removed
+Func _getUnownedRetainCount(_:) has been removed
+Func _getWeakRetainCount(_:) has been removed
 
 Struct AnyHashable has added a conformance to an existing protocol _HasCustomAnyHashableRepresentation
 Class AnyKeyPath has added a conformance to an existing protocol CustomDebugStringConvertible


### PR DESCRIPTION
There is no point to adding symbols for these, as they are only expected to be called interactively from lldb, which should handle @_aeic just fine.

rdar://120389342