### PR TITLE
[wasm] Enable `--gc-sections` for WebAssembly by default

### DIFF
--- a/stdlib/public/Resources/wasi/static-executable-args.lnk
+++ b/stdlib/public/Resources/wasi/static-executable-args.lnk
@@ -7,5 +7,4 @@
 -lwasi-emulated-signal
 -lwasi-emulated-process-clocks
 -Xlinker --error-limit=0
--Xlinker --no-gc-sections
 -Xlinker --threads=1

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -38,7 +38,7 @@ static const void *__backtraceRef __attribute__((used))
 #if defined(__ELF__)
 # define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"a\"\n");
 #elif defined(__wasm__)
-# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"\",@\n");
+# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"R\",@\n");
 #endif
 
 #define DECLARE_SWIFT_SECTION(name)                                                          \


### PR DESCRIPTION
This change enables the `--gc-sections` linker flag for WebAssembly targets by default. This flag has been disabled because it did not respect `llvm.used` and it caused stripping `swift5` metadata sections even though they were used through encapsulation symbols (a.k.a `__start`/`__stop`).

The issue has been fixed in the LLVM side (https://github.com/llvm/llvm-project/commit/ba3c1f9ce30cf4f8aee5f1961df74d65e11d53bc) by adding new segment flags to the WebAssembly object file format, which is represented by `"R"` flag in assembly or `llvm.used` in LLVM IR.
