### PR TITLE
[Concurrency] Don't add redundant implicit `@preconcurrency` attributes.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5009,7 +5009,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
             CustomAttr::create(ctx, SourceLoc(), typeExpr, /*implicit=*/true);
         value->getAttrs().add(attr);
 
-        if (inferred.preconcurrency()) {
+        if (inferred.preconcurrency() &&
+            !value->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
           auto preconcurrency =
               new (ctx) PreconcurrencyAttr(/*isImplicit*/true);
           value->getAttrs().add(preconcurrency);

--- a/test/ModuleInterface/concurrency.swift
+++ b/test/ModuleInterface/concurrency.swift
@@ -32,6 +32,7 @@ public protocol UnsafeMainProtocol {
 
 public struct InferredUnsafeMainActor: UnsafeMainProtocol {
   public func requirement() {}
+  @preconcurrency public func explicitPreconcurrency() {}
 }
 
 @preconcurrency @MainActor
@@ -41,6 +42,7 @@ public protocol PreconcurrencyMainProtocol {
 
 public struct InferredPreconcurrencyMainActor: PreconcurrencyMainProtocol {
   public func requirement() {}
+  @preconcurrency public func explicitPreconcurrency() {}
 }
 
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -I %t
@@ -67,6 +69,7 @@ func callFn() async {
 
 // CHECK:      @_Concurrency.MainActor @preconcurrency public struct InferredUnsafeMainActor :
 // CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency public func requirement()
+// CHECK-NEXT:   @preconcurrency @_Concurrency.MainActor public func explicitPreconcurrency()
 // CHECK-NEXT: }
 
 // CHECK:      @preconcurrency @_Concurrency.MainActor public protocol PreconcurrencyMainProtocol {
@@ -75,6 +78,7 @@ func callFn() async {
 
 // CHECK:      @_Concurrency.MainActor @preconcurrency public struct InferredPreconcurrencyMainActor :
 // CHECK-NEXT:   @_Concurrency.MainActor @preconcurrency public func requirement()
+// CHECK-NEXT:   @preconcurrency @_Concurrency.MainActor public func explicitPreconcurrency()
 // CHECK-NEXT: }
 
 


### PR DESCRIPTION
Declarations with inferred `@preconcurrency` attributes may already list the attribute explicitly. In that case, we don't need to add an implicit `@preconcurrency` attribute.

Resolves rdar://123250355