### PR TITLE
Support objcImpl + implementationOnly

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -65,6 +65,8 @@ ExportContext::ExportContext(
 bool swift::isExported(const ValueDecl *VD) {
   if (VD->getAttrs().hasAttribute<ImplementationOnlyAttr>())
     return false;
+  if (VD->isObjCMemberImplementation())
+    return false;
 
   // Is this part of the module's API or ABI?
   AccessScope accessScope =

--- a/test/decl/ext/Inputs/objc_implementation_internal.h
+++ b/test/decl/ext/Inputs/objc_implementation_internal.h
@@ -1,0 +1,8 @@
+@import Foundation;
+
+@interface InternalObjCClass : NSObject
+
+- (void)methodFromHeader1:(int)param;
+
+@end
+

--- a/test/decl/ext/Inputs/objc_implementation_private.modulemap
+++ b/test/decl/ext/Inputs/objc_implementation_private.modulemap
@@ -2,3 +2,7 @@ module objc_implementation_private {
   header "objc_implementation.h"
   export *
 }
+module objc_implementation_internal {
+  header "objc_implementation_internal.h"
+  export *
+}

--- a/test/decl/ext/objc_implementation_impl_only.swift
+++ b/test/decl/ext/objc_implementation_impl_only.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap
+// REQUIRES: objc_interop
+
+@_implementationOnly import objc_implementation_internal
+
+@_objcImplementation extension InternalObjCClass {
+  @objc public func method(fromHeader1: CInt) {
+    // OK
+  }
+}


### PR DESCRIPTION
Member implementations are never directly visible to clients of a module, even if they are formally public, but TypeCheckAvailability did not know this. As a result, it would incorrectly diagnose member implementations in an objcImpl extension as violating @_implementationOnly import rules or other, similar access checks. This commit excludes them from being considered as exported declarations.

Fixes rdar://121229058.