### PR TITLE
[Caching] Resolve BridgingHeader Module Deps correctly

### DIFF
--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -491,8 +491,8 @@ bool ClangImporter::addBridgingHeaderDependencies(
 
   // ... and all module dependencies.
   llvm::StringSet<> alreadyAddedModules;
-  for (const auto &moduleDep : clangModuleDependencies->ModuleGraph)
-    targetModule.addBridgingModuleDependency(moduleDep.ID.ModuleName,
+  for (const auto &moduleDep : clangModuleDependencies->ClangModuleDeps)
+    targetModule.addBridgingModuleDependency(moduleDep.ModuleName,
                                              alreadyAddedModules);
 
   if (auto TreeID = clangModuleDependencies->IncludeTreeID)

--- a/test/CAS/bridging-header.swift
+++ b/test/CAS/bridging-header.swift
@@ -1,0 +1,54 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
+// RUN:   %t/test.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas \
+// RUN:   -Xcc -fmodule-map-file=%t/a.modulemap -Xcc -fmodule-map-file=%t/b.modulemap -import-objc-header %t/Bridging.h
+
+// RUN: %{python} %S/Inputs/SwiftDepsExtractor.py %t/deps.json Test bridgingHeader | %FileCheck %s
+
+// CHECK:       "includeTree"
+// CHECK-NEXT:  "moduleDependencies": [
+// CHECK-NEXT:    "A"
+// CHECK-NEXT:  ],
+// CHECK-NEXT:  "commandLine": [
+// CHECK:         "-fmodule-file-cache-key",
+// CHECK-NEXT:    "-Xcc",
+// CHECK-NEXT:    "{{.*}}{{/|\\}}A-{{.*}}.pcm", 
+// CHECK-NEXT:    "-Xcc",
+// CHECK-NEXT:    "llvmcas://{{.*}}", 
+// CHECK-NEXT:    "-Xcc",
+// CHECK-NEXT:    "-fmodule-file-cache-key",
+// CHECK-NEXT:    "-Xcc",
+// CHECK-NEXT:    "{{.*}}{{/|\\}}B-{{.*}}.pcm", 
+// CHECK-NEXT:    "-Xcc",
+// CHECK-NEXT:    "llvmcas://{{.*}}"
+
+//--- test.swift
+import B
+public func test() {}
+
+//--- Bridging.h
+#include "Foo.h"
+
+//--- Foo.h
+#import "a.h"
+
+//--- a.h
+#include "b.h"
+
+//--- b.h
+void b(void);
+
+//--- a.modulemap
+module A {
+  header "a.h"
+  export *
+}
+
+//--- b.modulemap
+module B {
+  header "b.h"
+  export *
+}


### PR DESCRIPTION
Fix the bridging header dependencies calculation for explicit module build, especially for caching which needs an accurate list of deps for compute cache key correctly.

Previously, the bridging header deps are computed from `ModuleGraph` from the clang dependency scanner, which can be affected by already seen modules. It causes the dependencies to be missing for bridging header if the module is seen by main swift source module.

Now report only the directly module dependencies from bridging header, then compute all the transitive dependencies before calculating all the cache keys.

rdar://123156636
