### PR TITLE
NCGenerics: loosen builtin requirements

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -884,7 +884,7 @@ static ValueDecl *getTakeOperation(ASTContext &ctx, Identifier id) {
 
 static ValueDecl *getStoreOperation(ASTContext &ctx, Identifier id) {
   return getBuiltinFunction(ctx, id, _thin,
-                            _generics(_unrestricted, _conformsToDefaults(0)),
+                            _generics(_unrestricted),
                             _parameters(_owned(_typeparam(0)),
                                         _rawPointer),
                             _void);
@@ -892,7 +892,7 @@ static ValueDecl *getStoreOperation(ASTContext &ctx, Identifier id) {
 
 static ValueDecl *getDestroyOperation(ASTContext &ctx, Identifier id) {
   return getBuiltinFunction(ctx, id, _thin,
-                            _generics(_unrestricted, _conformsToDefaults(0)),
+                            _generics(_unrestricted),
                             _parameters(_metatype(_typeparam(0)),
                                         _rawPointer),
                             _void);
@@ -900,7 +900,7 @@ static ValueDecl *getDestroyOperation(ASTContext &ctx, Identifier id) {
 
 static ValueDecl *getDestroyArrayOperation(ASTContext &ctx, Identifier id) {
   return getBuiltinFunction(ctx, id, _thin,
-                            _generics(_unrestricted, _conformsToDefaults(0)),
+                            _generics(_unrestricted),
                             _parameters(_metatype(_typeparam(0)),
                                         _rawPointer,
                                         _word),
@@ -920,9 +920,20 @@ static ValueDecl *getAssumeAlignment(ASTContext &ctx, Identifier id) {
                             _rawPointer);
 }
 
+static ValueDecl *getCopyArrayOperation(ASTContext &ctx, Identifier id) {
+  return getBuiltinFunction(ctx, id, _thin,
+                            _generics(_unrestricted,
+                                      _conformsTo(_typeparam(0), _copyable)),
+                            _parameters(_metatype(_typeparam(0)),
+                                        _rawPointer,
+                                        _rawPointer,
+                                        _word),
+                            _void);
+}
+
 static ValueDecl *getTransferArrayOperation(ASTContext &ctx, Identifier id) {
   return getBuiltinFunction(ctx, id, _thin,
-                            _generics(_unrestricted, _conformsToDefaults(0)),
+                            _generics(_unrestricted),
                             _parameters(_metatype(_typeparam(0)),
                                         _rawPointer,
                                         _rawPointer,
@@ -985,9 +996,7 @@ static ValueDecl *getAllocWithTailElemsOperation(ASTContext &Context,
 static ValueDecl *getProjectTailElemsOperation(ASTContext &ctx,
                                                Identifier id) {
   return getBuiltinFunction(ctx, id, _thin,
-                            _generics(_unrestricted, _unrestricted,
-                                      _conformsToDefaults(0),
-                                      _conformsToDefaults(1)),
+                            _generics(_unrestricted, _unrestricted),
                             _parameters(_typeparam(0),
                                         _metatype(_typeparam(1))),
                             _rawPointer);
@@ -1007,9 +1016,7 @@ static ValueDecl *getGepOperation(ASTContext &ctx, Identifier id,
 static ValueDecl *getGetTailAddrOperation(ASTContext &ctx, Identifier id,
                                           Type argType) {
   return getBuiltinFunction(ctx, id, _thin,
-                            _generics(_unrestricted, _unrestricted,
-                                      _conformsToDefaults(0),
-                                      _conformsToDefaults(1)),
+                            _generics(_unrestricted, _unrestricted),
                             _parameters(_rawPointer,
                                         argType,
                                         _metatype(_typeparam(0)),
@@ -2785,12 +2792,15 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
     return getDestroyArrayOperation(Context, Id);
       
   case BuiltinValueKind::CopyArray:
-  case BuiltinValueKind::TakeArrayNoAlias:
-  case BuiltinValueKind::TakeArrayFrontToBack:
-  case BuiltinValueKind::TakeArrayBackToFront:
   case BuiltinValueKind::AssignCopyArrayNoAlias:
   case BuiltinValueKind::AssignCopyArrayFrontToBack:
   case BuiltinValueKind::AssignCopyArrayBackToFront:
+    if (!Types.empty()) return nullptr;
+    return getCopyArrayOperation(Context, Id);
+
+  case BuiltinValueKind::TakeArrayNoAlias:
+  case BuiltinValueKind::TakeArrayFrontToBack:
+  case BuiltinValueKind::TakeArrayBackToFront:
   case BuiltinValueKind::AssignTakeArray:
     if (!Types.empty()) return nullptr;
     return getTransferArrayOperation(Context, Id);

--- a/test/SILOptimizer/moveonly_builtins.swift
+++ b/test/SILOptimizer/moveonly_builtins.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-frontend-typecheck -verify %s -DILLEGAL \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-builtin-module \
+// RUN:   -verify-additional-prefix illegal-
+
+// RUN: %target-swift-frontend -emit-sil -sil-verify-all -verify %s \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-builtin-module
+
+import Builtin
+
+struct NC: ~Copyable {}
+
+func checkPointerBuiltins(_ ptr: Builtin.RawPointer, _ value: consuming NC) {
+  Builtin.initialize(value, ptr)
+#if ILLEGAL
+  Builtin.copy(value) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'copy'}}
+#endif
+}
+
+func checkArrayBuiltins(_ dest: Builtin.RawPointer, src: Builtin.RawPointer, count: Builtin.Word) {
+  Builtin.takeArrayFrontToBack(NC.self, dest, src, count)
+  Builtin.takeArrayBackToFront(NC.self, dest, src, count)
+  Builtin.assignTakeArray(NC.self, dest, src, count)
+  Builtin.destroyArray(NC.self, dest, count)
+
+#if ILLEGAL
+  Builtin.copyArray(NC.self, dest, src, count) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'copyArray'}}
+  Builtin.assignCopyArrayNoAlias(NC.self, dest, src, count) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'assignCopyArrayNoAlias'}}
+  Builtin.assignCopyArrayFrontToBack(NC.self, dest, src, count) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'assignCopyArrayFrontToBack'}}
+  Builtin.assignCopyArrayBackToFront(NC.self, dest, src, count) // expected-illegal-error {{noncopyable type 'NC' cannot be substituted for copyable generic parameter 'T' in 'assignCopyArrayBackToFront'}}
+#endif
+}


### PR DESCRIPTION
A number of builtins that do not actually copy their argument(s) were requiring Copyable anyway.

rdar://123253877
