### PR TITLE
Inverse requirement mangling and @_preInverseGenerics

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -932,6 +932,7 @@ now codified into the ABI; the index 0 is therefore reserved.
   requirement ::= protocol assoc-type-name 'Rp' GENERIC-PARAM-INDEX // protocol requirement on associated type
   requirement ::= protocol assoc-type-list 'RP' GENERIC-PARAM-INDEX // protocol requirement on associated type at depth
   requirement ::= protocol substitution 'RQ'                        // protocol requirement with substitution
+  requirement ::= 'Ri' GENERIC-PARAM-INDEX                          // inverse protocol requirement to Copyable
   requirement ::= type 'Rb' GENERIC-PARAM-INDEX                     // base class requirement
   requirement ::= type assoc-type-name 'Rc' GENERIC-PARAM-INDEX     // base class requirement on associated type
   requirement ::= type assoc-type-list 'RC' GENERIC-PARAM-INDEX     // base class requirement on associated type at depth
@@ -944,7 +945,6 @@ now codified into the ABI; the index 0 is therefore reserved.
   requirement ::= type assoc-type-name 'Rm' GENERIC-PARAM-INDEX LAYOUT-CONSTRAINT    // layout requirement on associated type
   requirement ::= type assoc-type-list 'RM' GENERIC-PARAM-INDEX LAYOUT-CONSTRAINT    // layout requirement on associated type at depth
   requirement ::= type substitution 'RM' LAYOUT-CONSTRAINT                           // layout requirement with substitution
-
   requirement ::= type 'Rh' GENERIC-PARAM-INDEX                     // same-shape requirement (only supported on a generic parameter)
 
   GENERIC-PARAM-INDEX ::= 'z'                // depth = 0,   idx = 0

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -451,14 +451,16 @@ protected:
 
   void appendContextOf(const ValueDecl *decl);
 
-  void appendContext(const DeclContext *ctx, StringRef useModuleName);
+  void appendContext(const DeclContext *ctx, StringRef useModuleName,
+                     bool shouldTreatAsConstrainedExtension = false);
 
   void appendModule(const ModuleDecl *module, StringRef useModuleName);
 
   void appendProtocolName(const ProtocolDecl *protocol,
                           bool allowStandardSubstitution = true);
 
-  void appendAnyGenericType(const GenericTypeDecl *decl);
+  void appendAnyGenericType(const GenericTypeDecl *decl,
+                            bool shouldTreatAsConstrainedExtension = false);
 
   enum FunctionManglingKind {
     NoFunctionMangling,
@@ -512,7 +514,8 @@ protected:
   /// \returns \c true if a generic signature was appended, \c false
   /// if it was empty.
   bool appendGenericSignature(GenericSignature sig,
-                              GenericSignature contextSig = nullptr);
+                              GenericSignature contextSig = nullptr,
+                              bool skipEquivalenceCheck = false);
 
   /// Append a requirement to the mangling.
   ///
@@ -526,10 +529,21 @@ protected:
   void appendRequirement(const Requirement &reqt, GenericSignature sig,
                          bool lhsBaseIsProtocolSelf = false);
 
+  /// Append an inverse requirement into the mangling.
+  ///
+  /// Instead of mangling the presence of an invertible protocol, we mangle
+  /// their absence, which is what an inverse represents.
+  ///
+  /// \param req The inverse requirement to mangle.
+  void appendInverseRequirement(const InverseRequirement &req,
+                                GenericSignature sig,
+                                bool lhsBaseIsProtocolSelf = false);
+
   void appendGenericSignatureParts(GenericSignature sig,
                                    ArrayRef<CanTypeWrapper<GenericTypeParamType>> params,
                                    unsigned initialParamDepth,
-                                   ArrayRef<Requirement> requirements);
+                                   ArrayRef<Requirement> requirements,
+                                   ArrayRef<InverseRequirement> inverseRequirements);
 
   DependentMemberType *dropProtocolFromAssociatedType(DependentMemberType *dmt,
                                                       GenericSignature sig);

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -547,8 +547,7 @@ protected:
   ///
   /// \param req The inverse requirement to mangle.
   void appendInverseRequirement(const InverseRequirement &req,
-                                GenericSignature sig,
-                                bool lhsBaseIsProtocolSelf = false);
+                                GenericSignature sig);
 
   void appendGenericSignatureParts(GenericSignature sig,
                                    ArrayRef<CanTypeWrapper<GenericTypeParamType>> params,

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -460,7 +460,7 @@ protected:
                           bool allowStandardSubstitution = true);
 
   void appendAnyGenericType(const GenericTypeDecl *decl,
-                            bool shouldTreatAsConstrainedExtension = false);
+                            bool shouldMangleInverseGenerics = false);
 
   enum FunctionManglingKind {
     NoFunctionMangling,
@@ -510,6 +510,16 @@ protected:
   ///
   /// \param contextSig The signature of the known context. This function
   /// will only mangle the difference between \c sig and \c contextSig.
+  ///
+  /// \param skipEquivalenceCheck Whether we should skip the sig == contextSig
+  /// check. Skipping this check means we will mangle the signature regardless
+  /// of if the surrounding context has the same signature. This should
+  /// generally always be false, but there are inverse generic mangling concerns
+  /// that need to force signature mangling.
+  ///
+  /// \param shouldMangleInverseGenerics Whether we should append inverse
+  /// generic requirements to the signature mangling. If @_preInverseGenerics is
+  /// present do not mangle them in addition to other requirements.
   ///
   /// \returns \c true if a generic signature was appended, \c false
   /// if it was empty.

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -452,7 +452,7 @@ protected:
   void appendContextOf(const ValueDecl *decl);
 
   void appendContext(const DeclContext *ctx, StringRef useModuleName,
-                     bool shouldTreatAsConstrainedExtension = false);
+                     bool shouldMangleInverseGenerics = false);
 
   void appendModule(const ModuleDecl *module, StringRef useModuleName);
 
@@ -515,7 +515,8 @@ protected:
   /// if it was empty.
   bool appendGenericSignature(GenericSignature sig,
                               GenericSignature contextSig = nullptr,
-                              bool skipEquivalenceCheck = false);
+                              bool skipEquivalenceCheck = false,
+                              bool shouldMangleInverseGenerics = true);
 
   /// Append a requirement to the mangling.
   ///

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1855,6 +1855,10 @@ public:
   /// resiliently moved into the original protocol itself.
   bool isEquivalentToExtendedContext() const;
 
+  /// Determine whether this extension context is in the same defining module as
+  /// the original nominal type context.
+  bool isInSameDefiningModule() const;
+
   /// Returns the name of the category specified by the \c \@_objcImplementation
   /// attribute, or \c None if the name is invalid or
   /// \c isObjCImplementation() is false.

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -485,7 +485,10 @@ SIMPLE_DECL_ATTR(_noExistentials, NoExistentials,
 SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
   OnAbstractFunction | OnSubscript | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   155)
-LAST_DECL_ATTR(NoObjCBridging)
+SIMPLE_DECL_ATTR(_preInverseGenerics, PreInverseGenerics,
+  OnAbstractFunction | OnSubscript | OnVar | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
+  156)
+LAST_DECL_ATTR(PreInverseGenerics)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -482,6 +482,16 @@ public:
   /// Utility wrapper for use when this is an opened existential signature.
   Type getExistentialType(Type type) const;
 
+  /// Determines if this generic signature is the complete opposite of a generic
+  /// signature with inverse requirements.
+  ///
+  /// Given the following 'other' signature (this assumes Equatable: ~Copyable):
+  ///   <T: ~Copyable & Equatable, U: ~Copyable, V: Copyable>
+  /// returns true iff our generic signature is:
+  ///   <T: Copyable & Equatable, U: Copyable, V: Copyable>
+  bool areAllRequirementsPositiveInverseRequirementsSatisfying(
+                                                  GenericSignature other) const;
+
   static void Profile(llvm::FoldingSetNodeID &ID,
                       ArrayRef<GenericTypeParamType *> genericParams,
                       ArrayRef<Requirement> requirements);

--- a/include/swift/Demangling/DemangleNodes.def
+++ b/include/swift/Demangling/DemangleNodes.def
@@ -390,5 +390,7 @@ NODE(OutlinedAssignWithTakeNoValueWitness)
 NODE(OutlinedAssignWithCopyNoValueWitness)
 NODE(OutlinedDestroyNoValueWitness)
 
+NODE(DependentGenericInverseConformanceRequirement)
+
 #undef CONTEXT_NODE
 #undef NODE

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3369,8 +3369,7 @@ void ASTMangler::appendRequirement(const Requirement &reqt,
 }
 
 void ASTMangler::appendInverseRequirement(const InverseRequirement &req,
-                                          GenericSignature sig,
-                                          bool lhsBaseIsProtocolSelf) {
+                                          GenericSignature sig) {
   appendOperator("R");
 
   assert(req.protocol->getInvertibleProtocolKind());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1754,7 +1754,7 @@ bool ExtensionDecl::isConstrainedExtension() const {
   return !typeSig->isEqual(extSig);
 }
 
-bool ExtensionDecl::isEquivalentToExtendedContext() const {
+bool ExtensionDecl::isInSameDefiningModule() const {
   auto decl = getExtendedNominal();
   bool extendDeclFromSameModule = false;
   auto extensionAlterName = getAlternateModuleName();
@@ -1763,23 +1763,24 @@ bool ExtensionDecl::isEquivalentToExtendedContext() const {
   if (!extensionAlterName.empty()) {
     if (!typeAlterName.empty()) {
       // Case I: type and extension are both moved from somewhere else
-      extendDeclFromSameModule = typeAlterName == extensionAlterName;
+      return typeAlterName == extensionAlterName;
     } else {
       // Case II: extension alone was moved from somewhere else
-      extendDeclFromSameModule = extensionAlterName ==
-        decl->getParentModule()->getNameStr();
+      return extensionAlterName == decl->getParentModule()->getNameStr();
     }
   } else {
     if (!typeAlterName.empty()) {
       // Case III: extended type alone was moved from somewhere else
-      extendDeclFromSameModule = typeAlterName == getParentModule()->getNameStr();
+      return typeAlterName == getParentModule()->getNameStr();
     } else {
       // Case IV: neither of type and extension was moved from somewhere else
-      extendDeclFromSameModule = getParentModule() == decl->getParentModule();
+      return getParentModule() == decl->getParentModule();
     }
   }
+}
 
-  return extendDeclFromSameModule
+bool ExtensionDecl::isEquivalentToExtendedContext() const {
+  return isInSameDefiningModule()
     && !isConstrainedExtension()
     && !getDeclaredInterfaceType()->isExistentialType();
 }

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -237,6 +237,7 @@ extension ASTGenVisitor {
         .objCMembers,
         .objCNonLazyRealization,
         .preconcurrency,
+        .preInverseGenerics,
         .propertyWrapper,
         .requiresStoredPropertyInits,
         .resultBuilder,

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -84,6 +84,7 @@ static bool isRequirement(Node::Kind kind) {
     case Node::Kind::DependentGenericSameShapeRequirement:
     case Node::Kind::DependentGenericLayoutRequirement:
     case Node::Kind::DependentGenericConformanceRequirement:
+    case Node::Kind::DependentGenericInverseConformanceRequirement:
       return true;
     default:
       return false;
@@ -4066,7 +4067,7 @@ NodePointer Demangler::demangleGenericSignature(bool hasParamCounts) {
 NodePointer Demangler::demangleGenericRequirement() {
 
   enum { Generic, Assoc, CompoundAssoc, Substitution } TypeKind;
-  enum { Protocol, BaseClass, SameType, SameShape, Layout, PackMarker } ConstraintKind;
+  enum { Protocol, BaseClass, SameType, SameShape, Layout, PackMarker, Inverse } ConstraintKind;
 
   switch (nextChar()) {
     case 'v': ConstraintKind = PackMarker; TypeKind = Generic; break;
@@ -4086,6 +4087,7 @@ NodePointer Demangler::demangleGenericRequirement() {
     case 'P': ConstraintKind = Protocol; TypeKind = CompoundAssoc; break;
     case 'Q': ConstraintKind = Protocol; TypeKind = Substitution; break;
     case 'h': ConstraintKind = SameShape; TypeKind = Generic; break;
+    case 'i': ConstraintKind = Inverse; TypeKind = Generic; break;
     default:  ConstraintKind = Protocol; TypeKind = Generic; pushBack(); break;
   }
 
@@ -4116,6 +4118,10 @@ NodePointer Demangler::demangleGenericRequirement() {
     return createWithChildren(
         Node::Kind::DependentGenericConformanceRequirement, ConstrTy,
         popProtocol());
+  case Inverse:
+    return createWithChildren(
+        Node::Kind::DependentGenericInverseConformanceRequirement, ConstrTy,
+        createSwiftType(Node::Kind::Protocol, "Copyable"));
   case BaseClass:
     return createWithChildren(
         Node::Kind::DependentGenericConformanceRequirement, ConstrTy,

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -641,6 +641,7 @@ private:
     case Node::Kind::ObjectiveCProtocolSymbolicReference:
     case Node::Kind::ParamLifetimeDependence:
     case Node::Kind::SelfLifetimeDependence:
+    case Node::Kind::DependentGenericInverseConformanceRequirement:
       return false;
     }
     printer_unreachable("bad node kind");
@@ -2817,6 +2818,14 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     NodePointer reqt = Node->getChild(1);
     print(type, depth + 1);
     Printer << ": ";
+    print(reqt, depth + 1);
+    return nullptr;
+  }
+  case Node::Kind::DependentGenericInverseConformanceRequirement: {
+    NodePointer type = Node->getChild(0);
+    NodePointer reqt = Node->getChild(1);
+    print(type, depth + 1);
+    Printer << ": ~";
     print(reqt, depth + 1);
     return nullptr;
   }

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -3007,3 +3007,9 @@ ManglingError Remangler::mangleHasSymbolQuery(Node *node, unsigned depth) {
   Buffer << "TwS";
   return ManglingError::Success;
 }
+
+ManglingError
+Remangler::mangleDependentGenericInverseConformanceRequirement(Node *node,
+                                                               unsigned depth) {
+  return MANGLING_ERROR(ManglingError::UnsupportedNodeKind, node);
+}

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -1046,6 +1046,25 @@ Remangler::mangleDependentGenericConformanceRequirement(Node *node,
   return ManglingError::Success;
 }
 
+ManglingError Remangler::mangleDependentGenericInverseConformanceRequirement(
+                                                  Node *node, unsigned depth) {
+  DEMANGLER_ASSERT(node->getNumChildren() == 2, node);
+  auto Mangling = mangleConstrainedType(node->getChild(0), depth + 1);
+
+  if (!Mangling.isSuccess()) {
+    return Mangling.error();
+  }
+
+  auto NumMembersAndParamIdx = Mangling.result();
+  DEMANGLER_ASSERT(
+      NumMembersAndParamIdx.first < 0 || NumMembersAndParamIdx.second, node);
+
+  Buffer << "Ri";
+
+  mangleDependentGenericParamIndex(NumMembersAndParamIdx.second);
+  return ManglingError::Success;
+}
+
 ManglingError Remangler::mangleDependentGenericParamCount(Node *node,
                                                           unsigned depth) {
   // handled inline in DependentGenericSignature

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -164,6 +164,7 @@ public:
   IGNORED_ATTR(BackDeployed)
   IGNORED_ATTR(Documentation)
   IGNORED_ATTR(LexicalLifetimes)
+  IGNORED_ATTR(PreInverseGenerics)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1635,6 +1635,7 @@ namespace  {
     UNINTERESTING_ATTR(NonEscapable)
     UNINTERESTING_ATTR(UnsafeNonEscapableResult)
     UNINTERESTING_ATTR(StaticExclusiveOnly)
+    UNINTERESTING_ATTR(PreInverseGenerics)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/test/SILGen/mangling_inverse_generics.swift
+++ b/test/SILGen/mangling_inverse_generics.swift
@@ -1,0 +1,217 @@
+// RUN: %target-swift-emit-silgen %s -module-name test | %FileCheck %s
+
+protocol NoncopyableProto: ~Copyable {}
+
+protocol CopyableProto {}
+
+protocol CopyableProto2 {}
+
+// <T: ~Copyable>
+struct A<T: ~Copyable> {
+  // Members in an extenion with the same generic signature as the nominal
+  // should mangle the same, so make sure we mangle the following as if it were
+  // in a constrained extension.
+
+  // (extension in test):test.A<A where A: ~Swift.Copyable>.foo() -> ()
+  // CHECK: $s4test1AVAARizlE3fooyyF
+  func foo() {}
+
+  // test.A.weird() -> ()
+  // CHECK: $s4test1AV5weirdyyF
+  func weird() where T: Copyable {}
+
+  // variable initialization expression of (extension in test):test.A<A where A: ~Swift.Copyable>.property : Swift.Int
+  // CHECK: $s4test1AVAARizlE8propertySivpfi
+  // (extension in test):test.A<A where A: ~Swift.Copyable>.property.getter : Swift.Int
+  // CHECK: $s4test1AVAARizlE8propertySivg
+  // (extension in test):test.A<A where A: ~Swift.Copyable>.property.setter : Swift.Int
+  // CHECK: $s4test1AVAARizlE8propertySivs
+  // (extension in test):test.A<A where A: ~Swift.Copyable>.property.modify : Swift.Int
+  // CHECK: $s4test1AVAARizlE8propertySivM
+  // default argument 0 of (extension in test):test.A<A where A: ~Swift.Copyable>.init(property: Swift.Int) -> test.A<A>
+  // CHECK: $s4test1AVAARizlE8propertyACyxGSi_tcfcfA_
+  var property: Int = 0
+
+  // (extension in test):test.A<A where A: ~Swift.Copyable>.computed.getter : Swift.String
+  // CHECK: $s4test1AVAARizlE8computedSSvg
+  var computed: String {
+    ""
+  }
+
+  // (extension in test):test.A<A where A: ~Swift.Copyable>.init() -> test.A<A>
+  // CHECK: $s4test1AVAARizlEACyxGycfC
+  // init(property:)
+}
+
+// <T: ~Copyable>
+extension A where T: ~Copyable {
+  // (extension in test):test.A<A where A: ~Swift.Copyable>.bar() -> ()
+  // CHECK: $s4test1AVAARizlE3baryyF
+  func bar() {}
+
+  // test.A.weird2() -> ()
+  // CHECK: $s4test1AV6weird2yyF
+  func weird2() where T: Copyable {}
+}
+
+// <T: ~Copyable & NoncopyableProto>
+extension A where T: ~Copyable & NoncopyableProto {
+  // (extension in test):test.A<A where A: test.NoncopyableProto, A: ~Swift.Copyable>.dumb() -> ()
+  // CHECK: $s4test1AVA2A16NoncopyableProtoRzRizlE4dumbyyF
+  func dumb() {}
+}
+
+// <T: Copyable>
+extension A {
+  // However, an extension that has all of the positive requirements to inverse
+  // requirements must be mangled as if there were no inverse generics.
+
+  // test.A.baz() -> ()
+  // CHECK: $s4test1AV3bazyyF
+  func baz() {}
+
+  // test.A.computedAgain.getter : Swift.Int
+  // CHECK: $s4test1AV13computedAgainSivg
+  var computedAgain: Int {
+    123
+  }
+}
+
+// <T: CopyableProto> (implies T: Copyable)
+extension A where T: CopyableProto {
+  // An extension where T: Copyable, but has extra constraints must be mangle
+  // the extra constraints and not any inverses.
+
+  // (extension in test):test.A<A where A: test.CopyableProto>.something() -> ()
+  // CHECK: $s4test1AVA2A13CopyableProtoRzlE9somethingyyF
+  func something() {}
+}
+
+// <T == Int>
+extension A where T == Int {
+  // (extension in test):test.A<A where A == Swift.Int>.int() -> ()
+  // CHECK: $s4test1AVAASiRszlE3intyyF
+  func int() {}
+}
+
+// <T: ~Copyable & NoncopyableProto>
+struct B<T: ~Copyable & NoncopyableProto> {}
+
+// <T: Copyable & NoncopyableProto>
+extension B {
+  // Members of this extension should be treated as if they were just in 'B' and
+  // not mangle any requirements about 'NoncopyableProto' because that's implied
+  // by the context.
+
+  // test.B.foo() -> ()
+  // CHECK: $s4test1BV3fooyyF
+  func foo() {}
+}
+
+// <T: Copyable>
+struct C<T> {
+  // test.C.foo() -> ()
+  // CHECK: $s4test1CV3fooyyF
+  func foo() {}
+
+  // test.C.something<A where A1: ~Swift.Copyable>() -> A1
+  // CHECK: $s4test1CV9somethingqd__yRid__lF
+  func something<U: ~Copyable>() -> U {
+    fatalError()
+  }
+}
+
+// <T: Copyable>
+extension C {
+  // test.C.bar() -> ()
+  // CHECK: $s4test1CV3baryyF
+  func bar() {}
+}
+
+// <T: CopyableProto> (implies T: Copyable)
+extension C where T: CopyableProto {
+  // (extension in test):test.C<A where A: test.CopyableProto>.baz() -> ()
+  // CHECK: $s4test1CVA2A13CopyableProtoRzlE3bazyyF
+  func baz() {}
+}
+
+// <T: CopyableProto> (implies T: Copyable)
+struct D<T: CopyableProto> {
+  // test.D.foo() -> ()
+  // CHECK: $s4test1DV3fooyyF
+  func foo() {}
+}
+
+// <T: CopyableProto> (implies T: Copyable)
+extension D {
+  // test.D.bar() -> ()
+  // CHECK: $s4test1DV3baryyF
+  func bar() {}
+}
+
+// <T: CopyableProto & CopyableProto2> (implies T: Copyable)
+extension D where T: CopyableProto2 {
+  // (extension in test):test.D< where A: test.CopyableProto2>.baz() -> ()
+  // CHECK: $s4test1DVA2A14CopyableProto2RzrlE3bazyyF
+  func baz() {}
+}
+
+//===----------------------------------------------------------------------===//
+// @_preInverseGenerics
+//===----------------------------------------------------------------------===//
+
+// Members with @_preInverseGenerics should completely ignore inverse
+// requirements.
+
+// <T: ~Copyable>
+struct E<T: ~Copyable> {
+  // test.E.foo() -> ()
+  // CHECK: $s4test1EV3fooyyF
+  @_preInverseGenerics
+  func foo() {}
+
+  // test.E.something<A>() -> A1
+  // CHECK: $s4test1EV9somethingqd__ylF
+  @_preInverseGenerics
+  func something<U: ~Copyable>() -> U {
+    fatalError()
+  }
+
+  // variable initialization expression of test.E.property : Swift.Int
+  // CHECK: $s4test1EV8propertySivpfi
+  // test.E.property.getter : Swift.Int
+  // CHECK: $s4test1EV8propertySivg
+  // test.E.property.setter : Swift.Int
+  // CHECK: $s4test1EV8propertySivs
+  // test.E.property.modify : Swift.Int
+  // CHECK: $s4test1EV8propertySivM
+
+  // Note: The default argument function will include inverse information because
+  // it's coming from the implicit init that doesn't have @_preInverseGenerics
+  // default argument 0 of (extension in test):test.E<A where A: ~Swift.Copyable>.init(property: Swift.Int) -> test.E<A>
+  // CHECK: $s4test1EVAARizlE8propertyACyxGSi_tcfcfA_
+  @_preInverseGenerics
+  var property: Int = 123
+
+  // Implicit inits are still mangled as if there was an inverse generic req.
+  // (extension in test):test.E<A where A: ~Swift.Copyable>.init(property: Swift.Int) -> test.E<A>
+  // CHECK: $s4test1EVAARizlE8propertyACyxGSi_tcfC
+}
+
+// <T: ~Copyable>
+extension E where T: ~Copyable {
+  // test.E.bar() -> ()
+  // CHECK: $s4test1EV3baryyF
+  @_preInverseGenerics
+  func bar() {}
+}
+
+// <T: ~Copyable & NoncopyableProto>
+extension E where T: ~Copyable & NoncopyableProto {
+  // (extension in test):test.E<A where A: test.NoncopyableProto>.dumb() -> ()
+  // CHECK: $s4test1EVA2A16NoncopyableProtoRzlE4dumbyyF
+  @_preInverseGenerics
+  func dumb() {}
+}
+
+


### PR DESCRIPTION
This patch implements mangling support for inverse generics as well as an attribute `@_preInverseGenerics` that can be applied to members that will completely ignore inverse requirements entirely.