### PR TITLE
SILGen: Add tests verifying obsoleted functions do not get stubbed

### DIFF
--- a/test/SILGen/unavailable_decl_optimization_stub.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub.swift
@@ -42,9 +42,20 @@ public var globalVar = S()
 
 public enum Uninhabited {}
 
-//
 // CHECK-LABEL: sil{{.*}}@$s4Test28unavailableTakingUninhabitedyyAA0D0OF : $@convention(thin) (Uninhabited) -> () {
 // CHECK:         unreachable
 // CHECK:       } // end sil function '$s4Test28unavailableTakingUninhabitedyyAA0D0OF'
 @available(*, unavailable)
 public func unavailableTakingUninhabited(_ u: Uninhabited) {}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test17obsoletedInSwift1yyF : $@convention(thin) () -> () {
+// CHECK-NOT:     ss36_diagnoseUnavailableCodeReached
+// CHECK:       } // end sil function '$s4Test17obsoletedInSwift1yyF'
+@available(swift, obsoleted: 1)
+public func obsoletedInSwift1() {}
+
+// CHECK-LABEL: sil{{.*}}@$s4Test17obsoletedInSwift5yyF : $@convention(thin) () -> () {
+// CHECK-NOT:     ss36_diagnoseUnavailableCodeReached
+// CHECK:       } // end sil function '$s4Test17obsoletedInSwift5yyF'
+@available(swift, obsoleted: 5)
+public func obsoletedInSwift5() {}

--- a/test/SILGen/unavailable_decl_optimization_stub_macos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos.swift
@@ -45,7 +45,13 @@ public func unavailableOnMacOSExtensionFunc() {}
 public func unavailableOnMacOSAndMacOSExtensionFunc() {}
 
 // CHECK-LABEL:     sil{{.*}}@$s4Test20unavailableOniOSFuncyyF
-// CHECK-NOT:         function_ref @$ss36_diagnoseUnavailableCodeReached{{.*}} : $@convention(thin) () -> Never
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
 // CHECK:           } // end sil function '$s4Test20unavailableOniOSFuncyyF'
 @available(iOS, unavailable)
 public func unavailableOniOSFunc() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test20obsoletedOnMacOS10_9yyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test20obsoletedOnMacOS10_9yyF'
+@available(macOS, obsoleted: 10.9)
+public func obsoletedOnMacOS10_9() {}


### PR DESCRIPTION
Functions that are marked `obsolete` may still be invoked at runtime so they should not be stubbed when `-unavailable-decl-optimization=stub` is specified.
