### PR TITLE
Sema: Effectively revert https://github.com/apple/swift/pull/70569

### DIFF
--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -112,3 +112,7 @@ class C5 {
 class C6: C5, ServiceProvider {
   @MainActor func allOperations() async -> [String] { [] }
 }
+
+extension ImplementsLoadable: @retroactive Loadable {
+  public func loadStuff(withOtherIdentifier otherIdentifier: Int, reply: @escaping () -> Void) {}
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/ObjCConcurrency.h
@@ -344,4 +344,15 @@ MAIN_ACTOR
                                                    error:(NSError * __autoreleasing *)error;
 @end
 
+@protocol Loadable
+- (void)loadStuffWithIdentifier:(NSInteger)identifier reply:(void (^)())reply;
+- (void)loadStuffWithOtherIdentifier:(NSInteger)otherIdentifier reply:(void (^)())reply;
+- (void)loadStuffWithGroupID:(NSInteger)groupID reply:(void (^)())reply;
+@end
+
+@interface ImplementsLoadable : NSObject
+- (void)loadStuffWithIdentifier:(NSInteger)identifier reply:(void (^)())reply;
+- (void)loadStuffWithGroupID:(NSInteger)groupID reply:(void (^)())reply;
+@end
+
 #pragma clang assume_nonnull end

--- a/test/Serialization/conformance-objc-async.swift
+++ b/test/Serialization/conformance-objc-async.swift
@@ -4,6 +4,8 @@
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Conformance.swiftinterface -module-name Conformance -o /dev/null -I %t
 // REQUIRES: objc_interop
 
+// REQUIRES: rdar119435253
+
 //--- module.modulemap
 module ObjCProto {
   header "objc_proto.h"


### PR DESCRIPTION
The fix caused a source break that is now captured as an additional test case in `objc_async_conformance.swift`.

Resolves rdar://121527977
