### PR TITLE
[region-isolation] Improve errors around strong transferring and wordsmith main error

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -976,6 +976,9 @@ ERROR(regionbasedisolation_named_transfer_yields_race, none,
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
      "%0 is transferred from %1 caller to %2 callee. Later uses in caller could race with potential uses in callee",
      (Identifier, ActorIsolation, ActorIsolation))
+NOTE(regionbasedisolation_transfer_non_transferrable_named_note, none,
+      "transferring %1 %0 to %2 callee could cause races between %2 and %1 uses",
+      (Identifier, ActorIsolation, ActorIsolation))
 NOTE(regionbasedisolation_named_info_isolated_capture, none,
      "%1 value %0 is captured by %2 closure. Later local uses could race",
      (Identifier, ActorIsolation, ActorIsolation))

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -973,6 +973,13 @@ NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
       "transferring %0 may cause a race",
       (Identifier))
+ERROR(regionbasedisolation_stronglytransfer_assignment_yields_race_name, none,
+      "assigning %0 to transferring parameter %1 may cause a race",
+      (Identifier, Identifier))
+NOTE(regionbasedisolation_stronglytransfer_taskisolated_assign_note, none,
+      "%0 is a task isolated value that is assigned into transferring parameter %1. Transferred uses of %1 may race with caller uses of %0",
+      (Identifier, Identifier))
+
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
      "%0 is transferred from %1 caller to %2 callee. Later uses in caller could race with potential uses in callee",
      (Identifier, ActorIsolation, ActorIsolation))

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -971,7 +971,7 @@ NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
 //
 
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
-      "transferring %0 could cause a race",
+      "transferring %0 may cause a race",
       (Identifier))
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
      "%0 is transferred from %1 caller to %2 callee. Later uses in caller could race with potential uses in callee",

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -971,7 +971,7 @@ NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
 //
 
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
-      "transferring non-Sendable value %0 could yield races with later accesses",
+      "transferring %0 could cause a race",
       (Identifier))
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
      "%0 is transferred from %1 caller to %2 callee. Later uses in caller could race with potential uses in callee",

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -125,10 +125,15 @@ public:
 
 private:
   void drainVariableNamePath();
+  void popSingleVariableName();
 
   /// Finds the SILValue that either provides the direct debug information or
   /// that has a debug_value user that provides the name of the value.
   SILValue findDebugInfoProvidingValue(SILValue searchValue);
+
+  /// Do not call this directly. Used just to improve logging for
+  /// findDebugInfoProvidingValue.
+  SILValue findDebugInfoProvidingValueHelper(SILValue searchValue);
 
   /// Given an initialized once allocation inst without a ValueDecl or a
   /// DebugVariable provided name, attempt to find a root value from its

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -10,20 +10,179 @@
 //
 //===----------------------------------------------------------------------===//
 
+#define DEBUG_TYPE "sil-variable-name-inference"
+
 #include "swift/SILOptimizer/Utils/VariableNameUtils.h"
 #include "swift/SIL/AddressWalker.h"
 #include "swift/SIL/Test.h"
 
 using namespace swift;
 
+namespace {
+struct AddressWalkerState {
+  bool foundError = false;
+  InstructionSet writes;
+  AddressWalkerState(SILFunction *fn) : writes(fn) {}
+};
+} // namespace
+
+static SILValue
+findRootValueForNonTupleTempAllocation(AllocationInst *allocInst,
+                                       AddressWalkerState &state) {
+  // Walk from our allocation to one of our writes. Then make sure that the
+  // write writes to our entire value.
+  for (auto &inst : allocInst->getParent()->getRangeStartingAtInst(allocInst)) {
+    // See if we have a full tuple value.
+
+    if (!state.writes.contains(&inst))
+      continue;
+
+    if (auto *copyAddr = dyn_cast<CopyAddrInst>(&inst)) {
+      if (copyAddr->getDest() == allocInst &&
+          copyAddr->isInitializationOfDest()) {
+        return copyAddr->getSrc();
+      }
+    }
+
+    if (auto *si = dyn_cast<StoreInst>(&inst)) {
+      if (si->getDest() == allocInst &&
+          si->getOwnershipQualifier() != StoreOwnershipQualifier::Assign) {
+        return si->getSrc();
+      }
+    }
+
+    // If we do not identify the write... return SILValue(). We weren't able
+    // to understand the write.
+    break;
+  }
+
+  return SILValue();
+}
+
+static SILValue findRootValueForTupleTempAllocation(AllocationInst *allocInst,
+                                                    AddressWalkerState &state) {
+  SmallVector<SILValue, 8> tupleValues;
+
+  for (unsigned i : range(allocInst->getType().getNumTupleElements())) {
+    (void)i;
+    tupleValues.push_back(nullptr);
+  }
+
+  unsigned numEltsLeft = tupleValues.size();
+
+  // If we have an empty tuple, just return SILValue() for now.
+  //
+  // TODO: What does this pattern look like out of SILGen?
+  if (!numEltsLeft)
+    return SILValue();
+
+  // Walk from our allocation to one of our writes. Then make sure that the
+  // write writes to our entire value.
+  DestructureTupleInst *foundDestructure = nullptr;
+  SILValue foundRootAddress;
+  for (auto &inst : allocInst->getParent()->getRangeStartingAtInst(allocInst)) {
+    if (!state.writes.contains(&inst))
+      continue;
+
+    if (auto *copyAddr = dyn_cast<CopyAddrInst>(&inst)) {
+      if (copyAddr->isInitializationOfDest()) {
+        if (auto *tei = dyn_cast<TupleElementAddrInst>(copyAddr->getDest())) {
+          if (tei->getOperand() == allocInst) {
+            unsigned i = tei->getFieldIndex();
+            if (auto *otherTei = dyn_cast_or_null<TupleElementAddrInst>(
+                    copyAddr->getSrc()->getDefiningInstruction())) {
+              // If we already were processing destructures, then we have a mix
+              // of struct/destructures... we do not support that, so bail.
+              if (foundDestructure)
+                return SILValue();
+
+              // Otherwise, update our root address. If we already had a root
+              // address and it doesn't match our tuple_element_addr's operand,
+              // bail. There is some sort of mix/match of tuple addresses that
+              // we do not support. We are looking for a specific SILGen
+              // pattern.
+              if (!foundRootAddress) {
+                foundRootAddress = otherTei->getOperand();
+              } else if (foundRootAddress != otherTei->getOperand()) {
+                return SILValue();
+              }
+
+              if (i != otherTei->getFieldIndex())
+                return SILValue();
+              if (tupleValues[i])
+                return SILValue();
+              tupleValues[i] = otherTei;
+
+              // If we have completely covered the tuple, break.
+              --numEltsLeft;
+              if (!numEltsLeft)
+                break;
+
+              // Otherwise, continue so we keep processing.
+              continue;
+            }
+          }
+        }
+      }
+    }
+
+    if (auto *si = dyn_cast<StoreInst>(&inst)) {
+      if (si->getOwnershipQualifier() != StoreOwnershipQualifier::Assign) {
+        if (auto *tei = dyn_cast<TupleElementAddrInst>(si->getDest())) {
+          if (tei->getOperand() == allocInst) {
+            unsigned i = tei->getFieldIndex();
+            if (auto *dti = dyn_cast_or_null<DestructureTupleInst>(
+                    si->getSrc()->getDefiningInstruction())) {
+              // If we already found a root address (meaning we were processing
+              // tuple_elt_addr), bail. We have some sort of unhandled mix of
+              // copy_addr and store [init].
+              if (foundRootAddress)
+                return SILValue();
+              if (!foundDestructure) {
+                foundDestructure = dti;
+              } else if (foundDestructure != dti) {
+                return SILValue();
+              }
+
+              if (i != dti->getIndexOfResult(si->getSrc()))
+                return SILValue();
+              if (tupleValues[i])
+                return SILValue();
+              tupleValues[i] = si->getSrc();
+
+              // If we have completely covered the tuple, break.
+              --numEltsLeft;
+              if (!numEltsLeft)
+                break;
+
+              // Otherwise, continue so we keep processing.
+              continue;
+            }
+          }
+        }
+      }
+    }
+
+    // Found a write that we did not understand... bail.
+    break;
+  }
+
+  // Now check if we have a complete tuple with all elements coming from the
+  // same destructure_tuple. In such a case, we can look through the
+  // destructure_tuple.
+  if (numEltsLeft)
+    return SILValue();
+
+  if (foundDestructure)
+    return foundDestructure->getOperand();
+  if (foundRootAddress)
+    return foundRootAddress;
+
+  return SILValue();
+}
+
 SILValue VariableNameInferrer::getRootValueForTemporaryAllocation(
     AllocationInst *allocInst) {
-  struct AddressWalkerState {
-    bool foundError = false;
-    InstructionSet writes;
-    AddressWalkerState(SILFunction *fn) : writes(fn) {}
-  };
-
   struct AddressWalker : public TransitiveAddressWalker<AddressWalker> {
     AddressWalkerState &state;
 
@@ -44,41 +203,34 @@ SILValue VariableNameInferrer::getRootValueForTemporaryAllocation(
       state.foundError)
     return SILValue();
 
-  // Walk from our allocation to one of our writes. Then make sure that the
-  // write writes to our entire value.
-  for (auto &inst : allocInst->getParent()->getRangeStartingAtInst(allocInst)) {
-    if (!state.writes.contains(&inst))
-      continue;
-
-    if (auto *copyAddr = dyn_cast<CopyAddrInst>(&inst)) {
-      if (copyAddr->getDest() == allocInst &&
-          copyAddr->isInitializationOfDest()) {
-        return copyAddr->getSrc();
-      }
-    }
-
-    if (auto *si = dyn_cast<StoreInst>(&inst)) {
-      if (si->getDest() == allocInst &&
-          si->getOwnershipQualifier() != StoreOwnershipQualifier::Assign) {
-        return si->getSrc();
-      }
-    }
-
-    // If we do not identify the write... return SILValue(). We weren't able to
-    // understand the write.
-    return SILValue();
-  }
-
-  return SILValue();
+  if (allocInst->getType().is<TupleType>())
+    return findRootValueForTupleTempAllocation(allocInst, state);
+  return findRootValueForNonTupleTempAllocation(allocInst, state);
 }
 
 SILValue
 VariableNameInferrer::findDebugInfoProvidingValue(SILValue searchValue) {
   if (!searchValue)
     return SILValue();
+  LLVM_DEBUG(llvm::dbgs() << "Searching for debug info providing value for: "
+                          << searchValue);
+  SILValue result = findDebugInfoProvidingValueHelper(searchValue);
+  if (result) {
+    LLVM_DEBUG(llvm::dbgs() << "Result: " << result);
+  } else {
+    LLVM_DEBUG(llvm::dbgs() << "Result: None\n");
+  }
+  return result;
+}
+
+SILValue
+VariableNameInferrer::findDebugInfoProvidingValueHelper(SILValue searchValue) {
+  assert(searchValue);
 
   while (true) {
     assert(searchValue);
+    LLVM_DEBUG(llvm::dbgs() << "Value: " << *searchValue);
+
     if (auto *allocInst = dyn_cast<AllocationInst>(searchValue)) {
       // If the instruction itself doesn't carry any variable info, see
       // whether it's copied from another place that does.
@@ -118,18 +270,60 @@ VariableNameInferrer::findDebugInfoProvidingValue(SILValue searchValue) {
       continue;
     }
 
-    if (auto *fArg = dyn_cast<SILFunctionArgument>(searchValue)) {
-      variableNamePath.push_back({fArg});
-      return fArg;
+    if (auto *sei = dyn_cast<StructExtractInst>(searchValue)) {
+      variableNamePath.push_back(sei);
+      searchValue = sei->getOperand();
+      continue;
     }
 
-    auto getNamePathComponentFromCallee =
-        [&](FullApplySite call) -> SILValue {
+    if (auto *tei = dyn_cast<TupleExtractInst>(searchValue)) {
+      variableNamePath.push_back(tei);
+      searchValue = tei->getOperand();
+      continue;
+    }
+
+    if (auto *sei = dyn_cast<StructElementAddrInst>(searchValue)) {
+      variableNamePath.push_back(sei);
+      searchValue = sei->getOperand();
+      continue;
+    }
+
+    if (auto *tei = dyn_cast<TupleElementAddrInst>(searchValue)) {
+      variableNamePath.push_back(tei);
+      searchValue = tei->getOperand();
+      continue;
+    }
+
+    if (auto *dti = dyn_cast_or_null<DestructureTupleInst>(
+            searchValue->getDefiningInstruction())) {
+      // Append searchValue, so we can find the specific tuple index.
+      variableNamePath.push_back(searchValue);
+      searchValue = dti->getOperand();
+      continue;
+    }
+
+    if (auto *dsi = dyn_cast_or_null<DestructureStructInst>(
+            searchValue->getDefiningInstruction())) {
+      // Append searchValue, so we can find the specific struct field.
+      variableNamePath.push_back(searchValue);
+      searchValue = dsi->getOperand();
+      continue;
+    }
+
+    if (auto *fArg = dyn_cast<SILFunctionArgument>(searchValue)) {
+      if (fArg->getDecl()) {
+        variableNamePath.push_back({fArg});
+        return fArg;
+      }
+    }
+
+    auto getNamePathComponentFromCallee = [&](FullApplySite call) -> SILValue {
       // Use the name of the property being accessed if we can get to it.
       if (isa<FunctionRefBaseInst>(call.getCallee()) ||
           isa<MethodInst>(call.getCallee())) {
         if (call.getSubstCalleeType()->hasSelfParam()) {
-          variableNamePath.push_back(call.getCallee()->getDefiningInstruction());
+          variableNamePath.push_back(
+              call.getCallee()->getDefiningInstruction());
           return call.getSelfArgument();
         }
 
@@ -149,11 +343,12 @@ VariableNameInferrer::findDebugInfoProvidingValue(SILValue searchValue) {
     }
 
     if (options.contains(Flag::InferSelfThroughAllAccessors)) {
-      if (auto fas =
-              FullApplySite::isa(searchValue->getDefiningInstruction())) {
-        if (auto selfParam = getNamePathComponentFromCallee(fas)) {
-          searchValue = selfParam;
-          continue;
+      if (auto *inst = searchValue->getDefiningInstruction()) {
+        if (auto fas = FullApplySite::isa(inst)) {
+          if (auto selfParam = getNamePathComponentFromCallee(fas)) {
+            searchValue = selfParam;
+            continue;
+          }
         }
       }
     }
@@ -211,7 +406,10 @@ VariableNameInferrer::findDebugInfoProvidingValue(SILValue searchValue) {
         isa<LoadBorrowInst>(searchValue) || isa<BeginAccessInst>(searchValue) ||
         isa<MarkUnresolvedNonCopyableValueInst>(searchValue) ||
         isa<ProjectBoxInst>(searchValue) || isa<CopyValueInst>(searchValue) ||
-        isa<ConvertFunctionInst>(searchValue)) {
+        isa<ConvertFunctionInst>(searchValue) ||
+        isa<MarkUninitializedInst>(searchValue) ||
+        isa<CopyableToMoveOnlyWrapperAddrInst>(searchValue) ||
+        isa<MoveOnlyWrapperToCopyableAddrInst>(searchValue)) {
       searchValue = cast<SingleValueInstruction>(searchValue)->getOperand(0);
       continue;
     }
@@ -235,35 +433,92 @@ static StringRef getNameFromDecl(Decl *d) {
   return "<unknown decl>";
 }
 
+void VariableNameInferrer::popSingleVariableName() {
+  auto next = variableNamePath.pop_back_val();
+
+  if (auto *inst = next.dyn_cast<SILInstruction *>()) {
+    if (auto i = DebugVarCarryingInst(inst)) {
+      resultingString += i.getName();
+      return;
+    }
+
+    if (auto i = VarDeclCarryingInst(inst)) {
+      resultingString += i.getName();
+      return;
+    }
+
+    if (auto f = dyn_cast<FunctionRefBaseInst>(inst)) {
+      if (auto dc = f->getInitiallyReferencedFunction()->getDeclContext()) {
+        resultingString += getNameFromDecl(dc->getAsDecl());
+        return;
+      }
+
+      resultingString += "<unknown decl>";
+      return;
+    }
+
+    if (auto m = dyn_cast<MethodInst>(inst)) {
+      resultingString += getNameFromDecl(m->getMember().getDecl());
+      return;
+    }
+
+    if (auto *sei = dyn_cast<StructExtractInst>(inst)) {
+      resultingString += getNameFromDecl(sei->getField());
+      return;
+    }
+
+    if (auto *tei = dyn_cast<TupleExtractInst>(inst)) {
+      llvm::raw_svector_ostream stream(resultingString);
+      stream << tei->getFieldIndex();
+      return;
+    }
+
+    if (auto *sei = dyn_cast<StructElementAddrInst>(inst)) {
+      resultingString += getNameFromDecl(sei->getField());
+      return;
+    }
+
+    if (auto *tei = dyn_cast<TupleElementAddrInst>(inst)) {
+      llvm::raw_svector_ostream stream(resultingString);
+      stream << tei->getFieldIndex();
+      return;
+    }
+
+    resultingString += "<unknown decl>";
+    return;
+  }
+
+  auto value = next.get<SILValue>();
+  if (auto *fArg = dyn_cast<SILFunctionArgument>(value)) {
+    resultingString += fArg->getDecl()->getBaseName().userFacingName();
+    return;
+  }
+
+  if (auto *dti = dyn_cast_or_null<DestructureTupleInst>(
+          value->getDefiningInstruction())) {
+    llvm::raw_svector_ostream stream(resultingString);
+    stream << *dti->getIndexOfResult(value);
+    return;
+  }
+
+  if (auto *dsi = dyn_cast_or_null<DestructureStructInst>(
+          value->getDefiningInstruction())) {
+    unsigned index = *dsi->getIndexOfResult(value);
+    resultingString +=
+        getNameFromDecl(dsi->getStructDecl()->getStoredProperties()[index]);
+    return;
+  }
+
+  resultingString += "<unknown decl>";
+}
+
 void VariableNameInferrer::drainVariableNamePath() {
   if (variableNamePath.empty())
     return;
 
   // Walk backwards, constructing our string.
   while (true) {
-    auto next = variableNamePath.pop_back_val();
-
-    if (auto *inst = next.dyn_cast<SILInstruction *>()) {
-      if (auto i = DebugVarCarryingInst(inst)) {
-        resultingString += i.getName();
-      } else if (auto i = VarDeclCarryingInst(inst)) {
-        resultingString += i.getName();
-      } else if (auto f = dyn_cast<FunctionRefBaseInst>(inst)) {
-        if (auto dc = f->getInitiallyReferencedFunction()->getDeclContext()) {
-          resultingString += getNameFromDecl(dc->getAsDecl());
-        } else {
-          resultingString += "<unknown decl>";
-        }
-      } else if (auto m = dyn_cast<MethodInst>(inst)) {
-        resultingString += getNameFromDecl(m->getMember().getDecl());
-      } else {
-        resultingString += "<unknown decl>";
-      }
-    } else {
-      auto value = next.get<SILValue>();
-      if (auto *fArg = dyn_cast<SILFunctionArgument>(value))
-        resultingString += fArg->getDecl()->getBaseName().userFacingName();
-    }
+    popSingleVariableName();
 
     if (variableNamePath.empty())
       return;

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -31,7 +31,7 @@ func iterate(stream: AsyncStream<Int>) async {
   // FIXME: Region isolation should consider a value from a 'nonisolated(unsafe)'
   // declaration to be in a disconnected region
 
-  // expected-region-isolation-warning @+3 {{transferring non-Sendable value 'it' could yield races with later accesses}}
+  // expected-region-isolation-warning @+3 {{transferring 'it' could cause a race}}
   // expected-region-isolation-note @+2 {{'it' is transferred from main actor-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-region-isolation-note @+1 {{access here could race}}
   while let element = await it.next() {

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -31,7 +31,7 @@ func iterate(stream: AsyncStream<Int>) async {
   // FIXME: Region isolation should consider a value from a 'nonisolated(unsafe)'
   // declaration to be in a disconnected region
 
-  // expected-region-isolation-warning @+3 {{transferring 'it' could cause a race}}
+  // expected-region-isolation-warning @+3 {{transferring 'it' may cause a race}}
   // expected-region-isolation-note @+2 {{'it' is transferred from main actor-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-region-isolation-note @+1 {{access here could race}}
   while let element = await it.next() {

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -39,7 +39,7 @@ class NotSendable {
   let ns = NotSendable(x: 0)
   MyActor.ns = ns
 
-  // expected-region-isolation-warning @+2 {{transferring 'ns' could cause a race}}
+  // expected-region-isolation-warning @+2 {{transferring 'ns' may cause a race}}
   // expected-region-isolation-note @+1 {{transferring global actor 'MyActor'-isolated 'ns' to global actor 'YourActor'-isolated callee could cause races between global actor 'YourActor'-isolated and global actor 'MyActor'-isolated uses}}
   await { @YourActor in
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in Swift 6}}

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -39,7 +39,8 @@ class NotSendable {
   let ns = NotSendable(x: 0)
   MyActor.ns = ns
 
-  // expected-region-isolation-warning@+1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller; this is an error in Swift 6}}
+  // expected-region-isolation-warning @+2 {{transferring 'ns' could cause a race}}
+  // expected-region-isolation-note @+1 {{transferring global actor 'MyActor'-isolated 'ns' to global actor 'YourActor'-isolated callee could cause races between global actor 'YourActor'-isolated and global actor 'MyActor'-isolated uses}}
   await { @YourActor in
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in Swift 6}}
     YourActor.ns = ns

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -251,11 +251,13 @@ final class NonSendable {
   func call() async {
     await update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{task isolated value of type 'NonSendable' transferred to main actor-isolated context; later accesses to value could race}}
+    // expected-tns-warning @-2 {{transferring 'self' could cause a race}}
+    // expected-tns-note @-3 {{transferring nonisolated 'self' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 
     await self.update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{task isolated value of type 'NonSendable' transferred to main actor-isolated context; later accesses to value could race}}
+    // expected-tns-warning @-2 {{transferring 'self' could cause a race}}
+    // expected-tns-note @-3 {{transferring nonisolated 'self' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 
     _ = await x
     // expected-warning@-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
@@ -293,13 +295,14 @@ func callNonisolatedAsyncClosure(
 ) async {
   await g(ns)
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{task isolated value of type 'NonSendable' transferred to nonisolated context; later accesses to value could race}}
+  // expected-tns-warning @-2 {{transferring 'ns' could cause a race}}
+  // expected-tns-note @-3 {{transferring main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{task isolated value of type 'NonSendable' transferred to nonisolated context; later accesses to value could race}}
-
+  // expected-tns-warning @-2 {{transferring 'ns' could cause a race}}
+  // expected-tns-note @-3 {{transferring main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -273,7 +273,7 @@ func testNonSendableBaseArg() async {
   let t = NonSendable() // expected-tns-note {{variable defined here}}
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring non-Sendable value 't' could yield races with later accesses}}
+  // expected-tns-warning @-2 {{transferring 't' could cause a race}}
   // expected-tns-note @-3 {{'t' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   _ = await t.x

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -251,12 +251,12 @@ final class NonSendable {
   func call() async {
     await update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{transferring 'self' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'self' may cause a race}}
     // expected-tns-note @-3 {{transferring nonisolated 'self' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 
     await self.update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{transferring 'self' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'self' may cause a race}}
     // expected-tns-note @-3 {{transferring nonisolated 'self' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 
     _ = await x
@@ -275,7 +275,7 @@ func testNonSendableBaseArg() async {
   let t = NonSendable() // expected-tns-note {{variable defined here}}
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 't' could cause a race}}
+  // expected-tns-warning @-2 {{transferring 't' may cause a race}}
   // expected-tns-note @-3 {{'t' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   _ = await t.x
@@ -295,13 +295,13 @@ func callNonisolatedAsyncClosure(
 ) async {
   await g(ns)
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns' could cause a race}}
+  // expected-tns-warning @-2 {{transferring 'ns' may cause a race}}
   // expected-tns-note @-3 {{transferring main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns' could cause a race}}
+  // expected-tns-warning @-2 {{transferring 'ns' may cause a race}}
   // expected-tns-note @-3 {{transferring main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -87,7 +87,7 @@ bb0(%0 : $*{ var NonSendableKlass }):
 
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
   destroy_value %1 : ${ var NonSendableKlass }
 
   %9999 = tuple ()

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -75,14 +75,14 @@ class TwoFieldKlassClassBox {
 extension Actor {
   func warningIfCallingGetter() async {
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'self.klass' could cause a race}}
+    // expected-tns-warning @-1 {{transferring 'self.klass' may cause a race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
   }
 
   func warningIfCallingAsyncOnFinalField() async {
     // Since we are calling finalKlass directly, we emit a warning here.
     await self.finalKlass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'self.finalKlass' could cause a race}}
+    // expected-tns-warning @-1 {{transferring 'self.finalKlass' may cause a race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'self.finalKlass' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
   }
 
@@ -96,7 +96,7 @@ extension FinalActor {
   func warningIfCallingAsyncOnFinalField() async {
     // Since our whole class is final, we emit the error directly here.
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'self.klass' could cause a race}}
+    // expected-tns-warning @-1 {{transferring 'self.klass' may cause a race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
   }
 }
@@ -126,7 +126,7 @@ func closureInOut(_ a: Actor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{transferring 'ns0' could cause a race}}
+  // expected-tns-warning @-2 {{transferring 'ns0' may cause a race}}
   // expected-tns-note @-3 {{'ns0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // We only emit a warning on the first use we see, so make sure we do both
@@ -149,13 +149,13 @@ func closureInOut2(_ a: Actor) async {
 
   var closure = {}
 
-  await a.useKlass(ns0) // expected-tns-warning {{transferring 'ns0' could cause a race}}
+  await a.useKlass(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
   // expected-tns-note @-1 {{'ns0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure = { useInOut(&contents) } // expected-tns-note {{access here could race}}
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' could cause a race}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' may cause a race}}
   // expected-tns-note @-1 {{'ns1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
@@ -177,7 +177,7 @@ func closureNonInOut(_ a: Actor) async {
 
   closure = { useValue(contents) }
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' could cause a race}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' may cause a race}}
   // expected-tns-note @-1 {{'ns1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
@@ -195,13 +195,13 @@ func transferNonIsolatedNonAsyncClosureTwice() async {
   var actorCaptureClosure = { print(a) }
   await transferToMain(actorCaptureClosure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'actorCaptureClosure' could cause a race}}
+  // expected-tns-warning @-2 {{transferring 'actorCaptureClosure' may cause a race}}
   // expected-tns-note @-3 {{transferring nonisolated 'actorCaptureClosure' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 
   actorCaptureClosure = { print(a) }
   await transferToMain(actorCaptureClosure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'actorCaptureClosure' could cause a race}}
+  // expected-tns-warning @-2 {{transferring 'actorCaptureClosure' may cause a race}}
   // expected-tns-note @-3 {{transferring nonisolated 'actorCaptureClosure' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 }
 
@@ -213,7 +213,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -246,7 +246,7 @@ extension Actor {
     }
     let x: Any? = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'x' could cause a race}}
+    // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -259,7 +259,7 @@ extension Actor {
     // store it all as once.
     let x: Any? = (closure, 1)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'x' could cause a race}}
+    // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -271,7 +271,7 @@ extension Actor {
     // Error here.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
 
     closure = {}
@@ -297,7 +297,7 @@ extension Actor {
     // Error here.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -307,7 +307,7 @@ extension Actor {
     // We get a transfer after use error.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{'closure' is transferred from actor-isolated caller to main actor-isolated callee}}
 
     if await booleanFlag {
@@ -319,7 +319,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-note @-2 {{access here could race}}
-    // expected-tns-warning @-3 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-3 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-4 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -342,7 +342,7 @@ extension Actor {
 
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -371,7 +371,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -382,7 +382,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -393,7 +393,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 }
@@ -403,7 +403,7 @@ func testSimpleLetClosureCaptureActor() async {
   let closure = { print(a) }
   await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+  // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
   // expected-tns-note @-3 {{transferring nonisolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 }
 
@@ -441,7 +441,7 @@ func testSimpleVarClosureCaptureActor() async {
   closure = { print(a) }
   await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+  // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
   // expected-tns-note @-3 {{transferring nonisolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 }
 
@@ -486,7 +486,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -499,7 +499,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 }
@@ -513,7 +513,7 @@ extension Actor {
     // This should error.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
 
     // This doesnt since we re-assign
@@ -527,7 +527,7 @@ extension Actor {
     // But this transfer should.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' could cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-3 {{'closure' is transferred from actor-isolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
     // But this will error since we race.
@@ -551,7 +551,7 @@ func testConversionsAndSendable(a: Actor, f: @Sendable () -> Void, f2: () -> Voi
   // Show that we error if we are not sendable.
   await a.useNonSendableFunction(f2) // expected-complete-warning {{passing argument of non-sendable type '() -> Void' into actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'f2' could cause a race}}
+  // expected-tns-warning @-2 {{transferring 'f2' may cause a race}}
   // expected-tns-note @-3 {{transferring nonisolated 'f2' to actor-isolated callee could cause races between actor-isolated and nonisolated uses}}
 }
 
@@ -596,7 +596,7 @@ func singleFieldVarMergeTest() async {
   useValue(box)
   useValue(box.k)
 
-  await transferToMain(box) // expected-tns-warning {{transferring 'box' could cause a race}}
+  await transferToMain(box) // expected-tns-warning {{transferring 'box' may cause a race}}
   // expected-tns-note @-1 {{'box' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
   
@@ -852,7 +852,7 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
 func letSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
@@ -862,7 +862,7 @@ func letSendableTrivialVarStructFieldTest() async {
 func letSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
@@ -872,7 +872,7 @@ func letSendableNonTrivialVarStructFieldTest() async {
 func letNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -929,7 +929,7 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
 func varSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
@@ -939,7 +939,7 @@ func varSendableTrivialVarStructFieldTest() async {
 func varSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
@@ -949,7 +949,7 @@ func varSendableNonTrivialVarStructFieldTest() async {
 func varNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -965,7 +965,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -980,7 +980,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -995,7 +995,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1011,7 +1011,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -1027,7 +1027,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -1043,7 +1043,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1058,7 +1058,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
     test.varSendableNonTrivial = SendableKlass()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1073,7 +1073,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
     useInOut(&test)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1088,7 +1088,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
     useInOut(&test.varSendableNonTrivial)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1106,7 +1106,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
     // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
@@ -1127,7 +1127,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
     }
     _ = cls
 
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
     // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1149,7 +1149,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
     // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1169,7 +1169,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
     // loop carry use and an error due to multiple params. Then we could emit
     // the error on test below. This is still correct though, just not as
     // good... that is QoI though.
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
     // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-tns-note @-2 {{access here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
@@ -1196,7 +1196,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   // this. This is a case where we are going to need to be able to have the
   // compiler explain the regions well.
   for _ in 0..<1024 {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-tns-note @-2 {{access here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
@@ -1220,11 +1220,11 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1241,7 +1241,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
   var cls = {}
 
   if await booleanFlag {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
@@ -1249,7 +1249,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1350,7 +1350,7 @@ func controlFlowTest2() async {
   var x = NonSendableKlass() // expected-tns-note {{variable defined here}}
 
   for _ in 0..<1024 {
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' could cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
     // expected-tns-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-tns-note @-2 {{access here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -123,7 +123,7 @@ func closureInOut(_ a: Actor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{transferring non-Sendable value 'ns0' could yield races with later accesses}}
+  // expected-tns-warning @-2 {{transferring 'ns0' could cause a race}}
   // expected-tns-note @-3 {{'ns0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // We only emit a warning on the first use we see, so make sure we do both
@@ -146,13 +146,13 @@ func closureInOut2(_ a: Actor) async {
 
   var closure = {}
 
-  await a.useKlass(ns0) // expected-tns-warning {{transferring non-Sendable value 'ns0' could yield races with later accesses}}
+  await a.useKlass(ns0) // expected-tns-warning {{transferring 'ns0' could cause a race}}
   // expected-tns-note @-1 {{'ns0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure = { useInOut(&contents) } // expected-tns-note {{access here could race}}
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring non-Sendable value 'ns1' could yield races with later accesses}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' could cause a race}}
   // expected-tns-note @-1 {{'ns1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
@@ -174,7 +174,7 @@ func closureNonInOut(_ a: Actor) async {
 
   closure = { useValue(contents) }
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring non-Sendable value 'ns1' could yield races with later accesses}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' could cause a race}}
   // expected-tns-note @-1 {{'ns1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
@@ -565,7 +565,7 @@ func singleFieldVarMergeTest() async {
   useValue(box)
   useValue(box.k)
 
-  await transferToMain(box) // expected-tns-warning {{transferring non-Sendable value 'box' could yield races with later accesses}}
+  await transferToMain(box) // expected-tns-warning {{transferring 'box' could cause a race}}
   // expected-tns-note @-1 {{'box' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
   
@@ -821,7 +821,7 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
 func letSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
@@ -831,7 +831,7 @@ func letSendableTrivialVarStructFieldTest() async {
 func letSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
@@ -841,7 +841,7 @@ func letSendableNonTrivialVarStructFieldTest() async {
 func letNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -898,7 +898,7 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
 func varSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
@@ -908,7 +908,7 @@ func varSendableTrivialVarStructFieldTest() async {
 func varSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
@@ -918,7 +918,7 @@ func varSendableNonTrivialVarStructFieldTest() async {
 func varNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests() // expected-tns-note {{variable defined here}}
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -934,7 +934,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -949,7 +949,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -964,7 +964,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -980,7 +980,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -996,7 +996,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
@@ -1012,7 +1012,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1027,7 +1027,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
     test.varSendableNonTrivial = SendableKlass()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1042,7 +1042,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
     useInOut(&test)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1057,7 +1057,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
     useInOut(&test.varSendableNonTrivial)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
@@ -1075,7 +1075,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
     // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
@@ -1096,7 +1096,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
     }
     _ = cls
 
-    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
     // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1118,7 +1118,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
     // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1138,7 +1138,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
     // loop carry use and an error due to multiple params. Then we could emit
     // the error on test below. This is still correct though, just not as
     // good... that is QoI though.
-    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
     // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-tns-note @-2 {{access here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
@@ -1165,7 +1165,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   // this. This is a case where we are going to need to be able to have the
   // compiler explain the regions well.
   for _ in 0..<1024 {
-    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-tns-note @-2 {{access here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
@@ -1189,11 +1189,11 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1210,7 +1210,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
   var cls = {}
 
   if await booleanFlag {
-    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
@@ -1218,7 +1218,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring non-Sendable value 'test' could yield races with later accesses}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' could cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1319,7 +1319,7 @@ func controlFlowTest2() async {
   var x = NonSendableKlass() // expected-tns-note {{variable defined here}}
 
   for _ in 0..<1024 {
-    await transferToMain(x) // expected-tns-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' could cause a race}}
     // expected-tns-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     // expected-tns-note @-2 {{access here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -607,12 +607,13 @@ func singleFieldVarMergeTest() async {
 }
 
 func multipleFieldVarMergeTest1() async {
-  var box = TwoFieldKlassBox()
+  var box = TwoFieldKlassBox() // expected-tns-note {{variable defined here}}
   box = TwoFieldKlassBox()
 
   // This transfers the entire region.
-  await transferToMain(box.k1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  await transferToMain(box.k1) // expected-tns-warning {{transferring 'box.k1' may cause a race}}
+  // expected-tns-note @-1 {{'box.k1' is transferred from nonisolated caller to main actor-isolated callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   
 
   // So even if we reassign over k1, since we did a merge, this should error.
@@ -647,12 +648,13 @@ func multipleFieldVarMergeTest2() async {
 }
 
 func multipleFieldTupleMergeTest1() async {
-  var box = (NonSendableKlass(), NonSendableKlass())
+  var box = (NonSendableKlass(), NonSendableKlass()) // expected-tns-note {{variable defined here}}
   box = (NonSendableKlass(), NonSendableKlass())
 
   // This transfers the entire region.
-  await transferToMain(box.0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  await transferToMain(box.0) // expected-tns-warning {{transferring 'box.0' may cause a race}}
+  // expected-tns-note @-1 {{'box.0' is transferred from nonisolated caller to main actor-isolated callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // So even if we reassign over k1, since we did a merge, this should error.
   box.0 = NonSendableKlass() // expected-tns-note {{access here could race}}

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -65,7 +65,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
     x = secondList.listHead!.next!
   }
 
-  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' could cause a race}}
+  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' may cause a race}}
   // expected-tns-note @-1 {{transferring global actor 'GlobalActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'GlobalActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
@@ -106,7 +106,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = StructContainingValue() // expected-tns-note {{variable defined here}}
   x = StructContainingValue()
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' could cause a race}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
   // expected-tns-note @-1 {{'x' is transferred from global actor 'GlobalActor'-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
@@ -117,7 +117,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = StructContainingValue()
   x.x = firstList
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' could cause a race}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
   // expected-tns-note @-1 {{transferring global actor 'GlobalActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'GlobalActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -48,12 +48,13 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 @GlobalActor func useGlobalActor1() async {
   let x = firstList
 
-  await transferToMainActor(x) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // TODO: This should say global actor isolated isolated.
+  await transferToMainActor(x) // expected-tns-warning {{task isolated value of type 'NonSendableLinkedList<Int>' transferred to main actor-isolated context}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
 
   let y = secondList.listHead!.next!
 
-  await transferToMainActor(y) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToMainActor(y) // expected-tns-warning {{task isolated value of type 'NonSendableLinkedListNode<Int>' transferred to main actor-isolated context}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
@@ -64,8 +65,9 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
     x = secondList.listHead!.next!
   }
 
-  await transferToMainActor(x) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
+  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' could cause a race}}
+  // expected-tns-note @-1 {{transferring global actor 'GlobalActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'GlobalActor'-isolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
 @GlobalActor func useGlobalActor3() async {
@@ -115,8 +117,9 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = StructContainingValue()
   x.x = firstList
 
-  await transferToNonIsolated(x) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' could cause a race}}
+  // expected-tns-note @-1 {{transferring global actor 'GlobalActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'GlobalActor'-isolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
   useValue(x)
 }
@@ -137,7 +140,8 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 
   x.1 = firstList
 
-  await transferToNonIsolated(x) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // TODO: This should be a global actor isolated error, not a task isolated error.
+  await transferToNonIsolated(x) // expected-tns-warning {{task isolated value of type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' transferred to nonisolated context}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -104,7 +104,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = StructContainingValue() // expected-tns-note {{variable defined here}}
   x = StructContainingValue()
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' could cause a race}}
   // expected-tns-note @-1 {{'x' is transferred from global actor 'GlobalActor'-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_globalactors.swift
+++ b/test/Concurrency/transfernonsendable_globalactors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -parse-as-library
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature RegionBasedIsolation -disable-availability-checking -verify %s -o /dev/null -parse-as-library
 
 // Tests specific to global actors.
 
@@ -39,16 +39,17 @@ struct CustomActor {
 /////////////////
 
 @MainActor func testTransferGlobalActorGuardedValue() async {
-  await transferToCustom(globalKlass) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // TODO: Global actor error needed.
+  await transferToCustom(globalKlass) // expected-warning {{task isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
 }
 
 @MainActor func testTransferGlobalActorGuardedValueWithlet() async {
   let x = globalKlass
-  await transferToCustom(x) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToCustom(x) // expected-warning {{task isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
 }
 
 @MainActor func testTransferGlobalActorGuardedValueWithlet(_ k: Klass) async {
   // expected-note @-1 {{value is task isolated since it is in the same region as 'k'}}
   globalKlass = k
-  await transferToCustom(k) // expected-tns-warning {{task isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context; later accesses to value could race}}
+  await transferToCustom(k) // expected-warning {{task isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context; later accesses to value could race}}
 }

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -310,7 +310,7 @@ bb0(%0 : @owned $NonSendableStruct):
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableStruct>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-warning @-1 {{task isolated value of type 'NonSendableStruct' transferred to global actor '<null>'-isolated context}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableStruct>(%2) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -328,7 +328,7 @@ bb0(%0 : $*NonSendableStruct):
   %2 = moveonlywrapper_to_copyable_addr %1 : $*@moveOnly NonSendableStruct
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableStruct>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-warning @-1 {{task isolated value of type 'NonSendableStruct' transferred to global actor '<null>'-isolated context}}
   %9999 = tuple ()
   return %9999 : $()
 }
@@ -340,7 +340,7 @@ bb0(%0 : @owned $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for 
   store %0 to [init] %blockAddr : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<() -> ()>(%blockAddr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-warning @-1 {{task isolated value of type '@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>' transferred to global actor '<null>'-isolated context}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<() -> ()>(%blockAddr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -393,7 +393,7 @@ bb0(%0 : $*NonSendableKlass):
   mark_unresolved_move_addr %0 to %1 : $*NonSendableKlass
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%1) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
   destroy_addr %0 : $*NonSendableKlass
   destroy_addr %1 : $*NonSendableKlass
   dealloc_stack %1 : $*NonSendableKlass
@@ -529,9 +529,9 @@ bb0(%0 : $Builtin.RawPointer):
   // Should error on both since the raw pointer is from an argument.
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%4) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  // expected-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%6) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}  
+  // expected-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
 
   destroy_value %4 : $NonSendableKlass
   destroy_value %6 : $NonSendableKlass
@@ -563,13 +563,13 @@ bb0(%0 : $Builtin.RawPointer):
   // But if we transfer the raw pointers and use them later we get separate errors.
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%0) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}  
+  // expected-warning @-1 {{task isolated value of type 'Builtin.RawPointer' transferred to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%2) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}  
+  // expected-warning @-1 {{task isolated value of type 'Builtin.RawPointer' transferred to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%3a) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%5a) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
+  // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context}}
 
   %useRawPointer = function_ref @useRawPointer : $@convention(thin) (Builtin.RawPointer) -> ()
   apply %useRawPointer(%3a) : $@convention(thin) (Builtin.RawPointer) -> ()

--- a/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
@@ -81,7 +81,7 @@ bb0(%owned_value : @owned $T):
   %unowned_value = unowned_copy_value %owned_value : $T
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<@sil_unowned T>(%unowned_value) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<@sil_unowned T>(%unowned_value) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{task isolated value of type 'T' transferred to global actor '<null>'-isolated context}}
 
   destroy_value %unowned_value : $@sil_unowned T
   //destroy_value %value : $T

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -353,7 +353,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns5_0) // expected-tns-warning {{transferring non-Sendable value 'ns5_0' could yield races with later accesses}}
+        await a.foo(ns5_0) // expected-tns-warning {{transferring 'ns5_0' could cause a race}}
         // expected-tns-note @-1 {{'ns5_0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
@@ -363,7 +363,7 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns5_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns5_1) // expected-tns-warning {{transferring non-Sendable value 'ns5_1' could yield races with later accesses}}
+        await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' could cause a race}}
         // expected-tns-note @-1 {{'ns5_1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -353,7 +353,7 @@ func test_indirect_regions(a : A, b : Bool) async {
     }
 
     if (b) {
-        await a.foo(ns5_0) // expected-tns-warning {{transferring 'ns5_0' could cause a race}}
+        await a.foo(ns5_0) // expected-tns-warning {{transferring 'ns5_0' may cause a race}}
         // expected-tns-note @-1 {{'ns5_0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
@@ -363,7 +363,7 @@ func test_indirect_regions(a : A, b : Bool) async {
           print(ns5_1) // expected-tns-note {{access here could race}}
         }
     } else {
-        await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' could cause a race}}
+        await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' may cause a race}}
         // expected-tns-note @-1 {{'ns5_1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -76,7 +76,7 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
     await a.foo(ns_let); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     // Not safe to consume an arg.
-    await a.foo(ns_arg); // expected-tns-warning {{task isolated value of type 'Any' transferred to actor-isolated context; later accesses to value could race}}
+    await a.foo(ns_arg); // expected-tns-warning {{task isolated value of type 'NonSendable' transferred to actor-isolated context; later accesses to value could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     // Check for no duplicate warnings once self is "consumed"
@@ -388,7 +388,7 @@ class C_NonSendable {
         foo_noniso(captures_self)
 
         // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
-        await a.foo(captures_self) // expected-tns-warning {{task isolated value of type 'Any' transferred to actor-isolated context; later accesses to value could race}}
+        await a.foo(captures_self) // expected-tns-warning {{task isolated value of type '() -> ()' transferred to actor-isolated context; later accesses to value could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
         // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }
@@ -424,7 +424,8 @@ actor A_Sendable {
         // actor and is non-Sendable. For now, we ban this since we do not
         // support the ability to dynamically invoke the synchronous closure on
         // the specific actor.
-        await a.foo(captures_self) // expected-tns-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+        // TODO: Should use special closure error.
+        await a.foo(captures_self) // expected-tns-warning {{task isolated value of type '() -> ()' transferred to actor-isolated context}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
         // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -138,7 +138,8 @@ actor MyActor {
   // Once we assign into the actor, we cannot transfer further.
   func assignTransferringIntoActor2(_ x: transferring Klass) async {
     field = x
-    await transferToMain(x) // expected-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+    await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
+    // expected-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 }
 
@@ -148,11 +149,13 @@ actor MyActor {
 
 @MainActor func canAssignTransferringIntoGlobalActor2(_ x: transferring Klass) async {
   globalKlass = x
-  await transferToCustom(x) // expected-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToCustom(x) // expected-warning {{transferring 'x' could cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
 @MainActor func canAssignTransferringIntoGlobalActor3(_ x: transferring Klass) async {
-  await transferToCustom(globalKlass) // expected-warning {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  await transferToCustom(globalKlass) // expected-warning {{transferring 'globalKlass' could cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'globalKlass' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
 func canTransferAssigningIntoLocal(_ x: transferring Klass) async {

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -93,14 +93,14 @@ func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) 
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
   // expected-note @-1:54 {{variable defined here}}
-  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   await transferToMain(x) // expected-note {{access here could race}}
 }
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
   // expected-note @-1 {{variable defined here}}
-  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   useValue(x) // expected-note {{access here could race}}
 }
@@ -116,14 +116,14 @@ actor MyActor {
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
     // expected-note @-1 {{variable defined here}}
-    await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+    await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
     // expected-note @-1 {{'x' is transferred from actor-isolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     await transferToMain(x) // expected-note {{access here could race}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
     // expected-note @-1 {{variable defined here}}
-    await transferToMain(x)  // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+    await transferToMain(x)  // expected-warning {{transferring 'x' could cause a race}}
   // expected-note @-1 {{'x' is transferred from actor-isolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     useValue(x) // expected-note {{access here could race}}
   }
@@ -163,7 +163,7 @@ func canTransferAssigningIntoLocal(_ x: transferring Klass) async {
 func canTransferAssigningIntoLocal2(_ x: transferring Klass) async {
   // expected-note @-1 {{variable defined here}}
   let _ = x
-  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   let _ = x // expected-note {{access here could race}}
 }
@@ -226,7 +226,7 @@ func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
   x = y
 
   // TODO: This should refer to the transferring parameter.
-  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   useValue(x) // expected-note {{access here could race}}
@@ -256,7 +256,7 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // y is assigned into a field of x, so we treat this like a merge.
@@ -274,7 +274,7 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // y is assigned into a field of x, so we treat this like a merge.

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -93,14 +93,14 @@ func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) 
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
   // expected-note @-1:54 {{variable defined here}}
-  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   await transferToMain(x) // expected-note {{access here could race}}
 }
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
   // expected-note @-1 {{variable defined here}}
-  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   useValue(x) // expected-note {{access here could race}}
 }
@@ -116,14 +116,14 @@ actor MyActor {
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
     // expected-note @-1 {{variable defined here}}
-    await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
+    await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
     // expected-note @-1 {{'x' is transferred from actor-isolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     await transferToMain(x) // expected-note {{access here could race}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
     // expected-note @-1 {{variable defined here}}
-    await transferToMain(x)  // expected-warning {{transferring 'x' could cause a race}}
+    await transferToMain(x)  // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from actor-isolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     useValue(x) // expected-note {{access here could race}}
   }
@@ -138,7 +138,7 @@ actor MyActor {
   // Once we assign into the actor, we cannot transfer further.
   func assignTransferringIntoActor2(_ x: transferring Klass) async {
     field = x
-    await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
+    await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
     // expected-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 }
@@ -149,12 +149,12 @@ actor MyActor {
 
 @MainActor func canAssignTransferringIntoGlobalActor2(_ x: transferring Klass) async {
   globalKlass = x
-  await transferToCustom(x) // expected-warning {{transferring 'x' could cause a race}}
+  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
 @MainActor func canAssignTransferringIntoGlobalActor3(_ x: transferring Klass) async {
-  await transferToCustom(globalKlass) // expected-warning {{transferring 'globalKlass' could cause a race}}
+  await transferToCustom(globalKlass) // expected-warning {{transferring 'globalKlass' may cause a race}}
   // expected-note @-1 {{transferring main actor-isolated 'globalKlass' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
@@ -166,7 +166,7 @@ func canTransferAssigningIntoLocal(_ x: transferring Klass) async {
 func canTransferAssigningIntoLocal2(_ x: transferring Klass) async {
   // expected-note @-1 {{variable defined here}}
   let _ = x
-  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   let _ = x // expected-note {{access here could race}}
 }
@@ -229,7 +229,7 @@ func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
   x = y
 
   // TODO: This should refer to the transferring parameter.
-  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   useValue(x) // expected-note {{access here could race}}
@@ -259,7 +259,7 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // y is assigned into a field of x, so we treat this like a merge.
@@ -277,7 +277,7 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring 'x' could cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
 
   // y is assigned into a field of x, so we treat this like a merge.

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -68,7 +68,7 @@ func simpleTest() async {
 func simpleTest2() async {
   let x = NonSendableKlass() // expected-note {{variable defined here}}
   let y = transferResultWithArg(x)
-  await transferToMainDirect(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  await transferToMainDirect(x) // expected-warning {{transferring 'x' could cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   useValue(y)
   useValue(x) // expected-note {{access here could race}}
@@ -79,14 +79,14 @@ func simpleTest3() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x) // expected-note {{variable defined here}}
   await transferToMainDirect(x)
-  await transferToMainDirect(y) // expected-warning {{transferring non-Sendable value 'y' could yield races with later accesses}}
+  await transferToMainDirect(y) // expected-warning {{transferring 'y' could cause a race}}
   // expected-note @-1 {{'y' is transferred from nonisolated caller to main actor-isolated callee}}
   useValue(y) // expected-note {{access here could race}}
 }
 
 func transferResult() async -> transferring NonSendableKlass {
   let x = NonSendableKlass() // expected-note {{variable defined here}}
-  await transferToMainDirect(x) // expected-warning {{transferring non-Sendable value 'x' could yield races with later accesses}}
+  await transferToMainDirect(x) // expected-warning {{transferring 'x' could cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   return x // expected-note {{access here could race}}
 }

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -68,7 +68,7 @@ func simpleTest() async {
 func simpleTest2() async {
   let x = NonSendableKlass() // expected-note {{variable defined here}}
   let y = transferResultWithArg(x)
-  await transferToMainDirect(x) // expected-warning {{transferring 'x' could cause a race}}
+  await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   useValue(y)
   useValue(x) // expected-note {{access here could race}}
@@ -79,14 +79,14 @@ func simpleTest3() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x) // expected-note {{variable defined here}}
   await transferToMainDirect(x)
-  await transferToMainDirect(y) // expected-warning {{transferring 'y' could cause a race}}
+  await transferToMainDirect(y) // expected-warning {{transferring 'y' may cause a race}}
   // expected-note @-1 {{'y' is transferred from nonisolated caller to main actor-isolated callee}}
   useValue(y) // expected-note {{access here could race}}
 }
 
 func transferResult() async -> transferring NonSendableKlass {
   let x = NonSendableKlass() // expected-note {{variable defined here}}
-  await transferToMainDirect(x) // expected-warning {{transferring 'x' could cause a race}}
+  await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   return x // expected-note {{access here could race}}
 }

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -39,7 +39,8 @@ func testAssignmentIntoTransferringParameter(_ x: transferring NonSendableType) 
 }
 
 func testAssigningParameterIntoTransferringParameter(_ x: transferring NonSendableType, _ y: NonSendableType) async {
-  x = y // expected-error {{call site passes `self` or a non-sendable argument of this function to another thread, potentially yielding a race with the caller}}
+  x = y // expected-error {{assigning 'y' to transferring parameter 'x' may cause a race}}
+  // expected-note @-1 {{'y' is a task isolated value that is assigned into transferring parameter 'x'. Transferred uses of 'x' may race with caller uses of 'y'}}
 }
 
 func testIsolationCrossingDueToCapture() async {

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -19,6 +19,7 @@ class ContainsKlass {
 sil @getKlass : $@convention(thin) () -> @owned Klass
 sil @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
 sil @useIndirect : $@convention(thin) <T> (@in_guaranteed T) -> ()
+sil @sideEffect : $@convention(thin) () -> ()
 
 //===----------------------------------------------------------------------===//
 //                                MARK: Tests
@@ -112,4 +113,38 @@ bb0:
   destroy_value %3 : $ContainsKlass
   %13 = tuple ()
   return %13 : $()
+}
+
+sil [thunk] @test_reabstraction_thunk : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out ()
+
+// CHECK-LABEL: begin running test {{.*}} of {{.*}} on handle_function_conversion_reabstraction_thunks: variable-name-inference with: @trace[0]
+// CHECK: Name: 'namedClosure'
+// CHECK: Root: %0 = alloc_stack [lexical] $@callee_guaranteed () -> (), var, name "namedClosure"
+// CHECK: end running test {{.*}} of {{.*}} on handle_function_conversion_reabstraction_thunks: variable-name-inference with: @trace[0]
+sil [ossa] @handle_function_conversion_reabstraction_thunks : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %namedStack = alloc_stack [lexical] $@callee_guaranteed () -> (), var, name "namedClosure"
+  %f = function_ref @sideEffect : $@convention(thin) () -> ()
+  %pa = partial_apply [callee_guaranteed] %f() : $@convention(thin) () -> ()
+  store %pa to [init] %namedStack : $*@callee_guaranteed () -> ()
+
+  %temp = alloc_stack $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
+  %access = begin_access [read] [static] %namedStack : $*@callee_guaranteed () -> ()
+  %load = load [copy] %access : $*@callee_guaranteed () -> ()
+  end_access %access : $*@callee_guaranteed () -> ()
+
+  %reabstract = function_ref @test_reabstraction_thunk : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out ()
+  %reabstract_partially_applied = partial_apply [callee_guaranteed] %reabstract(%load) : $@convention(thin) (@guaranteed @callee_guaranteed () -> ()) -> @out ()
+  %cvt = convert_function %reabstract_partially_applied : $@callee_guaranteed () -> @out () to $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
+  store %cvt to [init] %temp : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
+  debug_value [trace] %temp : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
+
+  destroy_addr %temp : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
+  dealloc_stack %temp : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
+  destroy_addr %namedStack : $*@callee_guaranteed () -> ()
+  dealloc_stack %namedStack : $*@callee_guaranteed () -> ()
+
+  %9999 = tuple ()
+  return %9999 : $()
 }

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -1,11 +1,28 @@
-// RUN: %target-sil-opt -test-runner %s 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -module-name infer -test-runner %s 2>&1 | %FileCheck %s
 
 import Builtin
 
-class Klass {}
+//===----------------------------------------------------------------------===//
+//                             MARK: Declarations
+//===----------------------------------------------------------------------===//
+
+class Klass {
+}
+
+class ContainsKlass {
+  var computedKlass: Klass { get }
+  final var klass: Klass
+
+  init()
+}
 
 sil @getKlass : $@convention(thin) () -> @owned Klass
+sil @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
 sil @useIndirect : $@convention(thin) <T> (@in_guaranteed T) -> ()
+
+//===----------------------------------------------------------------------===//
+//                                MARK: Tests
+//===----------------------------------------------------------------------===//
 
 // CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on simple_test_case: variable-name-inference with: @trace[0]
 // CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
@@ -73,4 +90,26 @@ bb0:
   dealloc_stack %temp : $*Klass
   %9999 = tuple ()
   return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} of {{.*}} on look_through_accessors_get: variable-name-inference with: @trace[0]
+// CHECK: Name: 'myName.computedKlass'
+// CHECK: Root: %2 = move_value [lexical] [var_decl]
+// CHECK: end running test {{.*}} of {{.*}} on look_through_accessors_get: variable-name-inference with: @trace[0]
+sil [ossa] @look_through_accessors_get : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
+  %1 = apply %0() : $@convention(thin) () -> @owned ContainsKlass
+  %3 = move_value [lexical] [var_decl] %1 : $ContainsKlass
+  debug_value %3 : $ContainsKlass, let, name "myName"
+  %5 = begin_borrow %3 : $ContainsKlass
+  %6 = class_method %5 : $ContainsKlass, #ContainsKlass.computedKlass!getter : (ContainsKlass) -> () -> Klass, $@convention(method) (@guaranteed ContainsKlass) -> @owned Klass
+  %7 = apply %6(%5) : $@convention(method) (@guaranteed ContainsKlass) -> @owned Klass
+  debug_value [trace] %7 : $Klass
+  end_borrow %5 : $ContainsKlass
+  destroy_value %7 : $Klass
+  destroy_value %3 : $ContainsKlass
+  %13 = tuple ()
+  return %13 : $()
 }

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -16,6 +16,16 @@ class ContainsKlass {
   init()
 }
 
+struct KlassPair {
+  var lhs: Klass
+  var rhs: Klass
+}
+
+class KlassWithKlassPair {
+  var ns1: KlassPair { get }
+  var ns2: (KlassPair, KlassPair) { get }
+}
+
 sil @getKlass : $@convention(thin) () -> @owned Klass
 sil @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
 sil @useIndirect : $@convention(thin) <T> (@in_guaranteed T) -> ()
@@ -147,4 +157,236 @@ bb0:
 
   %9999 = tuple ()
   return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} of {{.*}} on mark_uninitialized_test: variable-name-inference with: @trace[0]
+// CHECK: Name: 'self'
+// CHECK: Root: %0 = alloc_stack $Klass, var, name "self"
+// CHECK: end running test {{.*}} of {{.*}} on mark_uninitialized_test: variable-name-inference with: @trace[0]
+sil [ossa] @mark_uninitialized_test : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %1 = alloc_stack $Klass, var, name "self"
+  %2 = mark_uninitialized [rootself] %1 : $*Klass
+  debug_value [trace] %2 : $*Klass
+  dealloc_stack %1 : $*Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test {{.*}} of {{.*}} on copyable_to_moveonlywrapper_addr_test: variable-name-inference with: @trace[0]
+// CHECK: Name: 'self'
+// CHECK: Root: %0 = alloc_stack $Klass, var, name "self"
+// CHECK: end running test {{.*}} of {{.*}} on copyable_to_moveonlywrapper_addr_test: variable-name-inference with: @trace[0]
+sil [ossa] @copyable_to_moveonlywrapper_addr_test : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = alloc_stack $Klass, var, name "self"
+  %1 = copyable_to_moveonlywrapper_addr %0 : $*Klass
+  %2 = moveonlywrapper_to_copyable_addr %1 : $*@moveOnly Klass
+  debug_value [trace] %2 : $*Klass
+  dealloc_stack %0 : $*Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_tuple_destructure: variable-name-inference with: @trace[0]
+// CHECK: Input Value: (**%8**, %9) = destructure_tuple %7 : $(Klass, Klass)
+// CHECK: Name: 'y.0'
+// CHECK: Root:   %5 = tuple (%1 : $Klass, %2 : $Klass)
+// CHECK: end running test 1 of 1 on test_tuple_destructure: variable-name-inference with: @trace[0]
+sil [ossa] @test_tuple_destructure : $@convention(thin) (@owned Klass, @guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
+  specify_test "variable-name-inference @trace[0]"
+  %3 = alloc_stack [lexical] $Klass, var, name "x"
+  store %0 to [init] %3 : $*Klass
+  %5 = tuple (%1 : $Klass, %2 : $Klass)
+  debug_value %5 : $(Klass, Klass), let, name "y", argno 2
+  %9 = copy_value %5 : $(Klass, Klass)
+  (%10, %11) = destructure_tuple %9 : $(Klass, Klass)
+  %12 = begin_access [modify] [static] %3 : $*Klass
+  debug_value [trace] %10 : $Klass
+  store %10 to [assign] %12 : $*Klass
+  end_access %12 : $*Klass
+  destroy_value %11 : $Klass
+  destroy_addr %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  %18 = tuple ()
+  return %18 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_tuple_extract: variable-name-inference with: @trace[0]
+// CHECK: Input Value: %9 = tuple_extract %8 : $(Klass, Klass), 0
+// CHECK: Name: 'y.0'
+// CHECK: Root:   %5 = tuple (%1 : $Klass, %2 : $Klass)
+// CHECK: end running test 1 of 1 on test_tuple_extract: variable-name-inference with: @trace[0]
+sil [ossa] @test_tuple_extract : $@convention(thin) (@owned Klass, @guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
+  specify_test "variable-name-inference @trace[0]"
+  %3 = alloc_stack [lexical] $Klass, var, name "x"
+  store %0 to [init] %3 : $*Klass
+  %5 = tuple (%1 : $Klass, %2 : $Klass)
+  debug_value %5 : $(Klass, Klass), let, name "y", argno 2
+  %9 = copy_value %5 : $(Klass, Klass)
+  %9a = begin_borrow %9 : $(Klass, Klass)
+  %10 = tuple_extract %9a : $(Klass, Klass), 0
+  debug_value [trace] %10 : $Klass
+  end_borrow %9a : $(Klass, Klass)
+  destroy_value %9 : $(Klass, Klass)
+  destroy_addr %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  %18 = tuple ()
+  return %18 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_struct_destructure: variable-name-inference with: @trace[0]
+// CHECK: Input Value: (%8, **%9**) = destructure_struct %7 : $KlassPair
+// CHECK: Name: 'y.rhs'
+// CHECK: Root:   %5 = struct $KlassPair (%1 : $Klass, %2 : $Klass)
+// CHECK: end running test 1 of 1 on test_struct_destructure: variable-name-inference with: @trace[0]
+sil [ossa] @test_struct_destructure : $@convention(thin) (@owned Klass, @guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
+  specify_test "variable-name-inference @trace[0]"
+  %3 = alloc_stack [lexical] $Klass, var, name "x"
+  store %0 to [init] %3 : $*Klass
+  %5 = struct $KlassPair (%1 : $Klass, %2 : $Klass)
+  debug_value %5 : $KlassPair, let, name "y", argno 2
+  %9 = copy_value %5 : $KlassPair
+  (%10, %11) = destructure_struct %9 : $KlassPair
+  %12 = begin_access [modify] [static] %3 : $*Klass
+  debug_value [trace] %11 : $Klass
+  store %10 to [assign] %12 : $*Klass
+  end_access %12 : $*Klass
+  destroy_value %11 : $Klass
+  destroy_addr %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  %18 = tuple ()
+  return %18 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_struct_extract: variable-name-inference with: @trace[0]
+// CHECK: Input Value: %9 = struct_extract %8 : $KlassPair, #KlassPair.rhs
+// CHECK: Name: 'y.rhs'
+// CHECK: Root: %5 = struct $KlassPair (%1 : $Klass, %2 : $Klass)
+// CHECK: end running test 1 of 1 on test_struct_extract: variable-name-inference with: @trace[0]
+sil [ossa] @test_struct_extract : $@convention(thin) (@owned Klass, @guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @guaranteed $Klass, %2 : @guaranteed $Klass):
+  specify_test "variable-name-inference @trace[0]"
+  %3 = alloc_stack [lexical] $Klass, var, name "x"
+  store %0 to [init] %3 : $*Klass
+  %5 = struct $KlassPair (%1 : $Klass, %2 : $Klass)
+  debug_value %5 : $KlassPair, let, name "y", argno 2
+  %9 = copy_value %5 : $KlassPair
+  %9a = begin_borrow %9 : $KlassPair
+  %10 = struct_extract %9a : $KlassPair, #KlassPair.rhs
+  debug_value [trace] %10 : $Klass
+  end_borrow %9a : $KlassPair
+  destroy_value %9 : $KlassPair
+  destroy_addr %3 : $*Klass
+  dealloc_stack %3 : $*Klass
+  %18 = tuple ()
+  return %18 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_klass_tuple_struct_lookthrough: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %28 = load [copy] %27 : $*Klass
+// CHECK: Name: 'arg2.ns2.1.rhs'
+// CHECK: Root: %1 = argument of bb0 : $KlassWithKlassPair
+// CHECK: end running test 1 of 1 on test_klass_tuple_struct_lookthrough: variable-name-inference with: @trace[0]
+sil [ossa] @test_klass_tuple_struct_lookthrough : $@convention(thin) @async (@owned Klass, @guaranteed KlassWithKlassPair) -> () {
+bb0(%0 : @owned $Klass, %1 : @guaranteed $KlassWithKlassPair):
+  debug_value %0 : $Klass, let, name "arg1", argno 1
+  debug_value %1 : $KlassWithKlassPair, let, name "arg2", argno 2
+
+  specify_test "variable-name-inference @trace[0]"
+  %2 = alloc_stack [lexical] $Klass, var, name "x"
+  store %0 to [init] %2 : $*Klass
+  %7 = alloc_stack $KlassPair
+  %8 = class_method %1 : $KlassWithKlassPair, #KlassWithKlassPair.ns1!getter : (KlassWithKlassPair) -> () -> KlassPair, $@convention(method) (@guaranteed KlassWithKlassPair) -> @owned KlassPair
+  %9 = apply %8(%1) : $@convention(method) (@guaranteed KlassWithKlassPair) -> @owned KlassPair
+  store %9 to [init] %7 : $*KlassPair
+  %11 = struct_element_addr %7 : $*KlassPair, #KlassPair.rhs
+  %12 = load [copy] %11 : $*Klass
+  destroy_addr %7 : $*KlassPair
+  %14 = begin_access [modify] [static] %2 : $*Klass
+  store %12 to [assign] %14 : $*Klass
+  end_access %14 : $*Klass
+  dealloc_stack %7 : $*KlassPair
+  %18 = alloc_stack $(KlassPair, KlassPair)
+  %19 = tuple_element_addr %18 : $*(KlassPair, KlassPair), 0
+  %20 = tuple_element_addr %18 : $*(KlassPair, KlassPair), 1
+  %21 = class_method %1 : $KlassWithKlassPair, #KlassWithKlassPair.ns2!getter : (KlassWithKlassPair) -> () -> (KlassPair, KlassPair), $@convention(method) (@guaranteed KlassWithKlassPair) -> (@owned KlassPair, @owned KlassPair)
+  %22 = apply %21(%1) : $@convention(method) (@guaranteed KlassWithKlassPair) -> (@owned KlassPair, @owned KlassPair)
+  (%23, %24) = destructure_tuple %22 : $(KlassPair, KlassPair)
+  store %23 to [init] %19 : $*KlassPair
+  store %24 to [init] %20 : $*KlassPair
+  %27 = tuple_element_addr %18 : $*(KlassPair, KlassPair), 1
+  %28 = struct_element_addr %27 : $*KlassPair, #KlassPair.rhs
+  %29 = load [copy] %28 : $*Klass
+  destroy_addr %18 : $*(KlassPair, KlassPair)
+  %31 = begin_access [modify] [static] %2 : $*Klass
+  debug_value [trace] %29 : $Klass
+  store %29 to [assign] %31 : $*Klass
+  end_access %31 : $*Klass
+  dealloc_stack %18 : $*(KlassPair, KlassPair)
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  %37 = tuple ()
+  return %37 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on test_klass_tuple_struct_lookthrough_with_copyaddr: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %33 = load [copy] %32 : $*Klass
+// CHECK: Name: 'arg2.ns2.1.rhs'
+// CHECK: Root: %1 = argument of bb0 : $KlassWithKlassPair
+// CHECK: end running test 1 of 1 on test_klass_tuple_struct_lookthrough_with_copyaddr: variable-name-inference with: @trace[0]
+sil [ossa] @test_klass_tuple_struct_lookthrough_with_copyaddr : $@convention(thin) @async (@owned Klass, @guaranteed KlassWithKlassPair) -> () {
+bb0(%0 : @owned $Klass, %1 : @guaranteed $KlassWithKlassPair):
+  debug_value %0 : $Klass, let, name "arg1", argno 1
+  debug_value %1 : $KlassWithKlassPair, let, name "arg2", argno 2
+
+  specify_test "variable-name-inference @trace[0]"
+  %2 = alloc_stack [lexical] $Klass, var, name "x"
+  store %0 to [init] %2 : $*Klass
+  %7 = alloc_stack $KlassPair
+  %8 = class_method %1 : $KlassWithKlassPair, #KlassWithKlassPair.ns1!getter : (KlassWithKlassPair) -> () -> KlassPair, $@convention(method) (@guaranteed KlassWithKlassPair) -> @owned KlassPair
+  %9 = apply %8(%1) : $@convention(method) (@guaranteed KlassWithKlassPair) -> @owned KlassPair
+  store %9 to [init] %7 : $*KlassPair
+  %11 = struct_element_addr %7 : $*KlassPair, #KlassPair.rhs
+  %12 = load [copy] %11 : $*Klass
+  destroy_addr %7 : $*KlassPair
+  %14 = begin_access [modify] [static] %2 : $*Klass
+  store %12 to [assign] %14 : $*Klass
+  end_access %14 : $*Klass
+  dealloc_stack %7 : $*KlassPair
+  %18 = alloc_stack $(KlassPair, KlassPair)
+  %19 = tuple_element_addr %18 : $*(KlassPair, KlassPair), 0
+  %20 = tuple_element_addr %18 : $*(KlassPair, KlassPair), 1
+  %21 = class_method %1 : $KlassWithKlassPair, #KlassWithKlassPair.ns2!getter : (KlassWithKlassPair) -> () -> (KlassPair, KlassPair), $@convention(method) (@guaranteed KlassWithKlassPair) -> (@owned KlassPair, @owned KlassPair)
+  %22 = apply %21(%1) : $@convention(method) (@guaranteed KlassWithKlassPair) -> (@owned KlassPair, @owned KlassPair)
+  (%23, %24) = destructure_tuple %22 : $(KlassPair, KlassPair)
+  store %23 to [init] %19 : $*KlassPair
+  store %24 to [init] %20 : $*KlassPair
+
+  %18a = alloc_stack $(KlassPair, KlassPair)
+  %19a = tuple_element_addr %18a : $*(KlassPair, KlassPair), 0
+  copy_addr [take] %19 to [init] %19a : $*KlassPair
+  %20a = tuple_element_addr %18a : $*(KlassPair, KlassPair), 1
+  copy_addr [take] %20 to [init] %20a : $*KlassPair
+
+  %27 = tuple_element_addr %18a : $*(KlassPair, KlassPair), 1
+  %28 = struct_element_addr %27 : $*KlassPair, #KlassPair.rhs
+  %29 = load [copy] %28 : $*Klass
+
+  destroy_addr %18a : $*(KlassPair, KlassPair)
+  %31 = begin_access [modify] [static] %2 : $*Klass
+  debug_value [trace] %29 : $Klass
+  store %29 to [assign] %31 : $*Klass
+  end_access %31 : $*Klass
+  dealloc_stack %18a : $*(KlassPair, KlassPair)
+  dealloc_stack %18 : $*(KlassPair, KlassPair)
+  destroy_addr %2 : $*Klass
+  dealloc_stack %2 : $*Klass
+  %37 = tuple ()
+  return %37 : $()
 }


### PR DESCRIPTION
This series of commits:

1. Improves the diagnostics around strong transferring and wordsmiths the main transferring error to be smaller.
2. Adds a bunch more support in VariableNameInference for inferring more variable names.
3. Eliminates most of the call site passes `self` error. Still a little more to do, but this hits most of them.