### PR TITLE
SILGen: Avoid expanding #line directives with invalid source locations

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2179,13 +2179,14 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
 
   case MagicIdentifierLiteralExpr::Line:
   case MagicIdentifierLiteralExpr::Column: {
-    auto Loc = getLocInOutermostSourceFile(SGF.getSourceManager(),
-                                           magicLiteral->getStartLoc());
     unsigned Value = 0;
-    if (Loc.isValid()) {
-      Value = magicLiteral->getKind() == MagicIdentifierLiteralExpr::Line
-                  ? ctx.SourceMgr.getPresumedLineAndColumnForLoc(Loc).first
-                  : ctx.SourceMgr.getPresumedLineAndColumnForLoc(Loc).second;
+    if (auto Loc = magicLiteral->getStartLoc()) {
+      Loc = getLocInOutermostSourceFile(SGF.getSourceManager(), Loc);
+      if (Loc.isValid()) {
+        Value = magicLiteral->getKind() == MagicIdentifierLiteralExpr::Line
+                    ? ctx.SourceMgr.getPresumedLineAndColumnForLoc(Loc).first
+                    : ctx.SourceMgr.getPresumedLineAndColumnForLoc(Loc).second;
+      }
     }
 
     auto silTy = SILType::getBuiltinIntegerLiteralType(ctx);

--- a/test/SILGen/Inputs/objc_implementation.h
+++ b/test/SILGen/Inputs/objc_implementation.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ImplClass : NSObject
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithInt:(NSInteger)x;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/test/SILGen/objc_implementation.swift
+++ b/test/SILGen/objc_implementation.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -emit-silgen -import-objc-header %S/Inputs/objc_implementation.h -swift-version 5 %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+@_objcImplementation extension ImplClass {
+  public init(int: Int) {
+    super.init()
+  }
+
+  // CHECK-LABEL: sil{{.*}} @$sSo9ImplClassC19objc_implementationEABycfc : $@convention(method) (@owned ImplClass) -> @owned ImplClass {
+  // CHECK:         function_ref @$ss25_unimplementedInitializer9className04initD04file4line6columns5NeverOs12StaticStringV_A2JS2utF
+  // CHECK:       } // end sil function '$sSo9ImplClassC19objc_implementationEABycfc'
+}


### PR DESCRIPTION
Synthesized stub constructors contain `#line` directives and under certain circumstances these directives can have invalid source locations. SILGen would trigger an assert (or invoke UB in non-asserts builds) when attempting to expand these directives into literal values. Check the source location for validity before translating the location to a location in the outermost source file.

Resolves rdar://121971741
