### PR TITLE
[SIL] Trivial storage locations remain valid after consumption.

### DIFF
--- a/include/swift/SIL/MemoryLocations.h
+++ b/include/swift/SIL/MemoryLocations.h
@@ -233,11 +233,15 @@ public:
 
   /// Clears the location bits of \p addr in \p bits, if \p addr is associated
   /// with a location.
-  void clearBits(Bits &bits, SILValue addr) const {
-    if (auto *loc = getLocation(addr))
-      bits.reset(loc->subLocations);
+  void clearBits(Bits &bits, SILValue addr, bool evenTrivial) {
+    if (auto *loc = getLocation(addr)) {
+      const auto &sublocations =
+          evenTrivial ? loc->subLocations
+                      : loc->subLocations & getNonTrivialLocations();
+      bits.reset(sublocations);
+    }
   }
-  
+
   void genBits(Bits &genSet, Bits &killSet, SILValue addr) const {
     if (auto *loc = getLocation(addr)) {
       killSet.reset(loc->subLocations);
@@ -245,10 +249,13 @@ public:
     }
   }
 
-  void killBits(Bits &genSet, Bits &killSet, SILValue addr) const {
+  void killBits(Bits &genSet, Bits &killSet, SILValue addr, bool evenTrivial) {
     if (auto *loc = getLocation(addr)) {
-      killSet |= loc->subLocations;
-      genSet.reset(loc->subLocations);
+      const auto &sublocations =
+          evenTrivial ? loc->subLocations
+                      : loc->subLocations & getNonTrivialLocations();
+      killSet |= sublocations;
+      genSet.reset(sublocations);
     }
   }
 

--- a/include/swift/SIL/MemoryLocations.h
+++ b/include/swift/SIL/MemoryLocations.h
@@ -188,13 +188,9 @@ private:
   /// init_existential_addr and open_existential_addr.
   bool handleNonTrivialProjections;
 
-  /// If true, also analyze trivial memory locations.
-  bool handleTrivialLocations;
-
 public:
-  MemoryLocations(bool handleNonTrivialProjections, bool handleTrivialLocations) :
-    handleNonTrivialProjections(handleNonTrivialProjections),
-    handleTrivialLocations(handleTrivialLocations) {}
+  MemoryLocations(bool handleNonTrivialProjections)
+      : handleNonTrivialProjections(handleNonTrivialProjections) {}
 
   MemoryLocations(const MemoryLocations &) = delete;
   MemoryLocations &operator=(const MemoryLocations &) = delete;

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -176,12 +176,6 @@ void MemoryLocations::analyzeLocation(SILValue loc) {
   SILFunction *function = loc->getFunction();
   assert(function && "cannot analyze a SILValue which is not in a function");
 
-  // Ignore trivial types to keep the number of locations small. Trivial types
-  // are not interesting anyway, because such memory locations are not
-  // destroyed.
-  if (!handleTrivialLocations && loc->getType().isTrivial(*function))
-    return;
-
   /// We don't handle empty tuples and empty structs.
   ///
   /// Locations with empty types don't even need a store to count as

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -139,11 +139,9 @@ class MemoryLifetimeVerifier {
   }
 
 public:
-  MemoryLifetimeVerifier(SILFunction *function, CalleeCache *calleeCache) :
-    function(function),
-    calleeCache(calleeCache),
-    locations(/*handleNonTrivialProjections*/ true,
-              /*handleTrivialLocations*/ true) {}
+  MemoryLifetimeVerifier(SILFunction *function, CalleeCache *calleeCache)
+      : function(function), calleeCache(calleeCache),
+        locations(/*handleNonTrivialProjections*/ true) {}
 
   /// The main entry point to verify the lifetime of all memory locations in
   /// the function.

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -806,3 +806,19 @@ bb3:
   return %r : $()
 }
 
+sil [ossa] @trivial_in_guaranteed_to_in : $@convention(thin) (@in_guaranteed Int) -> () {
+entry(%addr : $*Int):
+  apply undef(%addr) : $@convention(thin) (@in Int) -> ()
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// Legal because Mixed.i was initialized and can never be uninitialized.
+sil [ossa] @test_mixed : $@convention(thin) (@in Mixed, Int) -> Int {
+bb0(%0 : $*Mixed, %1 : $Int):
+  %2 = struct_element_addr %0 : $*Mixed, #Mixed.i
+  store %1 to [trivial] %2 : $*Int
+  destroy_addr %0 : $*Mixed
+  %3 = load [trivial] %2 : $*Int
+  return %3 : $Int
+}

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -143,13 +143,14 @@ bb0(%0 : @owned $T):
 }
 
 // CHECK: SIL memory lifetime failure in @test_mixed: memory is not initialized, but should be
-sil [ossa] @test_mixed : $@convention(thin) (@in Mixed, Int) -> Int {
+sil [ossa] @test_mixed : $@convention(thin) (@in Mixed, Int) -> @owned T {
 bb0(%0 : $*Mixed, %1 : $Int):
   %2 = struct_element_addr %0 : $*Mixed, #Mixed.i
   store %1 to [trivial] %2 : $*Int
   destroy_addr %0 : $*Mixed
-  %3 = load [trivial] %2 : $*Int
-  return %3 : $Int
+  %3 = struct_element_addr %0 : $*Mixed, #Mixed.t
+  %4 = load [take] %3 : $*T
+  return %4 : $T
 }
 
 // CHECK: SIL memory lifetime failure in @test_missing_store_to_trivial: memory is not initialized, but should be

--- a/test/SIL/verifier_nofail.sil
+++ b/test/SIL/verifier_nofail.sil
@@ -10,6 +10,10 @@ sil_stage canonical
 
 import Builtin
 
+struct Int {
+  var _value: Builtin.Int64
+}
+
 protocol P {
 }
 
@@ -22,4 +26,11 @@ bb0(%0 : $*P):
   apply %2<@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", P) Self>(%1) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@inout_aliasable τ_0_0) -> ()
   %9999 = tuple()
   return %9999 : $()
+}
+
+sil @trivial_in_guaranteed_to_in : $@convention(thin) (@in_guaranteed Int) -> () {
+entry(%addr : $*Int):
+  apply undef(%addr) : $@convention(thin) (@in Int) -> ()
+  %7 = tuple ()
+  return %7 : $()
 }


### PR DESCRIPTION
Remove some overzealous verification:

Previously, memory locations whose stored type was trivial were treated just like those whose type was not.

Here, this is loosened so that once a location is initialized, it remains valid despite "consuming uses" unless and until it is _deallocated_.
