### PR TITLE
[Macros] Reproduce issue with peer+extension macro extension's methods not being checked as witnesses

### DIFF
--- a/stdlib/public/Distributed/DistributedMacros.swift
+++ b/stdlib/public/Distributed/DistributedMacros.swift
@@ -17,6 +17,7 @@ import _Concurrency
 
 #if $Macros
 
+// FIXME: the fact tha this is peer and extension makes the extension's methods not found as witnesses
 @attached(peer, names: prefixed(`$`)) // provides $Greeter concrete stub type
 @attached(extension, names: arbitrary) // provides extension for Greeter & _DistributedActorStub
 public macro _DistributedProtocol() =

--- a/stdlib/public/Distributed/DistributedMacros.swift
+++ b/stdlib/public/Distributed/DistributedMacros.swift
@@ -17,7 +17,6 @@ import _Concurrency
 
 #if $Macros
 
-// FIXME: the fact tha this is peer and extension makes the extension's methods not found as witnesses
 @attached(peer, names: prefixed(`$`)) // provides $Greeter concrete stub type
 @attached(extension, names: arbitrary) // provides extension for Greeter & _DistributedActorStub
 public macro _DistributedProtocol() =

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
@@ -7,10 +7,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
 
-// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -plugin-path %swift-plugin-dir -I %t -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s
-
-// FIXME: inheritance tests limited because cannot refer to any generated macro from the same module...
-// XFAIL: *
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -plugin-path %swift-plugin-dir -I %t -dump-macro-expansions %s 2>&1 | %FileCheck %s
 
 import Distributed
 
@@ -19,62 +16,48 @@ typealias System = LocalTestingDistributedActorSystem
 @_DistributedProtocol
 protocol EmptyBase {}
 
-// TODO: allow this?
-//@_DistributedProtocol
-//extension EmptyBase {}
-
 // @_DistributedProtocol ->
 //
-// CHECK: @freestanding(declaration)
-// CHECK: macro _distributed_stubs_EmptyBase() =
-// CHECK:   #distributedStubs(
-// CHECK:     module: "main", protocolName: "EmptyBase",
-// CHECK:     stubProtocols: []
-// CHECK:   )
-//
-// CHECK: // distributed actor $EmptyBase <ActorSystem>: EmptyBase  where SerializationRequirement == any Codable {
-// CHECK: distributed actor $EmptyBase : EmptyBase  {
-// CHECK:   typealias ActorSystem = LocalTestingDistributedActorSystem // FIXME: remove this
-//
-// CHECK:   #distributedStubs(
-// CHECK:     module: "main", protocolName: "EmptyBase",
-// CHECK:     stubProtocols: []
-// CHECK:   )
+// CHECK: distributed actor $EmptyBase<ActorSystem>: EmptyBase,
+// CHECK:   Distributed._DistributedActorStub
+// CHECK:   where ActorSystem: DistributedActorSystem<any Codable>,
+// CHECK:         ActorSystem.ActorID: Codable
+// CHECK:  {
+// CHECK:  }
+
+// CHECK: extension EmptyBase where Self: Distributed._DistributedActorStub {
 // CHECK: }
 
+// ==== ------------------------------------------------------------------------
+
 @_DistributedProtocol
-protocol G3: DistributedActor, EmptyBase where SerializationRequirement == any Codable {
+protocol G3<ActorSystem>: DistributedActor, EmptyBase where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func get() -> String
   distributed func greet(name: String) -> String
 }
 
 // @_DistributedProtocol ->
-//
-// Since we have also the EmptyBase we don't know what names it will introduce,
-// so this stubs macro must be "names: arbitrary":
-// CHECK: @freestanding(declaration, names: arbitrary)
-// CHECK: macro _distributed_stubs_G3() =
-// CHECK:   #distributedStubs(
-// CHECK:     module: "main", protocolName: "G3",
-// CHECK:     stubProtocols: ["EmptyBase"],
-// CHECK:     "distributed func get() -> String",
-// CHECK:     "distributed func greet(name: String) -> String"
-// CHECK:   )
-//
-// TODO: distributed actor $G3<ActorSystem>: Greeter where SerializationRequirement == any Codable {
-// CHECK: distributed actor $G3: G3, EmptyBase {
-// TODO:    Preferably, we could refer to our own macro like this: #_distributed_stubs_G3
-// WORKAROUND:
-// CHECK:   #distributedStubs(
-// CHECK:      module: "main", protocolName: "G3",
-// CHECK:      stubProtocols: ["EmptyBase"],
-// CHECK:      "distributed func get() -> String",
-// CHECK:      "distributed func greet(name: String) -> String"
-// CHECK:    )
-// CHECK:
-// FIXME: the below cannot find the macro because it's form the same module
-// CHECK:    // stub inherited members
-// CHECK:    #_distributed_stubs_EmptyBase
+// CHECK: distributed actor $G3<ActorSystem>: G3
+// CHECK:   Distributed._DistributedActorStub
+// CHECK:   where ActorSystem: DistributedActorSystem<any Codable>,
+// CHECK:         ActorSystem.ActorID: Codable
+// CHECK: {
 // CHECK: }
 
-// ==== ------------------------------------------------------------------------
+// CHECK: extension G3 where Self: Distributed._DistributedActorStub {
+// CHECK:   func get() -> String {
+// CHECK:     if #available (SwiftStdlib 5.11, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK:   distributed func greet(name: String) -> String {
+// CHECK:     if #available (SwiftStdlib 5.11, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
@@ -11,29 +11,26 @@
 
 import Distributed
 
-// FIXME: the errors below are bugs: the added methods should be considered witnesses rdar://123012943
-// expected-note@+1{{in expansion of macro '_DistributedProtocol' on protocol 'Greeter' here}}
 @_DistributedProtocol
 protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
-  // FIXME: this is a bug
-  // expected-note@+1{{protocol requires function 'greet(name:)' with type '(String) -> String'}}
   distributed func greet(name: String) -> String
 }
 
 // @_DistributedProtocol ->
 
-// CHECK: distributed actor $Greeter<ActorSystem>: Greeter, _DistributedActorStub
-// CHECK:   where ActorSystem: DistributedActorSystem<any Codable>,
-// CHECK:   ActorSystem.ActorID: Codable
-// CHECK: {
-// CHECK: }
+// CHECK: distributed actor $Greeter<ActorSystem>: Greeter,
+// CHECK-NEXT: Distributed._DistributedActorStub
+// CHECK-NEXT: where ActorSystem: DistributedActorSystem<any Codable>,
+// CHECK-NEXT: ActorSystem.ActorID: Codable
+// CHECK-NEXT: {
+// CHECK-NEXT: }
 
-// CHECK: extension Greeter {
-// CHECK:   distributed func greet(name: String) -> String {
-// CHECK:     if #available (SwiftStdlib 5.11, *) {
-// CHECK:       Distributed._distributedStubFatalError()
-// CHECK:     } else {
-// CHECK:       fatalError()
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
+// CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
+// CHECK-NEXT:   distributed func greet(name: String) -> String {
+// CHECK-NEXT:     if #available (SwiftStdlib 5.11, *) {
+// CHECK-NEXT:       Distributed._distributedStubFatalError()
+// CHECK-NEXT:     } else {
+// CHECK-NEXT:       fatalError()
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -158,9 +158,10 @@ func callNestedExpansionMember() {
   NestedMacroExpansion.member()
 }
 
-@attached(peer, names: arbitrary) // introduces `__GenerateStubsForProtocolRequirements
+@attached(peer, names: prefixed(`__`)) // introduces `__GenerateStubsForProtocolRequirements
 @attached(extension, names: arbitrary) // introduces `extension GenerateStubsForProtocolRequirements`
 macro GenerateStubsForProtocolRequirements() = #externalMacro(module: "MacroDefinition", type: "GenerateStubsForProtocolRequirementsMacro")
+
 protocol _TestStub {} // used by 'GenerateStubsForProtocolRequirements'
 
 @GenerateStubsForProtocolRequirements

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -157,3 +157,20 @@ struct NestedMacroExpansion {}
 func callNestedExpansionMember() {
   NestedMacroExpansion.member()
 }
+
+@attached(peer, names: arbitrary) // introduces `__GenerateStubsForProtocolRequirements
+@attached(extension, names: arbitrary) // introduces `extension GenerateStubsForProtocolRequirements`
+macro GenerateStubsForProtocolRequirements() = #externalMacro(module: "MacroDefinition", type: "GenerateStubsForProtocolRequirementsMacro")
+protocol _TestStub {} // used by 'GenerateStubsForProtocolRequirements'
+
+@GenerateStubsForProtocolRequirements
+protocol MacroExpansionRequirements {
+  func hello(name: String) -> String
+}
+// struct __MacroExpansionRequirements: _TestStub where ...
+// extension MacroExpansionRequirements where Self: _TestStub ...
+
+func testWitnessStub() {
+  let stub: any MacroExpansionRequirements = __MacroExpansionRequirements()
+  _ = stub.hello(name: "Caplin")
+}


### PR DESCRIPTION
This narrows down and reproduces rdar://123012943

This is blocking the `@_DistributedProtocol` macro from working entirely since the methods introduced by the extension macro are not seen as witnesses.

It happens when a macro is both peer and extension;

- the `extension` 
  - the role's names must be `names: arbitrary` because we don't know statically what method names we'll introduce -- it depends on the protocol we're attached to
- the peer role 
  - would want to be `names: prefixed('$')` ... that seems to break things and the methods in the extension don't get "noticed" as witnesses
  - perhaps the system assumes they're going to be $ prefixed -- even though the extension roles' names are arbitrary?
  - we cannot make peer role's names "arbitrary" because `'peer' macros are not allowed to introduce arbitrary names at global scope`

So this is somewhat blocked -- this looks like a bug in handling the names in the extension macro role, and not looking for the witnesses.

If a macro is made to be just extension the macro's introduced methods do properly witness the requirement.