### PR TITLE
stdlib: Avoid condfails resulting from typed throws adoption

### DIFF
--- a/stdlib/public/core/ArrayCast.swift
+++ b/stdlib/public/core/ArrayCast.swift
@@ -49,7 +49,11 @@ public func _arrayForceCast<SourceElement, TargetElement>(
     return Array(_immutableCocoaArray: source._buffer._asCocoaArray())
   }
 #endif
+#if $TypedThrows
   return source.map { $0 as! TargetElement }
+#else
+  return try! source.__rethrows_map { $0 as! TargetElement }
+#endif
 }
 
 /// Called by the casting machinery.

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -526,7 +526,11 @@ internal final class _SequenceBox<S: Sequence>: _AnySequenceBox<S.Element> {
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
+#if $TypedThrows
     try _base.map(transform)
+#else
+    try _base.__rethrows_map(transform)
+#endif
   }
   @inlinable
   internal override func _filter(
@@ -619,7 +623,11 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
+#if $TypedThrows
     try _base.map(transform)
+#else
+    try _base.__rethrows_map(transform)
+#endif
   }
   @inlinable
   internal override func _filter(
@@ -814,7 +822,11 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
+#if $TypedThrows
     try _base.map(transform)
+#else
+    try _base.__rethrows_map(transform)
+#endif
   }
   @inlinable
   internal override func _filter(
@@ -1027,7 +1039,11 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) throws -> [T] {
+#if $TypedThrows
     try _base.map(transform)
+#else
+    try _base.__rethrows_map(transform)
+#endif
   }
   @inlinable
   internal override func _filter(

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1332,6 +1332,7 @@ public struct UnsafeMutableRawPointer: _Pointer {
   ) {
     _debugPrecondition(_isPOD(T.self))
 
+#if $TypedThrows
     withUnsafePointer(to: value) { source in
       // FIXME: to be replaced by _memcpy when conversions are implemented.
       Builtin.int_memcpy_RawPointer_RawPointer_Int64(
@@ -1341,6 +1342,17 @@ public struct UnsafeMutableRawPointer: _Pointer {
         /*volatile:*/ false._value
       )
     }
+#else
+    try! __abi_withUnsafePointer(to: value) { source in
+      // FIXME: to be replaced by _memcpy when conversions are implemented.
+      Builtin.int_memcpy_RawPointer_RawPointer_Int64(
+        (self + offset)._rawValue,
+        source._rawValue,
+        UInt64(MemoryLayout<T>.size)._value,
+        /*volatile:*/ false._value
+      )
+    }
+#endif
   }
 
   // This unavailable implementation uses the expected mangled name


### PR DESCRIPTION
The standard library's swiftinterface must temporarily remain buildable when `$TypedThrows` evaluates to false since there are still supported Swift 5.11 compilers that did not have the feature enabled by default. Declarations using typed throws in their signatures are guarded in printed swiftinterface files with `#if $TypedThrows` and therefore `@inlinable` code that uses those declarations must also be conditionalized on `$TypedThrows`.

Addresses fallout from https://github.com/apple/swift/pull/69771 and https://github.com/apple/swift/pull/70971.
