### PR TITLE
Lazier first element

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1099,9 +1099,8 @@ extension Collection {
   ///     // Prints "10"
   @inlinable
   public var first: Element? {
-    let start = startIndex
-    if start != endIndex { return self[start] }
-    else { return nil }
+    var iterator = makeIterator()
+    return iterator.next()
   }
 
   /// A value less than or equal to the number of elements in the collection.


### PR DESCRIPTION
I found this issue (#55374) and propose a lazier Collection/first. The new approach uses `Iterator/next()`, similar to `first { _ in true }`. Currently, one may use the latter to circumvent a problem where the original code forces lazy collections to perform more work than necessary, as shown in the following example:

```swift
var a = 0 as Int
var b = 0 as Int

_ = (0...9).lazy.compactMap({ a += 1; return $0 }).first
_ = (0...9).lazy.compactMap({ b += 1; return $0 }).first { _ in true }

print(a) // 2 in Swift 5.9, 1 with the proposed approach
print(b) // 1
```

---

Godbolt: https://godbolt.org/z/c4o1xz8dW

---