### PR TITLE
[Autodiff] Adds part of the Autodiff specific closure-specialization optimization pass

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AutodiffClosureSpecialization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AutodiffClosureSpecialization.swift
@@ -1,0 +1,689 @@
+//===--- AutodiffClosureSpecialization.swift ---------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===-----------------------------------------------------------------------===//
+
+/// AutoDiff Closure Specialization
+/// ----------------------
+/// This optimization performs closure specialization tailored for the patterns seen in Swift Autodiff. In principle,
+/// the optimization does the same thing as the existing closure specialization pass. However, it is tailored to the
+/// patterns of Swift Autodiff.
+///
+/// The compiler performs reverse-mode differentiation on functions marked with `@differentiable(reverse)`. In doing so,
+/// it generates corresponding VJP and Pullback functions, which perform the forward and reverse pass respectively. You
+/// can think of VJPs as functions that "differentiate" an original function and Pullbacks as the calculated
+/// "derivative" of the original function. 
+/// 
+/// VJPs always return a tuple of 2 values -- the original result and the Pullback. Pullbacks are essentially a chain 
+/// of closures, where the closure-contexts are implicitly used as the so-called "tape" during the reverse
+/// differentiation process. It is this chain of closures contained within the Pullbacks that this optimization aims
+/// to optimize via closure specialization.
+///
+/// The code patterns that this optimization targets, look similar to the one below:
+/// ``` swift
+/// 
+/// // Since `foo` is marked with the `differentiable(reverse)` attribute the compiler
+/// // will generate corresponding VJP and Pullback functions in SIL. Let's assume that
+/// // these functions are called `vjp_foo` and `pb_foo` respectively.
+/// @differentiable(reverse) 
+/// func foo(_ x: Float) -> Float { 
+///   return sin(x)
+/// }
+///
+/// //============== Before optimization ==============// 
+/// // VJP of `foo`. Returns the original result and the Pullback of `foo`.
+/// sil @vjp_foo: $(Float) -> (originalResult: Float, pullback: (Float) -> Float) { 
+/// bb0(%0: $Float): 
+///   // vjp_sin returns the original result `sin(x)`, and the pullback of sin, `pb_sin`.
+///   // `pb_sin` is a closure.
+///   %(originalResult, pb_sin) = apply @vjp_sin(%0): $(Float) -> (Float, (Float) -> Float)
+///  
+///   %pb_foo = function_ref @pb_foo: $@convention(thin) (Float, (Float) -> Float) -> Float
+///   %partially_applied_pb_foo = partial_apply %pb_foo(%pb_sin): $(Float, (Float) -> Float) -> Float
+///  
+///   return (%originalResult, %partially_applied_pb_foo)
+/// }
+///
+/// // Pullback of `foo`. 
+/// //
+/// // It receives what are called as intermediate closures that represent
+/// // the calculations that the Pullback needs to perform to calculate a function's
+/// // derivative.
+/// //
+/// // The intermediate closures may themselves contain intermediate closures and
+/// // that is why the Pullback for a function differentiated at the "top" level
+/// // may end up being a "chain" of closures.
+/// sil @pb_foo: $(Float, (Float) -> Float) -> Float { 
+/// bb0(%0: $Float, %pb_sin: $(Float) -> Float): 
+///   %derivative_of_sin = apply %pb_sin(%0): $(Float) -> Float 
+///   return %derivative_of_sin: Float
+/// }
+///
+/// //============== After optimization ==============// 
+/// sil @vjp_foo: $(Float) -> (originalResult: Float, pullback: (Float) -> Float) { 
+/// bb0(%0: $Float): 
+///   %1 = apply @sin(%0): $(Float) -> Float 
+/// 
+///   // Before the optimization, pullback of `foo` used to take a closure for computing
+///   // pullback of `sin`. Now, the specialized pullback of `foo` takes the arguments that
+///   // pullback of `sin` used to close over and pullback of `sin` is instead copied over
+///   // inside pullback of `foo`.
+///   %specialized_pb_foo = function_ref @specialized_pb_foo: $@convention(thin) (Float, Float) -> Float
+///   %partially_applied_pb_foo = partial_apply %specialized_pb_foo(%0): $(Float, Float) -> Float 
+/// 
+///   return (%1, %partially_applied_pb_foo)
+/// }
+/// 
+/// sil @specialized_pb_foo: $(Float, Float) -> Float { 
+/// bb0(%0: $Float, %1: $Float): 
+///   %2 = partial_apply @pb_sin(%1): $(Float) -> Float 
+///   %3 = apply %2(): $() -> Float 
+///   return %3: $Float
+/// }
+/// ```
+
+import SIL
+
+private let verbose = false
+
+private func log(_ message: @autoclosure () -> String) {
+  if verbose {
+    print("### \(message())")
+  }
+}
+
+// =========== Entry point =========== //
+let autodiffClosureSpecialization = FunctionPass(name: "autodiff-closure-specialize") {
+  (function: Function, context: FunctionPassContext) in
+  // TODO: Pass is a WIP and current implementation is incomplete
+  if !function.isAutodiffVJP {
+    return
+  }
+}
+
+// =========== Top-level functions ========== //
+
+private let specializationLevelLimit = 2
+
+private func gatherCallSites(in caller: Function, _ context: FunctionPassContext) -> [CallSite] {
+  /// __Root__ closures created via `partial_apply` or `thin_to_thick_function` may be converted and reabstracted
+  /// before finally being used at an apply site. We do not want to handle these intermediate closures separately
+  /// as they are handled and cloned into the specialized function as part of the root closures. Therefore, we keep 
+  /// track of these intermediate closures in a set. 
+  /// 
+  /// This set is populated via the `markConvertedAndReabstractedClosuresAsUsed` function which is called when we're
+  /// handling the different uses of our root closures.
+  ///
+  /// Below SIL example illustrates the above point.
+  /// ```                                                                                                      
+  /// // The below set of a "root" closure and its reabstractions/conversions
+  /// // will be handled as a unit and the entire set will be copied over
+  /// // in the specialized version of `takesClosure` if we determine that we  
+  /// // can specialize `takesClosure` against its closure argument.
+  ///                                                                                                          __            
+  /// %someFunction = function_ref @someFunction: $@convention(thin) (Int, Int) -> Int                            \ 
+  /// %rootClosure = partial_apply [callee_guaranteed] %someFunction (%someInt): $(Int, Int) -> Int                \
+  /// %thunk = function_ref @reabstractionThunk : $@convention(thin) (@callee_guaranteed (Int) -> Int) -> @out Int /     
+  /// %reabstractedClosure = partial_apply [callee_guaranteed] %thunk(%rootClosure) :                             /      
+  ///                        $@convention(thin) (@callee_guaranteed (Int) -> Int) -> @out Int                  __/       
+  /// 
+  /// %takesClosure = function_ref @takesClosure : $@convention(thin) (@owned @callee_guaranteed (Int) -> @out Int) -> Int
+  /// %result = partial_apply %takesClosure(%reabstractedClosure) : $@convention(thin) (@owned @callee_guaranteed () -> @out Int) -> Int
+  /// ret %result
+  /// ```
+  var convertedAndReabstractedClosures = InstructionSet(context)
+
+  defer {
+    convertedAndReabstractedClosures.deinitialize()
+  }
+
+  var callSiteMap = CallSiteMap()
+
+  for inst in caller.instructions {
+    if !convertedAndReabstractedClosures.contains(inst),
+       let rootClosure = inst.asSupportedClosure
+    {
+      updateCallSites(for: rootClosure, in: &callSiteMap, 
+                      convertedAndReabstractedClosures: &convertedAndReabstractedClosures, context)
+    }
+  }
+
+  return callSiteMap.callSites
+}
+
+// ===================== Utility functions and extensions ===================== //
+
+private func updateCallSites(for rootClosure: SingleValueInstruction, in callSiteMap: inout CallSiteMap, 
+                             convertedAndReabstractedClosures: inout InstructionSet, _ context: FunctionPassContext) {
+  var rootClosurePossibleLifeRange = InstructionRange(begin: rootClosure, context)
+  defer {
+    rootClosurePossibleLifeRange.deinitialize()
+  }
+
+  var rootClosureApplies = OperandWorklist(context)                            
+  defer {
+    rootClosureApplies.deinitialize()
+  }
+
+  // A "root" closure undergoing conversions and/or reabstractions has additional restrictions placed upon it, in order
+  // for a call site to be specialized against it. We handle conversion/reabstraction uses before we handle apply uses
+  // to gather the parameters required to evaluate these restrictions or to skip call site uses of "unsupported" 
+  // closures altogether.
+  //
+  // There are currently 2 restrictions that are evaluated prior to specializing a callsite against a converted and/or 
+  // reabstracted closure -
+  // 1. A reabstracted root closure can only be specialized against, if the reabstracted closure is ultimately passed
+  //    trivially (as a noescape+thick function) into the call site.
+  //
+  // 2. A root closure may be a partial_apply [stack], in which case we need to make sure that all mark_dependence 
+  //    bases for it will be available in the specialized callee in case the call site is specialized against this root
+  //    closure.
+
+  let (foundUnexpectedUse, haveUsedReabstraction) = 
+    handleNonApplies(for: rootClosure, rootClosureApplies: &rootClosureApplies,
+                     rootClosurePossibleLifeRange: &rootClosurePossibleLifeRange, context);
+
+
+  if foundUnexpectedUse {
+    return
+  }
+
+  let intermediateClosureArgDescriptorData = 
+    handleApplies(for: rootClosure, callSiteMap: &callSiteMap, rootClosureApplies: &rootClosureApplies, 
+                  rootClosurePossibleLifeRange: &rootClosurePossibleLifeRange, 
+                  convertedAndReabstractedClosures: &convertedAndReabstractedClosures,
+                  haveUsedReabstraction: haveUsedReabstraction, context)
+
+  finalizeCallSites(for: rootClosure, in: &callSiteMap, 
+                    rootClosurePossibleLifeRange: rootClosurePossibleLifeRange,
+                    intermediateClosureArgDescriptorData: intermediateClosureArgDescriptorData, context)
+}
+
+/// Handles all non-apply direct and transitive uses of `rootClosure`.
+///
+/// Returns: 
+/// haveUsedReabstraction - whether the root closure is reabstracted via a thunk 
+/// foundUnexpectedUse - whether the root closure is directly or transitively used in an instruction that we don't know
+///                      how to handle. If true, then `rootClosure` should not be specialized against.
+private func handleNonApplies(for rootClosure: SingleValueInstruction, 
+                              rootClosureApplies: inout OperandWorklist,
+                              rootClosurePossibleLifeRange: inout InstructionRange, 
+                              _ context: FunctionPassContext) 
+  -> (foundUnexpectedUse: Bool, haveUsedReabstraction: Bool)
+{
+  var foundUnexpectedUse = false
+  var haveUsedReabstraction = false
+
+  /// The root closure or an intermediate closure created by reabstracting the root closure may be a `partial_apply
+  /// [stack]` and we need to make sure that all `mark_dependence` bases for this `onStack` closure will be available in
+  /// the specialized callee, in case the call site is specialized against this root closure.
+  ///
+  /// `possibleMarkDependenceBases` keeps track of all potential values that may be used as bases for creating
+  /// `mark_dependence`s for our `onStack` root/reabstracted closures. For root closures these values are non-trivial
+  /// closure captures (which are always available as function arguments in the specialized callee). For reabstracted
+  /// closures these values may be the root closure or its conversions (below is a short SIL example representing this
+  /// case).
+  /// ```
+  /// %someFunction = function_ref @someFunction : $@convention(thin) (Int) -> Int
+  /// %rootClosure = partial_apply [callee_guaranteed] %someFunction(%someInt) : $@convention(thin) (Int) -> Int
+  /// %noescapeRootClosure = convert_escape_to_noescape %rootClosure : $@callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> Int
+  /// %thunk = function_ref @reabstractionThunk : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  /// %thunkedRootClosure = partial_apply [callee_guaranteed] [on_stack] %thunk(%noescapeRootClosure) : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  /// %dependency = mark_dependence %thunkedRootClosure : $@noescape @callee_guaranteed () -> @out Int on %noescapeClosure : $@noescape @callee_guaranteed () -> Int
+  /// %takesClosure = function_ref @takesClosure : $@convention(thin) (@owned @noescape @callee_guaranteed () -> @out Int)
+  /// %ret = apply %takesClosure(%dependency) : $@convention(thin) (@owned @noescape @callee_guaranteed () -> @out Int)
+  /// ```
+  ///
+  /// Any value outside of the aforementioned values is not going to be available in the specialized callee and a
+  /// `mark_dependence` of the root closure on such a value means that we cannot specialize the call site against it.
+  var possibleMarkDependenceBases = ValueSet(context)
+  defer {
+    possibleMarkDependenceBases.deinitialize()
+  }
+
+  var rootClosureConversionsAndReabstractions = OperandWorklist(context)                            
+  rootClosureConversionsAndReabstractions.pushIfNotVisited(contentsOf: rootClosure.uses)
+  defer {
+    rootClosureConversionsAndReabstractions.deinitialize()
+  }
+
+  if let pai = rootClosure as? PartialApplyInst {
+    for arg in pai.arguments {
+      possibleMarkDependenceBases.insert(arg)
+    }
+  }
+  
+  while let use = rootClosureConversionsAndReabstractions.pop() {
+    switch use.instruction {
+    case let cfi as ConvertFunctionInst:
+      rootClosureConversionsAndReabstractions.pushIfNotVisited(contentsOf: cfi.uses)
+      possibleMarkDependenceBases.insert(cfi)
+      rootClosurePossibleLifeRange.insert(use.instruction)
+
+    case let cvt as ConvertEscapeToNoEscapeInst:
+      rootClosureConversionsAndReabstractions.pushIfNotVisited(contentsOf: cvt.uses)
+      possibleMarkDependenceBases.insert(cvt)
+      rootClosurePossibleLifeRange.insert(use.instruction)
+
+    case let pai as PartialApplyInst:
+      if !pai.isPullbackInResultOfAutodiffVJP,
+          pai.isPartialApplyOfReabstractionThunk,
+          pai.isSupportedClosure,
+          pai.callee.type.isNoEscapeFunction,
+          pai.callee.type.isThickFunction 
+      {
+        rootClosureConversionsAndReabstractions.pushIfNotVisited(contentsOf: pai.uses)
+        possibleMarkDependenceBases.insert(pai)
+        rootClosurePossibleLifeRange.insert(use.instruction)
+        haveUsedReabstraction = true
+      } else {
+        rootClosureApplies.pushIfNotVisited(use)
+      }
+
+    case let mv as MoveValueInst:
+      rootClosureConversionsAndReabstractions.pushIfNotVisited(contentsOf: mv.uses)
+      possibleMarkDependenceBases.insert(mv)
+      rootClosurePossibleLifeRange.insert(use.instruction)
+
+    // Uses of a copy of root-closure do not count as
+    // uses of the root-closure
+    case is CopyValueInst:
+      rootClosurePossibleLifeRange.insert(use.instruction)
+    
+    case is DestroyValueInst:
+      rootClosurePossibleLifeRange.insert(use.instruction)
+
+    case let mdi as MarkDependenceInst:
+      if possibleMarkDependenceBases.contains(mdi.base),  
+          mdi.value == use.value,
+          mdi.value.type.isNoEscapeFunction,
+          mdi.value.type.isThickFunction
+      {
+        rootClosureConversionsAndReabstractions.pushIfNotVisited(contentsOf: mdi.uses)
+        rootClosurePossibleLifeRange.insert(use.instruction)
+      }
+    
+    default:
+      foundUnexpectedUse = true
+      log("Found unexpected direct or transitive user of root closure: \(use.instruction)")
+      return (foundUnexpectedUse, haveUsedReabstraction)      
+    }
+  }
+
+  return (foundUnexpectedUse, haveUsedReabstraction)
+}
+
+private typealias IntermediateClosureArgDescriptorDatum = (applySite: SingleValueInstruction, closureArgIndex: Int, paramInfo: ParameterInfo)
+
+private func handleApplies(for rootClosure: SingleValueInstruction, callSiteMap: inout CallSiteMap, 
+                           rootClosureApplies: inout OperandWorklist, 
+                           rootClosurePossibleLifeRange: inout InstructionRange, 
+                           convertedAndReabstractedClosures: inout InstructionSet, haveUsedReabstraction: Bool, 
+                           _ context: FunctionPassContext) -> [IntermediateClosureArgDescriptorDatum] 
+{
+  var intermediateClosureArgDescriptorData: [IntermediateClosureArgDescriptorDatum] = []
+  
+  while let use = rootClosureApplies.pop() {
+    rootClosurePossibleLifeRange.insert(use.instruction)
+
+    // TODO [extend to general swift]: Handle full apply sites
+    guard let pai = use.instruction as? PartialApplyInst else {
+      continue
+    }
+
+    if pai.hasSubstitutions || !pai.calleeIsDynamicFunctionRef || !pai.isPullbackInResultOfAutodiffVJP {
+      continue
+    }
+
+    guard let callee = pai.referencedFunction else {
+      continue
+    }
+
+    if callee.isAvailableExternally {
+      continue
+    }
+
+    // Don't specialize non-fragile (read as non-serialized) callees if the caller is fragile; the specialized callee
+    // will have shared linkage, and thus cannot be referenced from the fragile caller.
+    let caller = rootClosure.parentFunction
+    if caller.isSerialized && !callee.isSerialized {
+      continue
+    }
+
+    // If the callee uses a dynamic Self, we cannot specialize it, since the resulting specialization might longer have
+    // 'self' as the last parameter.
+    //
+    // TODO: We could fix this by inserting new arguments more carefully, or changing how we model dynamic Self
+    // altogether.
+    if callee.mayBindDynamicSelf {
+      continue
+    }
+
+    // Proceed if the closure is passed as an argument (and not called). If it is called we have nothing to do.
+    //
+    // `closureArgumentIndex` is the index of the closure in the callee's argument list.
+    guard let closureArgumentIndex = pai.calleeArgumentIndex(of: use) else {
+      continue
+    }
+
+    // Ok, we know that we can perform the optimization but not whether or not the optimization is profitable. Check if
+    // the closure is actually called in the callee (or in a function called by the callee).
+    if !isClosureApplied(in: callee, closureArgIndex: closureArgumentIndex) {
+      continue
+    }
+
+    // We currently only support copying intermediate reabstraction closures if the final closure is ultimately passed
+    // trivially.
+    let closureType = use.value.type
+    let isClosurePassedTrivially = closureType.isNoEscapeFunction && closureType.isThickFunction
+
+    // Mark the converted/reabstracted closures as used.
+    if haveUsedReabstraction {
+      markConvertedAndReabstractedClosuresAsUsed(rootClosure: rootClosure, convertedAndReabstractedClosure: use.value, 
+                                                convertedAndReabstractedClosures: &convertedAndReabstractedClosures)
+
+      if !isClosurePassedTrivially {
+        continue
+      }
+    }
+
+    let onlyHaveThinToThickClosure = rootClosure is ThinToThickFunctionInst && !haveUsedReabstraction
+
+    guard let closureParamInfo = pai.operandConventions[parameter: use.index] else {
+      fatalError("While handling apply uses, parameter info not found for operand: \(use)!")
+    }
+
+    if (closureParamInfo.convention.isGuaranteed || isClosurePassedTrivially)
+      && !onlyHaveThinToThickClosure
+    {
+      continue
+    }
+
+    // Functions with a readnone, readonly or releasenone effect and a nontrivial context cannot be specialized.
+    // Inserting a release in such a function results in miscompilation after other optimizations. For now, the
+    // specialization is disabled.
+    //
+    // TODO: A @noescape closure should never be converted to an @owned argument regardless of the function's effect
+    // attribute.
+    if !callee.effectAllowsSpecialization && !onlyHaveThinToThickClosure {
+      continue
+    }
+
+    // Avoid an infinite specialization loop caused by repeated runs of ClosureSpecializer and CapturePropagation.
+    // CapturePropagation propagates constant function-literals. Such function specializations can then be optimized
+    // again by the ClosureSpecializer and so on. This happens if a closure argument is called _and_ referenced in
+    // another closure, which is passed to a recursive call. E.g.
+    //
+    // func foo(_ c: @escaping () -> ()) { 
+    //  c() foo({ c() })
+    // }
+    //
+    // A limit of 2 is good enough and will not be exceed in "regular" optimization scenarios.
+    let closureCallee = rootClosure is PartialApplyInst 
+                        ? (rootClosure as! PartialApplyInst).referencedFunction!
+                        : (rootClosure as! ThinToThickFunctionInst).referencedFunction!
+
+    if closureCallee.specializationLevel > specializationLevelLimit {
+      continue
+    }
+
+    if callSiteMap[pai] == nil {
+      callSiteMap.insert(key: pai, value: CallSite(applySite: pai))
+    }
+
+    intermediateClosureArgDescriptorData
+      .append((applySite: pai, closureArgIndex: closureArgumentIndex, paramInfo: closureParamInfo))
+  }
+
+  return intermediateClosureArgDescriptorData
+}
+
+/// Finalizes the call sites for a given root closure by adding a corresponding `ClosureArgDescriptor`
+/// to all call sites where the closure is ultimately passed as an argument.
+private func finalizeCallSites(for rootClosure: SingleValueInstruction, in callSiteMap: inout CallSiteMap, 
+                               rootClosurePossibleLifeRange: InstructionRange, 
+                               intermediateClosureArgDescriptorData: [IntermediateClosureArgDescriptorDatum], 
+                               _ context: FunctionPassContext) 
+{
+  let closureInfo = ClosureInfo(closure: rootClosure, lifetimeFrontier: Array(rootClosurePossibleLifeRange.ends))
+
+  for (applySite, closureArgumentIndex, parameterInfo) in intermediateClosureArgDescriptorData {
+    guard var callSite = callSiteMap[applySite] else {
+      fatalError("While finalizing call sites, call site descriptor not found for call site: \(applySite)!")
+    }
+    let closureArgDesc = ClosureArgDescriptor(closureInfo: closureInfo, closureArgumentIndex: closureArgumentIndex, 
+                                              parameterInfo: parameterInfo)
+    callSite.appendClosureArgDescriptor(closureArgDesc)
+    callSiteMap.update(key: applySite, value: callSite)
+  }
+}
+
+private func isClosureApplied(in callee: Function, closureArgIndex index: Int) -> Bool {
+  func inner(_ callee: Function, _ index: Int, _ handledFuncs: inout Set<Function>) -> Bool {
+    let closureArg = callee.argument(at: index)
+
+    for use in closureArg.uses {
+      if let fai = use.instruction as? FullApplySite {
+        if fai.callee == closureArg {
+          return true
+        }
+
+        if let faiCallee = fai.referencedFunction,
+           !faiCallee.blocks.isEmpty,
+           handledFuncs.insert(faiCallee).inserted,
+           handledFuncs.count <= recursionBudget
+        {
+          if inner(faiCallee, fai.calleeArgumentIndex(of: use)!, &handledFuncs) {
+            return true
+          }
+        }
+      }
+    }
+
+    return false
+  }
+
+  // Limit the number of recursive calls to not go into exponential behavior in corner cases.
+  let recursionBudget = 8
+  var handledFuncs: Set<Function> = []
+  return inner(callee, index, &handledFuncs)
+}
+
+/// Marks any converted/reabstracted closures, corresponding to a given root closure as used. We do not want to 
+/// look at such closures separately as during function specialization they will be handled as part of the root closure. 
+private func markConvertedAndReabstractedClosuresAsUsed(rootClosure: Value, convertedAndReabstractedClosure: Value, 
+                                                        convertedAndReabstractedClosures: inout InstructionSet) 
+{
+  if convertedAndReabstractedClosure != rootClosure {
+    switch convertedAndReabstractedClosure {
+    case let pai as PartialApplyInst:
+      convertedAndReabstractedClosures.insert(pai)
+      return 
+        markConvertedAndReabstractedClosuresAsUsed(rootClosure: rootClosure, 
+                                                   convertedAndReabstractedClosure: pai.callee, 
+                                                   convertedAndReabstractedClosures: &convertedAndReabstractedClosures)
+    case let cvt as ConvertFunctionInst:
+      convertedAndReabstractedClosures.insert(cvt)
+      return 
+        markConvertedAndReabstractedClosuresAsUsed(rootClosure: rootClosure, 
+                                                   convertedAndReabstractedClosure: cvt.fromFunction,
+                                                   convertedAndReabstractedClosures: &convertedAndReabstractedClosures)
+    case let cvt as ConvertEscapeToNoEscapeInst:
+      convertedAndReabstractedClosures.insert(cvt)
+      return 
+        markConvertedAndReabstractedClosuresAsUsed(rootClosure: rootClosure, 
+                                                   convertedAndReabstractedClosure: cvt.fromFunction,
+                                                   convertedAndReabstractedClosures: &convertedAndReabstractedClosures)
+    case let mdi as MarkDependenceInst:
+      convertedAndReabstractedClosures.insert(mdi)
+      return 
+        markConvertedAndReabstractedClosuresAsUsed(rootClosure: rootClosure, convertedAndReabstractedClosure: mdi.value,
+                                                   convertedAndReabstractedClosures: &convertedAndReabstractedClosures)
+    default:
+      fatalError("While marking converted/reabstracted closures as used, found unexpected instruction: \(convertedAndReabstractedClosure)")
+    }
+  }
+}
+
+private extension PartialApplyInst {
+  /// True, if the closure obtained from this partial_apply is the
+  /// pullback returned from an autodiff VJP
+  var isPullbackInResultOfAutodiffVJP: Bool {
+    if self.parentFunction.isAutodiffVJP,
+       let use = self.uses.singleUse,
+       let tupleInst = use.instruction as? TupleInst,
+       let returnInst = self.parentFunction.returnInstruction,
+       tupleInst == returnInst.returnedValue
+    {
+      return true
+    }
+
+    return false
+  }
+
+  var hasOnlyInoutIndirectArguments: Bool {
+    self.argumentOperands
+      .filter { !$0.value.type.isObject }
+      .allSatisfy { self.convention(of: $0)!.isInout } 
+  }
+}
+
+private extension Instruction {
+  var asSupportedClosure: SingleValueInstruction? {
+    switch self {
+    case let tttf as ThinToThickFunctionInst where tttf.callee is FunctionRefInst:
+      return tttf
+    // TODO: figure out what to do with non-inout indirect arguments
+    // https://forums.swift.org/t/non-inout-indirect-types-not-supported-in-closure-specialization-optimization/70826
+    case let pai as PartialApplyInst where pai.callee is FunctionRefInst && pai.hasOnlyInoutIndirectArguments:
+      return pai
+    default:
+      return nil
+    }
+  }
+
+  var isSupportedClosure: Bool {
+    asSupportedClosure != nil
+  }
+}
+
+private extension ApplySite {
+  var calleeIsDynamicFunctionRef: Bool {
+    return !(callee is DynamicFunctionRefInst || callee is PreviousDynamicFunctionRefInst)
+  }
+}
+
+private extension Function {
+  var effectAllowsSpecialization: Bool {
+    switch self.effectAttribute {
+    case .readNone, .readOnly, .releaseNone: return false
+    default: return true
+    }
+  }
+}
+
+// ===================== Utility Types ===================== //
+
+private struct OrderedDict<Key: Hashable, Value> {
+  private var valueIndexDict: [Key: Int] = [:]
+  private var entryList: [(Key, Value)] = []
+
+  public subscript(key: Key) -> Value? {
+    if let index = valueIndexDict[key] {
+      return entryList[index].1
+    }
+    return nil
+  }
+
+  public mutating func insert(key: Key, value: Value) {
+    if valueIndexDict[key] == nil {
+      valueIndexDict[key] = entryList.count
+      entryList.append((key, value))
+    }
+  }
+
+  public mutating func update(key: Key, value: Value) {
+    if let index = valueIndexDict[key] {
+      entryList[index].1 = value
+    }
+  }
+
+  public var keys: LazyMapSequence<Array<(Key, Value)>, Key> {
+    entryList.lazy.map { $0.0 }
+  }
+
+  public var values: LazyMapSequence<Array<(Key, Value)>, Value> {
+    entryList.lazy.map { $0.1 }
+  }
+}
+
+private typealias CallSiteMap = OrderedDict<SingleValueInstruction, CallSite>
+
+private extension CallSiteMap {
+  var callSites: [CallSite] {
+    Array(self.values)
+  }
+}
+
+
+/// Represents all the information required to represent a closure in isolation, i.e., outside of a callsite context
+/// where the closure may be getting passed as an argument.
+///
+/// Composed with other information inside a `ClosureArgDescriptor` to represent a closure as an argument at a callsite.
+private struct ClosureInfo {
+  let closure: SingleValueInstruction
+  let lifetimeFrontier: [Instruction]
+
+  init(closure: SingleValueInstruction, lifetimeFrontier: [Instruction]) {
+    self.closure = closure
+    self.lifetimeFrontier = lifetimeFrontier
+  }
+
+}
+
+/// Represents a closure as an argument at a callsite.
+private struct ClosureArgDescriptor {
+  let closureInfo: ClosureInfo
+  /// The index of the closure in the callsite's argument list.
+  let closureArgumentIndex: Int
+  let parameterInfo: ParameterInfo
+}
+
+/// Represents a callsite containing one or more closure arguments.
+private struct CallSite {
+  let applySite: ApplySite
+  var closureArgDescriptors: [ClosureArgDescriptor] = []
+
+  public init(applySite: ApplySite) {
+    self.applySite = applySite
+  }
+
+  public mutating func appendClosureArgDescriptor(_ descriptor: ClosureArgDescriptor) {
+    self.closureArgDescriptors.append(descriptor)
+  }
+}
+
+// ===================== Unit tests ===================== //
+
+let gatherCallSitesTest = FunctionTest("closure_specialize_gather_call_sites") { function, arguments, context in
+  print("Specializing closures in function: \(function.name)")
+  print("===============================================")
+  var callSites = gatherCallSites(in: function, context)
+
+  callSites.forEach { callSite in
+    print("PartialApply call site: \(callSite.applySite)")
+    print("Passed in closures: ")
+    for index in callSite.closureArgDescriptors.indices {
+      var closureArgDescriptor = callSite.closureArgDescriptors[index]
+      print("\(index+1). \(closureArgDescriptor.closureInfo.closure)")
+    }
+  }
+  print("\n")
+}

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -30,4 +30,5 @@ swift_compiler_sources(Optimizer
   SimplificationPasses.swift
   StackPromotion.swift
   StripObjectHeaders.swift
+  AutodiffClosureSpecialization.swift
 )

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -12,6 +12,7 @@ swift_compiler_sources(Optimizer
   AsyncDemotion.swift
   BooleanLiteralFolding.swift
   CleanupDebugSteps.swift
+  ClosureSpecialization.swift
   ComputeEscapeEffects.swift
   ComputeSideEffects.swift
   DeadStoreElimination.swift
@@ -30,5 +31,4 @@ swift_compiler_sources(Optimizer
   SimplificationPasses.swift
   StackPromotion.swift
   StripObjectHeaders.swift
-  AutodiffClosureSpecialization.swift
 )

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -93,6 +93,7 @@ private func registerSwiftPasses() {
   registerPass(lifetimeDependenceDiagnosticsPass, { lifetimeDependenceDiagnosticsPass.run($0) })
   registerPass(lifetimeDependenceInsertionPass, { lifetimeDependenceInsertionPass.run($0) })
   registerPass(lifetimeDependenceScopeFixupPass, { lifetimeDependenceScopeFixupPass.run($0) })
+  registerPass(generalClosureSpecialization, { generalClosureSpecialization.run($0) })
   registerPass(autodiffClosureSpecialization, { autodiffClosureSpecialization.run($0) })
 
   // Instruction passes

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -93,6 +93,8 @@ private func registerSwiftPasses() {
   registerPass(lifetimeDependenceDiagnosticsPass, { lifetimeDependenceDiagnosticsPass.run($0) })
   registerPass(lifetimeDependenceInsertionPass, { lifetimeDependenceInsertionPass.run($0) })
   registerPass(lifetimeDependenceScopeFixupPass, { lifetimeDependenceScopeFixupPass.run($0) })
+  registerPass(autodiffClosureSpecialization, { autodiffClosureSpecialization.run($0) })
+
   // Instruction passes
   registerForSILCombine(BeginCOWMutationInst.self, { run(BeginCOWMutationInst.self, $0) })
   registerForSILCombine(GlobalValueInst.self,      { run(GlobalValueInst.self, $0) })

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -398,6 +398,22 @@ extension LoadInst {
   }
 }
 
+extension PartialApplyInst {
+  var isPartialApplyOfReabstractionThunk: Bool {
+    // A partial_apply of a reabstraction thunk either has a single capture
+    // (a function) or two captures (function and dynamic Self type).
+    if self.numArguments == 1 || self.numArguments == 2, 
+       let fun = self.referencedFunction,
+       fun.isReabstractionThunk,
+       self.callee.type.isReferenceCounted(in: self.parentFunction) || self.callee.type.isThickFunction
+    {
+      return true
+    }
+    
+    return false
+  }
+}
+
 extension FunctionPassContext {
   /// Returns true if any blocks were removed.
   func removeDeadBlocks(in function: Function) -> Bool {
@@ -539,6 +555,10 @@ extension Function {
       }
     }
     return nil
+  }
+
+  var mayBindDynamicSelf: Bool {
+    self.bridged.mayBindDynamicSelf()
   }
 }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -405,7 +405,8 @@ extension PartialApplyInst {
     if self.numArguments == 1 || self.numArguments == 2, 
        let fun = self.referencedFunction,
        fun.isReabstractionThunk,
-       self.callee.type.isReferenceCounted(in: self.parentFunction) || self.callee.type.isThickFunction
+       self.arguments[0].type.isFunction,
+       self.arguments[0].type.isReferenceCounted(in: self.parentFunction) || self.callee.type.isThickFunction
     {
       return true
     }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/Test.swift
@@ -164,7 +164,8 @@ public func registerOptimizerTests() {
     lifetimeDependenceUseTest,
     linearLivenessTest,
     parseTestSpecificationTest,
-    variableIntroducerTest
+    variableIntroducerTest,
+    gatherCallSitesTest
   )
 
   // Finally register the thunk they all call through.

--- a/SwiftCompilerSources/Sources/SIL/ApplySite.swift
+++ b/SwiftCompilerSources/Sources/SIL/ApplySite.swift
@@ -108,6 +108,10 @@ public protocol ApplySite : Instruction {
 extension ApplySite {
   public var callee: Value { operands[ApplyOperandConventions.calleeIndex].value }
 
+  public var hasSubstitutions: Bool {
+    return substitutionMap.hasAnySubstitutableParams
+  }
+
   public var isAsync: Bool {
     return callee.type.isAsyncFunction
   }
@@ -126,7 +130,15 @@ extension ApplySite {
     return false
   }
 
-  /// Returns the subset of operands that are argument operands.
+  public var isCalleeNoReturn: Bool {
+    bridged.ApplySite_isCalleeNoReturn()  
+  }
+
+  public var isCalleeTrapNoReturn: Bool {
+    referencedFunction?.isTrapNoReturn ?? false
+  }
+
+  /// Returns the subset of operands which are argument operands.
   ///
   /// This does not include the callee function operand.
   public var argumentOperands: OperandArray {

--- a/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
+++ b/SwiftCompilerSources/Sources/SIL/BasicBlock.swift
@@ -57,6 +57,26 @@ final public class BasicBlock : CustomStringConvertible, HasShortDescription, Ha
     successors.count == 1 ? successors[0] : nil
   }
 
+  /// All function exiting blocks except for ones with an `unreachable` terminator,
+  /// not immediately preceded by an apply of a no-return function.
+  public var isReachableExitBlock: Bool {
+    switch terminator {
+      case let termInst where termInst.isFunctionExiting:
+        return true
+      case is UnreachableInst:
+        if let instBeforeUnreachable = terminator.previous,
+           let ai = instBeforeUnreachable as? ApplyInst,
+           ai.isCalleeNoReturn && !ai.isCalleeTrapNoReturn
+        {
+          return true
+        }
+
+        return false
+      default:
+        return false
+    }
+  }
+
   /// The index of the basic block in its function.
   /// This has O(n) complexity. Only use it for debugging
   public var index: Int {

--- a/SwiftCompilerSources/Sources/SIL/Function.swift
+++ b/SwiftCompilerSources/Sources/SIL/Function.swift
@@ -31,6 +31,12 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     hasher.combine(ObjectIdentifier(self))
   }
 
+  public var isTrapNoReturn: Bool { bridged.isTrapNoReturn() }
+
+  public var isAutodiffVJP: Bool { bridged.isAutodiffVJP() }
+
+  public var specializationLevel: Int { bridged.specializationLevel() }
+  
   public var hasOwnership: Bool { bridged.hasOwnership() }
 
   public var hasLoweredAddresses: Bool { bridged.hasLoweredAddresses() }
@@ -59,6 +65,10 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
     entryBlock.arguments.lazy.map { $0 as! FunctionArgument }
   }
 
+  public func argument(at index: Int) -> FunctionArgument {
+    entryBlock.arguments[index] as! FunctionArgument
+  }
+
   /// All instructions of all blocks.
   public var instructions: LazySequence<FlattenSequence<LazyMapSequence<BasicBlockList, InstructionList>>> {
     blocks.lazy.flatMap { $0.instructions }
@@ -82,6 +92,8 @@ final public class Function : CustomStringConvertible, HasShortDescription, Hash
   public var isTransparent: Bool { bridged.isTransparent() }
 
   public var isAsync: Bool { bridged.isAsync() }
+
+  public var isReabstractionThunk: Bool { bridged.isReabstractionThunk() }
 
   /// True if this is a `[global_init]` function.
   ///

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -893,7 +893,16 @@ class ConvertFunctionInst : SingleValueInstruction, UnaryInstruction {
 }
 
 final public
-class ThinToThickFunctionInst : SingleValueInstruction, UnaryInstruction {}
+class ThinToThickFunctionInst : SingleValueInstruction, UnaryInstruction {
+  public var callee: Value { operand.value }
+
+  public var referencedFunction: Function? {
+    if let fri = callee as? FunctionRefInst {
+      return fri.referencedFunction
+    }
+    return nil
+  }
+}
 
 final public class ThickToObjCMetatypeInst : SingleValueInstruction {}
 final public class ObjCToThickMetatypeInst : SingleValueInstruction {}

--- a/SwiftCompilerSources/Sources/SIL/SubstitutionMap.swift
+++ b/SwiftCompilerSources/Sources/SIL/SubstitutionMap.swift
@@ -25,6 +25,8 @@ public struct SubstitutionMap {
 
   public var isEmpty: Bool { bridged.isEmpty() }
 
+  public var hasAnySubstitutableParams: Bool { bridged.hasAnySubstitutableParams() }
+
   public var replacementTypes: OptionalTypeArray {
     let types = BridgedTypeArray.fromReplacementTypes(bridged)
     return OptionalTypeArray(bridged: types)

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -58,6 +58,7 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
   public var isMetatype: Bool { bridged.isMetatype() }
   public var isNoEscapeFunction: Bool { bridged.isNoEscapeFunction() }
   public var containsNoEscapeFunction: Bool { bridged.containsNoEscapeFunction() }
+  public var isThickFunction: Bool { bridged.isThickFunction() }
   public var isAsyncFunction: Bool { bridged.isAsyncFunction() }
 
   public var canBeClass: BridgedType.TraitResult { bridged.canBeClass() }

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -290,6 +290,10 @@ public:
   /// Are we building in embedded Swift + -no-allocations?
   bool NoAllocations = false;
 
+  /// Should we use the experimental Swift based closure-specialization
+  /// optimization pass instead of the existing C++ one.
+  bool EnableExperimentalSwiftBasedClosureSpecialization = false;
+
   /// The name of the file to which the backend should save optimization
   /// records.
   std::string OptRecordFile;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -359,6 +359,10 @@ def enable_experimental_async_top_level :
 // HIDDEN FLAGS
 let Flags = [FrontendOption, NoDriverOption, HelpHidden] in {
 
+def enable_experimental_swift_based_closure_specialization : 
+  Flag<["-"], "experimental-swift-based-closure-specialization">,
+  HelpText<"Use the experimental Swift based closure-specialization optimization pass instead of the existing C++ one">; 
+
 def checked_async_objc_bridging : Joined<["-"], "checked-async-objc-bridging=">,
   HelpText<"Control whether checked continuations are used when bridging "
            "async calls from Swift to ObjC: 'on', 'off' ">;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -347,6 +347,7 @@ struct BridgedType {
   BRIDGED_INLINE bool isMetatype() const;
   BRIDGED_INLINE bool isNoEscapeFunction() const;
   BRIDGED_INLINE bool containsNoEscapeFunction() const;
+  BRIDGED_INLINE bool isThickFunction() const;
   BRIDGED_INLINE bool isAsyncFunction() const;
   BRIDGED_INLINE bool isEmpty(BridgedFunction f) const;
   BRIDGED_INLINE TraitResult canBeClass() const;
@@ -373,7 +374,8 @@ struct BridgedType {
   BRIDGED_INLINE bool isEndCaseIterator(EnumElementIterator i) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getEnumCasePayload(EnumElementIterator i, BridgedFunction f) const;
   BRIDGED_INLINE SwiftInt getNumTupleElements() const;
-  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getTupleElementType(SwiftInt idx) const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType
+  getTupleElementType(SwiftInt idx) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getFunctionTypeWithNoEscape(bool withNoEscape) const;
 };
 
@@ -547,6 +549,7 @@ struct BridgedFunction {
   BRIDGED_INLINE bool isAvailableExternally() const;
   BRIDGED_INLINE bool isTransparent() const;
   BRIDGED_INLINE bool isAsync() const;
+  BRIDGED_INLINE bool isReabstractionThunk() const;
   BRIDGED_INLINE bool isGlobalInitFunction() const;
   BRIDGED_INLINE bool isGlobalInitOnceFunction() const;
   BRIDGED_INLINE bool isDestructor() const;
@@ -554,6 +557,7 @@ struct BridgedFunction {
   BRIDGED_INLINE bool hasSemanticsAttr(BridgedStringRef attrName) const;
   BRIDGED_INLINE bool hasUnsafeNonEscapableResult() const;
   BRIDGED_INLINE bool hasResultDependsOnSelf() const;
+  bool mayBindDynamicSelf() const;
   BRIDGED_INLINE EffectsKind getEffectAttribute() const;
   BRIDGED_INLINE PerformanceConstraints getPerformanceConstraints() const;
   BRIDGED_INLINE InlineStrategy getInlineStrategy() const;
@@ -566,6 +570,9 @@ struct BridgedFunction {
   BRIDGED_INLINE void setIsPerformanceConstraint(bool isPerfConstraint) const;
   BRIDGED_INLINE bool isResilientNominalDecl(BridgedNominalTypeDecl decl) const;
   BRIDGED_INLINE BridgedType getLoweredType(BridgedASTType type) const;
+  bool isTrapNoReturn() const;
+  bool isAutodiffVJP() const;
+  SwiftInt specializationLevel() const;
 
   enum class ParseEffectsMode {
     argumentEffectsFromSource,
@@ -658,6 +665,7 @@ struct BridgedSubstitutionMap {
 
   BRIDGED_INLINE BridgedSubstitutionMap();
   BRIDGED_INLINE bool isEmpty() const;
+  BRIDGED_INLINE bool hasAnySubstitutableParams() const;
 };
 
 struct BridgedTypeArray {
@@ -917,6 +925,7 @@ struct BridgedInstruction {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap ApplySite_getSubstitutionMap() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType ApplySite_getSubstitutedCalleeType() const;
   BRIDGED_INLINE SwiftInt ApplySite_getNumArguments() const;
+  BRIDGED_INLINE bool ApplySite_isCalleeNoReturn() const;
   BRIDGED_INLINE SwiftInt FullApplySite_numIndirectResultArguments() const;
 
   // =========================================================================//

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -262,6 +262,10 @@ bool BridgedType::containsNoEscapeFunction() const {
   return unbridged().containsNoEscapeFunction();
 }
 
+bool BridgedType::isThickFunction() const {
+  return unbridged().isThickFunction();
+}
+
 bool BridgedType::isAsyncFunction() const {
   return unbridged().isAsyncFunction();
 }
@@ -530,6 +534,10 @@ bool BridgedSubstitutionMap::isEmpty() const {
   return unbridged().empty();
 }
 
+bool BridgedSubstitutionMap::hasAnySubstitutableParams() const {
+  return unbridged().hasAnySubstitutableParams();
+}
+
 //===----------------------------------------------------------------------===//
 //                                BridgedLocation
 //===----------------------------------------------------------------------===//
@@ -633,6 +641,10 @@ bool BridgedFunction::isTransparent() const {
 
 bool BridgedFunction::isAsync() const {
   return getFunction()->isAsync();
+}
+
+bool BridgedFunction::isReabstractionThunk() const {
+  return getFunction()->isThunk() == swift::IsReabstractionThunk;
 }
 
 bool BridgedFunction::isGlobalInitFunction() const {
@@ -1281,6 +1293,10 @@ BridgedASTType BridgedInstruction::ApplySite_getSubstitutedCalleeType() const {
 
 SwiftInt BridgedInstruction::ApplySite_getNumArguments() const {
   return swift::ApplySite(unbridged()).getNumArguments();
+}
+
+bool BridgedInstruction::ApplySite_isCalleeNoReturn() const {
+  return swift::ApplySite(unbridged()).isCalleeNoReturn();
 }
 
 SwiftInt BridgedInstruction::FullApplySite_numIndirectResultArguments() const {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -555,6 +555,13 @@ public:
     // Handle whatever AST types are known to hold functions. Namely tuples.
     return ty->isNoEscape();
   }
+  
+  bool isThickFunction() const {
+    if (auto *fTy = getASTType()->getAs<SILFunctionType>()) {
+      return fTy->getRepresentation() == SILFunctionType::Representation::Thick;
+    }
+    return false;
+  }
 
   bool isAsyncFunction() const {
     if (auto *fTy = getASTType()->getAs<SILFunctionType>()) {

--- a/include/swift/SILOptimizer/IPO/ClosureSpecializer.h
+++ b/include/swift/SILOptimizer/IPO/ClosureSpecializer.h
@@ -1,0 +1,34 @@
+//===-------------------------- ClosureSpecializer.h ------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===-----------------------------------------------------------------------------===//
+#ifndef SWIFT_SILOPTIMIZER_CLOSURESPECIALIZER_H
+#define SWIFT_SILOPTIMIZER_CLOSURESPECIALIZER_H
+
+#include "swift/SIL/SILFunction.h"
+
+namespace swift {
+
+/// If \p function is a function-signature specialization for a constant-
+/// propagated function argument, returns 1.
+/// If \p function is a specialization of such a specialization, returns 2.
+/// And so on.
+int getSpecializationLevel(SILFunction *f);
+
+enum class AutoDiffFunctionComponent : char { JVP = 'f', VJP = 'r' };
+
+/// Returns true if the function is the JVP or the VJP corresponding to
+/// a differentiable function.
+bool isDifferentiableFuncComponent(
+    SILFunction *f,
+    AutoDiffFunctionComponent component = AutoDiffFunctionComponent::VJP);
+
+} // namespace swift
+#endif

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -239,6 +239,9 @@ struct BridgedPassContext {
   SWIFT_IMPORT_UNSAFE BridgedOwnedString mangleWithDeadArgs(const SwiftInt * _Nullable deadArgs,
                                                             SwiftInt numDeadArgs,
                                                             BridgedFunction function) const;
+  SWIFT_IMPORT_UNSAFE BridgedOwnedString mangleWithClosureArgs(BridgedValueArray closureArgs,
+                                                               BridgedArrayRef closureArgIndices,
+                                                               BridgedFunction applySiteCallee) const;
 
   SWIFT_IMPORT_UNSAFE BridgedGlobalVar createGlobalVariable(BridgedStringRef name, BridgedType type,
                                                             bool isPrivate) const;

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -19,11 +19,12 @@
 #ifndef SWIFT_SILOPTIMIZER_OPTIMIZERBRIDGING_IMPL_H
 #define SWIFT_SILOPTIMIZER_OPTIMIZERBRIDGING_IMPL_H
 
-#include "swift/SILOptimizer/OptimizerBridging.h"
+#include "swift/Demangling/Demangle.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
+#include "swift/SILOptimizer/OptimizerBridging.h"
 #include "swift/SILOptimizer/PassManager/PassManager.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -146,6 +146,8 @@ PASS(CapturePropagation, "capture-prop",
      "Captured Constant Propagation")
 PASS(ClosureSpecializer, "closure-specialize",
      "Closure Specialization on Constant Function Arguments")
+SWIFT_FUNCTION_PASS(AutodiffClosureSpecialization, "autodiff-closure-specialize",
+     "Autodiff specific closure-specialization pass")
 PASS(ClosureLifetimeFixup, "closure-lifetime-fixup",
      "Closure Lifetime Fixup")
 PASS(CodeSinking, "code-sinking",

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -146,8 +146,13 @@ PASS(CapturePropagation, "capture-prop",
      "Captured Constant Propagation")
 PASS(ClosureSpecializer, "closure-specialize",
      "Closure Specialization on Constant Function Arguments")
-SWIFT_FUNCTION_PASS(AutodiffClosureSpecialization, "autodiff-closure-specialize",
+
+// NOTE - ExperimentalSwiftBasedClosureSpecialization and AutodiffClosureSpecialization are a WIP
+SWIFT_FUNCTION_PASS(ExperimentalSwiftBasedClosureSpecialization, "experimental-swift-based-closure-specialization",
+     "General closure-specialization pass written in Swift")
+SWIFT_FUNCTION_PASS(AutodiffClosureSpecialization, "autodiff-closure-specialization",
      "Autodiff specific closure-specialization pass")
+
 PASS(ClosureLifetimeFixup, "closure-lifetime-fixup",
      "Closure Lifetime Fixup")
 PASS(CodeSinking, "code-sinking",

--- a/include/swift/SILOptimizer/Utils/CFGOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/CFGOptUtils.h
@@ -190,6 +190,8 @@ bool mergeBasicBlockWithSuccessor(SILBasicBlock *bb, DominanceInfo *domInfo,
 /// quadratic.
 bool mergeBasicBlocks(SILFunction *f);
 
+bool isTrapNoReturnFunction(SILFunction *f);
+
 /// Return true if we conservatively find all bb's that are non-failure exit
 /// basic blocks and place them in \p bbs. If we find something we don't
 /// understand, bail.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2609,6 +2609,9 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
 
   Opts.NoAllocations = Args.hasArg(OPT_no_allocations);
 
+  Opts.EnableExperimentalSwiftBasedClosureSpecialization = 
+      Args.hasArg(OPT_enable_experimental_swift_based_closure_specialization);
+
   return false;
 }
 

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -56,7 +56,9 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "closure-specialization"
+#include "swift/SILOptimizer/IPO/ClosureSpecializer.h"
 #include "swift/Basic/Range.h"
+#include "swift/Demangling/Demangle.h"
 #include "swift/Demangling/Demangler.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILCloner.h"
@@ -101,6 +103,101 @@ llvm::cl::opt<bool> EliminateDeadClosures(
 
 static bool isSupportedClosureKind(const SILInstruction *I) {
   return isa<ThinToThickFunctionInst>(I) || isa<PartialApplyInst>(I);
+}
+
+static const int SpecializationLevelLimit = 2;
+
+static int getSpecializationLevelRecursive(StringRef funcName,
+                                           Demangler &parent) {
+  using namespace Demangle;
+
+  Demangler demangler;
+  demangler.providePreallocatedMemory(parent);
+
+  // Check for this kind of node tree:
+  //
+  // kind=Global
+  //   kind=FunctionSignatureSpecialization
+  //     kind=SpecializationPassID, index=1
+  //     kind=FunctionSignatureSpecializationParam
+  //       kind=FunctionSignatureSpecializationParamKind, index=5
+  //       kind=FunctionSignatureSpecializationParamPayload, text="..."
+  //
+  Node *root = demangler.demangleSymbol(funcName);
+  if (!root)
+    return 0;
+  if (root->getKind() != Node::Kind::Global)
+    return 0;
+  Node *funcSpec = root->getFirstChild();
+  if (!funcSpec || funcSpec->getNumChildren() < 2)
+    return 0;
+  if (funcSpec->getKind() != Node::Kind::FunctionSignatureSpecialization)
+    return 0;
+
+  // Match any function specialization. We check for constant propagation at the
+  // parameter level.
+  Node *param = funcSpec->getChild(0);
+  if (param->getKind() != Node::Kind::SpecializationPassID)
+    return SpecializationLevelLimit + 1; // unrecognized format
+
+  unsigned maxParamLevel = 0;
+  for (unsigned paramIdx = 1; paramIdx < funcSpec->getNumChildren();
+       ++paramIdx) {
+    Node *param = funcSpec->getChild(paramIdx);
+    if (param->getKind() != Node::Kind::FunctionSignatureSpecializationParam)
+      return SpecializationLevelLimit + 1; // unrecognized format
+
+    // A parameter is recursive if it has a kind with index and type payload
+    if (param->getNumChildren() < 2)
+      continue;
+
+    Node *kindNd = param->getChild(0);
+    if (kindNd->getKind() !=
+        Node::Kind::FunctionSignatureSpecializationParamKind) {
+      return SpecializationLevelLimit + 1; // unrecognized format
+    }
+    auto kind = FunctionSigSpecializationParamKind(kindNd->getIndex());
+    if (kind != FunctionSigSpecializationParamKind::ConstantPropFunction)
+      continue;
+    Node *payload = param->getChild(1);
+    if (payload->getKind() !=
+        Node::Kind::FunctionSignatureSpecializationParamPayload) {
+      return SpecializationLevelLimit + 1; // unrecognized format
+    }
+    // Check if the specialized function is a specialization itself.
+    unsigned paramLevel =
+        1 + getSpecializationLevelRecursive(payload->getText(), demangler);
+    if (paramLevel > maxParamLevel)
+      maxParamLevel = paramLevel;
+  }
+  return maxParamLevel;
+}
+
+//===----------------------------------------------------------------------===//
+//                     Publicly visible for bridging
+//===----------------------------------------------------------------------===//
+
+int swift::getSpecializationLevel(SILFunction *f) {
+  Demangle::StackAllocatedDemangler<1024> demangler;
+  return getSpecializationLevelRecursive(f->getName(), demangler);
+}
+
+bool swift::isDifferentiableFuncComponent(
+    SILFunction *f, AutoDiffFunctionComponent expectedComponent) {
+  Demangle::Context Ctx;
+  if (auto *root = Ctx.demangleSymbolAsNode(f->getName())) {
+    if (auto *node =
+            root->findByKind(Demangle::Node::Kind::AutoDiffFunctionKind, 3)) {
+      if (node->hasIndex()) {
+        auto component = (char)node->getIndex();
+        if (component == (char)expectedComponent) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
 }
 
 //===----------------------------------------------------------------------===//
@@ -1082,82 +1179,6 @@ static bool canSpecializeFullApplySite(FullApplySiteKind kind) {
     return false;
   }
   llvm_unreachable("covered switch");
-}
-
-const int SpecializationLevelLimit = 2;
-
-static int getSpecializationLevelRecursive(StringRef funcName, Demangler &parent) {
-  using namespace Demangle;
-
-  Demangler demangler;
-  demangler.providePreallocatedMemory(parent);
-
-  // Check for this kind of node tree:
-  //
-  // kind=Global
-  //   kind=FunctionSignatureSpecialization
-  //     kind=SpecializationPassID, index=1
-  //     kind=FunctionSignatureSpecializationParam
-  //       kind=FunctionSignatureSpecializationParamKind, index=5
-  //       kind=FunctionSignatureSpecializationParamPayload, text="..."
-  //
-  Node *root = demangler.demangleSymbol(funcName);
-  if (!root)
-    return 0;
-  if (root->getKind() != Node::Kind::Global)
-    return 0;
-  Node *funcSpec = root->getFirstChild();
-  if (!funcSpec || funcSpec->getNumChildren() < 2)
-    return 0;
-  if (funcSpec->getKind() != Node::Kind::FunctionSignatureSpecialization)
-    return 0;
-
-  // Match any function specialization. We check for constant propagation at the
-  // parameter level.
-  Node *param = funcSpec->getChild(0);
-  if (param->getKind() != Node::Kind::SpecializationPassID)
-    return SpecializationLevelLimit + 1; // unrecognized format
-
-  unsigned maxParamLevel = 0;
-  for (unsigned paramIdx = 1; paramIdx < funcSpec->getNumChildren();
-       ++paramIdx) {
-    Node *param = funcSpec->getChild(paramIdx);
-    if (param->getKind() != Node::Kind::FunctionSignatureSpecializationParam)
-      return SpecializationLevelLimit + 1; // unrecognized format
-
-    // A parameter is recursive if it has a kind with index and type payload
-    if (param->getNumChildren() < 2)
-      continue;
-
-    Node *kindNd = param->getChild(0);
-    if (kindNd->getKind()
-        != Node::Kind::FunctionSignatureSpecializationParamKind) {
-      return SpecializationLevelLimit + 1; // unrecognized format
-    }
-    auto kind = FunctionSigSpecializationParamKind(kindNd->getIndex());
-    if (kind != FunctionSigSpecializationParamKind::ConstantPropFunction)
-      continue;
-    Node *payload = param->getChild(1);
-    if (payload->getKind()
-        != Node::Kind::FunctionSignatureSpecializationParamPayload) {
-      return SpecializationLevelLimit + 1; // unrecognized format
-    }
-    // Check if the specialized function is a specialization itself.
-    unsigned paramLevel =
-      1 + getSpecializationLevelRecursive(payload->getText(), demangler);
-    if (paramLevel > maxParamLevel)
-      maxParamLevel = paramLevel;
-  }
-  return maxParamLevel;
-}
-
-/// If \p function is a function-signature specialization for a constant-
-/// propagated function argument, returns 1.
-/// If \p function is a specialization of such a specialization, returns 2.
-/// And so on.
-static int getSpecializationLevel(SILFunction *f) {
-  Demangle::StackAllocatedDemangler<1024> demangler;
-  return getSpecializationLevelRecursive(f->getName(), demangler);
 }
 
 bool SILClosureSpecializerTransform::gatherCallSites(

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -10,25 +10,31 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cassert>
 #define DEBUG_TYPE "sil-passmanager"
 
 #include "swift/SILOptimizer/PassManager/PassManager.h"
+#include "../../IRGen/IRGenModule.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/SILOptimizerRequests.h"
 #include "swift/Demangling/Demangle.h"
-#include "../../IRGen/IRGenModule.h"
+#include "swift/Demangling/Demangler.h"
 #include "swift/SIL/ApplySite.h"
 #include "swift/SIL/DynamicCasts.h"
+#include "swift/SIL/SILBridging.h"
 #include "swift/SIL/SILCloner.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/FunctionOrder.h"
+#include "swift/SILOptimizer/IPO/ClosureSpecializer.h"
 #include "swift/SILOptimizer/OptimizerBridging.h"
 #include "swift/SILOptimizer/PassManager/PrettyStackTrace.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
-#include "swift/SILOptimizer/Utils/Devirtualize.h"
+#include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/ConstantFolding.h"
+#include "swift/SILOptimizer/Utils/Devirtualize.h"
+#include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/OptimizerStatsUtils.h"
 #include "swift/SILOptimizer/Utils/SILInliner.h"
 #include "swift/SILOptimizer/Utils/SILOptFunctionBuilder.h"
@@ -41,7 +47,6 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/GraphWriter.h"
 #include "llvm/Support/ManagedStatic.h"
-
 #include <fstream>
 
 using namespace swift;
@@ -1583,6 +1588,26 @@ void SwiftPassInvocation::endVerifyFunction() {
 SwiftPassInvocation::~SwiftPassInvocation() {}
 
 //===----------------------------------------------------------------------===//
+//                           SIL Bridging
+//===----------------------------------------------------------------------===//
+bool BridgedFunction::mayBindDynamicSelf() const {
+  return swift::mayBindDynamicSelf(getFunction());
+}
+
+bool BridgedFunction::isTrapNoReturn() const {
+  return swift::isTrapNoReturnFunction(getFunction());
+}
+
+bool BridgedFunction::isAutodiffVJP() const {
+  return swift::isDifferentiableFuncComponent(
+      getFunction(), swift::AutoDiffFunctionComponent::VJP);
+}
+
+SwiftInt BridgedFunction::specializationLevel() const {
+  return swift::getSpecializationLevel(getFunction());
+}
+
+//===----------------------------------------------------------------------===//
 //                           OptimizerBridging
 //===----------------------------------------------------------------------===//
 
@@ -1769,6 +1794,40 @@ BridgedOwnedString BridgedPassContext::mangleWithDeadArgs(const SwiftInt * _Null
     Mangler.setArgumentDead((unsigned)idx);
   }
   return Mangler.mangle();
+}
+
+BridgedOwnedString BridgedPassContext::mangleWithClosureArgs(
+  BridgedValueArray bridgedClosureArgs,
+  BridgedArrayRef bridgedClosureArgIndices,
+  BridgedFunction applySiteCallee
+) const {
+  auto pass = Demangle::SpecializationPass::ClosureSpecializer;
+  auto isSerialized = applySiteCallee.getFunction()->isSerialized();
+  Mangle::FunctionSignatureSpecializationMangler mangler(
+      pass, isSerialized, applySiteCallee.getFunction());
+
+  llvm::SmallVector<swift::SILValue, 16> closureArgsStorage;
+  auto closureArgs = bridgedClosureArgs.getValues(closureArgsStorage);
+  auto closureArgIndices = bridgedClosureArgIndices.unbridged<SwiftInt>();
+
+  assert(closureArgs.size() == closureArgIndices.size() &&
+         "Number of closures arguments and number of closure indices do not match!");
+
+  for (size_t i = 0; i < closureArgs.size(); i++) {
+    auto closureArg = closureArgs[i];
+    auto closureArgIndex = closureArgIndices[i];
+
+    if (auto *PAI = dyn_cast<PartialApplyInst>(closureArg)) {
+      mangler.setArgumentClosureProp(closureArgIndex,
+                                     const_cast<PartialApplyInst *>(PAI));
+    } else {
+      auto *TTTFI = cast<ThinToThickFunctionInst>(closureArg);
+      mangler.setArgumentClosureProp(closureArgIndex, 
+                                     const_cast<ThinToThickFunctionInst *>(TTTFI));
+    }
+  }
+
+  return mangler.mangle();
 }
 
 BridgedGlobalVar BridgedPassContext::createGlobalVariable(BridgedStringRef name, BridgedType type, bool isPrivate) const {

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cassert>
 #define DEBUG_TYPE "sil-passmanager"
 
 #include "swift/SILOptimizer/PassManager/PassManager.h"

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -768,7 +768,11 @@ static void addMidLevelFunctionPipeline(SILPassPipelinePlan &P) {
   P.addCapturePropagation();
 
   // Specialize closure.
-  P.addClosureSpecializer();
+  if (P.getOptions().EnableExperimentalSwiftBasedClosureSpecialization) {
+    P.addExperimentalSwiftBasedClosureSpecialization();
+  } else {
+    P.addClosureSpecializer();
+  }
 
   // Do the second stack promotion on low-level SIL.
   P.addStackPromotion();

--- a/test/AutoDiff/SILOptimizer/closure_specialization.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization.sil
@@ -1,0 +1,116 @@
+// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+import _Differentiation
+
+// ===================== Gathering callsites and corresponding closures ===================== //
+
+//////////////////////////////
+// Single closure call site //
+//////////////////////////////
+sil @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) 
+
+sil private @$pullback_f : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float {
+bb0(%0 : $Float, %1 : $@callee_guaranteed (Float) -> (Float, Float)):
+  %2 = apply %1(%0) : $@callee_guaranteed (Float) -> (Float, Float) // users: %5, %4
+  strong_release %1 : $@callee_guaranteed (Float) -> (Float, Float) // id: %3
+  %4 = tuple_extract %2 : $(Float, Float), 0      // user: %7
+  %5 = tuple_extract %2 : $(Float, Float), 1      // user: %6
+  %6 = struct_extract %5 : $Float, #Float._value  // user: %8
+  %7 = struct_extract %4 : $Float, #Float._value  // user: %8
+  %8 = builtin "fadd_FPIEEE32"(%6 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %9
+  %9 = struct $Float (%8 : $Builtin.FPIEEE32)     // users: %11, %10
+  debug_value %9 : $Float, let, name "x", argno 1 // id: %10
+  return %9 : $Float                              // id: %11
+}
+
+// reverse-mode derivative of f(_:)
+sil hidden @$s4test1fyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  specify_test "closure_specialize_gather_call_sites"
+  // CHECK-LABEL: Specializing closures in function: $s4test1fyS2fFTJrSpSr
+  // CHECK: PartialApply call site:   %8 = partial_apply [callee_guaranteed] %7(%6) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %9
+  // CHECK: Passed in closures:
+  // CHECK: 1.   %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %8
+
+  debug_value %0 : $Float, let, name "x", argno 1 // id: %1
+  %2 = struct_extract %0 : $Float, #Float._value  // users: %3, %3
+  %3 = builtin "fmul_FPIEEE32"(%2 : $Builtin.FPIEEE32, %2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %4
+  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     // user: %9
+  // function_ref closure #1 in static Float._vjpMultiply(lhs:rhs:)
+  %5 = function_ref @$vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %6
+  %6 = partial_apply [callee_guaranteed] %5(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %8
+  // function_ref pullback of f(_:)
+  %7 = function_ref @$pullback_f : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %8
+  %8 = partial_apply [callee_guaranteed] %7(%6) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %9
+  %9 = tuple (%4 : $Float, %8 : $@callee_guaranteed (Float) -> Float) // user: %10
+  return %9 : $(Float, @callee_guaranteed (Float) -> Float) // id: %10
+}
+
+///////////////////////////////
+// Multiple closure callsite //
+///////////////////////////////
+sil @$_vjpSin : $@convention(thin) (Float, Float) -> Float // user: %6
+sil @$_vjpCos : $@convention(thin) (Float, Float) -> Float // user: %10
+sil @$_vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float)
+
+// pullback of g(_:)
+sil private @$pullback_g : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float {
+bb0(%0 : $Float, %1 : $@callee_guaranteed (Float) -> Float, %2 : $@callee_guaranteed (Float) -> Float, %3 : $@callee_guaranteed (Float) -> (Float, Float)):
+  %4 = apply %3(%0) : $@callee_guaranteed (Float) -> (Float, Float) // users: %7, %6
+  strong_release %3 : $@callee_guaranteed (Float) -> (Float, Float) // id: %5
+  %6 = tuple_extract %4 : $(Float, Float), 0      // user: %10
+  %7 = tuple_extract %4 : $(Float, Float), 1      // user: %8
+  %8 = apply %2(%7) : $@callee_guaranteed (Float) -> Float // user: %12
+  strong_release %2 : $@callee_guaranteed (Float) -> Float // id: %9
+  %10 = apply %1(%6) : $@callee_guaranteed (Float) -> Float // user: %13
+  strong_release %1 : $@callee_guaranteed (Float) -> Float // id: %11
+  %12 = struct_extract %8 : $Float, #Float._value // user: %14
+  %13 = struct_extract %10 : $Float, #Float._value // user: %14
+  %14 = builtin "fadd_FPIEEE32"(%13 : $Builtin.FPIEEE32, %12 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %15
+  %15 = struct $Float (%14 : $Builtin.FPIEEE32)   // users: %17, %16
+  debug_value %15 : $Float, let, name "x", argno 1 // id: %16
+  return %15 : $Float                             // id: %17
+}
+
+// reverse-mode derivative of g(_:)
+sil hidden @$s4test1gyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  specify_test "closure_specialize_gather_call_sites"
+  // CHECK-LABEL: Specializing closures in function: $s4test1gyS2fFTJrSpSr
+  // CHECK: PartialApply call site:   %16 = partial_apply [callee_guaranteed] %15(%6, %10, %14) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %17
+  // CHECK: Passed in closures:
+  // CHECK: 1.   %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float // user: %16
+  // CHECK: 2.   %10 = partial_apply [callee_guaranteed] %9(%0) : $@convention(thin) (Float, Float) -> Float // user: %16
+  // CHECK: 3.   %14 = partial_apply [callee_guaranteed] %13(%8, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %16
+
+  debug_value %0 : $Float, let, name "x", argno 1 // id: %1
+  %2 = struct_extract %0 : $Float, #Float._value  // users: %7, %3
+  %3 = builtin "int_sin_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // users: %11, %4
+  %4 = struct $Float (%3 : $Builtin.FPIEEE32)     // user: %14
+  // function_ref closure #1 in _vjpSin(_:)
+  %5 = function_ref @$_vjpSin : $@convention(thin) (Float, Float) -> Float // user: %6
+  %6 = partial_apply [callee_guaranteed] %5(%0) : $@convention(thin) (Float, Float) -> Float // user: %16
+  %7 = builtin "int_cos_FPIEEE32"(%2 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // users: %11, %8
+  %8 = struct $Float (%7 : $Builtin.FPIEEE32)     // user: %14
+  // function_ref closure #1 in _vjpCos(_:)
+  %9 = function_ref @$_vjpCos : $@convention(thin) (Float, Float) -> Float // user: %10
+  %10 = partial_apply [callee_guaranteed] %9(%0) : $@convention(thin) (Float, Float) -> Float // user: %16
+  %11 = builtin "fmul_FPIEEE32"(%3 : $Builtin.FPIEEE32, %7 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %12
+  %12 = struct $Float (%11 : $Builtin.FPIEEE32)   // user: %17
+  // function_ref closure #1 in static Float._vjpMultiply(lhs:rhs:)
+  %13 = function_ref @$_vjpMultiply : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %14
+  %14 = partial_apply [callee_guaranteed] %13(%8, %4) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %16
+  // function_ref pullback of g(_:)
+  %15 = function_ref @$pullback_g : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %16
+  %16 = partial_apply [callee_guaranteed] %15(%6, %10, %14) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> Float, @owned @callee_guaranteed (Float) -> (Float, Float)) -> Float // user: %17
+  %17 = tuple (%12 : $Float, %16 : $@callee_guaranteed (Float) -> Float) // user: %18
+  return %17 : $(Float, @callee_guaranteed (Float) -> Float) // id: %18
+}

--- a/test/AutoDiff/SILOptimizer/closure_specialization_xfail.sil
+++ b/test/AutoDiff/SILOptimizer/closure_specialization_xfail.sil
@@ -1,0 +1,173 @@
+// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// XFAIL: *
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+import _Differentiation
+
+// ===================== Gathering callsites and corresponding closures ===================== //
+
+///////////////////////////////
+/// Parameter subset thunks ///
+///////////////////////////////
+struct X : Differentiable {
+  @_hasStorage var a: Float { get set }
+  @_hasStorage var b: Double { get set }
+  struct TangentVector : AdditiveArithmetic, Differentiable {
+    @_hasStorage var a: Float { get set }
+    @_hasStorage var b: Double { get set }
+    static func + (lhs: X.TangentVector, rhs: X.TangentVector) -> X.TangentVector
+    static func - (lhs: X.TangentVector, rhs: X.TangentVector) -> X.TangentVector
+    @_implements(Equatable, ==(_:_:)) static func __derived_struct_equals(_ a: X.TangentVector, _ b: X.TangentVector) -> Bool
+    typealias TangentVector = X.TangentVector
+    init(a: Float, b: Double)
+    static var zero: X.TangentVector { get }
+  }
+  init(a: Float, b: Double)
+  mutating func move(by offset: X.TangentVector)
+}
+
+sil [transparent] [thunk] @subset_parameter_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector
+
+sil @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector
+
+sil @pullback_g : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector
+
+sil hidden @$s5test21g1xSfAA1XV_tFTJrSpSr : $@convention(thin) (X) -> (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) {
+bb0(%0 : $X):
+  specify_test "closure_specialize_gather_call_sites"
+  // CHECK-LABEL: Specializing closures in function: $s5test21g1xSfAA1XV_tFTJrSpSr
+  // CHECK: PartialApply call site:   %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector // user: %10
+  // CHECK: Passed in closures:
+  // CHECK: 1.   %7 = partial_apply [callee_guaranteed] %6(%5) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector // user: %9
+
+  %3 = struct_extract %0 : $X, #X.a               // user: %10
+  %4 = function_ref @pullback_f : $@convention(thin) (Float, Double) -> X.TangentVector // user: %5
+  %5 = thin_to_thick_function %4 : $@convention(thin) (Float, Double) -> X.TangentVector to $@callee_guaranteed (Float, Double) -> X.TangentVector // user: %7
+  %6 = function_ref @subset_parameter_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector // user: %7
+  %7 = partial_apply [callee_guaranteed] %6(%5) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (Float, Double) -> X.TangentVector) -> X.TangentVector // user: %9
+  %8 = function_ref @pullback_g : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector // user: %9
+  %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> X.TangentVector) -> X.TangentVector // user: %10
+  %10 = tuple (%3 : $Float, %9 : $@callee_guaranteed (Float) -> X.TangentVector) // user: %11
+  return %10 : $(Float, @callee_guaranteed (Float) -> X.TangentVector) // id: %11
+}
+
+///////////////////////////////////////////////////////////////////////
+///////// Specialized generic closures - PartialApply Closure /////////
+///////////////////////////////////////////////////////////////////////
+
+// closure #1 in static Float._vjpMultiply(lhs:rhs:)
+sil @$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_ : $@convention(thin) (Float, Float, Float) -> (Float, Float)
+
+// thunk for @escaping @callee_guaranteed (@unowned Float) -> (@unowned Float, @unowned Float)
+sil [transparent] [reabstraction_thunk] @$sS3fIegydd_S3fIegnrr_TR : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float)
+
+// function_ref specialized pullback of f<A>(a:)
+sil [transparent] [thunk] @pullback_f_specialized : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float
+
+// thunk for @escaping @callee_guaranteed (@in_guaranteed Float) -> (@out Float)
+sil [transparent] [reabstraction_thunk] @$sS2fIegnr_S2fIegyd_TR : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float
+
+sil private [signature_optimized_thunk] [always_inline] @pullback_h : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float {
+bb0(%0 : $Float, %1 : $@callee_guaranteed (Float) -> Float):
+  %2 = integer_literal $Builtin.Int64, 0          // user: %3
+  %3 = builtin "sitofp_Int64_FPIEEE32"(%2 : $Builtin.Int64) : $Builtin.FPIEEE32 // users: %10, %5
+  %4 = struct_extract %0 : $Float, #Float._value  // user: %5
+  %5 = builtin "fadd_FPIEEE32"(%3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %6
+  %6 = struct $Float (%5 : $Builtin.FPIEEE32)     // user: %7
+  %7 = apply %1(%6) : $@callee_guaranteed (Float) -> Float // user: %9
+  strong_release %1 : $@callee_guaranteed (Float) -> Float // id: %8
+  %9 = struct_extract %7 : $Float, #Float._value  // user: %10
+  %10 = builtin "fadd_FPIEEE32"(%3 : $Builtin.FPIEEE32, %9 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %11
+  %11 = struct $Float (%10 : $Builtin.FPIEEE32)   // users: %13, %12
+  debug_value %11 : $Float, let, name "x", argno 1 // id: %12
+  return %11 : $Float                             // id: %13
+}
+
+// reverse-mode derivative of h(x:)
+sil hidden @$s5test21h1xS2f_tFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  specify_test "closure_specialize_gather_call_sites"
+  // CHECK-LABEL: Specializing closures in function: $s5test21h1xS2f_tFTJrSpSr
+  // CHECK: PartialApply call site:     %14 = partial_apply [callee_guaranteed] %13(%11) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %15
+  // CHECK: Passed in closures:
+  // CHECK: 1.   %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %11
+
+  %1 = struct_extract %0 : $Float, #Float._value  // users: %2, %2
+  %2 = builtin "fmul_FPIEEE32"(%1 : $Builtin.FPIEEE32, %1 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %12
+  
+  // function_ref closure #1 in static Float._vjpMultiply(lhs:rhs:)
+  %3 = function_ref @$sSf16_DifferentiationE12_vjpMultiply3lhs3rhsSf5value_Sf_SftSfc8pullbacktSf_SftFZSf_SftSfcfU_ : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %4
+  %4 = partial_apply [callee_guaranteed] %3(%0, %0) : $@convention(thin) (Float, Float, Float) -> (Float, Float) // user: %6
+  
+  // function_ref thunk for @escaping @callee_guaranteed (@unowned Float) -> (@unowned Float, @unowned Float)
+  %5 = function_ref @$sS3fIegydd_S3fIegnrr_TR : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %6
+  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (@in_guaranteed Float, @guaranteed @callee_guaranteed (Float) -> (Float, Float)) -> (@out Float, @out Float) // user: %7
+  %7 = convert_function %6 : $@callee_guaranteed (@in_guaranteed Float) -> (@out Float, @out Float) to $@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float> // user: %9
+  
+  // function_ref pullback_f_specialized
+  %8 = function_ref @pullback_f_specialized : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %9
+  %9 = partial_apply [callee_guaranteed] %8(%7) : $@convention(thin) (@in_guaranteed Float, @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @out τ_0_2) for <Float, Float, Float>) -> @out Float // user: %11
+  
+  // function_ref thunk for @escaping @callee_guaranteed (@in_guaranteed Float) -> (@out Float)
+  %10 = function_ref @$sS2fIegnr_S2fIegyd_TR : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %11
+  %11 = partial_apply [callee_guaranteed] %10(%9) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %14
+  %12 = struct $Float (%2 : $Builtin.FPIEEE32)    // user: %15
+  
+  // function_ref pullback_h
+  %13 = function_ref @pullback_h : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %14
+  %14 = partial_apply [callee_guaranteed] %13(%11) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %15
+  %15 = tuple (%12 : $Float, %14 : $@callee_guaranteed (Float) -> Float) // user: %16
+  return %15 : $(Float, @callee_guaranteed (Float) -> Float) // id: %16
+}
+
+//////////////////////////////////////////////////////////////////////////////
+///////// Specialized generic closures - ThinToThickFunction closure /////////
+//////////////////////////////////////////////////////////////////////////////
+
+sil [transparent] [thunk] @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float
+
+sil [transparent] [reabstraction_thunk] @reabstraction_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float
+
+sil private [signature_optimized_thunk] [always_inline] @pullback_z : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float {
+bb0(%0 : $Float, %1 : $@callee_guaranteed (Float) -> Float):
+  %2 = integer_literal $Builtin.Int64, 0          // user: %3
+  %3 = builtin "sitofp_Int64_FPIEEE32"(%2 : $Builtin.Int64) : $Builtin.FPIEEE32 // users: %10, %5
+  %4 = struct_extract %0 : $Float, #Float._value  // user: %5
+  %5 = builtin "fadd_FPIEEE32"(%3 : $Builtin.FPIEEE32, %4 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %6
+  %6 = struct $Float (%5 : $Builtin.FPIEEE32)     // user: %7
+  %7 = apply %1(%6) : $@callee_guaranteed (Float) -> Float // user: %9
+  strong_release %1 : $@callee_guaranteed (Float) -> Float // id: %8
+  %9 = struct_extract %7 : $Float, #Float._value  // user: %10
+  %10 = builtin "fadd_FPIEEE32"(%3 : $Builtin.FPIEEE32, %9 : $Builtin.FPIEEE32) : $Builtin.FPIEEE32 // user: %11
+  %11 = struct $Float (%10 : $Builtin.FPIEEE32)   // users: %13, %12
+  debug_value %11 : $Float, let, name "x", argno 1 // id: %12
+  return %11 : $Float                             // id: %13
+}
+
+sil hidden @$s5test21z1xS2f_tFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+bb0(%0 : $Float):
+  specify_test "closure_specialize_gather_call_sites"
+  // CHECK-LABEL: Specializing closures in function: $s5test21z1xS2f_tFTJrSpSr
+  // CHECK: PartialApply call site:   %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %7
+  // CHECK: Passed in closures:
+  // CHECK: 1.   %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float // user: %4
+
+  // function_ref pullback_y_specialized
+  %1 = function_ref @pullback_y_specialized : $@convention(thin) (@in_guaranteed Float) -> @out Float // user: %2
+  %2 = thin_to_thick_function %1 : $@convention(thin) (@in_guaranteed Float) -> @out Float to $@callee_guaranteed (@in_guaranteed Float) -> @out Float // user: %4
+  // function_ref reabstraction_thunk
+  %3 = function_ref @reabstraction_thunk : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %4
+  %4 = partial_apply [callee_guaranteed] %3(%2) : $@convention(thin) (Float, @guaranteed @callee_guaranteed (@in_guaranteed Float) -> @out Float) -> Float // user: %6
+  // function_ref pullback_z
+  %5 = function_ref @pullback_z : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %6
+  %6 = partial_apply [callee_guaranteed] %5(%4) : $@convention(thin) (Float, @owned @callee_guaranteed (Float) -> Float) -> Float // user: %7
+  %7 = tuple (%0 : $Float, %6 : $@callee_guaranteed (Float) -> Float) // user: %8
+  return %7 : $(Float, @callee_guaranteed (Float) -> Float) // id: %8
+}

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_spec_and_inline.swift
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_spec_and_inline.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -parse-as-library -O -module-name=test -experimental-swift-based-closure-specialization %s -emit-sil | %FileCheck %s
+// XFAIL: *
+
+func closure(_ a: Int, b: Int) -> Bool {
+  return a < b
+}
+
+// Check that closure() is inlined into call_closure after call_closure is
+// specialized for it.
+
+// CHECK-LABEL: sil shared [noinline] @$s4test12call_closureySbSi_SiSbSi_SitXEtF27$s4test7closure_1bSbSi_SitFTf1nnc_n
+// CHECK-NOT: apply
+// CHECK: builtin "cmp_slt_Int
+// CHECK-NOT: apply
+// CHECK: return
+@inline(never)
+func call_closure(_ a: Int, _ b: Int, _ f: (Int , Int) -> Bool) -> Bool {
+  return f(a, b)
+}
+
+public func testit() -> Bool {
+  return call_closure(0, 1, closure)
+}
+

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize.sil
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize.sil
@@ -1,0 +1,941 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -experimental-swift-based-closure-specialization %s | %FileCheck %s
+// XFAIL: *
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil shared [noinline] @$s7specgen12take_closureyyySi_SitcF023$s7specgen6calleryySiFyE8_SitcfU_SiTf1c_n : $@convention(thin) (Int) -> () {
+
+// CHECK: bb0(%0 : $Int)
+// CHECK: function_ref @$s7specgen6calleryySiFySi_SitcfU_
+// CHECK: partial_apply
+
+// CHECK-LABEL: sil shared [noinline] @$s7specgen12take_closureyyySi_SitcF26$s7specgen6calleeyySi_SitFTf1c_n : $@convention(thin) () -> () {
+// CHECK-NEXT: bb0:
+// CHECK: [[FUN:%.*]] = function_ref @$s7specgen6calleeyySi_SitF : $@convention(thin) (Int, Int) -> ()
+// CHECK: thin_to_thick_function [[FUN]] : $@convention(thin) (Int, Int) -> () to $@callee_owned (Int, Int) -> ()
+
+// CHECK-LABEL: sil [noinline] @$s7specgen12take_closureyyySi_SitcF : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> () {
+sil [noinline] @$s7specgen12take_closureyyySi_SitcF : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> () {
+bb0(%0 : $@callee_owned (Int, Int) -> ()):
+  %1 = alloc_stack $Int
+  %2 = load %1 : $*Int
+  %3 = apply %0(%2, %2) : $@callee_owned (Int, Int) -> ()
+  dealloc_stack %1 : $*Int
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil shared [noinline] @$s7specgen13take_closure2yyySi_SitcF023$s7specgen6calleryySiFyE8_SitcfU_SiTf1c_n : $@convention(thin) (Int) -> () {
+// CHECK: bb0(%0 : $Int)
+// CHECK: [[FUN:%.*]] = function_ref @$s7specgen6calleryySiFySi_SitcfU_
+// CHECK: partial_apply [[FUN]](
+
+// CHECK-LABEL: sil shared [noinline] @$s7specgen13take_closure2yyySi_SitcF26$s7specgen6calleeyySi_SitFTf1c_n : $@convention(thin) () -> () {
+// CHECK-NEXT: bb0:
+// CHECK: [[FUN:%.*]] = function_ref @$s7specgen6calleeyySi_SitF : $@convention(thin) (Int, Int) -> ()
+// CHECK: thin_to_thick_function [[FUN]] : $@convention(thin) (Int, Int) -> () to $@callee_owned (Int, Int) -> ()
+
+// CHECK-LABEL: sil [noinline] @$s7specgen13take_closure2yyySi_SitcF : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> () {
+sil [noinline] @$s7specgen13take_closure2yyySi_SitcF : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> () {
+bb0(%0 : $@callee_owned (Int, Int) -> ()):
+  %1 = alloc_stack $Int
+  %2 = load %1 : $*Int
+  %3 = apply %0(%2, %2) : $@callee_owned (Int, Int) -> ()
+  dealloc_stack %1 : $*Int
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [noinline] @$s7specgen6calleeyySi_S2itF : $@convention(thin) (Int, Int, Int) -> () {
+// specgen.callee (Swift.Int, Swift.Int, Swift.Int) -> ()
+sil [noinline] @$s7specgen6calleeyySi_S2itF : $@convention(thin) (Int, Int, Int) -> () {
+bb0(%0 : $Int, %1 : $Int, %2 : $Int):
+  %6 = tuple ()                                   // user: %7
+  return %6 : $()                                 // id: %7
+}
+
+// CHECK-LABEL: sil @$s7specgen6calleryySiF : $@convention(thin) (Int) -> () {
+// CHECK: [[ID1:%[0-9]+]] = function_ref @$s7specgen13take_closure2yyySi_SitcF023$s7specgen6calleryySiFyE8_SitcfU_SiTf1c_n : $@convention(thin) (Int) -> ()
+// CHECK: [[ID2:%[0-9]+]] = function_ref @$s7specgen12take_closureyyySi_SitcF023$s7specgen6calleryySiFyE8_SitcfU_SiTf1c_n : $@convention(thin) (Int) -> ()
+// CHECK: apply [[ID2]](%0) : $@convention(thin) (Int) -> ()
+// CHECK: apply [[ID1]](%0) : $@convention(thin) (Int) -> ()
+sil @$s7specgen6calleryySiF : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  // function_ref specgen.take_closure ((Swift.Int, Swift.Int) -> ()) -> ()
+  %2 = function_ref @$s7specgen12take_closureyyySi_SitcF : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> () // user: %5
+  // function_ref specgen.(caller (Swift.Int) -> ()).(closure #1)
+  %3 = function_ref @$s7specgen6calleryySiFySi_SitcfU_ : $@convention(thin) (Int, Int, Int) -> () // user: %4
+  %4 = partial_apply %3(%0) : $@convention(thin) (Int, Int, Int) -> () // user: %5
+  strong_retain %4 : $@callee_owned (Int, Int) -> ()
+  %5 = apply %2(%4) : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> ()
+  %6 = function_ref @$s7specgen13take_closure2yyySi_SitcF : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> () // user: %5
+  strong_retain %4 : $@callee_owned (Int, Int) -> ()
+  %7 = apply %6(%4) : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> ()
+  strong_release %4 : $@callee_owned (Int, Int) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil shared @$s7specgen6calleryySiFySi_SitcfU_ : $@convention(thin) (Int, Int, Int) -> () {
+sil shared @$s7specgen6calleryySiFySi_SitcfU_ : $@convention(thin) (Int, Int, Int) -> () {
+bb0(%0 : $Int, %1 : $Int, %2 : $Int):
+  %5 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>, var, name "p"                   // users: %6, %10, %14
+  %5a = project_box %5 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  store %0 to %5a : $*Int                        // id: %6
+  %7 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>, var, name "q"                   // users: %8, %11, %13
+  %7a = project_box %7 : $<τ_0_0> { var τ_0_0 } <Int>, 0
+  store %1 to %7a : $*Int                        // id: %8
+  // function_ref specgen.callee (Swift.Int, Swift.Int, Swift.Int) -> ()
+  %9 = function_ref @$s7specgen6calleeyySi_S2itF : $@convention(thin) (Int, Int, Int) -> () // user: %12
+  %10 = load %5a : $*Int                         // user: %12
+  %11 = load %7a : $*Int                         // user: %12
+  %12 = apply %9(%10, %11, %2) : $@convention(thin) (Int, Int, Int) -> ()
+  strong_release %7 : $<τ_0_0> { var τ_0_0 } <Int>
+  strong_release %5 : $<τ_0_0> { var τ_0_0 } <Int>
+  %15 = tuple ()                                  // user: %16
+  return %15 : $()                                // id: %16
+}
+
+//////////////////////////////////
+// Thin To Thick Function Tests //
+//////////////////////////////////
+
+// CHECK-LABEL: sil [noinline] @$s7specgen6calleeyySi_SitF : $@convention(thin) (Int, Int) -> () {
+// specgen.callee (Swift.Int, Swift.Int) -> ()
+sil [noinline] @$s7specgen6calleeyySi_SitF : $@convention(thin) (Int, Int) -> () {
+bb0(%0 : $Int, %1 : $Int):
+  %6 = tuple ()                                   // user: %7
+  return %6 : $()                                 // id: %7
+}
+
+// CHECK-LABEL: sil @$s7specgen11tttficalleryySiF : $@convention(thin) (Int) -> () {
+// CHECK: [[ID1:%[0-9]+]] = function_ref @$s7specgen13take_closure2yyySi_SitcF26$s7specgen6calleeyySi_SitFTf1c_n : $@convention(thin) () -> ()
+// CHECK: [[ID2:%[0-9]+]] = function_ref @$s7specgen12take_closureyyySi_SitcF26$s7specgen6calleeyySi_SitFTf1c_n : $@convention(thin) () -> ()
+// CHECK: apply [[ID2]]() : $@convention(thin) () -> ()
+// CHECK: apply [[ID1]]() : $@convention(thin) () -> ()
+sil @$s7specgen11tttficalleryySiF : $@convention(thin) (Int) -> () {
+bb0(%0 : $Int):
+  // function_ref specgen.take_closure ((Swift.Int, Swift.Int) -> ()) -> ()
+  %2 = function_ref @$s7specgen12take_closureyyySi_SitcF : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> () // user: %5
+  // function_ref specgen.(caller (Swift.Int) -> ()).(closure #1)
+  %3 = function_ref @$s7specgen6calleeyySi_SitF : $@convention(thin) (Int, Int) -> () // user: %4
+  %4 = thin_to_thick_function %3 : $@convention(thin) (Int, Int) -> () to $@callee_owned (Int, Int) -> () // user: %5
+  %5 = apply %2(%4) : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> ()
+  %6 = function_ref @$s7specgen13take_closure2yyySi_SitcF : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> ()
+  %7 = apply %6(%4) : $@convention(thin) (@owned @callee_owned (Int, Int) -> ()) -> ()
+  %9999 = tuple ()                                   // user: %7
+  return %9999 : $()                                 // id: %7
+}
+
+// We don't handle closures that close over address types (*NOTE* this includes
+// address and non-address only types) taken as @in or @in_guaranteed.
+
+// This is a temporary limitation.
+// CHECK-LABEL: sil @address_closure : $@convention(thin) (@in Int) -> () {
+sil @address_closure : $@convention(thin) (@in Int) -> () {
+bb0(%0 : $*Int):
+  %6 = tuple()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
+sil @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
+bb0(%0 : $@callee_owned () -> ()):
+  %1 = apply %0() : $@callee_owned () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @address_caller : $@convention(thin) (@in Int) -> () {
+// CHECK-NOT: _TTSf1cl15address_closureSi__address_closure_user
+sil @address_caller : $@convention(thin) (@in Int) -> () {
+bb0(%0 : $*Int):
+  %1 = function_ref @address_closure : $@convention(thin) (@in Int) -> ()
+  %2 = partial_apply %1(%0) : $@convention(thin) (@in Int) -> ()
+  %3 = function_ref @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %4 = apply %3(%2) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+class A {}
+
+sil hidden [noinline] @closure : $@convention(thin) (@owned A, @owned A) -> () {
+bb0(%0 : $A, %1 : $A):
+  strong_release %1 : $A
+  strong_release %0 : $A
+  %4 = tuple ()
+  return %4 : $()
+}
+
+// CHECK-LABEL: sil shared {{.*}} @$s11use_closure{{.*}}Tf{{.*}} : $@convention(thin) (@owned A) -> () {
+sil hidden [noinline] @use_closure : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> () {
+bb0(%0 : $@callee_owned (@owned A) -> ()):
+  %1 = alloc_ref $A
+  %2 = apply %0(%1) : $@callee_owned (@owned A) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil shared {{.*}} @$s17use_closure_throw{{.*}}Tf{{.*}} : $@convention(thin) (@owned A) -> @error any Error {
+sil hidden [noinline] @use_closure_throw : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> @error any Error {
+bb0(%0 : $@callee_owned (@owned A) -> ()):
+  %1 = alloc_ref $A
+  %2 = apply %0(%1) : $@callee_owned (@owned A) -> ()
+  %3 = tuple ()
+  return %3 : $()
+}
+
+// CHECK-LABEL: sil {{.*}} @different_execution_counts
+// CHECK: bb0([[ARG:%.*]] : $A
+// CHECK:   strong_retain [[ARG]]
+// CHECK-NOT: partial_apply
+// CHECK:  [[SPECIALIZED_CLOSURE_USER:%.*]] = function_ref @$s11use_closure{{.*}}Tf
+// CHECK:   retain_value [[ARG]]
+// CHECK-NOT: partial_apply
+// CHECK:   integer_literal $Builtin.Int64, 0
+// CHECK: br bb2
+
+// CHECK: bb1:
+// CHECK:  strong_release [[ARG]]
+// CHECK:  release_value [[ARG]]
+// CHECK:  return
+
+// CHECK: bb2({{.*}}):
+// Match the partial_apply consume of arg.
+// CHECK: retain_value [[ARG]]
+// CHECK: apply [[SPECIALIZED_CLOSURE_USER]]([[ARG]])
+// CHECK: cond_br {{.*}}, bb1, bb3
+
+sil hidden [noinline] @different_execution_counts : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  strong_retain %0 : $A
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %3 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %4 = integer_literal $Builtin.Int64, 0
+  %5 = integer_literal $Builtin.Int64, 5
+  %6 = integer_literal $Builtin.Int64, 1
+  %7 = integer_literal $Builtin.Int1, 0
+  %8 = function_ref @use_closure : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  br bb2(%4 : $Builtin.Int64)
+
+bb1:
+  strong_release %3 : $@callee_owned (@owned A) -> ()
+  %11 = tuple ()
+  return %11 : $()
+
+bb2(%13 : $Builtin.Int64):
+  %14 = builtin "sadd_with_overflow_Int64"(%13 : $Builtin.Int64, %6 : $Builtin.Int64, %7 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %15 = tuple_extract %14 : $(Builtin.Int64, Builtin.Int1), 0
+  strong_retain %3 : $@callee_owned (@owned A) -> ()
+  %17 = apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  %18 = builtin "cmp_eq_Int64"(%15 : $Builtin.Int64, %5 : $Builtin.Int64) : $Builtin.Int1
+  cond_br %18, bb1, bb3
+
+bb3:
+  br bb2(%15 : $Builtin.Int64)
+}
+
+// CHECK-LABEL: sil @insert_release_in_liferange_exit_block
+// CHECK: bb0(%0 : $A):
+// CHECK:   retain_value %0
+// CHECK: bb1:
+// CHECK-NEXT: release_value %0
+// CHECK-NEXT: br bb3
+// CHECK: bb2:
+// CHECK:   retain_value %0
+// CHECK:   apply %{{[0-9]+}}(%0)
+// CHECK:   release_value %0
+// CHECK: bb3:
+// CHECK-NOT: %0
+// CHECK:   return
+sil @insert_release_in_liferange_exit_block : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  strong_retain %0 : $A
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %3 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %8 = function_ref @use_closure : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  %5 = partial_apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  strong_retain %3 : $@callee_owned (@owned A) -> ()
+  %17 = apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  br bb3
+
+bb3:
+  strong_release %5 : $@callee_owned () -> ()
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @insert_release_at_critical_edge
+// CHECK: bb0(%0 : $A):
+// CHECK:   retain_value %0
+// CHECK: bb1:
+// CHECK-NEXT: release_value %0
+// CHECK-NEXT: br bb3
+// CHECK: bb2:
+// CHECK:   retain_value %0
+// CHECK:   apply %{{[0-9]+}}(%0)
+// CHECK:   release_value %0
+// CHECK: bb3:
+// CHECK-NOT: %0
+// CHECK:   return
+sil @insert_release_at_critical_edge : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  strong_retain %0 : $A
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %3 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %8 = function_ref @use_closure : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  %5 = partial_apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  strong_retain %3 : $@callee_owned (@owned A) -> ()
+  %17 = apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  br bb2
+
+bb2:
+  strong_release %5 : $@callee_owned () -> ()
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @insert_release_at_critical_loop_exit_edge
+// CHECK: bb0(%0 : $A):
+// CHECK:   retain_value %0
+// CHECK: bb1:
+// CHECK-NEXT:   br bb2
+// CHECK: bb2:
+// CHECK:   retain_value %0
+// CHECK:   apply %{{[0-9]+}}(%0)
+// CHECK-NOT:   %0
+// CHECK: bb3:
+// CHECK-NEXT: release_value %0
+// CHECK-NEXT: br bb5
+// CHECK: bb4:
+// CHECK-NEXT: release_value %0
+// CHECK-NEXT: br bb5
+// CHECK: bb5:
+// CHECK-NOT: %0
+// CHECK:   return
+sil @insert_release_at_critical_loop_exit_edge : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  strong_retain %0 : $A
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %3 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %8 = function_ref @use_closure : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  %5 = partial_apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  cond_br undef, bb3, bb1
+
+bb1:
+  br bb2
+
+bb2:
+  strong_retain %3 : $@callee_owned (@owned A) -> ()
+  %17 = apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  cond_br undef, bb2, bb4
+
+bb3:
+  br bb4
+
+bb4:
+  strong_release %5 : $@callee_owned () -> ()
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @insert_release_in_loop_exit_block
+// CHECK: bb0(%0 : $A):
+// CHECK:   retain_value %0
+// CHECK: bb1:
+// CHECK-NEXT:   br bb2
+// CHECK: bb2:
+// CHECK:   retain_value %0
+// CHECK:   apply %{{[0-9]+}}(%0)
+// CHECK-NOT:   %0
+// CHECK: bb3:
+// CHECK-NEXT: release_value %0
+// CHECK-NOT: %0
+// CHECK:   return
+sil @insert_release_in_loop_exit_block : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  strong_retain %0 : $A
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %3 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %8 = function_ref @use_closure : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  %5 = partial_apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  cond_br undef, bb3, bb1
+
+bb1:
+  br bb2
+
+bb2:
+  strong_retain %3 : $@callee_owned (@owned A) -> ()
+  %17 = apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> ()
+  cond_br undef, bb2, bb3
+
+bb3:
+  strong_release %5 : $@callee_owned () -> ()
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @insert_release_after_try_apply
+// CHECK: bb0(%0 : $A):
+// CHECK:   retain_value %0
+// CHECK: bb1:
+// CHECK:   retain_value %0
+// CHECK-NEXT:   try_apply
+// CHECK: bb2(%{{[0-9]+}} : $()):
+// CHECK-NEXT:   strong_release %0
+// CHECK-NEXT:   release_value %0
+// CHECK-NEXT:   br bb4
+// CHECK: bb3(%{{[0-9]+}} : $any Error):
+// CHECK-NEXT:   strong_release %0
+// CHECK-NEXT:   release_value %0
+// CHECK-NEXT:   br bb4
+// CHECK: bb4:
+// CHECK-NOT: %0
+// CHECK:   return
+sil @insert_release_after_try_apply : $@convention(thin) (@guaranteed A) -> () {
+bb0(%0 : $A):
+  %2 = function_ref @closure : $@convention(thin) (@owned A, @owned A) -> ()
+  %3 = partial_apply %2(%0) : $@convention(thin) (@owned A, @owned A) -> ()
+  %8 = function_ref @use_closure_throw : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> @error Error
+  br bb1
+
+bb1:
+  strong_retain %3 : $@callee_owned (@owned A) -> ()
+  try_apply %8(%3) : $@convention(thin) (@owned @callee_owned (@owned A) -> ()) -> @error Error, normal bb2, error bb3
+
+bb2(%n : $()):
+  br bb4
+
+bb3(%e : $Error):
+  br bb4
+
+bb4:
+  %11 = tuple ()
+  return %11 : $()
+}
+
+
+// Ensure that we can specialize and properly mangle functions that take closures with <τ_0_0> { var τ_0_0 } <arguments>.
+
+// CHECK-LABEL: sil shared [noinline] @$s4main5inneryys5Int32Vz_yADctF25closure_with_box_argumentxz_Bi32__lXXTf1nc_n : $@convention(thin) (@inout Builtin.Int32, @owned <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
+// CHECK: bb0
+// CHECK: [[FN:%.*]] = function_ref @closure_with_box_argument
+// CHECK: [[PARTIAL:%.*]] = partial_apply [[FN]](%1)
+// CHECK: [[ARG:%.*]] = load %0
+// CHECK: apply [[PARTIAL]]([[ARG]])
+
+// CHECK-LABEL: {{.*}} @$s4main5inneryys5Int32Vz_yADctF
+sil hidden [noinline] @$s4main5inneryys5Int32Vz_yADctF : $@convention(thin) (@inout Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> ()) -> () {
+bb0(%0 : $*Builtin.Int32, %1 : $@callee_owned (Builtin.Int32) -> ()):
+  strong_retain %1 : $@callee_owned (Builtin.Int32) -> ()
+  %5 = load %0 : $*Builtin.Int32
+  %6 = apply %1(%5) : $@callee_owned (Builtin.Int32) -> ()
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @pass_a_closure
+sil @pass_a_closure: $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, var, name "i"
+  %0a = project_box %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
+  %1 = integer_literal $Builtin.Int32, 0
+  store %1 to %0a : $*Builtin.Int32
+  %4 = function_ref @closure_with_box_argument : $@convention(thin) (Builtin.Int32, @owned <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
+  strong_retain %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  %6 = partial_apply %4(%0) : $@convention(thin) (Builtin.Int32, @owned <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> ()
+  %7 = alloc_stack $Builtin.Int32
+  %9 = integer_literal $Builtin.Int32, 1
+  store %9 to %7 : $*Builtin.Int32
+  %12 = function_ref @$s4main5inneryys5Int32Vz_yADctF: $@convention(thin) (@inout Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> ()) -> ()
+  strong_retain %6 : $@callee_owned (Builtin.Int32) -> ()
+  %14 = apply %12(%7, %6) : $@convention(thin) (@inout Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> ()) -> ()
+  strong_release %6 : $@callee_owned (Builtin.Int32) -> ()
+  %16 = tuple ()
+  dealloc_stack %7 : $*Builtin.Int32
+  %18 = load %0a : $*Builtin.Int32
+  strong_release %0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  return %18 : $Builtin.Int32
+}
+
+// CHECK-LABEL: sil shared @closure_with_box_argument
+sil shared @closure_with_box_argument : $@convention(thin) (Builtin.Int32, @owned <τ_0_0> { var τ_0_0 } <Builtin.Int32>) -> () {
+bb0(%0 : $Builtin.Int32, %1 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>):
+  %3 = project_box %1 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, 0
+  store %0 to %3 : $*Builtin.Int32
+  strong_release %1 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// Check that we don't crash with this:
+// CHECK-LABEL: sil @test_box_with_named_elements_tuple
+sil @test_box_with_named_elements_tuple: $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = alloc_box ${ let (first: Builtin.Int32, second: Builtin.Int32) }
+  %0p = project_box %0 : ${ let (first: Builtin.Int32, second: Builtin.Int32) }, 0
+  %0a = tuple_element_addr %0p : $*(first: Builtin.Int32, second: Builtin.Int32), 0
+  %0b = tuple_element_addr %0p : $*(first: Builtin.Int32, second: Builtin.Int32), 1
+  %1 = integer_literal $Builtin.Int32, 0
+  store %1 to %0a : $*Builtin.Int32
+  store %1 to %0b : $*Builtin.Int32
+  %4 = function_ref @closure_with_named_elements_tuple : $@convention(thin) (Builtin.Int32, @owned { let (first: Builtin.Int32, second: Builtin.Int32) }) -> ()
+  strong_retain %0 : ${ let (first: Builtin.Int32, second: Builtin.Int32) }
+  %6 = partial_apply %4(%0) : $@convention(thin) (Builtin.Int32, @owned { let (first: Builtin.Int32, second: Builtin.Int32) }) -> ()
+  %7 = alloc_stack $Builtin.Int32
+  %9 = integer_literal $Builtin.Int32, 1
+  store %9 to %7 : $*Builtin.Int32
+  %12 = function_ref @$s4main5inneryys5Int32Vz_yADctF: $@convention(thin) (@inout Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> ()) -> ()
+  strong_retain %6 : $@callee_owned (Builtin.Int32) -> ()
+  %14 = apply %12(%7, %6) : $@convention(thin) (@inout Builtin.Int32, @owned @callee_owned (Builtin.Int32) -> ()) -> ()
+  strong_release %6 : $@callee_owned (Builtin.Int32) -> ()
+  %16 = tuple ()
+  dealloc_stack %7 : $*Builtin.Int32
+  %18 = load %0a : $*Builtin.Int32
+  strong_release %0 : ${ let (first: Builtin.Int32, second: Builtin.Int32) }
+  return %18 : $Builtin.Int32
+}
+
+// CHECK-LABEL: sil shared @closure_with_named_elements_tuple
+sil shared @closure_with_named_elements_tuple : $@convention(thin) (Builtin.Int32, @owned { let (first: Builtin.Int32, second: Builtin.Int32) }) -> () {
+bb0(%0 : $Builtin.Int32, %1 : ${ let (first: Builtin.Int32, second: Builtin.Int32) }):
+  %3 = project_box %1 : ${ let (first: Builtin.Int32, second: Builtin.Int32) }, 0
+  %4 = tuple_element_addr %3 : $*(first: Builtin.Int32, second: Builtin.Int32), 0
+  store %0 to %4 : $*Builtin.Int32
+  strong_release %1 : ${ let (first: Builtin.Int32, second: Builtin.Int32) }
+  %7 = tuple ()
+  return %7 : $()
+}
+
+
+// The specialized function should always be a thin function, regardless of the
+// representation of the original function.
+
+public protocol P {
+  static func foo(cl: () -> Int) -> Int
+}
+
+public struct S : P {
+  public static func foo(cl: () -> Int) -> Int
+  init()
+}
+
+// CHECK-LABEL: sil shared @$s4test1SVAA1PA2aDP3fooyS2iycFZTW8closure2SiTf1cn_n : $@convention(thin) (@thick S.Type, Int) -> Int
+sil @$s4test1SVAA1PA2aDP3fooyS2iycFZTW : $@convention(witness_method: P) (@owned @callee_owned () -> Int, @thick S.Type) -> Int {
+bb0(%0 : $@callee_owned () -> Int, %1 : $@thick S.Type):
+  %3 = apply %0() : $@callee_owned () -> Int
+  return %3 : $Int
+}
+
+sil shared @closure2 : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  return %0 : $Int
+}
+
+sil @call_witness_method : $@convention(thin) (Int, S) -> Int {
+bb0(%0 : $Int, %1 : $S):
+  %3 = function_ref @closure2 : $@convention(thin) (Int) -> Int
+  %4 = partial_apply %3(%0) : $@convention(thin) (Int) -> Int
+  %5 = metatype $@thick S.Type
+  %6 = function_ref @$s4test1SVAA1PA2aDP3fooyS2iycFZTW : $@convention(witness_method: P) (@owned @callee_owned () -> Int, @thick S.Type) -> Int
+  %7 = apply %6(%4, %5) : $@convention(witness_method: P) (@owned @callee_owned () -> Int, @thick S.Type) -> Int
+  return %7 : $Int
+}
+
+sil_witness_table S: P module test {
+  method #P.foo: @$s4test1SVAA1PA2aDP3fooyS2iycFZTW
+}
+
+// Test partial_apply -> convert_function -> convert_function -> try_apply.
+sil @testClosureConvertHelper : $(Int) -> ()
+
+// specialized testClosureConvertThunk
+// FIXME: Need to handle closures with multiple exceptional exits.
+// CHECK-LABEL: sil shared @$s23testClosureConvertThunk0abC6HelperSiTf1nc_n : $@convention(thin) (Int) -> (@out (), @error any Error) {
+// CHECK: bb0(%0 : $*(), %1 : $Int):
+// CHECK:   [[F:%.*]] = function_ref @testClosureConvertHelper : $@convention(thin) (Int) -> ()
+// CHECK:   [[PA:%.*]] = partial_apply [[F]](%1) : $@convention(thin) (Int) -> ()
+// CHECK:   [[CVT1:%.*]] = convert_escape_to_noescape [[PA]] : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+// CHECK:   [[CVT2:%.*]] = convert_function [[CVT1]] : $@noescape @callee_owned () -> () to $@noescape @callee_owned () -> @error any Error
+// CHECK:   try_apply [[CVT2]]() : $@noescape @callee_owned () -> @error any Error, normal bb1, error bb2
+// CHECK:  bb1
+// CHECK: release_value [[PA]]
+// CHECK: return
+// CHECK: bb2
+// CHECK: release_value [[PA]]
+// CHECK: throw
+// CHECK-LABEL: } // end sil function '$s23testClosureConvertThunk0abC6HelperSiTf1nc_n'
+sil @testClosureConvertThunk : $@convention(thin) (@noescape @callee_owned () -> @error Error) -> (@out (), @error Error) {
+bb0(%0 : $*(), %1 : $@noescape @callee_owned () -> @error Error):
+  try_apply %1() : $@noescape @callee_owned () -> @error Error, normal bb1, error bb2
+
+bb1(%7 : $()):
+  %8 = tuple ()
+  return %8 : $()
+
+bb2(%10 : $Error):
+  throw %10 : $Error
+}
+
+// Test closure specialization when the closure type is converted before application.
+sil @testClosureConvert : $(Int) -> () {
+bb0(%0 : $Int):
+  %48 = alloc_stack $()
+  %49 = function_ref @testClosureConvertHelper : $@convention(thin) (Int) -> ()
+  %50 = partial_apply %49(%0) : $@convention(thin) (Int) -> ()
+  %51 = convert_escape_to_noescape %50 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  %52 = convert_function %51 : $@noescape @callee_owned () -> () to $@noescape @callee_owned () -> @error Error
+  %53 = function_ref @testClosureConvertThunk : $@convention(thin) (@noescape @callee_owned () -> @error Error) -> (@out (), @error Error)
+  try_apply %53(%48, %52) : $@convention(thin) (@noescape @callee_owned () -> @error Error) -> (@out (), @error Error), normal bb7, error bb11
+
+bb7(%callret : $()):
+  br bb99
+
+bb11(%128 : $Error):
+  br bb99
+
+bb99:
+  dealloc_stack %48 : $*()
+  %empty = tuple ()
+  return %empty : $()
+}
+
+sil @testClosureThunkNoEscape : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> () {
+bb0(%0 : $@noescape @callee_guaranteed () -> ()):
+  apply %0() : $@noescape @callee_guaranteed () -> ()
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil shared @$s24testClosureThunkNoEscape0aB13ConvertHelperSiTf1c_n : $@convention(thin) (Int) -> () {
+// CHECK: bb0([[ARG:%.*]] : $Int):
+// CHECK:   [[F:%.*]] = function_ref @testClosureConvertHelper : $@convention(thin) (Int) -> ()
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[F]]([[ARG]]) : $@convention(thin) (Int) -> ()
+// CHECK:   [[E:%.*]] = convert_escape_to_noescape [[PA]] : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+// CHECK:   apply [[E]]() : $@noescape @callee_guaranteed () -> ()
+// CHECK:   release_value [[PA]]
+// CHECK:   return
+// CHECK: }
+// CHECK-LABEL: sil @testClosureNoEscape : $@convention(thin) (Int) -> () {
+// CHECK-NOT: partial_apply
+// CHECK:   [[FN:%.*]] = function_ref @$s24testClosureThunkNoEscape0aB13ConvertHelperSiTf1c_n : $@convention(thin) (Int) -> ()
+// CHECK-NOT: partial_apply
+// CHECK:   %5 = apply [[FN]](%0) : $@convention(thin) (Int) -> ()
+// CHECK-NOT: release
+// CHECK:   return
+// CHECK: }
+
+sil @testClosureNoEscape : $(Int) -> () {
+bb0(%0 : $Int):
+  %48 = alloc_stack $()
+  %49 = function_ref @testClosureConvertHelper : $@convention(thin) (Int) -> ()
+  %50 = partial_apply [callee_guaranteed] %49(%0) : $@convention(thin) (Int) -> ()
+  %51 = convert_escape_to_noescape %50 : $@callee_guaranteed () -> () to $@noescape @callee_guaranteed () -> ()
+  %53 = function_ref @testClosureThunkNoEscape : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
+  apply %53(%51) : $@convention(thin) (@noescape @callee_guaranteed () -> ()) -> ()
+  release_value %50: $@callee_guaranteed () ->()
+  dealloc_stack %48 : $*()
+  %empty = tuple ()
+  return %empty : $()
+}
+
+
+sil @testClosureConvertHelper2 : $(Int) -> Int
+
+sil @testClosureThunkNoEscape2 : $@convention(thin) (@noescape @callee_guaranteed () -> @out Int) -> @out Int {
+bb0(%0 : $*Int, %1 : $@noescape @callee_guaranteed () -> @out Int):
+  apply %1(%0) : $@noescape @callee_guaranteed () -> @out Int
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil [reabstraction_thunk] @reabstractionThunk : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+
+// CHECK-LABEL: sil shared @$s25testClosureThunkNoEscape20aB14ConvertHelper2SiTf1nc_n : $@convention(thin) (Int) -> @out Int
+// CHECK: [[PA1:%.*]] = partial_apply
+// CHECK: convert_escape_to_noescape
+// CHECK: [[PA2:%.*]] = partial_apply
+// CHECK: convert_escape_to_noescape
+// CHECK: apply
+// CHECK: release_value [[PA1]]
+// CHECK: release_value [[PA2]]
+// CHECK: return
+
+// CHECK-LABEL: sil shared @$s25testClosureThunkNoEscape219reabstractionThunk2SiIegd_Tf1nc_n : $@convention(thin) (@owned @callee_guaranteed () -> Int) -> @out Int {
+// CHECK: bb0(%0 : $*Int, %1 : $@callee_guaranteed () -> Int):
+// CHECK:   [[F:%.*]] = function_ref @reabstractionThunk2
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[F]](%1)
+// CHECK:   [[CVT:%.*]] = convert_escape_to_noescape [[PA]]
+// CHECK:   apply [[CVT]](%0) : $@noescape @callee_guaranteed () -> @out Int
+// CHECK:   release_value [[PA]] : $@callee_guaranteed () -> @out Int
+// CHECK: return
+
+// CHECK-LABEL: sil @reabstractionTest : $@convention(thin) (Int) -> ()
+// CHECK: [[F:%.*]] = function_ref @$s25testClosureThunkNoEscape20aB14ConvertHelper2SiTf1nc_n
+// CHECK: apply [[F]]
+// CHECK: return
+sil @reabstractionTest : $(Int) -> () {
+bb0(%0 : $Int):
+  %48 = alloc_stack $Int
+  %49 = function_ref @testClosureConvertHelper2 : $@convention(thin) (Int) -> Int
+  %50 = partial_apply [callee_guaranteed] %49(%0) : $@convention(thin) (Int) -> Int
+  %51 = convert_escape_to_noescape %50 : $@callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> Int
+  %52 = function_ref @reabstractionThunk : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  %53 = partial_apply [callee_guaranteed] %52(%51) : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  %54 = convert_escape_to_noescape %53 : $@callee_guaranteed () -> @out Int to $@noescape @callee_guaranteed () -> @out Int
+  %55 = function_ref @testClosureThunkNoEscape2 : $@convention(thin) (@noescape @callee_guaranteed () -> @out Int) -> @out Int
+  apply %55(%48, %54) : $@convention(thin) (@noescape @callee_guaranteed () -> @out Int) -> @out Int
+  release_value %50: $@callee_guaranteed () -> Int
+  release_value %53: $@callee_guaranteed () -> @out Int
+  dealloc_stack %48 : $*Int
+  %empty = tuple ()
+  return %empty : $()
+}
+
+sil @testClosureConvertHelper3 : $@convention(thin) (Int) -> Int
+sil [reabstraction_thunk] @reabstractionThunk3 : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+
+sil @testClosureThunkNoEscape3 : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @out () {
+entry(%empty : $*(), %closure : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>):
+  %out = alloc_stack $Int
+  %ret = apply %closure(%out) : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  dealloc_stack %out : $*Int
+  store %ret to %empty : $*()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @reabstractionTest4 {{.*}} {
+// CHECK:         [[HELPER:%[^,]+]] = function_ref @testClosureConvertHelper3
+// CHECK:         [[SPECIALIZATION:%[^,]+]] = function_ref @$s25testClosureThunkNoEscape30aB14ConvertHelper3SiTf1nc_n
+// CHECK:         [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [[HELPER]]
+// CHECK:         [[NOESCAPE_CLOSURE:%[^,]+]] = convert_escape_to_noescape [[CLOSURE]]
+// CHECK:         apply [[SPECIALIZATION]]{{.*}}
+// CHECK:         release_value [[CLOSURE]]
+// CHECK-NOT:     release_value [[CLOSURE]]
+// CHECK:         strong_release [[NOESCAPE_CLOSURE]]
+// CHECK-LABEL: } // end sil function 'reabstractionTest4'
+sil @reabstractionTest4 : $(Int) -> () {
+bb0(%value : $Int):
+  %testThrowingClosureConvertHelper = function_ref @testClosureConvertHelper3 : $@convention(thin) (Int) -> Int
+  %closure = partial_apply [callee_guaranteed] %testThrowingClosureConvertHelper(%value) : $@convention(thin) (Int) -> Int
+  %noescapeClosure = convert_escape_to_noescape %closure : $@callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> Int
+  %thunk = function_ref @reabstractionThunk3 : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  %appliedThunk = partial_apply [callee_guaranteed] [on_stack] %thunk(%noescapeClosure) : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+
+  %dependency = mark_dependence %appliedThunk : $@noescape @callee_guaranteed () -> @out Int on %noescapeClosure : $@noescape @callee_guaranteed () -> Int
+  %generified = convert_function %dependency : $@noescape @callee_guaranteed () -> @out Int to $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %test = function_ref @testClosureThunkNoEscape3 : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @out ()
+  strong_retain %generified : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>
+  %out = alloc_stack $()
+  %ret = apply %test(%out, %generified) : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <Int>) -> @out ()
+  dealloc_stack %out : $*()
+  release_value %closure : $@callee_guaranteed () -> Int
+  strong_release %noescapeClosure : $@noescape @callee_guaranteed () -> Int
+  dealloc_stack %appliedThunk : $@noescape @callee_guaranteed () -> @out Int
+  %empty = tuple ()
+  return %empty : $()
+}
+
+sil @testThrowingClosureConvertHelper : $@convention(thin) (Int) -> (Int, @error any Error)
+sil [reabstraction_thunk] @reabstractionThunkThrowing : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error any Error)) -> (@out Int, @error any Error)
+
+sil @testClosureThunkNoEscapeThrowing : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>) -> (@out (), @error any Error) {
+entry(%empty : $*(), %closure : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>):
+  %out = alloc_stack $Int
+  try_apply %closure(%out) : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>, normal bb1, error bb2
+
+bb1(%ret : $()):
+  dealloc_stack %out : $*Int
+  store %ret to %empty : $*()
+  %retval = tuple ()
+  return %retval : $()
+
+bb2(%error : $any Error):
+  dealloc_stack %out : $*Int
+  throw %error : $any Error
+}
+
+// CHECK-LABEL: sil @reabstractionThrowing : $@convention(thin) (Int) -> ((), @error any Error) {
+// CHECK:         [[HELPER:%[^,]+]] = function_ref @testThrowingClosureConvertHelper
+// CHECK:         [[SPECIALIZATION:%[^,]+]] = function_ref @$s32testClosureThunkNoEscapeThrowing0afB13ConvertHelperSiTf1nc_n
+// CHECK:         [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [[HELPER]]
+// CHECK:         [[NOESCAPE_CLOSURE:%[^,]+]] = convert_escape_to_noescape [[CLOSURE]]
+// CHECK:         try_apply [[SPECIALIZATION]]{{.*}}normal [[NORMAL_BLOCK:bb[0-9]+]], error [[ERROR_BLOCK:bb[0-9]+]]
+// CHECK:       [[NORMAL_BLOCK]]
+// CHECK:         release_value [[CLOSURE]]
+// CHECK-NOT:     release_value [[CLOSURE]]
+// CHECK:         strong_release [[NOESCAPE_CLOSURE]]
+// CHECK:       [[ERROR_BLOCK]]
+// CHECK:         release_value [[CLOSURE]]
+// CHECK-NOT:     release_value [[CLOSURE]]
+// CHECK:         strong_release [[NOESCAPE_CLOSURE]]
+// CHECK-LABEL: } // end sil function 'reabstractionThrowing'
+sil @reabstractionThrowing : $(Int) -> ((), @error any Error) {
+bb0(%value : $Int):
+  %testThrowingClosureConvertHelper = function_ref @testThrowingClosureConvertHelper : $@convention(thin) (Int) -> (Int, @error any Error)
+  %closure = partial_apply [callee_guaranteed] %testThrowingClosureConvertHelper(%value) : $@convention(thin) (Int) -> (Int, @error any Error)
+  %noescapeClosure = convert_escape_to_noescape %closure : $@callee_guaranteed () -> (Int, @error any Error) to $@noescape @callee_guaranteed () -> (Int, @error any Error)
+  %thunk = function_ref @reabstractionThunkThrowing : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error any Error)) -> (@out Int, @error any Error)
+  %appliedThunk = partial_apply [callee_guaranteed] [on_stack] %thunk(%noescapeClosure) : $@convention(thin) (@noescape @callee_guaranteed () -> (Int, @error any Error)) -> (@out Int, @error any Error)
+
+  %dependency = mark_dependence %appliedThunk : $@noescape @callee_guaranteed () -> (@out Int, @error any Error) on %noescapeClosure : $@noescape @callee_guaranteed () -> (Int, @error any Error)
+  %generified = convert_function %dependency : $@noescape @callee_guaranteed () -> (@out Int, @error any Error) to $@noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>
+  %test = function_ref @testClosureThunkNoEscapeThrowing : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>) -> (@out (), @error any Error)
+  strong_retain %generified : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>
+  %out = alloc_stack $()
+  try_apply %test(%out, %generified) : $@convention(thin) (@owned @noescape @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>) -> (@out (), @error any Error), normal bb1, error bb2
+
+bb1(%ret : $()):
+  dealloc_stack %out : $*()
+  release_value %closure : $@callee_guaranteed () -> (Int, @error any Error)
+  strong_release %noescapeClosure : $@noescape @callee_guaranteed () -> (Int, @error any Error)
+  dealloc_stack %appliedThunk : $@noescape @callee_guaranteed () -> (@out Int, @error any Error)
+  %empty = tuple ()
+  return %empty : $()
+
+bb2(%error : $any Error):
+  dealloc_stack %out : $*()
+  release_value %closure : $@callee_guaranteed () -> (Int, @error any Error)
+  strong_release %noescapeClosure : $@noescape @callee_guaranteed () -> (Int, @error any Error)
+  dealloc_stack %appliedThunk : $@noescape @callee_guaranteed () -> (@out Int, @error any Error)
+  throw %error : $any Error
+}
+
+// Currently not supported cases.
+
+sil @testClosureThunk4 : $@convention(thin) (@owned @callee_guaranteed () -> @out Int) -> @out Int {
+bb0(%0 : $*Int, %1 : $@callee_guaranteed () -> @out Int):
+  apply %1(%0) : $@callee_guaranteed () -> @out Int
+  release_value %1: $@callee_guaranteed () -> @out Int
+  %8 = tuple ()
+  return %8 : $()
+}
+// CHECK-LABEL: sil @reabstractionTest2
+// CHECK: bb0(%0 : $Int):
+// CHECK: [[STK:%.*]] = alloc_stack $Int
+// CHECK: [[F:%.*]] = function_ref @testClosureConvertHelper2
+// CHECK: [[PA:%.*]] = partial_apply [callee_guaranteed] [[F]](%0)
+// CHECK: [[CVT:%.*]] = convert_escape_to_noescape [[PA]]
+// CHECK: [[F2:%.*]] = function_ref @reabstractionThunk
+// CHECK: [[PA2:%.*]] = partial_apply [callee_guaranteed] [[F2]]([[CVT]])
+// CHECK: [[F3:%.*]] = function_ref @testClosureThunk4
+// CHECK:  apply [[F3]]([[STK]], [[PA2]])
+// CHECK:  release_value [[PA]]
+// CHECK:  dealloc_stack [[STK]]
+// CHECK:  return
+
+sil @reabstractionTest2 : $(Int) -> () {
+bb0(%0 : $Int):
+  %48 = alloc_stack $Int
+  %49 = function_ref @testClosureConvertHelper2 : $@convention(thin) (Int) -> Int
+  %50 = partial_apply [callee_guaranteed] %49(%0) : $@convention(thin) (Int) -> Int
+  %51 = convert_escape_to_noescape %50 : $@callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> Int
+  %52 = function_ref @reabstractionThunk : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  %53 = partial_apply [callee_guaranteed] %52(%51) : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  %55 = function_ref @testClosureThunk4 : $@convention(thin) (@owned @callee_guaranteed () -> @out Int) -> @out Int
+  apply %55(%48, %53) : $@convention(thin) (@owned @callee_guaranteed () -> @out Int) -> @out Int
+  release_value %50: $@callee_guaranteed () -> Int
+  dealloc_stack %48 : $*Int
+  %empty = tuple ()
+  return %empty : $()
+}
+
+// Only support the ultimate partial_apply.
+sil [reabstraction_thunk] @reabstractionThunk2 : $@convention(thin) (@guaranteed @callee_guaranteed () -> Int) -> @out Int
+
+// CHECK-LABEL: sil @reabstractionTest3 : $@convention(thin) (Int) -> () {
+// CHECK: bb0(%0 : $Int):
+// CHECK:  [[STK:%.*]] = alloc_stack $Int
+// CHECK:  [[F:%.*]] = function_ref @testClosureConvertHelper2
+// CHECK:  [[PA:%.*]] = partial_apply [callee_guaranteed] [[F]](%0)
+// CHECK:  [[F2:%.*]] = function_ref @reabstractionThunk2
+// CHECK:  [[SPEC:%.*]] = function_ref @$s25testClosureThunkNoEscape219reabstractionThunk2SiIegd_Tf1nc_n : $@convention(thin) (@owned @callee_guaranteed () -> Int) -> @out Int
+// CHECK:  retain_value [[PA]] : $@callee_guaranteed () -> Int
+// CHECK:  %8 = apply [[SPEC]]([[STK]], [[PA]]) : $@convention(thin) (@owned @callee_guaranteed () -> Int) -> @out Int
+// CHECK:  strong_release [[PA]] : $@callee_guaranteed () -> Int
+// CHECK:  dealloc_stack [[STK]] : $*Int
+// CHECK:  return
+
+sil @reabstractionTest3 : $(Int) -> () {
+bb0(%0 : $Int):
+  %48 = alloc_stack $Int
+  %49 = function_ref @testClosureConvertHelper2 : $@convention(thin) (Int) -> Int
+  %50 = partial_apply [callee_guaranteed] %49(%0) : $@convention(thin) (Int) -> Int
+  %52 = function_ref @reabstractionThunk2 : $@convention(thin) (@guaranteed @callee_guaranteed () -> Int) -> @out Int
+  %53 = partial_apply [callee_guaranteed] %52(%50) : $@convention(thin) (@guaranteed @callee_guaranteed () -> Int) -> @out Int
+  %54 = convert_escape_to_noescape %53 : $@callee_guaranteed () -> @out Int to $@noescape @callee_guaranteed () -> @out Int
+  %55 = function_ref @testClosureThunkNoEscape2 : $@convention(thin) (@noescape @callee_guaranteed () -> @out Int) -> @out Int
+  apply %55(%48, %54) : $@convention(thin) (@noescape @callee_guaranteed () -> @out Int) -> @out Int
+  release_value %53: $@callee_guaranteed () -> @out Int
+  dealloc_stack %48 : $*Int
+  %empty = tuple ()
+  return %empty : $()
+}
+
+//////////////////////
+// Begin Apply Test //
+//////////////////////
+
+sil @coroutine_user : $@yield_once @convention(thin) (@noescape @callee_guaranteed () -> Int) -> @yields Int {
+bb0(%0 : $@noescape @callee_guaranteed () -> Int):
+  %1 = apply %0() : $@noescape @callee_guaranteed () -> Int
+  unreachable
+}
+
+// CHECK-LABEL: sil @test_coroutine_user : $@convention(thin) (Int) -> Int {
+// CHECK: [[COROUTINE_USER:%.*]] = function_ref @coroutine_user
+// CHECK: begin_apply [[COROUTINE_USER]](
+// CHECK: } // end sil function 'test_coroutine_user'
+sil @test_coroutine_user : $@convention(thin) (Int) -> Int {
+bb0(%0 : $Int):
+  %1 = function_ref @testClosureConvertHelper2 : $@convention(thin) (Int) -> Int
+  %2 = partial_apply [callee_guaranteed] %1(%0) : $@convention(thin) (Int) -> Int
+  %3 = convert_escape_to_noescape %2 : $@callee_guaranteed () -> Int to $@noescape @callee_guaranteed () -> Int
+  %4 = function_ref @coroutine_user : $@yield_once @convention(thin) (@noescape @callee_guaranteed () -> Int) -> @yields Int
+  (%value, %token) = begin_apply %4(%3) : $@yield_once @convention(thin) (@noescape @callee_guaranteed () -> Int) -> @yields Int
+  cond_br undef, bb1, bb2
+
+bb1:
+  end_apply %token as $()
+  br bb3
+
+bb2:
+  abort_apply %token
+  br bb3
+
+bb3:
+  release_value %2 : $@callee_guaranteed () -> Int
+  return %value : $Int
+}
+// CHECK-LABEL: sil @reabstractionTest_on_stack
+// CHECK: bb0([[A:%.*]] : $Int):
+// CHECK:  [[R:%.*]] = alloc_stack $Int
+// CHECK:  [[F:%.*]] = function_ref @$s25testClosureThunkNoEscape20aB14ConvertHelper2SiTf1nc_n
+// CHECK: apply [[F]]([[R]], [[A]])
+sil @reabstractionTest_on_stack : $(Int) -> () {
+bb0(%0 : $Int):
+  %48 = alloc_stack $Int
+  %49 = function_ref @testClosureConvertHelper2 : $@convention(thin) (Int) -> Int
+  %50 = partial_apply [callee_guaranteed] [on_stack] %49(%0) : $@convention(thin) (Int) -> Int
+  %52 = function_ref @reabstractionThunk : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  %53 = partial_apply [callee_guaranteed] [on_stack] %52(%50) : $@convention(thin) (@noescape @callee_guaranteed () -> Int) -> @out Int
+  %55 = function_ref @testClosureThunkNoEscape2 : $@convention(thin) (@noescape @callee_guaranteed () -> @out Int) -> @out Int
+  apply %55(%48, %53) : $@convention(thin) (@noescape @callee_guaranteed () -> @out Int) -> @out Int
+  dealloc_stack %53 : $@noescape @callee_guaranteed () -> @out Int
+  dealloc_stack %50 : $@noescape @callee_guaranteed () -> Int
+  dealloc_stack %48 : $*Int
+  %empty = tuple ()
+  return %empty : $()
+}

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize.sil
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize.sil
@@ -132,6 +132,8 @@ bb0(%0 : $Int):
 // address and non-address only types) taken as @in or @in_guaranteed.
 
 // This is a temporary limitation.
+// TODO: figure out what to do with non-inout indirect arguments
+// https://forums.swift.org/t/non-inout-indirect-types-not-supported-in-closure-specialization-optimization/70826
 // CHECK-LABEL: sil @address_closure : $@convention(thin) (@in Int) -> () {
 sil @address_closure : $@convention(thin) (@in Int) -> () {
 bb0(%0 : $*Int):

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_and_cfg.sil
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_and_cfg.sil
@@ -1,0 +1,49 @@
+// RUN: %target-sil-opt -sil-verify-without-invalidation -enable-sil-verify-all -simplify-cfg -experimental-swift-based-closure-specialization %s
+
+// Test if the ClosureSpecializer correctly invalidates the dominator tree
+// even if there are no functions specialized.
+// The test just checks if the compiler does not crash.
+// First running SimplifyCFG creates the dominator tree, which should then be
+// invalidated by the ClosureSpecializer.
+// If this is not done correctly the verification will complain that the
+// dominator tree is not up to date.
+
+import Builtin
+import Swift
+
+sil @closure : $@convention(thin) () -> ()
+
+sil @use_closure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+
+sil hidden [noinline] @use_closure2 : $@convention(thin) (@owned @callee_owned () -> (), @owned @callee_owned () -> ()) -> () {
+bb0(%0 : $@callee_owned () -> (), %1 : $@callee_owned () -> ()):
+  %2 = apply %0() : $@callee_owned () -> ()
+  %3 = apply %1() : $@callee_owned () -> ()
+  %4 = tuple ()
+  return %3 : $()
+}
+
+sil @insert_release_in_liferange_exit_block : $@convention(thin) () -> () {
+bb0:
+  %2 = function_ref @closure : $@convention(thin) () -> ()
+  %3 = partial_apply %2() : $@convention(thin) () -> ()
+  %8 = function_ref @use_closure : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %5 = partial_apply %8(%3) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+
+  // There is a critical edge from bb0 to bb2 which is broken by ValueLifetimeAnalysis.
+  cond_br undef, bb2, bb1
+
+bb1:
+  strong_retain %3 : $@callee_owned () -> ()
+  strong_retain %3 : $@callee_owned () -> ()
+  %10 = function_ref @use_closure2 : $@convention(thin) (@owned @callee_owned () -> (), @owned @callee_owned () -> ()) -> ()
+
+  // Passing two closures actually prevents closure specialization.
+  %17 = apply %10(%3, %3) : $@convention(thin) (@owned @callee_owned () -> (), @owned @callee_owned () -> ()) -> ()
+  br bb2
+
+bb2:
+  strong_release %5 : $@callee_owned () -> ()
+  %11 = tuple ()
+  return %11 : $()
+}

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_attrs.sil
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_attrs.sil
@@ -1,0 +1,87 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -experimental-swift-based-closure-specialization %s | %FileCheck %s
+// XFAIL: *
+
+import Builtin
+
+class C {}
+
+sil [ossa] @getC : $@convention(thin) () -> @owned C
+
+class Storage {}
+
+struct Val {}
+
+// Verify that the argument to the specialized take_closure is still @_eagerMove.
+
+// CHECK-LABEL: sil {{.*}}@$s12take_closure0B04main1CCTf1nc_n : {{.*}}{
+// CHECK:           {{bb[0-9]+}}({{%[^,]+}} : @_eagerMove @owned $C, {{%[^,]+}} :
+// CHECK-LABEL: } // end sil function '$s12take_closure0B04main1CCTf1nc_n'
+
+sil [ossa] [noinline] @take_closure : $@convention(thin) (@owned C, @guaranteed @noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()) -> () {
+bb0(%c : @_eagerMove @owned $C, %0 : @guaranteed $@noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()):
+  %getC = function_ref @getC : $@convention(thin) () -> @owned C
+  %c1 = apply %getC() : $@convention(thin) () -> @owned C
+  %c2 = apply %getC() : $@convention(thin) () -> @owned C
+  %3 = apply %0(%c1, %c2) : $@noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()
+  destroy_value %c2 : $C
+  destroy_value %c1 : $C
+  destroy_value %c : $C
+  %retval = tuple()
+  return %retval : $()
+}
+
+sil shared [ossa] @closure : $@convention(thin) (@guaranteed C, @guaranteed C, @guaranteed C) -> () {
+bb0(%0 : @guaranteed $C, %1 : @guaranteed $C, %2 : @guaranteed $C):
+  %15 = tuple ()
+  return %15 : $()
+}
+
+sil @caller : $@convention(thin) (@owned C) -> () {
+bb0(%0 : $C):
+  %3 = function_ref @closure : $@convention(thin) (@guaranteed C, @guaranteed C, @guaranteed C) -> ()
+  %4 = partial_apply [callee_guaranteed] [on_stack] %3(%0) : $@convention(thin) (@guaranteed C, @guaranteed C, @guaranteed C) -> ()
+  %take_closure = function_ref @take_closure : $@convention(thin) (@owned C, @guaranteed @noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()) -> ()
+  strong_retain %0 : $C
+  %5 = apply %take_closure(%0, %4) : $@convention(thin) (@owned C, @guaranteed @noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()) -> ()
+  strong_release %0 : $C
+  dealloc_stack %4 : $@noescape @callee_guaranteed (@guaranteed C, @guaranteed C) -> ()
+  %retval = tuple()
+  return %retval : $()
+}
+
+// =============================================================================
+// rdar://105887096: do not insert a retain inside a read-only function.
+// For now, the specialization is disabled.
+//
+// TODO: A @noescape closure should never be converted to an @owned argument
+// regardless of the function attribute.
+
+// This should not be specialized until we support guaranteed arguments.
+// CHECK-NOT: @$s20takesReadOnlyClosure
+sil private [readonly] @takesReadOnlyClosure : $@convention(thin) (@noescape @callee_guaranteed (Val) -> Val) -> Val {
+bb0(%2 : $@noescape @callee_guaranteed (Val) -> Val):
+  %46 = struct $Val ()
+  %261 = apply %2(%46) : $@noescape @callee_guaranteed (Val) -> Val
+  return %261 : $Val
+}
+
+sil private @readOnlyClosure : $@convention(thin) (Val, @guaranteed Storage) -> Val {
+bb0(%0 : $Val, %1 : @closureCapture $Storage):
+  %46 = struct $Val ()
+  return %46 : $Val
+}
+
+// CHECK-LABEL: sil @testPassReadOnlyClosure : $@convention(method) (@guaranteed Storage) -> Val {
+// CHECK-NOT: @owned Storage
+// CHECK: apply %{{.*}} : $@convention(thin) (@noescape @callee_guaranteed (Val) -> Val) -> Val
+// CHECK-LABEL: } // end sil function 'testPassReadOnlyClosure'
+sil @testPassReadOnlyClosure : $@convention(method) (@guaranteed Storage) -> Val {
+bb0(%0 : $Storage):
+  %176 = function_ref @readOnlyClosure : $@convention(thin) (Val, @guaranteed Storage) -> Val
+  %177 = partial_apply [callee_guaranteed] [on_stack] %176(%0) : $@convention(thin) (Val, @guaranteed Storage) -> Val
+  %178 = mark_dependence %177 : $@noescape @callee_guaranteed (Val) -> Val on %0 : $Storage
+  %188 = function_ref @takesReadOnlyClosure : $@convention(thin) (@noescape @callee_guaranteed (Val) -> Val) -> Val
+  %189 = apply %188(%178) : $@convention(thin) (@noescape @callee_guaranteed (Val) -> Val) -> Val
+  dealloc_stack %177 : $@noescape @callee_guaranteed (Val) -> Val
+  return %189 : $Val
+}

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_consolidated.sil
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_consolidated.sil
@@ -1,0 +1,725 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -experimental-swift-based-closure-specialization %s | %FileCheck %s -check-prefix=REMOVECLOSURES
+// RUN: %target-sil-opt -enable-sil-verify-all -closure-specialize-eliminate-dead-closures=0 -experimental-swift-based-closure-specialization %s | %FileCheck %s
+// XFAIL: *
+
+import Builtin
+import Swift
+
+///////////////////
+// Utility Types //
+///////////////////
+
+protocol P {
+  func foo(f: (Int32)->Int32, _ j: Int32) -> Int32
+}
+
+protocol Q {
+}
+
+public class C {
+  @_hasStorage var c: C? { get set }
+  init()
+}
+
+public struct S: Q {
+  @_hasStorage var c: C? { get set }
+  init(c: C?)
+  init()
+}
+
+// = Test Summary =
+// We test the following things here:
+//
+// 1. Address Argument
+// 2. ThinToThick, Partial Apply:
+//   a. with and without removal of closure.
+//   b. @owned and @guaranteed.
+// 3. Bad NonFailureExitBB.
+// 4. No Call in Apply Callee.
+// 5. Non simple closure (i.e. non function_ref closure).
+// 6. Handle interface return types correctly.
+
+////////////////////////////
+// Address Argument Tests //
+////////////////////////////
+//
+// Make sure that we can specialize even if we have address arguments.
+//
+// But we don't handle closures that close over address types passed as @in or
+// @in_guaranteed.
+// (*NOTE* this includes address and non-address only types).
+// This is a temporary limitation.
+// CHECK-LABEL: sil @address_closure : $@convention(thin) (@in Int32) -> () {
+sil @address_closure : $@convention(thin) (@in Int32) -> () {
+bb0(%0 : $*Int32):
+  %6 = tuple()
+  return %6 : $()
+}
+
+sil @address_closure_struct_complex : $@convention(thin) (@in S) -> () {
+bb0(%0 : $*S):
+  %6 = tuple()
+  return %6 : $()
+}
+
+// CHECK-LABEL: sil @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
+sil @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
+bb0(%0 : $@callee_owned () -> ()):
+  %1 = apply %0() : $@callee_owned () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Check that a specialization of address_closure_noescape_user was generated which does not
+// take a closure as a parameter anymore.
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
+// CHECK: function_ref @address_closure_trivial : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
+// CHECK: partial_apply %{{.*}} : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
+// CHECK: apply
+// CHECK: return
+
+// Check that a specialization of address_closure_noescape_user was generated which does not
+// take a closure as a parameter anymore.
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable Int32) -> ()
+// CHECK: function_ref @address_closure_trivial_mutating : $@convention(thin) (@inout_aliasable Int32) -> ()
+// CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable Int32) -> ()
+// CHECK: apply
+// CHECK: return
+
+// Check that a specialization of address_closure_noescape_user was generated which does not
+// take a closure as a parameter anymore.
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable any P) -> ()
+// CHECK: function_ref @address_closure_existential : $@convention(thin) (@inout_aliasable any P) -> ()
+// CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable any P) -> ()
+// CHECK: apply
+// CHECK: return
+
+// Check that a specialization of address_closure_noescape_user was generated which does not
+// take a closure as a parameter anymore.
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+// CHECK: function_ref @address_closure_struct1 : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+// CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+// CHECK: apply
+// CHECK: return
+
+// Check that a specialization of address_closure_user was generated which does not
+// take a closure as a parameter anymore.
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+// CHECK: function_ref @address_closure_struct2 : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+// CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+// CHECK: apply
+// CHECK: return
+
+// Check that a specialization of address_closure_user was generated which does not
+// take a closure as a parameter anymore.
+// CHECK-LABEL: sil shared @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+// CHECK: function_ref @address_closure_class1 : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+// CHECK: partial_apply %{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+// CHECK: apply
+// CHECK: return
+
+// CHECK-LABEL: sil @address_closure_noescape_user : $@convention(thin) (@noescape @callee_owned () -> ()) -> () {
+sil @address_closure_noescape_user : $@convention(thin) (@noescape @callee_owned () -> ()) -> () {
+bb0(%0 : $@noescape @callee_owned () -> ()):
+  %1 = apply %0() : $@noescape @callee_owned () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @address_caller : $@convention(thin) (@in Int32) -> () {
+// CHECK-NOT: _TTSf1cl15address_closureSi__address_closure_user
+sil @address_caller : $@convention(thin) (@in Int32) -> () {
+bb0(%0 : $*Int32):
+  %1 = function_ref @address_closure : $@convention(thin) (@in Int32) -> ()
+  %2 = partial_apply %1(%0) : $@convention(thin) (@in Int32) -> ()
+  %3 = function_ref @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %4 = apply %3(%2) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We don't handle closures that close over address types passed as @in or
+// @in_guaranteed.
+// (*NOTE* this includes address and non-address only types).
+// This is a temporary limitation.
+//
+// CHECK-LABEL: sil @address_caller_complex : $@convention(thin) (@in Int32) -> ()
+// CHECK-NOT: function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@in Int32) -> ()
+// CHECK: partial_apply
+// CHECK-NOT: function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@in Int32) -> ()
+// CHECK: return
+sil @address_caller_complex : $@convention(thin) (@in Int32) -> () {
+bb0(%0 : $*Int32):
+  %00 = alloc_stack $Int32
+  %01 = load %0 : $*Int32
+  store %01 to %00 : $*Int32
+  %1 = function_ref @address_closure : $@convention(thin) (@in Int32) -> ()
+  %2 = partial_apply %1(%00) : $@convention(thin) (@in Int32) -> ()
+  %3 = function_ref @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %4 = apply %3(%2) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  dealloc_stack %00 : $*Int32
+  br bb1
+
+bb1:
+  %6 = apply %3(%2) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// We don't handle closures that close over address types passed as @in or
+// @in_guaranteed.
+// (*NOTE* this includes address and non-address only types).
+// This is a temporary limitation.
+//
+// CHECK-LABEL: sil @address_caller_struct_complex : $@convention(thin) (@in S) -> ()
+// CHECK-NOT:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@in S) -> ()
+// CHECK: partial_apply 
+// CHECK-NOT:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user{{.*}} : $@convention(thin) (@in S) -> ()
+// CHECK: return
+sil @address_caller_struct_complex : $@convention(thin) (@in S) -> () {
+bb0(%0 : $*S):
+  %00 = alloc_stack $S
+  %01 = load %0 : $*S
+  retain_value %01 : $S
+  store %01 to %00 : $*S
+  %1 = function_ref @address_closure_struct_complex : $@convention(thin) (@in S) -> ()
+  %2 = partial_apply %1(%00) : $@convention(thin) (@in S) -> ()
+  %3 = function_ref @address_closure_user : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %4 = apply %3(%2) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %5  = load %00 : $*S
+  release_value %5 : $S
+  dealloc_stack %00 : $*S
+  br bb1
+
+bb1:
+  %6 = apply %3(%2) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// More complex tests involving address arguments.
+
+sil @address_closure_trivial : $@convention(thin) (Int32, @inout_aliasable Int32) -> () {
+bb0(%0 : $Int32, %1 : $*Int32):
+  %9 = integer_literal $Builtin.Int32, 42
+  %10 = struct $Int32 (%9 : $Builtin.Int32)
+  store %10 to %1 : $*Int32
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// CHECK-LABEL: sil @address_caller_trivial
+// CHECK-NOT: partial_apply
+// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
+// CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
+// CHECK-NOT: partial_apply
+// CHECK: return
+sil @address_caller_trivial: $@convention(thin) (Int32) -> Int32 {
+bb0(%0 : $Int32):
+  %2 = alloc_stack $Int32, var, name "xx"
+  store %0 to %2 : $*Int32
+  // function_ref address_closure_noescape_user(f:)
+  %4 = function_ref @address_closure_noescape_user : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  // function_ref address_closure_trivial(x:)
+  %5 = function_ref @address_closure_trivial : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
+  %6 = partial_apply %5(%0, %2) : $@convention(thin) (Int32, @inout_aliasable Int32) -> ()
+  %6b = convert_escape_to_noescape %6 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  %7 = apply %4(%6b) : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  %8 = load %2 : $*Int32
+  dealloc_stack %2 : $*Int32
+  return %8 : $Int32
+}
+
+sil @address_closure_trivial_mutating : $@convention(thin) (@inout_aliasable Int32) -> () {
+bb0(%0 : $*Int32):
+  %2 = struct_element_addr %0 : $*Int32, #Int32._value
+  %3 = load %2 : $*Builtin.Int32
+  %4 = integer_literal $Builtin.Int32, 1
+  %5 = integer_literal $Builtin.Int1, -1
+  %6 = builtin "sadd_with_overflow_Int32"(%3 : $Builtin.Int32, %4 : $Builtin.Int32, %5 : $Builtin.Int1) : $(Builtin.Int32, Builtin.Int1)
+  %7 = tuple_extract %6 : $(Builtin.Int32, Builtin.Int1), 0
+  %8 = tuple_extract %6 : $(Builtin.Int32, Builtin.Int1), 1
+  cond_fail %8 : $Builtin.Int1
+  %10 = struct $Int32 (%7 : $Builtin.Int32)
+  store %10 to %0 : $*Int32
+  %12 = tuple ()
+  return %12 : $()
+}
+
+// CHECK-LABEL: sil @address_caller_trivial_mutating
+// CHECK-NOT: partial_apply
+// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable Int32) -> ()
+// CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
+// CHECK-NOT: partial_apply
+// CHECK: return
+sil @address_caller_trivial_mutating: $@convention(thin) (Int32) -> Int32 {
+bb0(%0 : $Int32):
+  %2 = alloc_stack $Int32, var, name "xx"
+  store %0 to %2 : $*Int32
+  %4 = function_ref @address_closure_noescape_user : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  %5 = function_ref @address_closure_trivial_mutating : $@convention(thin) (@inout_aliasable Int32) -> ()
+  %6 = partial_apply %5(%2) : $@convention(thin) (@inout_aliasable Int32) -> ()
+  %6b = convert_escape_to_noescape %6 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  %7 = apply %4(%6b) : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  %8 = load %2 : $*Int32
+  dealloc_stack %2 : $*Int32
+  return %8 : $Int32
+}
+
+sil @S_init : $@convention(method) (@thin S.Type) -> @owned S
+
+sil hidden @address_closure_body_out_result : $@convention(thin) (@in Q, @in Q) -> @out Q {
+bb0(%0 : $*Q, %1 : $*Q, %2 : $*Q):
+  %5 = init_existential_addr %0 : $*Q, $S
+  // function_ref S.init()
+  %6 = function_ref @S_init : $@convention(method) (@thin S.Type) -> @owned S
+  %7 = metatype $@thin S.Type
+  %8 = apply %6(%7) : $@convention(method) (@thin S.Type) -> @owned S
+  store %8 to %5 : $*S
+  destroy_addr %2 : $*Q
+  destroy_addr %1 : $*Q
+  %12 = tuple ()
+  return %12 : $()
+}
+
+sil @address_closure_out_result : $@convention(thin) (@in Q, @inout_aliasable Q, @inout_aliasable Q) -> @out Q {
+bb0(%0 : $*Q, %1 : $*Q, %2 : $*Q, %3 : $*Q):
+  %7 = function_ref @address_closure_body_out_result : $@convention(thin) (@in Q, @in Q) -> @out Q
+  %8 = alloc_stack $Q
+  copy_addr %2 to [init] %8 : $*Q
+  %10 = alloc_stack $Q
+  copy_addr %3 to [init] %10 : $*Q
+  %12 = apply %7(%0, %8, %10) : $@convention(thin) (@in Q, @in Q) -> @out Q
+  dealloc_stack %10 : $*Q
+  dealloc_stack %8 : $*Q
+  destroy_addr %1 : $*Q
+  %16 = tuple ()
+  return %16 : $()
+}
+
+// Check that a specialization of address_closure_user_out_result was generated which does not
+// take a closure as a parameter anymore.
+// CHECK-LABEL: sil shared @{{.*}}address_closure_user_out_result{{.*}} : $@convention(thin) (@inout_aliasable any Q, @inout_aliasable any Q) -> @out any Q
+// CHECK: function_ref @address_closure_out_result : $@convention(thin) (@in any Q, @inout_aliasable any Q, @inout_aliasable any Q) -> @out any Q
+// CHECK: [[PARTIAL_APPLY:%.*]] = partial_apply %{{.*}} : $@convention(thin) (@in any Q, @inout_aliasable any Q, @inout_aliasable any Q) -> @out any Q
+// CHECK: apply [[PARTIAL_APPLY]]
+// CHECK: return
+
+sil @address_closure_user_out_result : $@convention(thin) (@noescape @callee_owned (@in Q) -> @out Q) -> @out Q {
+bb0(%0 : $*Q, %1 : $@noescape @callee_owned (@in Q) -> @out Q):
+  %4 = alloc_stack $Q
+  %5 = init_existential_addr %4 : $*Q, $S
+  %6 = function_ref @S_init : $@convention(method) (@thin S.Type) -> @owned S
+  %7 = metatype $@thin S.Type
+  %8 = apply %6(%7) : $@convention(method) (@thin S.Type) -> @owned S
+  store %8 to %5 : $*S
+  %10 = apply %1(%0, %4) : $@noescape @callee_owned (@in Q) -> @out Q
+  dealloc_stack %4 : $*Q
+  %13 = tuple ()
+  return %13 : $()
+}
+
+// Check that closure specialization can handle cases where the full closure type may have
+// unsupported address type arguments (e.g. @in or @out), but the partial_apply has only
+// supported address type arguments, i.e. @inout or @inout_aliasable.
+//
+// CHECK-LABEL: sil @address_caller_out_result : $@convention(thin) (@in any Q, @in any Q) -> @out any Q
+// CHECK-NOT: partial_apply
+// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_user_out_result{{.*}} : $@convention(thin) (@inout_aliasable any Q, @inout_aliasable any Q) -> @out any Q
+// CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
+// CHECK-NOT: partial_apply
+// CHECK: return
+sil @address_caller_out_result: $@convention(thin) (@in Q, @in Q) -> @out Q {
+bb0(%0 : $*Q, %1 : $*Q, %2 : $*Q):
+  %5 = function_ref @address_closure_user_out_result : $@convention(thin) (@noescape @callee_owned (@in Q) -> @out Q) -> @out Q
+  %6 = function_ref @address_closure_out_result : $@convention(thin) (@in Q, @inout_aliasable Q, @inout_aliasable Q) -> @out Q
+  %7 = partial_apply %6(%1, %2) : $@convention(thin) (@in Q, @inout_aliasable Q, @inout_aliasable Q) -> @out Q 
+  %7b = convert_escape_to_noescape %7 : $@callee_owned (@in Q) -> @out Q to $@noescape @callee_owned (@in Q) -> @out Q
+  %8 = apply %5(%0, %7b) : $@convention(thin) (@noescape @callee_owned (@in Q) -> @out Q) -> @out Q
+  destroy_addr %2 : $*Q
+  destroy_addr %1 : $*Q
+  %11 = tuple ()
+  return %11 : $()
+}
+
+// CHECK-LABEL: sil @address_caller_existential
+// CHECK-NOT: partial_apply
+// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable any P) -> ()
+// CHECK:  [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable any P) -> ()
+// CHECK: apply [[SPECIALIZED_FN2]]{{.*}}
+// CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
+// CHECK-NOT: partial_apply
+// CHECK: return
+sil @address_caller_existential : $@convention(thin) (@in P, @in P, Int32) -> @out P {
+bb0(%0 : $*P, %1 : $*P, %2 : $*P, %3 : $Int32):
+  %7 = alloc_stack $P
+  copy_addr %1 to [init] %7 : $*P
+  %9 = function_ref @address_closure_existential : $@convention(thin) (@inout_aliasable P) -> ()
+  %10 = partial_apply %9(%7) : $@convention(thin) (@inout_aliasable P) -> ()
+  %10b = convert_escape_to_noescape %10 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  %12 = function_ref @address_closure_noescape_user : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  strong_retain %10 : $@callee_owned () -> ()
+  %14 = apply %12(%10b) : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  strong_retain %10 : $@callee_owned () -> ()
+  %16 = apply %12(%10b) : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  %17 = integer_literal $Builtin.Int32, 10
+  %18 = struct_extract %3 : $Int32, #Int32._value
+  %19 = builtin "cmp_slt_Int32"(%17 : $Builtin.Int32, %18 : $Builtin.Int32) : $Builtin.Int1
+  cond_br %19, bb1, bb2
+
+bb1:
+  destroy_addr %2 : $*P
+  copy_addr %1 to [init] %0 : $*P
+  destroy_addr %1 : $*P
+  strong_release %10 : $@callee_owned () -> ()
+  br bb3
+
+bb2:
+  destroy_addr %1 : $*P
+  copy_addr %2 to [init] %0 : $*P
+  destroy_addr %2 : $*P
+  strong_release %10 : $@callee_owned () -> ()
+  br bb3
+
+bb3:
+  destroy_addr %7 : $*P
+  dealloc_stack %7 : $*P
+  %33 = tuple ()
+  return %33 : $()
+}
+
+sil shared @address_closure_existential : $@convention(thin) (@inout_aliasable P) -> () {
+bb0(%0 : $*P):
+  %7 = tuple ()
+  return %7 : $()
+}
+
+sil @address_closure_struct1 : $@convention(thin) (@inout_aliasable S, @owned S) -> () {
+bb0(%0 : $*S, %1 : $S):
+  %4 = struct_element_addr %0 : $*S, #S.c
+  %5 = load %4 : $*Optional<C>
+  store %1 to %0 : $*S
+  release_value %5 : $Optional<C>
+  %8 = tuple ()
+  return %8 : $()
+}
+
+sil @address_closure_struct2 : $@convention(thin) (@inout_aliasable S, @owned S) -> () {
+bb0(%0 : $*S, %1 : $S):
+  %4 = struct_element_addr %0 : $*S, #S.c
+  %5 = load %4 : $*Optional<C>
+  store %1 to %0 : $*S
+  release_value %5 : $Optional<C>
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil @address_caller_struct
+// CHECK-NOT: partial_apply
+// CHECK: [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> () 
+// CHECK: apply [[SPECIALIZED_FN1]]
+// CHECK: [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable S, @owned S) -> () 
+// CHECK: apply [[SPECIALIZED_FN2]]
+// CHECK-NOT: partial_apply
+// CHECK: return
+sil @address_caller_struct : $@convention(thin) (@guaranteed S, @guaranteed S) -> @owned S {
+bb0(%0 : $S, %1 : $S):
+  %4 = alloc_stack $S, var, name "xx"
+  %5 = struct_extract %0 : $S, #S.c
+  store %0 to %4 : $*S
+  %7 = function_ref @address_closure_noescape_user : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  %8 = function_ref @address_closure_struct1 : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+  %9 = partial_apply %8(%4, %1) : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+  %9b = convert_escape_to_noescape %9 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  retain_value %0 : $S
+  retain_value %1 : $S
+  %12 = apply %7(%9b) : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  %13 = function_ref @address_closure_struct2 : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+  %14 = partial_apply %13(%4, %0) : $@convention(thin) (@inout_aliasable S, @owned S) -> ()
+  %14b = convert_escape_to_noescape %14 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  retain_value %5 : $Optional<C>
+  %16 = apply %7(%14b) : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  %17 = load %4 : $*S
+  dealloc_stack %4 : $*S
+  return %17 : $S
+}
+
+sil shared @address_closure_class1 : $@convention(thin) (@inout_aliasable C, @owned C) -> () {
+bb0(%0 : $*C, %1 : $C):
+  %4 = load %0 : $*C
+  store %1 to %0 : $*C
+  strong_release %4 : $C
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: sil @address_caller_class1
+// CHECK-NOT: partial_apply
+// CHECK:  [[SPECIALIZED_FN1:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+// CHECK:  [[SPECIALIZED_FN2:%.*]] = function_ref @{{.*}}address_closure_noescape_user{{.*}} : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+// CHECK: apply [[SPECIALIZED_FN2]]{{.*}}
+// CHECK: apply [[SPECIALIZED_FN1]]{{.*}}
+// CHECK-NOT: partial_apply
+// CHECK: return
+sil @address_caller_class1 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
+bb0(%0 : $C, %1 : $C):
+  %4 = alloc_stack $C, var, name "xx"
+  store %0 to %4 : $*C
+  %7 = function_ref @address_closure_class1 : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+  %8 = partial_apply %7(%4, %1) : $@convention(thin) (@inout_aliasable C, @owned C) -> ()
+  %8b = convert_escape_to_noescape %8 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
+  %10 = function_ref @address_closure_noescape_user : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  strong_retain %0 : $C
+  strong_retain %1 : $C
+  strong_retain %8 : $@callee_owned () -> ()
+  %14 = apply %10(%8b) : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  strong_retain %8 : $@callee_owned () -> ()
+  %16 = apply %10(%8b) : $@convention(thin) (@noescape @callee_owned () -> ()) -> ()
+  %17 = load %4 : $*C
+  strong_retain %17 : $C
+  strong_release %8 : $@callee_owned () -> ()
+  %20 = load %4 : $*C
+  strong_release %20 : $C
+  dealloc_stack %4 : $*C
+  return %17 : $C
+}
+
+/////////////////////////////////////
+// Thin To Thick and Partial Apply //
+/////////////////////////////////////
+//
+// Make sure that we handle these correctly with and without removal of the
+// closure and @owned and @guaranteed.
+//
+
+// CHECK-LABEL: sil @large_closure_callee : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+sil @large_closure_callee : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.Int32, %2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject, %4 : $Builtin.NativeObject, %5 : $Builtin.Int32, %6 : $Builtin.NativeObject, %7 : $Builtin.NativeObject):
+  %9999 = tuple ()
+
+  release_value %2 : $Builtin.NativeObject
+  release_value %6 : $Builtin.NativeObject
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @small_closure_callee : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+sil @small_closure_callee : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.Int32, %2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject):
+  %9999 = tuple ()
+  release_value %2 : $Builtin.NativeObject
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil shared @$s18owned_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0
+// CHECK: [[FUN:%.*]] = function_ref @large_closure_callee : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+// CHECK: [[CLOSURE:%.*]] = partial_apply [[FUN]](
+// CHECK: apply [[CLOSURE]](
+// CHECK: release_value [[CLOSURE]]
+
+// CHECK-LABEL: sil shared @$s18owned_apply_callee014small_closure_C0Tf1cnnnn_n : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: bb0
+// CHECK: [[FUN:%.*]] = function_ref @small_closure_callee
+// CHECK: [[CLOSURE:%.*]] = thin_to_thick_function [[FUN]] : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () to $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+// CHECK: apply [[CLOSURE]](
+// CHECK: release_value [[CLOSURE]]
+
+// CHECK-LABEL: sil @owned_apply_callee : $@convention(thin) (@owned @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+sil @owned_apply_callee : $@convention(thin) (@owned @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), %1 : $Builtin.NativeObject, %2 : $Builtin.Int32, %3 : $Builtin.NativeObject, %4 : $Builtin.NativeObject):
+  retain_value %3 : $Builtin.NativeObject
+  apply %0(%1, %2, %3, %4) : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  release_value %3 : $Builtin.NativeObject
+  release_value %0 : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil shared @$s23guaranteed_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK: bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.Int32, %2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject, %4 : $Builtin.NativeObject, %5 : $Builtin.Int32, %6 : $Builtin.NativeObject, %7 : $Builtin.NativeObject):
+// CHECK: [[FUN:%.*]] = function_ref @large_closure_callee : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+// CHECK: [[CLOSURE:%.*]] = partial_apply [[FUN]](
+// CHECK: apply [[CLOSURE]](
+// CHECK: release_value [[CLOSURE]]
+
+// CHECK-LABEL: sil shared @$s23guaranteed_apply_callee014small_closure_C0Tf1cnnnn_n : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+// CHECK: bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.Int32, %2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject):
+// CHECK: [[FUN:%.*]] = function_ref @small_closure_callee
+// CHECK: [[CLOSURE:%.*]] = thin_to_thick_function [[FUN]] :
+// CHECK: apply [[CLOSURE]](
+// CHECK-NOT: release_value [[CLOSURE]]
+
+// CHECK-LABEL: sil @guaranteed_apply_callee : $@convention(thin) (@guaranteed @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+sil @guaranteed_apply_callee : $@convention(thin) (@guaranteed @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), %1 : $Builtin.NativeObject, %2 : $Builtin.Int32, %3 : $Builtin.NativeObject, %4 : $Builtin.NativeObject):
+  retain_value %3 : $Builtin.NativeObject
+  apply %0(%1, %2, %3, %4) : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  release_value %3 : $Builtin.NativeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+sil @guaranteed_apply_callee_throw : $@convention(thin) (@guaranteed @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned Error) -> @error Error {
+bb0(%0 : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), %1 : $Builtin.NativeObject, %2 : $Builtin.Int32, %3 : $Builtin.NativeObject, %4 : $Builtin.NativeObject, %5: $Error):
+  retain_value %3 : $Builtin.NativeObject
+  apply %0(%1, %2, %3, %4) : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  release_value %3 : $Builtin.NativeObject
+  throw %5 : $Error
+}
+// CHECK-LABEL: sil @thin_thick_and_partial_apply_test : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned any Error) -> () {
+// CHECK: bb0([[ARG0:%.*]] : $Builtin.NativeObject, [[ARG1:%.*]] : $Builtin.Int32, [[ARG2:%.*]] : $Builtin.NativeObject, [[ARG3:%.*]] : $Builtin.NativeObject, [[ARG4:%.*]] : $any Error):
+// CHECK: [[OLD_CLOSURE_CALLEE1:%.*]] = function_ref @large_closure_callee
+// CHECK: [[OLD_CLOSURE_CALLEE2:%.*]] = function_ref @small_closure_callee
+// CHECK: retain_value [[ARG0]] : $Builtin.NativeObject
+// CHECK-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
+// CHECK-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
+// CHECK: [[SPECFUN0:%.*]] = function_ref @$s23guaranteed_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
+// CHECK: retain_value [[ARG0]] : $Builtin.NativeObject
+// CHECK-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
+// CHECK-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
+// CHECK: [[SPECFUN1:%.*]] = function_ref @$s18owned_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
+// CHECK: retain_value [[ARG0]] : $Builtin.NativeObject
+// CHECK-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
+// CHECK-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
+// CHECK: [[DEAD_CLOSURE_1:%.*]] = partial_apply [[OLD_CLOSURE_CALLEE1]]
+// CHECK: [[SPECFUN2:%.*]] = function_ref @$s23guaranteed_apply_callee014small_closure_C0Tf1cnnnn_n 
+// CHECK: [[SPECFUN3:%.*]] = function_ref @$s18owned_apply_callee014small_closure_C0Tf1cnnnn_n
+// CHECK: [[DEAD_CLOSURE_2:%.*]] = thin_to_thick_function [[OLD_CLOSURE_CALLEE2]]
+// CHECK: retain_value [[DEAD_CLOSURE_1]]
+// CHECK-NOT: retain_value [[DEAD_CLOSURE_2]]
+// CHECK-NOT: apply [[DEAD_CLOSURE_1]]
+// CHECK-NOT: apply [[DEAD_CLOSURE_2]]
+// CHECK: apply [[SPECFUN1]](
+// CHECK-NEXT: release_value [[DEAD_CLOSURE_1]]
+// CHECK-NOT: release_value [[DEAD_CLOSURE_2]]
+// CHECK: apply [[SPECFUN3]](
+// CHECK-NOT: release_value [[DEAD_CLOSURE_1]]
+// CHECK-NOT: release_value [[DEAD_CLOSURE_2]]
+// CHECK: apply [[SPECFUN0]](
+// CHECK-NOT: release_value [[DEAD_CLOSURE_1]]
+// CHECK-NOT: release_value [[DEAD_CLOSURE_2]]
+// CHECK: apply [[SPECFUN2]](
+// CHECK-NEXT: release_value [[DEAD_CLOSURE_1]]
+// CHECK-NOT: release_value [[DEAD_CLOSURE_2]]
+
+// REMOVECLOSURES-LABEL: sil @thin_thick_and_partial_apply_test : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned any Error) -> () {
+// REMOVECLOSURES: bb0([[ARG0:%.*]] : $Builtin.NativeObject, [[ARG1:%.*]] : $Builtin.Int32, [[ARG2:%.*]] : $Builtin.NativeObject, [[ARG3:%.*]] : $Builtin.NativeObject, [[ARG4:%.*]] : $any Error):
+// REMOVECLOSURES: [[OLD_CLOSURE_CALLEE1:%.*]] = function_ref @large_closure_callee
+// REMOVECLOSURES: [[OLD_CLOSURE_CALLEE2:%.*]] = function_ref @small_closure_callee
+// REMOVECLOSURES: retain_value [[ARG0]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
+// REMOVECLOSURES: [[SPECFUN0:%.*]] = function_ref @$s23guaranteed_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
+// REMOVECLOSURES: retain_value [[ARG0]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
+// REMOVECLOSURES: [[SPECFUN1:%.*]] = function_ref @$s18owned_apply_callee014large_closure_C0BoBi32_BoBoTf1cnnnn_n
+// REMOVECLOSURES: retain_value [[ARG0]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: retain_value [[ARG2]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: retain_value [[ARG3]] : $Builtin.NativeObject
+// REMOVECLOSURES-NOT: partial_apply [[OLD_CLOSURE_CALLEE1]]
+// REMOVECLOSURES: [[SPECFUN4:%.*]] = function_ref @$s29guaranteed_apply_callee_throw014small_closure_C0Tf1cnnnnn_n
+// REMOVECLOSURES: [[SPECFUN2:%.*]] = function_ref @$s23guaranteed_apply_callee014small_closure_C0Tf1cnnnn_n
+// REMOVECLOSURES: [[SPECFUN3:%.*]] = function_ref @$s18owned_apply_callee014small_closure_C0Tf1cnnnn_n
+// REMOVECLOSURES-NOT: thin_to_thick_function [[OLD_CLOSURE_CALLEE2]]
+// REMOVECLOSURES: apply [[SPECFUN1]](
+// REMOVECLOSURES-NEXT: apply [[SPECFUN3]](
+// REMOVECLOSURES-NEXT: apply [[SPECFUN0]](
+// REMOVECLOSURES-NEXT: apply [[SPECFUN2]](
+// REMOVECLOSURES-NEXT: strong_release [[ARG0]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: strong_release [[ARG2]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: strong_release [[ARG3]] : $Builtin.NativeObject
+// REMOVECLOSURES-NEXT: try_apply [[SPECFUN4]](
+sil @thin_thick_and_partial_apply_test : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned Error) -> () {
+bb0(%0 : $Builtin.NativeObject, %1 : $Builtin.Int32, %2 : $Builtin.NativeObject, %3 : $Builtin.NativeObject, %11: $Error):
+  %4 = function_ref @owned_apply_callee : $@convention(thin) (@owned @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  %5 = function_ref @guaranteed_apply_callee : $@convention(thin) (@guaranteed @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  %6 = function_ref @large_closure_callee : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  %7 = function_ref @small_closure_callee : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  %10 = function_ref @guaranteed_apply_callee_throw : $@convention(thin) (@guaranteed @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned Error) -> @error Error
+
+  retain_value %0 : $Builtin.NativeObject
+  retain_value %2 : $Builtin.NativeObject
+  retain_value %3 : $Builtin.NativeObject
+  %8 = partial_apply %6(%0, %1, %2, %3) : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  %9 = thin_to_thick_function %7 : $@convention(thin) (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> () to $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+
+  retain_value %8 : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  apply %4(%8, %0, %1, %2, %3) : $@convention(thin) (@owned @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  apply %4(%9, %0, %1, %2, %3) : $@convention(thin) (@owned @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  apply %5(%8, %0, %1, %2, %3) : $@convention(thin) (@guaranteed @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  apply %5(%9, %0, %1, %2, %3) : $@convention(thin) (@guaranteed @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+
+  release_value %8 : $@callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> ()
+  try_apply %10(%9, %0, %1, %2, %3, %11) : $@convention(thin) (@guaranteed @callee_owned (Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject) -> (), Builtin.NativeObject, Builtin.Int32, @owned Builtin.NativeObject, @guaranteed Builtin.NativeObject, @owned Error) -> @error Error, normal bb2, error bb3
+
+bb2(%n : $()):
+  br bb4
+
+bb3(%e : $Error):
+  br bb4
+
+bb4:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+//////////////////////////////
+// Non Function Ref Closure //
+//////////////////////////////
+//
+// Make sure we do not try to specialize a closure if we are not closing over a
+// direct function ref.
+
+// CHECK-LABEL: @$s4test3barSiAA1P_p_SitF : $@convention(thin) (@in any P, Int32) -> Int32 {
+// CHECK: partial_apply
+// CHECK: apply
+sil [noinline] @$s4test3barSiAA1P_p_SitF : $@convention(thin) (@in P, Int32) -> Int32 {
+bb0(%0 : $*P, %1 : $Int32):
+  %2 = open_existential_addr mutable_access %0 : $*P to $*@opened("01234567-89ab-cdef-0123-000000000000", P) Self
+  %3 = witness_method $@opened("01234567-89ab-cdef-0123-000000000000", P) Self, #P.foo, %2 : $*@opened("01234567-89ab-cdef-0123-000000000000", P) Self : $@convention(witness_method: P) @callee_owned <T: P> (@callee_owned (Int32) -> Int32, Int32, @inout T) -> Int32
+  %4 = integer_literal $Builtin.Int32, 2
+  %5 = struct $Int32 (%4 : $Builtin.Int32)
+  // function_ref test.baz (Swift.Int32)(m : Swift.Int32) -> Swift.Int32
+  %6 = function_ref @$s4test3bazSiSi1m_tcSiF : $@convention(thin) (Int32, Int32) -> Int32
+  %7 = partial_apply %6(%5) : $@convention(thin) (Int32, Int32) -> Int32
+  %8 = apply %3<@opened("01234567-89ab-cdef-0123-000000000000", P) Self>(%7, %1, %2) : $@convention(witness_method: P) @callee_owned <T: P> (@callee_owned (Int32) -> Int32, Int32, @inout T) -> Int32
+  destroy_addr %0 : $*P
+  return %8 : $Int32
+}
+
+sil @$s4test3bazSiSi1m_tcSiF : $@convention(thin) (Int32, Int32) -> Int32
+
+//////////////////////////////////////////////////////////////////////////////////
+// Make sure that we properly set a specialized closure's indirect return type. //
+//////////////////////////////////////////////////////////////////////////////////
+//
+// SIL verification should catch the incorrect type.
+// rdar:://19321284
+
+// CHECK-LABEL: sil [serialized] @callee : $@convention(thin) (Builtin.Int32) -> () {
+sil [serialized] @callee : $@convention(thin) (Builtin.Int32) -> () {
+bb0(%0 : $Builtin.Int32):
+  unreachable
+}
+
+sil shared [serialized] @thunk : $@convention(thin) (@callee_owned () -> ()) -> @out () {
+bb0(%0 : $*(), %1 : $@callee_owned () -> ()):
+  apply %1() : $@callee_owned () -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: @test_closure_propagation : $@convention(thin) () -> () {
+// REMOVECLOSURES-LABEL: @test_closure_propagation : $@convention(thin) () -> () {
+// REMOVECLOSURES-NOT: partial_apply
+sil [serialized] @test_closure_propagation : $@convention(thin) () -> () {
+bb0:
+  %f1 = function_ref @callee : $@convention(thin) (Builtin.Int32) -> ()
+  %i1 = integer_literal $Builtin.Int32, 24
+  %p1 = partial_apply %f1(%i1) : $@convention(thin) (Builtin.Int32) -> ()
+  %f2 = function_ref @thunk : $@convention(thin) (@callee_owned () -> ()) -> @out ()
+  %s1 = alloc_stack $()
+  %a1 = apply %f2(%s1, %p1) : $@convention(thin) (@callee_owned () -> ()) -> @out ()
+  dealloc_stack %s1 : $*()
+  unreachable
+}

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_dynamic_self.swift
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_dynamic_self.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-sil -O -primary-file %s
+
+// Just make sure we skip the optimization and not crash here.
+//
+// Eventually, we can make this work.
+//
+// <rdar://problem/31725007>
+
+class Foo {
+  required init() {}
+
+  static func foo(_ f: () -> ()) -> Self {
+    f()
+    return self.init()
+  }
+}
+
+class Bar: Foo {}
+
+func closures(_ x: String) {
+  print(Foo.foo { _ = x })
+  print(Bar.foo { _ = x })
+}

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_dynamic_self.swift
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_dynamic_self.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -O -primary-file %s
+// RUN: %target-swift-frontend -emit-sil -O -experimental-swift-based-closure-specialization -primary-file %s
 
 // Just make sure we skip the optimization and not crash here.
 //

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_fragile.sil
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_fragile.sil
@@ -1,0 +1,60 @@
+// RUN: %target-sil-opt  %s -verify -experimental-swift-based-closure-specialization -o -  | %FileCheck %s
+
+// Make sure we do not specialize resilientCallee.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+@_optimize(none) public func action()
+
+@inline(__always) public func fragileCaller()
+
+public func resilientCallee(fn: () -> ())
+
+// action()
+sil [Onone] @$s26closure_specialize_fragile6actionyyF : $@convention(thin) () -> () {
+bb0:
+  %0 = tuple ()
+  return %0 : $()
+} // end sil function '$s26closure_specialize_fragile6actionyyF'
+
+// CHECK-LABEL: sil [serialized] [always_inline] @$s26closure_specialize_fragile0C6CalleryyF : $@convention(thin) () -> ()
+// CHECK: function_ref @$s26closure_specialize_fragile15resilientCalleeyyyc2fn_tF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+// CHECK: return
+// fragileCaller()
+sil [serialized] [always_inline] @$s26closure_specialize_fragile0C6CalleryyF : $@convention(thin) () -> () {
+bb0:
+  // function_ref resilientCallee(fn:)
+  %0 = function_ref @$s26closure_specialize_fragile15resilientCalleeyyyc2fn_tF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  // function_ref closure #1 in fragileCaller()
+  %1 = function_ref @$s26closure_specialize_fragile0C6CalleryyFyycfU_ : $@convention(thin) () -> () 
+  %2 = thin_to_thick_function %1 : $@convention(thin) () -> () to $@callee_owned () -> () 
+  %3 = apply %0(%2) : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+  %4 = tuple ()
+  return %4 : $()
+} // end sil function '$s26closure_specialize_fragile0C6CalleryyF'
+
+// CHECK-LABEL: sil @$s26closure_specialize_fragile15resilientCalleeyyyc2fn_tF : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
+
+// resilientCallee(fn:)
+sil @$s26closure_specialize_fragile15resilientCalleeyyyc2fn_tF : $@convention(thin) (@owned @callee_owned () -> ()) -> () {
+bb0(%0 : $@callee_owned () -> ()):
+  strong_retain %0 : $@callee_owned () -> ()
+  %3 = apply %0() : $@callee_owned () -> ()
+  strong_release %0 : $@callee_owned () -> ()
+  %5 = tuple ()
+  return %5 : $()
+} // end sil function '$s26closure_specialize_fragile15resilientCalleeyyyc2fn_tF'
+
+// closure #1 in fragileCaller()
+sil shared [serialized] @$s26closure_specialize_fragile0C6CalleryyFyycfU_ : $@convention(thin) () -> () {
+bb0:
+  // function_ref action()
+  %0 = function_ref @$s26closure_specialize_fragile6actionyyF : $@convention(thin) () -> () 
+  %1 = apply %0() : $@convention(thin) () -> ()
+  %2 = tuple ()
+  return %2 : $()
+} // end sil function '$s26closure_specialize_fragile0C6CalleryyFyycfU_'

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_loop.swift
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_loop.swift
@@ -1,0 +1,81 @@
+// RUN: %{python} %S/../Inputs/timeout.py 10 %target-swift-frontend -O -parse-as-library -experimental-swift-based-closure-specialization %s -emit-sil | %FileCheck %s
+// XFAIL: *
+public func callit() {
+    testit { false }
+}
+
+// Check if the compiler terminates and does not full into an infinite optimization
+// loop between the ClosureSpecializer and CapturePropagation.
+
+// CHECK-LABEL: sil @$s23closure_specialize_loop6testit1cySbyc_tF
+public func testit(c: @escaping () -> Bool) {
+  if c() {
+    testit { !c() }
+  }
+}
+
+// PR: https://github.com/apple/swift/pull/61956
+// Optimizing Expression.contains(where:) should not timeout.
+//
+// Repeated capture propagation leads to:
+//   func contains$termPred@arg0$[termPred$falsePred@arg1]@arg1(expr) {
+//     closure = termPred$[termPred$falsePred@arg1]@arg1
+//     falsePred(expr)
+//     contains$termPred@arg0$termPred$[termPred$falsePred@arg1]@arg1(expr)
+//   }
+//
+//   func contains$termPred@arg0$termPred$[termPred$falsePred@arg1]@arg1(expr) {
+//   closure = [termPred(termPred$[termPred$falsePred@arg1]@arg1)]
+//   closure(expr)
+//   contains$termPred@arg0(expr, closure)
+// }
+// The Demangled type tree looks like:
+//   kind=FunctionSignatureSpecialization
+//     kind=SpecializationPassID, index=3
+//     kind=FunctionSignatureSpecializationParam
+//     kind=FunctionSignatureSpecializationParam
+//       kind=FunctionSignatureSpecializationParamKind, index=0
+//       kind=FunctionSignatureSpecializationParamPayload, text="$s4test10ExpressionO8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_36$s4test12IndirectEnumVACycfcS2bXEfU_Tf3npf_n"
+//
+// CHECK-LABEL: $s23closure_specialize_loop10ExpressionO8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_012$s23closure_b7_loop10d44O8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_012g13_b7_loop10d44ijk2_tlm2U_no52U_012g30_B34_loop12IndirectEnumVACycfcnO10U_Tf3npf_nY2_nTf3npf_n
+// ---> function signature specialization
+//     <Arg[1] = [Constant Propagated Function : function signature specialization
+//                <Arg[1] = [Constant Propagated Function : function signature specialization
+//                           <Arg[1] = [Constant Propagated Function : closure #1 (Swift.Bool) -> Swift.Bool
+//                                      in closure_specialize_loop.IndirectEnum.init() -> closure_specialize_loop.IndirectEnum]>
+//                           of closure #1 (Swift.Bool) -> Swift.Bool
+//                           in closure #1 (closure_specialize_loop.Expression) -> Swift.Bool
+//                           in closure_specialize_loop.Expression.contains(where: (Swift.Bool) -> Swift.Bool) -> Swift.Bool]>
+//                of closure #1 (Swift.Bool) -> Swift.Bool
+//                in closure #1 (closure_specialize_loop.Expression) -> Swift.Bool
+//                in closure_specialize_loop.Expression.contains(where: (Swift.Bool) -> Swift.Bool) -> Swift.Bool]>
+//     of closure #1 (Swift.Bool) -> Swift.Bool
+//     in closure #1 (closure_specialize_loop.Expression) -> Swift.Bool
+//     in closure_specialize_loop.Expression.contains(where: (Swift.Bool) -> Swift.Bool) -> Swift.Bool
+//
+public indirect enum Expression {
+    case term(Bool)
+    case list(_ expressions: [Expression])
+
+    public func contains(where predicate: (Bool) -> Bool) -> Bool {
+        switch self {
+        case let .term(term):
+            return predicate(term)
+        case let .list(expressions):
+            return expressions.contains { expression in
+                expression.contains { term in
+                    predicate(term)
+                }
+            }
+        }
+    }
+}
+
+public struct IndirectEnum {
+    public init() {
+        let containsFalse = Expression.list([.list([.term(true), .term(false)]), .term(true)]).contains { term in
+            term == false
+        }
+        print(containsFalse)
+    }
+}

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_opaque.sil
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_opaque.sil
@@ -1,0 +1,43 @@
+// RUN: %target-sil-opt -enable-sil-opaque-values -enable-sil-verify-all -experimental-swift-based-closure-specialization %s | %FileCheck %s
+// XFAIL: *
+
+struct TestView {}
+struct TestRange {}
+struct TestSlice {}
+
+// helper
+sil @closure : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> () {
+bb0(%0 : $*TestView, %1 : $TestRange, %2 : $TestSlice):
+  %1284 = tuple ()
+  return %1284 : $()
+}
+
+// helper
+sil @thunk : $@convention(thin) (@inout TestView, @owned @callee_owned (@inout TestView) -> ()) -> @out () {
+bb0(%0 : $*TestView, %1 : $@callee_owned (@inout TestView) ->()):
+  %call = apply %1(%0) : $@callee_owned (@inout TestView) -> ()
+  %1284 = tuple ()
+  return %1284 : $()
+}
+
+// Test that ClosureSpecializer can handle captured @in args, in addition to direct args.
+//
+// CHECK-LABEL: sil @testSpecializeThunk : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> () {
+// CHECK: bb0(%0 : $*TestView, %1 : $TestRange, %2 : $TestSlice):
+// CHECK:   [[CLOSURE:%.*]] = function_ref @closure : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> ()
+// CHECK:   [[SPECIALIZED:%.*]] = function_ref @$s5thunk7closure4main9TestRangeVAC0D5SliceVTf1nc_n : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> @out () // user: %6
+// CHECK:   [[THUNK:%.*]] = function_ref @thunk : $@convention(thin) (@inout TestView, @owned @callee_owned (@inout TestView) -> ()) -> @out ()
+// CHECK:   [[CALL:%.*]] = apply [[SPECIALIZED]](%0, %1, %2) : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> @out ()
+// CHECK:   %{{.*}} = tuple ()
+// CHECK:   return %{{.*}} : $()
+// CHECK-LABEL: } // end sil function 'testSpecializeThunk'
+sil @testSpecializeThunk : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> () {
+bb0(%0 : $*TestView, %1 : $TestRange, %2 : $TestSlice):
+  %closurefn = function_ref @closure : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> ()
+  %pa = partial_apply %closurefn(%1, %2) : $@convention(thin) (@inout TestView, TestRange, @in TestSlice) -> ()
+  %thunk = function_ref @thunk : $@convention(thin) (@inout TestView, @owned @callee_owned (@inout TestView) -> ()) -> @out ()
+  strong_retain %pa : $@callee_owned (@inout TestView) -> ()
+  %call = apply %thunk(%0, %pa) : $@convention(thin) (@inout TestView, @owned @callee_owned (@inout TestView) -> ()) -> @out ()
+  %1284 = tuple ()
+  return %1284 : $()
+}

--- a/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_simple.sil
+++ b/test/SILOptimizer/experimental-swift-based-closure-specialization/closure_specialize_simple.sil
@@ -1,0 +1,292 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -experimental-swift-based-closure-specialization %s | %FileCheck %s
+// XFAIL: *
+
+import Builtin
+import Swift
+
+sil @simple_partial_apply_fun : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
+
+// CHECK-LABEL: sil shared @$s27simple_partial_apply_caller0a1_b1_C4_funBi1_Tf1c_n : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
+// CHECK: bb0([[CAPTURED_ARG:%.*]] : $Builtin.Int1):
+// CHECK: [[CLOSED_OVER_FUN:%.*]] = function_ref @simple_partial_apply_fun :
+// CHECK: [[NEW_PAI:%.*]] = partial_apply [[CLOSED_OVER_FUN]]
+// CHECK: strong_release [[NEW_PAI]]
+sil @simple_partial_apply_caller : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1):
+  br bb1
+
+bb1:
+  %1 = integer_literal $Builtin.Int1, 0
+  // We cannot do anything here for now but in the future I think we should try
+  // to handle this in closure specialization potentially.
+  %2 = apply %0(%1) : $@callee_owned (Builtin.Int1) -> Builtin.Int1
+  strong_release %0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  return %2 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil shared @$s37simple_partial_apply_2nd_level_caller0a1_b1_C4_funBi1_Tf1c_n : $@convention(thin) (Builtin.Int1) -> Builtin.Int1 {
+// CHECK: bb0([[CAPTURED_ARG:%.*]] : $Builtin.Int1):
+// CHECK: [[SPECIALIZED_CALLEE:%.*]] = function_ref @$s27simple_partial_apply_caller0a1_b1_C4_funBi1_Tf1c_n  :
+// CHECK: [[RET:%.*]]= apply [[SPECIALIZED_CALLEE]]([[CAPTURED_ARG]])
+// CHECK: return [[RET]]
+sil @simple_partial_apply_2nd_level_caller : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1):
+  br bb1
+
+bb1:
+  %1 = function_ref @simple_partial_apply_caller : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+  %2 = apply %1(%0) : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  return %2 : $Builtin.Int1
+}
+sil @simple_partial_apply_caller_decl : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+
+sil @simple_multiple_partial_apply_caller : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1, @owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1, %1 : $@callee_owned (Builtin.Int1) -> Builtin.Int1):
+  br bb1
+
+bb1:
+  %2 = integer_literal $Builtin.Int1, 0
+  // We cannot do anything here for now but in the future I think we should try
+  // to handle this in closure specialization potentially.
+  apply %0(%2) : $@callee_owned (Builtin.Int1) -> Builtin.Int1
+  strong_release %0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1
+  apply %1(%2) : $@callee_owned (Builtin.Int1) -> Builtin.Int1
+  strong_release %1 : $@callee_owned (Builtin.Int1) -> Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  return %2 : $Builtin.Int1
+}
+
+sil @simple_partial_apply_fun2 : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
+sil @simple_partial_apply_caller2 : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1 {
+bb0(%0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1):
+  br bb1
+
+bb1:
+  %1 = integer_literal $Builtin.Int1, 0
+  // We cannot do anything here for now but in the future I think we should try
+  // to handle this in closure specialization potentially.
+  %2 = apply %0(%1) : $@callee_owned (Builtin.Int1) -> Builtin.Int1
+  strong_release %0 : $@callee_owned (Builtin.Int1) -> Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  return %2 : $Builtin.Int1
+}
+
+
+sil @indirect_parameter_partial_apply_fun : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+
+sil @indirect_parameter_partial_apply_caller1 : $@convention(thin) (@callee_owned (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1) -> () {
+bb0(%0 : $@callee_owned (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1):
+  br bb1
+
+bb1:
+  %1 = alloc_stack $Builtin.Int1
+  %2 = integer_literal $Builtin.Int1, 0
+  apply %0(%1, %1, %2, %1) : $@callee_owned (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  dealloc_stack %1 : $*Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @indirect_parameter_partial_apply_caller2 : $@convention(thin) (@callee_owned (@in Builtin.Int1, Builtin.Int1) -> @out Builtin.Int1) -> () {
+bb0(%0 : $@callee_owned (@in Builtin.Int1, Builtin.Int1) -> @out Builtin.Int1):
+  br bb1
+
+bb1:
+  %1 = alloc_stack $Builtin.Int1
+  %2 = integer_literal $Builtin.Int1, 0
+  apply %0(%1, %1, %2) : $@callee_owned (@in Builtin.Int1, Builtin.Int1) -> @out Builtin.Int1
+  dealloc_stack %1 : $*Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @indirect_parameter_partial_apply_caller3 : $@convention(thin) (@callee_owned (@in Builtin.Int1) -> @out Builtin.Int1) -> () {
+bb0(%0 : $@callee_owned (@in Builtin.Int1) -> @out Builtin.Int1):
+  br bb1
+
+bb1:
+  %1 = alloc_stack $Builtin.Int1
+  apply %0(%1, %1) : $@callee_owned (@in Builtin.Int1) -> @out Builtin.Int1
+  dealloc_stack %1 : $*Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @indirect_parameter_partial_apply_caller4 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> () {
+bb0(%0 : $@callee_owned () -> @out Builtin.Int1):
+  br bb1
+
+bb1:
+  %1 = alloc_stack $Builtin.Int1
+  apply %0(%1) : $@callee_owned () -> @out Builtin.Int1
+  dealloc_stack %1 : $*Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @indirect_parameter_partial_apply_caller5 : $@convention(thin) (@callee_owned () -> ()) -> () {
+bb0(%0 : $@callee_owned () -> ()):
+  br bb1
+
+bb1:
+  apply %0() : $@callee_owned () -> ()
+  cond_br undef, bb1, bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @indirect_parameter_partial_apply_caller6 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out Builtin.Int1 {
+bb0(%1 : $*Builtin.Int1, %0 : $@callee_owned () -> @out Builtin.Int1):
+  br bb1
+
+bb1:
+  apply %0(%1) : $@callee_owned () -> @out Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @indirect_parameter_partial_apply_caller7 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out (Builtin.Int1, Builtin.Int1) {
+bb0(%1 : $*(Builtin.Int1, Builtin.Int1), %0 : $@callee_owned () -> @out Builtin.Int1):
+  br bb1
+
+bb1:
+  %2 = alloc_stack $Builtin.Int1
+  %3 = alloc_stack $Builtin.Int1
+  apply %0(%2) : $@callee_owned () -> @out Builtin.Int1
+  apply %0(%3) : $@callee_owned () -> @out Builtin.Int1
+  %4 = load %2: $*Builtin.Int1
+  %5 = load %3: $*Builtin.Int1
+  %6 = tuple(%4 : $Builtin.Int1, %5: $Builtin.Int1)
+  store %6 to %1 : $*(Builtin.Int1, Builtin.Int1)
+  dealloc_stack %3: $*Builtin.Int1
+  dealloc_stack %2: $*Builtin.Int1
+  cond_br undef, bb1, bb2
+
+bb2:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @loop_driver : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> () {
+// CHECK-DAG: [[SPECIALIZED_FUN:%.*]] = function_ref @$s27simple_partial_apply_caller0a1_b1_C4_funBi1_Tf1c_n : $@convention(thin) (Builtin.Int1) -> Builtin.Int1
+// CHECK-DAG: [[SPECIALIZED_FUN2:%.*]] = function_ref @$s37simple_partial_apply_2nd_level_caller0a1_b1_C4_funBi1_Tf1c_n : $@convention(thin) (Builtin.Int1) -> Builtin.Int1
+// CHECK: apply [[SPECIALIZED_FUN]]
+// CHECK: apply [[SPECIALIZED_FUN2]]
+
+// We can't call this one b/c it is just a declaration.
+// CHECK: [[UNSPECIALIZED_FUN_DECL:%.*]] = function_ref @simple_partial_apply_caller_decl : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+// CHECK: apply [[UNSPECIALIZED_FUN_DECL]]
+
+// We handle closures with indirect results.
+// CHECK: [[CLOSUREFUN:%.*]] = function_ref @indirect_parameter_partial_apply_fun
+// CHECK-NOT: partial_apply [[CLOSUREFUN]]()
+// CHECK: [[INLINEDCLOSURE_CALLER1:%.*]] = function_ref @$s40indirect_parameter_partial_apply_caller10a1_b1_c1_D4_funTf1c_n
+// CHECK-NOT: partial_apply [[CLOSUREFUN]]()
+
+// We don't handle captured indirect @in and @in_guaranteed parameters yet.
+// CHECK: [[CLOSURE2:%.*]] = partial_apply [[CLOSUREFUN]](%{{.*}})
+// CHECK: [[CLOSURE3:%.*]] = partial_apply [[CLOSUREFUN]](%{{.*}})
+// CHECK: [[CLOSURE4:%.*]] = partial_apply [[CLOSUREFUN]](%{{.*}})
+
+// CHECK:  [[CALLER1:%.*]] = function_ref @indirect_parameter_partial_apply_caller1
+// CHECK:  [[CALLER2:%.*]] = function_ref @indirect_parameter_partial_apply_caller2
+// CHECK:  [[CALLER3:%.*]] = function_ref @indirect_parameter_partial_apply_caller3
+// CHECK:  [[CALLER4:%.*]] = function_ref @indirect_parameter_partial_apply_caller4
+
+// Closure with indirect result but no captured indirect parameter.
+// CHECK-NOT: apply [[CALLER1]]
+// apply [[INLINEDCLOSURE_CALLER1]]()
+// CHECK-NOT: apply [[CALLER1]]
+
+// Closures with captured indirect parameters.
+// apply [[CALLER2]]([[CLOSURE2]])
+// apply [[CALLER3]]([[CLOSURE3]])
+// apply [[CALLER4]]([[CLOSURE4]])
+
+// CHECK: return
+sil @loop_driver : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> () {
+bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
+  %2 = function_ref @simple_partial_apply_fun : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
+  %3 = partial_apply %2(%0) : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
+  %4 = function_ref @simple_partial_apply_caller : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+  %5 = apply %4(%3) : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+
+  %51 = function_ref @simple_partial_apply_2nd_level_caller : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+  %52 = apply %51(%3) : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+
+  %6 = partial_apply %2(%0) : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
+  %7 = function_ref @simple_partial_apply_caller_decl : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+  %8 = apply %7(%6) : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+
+  %9 = alloc_stack $Builtin.Int1
+
+  %10 = function_ref @indirect_parameter_partial_apply_fun : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  %11 = partial_apply %10() : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  %12 = partial_apply %10(%9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  %13 = partial_apply %10(%1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  %14 = partial_apply %10(%9, %1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+
+  %16 = function_ref @indirect_parameter_partial_apply_caller1 : $@convention(thin) (@callee_owned (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1) -> ()
+  %17 = function_ref @indirect_parameter_partial_apply_caller2 : $@convention(thin) (@callee_owned (@in Builtin.Int1, Builtin.Int1) -> @out Builtin.Int1) -> ()
+  %18 = function_ref @indirect_parameter_partial_apply_caller3 : $@convention(thin) (@callee_owned (@in Builtin.Int1) -> @out Builtin.Int1) -> ()
+  %19 = function_ref @indirect_parameter_partial_apply_caller4 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> ()
+  %20 = function_ref @indirect_parameter_partial_apply_caller5 : $@convention(thin) (@callee_owned () -> ()) -> ()
+
+  apply %16(%11) : $@convention(thin) (@callee_owned (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1) -> ()
+  apply %17(%12) : $@convention(thin) (@callee_owned (@in Builtin.Int1, Builtin.Int1) -> @out Builtin.Int1) -> ()
+  apply %18(%13) : $@convention(thin) (@callee_owned (@in Builtin.Int1) -> @out Builtin.Int1) -> ()
+  apply %19(%14) : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> ()
+
+  // Make sure we handle when we already have an out parameter correctly.
+  %21 = alloc_stack $(Builtin.Int1, Builtin.Int1)
+  %22 = function_ref @indirect_parameter_partial_apply_caller6 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out Builtin.Int1
+  %23 = function_ref @indirect_parameter_partial_apply_caller7 : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out (Builtin.Int1, Builtin.Int1)
+  %24 = partial_apply %10(%9, %1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  %25 = partial_apply %10(%9, %1, %9) : $@convention(thin) (@in Builtin.Int1, Builtin.Int1, @in Builtin.Int1) -> @out Builtin.Int1
+  apply %22(%9, %24) : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out Builtin.Int1
+  apply %23(%21, %25) : $@convention(thin) (@callee_owned () -> @out Builtin.Int1) -> @out (Builtin.Int1, Builtin.Int1)
+
+  dealloc_stack %21 : $*(Builtin.Int1, Builtin.Int1)
+  dealloc_stack %9 : $*Builtin.Int1
+
+  %26 = partial_apply %2(%0) : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
+  %27 = partial_apply %2(%0) : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
+  %28 = function_ref @simple_multiple_partial_apply_caller : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1, @owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+  %29 = apply %28(%26, %27) : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1, @owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+
+  %30 = function_ref @simple_partial_apply_fun2 : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
+  %31 = partial_apply %30(%1) : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1
+  %32 = function_ref @simple_partial_apply_caller2 : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+  %33 = apply %32(%31) : $@convention(thin) (@owned @callee_owned (Builtin.Int1) -> Builtin.Int1) -> Builtin.Int1
+
+
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
This PR is divided into 3 commits.

1. **Commit 1** - Adds bridging code in preparation for the Swift based Autodiff closure-spec pass
2. **Commit 2** - Adds SwiftCompilerSources changes in preparation for the Autodiff closure-spec optimization pass
3. **Commit 3** - Adds part of the closure-specialization optimization pass. **The pass does not modify any code nor does it even exist in any of the optimization pipelines**. The rationale for pushing this partially complete optimization pass upstream is to keep up with the breaking changes in the underlying Swift based compiler infrastructure.
4. **Commit 4** - Makes the swift-based closure-spec pass an experimental frontend feature.
5. **Commit 5** - Copies over original closure-spec tests as XFAIL (when needed).
