### PR TITLE
[Concurrency] Enable `OptionalIsolatedParameters`.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5558,8 +5558,6 @@ ERROR(isolated_attr_global_actor_type,none,
 ERROR(isolated_attr_bad_convention,none,
       "'@isolated(%0)' function type cannot have %1 convention",
       (StringRef, StringRef))
-ERROR(isolation_macro_experimental,none,
-      "#isolation macro is experimental", ())
 
 NOTE(in_derived_conformance, none,
      "in derived conformance to %0",

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -122,6 +122,7 @@ LANGUAGE_FEATURE(FreestandingMacros, 397, "freestanding declaration macros")
 SUPPRESSIBLE_LANGUAGE_FEATURE(RetroactiveAttribute, 364, "@retroactive")
 SUPPRESSIBLE_LANGUAGE_FEATURE(ExtensionMacroAttr, 0, "@attached(extension)")
 LANGUAGE_FEATURE(TypedThrows, 413, "Typed throws")
+LANGUAGE_FEATURE(OptionalIsolatedParameters, 420, "Optional isolated parameters")
 SUPPRESSIBLE_LANGUAGE_FEATURE(Extern, 0, "@_extern")
 LANGUAGE_FEATURE(ExpressionMacroDefaultArguments, 422, "Expression macro as caller-side default argument")
 
@@ -260,9 +261,6 @@ EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 /// Enable non-escapable type attributes and function attributes that support
 /// lifetime-dependent results.
 EXPERIMENTAL_FEATURE(NonescapableTypes, true)
-
-// Allow optional isolated parameters.
-EXPERIMENTAL_FEATURE(OptionalIsolatedParameters, true)
 
 /// Enable the `@_staticExclusiveOnly` attribute.
 EXPERIMENTAL_FEATURE(StaticExclusiveOnly, true)

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3923,6 +3923,13 @@ namespace {
     }
 
     Type visitCurrentContextIsolationExpr(CurrentContextIsolationExpr *E) {
+      // If this was expanded from the builtin `#isolation` macro, it
+      // already has a type.
+      if (auto type = E->getType())
+        return type;
+
+      // Otherwise, this was created for a `for await` loop, where its
+      // type is always `(any Actor)?`.
       auto actorProto = CS.getASTContext().getProtocol(
           KnownProtocolKind::Actor);
       return OptionalType::get(actorProto->getDeclaredExistentialType());

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1132,10 +1132,6 @@ evaluateFreestandingMacro(FreestandingMacroExpansion *expansion,
       return nullptr;
 
     case BuiltinMacroKind::IsolationMacro:
-      if (!ctx.LangOpts.hasFeature(Feature::OptionalIsolatedParameters)) {
-        ctx.Diags.diagnose(loc, diag::isolation_macro_experimental);
-      }
-
       // Create a buffer full of scratch space; this will be populated
       // much later.
       std::string scratchSpace(128, ' ');

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4944,13 +4944,10 @@ TypeResolver::resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
   Type unwrappedType = type;
 
   // Optional actor types are fine - `nil` represents `nonisolated`.
-  auto allowOptional = getASTContext().LangOpts
-                           .hasFeature(Feature::OptionalIsolatedParameters);
-  if (allowOptional) {
-    if (auto wrappedOptionalType = unwrappedType->getOptionalObjectType()) {
-      unwrappedType = wrappedOptionalType;
-    }
+  if (auto wrappedOptionalType = unwrappedType->getOptionalObjectType()) {
+    unwrappedType = wrappedOptionalType;
   }
+
   if (auto dynamicSelfType = dyn_cast<DynamicSelfType>(unwrappedType)) {
     unwrappedType = dynamicSelfType->getSelfType();
   }

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -76,8 +76,12 @@ internal func _enqueueOnMain(_ job: UnownedJob)
 #if $Macros
 /// Produce a reference to the actor to which the enclosing code is
 /// isolated, or `nil` if the code is nonisolated.
+///
+/// If the type annotation provided for `#isolation` is not `(any Actor)?`,
+/// the type must match the enclosing actor type. If no type annotation is
+/// provided, the type defaults to `(any Actor)?`.
 @available(SwiftStdlib 5.1, *)
 @freestanding(expression)
-public macro isolation() -> (any Actor)? = Builtin.IsolationMacro
+public macro isolation<T>() -> T = Builtin.IsolationMacro
 #endif
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -61,11 +61,6 @@ else()
 endif()
 
 
-list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
-  "-enable-experimental-feature"
-  "OptionalIsolatedParameters"
-)
-
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
   "-D__STDC_WANT_LIB_EXT1__=1")
 

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -1,8 +1,7 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature OptionalIsolatedParameters %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature OptionalIsolatedParameters %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -enable-experimental-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
-// REQUIRES: asserts
 // REQUIRES: swift_swift_parser
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/isolation_macro.swift
+++ b/test/Concurrency/isolation_macro.swift
@@ -1,12 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -dump-ast %s -enable-experimental-feature OptionalIsolatedParameters | %FileCheck %s
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
 // Diagnostics testing
-// RUN: not %target-swift-frontend -swift-version 5 -typecheck -enable-experimental-feature OptionalIsolatedParameters -DTEST_DIAGNOSTICS %s > %t/diagnostics.txt 2>&1
+// RUN: not %target-swift-frontend -swift-version 5 -typecheck -DTEST_DIAGNOSTICS %s > %t/diagnostics.txt 2>&1
 // RUN: %FileCheck %s --check-prefix CHECK-DIAGS < %t/diagnostics.txt
 
 // REQUIRES: concurrency
-// REQUIRES: asserts
 // REQUIRES: swift_swift_parser
 
 // CHECK-LABEL: nonisolatedFunc()

--- a/test/Concurrency/optional_isolated_parameters.swift
+++ b/test/Concurrency/optional_isolated_parameters.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -enable-experimental-feature OptionalIsolatedParameters %s -o %t/main
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking %s -o %t/main
 // RUN: %target-codesign %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 

--- a/test/Distributed/isolation_macro.swift
+++ b/test/Distributed/isolation_macro.swift
@@ -1,9 +1,8 @@
-// RUN: %target-swift-frontend -typecheck %s -enable-experimental-feature OptionalIsolatedParameters -verify
+// RUN: %target-swift-frontend -typecheck %s -verify
 
-// RUN: %target-swift-frontend -dump-ast %s -enable-experimental-feature OptionalIsolatedParameters | %FileCheck %s
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
 
 // REQUIRES: concurrency
-// REQUIRES: asserts
 // REQUIRES: distributed
 // REQUIRES: swift_swift_parser
 

--- a/test/SILGen/isolated_parameters.swift
+++ b/test/SILGen/isolated_parameters.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature OptionalIsolatedParameters %s -module-name test -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 | %FileCheck %s
 // REQUIRES: concurrency
 
 @available(SwiftStdlib 5.1, *)


### PR DESCRIPTION
Promote `OptionalIsolatedParameters` from an experimental feature to an upcoming feature per the acceptance of SE-0420: Actor isolation inheritance.