### PR TITLE
ModuleInterface: Improve TypedThrows feature guards

### DIFF
--- a/test/ModuleInterface/typed_throws.swift
+++ b/test/ModuleInterface/typed_throws.swift
@@ -11,3 +11,15 @@ public enum MyError: Error {
 // CHECK-NEXT: public func throwsMyError() throws(Test.MyError)
 // CHECK-NEXT: #endif
 public func throwsMyError() throws(MyError) { }
+
+// CHECK:      #if compiler(>=5.3) && $TypedThrows
+// CHECK-NEXT: public func takesClosureThrowingMyError(_ closure: () throws(Test.MyError) -> Swift.Void)
+// CHECK-NEXT: #endif
+public func takesClosureThrowingMyError(_ closure: () throws(MyError) -> Void) {}
+
+public struct HasThrowingInit {
+  // CHECK:      #if compiler(>=5.3) && $TypedThrows
+  // CHECK-NEXT: public init() throws(Test.MyError)
+  // CHECK-NEXT: #endif
+  public init() throws(MyError) { }
+}


### PR DESCRIPTION
Functions that use typed throws _anywhere_ in their signature (including in closure types) need to be surrounded with `if $TypedThrows` guards in swiftinterfaces.
