### PR TITLE
[Dependency Scanning] Guard access to shared state of the `DependencyScannerDiagnosticCollectingConsumer`

### DIFF
--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -39,10 +39,11 @@ private:
   
   void handleDiagnostic(SourceManager &SM,
                         const DiagnosticInfo &Info) override;
-  ScannerDiagnosticInfo convertDiagnosticInfo(SourceManager &SM,
-                                              const DiagnosticInfo &Info);
   void addDiagnostic(SourceManager &SM, const DiagnosticInfo &Info);
   std::vector<ScannerDiagnosticInfo> Diagnostics;
+  // FIXME: For now, we isolate access to shared state of this object
+  // but we really should make sure that it doesn't get shared.
+  llvm::sys::SmartMutex<true> ScanningDiagnosticConsumerStateLock;
 };
 
 
@@ -91,8 +92,8 @@ public:
   bool loadCache(llvm::StringRef path);
   /// Discard the tool's current `SharedCache` and start anew.
   void resetCache();
-  
-  const std::vector<DependencyScannerDiagnosticCollectingConsumer::ScannerDiagnosticInfo>& getDiagnostics() const { return CDC.Diagnostics; }
+  /// Query diagnostics consumed so far.
+  std::vector<DependencyScannerDiagnosticCollectingConsumer::ScannerDiagnosticInfo> getDiagnostics();
   /// Discared the collection of diagnostics encountered so far.
   void resetDiagnostics();
 

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -77,6 +77,7 @@ void DependencyScannerDiagnosticCollectingConsumer::handleDiagnostic(SourceManag
 }
 
 void DependencyScannerDiagnosticCollectingConsumer::addDiagnostic(SourceManager &SM, const DiagnosticInfo &Info) {
+  llvm::sys::SmartScopedLock<true> Lock(ScanningDiagnosticConsumerStateLock);
   // Determine what kind of diagnostic we're emitting.
   llvm::SourceMgr::DiagKind SMKind;
   switch (Info.Kind) {
@@ -217,6 +218,13 @@ bool DependencyScanningTool::loadCache(llvm::StringRef path) {
 void DependencyScanningTool::resetCache() {
   llvm::sys::SmartScopedLock<true> Lock(DependencyScanningToolStateLock);
   ScanningService.reset(new SwiftDependencyScanningService());
+}
+
+std::vector<
+    DependencyScannerDiagnosticCollectingConsumer::ScannerDiagnosticInfo>
+DependencyScanningTool::getDiagnostics() {
+  llvm::sys::SmartScopedLock<true> Lock(DependencyScanningToolStateLock);
+  return CDC.Diagnostics;
 }
 
 void DependencyScanningTool::resetDiagnostics() {

--- a/tools/libSwiftScan/libSwiftScan.cpp
+++ b/tools/libSwiftScan/libSwiftScan.cpp
@@ -613,14 +613,15 @@ swiftscan_compiler_supported_features_query() {
 swiftscan_diagnostic_set_t*
 swiftscan_scanner_diagnostics_query(swiftscan_scanner_t scanner) {
   DependencyScanningTool *ScanningTool = unwrap(scanner);
-  auto NumDiagnostics = ScanningTool->getDiagnostics().size();
-  
+  auto Diagnostics = ScanningTool->getDiagnostics();
+  auto NumDiagnostics = Diagnostics.size();
+
   swiftscan_diagnostic_set_t *Result = new swiftscan_diagnostic_set_t;
   Result->count = NumDiagnostics;
   Result->diagnostics = new swiftscan_diagnostic_info_t[NumDiagnostics];
   
   for (size_t i = 0; i < NumDiagnostics; ++i) {
-    const auto &Diagnostic = ScanningTool->getDiagnostics()[i];
+    const auto &Diagnostic = Diagnostics[i];
     swiftscan_diagnostic_info_s *DiagnosticInfo = new swiftscan_diagnostic_info_s;
     DiagnosticInfo->message = swift::c_string_utils::create_clone(Diagnostic.Message.c_str());
     switch (Diagnostic.Severity) {


### PR DESCRIPTION
`DependencyScanningTool` has one `DependencyScannerDiagnosticCollectingConsumer` which gets associated with each individual scan query during lifetime of the tool. This isn't a valid use of such diagnostic consumer because the tool may be handling multiple scan queries at any given time, which may all be adding/resetting/querying diagnostics. For now, guard the shared state of the shared consumer as a short-term fix. 

A follow-up change will refactor the diagnostic consumer to be per-client-scan. 

Resolves rdar://123344065
