### PR TITLE
[SE-0286] Fix issue where forward scanning default value heuristic wouldn't be applied in Swift 6 mode

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -563,8 +563,6 @@ static bool matchCallArgumentsImpl(
       // backward-match rule that skips this parameter if doing so is the only
       // way to successfully match arguments to parameters.
       if (!parameterRequiresArgument(params, paramInfo, paramIdx) &&
-          !param.getPlainType()->getASTContext().LangOpts.hasFeature(
-              Feature::ForwardTrailingClosures) &&
           anyParameterRequiresArgument(
               params, paramInfo, paramIdx + 1,
               nextArgIdx + 1 < numArgs

--- a/test/expr/postfix/call/forward_trailing_closure_errors.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_errors.swift
@@ -17,8 +17,7 @@ func testUnlabeledParamMatching(i: Int, fn: ((Int) -> Int) -> Void) {
   fn { $0 + i} // okay because the parameter label is empty
 }
 
-// When "fuzzy matching is disabled, this will fail.
-func forwardMatchFailure( // expected-note{{declared here}}
+func forwardMatchFailure(
   onError: ((any Error) -> Void)? = nil,
   onCompletion: (Int) -> Void
 ) { }
@@ -26,5 +25,90 @@ func forwardMatchFailure( // expected-note{{declared here}}
 func testForwardMatchFailure() {
   forwardMatchFailure { x in
     print(x)
-  } // expected-error{{missing argument for parameter 'onCompletion' in call}}{{4-4= onCompletion: <#(Int) -> Void#>}}
+  }
+}
+
+func sheet(
+  isPresented: Bool,
+  onDismiss: (() -> Void)? = nil,
+  content: () -> String
+) -> String {
+  content()
+}
+
+func testSwiftUISheetExample() {
+  _ = sheet(isPresented: true) {
+    "Hello world"
+  }
+
+  _ = sheet(isPresented: true)  {
+    print("Was dismissed")
+  } content: {
+    "Hello world"
+  }
+}
+
+// https://github.com/apple/swift/issues/65921
+func issue_65921(onStart: ((String) -> Void)? = nil, onEnd: (String) -> Void) { }
+
+func testIssue65921() {
+  issue_65921 { end in
+    _ = end
+  }
+
+  issue_65921 { start in
+    _ = start
+  } onEnd: { end in
+    _ = end
+  }
+}
+
+struct BlockObserver {
+  var startHandler: ((Any) -> Void)? = nil
+  var produceHandler: ((Any, Any) -> Void)? = nil
+  var finishHandler: ((Any, Any, Any) -> Void)? = nil
+}
+
+func testBlockObserverExample() {
+  // This was valid under the backwards scan rule in Swift 5 but is no longer valid in Swift 6
+  _ = BlockObserver { _, _, _ in } // expected-error {{contextual closure type '(Any) -> Void' expects 1 argument, but 3 were used in closure body}}
+  
+  _ = BlockObserver { _ in } produceHandler: { _, _ in }
+  _ = BlockObserver { _ in } finishHandler: { _, _, _ in }
+  
+  _ = BlockObserver { _ in }
+    produceHandler: { _, _ in }
+    finishHandler: { _, _, _ in }
+}
+
+func trailingClosures(
+  arg1: () -> Void,
+  arg2: () -> Void = {},
+  arg3: () -> Void = {}
+) {}
+
+func testTrailingClosures() {
+  trailingClosures { print("Hello!") }
+  trailingClosures { print("Hello,") } arg3: { print("world!") }
+}
+
+// In Swift 5 mode either f or g can be used as a trailing closure.
+// In Swift 6 mode only f can be used as a trailing closure.
+func trailingClosureEitherDirection(
+  f: (Int) -> Int = { $0 }, g: (Int, Int) -> Int = { $0 + $1 }
+) { }
+
+func testTrailingClosureEitherDirection() {
+  trailingClosureEitherDirection { -$0 }
+  trailingClosureEitherDirection { $0 * $1 } // expected-error{{contextual closure type '(Int) -> Int' expects 1 argument, but 2 were used in closure body}}
+}
+
+// This example was allowed as a trailing closure in Swift 5 mode but is no longer allowed in Swift 6 mode
+struct AccidentalReorder {
+  let content: () -> Int
+  var optionalInt: Int?
+}
+
+func testAccidentalReorder() {
+  _ = AccidentalReorder(optionalInt: 17) { 42 } // expected-error{{incorrect argument label in call (have 'optionalInt:_:', expected 'content:optionalInt:')}}
 }

--- a/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
+++ b/test/expr/postfix/call/forward_trailing_closure_fuzzy.swift
@@ -58,3 +58,55 @@ struct AccidentalReorder { // expected-note{{'init(content:optionalInt:)' declar
 func testAccidentalReorder() {
   _ = AccidentalReorder(optionalInt: 17) { 42 } // expected-warning{{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'content' to suppress this warning}}
 }
+
+func sheet(
+  isPresented: Bool,
+  onDismiss: (() -> Void)? = nil,
+  content: () -> String
+) -> String {
+  content()
+}
+
+func testSwiftUISheetExample() {
+  _ = sheet(isPresented: true) {
+    "Hello world"
+  }
+
+  _ = sheet(isPresented: true)  {
+    print("Was dismissed")
+  } content: {
+    "Hello world"
+  }
+}
+
+// https://github.com/apple/swift/issues/65921
+func issue_65921(onStart: ((String) -> Void)? = nil, onEnd: (String) -> Void) { }
+
+func testIssue65921() {
+  issue_65921 { end in
+    _ = end
+  }
+
+  issue_65921 { start in
+    _ = start
+  } onEnd: { end in
+    _ = end
+  }
+}
+
+struct BlockObserver { // expected-note {{'init(startHandler:produceHandler:finishHandler:)' declared here}}
+  var startHandler: ((Any) -> Void)? = nil
+  var produceHandler: ((Any, Any) -> Void)? = nil
+  var finishHandler: ((Any, Any, Any) -> Void)? = nil
+}
+
+func testBlockObserverExample() {
+  _ = BlockObserver { _, _, _ in } // expected-warning {{backward matching of the unlabeled trailing closure is deprecated; label the argument with 'finishHandler' to suppress this warning}}
+  
+  _ = BlockObserver { _ in } produceHandler: { _, _ in }
+  _ = BlockObserver { _ in } finishHandler: { _, _, _ in }
+  
+  _ = BlockObserver { _ in }
+    produceHandler: { _, _ in }
+    finishHandler: { _, _, _ in }
+}


### PR DESCRIPTION
This PR fixes https://github.com/apple/swift/issues/65921, which is a bug related to [SE-0286](https://github.com/apple/swift-evolution/blob/master/proposals/0286-forward-scan-trailing-closures.md).

The following examples compile successfully in Swift 5 mode, but currently fail to compile in Swift 6 mode, or in Swift 5 mode with the `ForwardTrailingClosures` upcoming feature enabled:

```swift
func sheet(
  isPresented: Bool,
  onDismiss: (() -> Void)? = nil,
  content: () -> String
) -> String { content() }

// error: missing argument for parameter 'content' in call
_ = sheet(isPresented: true) {
  "Hello world"
}

func issue_65921(onStart: ((String) -> Void)? = nil, onEnd: (String) -> Void) { }

// error: missing argument for parameter 'onEnd' in call
issue_65921 { end in
  _ = end
}
```

I believe these examples are expected to compile in Swift 6 based on this section of SE-0286, which says it applies to all language versions and not just Swift 5:

> ## Mitigating the source compatibility impact (all language versions)
> ... We can turn this into an heuristic to accept more existing code, reducing the source breaking impact of the proposal. Specifically, if
>  - the parameter that would match the unlabeled trailing closure argument does not require an argument (because it is variadic or has a default argument), and
>  - there are parameters after that parameter that require an argument, up until the first parameter whose label matches that of the next trailing closure (if any)
>
> then do not match the unlabeled trailing closure to that parameter. Instead, skip it and examine the next parameter to see if that should be matched against the unlabeled trailing closure. For the `View.sheet(isPresented:onDismiss:content:`) API, this means that `onDismiss`, which has a default argument, will be skipped in the forward match so that the unlabeled trailing closure will match `content:`, allowing this code to continue to compile correctly.

This issue appears to be that the code implementing the heuristic described above is disabled in Swift 6 mode. Updating the code to apply to all language modes makes it so these examples compile successfully.

Please review: @DougGregor