### PR TITLE
ASTPrinter: fix nested inverse printing (v18)

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2852,10 +2852,13 @@ void PrintAST::printSynthesizedExtension(Type ExtendedType,
 void PrintAST::printSynthesizedExtensionImpl(Type ExtendedType,
                                              ExtensionDecl *ExtDecl) {
   auto printRequirementsFrom = [&](ExtensionDecl *ED, bool &IsFirst) {
+    SmallVector<Requirement, 2> requirements;
+    SmallVector<InverseRequirement, 2> inverses;
     auto Sig = ED->getGenericSignature();
+    Sig->getRequirementsWithInverses(requirements, inverses);
     printSingleDepthOfGenericSignature(Sig.getGenericParams(),
-                                       Sig.getRequirements(),
-                                       /*inverses=*/{},
+                                       requirements,
+                                       inverses,
                                        IsFirst,
                                        PrintRequirements | PrintInverseRequirements,
                                        [](const Requirement &Req){

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -963,6 +963,7 @@ public:
     SwapSelfAndDependentMemberType = 8,
     PrintInherited = 16,
     PrintInverseRequirements = 32,
+    IncludeOuterInverses = 64,
   };
 
   void printInheritedFromRequirementSignature(ProtocolDecl *proto,
@@ -1666,6 +1667,17 @@ void PrintAST::printGenericSignature(
   } else {
     requirements.append(genericSig.getRequirements().begin(),
                         genericSig.getRequirements().end());
+  }
+
+  // Unless `IncludeOuterInverses` is enabled, limit inverses to the
+  // innermost generic parameters.
+  if (!(flags & IncludeOuterInverses) && !inverses.empty()) {
+    auto innerParams = genericSig.getInnermostGenericParams();
+    SmallPtrSet<TypeBase *, 4> innerParamSet(innerParams.begin(),
+                                             innerParams.end());
+    llvm::erase_if(inverses, [&](InverseRequirement inverse) -> bool {
+      return !innerParamSet.contains(inverse.subject.getPointer());
+    });
   }
 
   if (flags & InnermostOnly) {
@@ -2696,9 +2708,17 @@ void PrintAST::printDeclGenericRequirements(GenericContext *decl) {
   if (parentSig && parentSig->isEqual(genericSig))
     return;
 
+  unsigned flags = PrintRequirements | PrintInverseRequirements;
+
+  // In many cases, inverses should not be printed for outer generic parameters.
+  // Exceptions to that include extensions, as it's valid to write an inverse
+  // on the generic parameters they get from the extended nominal.
+  if (isa<ExtensionDecl>(decl))
+    flags |= IncludeOuterInverses;
+
   Printer.printStructurePre(PrintStructureKind::DeclGenericParameterClause);
   printGenericSignature(genericSig,
-                        PrintRequirements | PrintInverseRequirements,
+                        flags,
                         [parentSig](const Requirement &req) {
                           if (parentSig)
                             return !parentSig->isRequirementSatisfied(req);
@@ -2959,7 +2979,9 @@ void PrintAST::printExtension(ExtensionDecl *decl) {
       assert(baseGenericSig &&
              "an extension can't be generic if the base type isn't");
       printGenericSignature(genericSig,
-                            PrintRequirements | PrintInverseRequirements,
+                            PrintRequirements
+                              | PrintInverseRequirements
+                              | IncludeOuterInverses,
                             [baseGenericSig](const Requirement &req) -> bool {
         // Only include constraints that are not satisfied by the base type.
         return !baseGenericSig->isRequirementSatisfied(req);

--- a/test/Generics/inverse_extension_signatures.swift
+++ b/test/Generics/inverse_extension_signatures.swift
@@ -1,0 +1,91 @@
+// RUN: %target-swift-frontend \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -verify -typecheck %s -debug-generic-signatures \
+// RUN:   -debug-inverse-requirements 2>&1 | %FileCheck %s --implicit-check-not "error:"
+
+// CHECK-LABEL: .Outer@
+// CHECK: Generic signature: <A where A : Escapable>
+
+// CHECK-LABEL: .Outer.innerFn@
+// CHECK: Generic signature: <A, B where A : Escapable, B : Escapable>
+
+// CHECK-LABEL: .Outer.InnerStruct@
+// CHECK: Generic signature: <A, C where A : Escapable, C : Escapable>
+
+// CHECK-LABEL: .Outer.InnerStruct.g@
+// CHECK: Generic signature: <A, C, D where A : Escapable, C : Escapable, D : Escapable>
+
+// CHECK-LABEL: .Outer.InnerStruct.init()@
+// CHECK: Generic signature: <A, C where A : Escapable, C : Escapable>
+
+// CHECK: (normal_conformance type="Outer<A>.InnerStruct<C>" protocol="Escapable")
+
+// CHECK-LABEL: .Outer.InnerVariation1@
+// CHECK: Generic signature: <A, D where A : Escapable, D : Escapable>
+
+// CHECK-LABEL: .Outer.InnerVariation2@
+// CHECK: Generic signature: <A, D where A : Escapable, D : Copyable>
+
+// CHECK-LABEL: ExtensionDecl {{.*}} base=Outer.InnerStruct
+// CHECK: Generic signature: <A, C where A : Copyable, A : Escapable, C : Copyable, C : Escapable>
+
+// CHECK-LABEL: .InnerStruct extension.hello@
+// CHECK: Generic signature: <A, C, T where A : Copyable, A : Escapable, C : Copyable, C : Escapable, T : Copyable>
+
+// CHECK-LABEL: .Freestanding@
+// CHECK: Generic signature: <T>
+
+// CHECK-LABEL: ExtensionDecl {{.*}} base=Outer
+// CHECK: Generic signature: <A where A : Copyable, A : Escapable>
+
+// CHECK-LABEL: ExtensionDecl {{.*}} base=Outer.InnerVariation1
+// CHECK: Generic signature: <A, D where A : Escapable, D : Copyable, D : Escapable>
+
+// CHECK-LABEL: ExtensionDecl {{.*}} base=Outer.InnerVariation2
+// CHECK: Generic signature: <A, D where A : Escapable, D : Copyable>
+
+// CHECK-LABEL: ExtensionDecl line=0 base=Outer<A>.InnerStruct<C>
+// CHECK-NEXT: (normal_conformance type="Outer<A>.InnerStruct<C>" protocol="Copyable"
+// CHECK-NEXT:   (requirement "A" conforms_to "Copyable")
+// CHECK-NEXT:   (requirement "C" conforms_to "Copyable"))
+
+// CHECK-LABEL: ExtensionDecl line=0 base=Outer<A>.InnerVariation1<D>
+// CHECK-NEXT: (normal_conformance type="Outer<A>.InnerVariation1<D>" protocol="Copyable"
+// CHECK-NEXT:   (requirement "A" conforms_to "Copyable")
+// CHECK-NEXT:   (requirement "D" conforms_to "Copyable"))
+
+// CHECK-LABEL: ExtensionDecl line=0 base=Outer<A>.InnerVariation2<D>
+// CHECK-NEXT: (normal_conformance type="Outer<A>.InnerVariation2<D>" protocol="Escapable"
+// CHECK-NEXT:   (requirement "D" conforms_to "Escapable"))
+
+// CHECK-LABEL: ExtensionDecl line=0 base=Outer<A>
+// CHECK-NEXT: (normal_conformance type="Outer<A>" protocol="Copyable"
+// CHECK-NEXT:   (requirement "A" conforms_to "Copyable"))
+
+// CHECK-LABEL: ExtensionDecl line=0 base=Freestanding<T>
+// CHECK-NEXT: (normal_conformance type="Freestanding<T>" protocol="Copyable"
+// CHECK-NEXT:   (requirement "T" conforms_to "Copyable"))
+  
+// CHECK-LABEL: ExtensionDecl line=0 base=Freestanding<T>
+// CHECK-NEXT: (normal_conformance type="Freestanding<T>" protocol="Escapable"
+// CHECK-NEXT:   (requirement "T" conforms_to "Escapable"))
+
+public struct Outer<A: ~Copyable> {
+  public func innerFn<B: ~Copyable>(_ b: borrowing B) {}
+  public struct InnerStruct<C: ~Copyable> {
+    public func g<D>(_ d: borrowing D) where D: ~Copyable {}
+  }
+  public struct InnerVariation1<D: ~Copyable>: ~Escapable {}
+  public struct InnerVariation2<D: ~Escapable>: ~Copyable {}
+}
+
+extension Outer.InnerStruct {
+    public func hello<T: ~Escapable>(_ t: T) {}
+}
+
+public struct Freestanding<T: ~Copyable> where T: ~Escapable {}
+
+extension Outer {}
+extension Outer.InnerVariation1 where A: ~Copyable {}
+extension Outer.InnerVariation2 where D: ~Escapable, A: ~Copyable {}

--- a/test/Generics/inverse_extensions.swift
+++ b/test/Generics/inverse_extensions.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-experimental-feature NonescapableTypes
+
+struct Turtle<T> {}
+extension Turtle where T: ~Copyable {} // expected-error {{'T' required to be 'Copyable' but is marked with '~Copyable'}}
+
+struct Rabbit<T> where T: ~Copyable {}
+extension Rabbit where T: ~Escapable {} // expected-error {{'T' required to be 'Escapable' but is marked with '~Escapable'}}
+
+protocol P {}
+extension P where Self: ~Escapable {} // expected-error {{'Self' required to be 'Escapable' but is marked with '~Escapable'}}
+
+protocol HasAssoc {
+  associatedtype A
+}
+extension HasAssoc where Self.A: ~Copyable {}
+// expected-error@-1 {{cannot add inverse constraint 'Self.A: ~Copyable' on generic parameter 'Self.A' defined in outer scope}}
+// expected-error@-2 {{'Self.A' required to be 'Copyable' but is marked with '~Copyable'}}
+
+class Box<T: ~Copyable> {}
+extension Box where T: ~Copyable {}

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -80,3 +80,19 @@ public func noInversesEND() {}
 public func checkAnyInv1<Result>(_ t: borrowing Result) where Result: Any & ~Copyable {}
 public func checkAnyInv2<Result: Any>(_ t: borrowing Result) where Result: ~Copyable & ~Escapable {}
 public func checkAnyObject<Result>(_ t: Result) where Result: AnyObject {}
+
+// coverage for rdar://123281976
+public struct Outer<A: ~Copyable> {
+  public func innerFn<B: ~Copyable>(_ b: borrowing B) {}
+  public struct InnerStruct<C: ~Copyable> {
+    public func g<D>(_ d: borrowing D) where D: ~Copyable {}
+  }
+  public struct InnerVariation1<D: ~Copyable>: ~Escapable {}
+  public struct InnerVariation2<D: ~Escapable>: ~Copyable {}
+}
+
+extension Outer.InnerStruct {
+    public func hello<T: ~Escapable>(_ t: T) {}
+}
+
+public struct Freestanding<T: ~Copyable> where T: ~Escapable {}

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -104,11 +104,38 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC: public func checkAnyInv2<Result>(_ t: borrowing Result) where Result : ~Copyable, Result : ~Escapable
 // CHECK-MISC: public func checkAnyObject<Result>(_ t: Result) where Result : AnyObject
 
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public struct Outer<A> where A : ~Copyable {
+// CHECK-MISC-NEXT:   public func innerFn<B>(_ b: borrowing B) where B : ~Copyable
+// CHECK-MISC:   public struct InnerStruct<C> where C : ~Copyable {
+// CHECK-MISC-NEXT:     public func g<D>(_ d: borrowing D) where D : ~Copyable
+// CHECK-MISC:   public struct InnerVariation1<D> : ~Escapable where D : ~Copyable
+// CHECK-MISC:   public struct InnerVariation2<D> : ~Copyable where D : ~Escapable
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: extension {{.*}}.Outer.InnerStruct {
+// CHECK-MISC-NEXT:   public func hello<T>(_ t: T) where T : ~Escapable
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public struct Freestanding<T> where T : ~Copyable, T : ~Escapable {
+
 ///////////////////////////////////////////////////////////////////////
 // Synthesized conditional conformances are next
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-MISC-NEXT: extension {{.*}}.Hello : Swift.Copyable where T : ~Escapable {
+
+// FIXME: (rdar://123293620) inner struct extensions are not feature-guarded correctly
+// CHECK-MISC: extension {{.*}}.Outer.InnerStruct : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}.Outer.InnerVariation1 : Swift.Copyable {
+// CHECK-MISC: extension {{.*}}.Outer.InnerVariation2 : Swift.Escapable where A : ~Copyable {
+// CHECK-MISC: extension {{.*}}.Outer : Swift.Copyable {
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: extension {{.*}}.Freestanding : Swift.Copyable where T : ~Escapable {
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: extension {{.*}}.Freestanding : Swift.Escapable where T : ~Copyable {
 
 ////////////////////////////////////////////////////////////////////////
 //    At the end, ensure there are no synthesized Copyable extensions


### PR DESCRIPTION
Nested types with inverse requirements on generic parameters would
sometimes print incorrectly. We only print the inverses on outer generic
parameters for extensions.

fixes rdar://123281976