### PR TITLE
Lazier lazy sequences

### DIFF
--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -346,12 +346,13 @@ extension BidirectionalCollection where SubSequence == Self {
   public mutating func removeLast(_ k: Int) {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
-    guard let end = index(endIndex, offsetBy: -k, limitedBy: startIndex)
+    let start = startIndex
+    guard let end = index(endIndex, offsetBy: -k, limitedBy: start)
     else {
       _preconditionFailure(
         "Can't remove more items from a collection than it contains")
     }
-    self = self[startIndex..<end]
+    self = self[start..<end]
   }
 }
 

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -379,11 +379,9 @@ extension BidirectionalCollection {
   public __consuming func dropLast(_ k: Int) -> SubSequence {
     _precondition(
       k >= 0, "Can't drop a negative number of elements from a collection")
-    let end = index(
-      endIndex,
-      offsetBy: -k,
-      limitedBy: startIndex) ?? startIndex
-    return self[startIndex..<end]
+    let start = startIndex
+    let end = index(endIndex, offsetBy: -k, limitedBy: start) ?? start
+    return self[start..<end]
   }
 
   /// Returns a subsequence, up to the given maximum length, containing the

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -411,11 +411,10 @@ extension BidirectionalCollection {
     _precondition(
       maxLength >= 0,
       "Can't take a suffix of negative length from a collection")
-    let start = index(
-      endIndex,
-      offsetBy: -maxLength,
-      limitedBy: startIndex) ?? startIndex
-    return self[start..<endIndex]
+    let end = endIndex
+    let limit = startIndex
+    let start = index(end, offsetBy: -maxLength, limitedBy: limit) ?? limit
+    return self[start..<end]
   }
 }
 

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1379,10 +1379,10 @@ extension Collection {
     _precondition(
       maxLength >= 0,
       "Can't take a suffix of negative length from a collection")
+    let end = endIndex
     let amount = Swift.max(0, count - maxLength)
-    let start = index(startIndex,
-      offsetBy: amount, limitedBy: endIndex) ?? endIndex
-    return self[start..<endIndex]
+    let start = index(startIndex, offsetBy: amount, limitedBy: end) ?? end
+    return self[start..<end]
   }
 
   /// Returns a subsequence from the start of the collection up to, but not

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1345,11 +1345,13 @@ extension Collection {
   public __consuming func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
-    var end = startIndex
-    while try end != endIndex && predicate(self[end]) {
+    let start = startIndex
+    let limit = endIndex
+    var end = start
+    while try end != limit && predicate(self[end]) {
       formIndex(after: &end)
     }
-    return self[startIndex..<end]
+    return self[start..<end]
   }
 
   /// Returns a subsequence, up to the given maximum length, containing the

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1295,10 +1295,11 @@ extension Collection {
     while predicate: (Element) throws -> Bool
   ) rethrows -> SubSequence {
     var start = startIndex
-    while try start != endIndex && predicate(self[start]) {
+    let end = endIndex
+    while try start != end && predicate(self[start]) {
       formIndex(after: &start)
     } 
-    return self[start..<endIndex]
+    return self[start..<end]
   }
 
   /// Returns a subsequence, up to the specified maximum length, containing

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1689,10 +1689,11 @@ extension Collection where SubSequence == Self {
   public mutating func removeFirst(_ k: Int) {
     if k == 0 { return }
     _precondition(k >= 0, "Number of elements to remove should be non-negative")
-    guard let idx = index(startIndex, offsetBy: k, limitedBy: endIndex) else {
+    let end = endIndex
+    guard let idx = index(startIndex, offsetBy: k, limitedBy: end) else {
       _preconditionFailure(
         "Can't remove more items from a collection than it contains")
     }
-    self = self[idx..<endIndex]
+    self = self[idx..<end]
   }
 }

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1275,10 +1275,11 @@ extension Collection {
   public __consuming func dropLast(_ k: Int = 1) -> SubSequence {
     _precondition(
       k >= 0, "Can't drop a negative number of elements from a collection")
+    let start = startIndex
+    let limit = endIndex
     let amount = Swift.max(0, count - k)
-    let end = index(startIndex,
-      offsetBy: amount, limitedBy: endIndex) ?? endIndex
-    return self[startIndex..<end]
+    let end = index(start, offsetBy: amount, limitedBy: limit) ?? limit
+    return self[start..<end]
   }
     
   /// Returns a subsequence by skipping elements while `predicate` returns

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1326,9 +1326,10 @@ extension Collection {
     _precondition(
       maxLength >= 0,
       "Can't take a prefix of negative length from a collection")
-    let end = index(startIndex,
-      offsetBy: maxLength, limitedBy: endIndex) ?? endIndex
-    return self[startIndex..<end]
+    let start = startIndex
+    let limit = endIndex
+    let end = index(start, offsetBy: maxLength, limitedBy: limit) ?? limit
+    return self[start..<end]
   }
   
   /// Returns a subsequence containing the initial elements until `predicate`

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1247,8 +1247,9 @@ extension Collection {
   @inlinable
   public __consuming func dropFirst(_ k: Int = 1) -> SubSequence {
     _precondition(k >= 0, "Can't drop a negative number of elements from a collection")
-    let start = index(startIndex, offsetBy: k, limitedBy: endIndex) ?? endIndex
-    return self[start..<endIndex]
+    let end = endIndex
+    let start = index(startIndex, offsetBy: k, limitedBy: end) ?? end
+    return self[start..<end]
   }
 
   /// Returns a subsequence containing all but the specified number of final


### PR DESCRIPTION
I had a look at (#55295) and noticed that some lazy collections could be lazier, specifically by caching `startIndex` and `endIndex` in methods like `Collection/prefix(_:) -> SubSequence`. I have, therefore, written such calls to local variables in Collection.swift and BidirectionalCollection.swift.

#### Example

Take a look at the current implementation of `Collection/prefix(_:) -> SubSequence`:

https://github.com/apple/swift/blob/1ecd9388eca329fecf03904032875b08ce47445f/stdlib/public/core/Collection.swift#L1324-L1332

As you see, it calls `startIndex` twice and `endIndex` once or twice. Most collections can access these in `O(1)`, but some cannot. `LazyFilterSequence` may look at every element in its base sequence to find `startIndex`, for example. Here's how `LazyFilterSequence` computes its `startIndex`: 

https://github.com/apple/swift/blob/30984f5e44e73bf2be69032e6d26ac9bcd3f3baf/stdlib/public/core/Filter.swift#L140-L147

By writing `startIndex` (and `endIndex`) to local variables, `LazyFilterSequence` only has to compute its `startIndex` once:

```
- let end = index(startIndex,
- offsetBy: maxLength, limitedBy: endIndex) ?? endIndex
- return self[startIndex..<end]
+ let start = startIndex
+ let limit = endIndex
+ let end = index(start, offsetBy: maxLength, limitedBy: limit) ?? limit
+ return self[start..<end]
```