### PR TITLE
[wasm] Repair IRGen/async.swift test

### DIFF
--- a/test/IRGen/async.swift
+++ b/test/IRGen/async.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir  -disable-availability-checking -enable-library-evolution
 
 // REQUIRES: concurrency
+// UNSUPPORTED: CPU=wasm32
 
 // CHECK: "$s5async1fyyYaF"
 public func f() async { }

--- a/test/IRGen/async_wasm.swift
+++ b/test/IRGen/async_wasm.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -primary-file %S/async.swift -emit-ir  -disable-availability-checking | %FileCheck %s --check-prefix=NOTAIL
+// TODO(katei): %target-swift-frontend -primary-file %S/async.swift -emit-ir  -disable-availability-checking -Xcc -mtail-call | %FileCheck %s --check-prefix=TAIL
+
+// REQUIRES: concurrency && CPU=wasm32
+
+// NOTAIL: "$s5async1fyyYaF"
+// NOTAIL: "$s5async1gyyYaKF"
+// NOTAIL: "$s5async1hyyS2iYbXEF"
+
+// NOTAIL: define{{.*}} swiftcc void @"$s5async8testThisyyAA9SomeClassCnYaF"(ptr swiftasync %0{{.*}}
+// NOTAIL-NOT: @swift_task_alloc
+// NOTAIL-NOT: musttail call
+// NOTAIL: call swiftcc void @swift_task_future_wait_throwing(ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}}, ptr {{.*}})


### PR DESCRIPTION
The test has been crashed with WebAssembly target due to lack of tail-call support guard in the CoroSplit llvm pass. The crash has been fixed by https://github.com/llvm/llvm-project/commit/8c5c4d9a63bd0cba7f025431e06f63d032010393 but the new codegen produces slightly different IR (`call` instead of `tail call`, while they are lowered to the same wasm instruction). So this patch adds new checks for wasm target.
