### PR TITLE
[ConstraintSystem] Account for situations when witness for associated…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4224,7 +4224,7 @@ struct TypeSimplifier {
 
         auto result = conformance.getAssociatedType(
             lookupBaseType, assocType->getDeclaredInterfaceType());
-        if (!result->hasError())
+        if (result && !result->hasError())
           return result;
       }
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar122598934.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar122598934.swift
@@ -1,0 +1,31 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+public protocol P1 {
+  associatedtype A
+
+  init(a: A)
+}
+
+public protocol P2: P1 {
+  associatedtype B
+
+  init()
+}
+
+extension P2 where A == B {
+  public init() { fatalError() }
+  public init(a: B) { fatalError() }
+}
+
+public protocol P3: P2 {
+  associatedtype B = Self
+
+  static var y: B { get }
+}
+
+public struct S: P3 {
+  public static let x = S(c: 1)
+  public static let y = S(c: 2)
+
+  public init(c: Int) {}
+}


### PR DESCRIPTION
… type is null

In some circularity cases `getAssociatedType` would produce a `Type()`,
we need to account for that in `TypeSimplifier` to avoid crashing.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
