### PR TITLE
Serialization: Skip invalid decls during module serialization

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -811,6 +811,9 @@ ERROR(sema_opening_import,Fatal,
 REMARK(serialization_skipped_invalid_decl,none,
        "serialization skipped invalid %kind0",
        (const Decl *))
+REMARK(serialization_skipped_invalid_type,none,
+       "serialization skipped for invalid type %0",
+       (TypeRepr *))
 ERROR(serialization_failed,none,
       "serialization of module %0 failed due to the errors above",
       (const ModuleDecl *))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -808,6 +808,13 @@ WARNING(sema_import_current_module_with_file,none,
 ERROR(sema_opening_import,Fatal,
       "opening import file for module %0: %1", (Identifier, StringRef))
 
+REMARK(serialization_skipped_invalid_decl,none,
+       "serialization skipped invalid %kind0",
+       (const Decl *))
+ERROR(serialization_failed,none,
+      "serialization of module %0 failed due to the errors above",
+      (const ModuleDecl *))
+
 ERROR(serialization_load_failed,Fatal,
       "failed to load module '%0'", (StringRef))
 ERROR(module_interface_build_failed,Fatal,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -814,6 +814,9 @@ REMARK(serialization_skipped_invalid_decl,none,
 REMARK(serialization_skipped_invalid_type,none,
        "serialization skipped for invalid type %0",
        (TypeRepr *))
+REMARK(serialization_skipped_invalid_type_unknown_name,none,
+       "serialization skipped for invalid type",
+       ())
 ERROR(serialization_failed,none,
       "serialization of module %0 failed due to the errors above",
       (const ModuleDecl *))

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -243,6 +243,9 @@ namespace swift {
     /// Emit remarks about contextual inconsistencies in loaded modules.
     bool EnableModuleRecoveryRemarks = false;
 
+    /// Emit remarks for unexpected conditions when serializing a module.
+    bool EnableModuleSerializationRemarks = false;
+
     /// Emit remarks about the source of each element exposed by the module API.
     bool EnableModuleApiImportRemarks = false;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -417,6 +417,10 @@ def remark_skip_explicit_interface_build : Flag<["-"], "Rskip-explicit-interface
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit a remark if an explicit module interface invocation has an early exit because the expected output is up-to-date">;
 
+def remark_module_serialization : Flag<["-"], "Rmodule-serialization">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit remarks about module serialization">;
+
 def emit_tbd : Flag<["-"], "emit-tbd">,
   HelpText<"Emit a TBD file">,
   Flags<[FrontendOption, NoInteractiveOption, SupplementaryOutput]>;

--- a/include/swift/Serialization/SerializationOptions.h
+++ b/include/swift/Serialization/SerializationOptions.h
@@ -159,6 +159,7 @@ namespace swift {
     bool IsOSSA = false;
     bool SkipNonExportableDecls = false;
     bool ExplicitModuleBuild = false;
+    bool EnableSerializationRemarks = false;
   };
 
 } // end namespace swift

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1088,6 +1088,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
   Opts.EnableModuleRecoveryRemarks = Args.hasArg(OPT_remark_module_recovery);
+  Opts.EnableModuleSerializationRemarks =
+      Args.hasArg(OPT_remark_module_serialization);
   Opts.EnableModuleApiImportRemarks = Args.hasArg(OPT_remark_module_api_import);
   Opts.EnableMacroLoadingRemarks = Args.hasArg(OPT_remark_macro_loading);
   Opts.EnableIndexingSystemModuleRemarks = Args.hasArg(OPT_remark_indexing_system_module);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -253,6 +253,9 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
 
   serializationOpts.ExplicitModuleBuild = FrontendOpts.DisableImplicitModules;
 
+  serializationOpts.EnableSerializationRemarks =
+      getLangOptions().EnableModuleSerializationRemarks;
+
   return serializationOpts;
 }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -583,6 +583,10 @@ private:
   /// If the type is invalid, records that an error occurred and returns
   /// true if the type should be skipped.
   bool skipTypeIfInvalid(Type ty, TypeRepr *tyRepr);
+
+  /// If the type is invalid, records that an error occurred and returns
+  /// true if the type should be skipped.
+  bool skipTypeIfInvalid(Type ty, SourceLoc loc);
 };
 
 } // end namespace serialization

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -579,6 +579,10 @@ private:
   /// If the declaration is invalid, records that an error occurred and returns
   /// true if the decl should be skipped.
   bool skipDeclIfInvalid(const Decl *decl);
+
+  /// If the type is invalid, records that an error occurred and returns
+  /// true if the type should be skipped.
+  bool skipTypeIfInvalid(Type ty, TypeRepr *tyRepr);
 };
 
 } // end namespace serialization

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -112,6 +112,10 @@ class Serializer : public SerializerBase {
 
   SmallVector<DeclID, 16> exportedPrespecializationDecls;
 
+  /// Will be set to true if any serialization step failed, for example due to
+  /// an error in the AST.
+  bool hadError = false;
+
   /// Helper for serializing entities in the AST block object graph.
   ///
   /// Keeps track of assigning IDs to newly-seen entities, and collecting
@@ -570,6 +574,11 @@ public:
   void writePrimaryAssociatedTypes(ArrayRef<AssociatedTypeDecl *> assocTypes);
 
   bool allowCompilerErrors() const;
+
+private:
+  /// If the declaration is invalid, records that an error occurred and returns
+  /// true if the decl should be skipped.
+  bool skipDeclIfInvalid(const Decl *decl);
 };
 
 } // end namespace serialization

--- a/test/Serialization/lazy-typecheck-errors.swift
+++ b/test/Serialization/lazy-typecheck-errors.swift
@@ -16,3 +16,7 @@ public func returnsInvalidType() -> InvalidType { fatalError() }
 public func takesInvalidType(_ x: InvalidType) {}
 // expected-error@-1 {{cannot find type 'InvalidType' in scope}}
 // expected-serialization-remark@-2 {{serialization skipped invalid global function 'takesInvalidType'}}
+
+@InvalidCustomAttr public struct HasInvalidCustomAttr {}
+// FIXME: An error should be emitted for the invalid attribute
+// expected-serialization-remark@-2 {{serialization skipped for invalid type 'InvalidCustomAttr'}}

--- a/test/Serialization/lazy-typecheck-errors.swift
+++ b/test/Serialization/lazy-typecheck-errors.swift
@@ -1,0 +1,18 @@
+// Verify the -emit-module job fails with a broken AST.
+// RUN: not %target-swift-frontend -emit-module %s -emit-module-path /dev/null -module-name lazy_typecheck -swift-version 5 -enable-library-evolution -parse-as-library -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls 2>&1 | %FileCheck %s
+
+// CHECK: <unknown>:0: error: serialization of module 'lazy_typecheck' failed due to the errors above
+
+// Verify typechecking errors are emitted.
+// RUN: %target-swift-frontend -emit-module %s -emit-module-path /dev/null -module-name lazy_typecheck -swift-version 5 -enable-library-evolution -parse-as-library -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -verify -verify-ignore-unknown
+
+// Verify output with -Rmodule-serialization.
+// RUN: %target-swift-frontend -emit-module %s -emit-module-path /dev/null -module-name lazy_typecheck -swift-version 5 -enable-library-evolution -parse-as-library -experimental-lazy-typecheck -experimental-skip-all-function-bodies -experimental-skip-non-exportable-decls -verify -verify-ignore-unknown -Rmodule-serialization -verify-additional-prefix serialization-
+
+public func returnsInvalidType() -> InvalidType { fatalError() }
+// expected-error@-1 {{cannot find type 'InvalidType' in scope}}
+// expected-serialization-remark@-2 {{serialization skipped invalid global function 'returnsInvalidType()'}}
+
+public func takesInvalidType(_ x: InvalidType) {}
+// expected-error@-1 {{cannot find type 'InvalidType' in scope}}
+// expected-serialization-remark@-2 {{serialization skipped invalid global function 'takesInvalidType'}}

--- a/test/Serialization/lazy-typecheck-errors.swift
+++ b/test/Serialization/lazy-typecheck-errors.swift
@@ -20,3 +20,15 @@ public func takesInvalidType(_ x: InvalidType) {}
 @InvalidCustomAttr public struct HasInvalidCustomAttr {}
 // FIXME: An error should be emitted for the invalid attribute
 // expected-serialization-remark@-2 {{serialization skipped for invalid type 'InvalidCustomAttr'}}
+
+public var varWithExplicitInvalidType: InvalidType
+// expected-error@-1 {{cannot find type 'InvalidType' in scope}}
+// expected-serialization-remark@-2 {{serialization skipped invalid var 'varWithExplicitInvalidType'}}
+// expected-serialization-remark@-3 {{serialization skipped for invalid type 'InvalidType'}}
+
+public var varWithImplicitInvalidType = (1 as InvalidType)
+// expected-error@-1 {{cannot find type 'InvalidType' in scope}}
+// expected-serialization-remark@-2 {{serialization skipped invalid var 'varWithImplicitInvalidType'}}
+// expected-serialization-remark@-3 {{serialization skipped for invalid type}}
+
+public var _: InvalidType


### PR DESCRIPTION
When `-enable-lazy-typecheck` is specified, serialization may be expected to run on an AST containing invalid declarations since type checking may happen on-demand, during serialization, in this mode. If the declarations that are invalid are not skipped, then the compiler is likely to crash when attempting to serialize them. Now, invalid declarations are skipped and an error is emitted at the end of serialization to note that serialization failed.

Additionally, a new `-Rmodule-serialization` flag can be specified to request more detailed information about module serialization failures. This would be useful in a situation where lazy typechecking does not produce any diagnostic for some reason, but module serialization fails and more information is therefore required to debug.

Resolves rdar://123260476
