### PR TITLE
Test: allow one retry for flaky test

### DIFF
--- a/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_dontLeak.swift
@@ -8,6 +8,9 @@
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: freestanding
 
+// FIXME: this test is flaky; rdar://115756502
+// ALLOW_RETRIES: 1
+
 // FIXME: enable discarding taskgroup on windows; rdar://104762037
 // UNSUPPORTED: OS=windows-msvc
 


### PR DESCRIPTION
this test fails occasionally, but it's not disabled. lit supports an `ALLOW_RETRIES` option, which is the number of times to re-reun the test after the first attempt fails (thus, ALLOW_RETRIES = 1 means the test is run at most twice). If a test passed only because of a retry, it'll be reported in the summary as a FLAKYPASS