### PR TITLE
[Driver] Don’t crash if the output file map is incomplete

### DIFF
--- a/lib/Basic/OutputFileMap.cpp
+++ b/lib/Basic/OutputFileMap.cpp
@@ -209,6 +209,12 @@ OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer,
       llvm::yaml::Node *Key = OutputPair.getKey();
       llvm::yaml::Node *Value = OutputPair.getValue();
 
+      if (!Key)
+        return constructError("bad kind");
+
+      if (!Value)
+        return constructError("bad path");
+
       auto *KindNode = dyn_cast<llvm::yaml::ScalarNode>(Key);
       if (!KindNode)
         return constructError("kind not a ScalarNode");

--- a/test/Driver/malformed-ofm.swift
+++ b/test/Driver/malformed-ofm.swift
@@ -1,0 +1,14 @@
+// Ensure that an incomplete output-file-map path does not crash the driver,
+// but instead outputs a nice diagnostic.
+//
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: not %swiftc_driver -c %S/../Inputs/empty.swift -output-file-map %t/malformed-output-file-map.json 2>&1 | %FileCheck %s
+//
+// CHECK: error: Expected quote at end of scalar
+// CHECK-NOT: Assertion failed
+
+//--- malformed-output-file-map.json
+{
+  "/path/to/some/file.swift": {
+    "dependencies": "


### PR DESCRIPTION
When using VS Code, it semi-frequently happens that sourcekitd is reading the output file map and the memory buffer containing the memory buffer containing the output file map is not complete and terminates at distinct powers of 2. I managed to attach a debugger once and the memory buffer containing the output file had size 0x3000 = 12288 while the actual output file map is 20319 bytes large. One hypothesis for this is that the read of output file map is racing with a write from a SwiftPM build but I haven’t been able to confirm it.

In either case, the result is that the output file map buffer ends with an unterminated string literal, which causes `getKey()` or `getValue()` in the JSON parser to return `nullptr` and then consequently hits an assertion failure in `dyn_cast`. Add a check for nullptr before invoking `dyn_cast` just like we do it in the outer `for` loop.

rdar://122364031
