### PR TITLE
Consume switch subjects under an opaque sub-access.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyUtils.cpp
@@ -313,6 +313,8 @@ bool noncopyable::memInstMustConsume(Operand *memOper) {
   case SILInstructionKind::LoadInst:
     return cast<LoadInst>(memInst)->getOwnershipQualifier() ==
            LoadOwnershipQualifier::Take;
+  case SILInstructionKind::BeginAccessInst:
+    return cast<BeginAccessInst>(memInst)->getAccessKind() == SILAccessKind::Deinit;
   }
 }
 

--- a/test/SILOptimizer/moveonly_borrowing_switch.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch.swift
@@ -236,8 +236,8 @@ func testOuterAO(consuming bas: consuming AOBas) { // expected-error{{'bas' used
         break
     }
 
-    switch bas {
-    case _borrowing x: // expected-warning{{}} expected-note{{used here}}
+    switch bas { // expected-note{{used here}}
+    case _borrowing x: // expected-warning{{}}
         break
     }
 }

--- a/test/SILOptimizer/moveonly_consuming_switch.swift
+++ b/test/SILOptimizer/moveonly_consuming_switch.swift
@@ -1,0 +1,80 @@
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -verify %s
+struct MyPointer<Wrapped: ~Copyable>: Copyable {
+    var v: UnsafeMutablePointer<Int>
+
+    static func allocate(capacity: Int) -> Self {
+        fatalError()
+    }
+
+    func initialize(to: consuming Wrapped) {
+    }
+    func deinitialize(count: Int) {
+    }
+    func deallocate() {
+    }
+    func move() -> Wrapped {
+        fatalError()
+    }
+}
+
+struct Box<Wrapped: ~Copyable>: ~Copyable {
+    private let _pointer: MyPointer<Wrapped>
+    
+    init(_ element: consuming Wrapped) {
+        _pointer = .allocate(capacity: 1)
+        print("allocating",_pointer)
+        _pointer.initialize(to: element)
+    }
+        
+    deinit {
+        print("deallocating",_pointer)
+        _pointer.deinitialize(count: 1)
+        _pointer.deallocate()
+    }
+    
+    consuming func move() -> Wrapped {
+        let wrapped = _pointer.move()
+        print("deallocating", _pointer)
+        _pointer.deallocate()
+        discard self
+        return wrapped
+    }
+}
+
+
+
+
+
+
+
+
+
+enum List<Element: ~Copyable>: ~Copyable {
+    case empty
+    case node(Element, Box<List>)
+}
+
+extension List {
+    init() { self = .empty }
+    
+    mutating func push(_ element: consuming Element) {
+        self = .node(element, Box(self))
+    }
+        
+    mutating func pop() -> Element {
+        switch self {
+        case .node(let element, let box):
+            self = box.move()
+            return element
+        case .empty:
+            fatalError()
+        }
+    }
+    
+    var isEmpty: Bool {
+        switch self {
+        case .empty: true
+        case .node: false
+        }
+    }
+}

--- a/test/SILOptimizer/moveonly_consuming_switch_2.swift
+++ b/test/SILOptimizer/moveonly_consuming_switch_2.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -verify %s
+
+struct Box: ~Copyable {
+    let ptr: UnsafeMutablePointer<Int>
+    deinit { print("butt") }
+}
+
+enum List<Element>: ~Copyable {
+    case end
+    case more(Element, Box)
+}
+
+extension List {
+    init() {
+        self = .end
+    }
+
+    mutating func pop() -> Element {
+        switch consume self {
+        case .more(let element, let box): // expected-warning{{}}
+            self = .end
+            return element
+        case .end: fatalError()
+        }
+    }
+}
+


### PR DESCRIPTION
This prevents the move-only checker from trying to analyze the bindings as partial consumptions, which ought to be unnecessary since SILGen will always fully consume the subject as part of forming the bindings.