### PR TITLE
[Distributed] Undo new record and mangling scheme for dist.p.witnesses

### DIFF
--- a/include/swift/RemoteInspection/RuntimeHeaders/llvm/BinaryFormat/Swift.def
+++ b/include/swift/RemoteInspection/RuntimeHeaders/llvm/BinaryFormat/Swift.def
@@ -30,6 +30,4 @@ HANDLE_SWIFT_SECTION(protocs, "__swift5_protos", "swift5_protocols",
                      ".sw5prt$B")
 HANDLE_SWIFT_SECTION(acfuncs, "__swift5_acfuncs", "swift5_accessible_functions",
                      ".sw5acfn$B")
-HANDLE_SWIFT_SECTION(dacfuncs, "__swift5_acpfuns", "swift5_accessible_protocol_requirement_functions",
-                     ".sw5acpfn$B")
 HANDLE_SWIFT_SECTION(mpenum, "__swift5_mpenum", "swift5_mpenum", ".sw5mpen$B")

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -307,10 +307,6 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_accessible_function_record                             \
   __ptrauth(ptrauth_key_process_independent_data, 1,                           \
             SpecialPointerAuthDiscriminators::AccessibleFunctionRecord)
-#define __ptrauth_swift_accessible_protocol_requirement_function_record        \
-  __ptrauth(ptrauth_key_process_independent_data, 1,                           \
-            SpecialPointerAuthDiscriminators::                                 \
-                AccessibleProtocolRequirementFunctionRecord)
 #define __ptrauth_swift_objc_superclass                                        \
   __ptrauth(ptrauth_key_process_independent_data, 1,                           \
             swift::SpecialPointerAuthDiscriminators::ObjCSuperclass)
@@ -359,7 +355,6 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 #define __ptrauth_swift_escalation_notification_function
 #define __ptrauth_swift_dispatch_invoke_function
 #define __ptrauth_swift_accessible_function_record
-#define __ptrauth_swift_accessible_protocol_requirement_function_record
 #define __ptrauth_swift_objc_superclass
 #define __ptrauth_swift_runtime_function_entry
 #define __ptrauth_swift_runtime_function_entry_with_key(__key)

--- a/lib/AST/DistributedDecl.cpp
+++ b/lib/AST/DistributedDecl.cpp
@@ -390,6 +390,7 @@ bool swift::checkDistributedSerializationRequirementIsExactlyCodable(
       std::count(protocols.begin(), protocols.end(), decodable) == 1;
 }
 
+// TODO(distributed): probably can be removed?
 llvm::ArrayRef<ValueDecl *>
 AbstractFunctionDecl::getDistributedMethodWitnessedProtocolRequirements() const {
   auto mutableThis = const_cast<AbstractFunctionDecl *>(this);

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2232,8 +2232,3 @@ bool swift::writeEmptyOutputFilesFor(
   }
   return false;
 }
-IRGenModule::AccessibleProtocolFunctionsData::AccessibleProtocolFunctionsData(
-    SILFunction *function, const std::optional<std::string> &mangledRecordName,
-    const std::optional<std::string> &concreteMangledTypeName)
-    : function(function), mangledRecordName(mangledRecordName),
-      concreteMangledTypeName(concreteMangledTypeName) {}

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1152,10 +1152,6 @@ public:
   void addObjCClassStub(llvm::Constant *addr);
   void addProtocolConformance(ConformanceDescription &&conformance);
   void addAccessibleFunction(SILFunction *func);
-  void addAccessibleFunctionDistributedAliased(
-      std::string mangledRecordName,
-      std::optional<std::string> mangledActorTypeName,
-      SILFunction *func);
 
   llvm::Constant *emitSwiftProtocols(bool asContiguousArray);
   llvm::Constant *emitProtocolConformances(bool asContiguousArray);
@@ -1313,25 +1309,6 @@ private:
   /// List of all of the functions, which can be lookup by name
   /// up at runtime.
   SmallVector<SILFunction *, 4> AccessibleFunctions;
-
-  struct AccessibleProtocolFunctionsData {
-    SILFunction *function;
-    /// Mangled name of the requirement function.
-    std::optional<std::string> mangledRecordName;
-    std::optional<std::string> concreteMangledTypeName;
-    AccessibleProtocolFunctionsData(
-        SILFunction *function,
-        const std::optional<std::string> &mangledRecordName,
-        const std::optional<std::string> &concreteMangledTypeName);
-  };
-  /// List of all functions which are protocol *requirements* which may be
-  /// looked up by name at runtime. The record can be used to pair
-  /// a concrete implementation type with the protocol (record) name,
-  /// in order to locate the *witness* function name on this specific type.
-  ///
-  /// The witness function name can then be used to look up the witness at
-  /// runtime by inspecting `AccessibleFunctions`.
-  SmallVector<AccessibleProtocolFunctionsData, 4> AccessibleProtocolFunctions;
 
   /// Map of Objective-C protocols and protocol references, bitcast to i8*.
   /// The interesting global variables relating to an ObjC protocol.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2476,36 +2476,7 @@ void IRGenSILFunction::emitSILFunction() {
     IGM.emitDistributedTargetAccessor(CurSILFn);
     IGM.addAccessibleFunction(CurSILFn);
 
-    if (auto val = CurSILFn->getLocation().castToASTNode<ValueDecl>()) {
-      if (auto attr =
-              val->getAttrs().getAttribute<DistributedThunkTargetAttr>()) {
-
-        // the original `distributed func`
-        auto func = attr->getTargetFunction();
-
-        auto distributedRequirements = func->getDistributedMethodWitnessedProtocolRequirements();
-        if (distributedRequirements.size() == 1) {
-          auto protocolFunc = distributedRequirements.front();
-          Mangle::ASTMangler mangler;
-          // The mangled name of the requirement is the name of the record
-          auto mangledProtocolFuncName =
-            mangler.mangleDistributedThunk(cast<FuncDecl>(protocolFunc));
-
-          std::optional<std::string> mangledActorTypeName;
-          if (isa<ClassDecl>(func->getDeclContext()->getAsDecl())) {
-            // a concrete type, not a "distributed" protocol
-            mangledActorTypeName = mangler.mangleAnyDecl(
-                func->getDeclContext()->getSelfNominalTypeDecl(),
-                /*prefix=*/true);
-          }
-
-          IGM.addAccessibleFunctionDistributedAliased(
-              /*mangledRecordName=*/mangledProtocolFuncName,
-              /*mangledActorTypeName=*/mangledActorTypeName,
-              CurSILFn);
-        }
-      }
-    }
+    // TODO(distributed): for protocols emit a special accessor
   }
 
   // Configure the dominance resolver.

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -195,6 +195,17 @@ static void forwardParameters(AbstractFunctionDecl *afd,
   }
 }
 
+static llvm::StringRef
+mangleDistributedThunkForAccessorRecordName(
+    ASTContext &C, AbstractFunctionDecl *thunk) {
+  Mangle::ASTMangler mangler;
+
+  // default mangling
+  auto mangled =
+      C.AllocateCopy(mangler.mangleDistributedThunk(cast<FuncDecl>(thunk)));
+  return mangled;
+}
+
 static std::pair<BraceStmt *, bool>
 deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
   auto implicit = true;
@@ -519,34 +530,12 @@ deriveBodyDistributed_thunk(AbstractFunctionDecl *thunk, void *context) {
 
   {
     // --- Mangle the thunk name
-    Mangle::ASTMangler mangler;
+    auto mangledAccessorRecordName =
+        mangleDistributedThunkForAccessorRecordName(C, thunk);
 
-    // FIXME: cleanup
-    StringLiteralExpr *mangledTargetStringLiteral = nullptr;
-    auto witnessedDistributedRequirements =
-        func->getDistributedMethodWitnessedProtocolRequirements();
-
-    if (witnessedDistributedRequirements.size() == 1) {
-      auto protocolFunc = witnessedDistributedRequirements.front();
-
-      // we expect to witness exactly one distributed requirement,
-      // otherwise we should have diagnosed errors about more than 1 already.
-      std::string mangledString =
-          mangler.mangleDistributedThunk(cast<FuncDecl>(protocolFunc));
-      // FIXME: make it THUNK so the mangling is right
-      // MUST BE LIKE: s4main28GreeterP_ConcreteSystem_StubC5greetSSyYaKFTE
-
-      StringRef mangled = C.AllocateCopy(mangledString);
-      mangledTargetStringLiteral =
-          new (C) StringLiteralExpr(mangled, SourceRange(), implicit);
-    } else {
-      // default mangling
-      auto mangled =
-          C.AllocateCopy(mangler.mangleDistributedThunk(cast<FuncDecl>(thunk)));
-      mangledTargetStringLiteral =
-          new (C) StringLiteralExpr(mangled, SourceRange(), implicit);
-    }
-    assert(mangledTargetStringLiteral && "must be initialized");
+    StringLiteralExpr *mangledTargetStringLiteral =
+        new (C) StringLiteralExpr(mangledAccessorRecordName,
+                                  SourceRange(), implicit);
 
     // --- let target = RemoteCallTarget(<mangled name>)
     targetVar->setInterfaceType(remoteCallTargetTy);

--- a/stdlib/public/Distributed/DistributedMetadata.swift
+++ b/stdlib/public/Distributed/DistributedMetadata.swift
@@ -95,25 +95,6 @@ func __getReturnTypeInfo(
 /// uses to return String data/length pairs.
 typealias _SwiftNamePair = (UnsafePointer<UInt8>, Int)
 
-@available(SwiftStdlib 5.11, *)
-@_silgen_name("swift_distributed_getConcreteAccessibleWitnessName")
-func _getConcreteAccessibleWitnessName(
-  on actor: AnyObject, // : DistributedActor
-  _ targetNameStart: UnsafePointer<UInt8>,
-  _ targetNameLength: UInt
-) -> _SwiftNamePair
-
-/// Retrieve a generic environment descriptor associated with
-/// the given distributed target.
-@available(SwiftStdlib 5.11, *)
-@_silgen_name("swift_distributed_getGenericEnvironmentForConcreteActor")
-// SPI Distributed
-func _getGenericEnvironmentOfDistributedTarget(
-    on actor: AnyObject, // : DistributedActor
-    _ targetNameStart: UnsafePointer<UInt8>,
-    _ targetNameLength: UInt
-) -> UnsafeRawPointer?
-
 /// Deprecated SPI: Instead use the entry point with the actor parameter passed.
 @available(SwiftStdlib 5.7, *)
 @_silgen_name("swift_distributed_getGenericEnvironment")

--- a/stdlib/public/SwiftShims/swift/shims/MetadataSections.h
+++ b/stdlib/public/SwiftShims/swift/shims/MetadataSections.h
@@ -97,7 +97,6 @@ struct MetadataSections {
   MetadataSectionRange swift5_capture;
   MetadataSectionRange swift5_mpenum;
   MetadataSectionRange swift5_accessible_functions;
-  MetadataSectionRange swift5_accessible_protocol_requirement_functions;
   MetadataSectionRange swift5_runtime_attributes;
   MetadataSectionRange swift5_tests;
 };

--- a/stdlib/public/runtime/AccessibleFunction.cpp
+++ b/stdlib/public/runtime/AccessibleFunction.cpp
@@ -51,32 +51,6 @@ struct AccessibleFunctionsSection {
   const AccessibleFunctionRecord *end() const { return End; }
 };
 
-struct AccessibleProtocolFunctionsSection {
-  const AccessibleProtocolRequirementFunctionRecord
-      *__ptrauth_swift_accessible_protocol_requirement_function_record Begin;
-  const AccessibleProtocolRequirementFunctionRecord
-      *__ptrauth_swift_accessible_protocol_requirement_function_record End;
-
-  AccessibleProtocolFunctionsSection(
-      const AccessibleProtocolRequirementFunctionRecord *begin,
-      const AccessibleProtocolRequirementFunctionRecord *end)
-      : Begin(begin), End(end) {}
-
-  AccessibleProtocolFunctionsSection(const void *ptr, uintptr_t size) {
-    auto bytes = reinterpret_cast<const char *>(ptr);
-    Begin =
-        reinterpret_cast<const AccessibleProtocolRequirementFunctionRecord *>(
-            ptr);
-    End = reinterpret_cast<const AccessibleProtocolRequirementFunctionRecord *>(
-        bytes + size);
-  }
-
-  const AccessibleProtocolRequirementFunctionRecord *begin() const {
-    return Begin;
-  }
-  const AccessibleProtocolRequirementFunctionRecord *end() const { return End; }
-};
-
 struct AccessibleFunctionCacheEntry {
 private:
   const char *Name;
@@ -121,62 +95,10 @@ public:
     return hash_value(llvm::hash_combine(value.TypeName, value.TargetName));
   }
 };
-struct AccessibleProtocolFunctionCacheEntry {
-private:
-  const char *TypeName; // TODO(distributed): Optimize and use metadata pointer
-  size_t TypeNameLength;
-
-  const char *TargetName;
-  size_t TargetNameLength;
-
-  const AccessibleProtocolRequirementFunctionRecord
-      *__ptrauth_swift_accessible_protocol_requirement_function_record R;
-
-public:
-  AccessibleProtocolFunctionCacheEntry(
-      llvm::StringRef typeName, llvm::StringRef targetName,
-      const AccessibleProtocolRequirementFunctionRecord *record)
-      : R(record) {
-    char *TheTypeName = reinterpret_cast<char *>(malloc(typeName.size()));
-    memcpy(TheTypeName, typeName.data(), typeName.size());
-    this->TypeName = TheTypeName;
-    this->TypeNameLength = typeName.size();
-
-    char *TheTargetName = reinterpret_cast<char *>(malloc(targetName.size()));
-    memcpy(TheTargetName, targetName.data(), targetName.size());
-    this->TargetName = TheTargetName;
-    this->TargetNameLength = targetName.size();
-  }
-
-  const AccessibleProtocolRequirementFunctionRecord *getRecord() const {
-    return R;
-  }
-
-  bool matchesKey(AccessibleProtocolFunctionCacheKey key) {
-    return key.TypeName == llvm::StringRef{TypeName, TypeNameLength} &&
-           key.TargetName == llvm::StringRef{TargetName, TargetNameLength};
-  }
-
-  friend llvm::hash_code
-  hash_value(const AccessibleProtocolFunctionCacheEntry &value) {
-    return hash_value(llvm::hash_combine(
-        llvm::StringRef{value.TypeName, value.TypeNameLength},
-        llvm::StringRef{value.TargetName, value.TargetNameLength}));
-  }
-
-  template <class... T>
-  static size_t getExtraAllocationSize(T &&...ignored) {
-    return 0;
-  }
-};
 
 struct AccessibleFunctionsState {
-  ConcurrentReadableHashMap<AccessibleFunctionCacheEntry> FunctionCache;
-  ConcurrentReadableHashMap<AccessibleProtocolFunctionCacheEntry>
-      ProtocolRequirementFunctionCache;
+  ConcurrentReadableHashMap<AccessibleFunctionCacheEntry> Cache;
   ConcurrentReadableArray<AccessibleFunctionsSection> SectionsToScan;
-  ConcurrentReadableArray<AccessibleProtocolFunctionsSection>
-      WitnessSectionsToScan;
 
   AccessibleFunctionsState() {
     initializeAccessibleFunctionsLookup();
@@ -192,14 +114,8 @@ static void _registerAccessibleFunctions(AccessibleFunctionsState &C,
   C.SectionsToScan.push_back(section);
 }
 
-static void _registerAccessibleProtocolFunctions(
-    AccessibleFunctionsState &C, AccessibleProtocolFunctionsSection section) {
-  C.WitnessSectionsToScan.push_back(section);
-}
-
 void swift::addImageAccessibleFunctionsBlockCallbackUnsafe(
-  const void *baseAddress,
-    const void *functions, uintptr_t size) {
+  const void *baseAddress, const void *functions, uintptr_t size) {
   assert(
       size % sizeof(AccessibleFunctionRecord) == 0 &&
       "accessible function section not a multiple of AccessibleFunctionRecord");
@@ -208,29 +124,10 @@ void swift::addImageAccessibleFunctionsBlockCallbackUnsafe(
   _registerAccessibleFunctions(C, AccessibleFunctionsSection{functions, size});
 }
 
-void swift::addImageAccessibleProtocolFunctionsBlockCallbackUnsafe(
-    const void *baseAddress, const void *dfunctions, uintptr_t dsize) {
-  assert(dsize % sizeof(AccessibleProtocolRequirementFunctionRecord) == 0 &&
-         "accessible protocol function section not a multiple of "
-         "AccessibleProtocolRequirementFunctionRecord");
-
-  auto &C = Functions.unsafeGetAlreadyInitialized();
-  _registerAccessibleProtocolFunctions(
-      C, AccessibleProtocolFunctionsSection{dfunctions, dsize});
-}
-
 void swift::addImageAccessibleFunctionsBlockCallback(
-  const void *baseAddress,
-    const void *functions, uintptr_t size) {
+  const void *baseAddress, const void *functions, uintptr_t size) {
   Functions.get();
   addImageAccessibleFunctionsBlockCallbackUnsafe(baseAddress, functions, size);
-}
-
-void swift::addImageAccessibleProtocolFunctionsBlockCallback(
-    const void *baseAddress, const void *functions, uintptr_t size) {
-  Functions.get();
-  addImageAccessibleProtocolFunctionsBlockCallbackUnsafe(baseAddress, functions,
-                                                         size);
 }
 
 static const AccessibleFunctionRecord *
@@ -241,118 +138,40 @@ _searchForFunctionRecord(AccessibleFunctionsState &S, llvm::StringRef name) {
     for (auto &record : section) {
       auto recordName =
           swift::Demangle::makeSymbolicMangledNameStringRef(record.Name.get());
-      if (recordName == name) {
+      if (recordName == name)
         return traceState.end(&record);
-      }
     }
   }
   return nullptr;
-}
-
-static const AccessibleProtocolRequirementFunctionRecord *
-_searchForProtocolRequirementFunctionRecord(
-    AccessibleFunctionsState &S, std::optional<llvm::StringRef> actorTypeName,
-    llvm::StringRef targetFuncName) {
-  auto traceState = runtime::trace::accessible_protocol_requirement_function_scan_begin(
-      targetFuncName);
-  for (const auto &section : S.WitnessSectionsToScan.snapshot()) {
-    for (auto &record : section) {
-      llvm::StringRef recordName =
-          swift::Demangle::makeSymbolicMangledNameStringRef(record.Name.get());
-
-      if (recordName == targetFuncName) {
-        if (actorTypeName) {
-          auto recordConcreteActorName =
-              swift::Demangle::makeSymbolicMangledNameStringRef(
-                  record.ConcreteActorName.get());
-          // FIXME: this is missing the "$s" on right side
-          if (recordConcreteActorName.endswith(*actorTypeName)) {
-            return traceState.end(&record);
-          }
-        }
-      }
-    }
-  }
-
-  return nullptr;
-}
-
-SWIFT_RUNTIME_STDLIB_SPI
-const AccessibleFunctionRecord *
-swift::runtime::swift_findAccessibleFunctionForConcreteType(
-    bool findConcreteWitness, const char *targetActorTypeNameStart,
-    size_t targetActorTypeNameLength, const char *targetNameStart,
-    size_t targetNameLength) {
-  auto &S = Functions.get();
-
-  llvm::StringRef actorName{targetActorTypeNameStart,
-                            targetActorTypeNameLength};
-  llvm::StringRef targetFuncName{targetNameStart, targetNameLength};
-
-  // Look for an existing entry by name only
-  if (actorName.empty()) {
-    // Check cached functions, we may be looking for a concrete function
-    // directly
-    auto snapshot = S.FunctionCache.snapshot();
-    if (auto E = snapshot.find(targetFuncName)) {
-      return E->getRecord();
-    }
-  } else {
-    // Check cached protocol requirement functions
-    auto snapshot = S.ProtocolRequirementFunctionCache.snapshot();
-    AccessibleProtocolFunctionCacheKey actorAndTarget = {actorName,
-                                                         targetFuncName};
-    if (auto E = snapshot.find(actorAndTarget)) {
-      return E->getRecord();
-    }
-  }
-
-  // If entry doesn't exist (either record doesn't exist, hasn't been loaded, or
-  // requested yet), let's try to find it and add to the cache.
-  // FIXME: fix up the caching scheme we do here; Cache the protocol funcs too.
-  auto *record = _searchForFunctionRecord(S, targetFuncName);
-  if (record) {
-    if (actorName.empty()) {
-      S.FunctionCache.getOrInsert(
-          targetFuncName,
-          [&](AccessibleFunctionCacheEntry *entry, bool created) {
-            if (created)
-              ::new (entry)
-                  AccessibleFunctionCacheEntry{targetFuncName, record};
-            return true;
-          });
-    }
-  }
-
-  if (!record) {
-    // We did not find it directly, so let's scan protocol requirement funcs
-    auto requirementFuncRecord = _searchForProtocolRequirementFunctionRecord(
-        S, actorName, targetFuncName);
-
-    if (findConcreteWitness && requirementFuncRecord) {
-      assert(requirementFuncRecord->ConcreteWitnessMethodName);
-      auto witnessFuncName = swift::Demangle::makeSymbolicMangledNameStringRef(
-          requirementFuncRecord->ConcreteWitnessMethodName.get());
-
-      auto concreteRecord = swift_findAccessibleFunctionForConcreteType(
-          // don't try again, no recursive trying again forever
-          /*findConcreteWitness=*/false, targetActorTypeNameStart,
-          targetActorTypeNameLength, witnessFuncName.data(),
-          witnessFuncName.size());
-
-      return concreteRecord;
-    }
-  }
-
-  return record;
 }
 
 SWIFT_RUNTIME_STDLIB_SPI
 const AccessibleFunctionRecord *
 swift::runtime::swift_findAccessibleFunction(const char *targetNameStart,
                                              size_t targetNameLength) {
-  return swift_findAccessibleFunctionForConcreteType(
-      /*findConcreteWitness=*/false,
-      /*targetActorTypeNameStart=*/nullptr, /*targetActorTypeNameLength=*/0,
-      targetNameStart, targetNameLength);
+  auto &S = Functions.get();
+
+  llvm::StringRef name{targetNameStart, targetNameLength};
+
+  // Look for an existing entry.
+  {
+    auto snapshot = S.Cache.snapshot();
+    if (auto E = snapshot.find(name))
+      return E->getRecord();
+  }
+
+  // If entry doesn't exist (either record doesn't exist, hasn't been loaded, or
+  // requested yet), let's try to find it and add to the cache.
+
+  auto *record = _searchForFunctionRecord(S, name);
+  if (record) {
+    S.Cache.getOrInsert(
+        name, [&](AccessibleFunctionCacheEntry *entry, bool created) {
+          if (created)
+            ::new (entry) AccessibleFunctionCacheEntry{name, record};
+          return true;
+        });
+  }
+
+  return record;
 }

--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -84,12 +84,6 @@ void addImageAccessibleFunctionsBlockCallbackUnsafe(const void *baseAddress,
                                                     const void *start,
                                                     uintptr_t size);
 
-void addImageAccessibleProtocolFunctionsBlockCallback(const void *baseAddress,
-                                                      const void *start,
-                                                      uintptr_t size);
-void addImageAccessibleProtocolFunctionsBlockCallbackUnsafe(
-    const void *baseAddress, const void *start, uintptr_t size);
-
 } // end namespace swift
 
 #endif

--- a/stdlib/public/runtime/ImageInspectionCommon.cpp
+++ b/stdlib/public/runtime/ImageInspectionCommon.cpp
@@ -130,14 +130,6 @@ void swift_addNewDSOImage(swift::MetadataSections *sections) {
         baseAddress, functions, accessible_funcs_section.length);
   }
 
-  const auto &dist_accessible_funcs_section = sections->swift5_accessible_protocol_requirement_functions;
-  const void *dist_functions =
-      reinterpret_cast<void *>(dist_accessible_funcs_section.start);
-  if (dist_accessible_funcs_section.length) {
-    swift::addImageAccessibleProtocolFunctionsBlockCallback(
-        baseAddress, dist_functions, dist_accessible_funcs_section.length);
-  }
-
   // Register this section for future enumeration by clients. This should occur
   // after this function has done all other relevant work to avoid a race
   // condition when someone calls swift_enumerateAllMetadataSections() on

--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -40,7 +40,6 @@
 /// The Mach-O section name for the section containing accessible functions.
 /// This lives within SEG_TEXT.
 #define MachOAccessibleFunctionsSection "__swift5_acfuncs"
-#define MachOAccessibleProtocolFunctionsSection "__swift5_acpfuns"
 
 #define MachOTextSegment "__TEXT"
 

--- a/stdlib/public/runtime/ImageInspectionMachO.cpp
+++ b/stdlib/public/runtime/ImageInspectionMachO.cpp
@@ -93,8 +93,6 @@ constexpr const char DynamicReplacementSomeSection[] =
     MachODynamicReplacementSomeSection;
 constexpr const char AccessibleFunctionsSection[] =
     MachOAccessibleFunctionsSection;
-constexpr const char AccessibleProtocolFunctionsSection[] =
-    MachOAccessibleProtocolFunctionsSection;
 constexpr const char TextSegment[] = MachOTextSegment;
 
 #if __POINTER_WIDTH__ == 64
@@ -290,10 +288,6 @@ void swift::initializeAccessibleFunctionsLookup() {
       addImageCallback<TextSegment, AccessibleFunctionsSection,
                        _dyld_section_location_text_swift5_ac_funcs,
                        addImageAccessibleFunctionsBlockCallbackUnsafe>);
-  REGISTER_FUNC(
-      addImageCallback<TextSegment, AccessibleProtocolFunctionsSection,
-                       _dyld_section_location_text_swift5_ac_p_funcs,
-                       addImageAccessibleProtocolFunctionsBlockCallbackUnsafe>);
 }
 
 #endif // defined(__APPLE__) && defined(__MACH__) &&

--- a/stdlib/public/runtime/ImageInspectionStatic.cpp
+++ b/stdlib/public/runtime/ImageInspectionStatic.cpp
@@ -85,16 +85,6 @@ void swift::initializeAccessibleFunctionsLookup() {
   if (start != nullptr && size > 0) {
     addImageAccessibleFunctionsBlockCallbackUnsafe(__dso_handle, start, size);
   }
-
-  void *dstart;
-  uintptr_t dsize;
-  GET_SECTION_START_AND_SIZE(dstart, dsize, MachOTextSegment,
-                             MachOAccessibleProtocolFunctionsSection);
-  if (dstart != nullptr && dsize > 0) {
-    addImageAccessibleProtocolFunctionsBlockCallbackUnsafe(__dso_handle, dstart,
-                                                           dsize);
-  }
-
 }
 
 #endif // defined(__MACH__) && defined(SWIFT_RUNTIME_STATIC_IMAGE_INSPECTION)

--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -61,7 +61,6 @@ DECLARE_SWIFT_SECTION(swift5_builtin)
 DECLARE_SWIFT_SECTION(swift5_capture)
 DECLARE_SWIFT_SECTION(swift5_mpenum)
 DECLARE_SWIFT_SECTION(swift5_accessible_functions)
-DECLARE_SWIFT_SECTION(swift5_accessible_protocol_requirement_functions)
 DECLARE_SWIFT_SECTION(swift5_runtime_attributes)
 DECLARE_SWIFT_SECTION(swift5_tests)
 }
@@ -99,7 +98,6 @@ static void swift_image_constructor() {
       SWIFT_SECTION_RANGE(swift5_capture),
       SWIFT_SECTION_RANGE(swift5_mpenum),
       SWIFT_SECTION_RANGE(swift5_accessible_functions),
-      SWIFT_SECTION_RANGE(swift5_accessible_protocol_requirement_functions),
       SWIFT_SECTION_RANGE(swift5_runtime_attributes),
       SWIFT_SECTION_RANGE(swift5_tests),
   };

--- a/stdlib/public/runtime/Tracing.h
+++ b/stdlib/public/runtime/Tracing.h
@@ -87,17 +87,6 @@ accessible_function_scan_begin(llvm::StringRef name) {
   return {id};
 }
 
-static inline ScanTraceState
-accessible_protocol_requirement_function_scan_begin(llvm::StringRef name) {
-  ENSURE_LOG(ScanLog);
-
-  auto id = os_signpost_id_generate(ScanLog);
-  os_signpost_interval_begin(ScanLog, id, SWIFT_LOG_SECTION_SCAN,
-                             "distributed accessible function scan for '%.*s'",
-                             (int)name.size(), name.data());
-  return {id};
-}
-
 static inline ScanTraceState metadata_scan_begin(Demangle::NodePointer node) {
   ENSURE_LOG(ScanLog);
 
@@ -170,11 +159,6 @@ struct ScanTraceState {
 
 static inline ScanTraceState
 accessible_function_scan_begin(llvm::StringRef name) {
-  return {};
-}
-
-static inline ScanTraceState
-accessible_protocol_requirement_function_scan_begin(llvm::StringRef name) {
   return {};
 }
 

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_through_generic.swift
@@ -114,7 +114,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   do {
     let reply = try await remoteW.dist_sync(work: "Direct")
     print("replySync direct (remote): \(reply)")
-    // CHECK: >> remoteCall: on:main.TheWorker, target:dist_sync(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_sync(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
     // CHECK: replySync direct (remote): dist_sync(work:): Direct
   }
   print("==== ----------------------------------------------------------------")
@@ -122,7 +122,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   do {
     let reply = try await remoteW.dist_async(work: "Direct")
     print("replyAsync direct (remote): \(reply)")
-    // CHECK: >> remoteCall: on:main.TheWorker, target:dist_async(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_async(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
     // CHECK: replyAsync direct (remote): dist_async(work:): Direct
   }
   print("==== ----------------------------------------------------------------")
@@ -130,7 +130,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   do {
     let reply = try await remoteW.dist_syncThrows(work: "Direct")
     print("replyThrows direct (remote): \(reply)")
-    // CHECK: >> remoteCall: on:main.TheWorker, target:dist_syncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_syncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
     // CHECK: replyThrows direct (remote): dist_syncThrows(work:): Direct
   }
   print("==== ----------------------------------------------------------------")
@@ -138,7 +138,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   do {
     let reply = try await remoteW.dist_asyncThrows(work: "Direct")
     print("replyAsyncThrows direct (remote): \(reply)")
-    // CHECK: >> remoteCall: on:main.TheWorker, target:dist_asyncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_asyncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Direct"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
     // CHECK: replyAsyncThrows direct (remote): dist_asyncThrows(work:): Direct
   }
   print("==== ----------------------------------------------------------------")
@@ -150,7 +150,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   do {
     let reply = try await call_dist_sync(w: remoteW)
     print("reply (remote): \(reply)")
-    // CHECK: >> remoteCall: on:main.TheWorker, target:dist_sync(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_sync(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
     // CHECK: << remoteCall return: dist_sync(work:): Hello
     // CHECK: reply (remote): dist_sync(work:): Hello
 
@@ -167,7 +167,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   do {
     let reply = try await call_dist_async(w: remoteW)
     print("reply (remote): \(reply)")
-    // CHECK: >> remoteCall: on:main.TheWorker, target:dist_async(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_async(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: nil), throwing:Swift.Never, returning:Swift.String
     // CHECK: << remoteCall return: dist_async(work:): Hello
     // CHECK: reply (remote): dist_async(work:): Hello
 
@@ -184,7 +184,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   do {
     let reply = try await call_dist_throws(w: remoteW)
     print("reply (remote): \(reply)")
-    // CHECK: >> remoteCall: on:main.TheWorker, target:dist_syncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_syncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
     // CHECK: << remoteCall return: dist_syncThrows(work:): Hello
     // CHECK: reply (remote): dist_syncThrows(work:): Hello
 
@@ -201,7 +201,7 @@ func test_generic(system: DefaultDistributedActorSystem) async throws {
   do {
     let reply = try await call_dist_asyncThrows(w: remoteW)
     print("reply (remote): \(reply)")
-    // CHECK: >> remoteCall: on:main.TheWorker, target:dist_asyncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
+    // CHECK: >> remoteCall: on:main.TheWorker, target:main.TheWorker.dist_asyncThrows(work:), invocation:FakeInvocationEncoder(genericSubs: [], arguments: ["Hello"], returnType: Optional(Swift.String), errorType: Optional(Swift.Error)), throwing:Swift.Error, returning:Swift.String
     // CHECK: << remoteCall return: dist_asyncThrows(work:): Hello
     // CHECK: reply (remote): dist_asyncThrows(work:): Hello
 

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method.swift
@@ -14,6 +14,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
+// FIXME(distributed): pending rework of distributed protocol target mangling
+// XFAIL: *
+
 import Distributed
 import FakeDistributedActorSystems
 

--- a/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method_in_presence_of_multiple_systems.swift
+++ b/test/Distributed/Runtime/distributed_actor_remoteCall_protocol_method_in_presence_of_multiple_systems.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main  -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift -plugin-path %swift-plugin-dir
+// RUN: %target-build-swift -module-name main  -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -plugin-path %swift-plugin-dir -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
 
@@ -15,24 +15,24 @@
 import Distributed
 import FakeDistributedActorSystems
 
-// @DistributedRemotelyJustViaProxyAccessible
-protocol GreeterP_UnknownSystem: DistributedActor {
+// FIXME(distributed): enable via @_DistributedProtocol
+protocol GreeterProtocol: DistributedActor {
   distributed func greet() -> String
 }
 
 // TODO: remove manual stubs code
-extension GreeterP_UnknownSystem where Self == GreeterP_UnknownSystem_FakeRoundtripActorSystem_Stub {
+extension GreeterProtocol where Self == GreeterProtocol_FakeRoundtripActorSystem_Stub {
   static func resolve(
     id: ID, using system: ActorSystem
-  ) throws -> any GreeterP_UnknownSystem {
-    print("\(Self.self).\(#function) -> return \(GreeterP_UnknownSystem_FakeRoundtripActorSystem_Stub.self)")
+  ) throws -> any GreeterProtocol {
+    print("\(Self.self).\(#function) -> return \(GreeterProtocol_FakeRoundtripActorSystem_Stub.self)")
 
-    return try GreeterP_UnknownSystem_FakeRoundtripActorSystem_Stub(actorSystem: system)
+    return try GreeterProtocol_FakeRoundtripActorSystem_Stub(actorSystem: system)
   }
 }
 
 // TODO: remove manual stubs code
-distributed actor GreeterP_UnknownSystem_FakeRoundtripActorSystem_Stub: GreeterP_UnknownSystem {
+distributed actor GreeterProtocol_FakeRoundtripActorSystem_Stub: GreeterProtocol {
   typealias ActorSystem = FakeRoundtripActorSystem
 
   distributed func greet() -> String {
@@ -43,18 +43,18 @@ distributed actor GreeterP_UnknownSystem_FakeRoundtripActorSystem_Stub: GreeterP
 }
 
 // TODO: remove manual stubs code
-extension GreeterP_UnknownSystem where Self == GreeterP_UnknownSystem_LocalTestingDistributedActorSystem_Stub {
+extension GreeterProtocol where Self == GreeterProtocol_LocalTestingDistributedActorSystem_Stub {
   static func resolve(
     id: Self.ID, using system: Self.ActorSystem
-  ) throws -> any GreeterP_UnknownSystem {
-    print("\(Self.self).\(#function) -> return \(GreeterP_UnknownSystem_LocalTestingDistributedActorSystem_Stub.self)")
+  ) throws -> any GreeterProtocol {
+    print("\(Self.self).\(#function) -> return \(GreeterProtocol_LocalTestingDistributedActorSystem_Stub.self)")
 
-    return try GreeterP_UnknownSystem_LocalTestingDistributedActorSystem_Stub(actorSystem: system)
+    return try GreeterProtocol_LocalTestingDistributedActorSystem_Stub(actorSystem: system)
   }
 }
 
 // TODO: remove manual stubs code
-distributed actor GreeterP_UnknownSystem_LocalTestingDistributedActorSystem_Stub: GreeterP_UnknownSystem {
+distributed actor GreeterProtocol_LocalTestingDistributedActorSystem_Stub: GreeterProtocol {
   typealias ActorSystem = LocalTestingDistributedActorSystem
 
   distributed func greet() -> String {
@@ -82,14 +82,14 @@ distributed actor DAL {
     let localTestingSystem = LocalTestingDistributedActorSystem()
     let gid = localTestingSystem.assignID(DAL.self)
 
-    let gf: any GreeterP_UnknownSystem = try .resolve(id: fid, using: fakeRoundtripSystem)
+    let gf: any GreeterProtocol = try .resolve(id: fid, using: fakeRoundtripSystem)
     print("resolved on \(fakeRoundtripSystem): \(type(of: gf))")
-    // CHECK: resolved on main.FakeRoundtripActorSystem: GreeterP_UnknownSystem_FakeRoundtripActorSystem_Stub
+    // CHECK: resolved on main.FakeRoundtripActorSystem: GreeterProtocol_FakeRoundtripActorSystem_Stub
     print()
 
-    let gl: any GreeterP_UnknownSystem = try .resolve(id: gid, using: localTestingSystem)
+    let gl: any GreeterProtocol = try .resolve(id: gid, using: localTestingSystem)
     print("resolved on \(localTestingSystem): \(type(of: gl))")
-    // CHECK: resolved on Distributed.LocalTestingDistributedActorSystem: GreeterP_UnknownSystem_LocalTestingDistributedActorSystem_Stub
+    // CHECK: resolved on Distributed.LocalTestingDistributedActorSystem: GreeterProtocol_LocalTestingDistributedActorSystem_Stub
 
     print("ok") // CHECK: ok
   }

--- a/test/abi/macOS/arm64/stdlib-asserts.swift
+++ b/test/abi/macOS/arm64/stdlib-asserts.swift
@@ -59,7 +59,4 @@ Added: _$ss20__StaticArrayStorageCfd
 Added: _OBJC_CLASS_$__TtCs20__StaticArrayStorage
 Added: _OBJC_METACLASS_$__TtCs20__StaticArrayStorage
 
-// Distributed actors: finding accessible function by protocol method + act type
-Added: _swift_findAccessibleFunctionForConcreteType
-
 // Runtime Symbols

--- a/test/abi/macOS/x86_64/stdlib-asserts.swift
+++ b/test/abi/macOS/x86_64/stdlib-asserts.swift
@@ -59,7 +59,4 @@ Added: _$ss20__StaticArrayStorageCfd
 Added: _OBJC_CLASS_$__TtCs20__StaticArrayStorage
 Added: _OBJC_METACLASS_$__TtCs20__StaticArrayStorage
 
-// Distributed actors: finding accessible function by protocol method + act type
-Added: _swift_findAccessibleFunctionForConcreteType
-
 // Runtime Symbols


### PR DESCRIPTION
This change undoes an approach we thought viable to encode distributed
actor remote targets, as encoding their protocol method names. This also
needed extra metadata sections and tricky "find if this is a witness or
not" methods;

Instead, we will be mangling the concrete names; and special handle
proxy types that are prefixed with `$`. This way we will not need extra
metadata records, and can handle generic calls more properly.

This XFAILs one test which was testing new functionality, that is
pending now until we implement the new mangling scheme.