### PR TITLE
[CSSimplify] Adjust `isBindable` to reject binding if it's directly t…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4358,8 +4358,13 @@ static bool isBindable(TypeVariableType *typeVar, Type type) {
   // what the \c type is, because contextual type is just a hint
   // in this situation and type variable would be bound to its
   // opened type instead.
+  //
+  // Note that although inference doesn't allow direct bindings to
+  // type variables, they can still get through via `matchTypes`
+  // when type is a partially resolved pack expansion that simplifies
+  // down to a type variable.
   return typeVar->getImpl().isPackExpansion() ||
-         !type->is<DependentMemberType>();
+         !(type->is<TypeVariableType>() || type->is<DependentMemberType>());
 }
 
 ConstraintSystem::TypeMatchResult

--- a/validation-test/Sema/type_checker_crashers_fixed/issue-71701.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/issue-71701.swift
@@ -1,0 +1,10 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+// https://github.com/apple/swift/issues/71701
+
+struct S<each T> {
+  init(_ values: repeat each T) {}
+}
+
+_ = S(nil)
+_ = S.init(nil)


### PR DESCRIPTION
…o a type variable

Although inference doesn't allow direct bindings to type variables, 
they can still get through via `matchTypes` when type is a partially
resolved pack expansion that simplifies down to a type variable.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
