### PR TITLE
MoveOnlyAddressChecker: Relax more checks to accommodate borrowing switch codegen.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1128,11 +1128,10 @@ void UseState::initializeLiveness(
     liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
   }
 
-  // Assume a strict check of a temporary is initialized before the check.
-  if (auto *asi = dyn_cast<BeginAccessInst>(address->getOperand());
-      asi && address->isStrict()) {
+  // Assume a strict-checked value initialized before the check.
+  if (address->isStrict()) {
     LLVM_DEBUG(llvm::dbgs()
-               << "Adding strict-marked begin_access as init!\n");
+               << "Adding strict marker as init!\n");
     recordInitUse(address, address, liveness.getTopLevelSpan());
     liveness.initializeDef(SILValue(address), liveness.getTopLevelSpan());
   }

--- a/test/SILOptimizer/moveonly_borrowing_switch.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch.swift
@@ -242,3 +242,24 @@ func testOuterAO(consuming bas: consuming AOBas) { // expected-error{{'bas' used
     }
 }
 
+enum E<T>: ~Copyable {
+    case a(T)
+}
+
+extension E {
+    func f() {
+        switch self {
+        case .a:
+            print("a")
+        }
+    }
+
+    func g() {
+        switch self {
+        case .a(_borrowing t): // expected-warning{{}}
+            print("a")
+        }
+    }
+}
+
+E.a(1).f()


### PR DESCRIPTION
`unchecked_take_enum_data_addr` should not be considered a write when it's non- destructive; this should eventually be an inherent property of the instruction, but there are other passes which miscompile currently if we change that now. Meanwhile, wrapping a copyable value should always be considered an initialization too.