### PR TITLE
[SourceKit] Exit the `SourceKitService` process on a SIGTERM

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Threading.h"
 
+#include <csignal>
 #include <xpc/xpc.h>
 
 using namespace SourceKit;
@@ -385,6 +386,7 @@ static void fatal_error_handler(void *user_data, const char *reason,
 }
 
 int main(int argc, const char *argv[]) {
+  std::signal(SIGTERM, SIG_DFL);
   llvm::install_fatal_error_handler(fatal_error_handler, 0);
   sourcekitd::enableLogging("sourcekit-serv");
   sourcekitd_set_uid_handlers(


### PR DESCRIPTION
Sending a `SIGTERM` to sourcekitd XPC service lead to very surprising results: XPC thought that the process was about to die and sends a Connection Interrupted notification to the client. But other than that, we didn’t actually handle the signal and the service stayed alive. This caused us to send a `sema_disabled` notification to the client but since the service never got relaunched, we never sent the corresponding `sema_enabled` notification.

To fix this, just properly die on `SIGTERM` by calling `abort`.