### PR TITLE
LargeTypesReg2Mem: Remove overzealous assert

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -4245,11 +4245,7 @@ static void runPeepholesAndReg2Mem(SILPassManager *pm, SILModule *silMod,
       if (&bb == entryBB) {
         for (auto *arg : bb.getArguments()) {
           auto ty = arg->getType();
-          // This is an idiosyncrasy of the large loadable types pass which
-          // ignores tuple types (considers them always "small").
           if (assignment.isLargeLoadableType(ty)) {
-            assert(isa<TupleType>(ty.getASTType()));
-            ;
             auto addr = assignment.createAllocStack(ty);
             assignment.mapValueToAddress(arg, addr);
             // We will emit the store to initialize after parsing all other

--- a/test/IRGen/Inputs/large_c.h
+++ b/test/IRGen/Inputs/large_c.h
@@ -1,0 +1,31 @@
+#pragma once
+
+struct SamplesType {
+    void* A;
+    void* B;
+    void* C;
+    void* D;
+    void* E;
+    void* F;
+    void* G;
+    void* H;
+    void* I;
+    void* J;
+    void* K;
+    void* L;
+    void* M;
+    void* N;
+    void* O;
+    void* P;
+    void* Q;
+    void* R;
+    void* S;
+    void* T;
+    void* U;
+    void* V;
+    void* W;
+    void* X;
+    void* Y;
+    void* Z;
+    void* AA;
+};

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s  -Xllvm -sil-print-after=loadable-address -c -o %t/t.o 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend %s  -Xllvm -sil-print-after=loadable-address -import-objc-header %S/Inputs/large_c.h -c -o %t/t.o 2>&1 | %FileCheck %s
 
 sil_stage canonical
 
@@ -212,6 +212,20 @@ bb0(%0 : $*Y):
   %4 = struct_extract %2 : $Y, #Y.y1
   store %4 to %1 : $*X
   dealloc_stack %1 : $*X
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK: sil @test8
+// CHECK: bb0(%0 : $SamplesType):
+// CHECK:   %1 = alloc_stack $SamplesType
+// CHECK:   store %0 to %1 : $*SamplesType
+sil @helper : $@convention(thin) (SamplesType) -> ()
+
+sil @test8 : $@convention(c) (SamplesType) -> () {
+bb0(%0 : $SamplesType):
+  %1 = function_ref @helper : $@convention(thin) (SamplesType) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (SamplesType) -> ()
   %t = tuple ()
   return %t : $()
 }


### PR DESCRIPTION
Functions with c convention can have large direct arguments that are not re-written by the LoadableByAddress pass before they get to reg2Mem optimization.

https://github.com/apple/swift/issues/71757