### PR TITLE
Allow resilience bypassing package optimization for all decls within a package boundary.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4099,20 +4099,36 @@ public:
   
   void setBraces(SourceRange braces) { Braces = braces; }
 
-  /// Should this declaration behave as if it must be accessed
-  /// resiliently, even when we're building a non-resilient module?
+  /// Returns whether this declaration is resilient at the definition site, i.e.
+  /// must be accessed resiliently even when its defining module is built
+  /// non-resiliently.
   ///
   /// This is used for diagnostics, because we do not want a behavior
   /// change between builds with resilience enabled and disabled.
   bool isFormallyResilient() const;
 
-  /// Do we need to use resilient access patterns outside of this type's
-  /// resilience domain?
+  /// Returns whether this decl is resilient at the definition site
+  /// \c isFormallyResilient or whether its defining module
+  /// is built resiliently.
   bool isResilient() const;
 
-  /// Do we need to use resilient access patterns when accessing this
-  /// type from the given module?
-  bool isResilient(ModuleDecl *M, ResilienceExpansion expansion) const;
+  /// Returns whether this decl is accessed non/resiliently at the _use_ site
+  /// in \p accessingModule, depending on \p expansion.
+  ///
+  /// If \p expansion is maximal, the decl could be treated as non-resilient
+  /// even though the decl is resilient by definition or its defining module is built
+  /// resiliently. For example, if accessing a decl defined in the same module or
+  /// another module in the same package as the \p accessingModule, the
+  /// decl could be treated as non-resilient (with package optimization enabled in
+  /// case of different modules); this enables bypassing resilience checks at the
+  /// use site so the decl can be accessed directly.
+  ///
+  /// \p accessingModule The module from which this decl is accessed. Might
+  ///                    be the same module as its defining module.
+  /// \p expansion Used to determine whether non-resilience / direct access
+  ///              to this decl is possible.
+  bool isResilient(ModuleDecl *accessingModule,
+                   ResilienceExpansion expansion) const;
 
   /// Determine whether we have already attempted to add any
   /// implicitly-defined initializers to this declaration.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4206,10 +4206,8 @@ bool ValueDecl::hasOpenAccess(const DeclContext *useDC) const {
 
 bool ValueDecl::bypassResilienceInPackage(ModuleDecl *accessingModule) const {
   return getASTContext().LangOpts.EnableBypassResilienceInPackage &&
-          getModuleContext()->inSamePackage(accessingModule) &&
-          !getModuleContext()->isBuiltFromInterface() &&
-          getFormalAccessScope(/*useDC=*/nullptr,
-                               /*treatUsableFromInlineAsPublic=*/true).isPackage();
+         getModuleContext()->inSamePackage(accessingModule) &&
+         !getModuleContext()->isBuiltFromInterface();
 }
 
 /// Given the formal access level for using \p VD, compute the scope where

--- a/test/SILGen/package_bypass_resilience.swift
+++ b/test/SILGen/package_bypass_resilience.swift
@@ -34,12 +34,13 @@ func foo() {
 // CHECK: sil hidden [ossa] @$s6Client3fooyyF : $@convention(thin) () -> () {
 // CHECK-DEFAULT: [[F_REF:%.*]] = function_ref @$s5Utils9PkgStructV6pkgVarSivg : $@convention(method) (@in_guaranteed PkgStruct) -> Int
 // CHECK-DEFAULT: sil package_external @$s5Utils9PkgStructV6pkgVarSivg : $@convention(method) (@in_guaranteed PkgStruct) -> Int
-// CHECK-BYPASS:  [[ADDR:%.*]] = struct_element_addr %7 : $*PkgStruct, #PkgStruct.pkgVar
+// CHECK-BYPASS:  [[ADDR:%.*]] = struct_element_addr {{.*}} : $*PkgStruct, #PkgStruct.pkgVar
 
 func bar() {
   print(PubStruct().pubVar)
 }
 
 // CHECK: sil hidden [ossa] @$s6Client3baryyF : $@convention(thin) () -> () {
-// CHECK: [[F_REF:%.*]] = function_ref @$s5Utils9PubStructV6pubVarSivg : $@convention(method) (@in_guaranteed PubStruct) -> Int
-// CHECK: sil @$s5Utils9PubStructV6pubVarSivg : $@convention(method) (@in_guaranteed PubStruct) -> Int
+// CHECK-DEFAULT: [[F_REF:%.*]] = function_ref @$s5Utils9PubStructV6pubVarSivg : $@convention(method) (@in_guaranteed PubStruct) -> Int
+// CHECK-DEFAULT: sil @$s5Utils9PubStructV6pubVarSivg : $@convention(method) (@in_guaranteed PubStruct) -> Int
+// CHECK-BYPASS:  [[ADDR:%.*]] = struct_element_addr {{.*}} : $*PubStruct, #PubStruct.pubVar

--- a/test/Sema/package_resilience_bypass_exhaustive_switch.swift
+++ b/test/Sema/package_resilience_bypass_exhaustive_switch.swift
@@ -35,12 +35,6 @@ public enum FrozenPublicEnum {
   case two(Int)
 }
 
-@usableFromInline
-enum UfiInternalEnum {
-  case one
-  case two(Int)
-}
-
 //--- ClientDefault.swift
 import Utils
 
@@ -53,7 +47,7 @@ package func f(_ arg: PkgEnum) -> Int {
   }
 }
 
-public func g(_ arg: UfiPkgEnum) -> Int {
+package func g(_ arg: UfiPkgEnum) -> Int {
   switch arg { // expected-warning {{switch covers known cases, but 'UfiPkgEnum' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}}
   case .one:
     return 1
@@ -80,14 +74,6 @@ public func k(_ arg: FrozenPublicEnum) -> Int {
   }
 }
 
-public func m(_ arg: UfiInternalEnum) -> Int {
-  switch arg { // no-warning
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val
-  }
-}
 
 //--- ClientOptimized.swift
 import Utils
@@ -104,7 +90,7 @@ package func f(_ arg: PkgEnum) -> Int {
   }
 }
 
-public func g(_ arg: UfiPkgEnum) -> Int {
+package func g(_ arg: UfiPkgEnum) -> Int {
   switch arg { // no-warning
   case .one:
     return 1
@@ -123,15 +109,6 @@ public func h(_ arg: PublicEnum) -> Int {
 }
 
 public func k(_ arg: FrozenPublicEnum) -> Int {
-  switch arg { // no-warning
-  case .one:
-    return 1
-  case .two(let val):
-    return 2 + val
-  }
-}
-
-public func m(_ arg: UfiInternalEnum) -> Int {
   switch arg { // no-warning
   case .one:
     return 1


### PR DESCRIPTION
Currently only `package` decls are treated as non-resilient when resilience bypassing package optimization is enabled. This PR allows such optimization to be applied to `public` decls as well within a package boundary.  It also allows skipping a requirement of `@unknown default` in switch statements for resilient `public` (besides `package`) enums. 

Resolves rdar://123344579
