### PR TITLE
[Dependency Scanning] Detect cycles of main target module depending on an existing Swift textual or prebuilt binary module

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1299,6 +1299,9 @@ static bool diagnoseCycle(CompilerInstance &instance,
         [&buffer](const ModuleDependencyID &id) {
           buffer.append(id.ModuleName);
           switch (id.Kind) {
+          case swift::ModuleDependencyKind::SwiftSource:
+            buffer.append(" (Source Target)");
+            break;
           case swift::ModuleDependencyKind::SwiftInterface:
             buffer.append(".swiftinterface");
             break;
@@ -1318,11 +1321,12 @@ static bool diagnoseCycle(CompilerInstance &instance,
         [&buffer] { buffer.append(" -> "); });
   };
 
-  auto emitCycleDiagnostic = [&](const ModuleDependencyID &dep) {
-    auto startIt = std::find(openSet.begin(), openSet.end(), dep);
+  auto emitCycleDiagnostic = [&](const ModuleDependencyID &sourceId,
+				 const ModuleDependencyID &sinkId) {
+    auto startIt = std::find(openSet.begin(), openSet.end(), sourceId);
     assert(startIt != openSet.end());
     std::vector<ModuleDependencyID> cycleNodes(startIt, openSet.end());
-    cycleNodes.push_back(*startIt);
+    cycleNodes.push_back(sinkId);
     llvm::SmallString<64> errorBuffer;
     emitModulePath(cycleNodes, errorBuffer);
     instance.getASTContext().Diags.diagnose(
@@ -1361,13 +1365,20 @@ static bool diagnoseCycle(CompilerInstance &instance,
     auto beforeSize = openSet.size();
     assert(cache.findDependency(lastOpen).has_value() &&
            "Missing dependency info during cycle diagnosis.");
-    for (const auto &dep : cache.getAllDependencies(lastOpen)) {
-      if (closeSet.count(dep))
+    for (const auto &depId : cache.getAllDependencies(lastOpen)) {
+      if (closeSet.count(depId))
         continue;
-      if (openSet.insert(dep)) {
+      // Ensure we detect dependency of the Source target
+      // on an existing Swift module with the same name
+      if (kindIsSwiftDependency(depId) &&
+          depId.ModuleName == mainId.ModuleName && openSet.contains(mainId)) {
+        emitCycleDiagnostic(mainId, depId);
+        return true;
+      }
+      if (openSet.insert(depId)) {
         break;
       } else {
-        emitCycleDiagnostic(dep);
+        emitCycleDiagnostic(depId, depId);
         return true;
       }
     }

--- a/test/ScanDependencies/diagnose_dependency_cycle_source_target.swift
+++ b/test/ScanDependencies/diagnose_dependency_cycle_source_target.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/module-cache)
+
+// RUN: not %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -module-name CycleOverlay &> %t/out.txt
+
+// RUN: %FileCheck %s < %t/out.txt
+
+// CHECK: module dependency cycle: 'CycleOverlay (Source Target) -> CycleSwiftMiddle.swiftinterface -> CycleOverlay.swiftinterface'
+// CHECK: Swift Overlay dependency of 'CycleSwiftMiddle' on 'CycleOverlay' via Clang module dependency: 'CycleSwiftMiddle.swiftinterface -> CycleClangMiddle.pcm -> CycleOverlay.pcm'
+
+import CycleSwiftMiddle
+
+


### PR DESCRIPTION
Resolves rdar://123112402