### PR TITLE
[Debugging] Use SWIFT_NATIVE_SWIFT_TOOLS_PATH if defined

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -315,7 +315,7 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Freestand
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Extern")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BitwiseCopyable")
 
-if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUALS "")
+if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
   set(swift_bin_dir "${CMAKE_BINARY_DIR}/bin")
   set(swift_lib_dir "${CMAKE_BINARY_DIR}/lib")
 else()

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -315,8 +315,16 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Freestand
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Extern")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BitwiseCopyable")
 
+if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUALS "")
+  set(swift_bin_dir "${CMAKE_BINARY_DIR}/bin")
+  set(swift_lib_dir "${CMAKE_BINARY_DIR}/lib")
+else()
+  set(swift_bin_dir "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}")
+  set(swift_lib_dir "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib")
+endif()
+
 list(APPEND swift_stdlib_compile_flags "-external-plugin-path"
-  "${CMAKE_BINARY_DIR}/lib/swift/host/plugins#${CMAKE_BINARY_DIR}/bin/swift-plugin-server")
+  "${swift_lib_dir}/swift/host/plugins#${swift_bin_dir}/swift-plugin-server")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "SymbolLinkageMarkers")
 
 set(swift_core_incorporate_object_libraries)


### PR DESCRIPTION
Fixes cross-host builds. See https://github.com/apple/swift/pull/71425/files#r1498582734