### PR TITLE
[cxx-interop] Correctly generate the list of transitive dependencies for CxxStdlib overlay

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4232,9 +4232,22 @@ void ClangModuleUnit::getImportedModulesForLookup(
   for (auto importMod : topLevelImported) {
     auto wrapper = owner.getWrapperForModule(importMod);
 
-    auto actualMod = wrapper->getOverlayModule();
-    if (!actualMod || actualMod == topLevelOverlay)
+    ModuleDecl *actualMod = nullptr;
+    if (owner.SwiftContext.LangOpts.EnableCXXInterop && topLevel &&
+        isCxxStdModule(topLevel) && wrapper->clangModule &&
+        isCxxStdModule(wrapper->clangModule)) {
+      // The CxxStdlib overlay re-exports the clang module std, which in recent
+      // libc++ versions re-exports top-level modules for different std headers
+      // (std_string, std_vector, etc). The overlay module for each of the std
+      // modules is the CxxStdlib module itself. Make sure we return the actual
+      // clang modules (std_xyz) as transitive dependencies instead of just
+      // CxxStdlib itself.
       actualMod = wrapper->getParentModule();
+    } else {
+      actualMod = wrapper->getOverlayModule();
+      if (!actualMod || actualMod == topLevelOverlay)
+        actualMod = wrapper->getParentModule();
+    }
 
     assert(actualMod && "Missing imported overlay");
     imports.push_back({ImportPath::Access(), actualMod});


### PR DESCRIPTION
This fixes a compiler error that occurred while building `CxxStdlib.swiftmodule` and other projects that use C++ interop: `error: cannot find type 'std' in scope`.

The compiler was creating two distinct `swift::ModuleDecl` instances for the CxxStdlib module while building the CxxStdlib overlay: one as a main module (the module that is currently being compiled), one as a dependency of the main module. This confused the Swift name lookup logic down the road.

This only happened with recent libc++.

See the inline comment for more details.

rdar://122815523