### PR TITLE
[presets] Temporarily disable Swift DocC testing on Linux to unblock CI

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -892,6 +892,8 @@ mixin-preset=
     mixin_lightweight_assertions,no-stdlib-asserts
     buildbot_linux_base
 
+skip-test-swiftdocc
+
 [preset: buildbot_linux_crosscompile_wasm]
 mixin-preset=buildbot_linux
 


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
