### PR TITLE
[IRGen] Outlined value functions that destroy move-only-with-deinit types take and forward those types' metadata.

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -253,7 +253,8 @@ namespace {
         asDerived().emitValueAssignWithCopy(IGF, destValue, srcValue);
         emitCopyOfTables(IGF, dest, src);
       } else {
-        OutliningMetadataCollector collector(IGF);
+        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+                                             DeinitIsNotNeeded);
         collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                          IsNotInitialization, IsNotTake);
       }
@@ -267,7 +268,8 @@ namespace {
         asDerived().emitValueInitializeWithCopy(IGF, destValue, srcValue);
         emitCopyOfTables(IGF, dest, src);
       } else {
-        OutliningMetadataCollector collector(IGF);
+        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+                                             DeinitIsNotNeeded);
         collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                          IsInitialization, IsNotTake);
       }
@@ -281,7 +283,8 @@ namespace {
         asDerived().emitValueAssignWithTake(IGF, destValue, srcValue);
         emitCopyOfTables(IGF, dest, src);
       } else {
-        OutliningMetadataCollector collector(IGF);
+        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+                                             DeinitIsNotNeeded);
         collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                          IsNotInitialization, IsTake);
       }
@@ -295,7 +298,8 @@ namespace {
         asDerived().emitValueInitializeWithTake(IGF, destValue, srcValue);
         emitCopyOfTables(IGF, dest, src);
       } else {
-        OutliningMetadataCollector collector(IGF);
+        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+                                             DeinitIsNotNeeded);
         collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                          IsInitialization, IsTake);
       }
@@ -307,7 +311,8 @@ namespace {
         Address valueAddr = projectValue(IGF, existential);
         asDerived().emitValueDestroy(IGF, valueAddr);
       } else {
-        OutliningMetadataCollector collector(IGF);
+        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+                                             DeinitIsNeeded);
         collector.emitCallToOutlinedDestroy(existential, T, *this);
       }
     }
@@ -963,7 +968,8 @@ public:
                                                srcBuffer);
     } else {
       // Create an outlined function to avoid explosion
-      OutliningMetadataCollector collector(IGF);
+      OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+                                           DeinitIsNotNeeded);
       collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                        IsInitialization, IsNotTake);
     }
@@ -979,7 +985,8 @@ public:
       IGF.emitMemCpy(dest, src, getLayout().getSize(IGF.IGM));
     } else {
       // Create an outlined function to avoid explosion
-      OutliningMetadataCollector collector(IGF);
+      OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+                                           DeinitIsNotNeeded);
       collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                        IsInitialization, IsTake);
     }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -184,7 +184,8 @@ void LoadableTypeInfo::initializeWithCopy(IRGenFunction &IGF, Address destAddr,
     loadAsCopy(IGF, srcAddr, copy);
     initialize(IGF, copy, destAddr, true);
   } else {
-    OutliningMetadataCollector collector(IGF);
+    OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+                                         DeinitIsNotNeeded);
     // No need to collect anything because we assume loadable types can be
     // loaded without enums.
     collector.emitCallToOutlinedCopy(

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1193,8 +1193,10 @@ public:
   llvm::Constant *getOrCreateRetainFunction(const TypeInfo &objectTI, SILType t,
                               llvm::Type *llvmType, Atomicity atomicity);
 
-  llvm::Constant *getOrCreateReleaseFunction(const TypeInfo &objectTI, SILType t,
-                              llvm::Type *llvmType, Atomicity atomicity);
+  llvm::Constant *
+  getOrCreateReleaseFunction(const TypeInfo &objectTI, SILType t,
+                             llvm::Type *llvmType, Atomicity atomicity,
+                             const OutliningMetadataCollector &collector);
 
   llvm::Constant *getOrCreateOutlinedInitializeWithTakeFunction(
                               SILType objectType, const TypeInfo &objectTI,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5098,15 +5098,9 @@ void IRGenSILFunction::visitReleaseValueAddrInst(
   if (tryEmitDestroyUsingDeinit(*this, addr, addrTy)) {
     return;
   }
-  llvm::Type *llvmType = addr.getAddress()->getType();
   const TypeInfo &addrTI = getTypeInfo(addrTy);
   auto atomicity = i->isAtomic() ? Atomicity::Atomic : Atomicity::NonAtomic;
-  auto *outlinedF = cast<llvm::Function>(
-      IGM.getOrCreateReleaseFunction(addrTI, objectT, llvmType, atomicity));
-  llvm::Value *args[] = {addr.getAddress()};
-  llvm::CallInst *call =
-      Builder.CreateCall(outlinedF->getFunctionType(), outlinedF, args);
-  call->setCallingConv(IGM.DefaultCC);
+  addrTI.callOutlinedRelease(*this, addr, objectT, atomicity);
 }
 
 void IRGenSILFunction::visitDestroyValueInst(swift::DestroyValueInst *i) {

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -32,18 +32,17 @@
 using namespace swift;
 using namespace irgen;
 
-void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType type) {
+void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType ty) {
   // If the type has no archetypes, we can emit it from scratch in the callee.
-  if (!type.hasArchetype()) {
+  if (!ty.hasArchetype()) {
     return;
   }
 
   // Substitute opaque types if allowed.
-  type =
-      IGF.IGM.substOpaqueTypesWithUnderlyingTypes(type, CanGenericSignature());
+  ty = IGF.IGM.substOpaqueTypesWithUnderlyingTypes(ty, CanGenericSignature());
 
-  auto formalType = type.getASTType();
-  auto &ti = IGF.IGM.getTypeInfoForLowered(formalType);
+  auto astType = ty.getASTType();
+  auto &ti = IGF.IGM.getTypeInfoForLowered(astType);
 
   // We don't need the metadata for fixed size types or types that are not ABI
   // accessible. Outlining will call the value witness of the enclosing type of
@@ -55,11 +54,11 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType type) {
   // If the type is a legal formal type, add it as a formal type.
   // FIXME: does this force us to emit a more expensive metadata than we need
   // to?
-  if (formalType->isLegalFormalType()) {
-    return collectFormalTypeMetadata(formalType);
+  if (astType->isLegalFormalType()) {
+    return collectFormalTypeMetadata(astType);
   }
 
-  collectRepresentationTypeMetadata(type);
+  collectRepresentationTypeMetadata(ty);
 }
 
 void OutliningMetadataCollector::collectFormalTypeMetadata(CanType type) {

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -59,12 +59,7 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType type) {
     return collectFormalTypeMetadata(formalType);
   }
 
-  auto key = LocalTypeDataKey(type.getASTType(),
-                            LocalTypeDataKind::forRepresentationTypeMetadata());
-  if (Values.count(key)) return;
-
-  auto metadata = IGF.emitTypeMetadataRefForLayout(type);
-  Values.insert({key, metadata});
+  collectRepresentationTypeMetadata(type);
 }
 
 void OutliningMetadataCollector::collectFormalTypeMetadata(CanType type) {
@@ -78,6 +73,15 @@ void OutliningMetadataCollector::collectFormalTypeMetadata(CanType type) {
   Values.insert({key, metadata});
 }
 
+void OutliningMetadataCollector::collectRepresentationTypeMetadata(SILType ty) {
+  auto key = LocalTypeDataKey(
+      ty.getASTType(), LocalTypeDataKind::forRepresentationTypeMetadata());
+  if (Values.count(key))
+    return;
+
+  auto metadata = IGF.emitTypeMetadataRefForLayout(ty);
+  Values.insert({key, metadata});
+}
 
 void OutliningMetadataCollector::addMetadataArguments(
                                     SmallVectorImpl<llvm::Value*> &args) const {

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -443,6 +443,17 @@ llvm::Constant *IRGenModule::getOrCreateRetainFunction(const TypeInfo &ti,
       true /*setIsNoInline*/);
 }
 
+void TypeInfo::callOutlinedRelease(IRGenFunction &IGF, Address addr, SILType T,
+                                   Atomicity atomicity) const {
+  llvm::Type *llvmType = addr.getAddress()->getType();
+  auto *outlinedF = cast<llvm::Function>(
+      IGF.IGM.getOrCreateReleaseFunction(*this, T, llvmType, atomicity));
+  llvm::Value *args[] = {addr.getAddress()};
+  llvm::CallInst *call =
+      IGF.Builder.CreateCall(outlinedF->getFunctionType(), outlinedF, args);
+  call->setCallingConv(IGF.IGM.DefaultCC);
+}
+
 llvm::Constant *
 IRGenModule::getOrCreateReleaseFunction(const TypeInfo &ti,
                                         SILType t,

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -68,6 +68,8 @@ public:
                                  const TypeInfo &ti) const;
 
 private:
+  void collectRepresentationTypeMetadata(SILType ty);
+
   void addMetadataArguments(SmallVectorImpl<llvm::Value *> &args) const ;
   void addMetadataParameterTypes(SmallVectorImpl<llvm::Type *> &paramTys) const;
   void bindMetadataParameters(IRGenFunction &helperIGF,

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -58,7 +58,6 @@ private:
 public:
   OutliningMetadataCollector(IRGenFunction &IGF) : IGF(IGF) {}
 
-  void collectFormalTypeMetadata(CanType type);
   void collectTypeMetadataForLayout(SILType type);
 
   void emitCallToOutlinedCopy(Address dest, Address src,
@@ -68,6 +67,7 @@ public:
                                  const TypeInfo &ti) const;
 
 private:
+  void collectFormalTypeMetadata(CanType type);
   void collectRepresentationTypeMetadata(SILType ty);
 
   void addMetadataArguments(SmallVectorImpl<llvm::Value *> &args) const ;

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_IRGEN_OUTLINING_H
 #define SWIFT_IRGEN_OUTLINING_H
 
+#include "IRGen.h"
 #include "LocalTypeDataKind.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/MapVector.h"
@@ -79,6 +80,8 @@ public:
                               IsInitialization_t isInit, IsTake_t isTake) const;
   void emitCallToOutlinedDestroy(Address addr, SILType T,
                                  const TypeInfo &ti) const;
+  void emitCallToOutlinedRelease(Address addr, SILType T, const TypeInfo &ti,
+                                 Atomicity atomicity) const;
 
 private:
   void collectFormalTypeMetadata(CanType type);

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -20,7 +20,6 @@
 #include "LocalTypeDataKind.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/MapVector.h"
-#include "LocalTypeDataKind.h"
 
 namespace llvm {
   class Value;
@@ -41,6 +40,16 @@ class IRGenFunction;
 class IRGenModule;
 class TypeInfo;
 
+enum LayoutIsNeeded_t : bool {
+  LayoutIsNotNeeded = false,
+  LayoutIsNeeded = true
+};
+
+enum DeinitIsNeeded_t : bool {
+  DeinitIsNotNeeded = false,
+  DeinitIsNeeded = true
+};
+
 /// A helper class for emitting outlined value operations.
 ///
 /// The use-pattern for this class is:
@@ -51,12 +60,17 @@ class TypeInfo;
 class OutliningMetadataCollector {
 public:
   IRGenFunction &IGF;
+  const unsigned needsLayout : 1;
+  const unsigned needsDeinit : 1;
+
 private:
   llvm::MapVector<LocalTypeDataKey, llvm::Value *> Values;
   friend class IRGenModule;
 
 public:
-  OutliningMetadataCollector(IRGenFunction &IGF) : IGF(IGF) {}
+  OutliningMetadataCollector(IRGenFunction &IGF, LayoutIsNeeded_t needsLayout,
+                             DeinitIsNeeded_t needsDeinitTypes)
+      : IGF(IGF), needsLayout(needsLayout), needsDeinit(needsDeinitTypes) {}
 
   void collectTypeMetadataForLayout(SILType type);
 

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -583,6 +583,9 @@ public:
                         IsTake_t isTake) const;
 
   void callOutlinedDestroy(IRGenFunction &IGF, Address addr, SILType T) const;
+
+  void callOutlinedRelease(IRGenFunction &IGF, Address addr, SILType T,
+                           Atomicity atomicity) const;
 };
 
 } // end namespace irgen

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -26,6 +26,7 @@
 #define SWIFT_IRGEN_TYPEINFO_H
 
 #include "IRGen.h"
+#include "Outlining.h"
 #include "swift/AST/ReferenceCounting.h"
 #include "llvm/ADT/MapVector.h"
 
@@ -575,7 +576,8 @@ public:
   /// Returns whether there was an appropriate metadata collector (and whether
   /// \p invocation was called.
   bool withMetadataCollector(
-      IRGenFunction &IGF, SILType T,
+      IRGenFunction &IGF, SILType T, LayoutIsNeeded_t needsLayout,
+      DeinitIsNeeded_t needsDeinit,
       llvm::function_ref<void(OutliningMetadataCollector &)> invocation) const;
 
   void callOutlinedCopy(IRGenFunction &IGF, Address dest, Address src,

--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -1,0 +1,130 @@
+// RUN: %target-swift-emit-irgen -O                          \
+// RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -disable-type-layout                             \
+// RUN:     %s                                               \
+// RUN: |                                                    \
+// RUN: %FileCheck %s
+
+@_silgen_name("external_symbol")
+func external_symbol()
+
+public class C<T> {
+  deinit {
+    external_symbol()
+  }
+}
+
+public struct InnerDeinitingReleasableNC<T> : ~Copyable {
+  public let i1: Int
+  public let i2: Int
+  public let i3: Int
+  public let i4: Int
+  public let c1: C<T>
+  public let c2: C<T>
+  public let c3: C<T>
+  public let c4: C<T>
+
+  deinit {
+    external_symbol()
+  }
+}
+
+public struct InnerDeinitingDestructableNC<T> : ~Copyable {
+  public let t: T
+  public let i1: Int
+  public let i2: Int
+  public let i3: Int
+  public let i4: Int
+  public let c1: C<T>
+  public let c2: C<T>
+  public let c3: C<T>
+  public let c4: C<T>
+
+  deinit {
+    external_symbol()
+  }
+}
+
+public struct OuterDeinitingNC_1<T> : ~Copyable {
+  public let i1: Int
+  public let c1: C<T>
+  public let i: InnerDeinitingReleasableNC<T>
+  deinit {
+    external_symbol()
+  }
+}
+
+public struct OuterNC_1<T> : ~Copyable {
+  public let i1: Int
+  public let c1: C<T>
+  public let i: InnerDeinitingReleasableNC<T>
+}
+
+public struct OuterNC_2<T> : ~Copyable {
+  public let i1: Int
+  public let c1: C<T>
+  public let i: InnerDeinitingDestructableNC<T>
+}
+
+// Destroyed value:
+// - has deinit
+// On lifetime end:
+// - call deinit
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions22takeOuterDeinitingNC_1yyAA0efG2_1VyxGnlF"(
+// CHECK-SAME:      ptr{{.*}} %0,
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE:%[^,]+]] = call{{.*}} @"$s24moveonly_value_functions18OuterDeinitingNC_1VMa"(
+//           :        i64 0,
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[OUTER_DEINITING_NC_1_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]]
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions18OuterDeinitingNC_1VfD"(
+// CHECK-SAME:        ptr [[OUTER_DEINITING_NC_1_METADATA]],
+// CHECK-SAME:        ptr{{.*}} %0)
+// CHECK:       }
+public func takeOuterDeinitingNC_1<T>(_ t: consuming OuterDeinitingNC_1<T>) {
+  external_symbol()
+}
+
+// If the destroyed value has no deinit, is releasable, and contains a
+// noncopyable value with a deinit, call the outlined destroy function.
+// Destroyed value:
+// - has NO deinit
+// - contains value type with deinit
+// - is NOT releasable
+// On lifetime end:
+// - call outlined destroy destroy
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions13takeOuterNC_2yyAA0eF2_2VyxGnlF"(
+// CHECK-SAME:      ptr{{.*}} %0,
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE:%[^,]+]] = call{{.*}} @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"(
+// CHECK-SAME:        i64 0,
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[INNER_DEINITING_DESTRUCTABLE_NC_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]]
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions9OuterNC_2VyxGlWOh"(
+// CHECK-SAME:        ptr %0,
+// CHECK-SAME:        ptr %T,
+// CHECK-SAME:        ptr [[INNER_DEINITING_DESTRUCTABLE_NC_METADATA]],
+//           :        ptr %4)
+// CHECK:       }
+
+// Verify that the outlined destroy function takes the metadata for the
+// move-only-with-deinit type InnerDeinitingDestructable<T> and passes it along
+// to that deinit.
+// $s24moveonly_value_functions9OuterNC_2VyxGlWOh ---> outlined destroy of moveonly_value_functions.OuterNC_2<A>
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions9OuterNC_2VyxGlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T, 
+// CHECK-SAME:      ptr %"InnerDeinitingDestructableNC<T>", 
+// CHECK-SAME:      ptr %"OuterNC_2<T>")
+// CHECK-SAME:  {
+//                ...
+//                ...
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVfD"(
+// CHECK-SAME:        ptr %"InnerDeinitingDestructableNC<T>", 
+//           :        ptr noalias swiftself %3)
+// CHECK:       }
+public func takeOuterNC_2<T>(_ o: consuming OuterNC_2<T>) {
+  external_symbol()
+}

--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -87,6 +87,45 @@ public func takeOuterDeinitingNC_1<T>(_ t: consuming OuterDeinitingNC_1<T>) {
 }
 
 // If the destroyed value has no deinit, is releasable, and contains a
+// noncopyable value with a deinit, call the outlined release function.
+// Destroyed value:
+// - has NO deinit
+// - contains value type with deinit
+// - is releasable
+// On lifetime end:
+// - call outlined release function
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions13takeOuterNC_1yyAA0eF2_1VyxGnlF"(
+// CHECK-SAME:      ptr{{.*}} %0,
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE:%[^,]+]] = call{{.*}} @"$s24moveonly_value_functions26InnerDeinitingReleasableNCVMa"(
+//           :        i64 0,
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[INNER_DEINITING_RELEASABLE_NC_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]]
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions9OuterNC_1VyxGlWOs"(
+// CHECK-SAME:        ptr %0,
+// CHECK-SAME:        ptr [[INNER_DEINITING_RELEASABLE_NC_METADATA]])
+// CHECK:       }
+
+// Verify that the outlined release function takes the metadata for the
+// move-only-with-deinit type InnerDeinitingReleasableNC<T> and passes it along
+// to that deinit.
+// $s24moveonly_value_functions9OuterNC_1VyxGlWOs ---> outlined release of moveonly_value_functions.OuterNC_2<A>
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions9OuterNC_1VyxGlWOs"(
+// CHECK-SAME:      ptr %0,
+// CHECK-SAME:      ptr %"InnerDeinitingReleasableNC<T>")
+// CHECK-SAME:  {
+//                ...
+//                ...
+// CHECK:         call swiftcc void @"$s24moveonly_value_functions26InnerDeinitingReleasableNCVfD"(
+// CHECK-SAME:        ptr %"InnerDeinitingReleasableNC<T>",
+//           :        ptr noalias nocapture swiftself dereferenceable(64) %deinit.arg)
+// CHECK:       }
+public func takeOuterNC_1<T>(_ o: consuming OuterNC_1<T>) {
+  external_symbol()
+}
+
+// If the destroyed value has no deinit, is releasable, and contains a
 // noncopyable value with a deinit, call the outlined destroy function.
 // Destroyed value:
 // - has NO deinit


### PR DESCRIPTION
When it's needed (for outlined release and destroy functions) by outlined value functions, pass the metadata of generic, noncopyable value types with deinits that appear within the type's layout.  Because the deinit takes the metadata for the type being destroyed itself, this is straightforward.
