### PR TITLE
[IRGen] Noncopyable enums dont forward.

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1953,7 +1953,8 @@ namespace {
              "extra inhabitant zero");
         
         unsigned numTags = ElementsWithNoPayload.size();
-        if (payloadTI.canValueWitnessExtraInhabitantsUpTo(IGM, numTags-1)) {
+        if (payloadTI.canValueWitnessExtraInhabitantsUpTo(IGM, numTags - 1) &&
+            payloadTI.isCopyable(ResilienceExpansion::Maximal)) {
           CopyDestroyKind = ForwardToPayload;
         }
       }

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -387,6 +387,7 @@ bool StructLayoutBuilder::addField(ElementLayout &elt,
   IsKnownBitwiseTakable &= eltTI.isBitwiseTakable(ResilienceExpansion::Maximal);
   IsKnownAlwaysFixedSize &= eltTI.isFixedSize(ResilienceExpansion::Minimal);
   IsLoadable &= eltTI.isLoadable();
+  IsKnownCopyable &= eltTI.isCopyable(ResilienceExpansion::Maximal);
 
   if (eltTI.isKnownEmpty(ResilienceExpansion::Maximal)) {
     addEmptyElement(elt);

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -2419,7 +2419,9 @@ void EnumTypeLayoutEntry::computeProperties() {
 
 EnumTypeLayoutEntry::CopyDestroyStrategy
 EnumTypeLayoutEntry::copyDestroyKind(IRGenModule &IGM) const {
-  if (isTriviallyDestroyable()) {
+  if (ty.isMoveOnly()) {
+    return Normal;
+  } else if (isTriviallyDestroyable()) {
     return TriviallyDestroyable;
   } else if (isSingleton()) {
     return ForwardToPayload;

--- a/test/IRGen/moveonly_enum_deinits.swift
+++ b/test/IRGen/moveonly_enum_deinits.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-emit-irgen \
+// RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     %s \
+// RUN: | \
+// RUN: %FileCheck %s
+
+// CHECK-LABEL: define{{.*}} void @"$s21moveonly_enum_deinits4ListOwxx"(
+// CHECK-SAME:      ptr noalias %object, 
+// CHECK-SAME:      ptr %List)
+// CHECK:       entry:
+// CHECK:         br i1 {{%[^,]+}},
+// CHECK-SAME:        label %[[EXIT:[^,]+]],
+// CHECK-SAME:        label %[[PAYLOAD:[^,]+]]
+// CHECK:       [[PAYLOAD]]:
+// CHECK:         br label %[[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK:         ret void
+// CHECK:       }
+
+struct Box<T : ~Copyable> : ~Copyable {
+    public init(_ l: consuming T) {}
+        
+    deinit {}
+}
+
+enum List: ~Copyable {
+    case end
+    case more(Int, Box<List>)
+}


### PR DESCRIPTION
If a payload is non-copyable, do not use the forward-to-payload strategy for single-payload enums.

rdar://123197700
