### PR TITLE
Windows build: Pass `SwiftDriver_DIR` to SourceKit-LSP in build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1744,6 +1744,7 @@ function Build-SourceKitLSP($Arch) {
     -BuildTargets default `
     -Defines @{
       SwiftSyntax_DIR = (Get-HostProjectCMakeModules Compilers);
+      SwiftDriver_DIR = (Get-HostProjectCMakeModules Driver);
       SwiftSystem_DIR = (Get-HostProjectCMakeModules System);
       TSC_DIR = (Get-HostProjectCMakeModules ToolsSupportCore);
       LLBuild_DIR = (Get-HostProjectCMakeModules LLBuild);


### PR DESCRIPTION
With https://github.com/apple/swift-package-manager/pull/7258 SourceKit-LSP gains an explicit dependency on Swift Driver, which we have to express in CMake builds too.