### PR TITLE
[IRGen] Lower release_value_addr of noncopyable to deinit call.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5095,6 +5095,9 @@ void IRGenSILFunction::visitReleaseValueAddrInst(
   Address addr = getLoweredAddress(operandValue);
   SILType addrTy = operandValue->getType();
   SILType objectT = addrTy.getObjectType();
+  if (tryEmitDestroyUsingDeinit(*this, addr, addrTy)) {
+    return;
+  }
   llvm::Type *llvmType = addr.getAddress()->getType();
   const TypeInfo &addrTI = getTypeInfo(addrTy);
   auto atomicity = i->isAtomic() ? Atomicity::Atomic : Atomicity::NonAtomic;

--- a/test/IRGen/moveonly_enum_deinits.swift
+++ b/test/IRGen/moveonly_enum_deinits.swift
@@ -1,8 +1,54 @@
-// RUN: %target-swift-emit-irgen \
+// RUN: %target-swift-emit-irgen                             \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
-// RUN:     %s \
-// RUN: | \
+// RUN:     -disable-type-layout                             \
+// RUN:     %s                                               \
+// RUN: |                                                    \
 // RUN: %FileCheck %s
+
+// Check that UMA_Large.deinit is called directly from FIFO_Large.deinit,
+// rather than through an outlined release function.
+// CHECK-LABEL: define{{.*}} void @"$s21moveonly_enum_deinits10FIFO_LargeVfD"
+// CHECK:         call{{.*}} void @"$s21moveonly_enum_deinits9UMA_LargeVfD"
+// CHECK:       }
+public struct FIFO_Large<T>: ~Copyable {
+  public var uma: UMA_Large<T>
+  public var i1: Int
+  public var i2: Int
+
+  deinit {
+    something(self)
+  }
+}
+
+public struct UMA_Large<T>: ~Copyable {
+  public let umbp: UnsafeMutableBufferPointer<T>
+  public var allocd: [Bool] = []
+  deinit {
+    something(self)
+  }
+}
+
+// Check that UMA_Small.deinit is called directly from FIFO_Small.deinit,
+// rather than through an outlined release function.
+// CHECK-LABEL: define{{.*}} void @"$s21moveonly_enum_deinits10FIFO_SmallVfD"
+// CHECK:         call{{.*}} void @"$s21moveonly_enum_deinits9UMA_SmallVfD"
+// CHECK:       }
+public struct FIFO_Small<T>: ~Copyable {
+  public var uma: UMA_Small<T>
+  public var i1: Int
+  public var i2: Int
+
+  deinit {
+    something(self)
+  }
+}
+
+public struct UMA_Small<T>: ~Copyable {
+  public var allocd: [Bool] = []
+  deinit {
+    something(self)
+  }
+}
 
 // CHECK-LABEL: define{{.*}} void @"$s21moveonly_enum_deinits4ListOwxx"(
 // CHECK-SAME:      ptr noalias %object, 
@@ -17,13 +63,16 @@
 // CHECK:         ret void
 // CHECK:       }
 
-struct Box<T : ~Copyable> : ~Copyable {
-    public init(_ l: consuming T) {}
-        
-    deinit {}
+public struct Box<T : ~Copyable> : ~Copyable {
+  public init(_ l: consuming T) {}
+      
+  deinit {}
 }
 
-enum List: ~Copyable {
-    case end
-    case more(Int, Box<List>)
+public enum List: ~Copyable {
+  case end
+  case more(Int, Box<List>)
 }
+
+@_silgen_name("something")
+func something<T : ~Copyable>(_ t: borrowing T)


### PR DESCRIPTION
When lowering a `release_value_addr` instruction whose operand is a value type with a deinit, directly emit a call to the deinit.
