### PR TITLE
[AST] Skip invertible protocols requirements in `IsBindableVisitor`

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2316,6 +2316,9 @@ public:
       llvm::DenseMap<std::pair<CanType, ProtocolDecl*>, ProtocolConformanceRef> addedConformances;
       
       for (auto proto : upperBound->getConformsTo()) {
+        if (proto->getInvertibleProtocolKind())
+          continue;
+
         // Find the DeclContext providing the conformance for the type.
         auto nomConformance = moduleDecl->lookupConformance(
             substType, proto, /*allowMissing=*/true);
@@ -2426,6 +2429,11 @@ public:
       SmallVector<ProtocolConformanceRef, 4> paramSubstConformances;
       if (paramUpperBound) {
         for (auto proto : paramUpperBound->getConformsTo()) {
+          // FIXME: Skip invertible protocol requirements because they won't
+          // be in the substitution map.
+          if (proto->getInvertibleProtocolKind())
+            continue;
+
           auto conformance = upperBoundSubstMap.lookupConformance(gp, proto);
           if (!conformance)
             return CanType();

--- a/test/Generics/copyable_and_self_conforming_protocols.swift
+++ b/test/Generics/copyable_and_self_conforming_protocols.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes %s -verify
+
+// REQUIRES: objc_interop
+// REQUIRES: asserts
+
+import Foundation
+
+@objc protocol MyResult {
+}
+
+class Request<T : MyResult> {
+}
+
+struct Test {
+  let closure: (Request<MyResult>) -> Void
+
+  func test<R>(_ request: Request<R>) {
+    self.closure(request as! Request<MyResult>)
+  }
+}


### PR DESCRIPTION
Skip invertible protocol conformance requirements while building generic parameter
substitutions from upper bound because they are not present in the substitution map.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
