### PR TITLE
[Frontend] Add print for supported features

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -283,6 +283,9 @@ EXPERIMENTAL_FEATURE(BorrowingSwitch, true)
 // Enable isolated(any) attribute on function types.
 EXPERIMENTAL_FEATURE(IsolatedAny, false)
 
+// Used for test purposes only.
+EXPERIMENTAL_FEATURE(SupportedFeaturesTest, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3933,6 +3933,8 @@ static bool usesFeatureIsolatedAny(Decl *decl) {
   });
 }
 
+static bool usesFeatureSupportedFeaturesTest(Decl *decl) { return false; }
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {

--- a/test/Frontend/emit-supported-features.swift
+++ b/test/Frontend/emit-supported-features.swift
@@ -1,8 +1,12 @@
-// RUN: %target-swift-frontend -emit-supported-features %s | %FileCheck %s
+// REQUIRES: asserts
+
+// RUN: %target-swift-frontend -emit-supported-features %s -enable-experimental-feature SupportedFeaturesTest | %FileCheck %s
 
 // CHECK: "SupportedArguments"
 // CHECK: "abi"
 // CHECK: "emit-module"
 // CHECK: "LastOption"
 // CHECK: "SupportedFeatures"
+// CHECK: "AsyncAwait"
+// CHECK: "SupportedFeaturesTest
 // CHECK: "LastFeature"

--- a/test/Frontend/lang_feature.swift
+++ b/test/Frontend/lang_feature.swift
@@ -1,0 +1,12 @@
+// Check that hasFeature and the legacy $<Feature> both succeed for promoted
+// language features.
+
+// RUN: %target-swift-frontend -typecheck %s
+
+#if !hasFeature(AsyncAwait)
+#error("boom") // expected-error{{'boom'}}
+#endif
+
+#if !$AsyncAwait
+#error("boom") // expected-error{{'boom'}}
+#endif


### PR DESCRIPTION
Supported features were never actually added to
`-emit-supported-features`, add them.