### PR TITLE
[IRGen] Make sure a C++ constructor thunk is called when it's needed

### DIFF
--- a/test/Interop/Cxx/class/constructors-irgen-windows.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-windows.swift
@@ -12,7 +12,7 @@ public func createHasVirtualBase() -> HasVirtualBase {
   // MICROSOFT_X64: define dllexport swiftcc void @"$s7MySwift20createHasVirtualBaseSo0{{bcD0VyF|deF0VyF}}"(ptr noalias sret({{.*}}) [[V0:%.*]])
   // MICROSOFT_X64-NOT: define
   // Note `this` return type and implicit "most derived" argument.
-  // [[V1:%.*]] = alloca %{{.*}}, align 8
+  // MICROSOFT_X64: [[V1:%.*]] = alloca %{{.*}}, align 8
   // MICROSOFT_X64: call ptr @"??0HasVirtualBase@@QEAA@UArgType@@@Z"(ptr [[V1]], i32 %{{[0-9]+}}, i32 1)
   // MICROSOFT_X64: call ptr @"??0HasVirtualBase@@QEAA@UArgType@@@Z"(ptr [[V0]], i32 %{{[0-9]+}}, i32 1)
   let _ : HasVirtualBase = HasVirtualBase(ArgType())

--- a/test/Interop/Cxx/class/constructors-irgen-windows.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-windows.swift
@@ -9,10 +9,13 @@ import Constructors
 import TypeClassification
 
 public func createHasVirtualBase() -> HasVirtualBase {
-  // MICROSOFT_X64: define dllexport swiftcc void @"$s7MySwift20createHasVirtualBaseSo0{{bcD0VyF|deF0VyF}}"(ptr noalias sret({{.*}}) %0)
+  // MICROSOFT_X64: define dllexport swiftcc void @"$s7MySwift20createHasVirtualBaseSo0{{bcD0VyF|deF0VyF}}"(ptr noalias sret({{.*}}) [[V0:%.*]])
   // MICROSOFT_X64-NOT: define
   // Note `this` return type and implicit "most derived" argument.
-  // MICROSOFT_X64: call ptr @"??0HasVirtualBase@@QEAA@UArgType@@@Z"(ptr %{{[0-9]+}}, i32 %{{[0-9]+}}, i32 1)
+  // [[V1:%.*]] = alloca %{{.*}}, align 8
+  // MICROSOFT_X64: call ptr @"??0HasVirtualBase@@QEAA@UArgType@@@Z"(ptr [[V1]], i32 %{{[0-9]+}}, i32 1)
+  // MICROSOFT_X64: call ptr @"??0HasVirtualBase@@QEAA@UArgType@@@Z"(ptr [[V0]], i32 %{{[0-9]+}}, i32 1)
+  let _ : HasVirtualBase = HasVirtualBase(ArgType())
   return HasVirtualBase(ArgType())
 }
 

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
@@ -6,7 +6,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fno-rtti -O)
 //
 // REQUIRES: executable_test
-// XFAIL: OS=windows-msvc
 
 import CustomDestructor
 import StdlibUnittest


### PR DESCRIPTION
This fixes a bug where the thunk for a C++ constructor call wasn't being called when the constructor was called the second time.