### PR TITLE
Casting: check conditional Copyable requirements

### DIFF
--- a/include/swift/ABI/ValueWitnessTable.h
+++ b/include/swift/ABI/ValueWitnessTable.h
@@ -171,6 +171,11 @@ template <typename Runtime> struct TargetValueWitnessTable {
     return flags.isBitwiseTakable();
   }
 
+  // Is this type copyable?
+  bool isCopyable() const {
+    return flags.isCopyable();
+  }
+
   /// Return the size of this type.  Unlike in C, this has not been
   /// padded up to the alignment; that value is maintained as
   /// 'stride'.

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -213,6 +213,20 @@ public:
   SmallVector<Requirement, 4>
   requirementsNotSatisfiedBy(GenericSignature otherSig) const;
 
+  /// Return the requirements of this generic signature that are not also
+  /// satisfied by \c otherSig.
+  ///
+  /// Requirements for invertible protocols are omitted. Instead, their absence
+  /// in this generic signature is noted in the \c inverses output.
+  ///
+  /// \param otherSig Another generic signature whose generic parameters are
+  /// equivalent to or a subset of the generic parameters in this signature, and
+  /// whose inverses are a superset of the inverses in this generic signature.
+  void requirementsAndInversesWhenExtending(
+                            GenericSignature otherSig,
+                            SmallVector<Requirement, 2> &result,
+                            SmallVector<InverseRequirement, 2> &inverses) const;
+
   /// Return the reduced version of the given type under this generic
   /// signature.
   CanType getReducedType(Type type) const;
@@ -527,6 +541,20 @@ private:
   /// equivalent to or a subset of the generic parameters in this signature.
   SmallVector<Requirement, 4>
   requirementsNotSatisfiedBy(GenericSignature otherSig) const;
+
+  /// Return the requirements of this generic signature that are not also
+  /// satisfied by \c otherSig.
+  ///
+  /// Requirements for invertible protocols are omitted. Instead, their absence
+  /// in this generic signature is noted in the \c inverses output.
+  ///
+  /// \param otherSig Another generic signature whose generic parameters are
+  /// equivalent to or a subset of the generic parameters in this signature, and
+  /// whose inverses are a superset of the inverses in this generic signature.
+  void requirementsAndInversesWhenExtending(
+                            GenericSignature otherSig,
+                            SmallVector<Requirement, 2> &reqs,
+                            SmallVector<InverseRequirement, 2> &inverses) const;
 
   /// Return the reduced version of the given type under this generic
   /// signature.

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -595,6 +595,13 @@ public:
   std::optional<ArrayRef<Requirement>>
   getConditionalRequirementsIfAvailable() const;
 
+  /// Get any additional requirements that are required for this conformance to
+  /// be satisfied, and inverses, which indicate generic parameters that do
+  /// *not* require conformance to an invertible protocol.
+  void getConditionalRequirementsWithInverses(
+                            SmallVector<Requirement, 2> &requirements,
+                            SmallVector<InverseRequirement, 2> &inverses) const;
+
   /// Retrieve the state of this conformance.
   ProtocolConformanceState getState() const {
     return static_cast<ProtocolConformanceState>(

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -2113,8 +2113,9 @@ namespace {
       if (!normal)
         return;
 
-      // FIXME(kavon): probably need to emit the inverse requirements in the
-      //  metadata so the runtime knows not to check for Copyable?
+      // FIXME(kavon): emit the inverse requirements in the
+      //  metadata so the runtime knows not to check for Copyable.
+      //  (rdar://123466649)
       SmallVector<Requirement, 2> condReqs;
       SmallVector<InverseRequirement, 2> inverses;
       normal->getConditionalRequirementsWithInverses(condReqs, inverses);

--- a/test/Interpreter/moveonly_generics_casting.swift
+++ b/test/Interpreter/moveonly_generics_casting.swift
@@ -1,0 +1,46 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
+
+protocol P {
+  func speak()
+}
+
+extension P {
+  func speak() { print("hello") }
+}
+
+struct Noncopyable: ~Copyable {}
+struct Ordinary {}
+
+struct Dog<T: ~Copyable>: Copyable {}
+extension Dog: P where T: Copyable {}
+
+enum Cat<Left: ~Copyable, Right: ~Copyable>: Copyable {
+    case meows
+    init() { self = .meows }
+}
+extension Cat: P where Left: Copyable {}
+
+func attemptCall(_ a: Any) {
+  if let value = a as? P {
+    value.speak()
+    return
+  }
+  print("failed to cast")
+}
+
+defer { main() }
+func main() {
+  // CHECK: hello
+  attemptCall(Dog<Ordinary>())
+
+  // CHECK: failed to cast
+  attemptCall(Dog<Noncopyable>())
+
+  // FIXME: this is suppose to succeed! (rdar://123466649)
+  // CHECK: failed to cast
+  attemptCall(Cat<Ordinary, Noncopyable>())
+
+  // CHECK: failed to cast
+  attemptCall(Cat<Noncopyable, Ordinary>())
+}

--- a/test/Interpreter/moveonly_generics_casting2.swift
+++ b/test/Interpreter/moveonly_generics_casting2.swift
@@ -1,0 +1,32 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
+
+// `G<Duck>() as? P` triggers a crash (rdar://123466649)
+// XFAIL: *
+
+protocol Q {
+  associatedtype A: ~Copyable
+}
+
+struct G<T: Q> {}; extension G: P where T.A: Copyable {}
+
+protocol P {func speak()}; extension P {func speak() { print("hello") }}
+
+struct Chicken: Q {
+  struct A: ~Copyable {}
+}
+
+struct Duck: Q {
+  struct A {}
+}
+
+defer { check() }
+func check() {
+  if let p = G<Duck>() as? P {
+    p.speak() // CHECK: hello
+  }
+
+  if (G<Chicken>() as? P) == nil {
+    print("correct") // CHECK: correct
+  }
+}


### PR DESCRIPTION
When dynamically casting a value to `any P`, we have to check whether
the value's conformance to `P` is conditional, and all conditions are
satisfied.

Now that noncopyable generic parameters can appear in types, we need to
check at runtime if the arguments for those parameters all conform to
Copyable. Rather than actually emit Copyable requirements for every generic parameter, we will omit those and implicitly check each one for Copyable, unless there's an inverse requirement.

We don't yet emit protocol conformance descriptors that list the inverse
requirements to loosen that check for individual parameters, so for now in this PR, we just check unconditionally.