### PR TITLE
[embedded] Promote -g to -gdwarf-types by default on embedded Swift

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3274,6 +3274,10 @@ bool CompilerInvocation::parseArgs(
     SILOpts.EmbeddedSwift = true;
     // OSSA modules are required for deinit de-virtualization.
     SILOpts.EnableOSSAModules = true;
+    // -g is promoted to -gdwarf-types in embedded Swift
+    if (IRGenOpts.DebugInfoLevel == IRGenDebugInfoLevel::ASTTypes) {
+      IRGenOpts.DebugInfoLevel = IRGenDebugInfoLevel::DwarfTypes;
+    }
   } else {
     if (SILOpts.NoAllocations) {
       Diags.diagnose(SourceLoc(), diag::no_allocations_without_embedded);

--- a/test/embedded/debuginfo-dwarf-types.swift
+++ b/test/embedded/debuginfo-dwarf-types.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -g -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=CHECK-G
+// RUN: %target-swift-frontend -g -O -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=CHECK-G
+// RUN: %target-swift-frontend -g -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=CHECK-G
+// RUN: %target-swift-frontend -gdwarf-types -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=CHECK-G
+// RUN: %target-swift-frontend -gdwarf-types -O -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=CHECK-G
+// RUN: %target-swift-frontend -gdwarf-types -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=CHECK-G
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=CHECK-GNONE
+// RUN: %target-swift-frontend -O -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=CHECK-GNONE
+// RUN: %target-swift-frontend -Osize -emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s --check-prefix=CHECK-GNONE
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public struct MyType {
+    var x, y: Int
+}
+public func foo(_ t: MyType) {}
+
+// CHECK-G: !DICompositeType(tag: DW_TAG_structure_type, name: "MyType"
+// CHECK-G: !DIDerivedType(tag: DW_TAG_member, name: "x"
+// CHECK-G: !DIDerivedType(tag: DW_TAG_member, name: "y"
+
+// CHECK-GNONE-NOT: !DICompositeType(tag: DW_TAG_structure_type, name: "MyType"


### PR DESCRIPTION
Embedded Swift doesn't produce reflection metadata, which means the debugger can't use those to provide type information. There has been ongoing development to get the existing `-gdwarf-types` debug info generation into a good shape, so let's start using that in -g build of embedded Swift.