### PR TITLE
LargeTypesReg2Mem: Gracefully handle the case when the Container type is deemed small but the Containee is not

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -3306,7 +3306,7 @@ bool Peepholes::optimizeLoad(SILBasicBlock &BB, SILInstruction *I) {
     if (next2It == BB.end())
       return false;
     auto *store = dyn_cast<StoreInst>(&*next2It);
-    if (!store)
+    if (!store || store->getSrc() != LI)
       return false;
     if (ignore(store))
       return false;

--- a/test/IRGen/Inputs/large_c.h
+++ b/test/IRGen/Inputs/large_c.h
@@ -29,3 +29,14 @@ struct SamplesType {
     void* Z;
     void* AA;
 };
+
+
+typedef struct _ContainedType {
+  unsigned int f1;
+  float    f2;
+} __attribute__((packed)) ContainedType;
+
+typedef struct _ContainerType {
+  char x1;
+  ContainedType l[10];
+}  __attribute__((packed)) ContainerType;

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -29,6 +29,16 @@ struct Y {
   var y2: X
 }
 
+class C1 {
+}
+
+sil_vtable C1 {
+}
+
+struct Small {
+  var x1 : Int
+}
+
 // CHECK: sil @test1 : $@convention(thin) () -> () {
 // CHECK: bb0:
 // CHECK:   %0 = alloc_stack $Optional<X>
@@ -245,6 +255,17 @@ bb0:
   dealloc_stack %2 : $*(_ContainedType, _ContainedType, _ContainedType, _ContainedType, _ContainedType,
                      _ContainedType, _ContainedType, _ContainedType, _ContainedType, _ContainedType)
   dealloc_stack %0 : $*_ContainerType
+  %t = tuple ()
+  return %t : $()
+}
+
+sil @test10 : $@convention(thin) (@in_guaranteed C1, @in Small) -> () {
+bb0(%0 : $*C1, %1 : $*Small):
+  %2 = load %1 : $*Small
+  %3 = load %0 : $*C1
+  retain_value %3 : $C1
+  store %2 to %1 : $*Small
+  retain_value %3 : $C1
   %t = tuple ()
   return %t : $()
 }

--- a/test/IRGen/loadable_by_address_reg2mem.sil
+++ b/test/IRGen/loadable_by_address_reg2mem.sil
@@ -229,3 +229,22 @@ bb0(%0 : $SamplesType):
   %t = tuple ()
   return %t : $()
 }
+
+// In this test case Container type is identified as not large but contained
+// type is.
+sil @test9 : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $_ContainerType
+  %1 = load %0 : $*_ContainerType
+  %2 = alloc_stack $(_ContainedType, _ContainedType, _ContainedType, _ContainedType, _ContainedType,
+                     _ContainedType, _ContainedType, _ContainedType, _ContainedType, _ContainedType)
+
+  %3 = struct_extract %1 : $_ContainerType, #_ContainerType.l
+  store %3 to %2 : $*(_ContainedType, _ContainedType, _ContainedType, _ContainedType, _ContainedType,
+                     _ContainedType, _ContainedType, _ContainedType, _ContainedType, _ContainedType)
+  dealloc_stack %2 : $*(_ContainedType, _ContainedType, _ContainedType, _ContainedType, _ContainedType,
+                     _ContainedType, _ContainedType, _ContainedType, _ContainedType, _ContainedType)
+  dealloc_stack %0 : $*_ContainerType
+  %t = tuple ()
+  return %t : $()
+}


### PR DESCRIPTION


rdar://123340151
