### PR TITLE
[ClangImporter] Produce `ErrorType` for invalid variables

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2654,6 +2654,11 @@ public:
       if (!var->hasInterfaceType())
         return;
 
+      // The types for imported vars are produced lazily and
+      // could fail to import.
+      if (var->getClangDecl() && var->isInvalid())
+        return;
+
       PrettyStackTraceDecl debugStack("verifying VarDecl", var);
 
       // Variables must have materializable type.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6510,7 +6510,7 @@ Type ClangImporter::importVarDeclType(
                       getImportTypeAttrs(decl));
 
   if (!importedType)
-    return nullptr;
+    return ErrorType::get(Impl.SwiftContext);
 
   if (importedType.isImplicitlyUnwrapped())
     swiftDecl->setImplicitlyUnwrappedOptional(true);

--- a/test/ClangImporter/invalid_vars_should_have_error_type.swift
+++ b/test/ClangImporter/invalid_vars_should_have_error_type.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t/src)
+// RUN: split-file %s %t/src
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %t/src/main.swift \
+// RUN:   -import-objc-header %t/src/Test.h \
+// RUN:   -module-name main -I %t -verify
+
+// REQUIRES: objc_interop
+
+//--- Test.h
+@import Foundation;
+
+extern const unsigned char TestDir[];
+
+extern NSString * _Nonnull __TestDir __attribute__((swift_name("TestDir")));
+
+//--- main.swift
+import Foundation
+
+func test() {
+  print(TestDir)
+}


### PR DESCRIPTION
If type couldn't be imported, produce error type instead of `Type()` to align with other checks.

Resolves: rdar://123244479

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
