### PR TITLE
SwiftCompilerSources: support for ForwardingInstructions, ConversionInstructions, OwnershipTransitionInstruction

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
@@ -162,11 +162,11 @@ private func constructLetInitRegion(
       initRegion.insert(inst)
 
     case let beginBorrow as BeginBorrowInst
-         where beginBorrow.borrowedValue.referenceRoot == markUninitialized:
+           where beginBorrow.borrowedValue.isReferenceDerived(from: markUninitialized):
       borrows.append(beginBorrow)
 
     case let storeBorrow as StoreBorrowInst
-         where storeBorrow.source.referenceRoot == markUninitialized:
+           where storeBorrow.source.isReferenceDerived(from: markUninitialized):
       borrows.append(storeBorrow)
 
     default:
@@ -202,10 +202,28 @@ private extension RefElementAddrInst {
 }
 
 private extension Value {
+  func isReferenceDerived(from root: Value) -> Bool {
+    var parent: Value = self
+    while true {
+      if parent == root {
+        return true
+      }
+      if let operand = parent.forwardingInstruction?.singleForwardedOperand {
+        parent = operand.value
+        continue
+      }
+      if let transition = parent.definingInstruction as? OwnershipTransitionInstruction {
+        parent = transition.operand.value
+        continue
+      }
+      return false
+    }
+  }
+
   func isLetFieldAddress(of markUninitialized: MarkUninitializedInst) -> Bool {
     if case .class(let rea) = self.accessBase,
        rea.fieldIsLet,
-       rea.instance.referenceRoot == markUninitialized
+       rea.instance.isReferenceDerived(from: markUninitialized)
     {
       return true
     }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
@@ -156,7 +156,7 @@ private func constructLetInitRegion(
       initRegion.insert(inst)
 
     case let beginAccess as BeginAccessInst
-         where beginAccess.accessKind == .Deinit &&
+         where beginAccess.accessKind == .deinit &&
                beginAccess.address.isLetFieldAddress(of: markUninitialized):
       // Include let-field partial de-initializations in the region.
       initRegion.insert(inst)

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
@@ -355,7 +355,7 @@ private struct StackProtectionOptimization {
   /// Moves the value of a `beginAccess` to a temporary stack location, if possible.
   private func moveToTemporary(scope beginAccess: BeginAccessInst, mustFixStackNesting: inout Bool,
                                _ context: FunctionPassContext) {
-    if beginAccess.accessKind != .Modify {
+    if beginAccess.accessKind != .modify {
       // We can only move from a `modify` access.
       // Also, read-only accesses shouldn't be subject to buffer overflows (because
       // no one should ever write to such a storage).

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -706,12 +706,8 @@ extension LifetimeDependenceUseDefWalker {
   mutating func walkUpDefault(dependent value: Value, owner: Value?)
     -> WalkResult {
     switch value.definingInstruction {
-    case let copyInst as CopyValueInst:
-      return walkUp(newLifetime: copyInst.fromValue)
-    case let moveInst as MoveValueInst:
-      return walkUp(value: moveInst.fromValue, owner)
-    case let borrow as BeginBorrowInst:
-      return walkUp(newLifetime: borrow.borrowedValue)
+    case let transition as OwnershipTransitionInstruction:
+      return walkUp(newLifetime: transition.operand.value)
     case let load as LoadInstruction:
       return walkUp(address: load.address)
     case let markDep as MarkDependenceInst:
@@ -862,11 +858,8 @@ extension LifetimeDependenceDefUseWalker {
       return leafUse(of: operand)
     }
     switch operand.instruction {
-    case let copy as CopyingInstruction:
-      return walkDownUses(of: copy, using: operand)
-
-    case let move as MoveValueInst:
-      return walkDownUses(of: move, using: operand)
+    case let transition as OwnershipTransitionInstruction:
+      return walkDownUses(of: transition.ownershipResult, using: operand)
 
     case let mdi as MarkDependenceInst where mdi.isUnresolved:
       // Override mark_dependence [unresolved] to handle them just

--- a/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
@@ -265,6 +265,12 @@ extension MoveOnlyWrapperToCopyableValueInst : ConversionInstruction {
   public var canForwardOwnedValues: Bool { true }
 }
 
+extension MoveOnlyWrapperToCopyableBoxInst : ConversionInstruction {
+  public var preservesRepresentation: Bool { true }
+  public var canForwardGuaranteedValues: Bool { true }
+  public var canForwardOwnedValues: Bool { true }
+}
+
 extension UpcastInst : ConversionInstruction {
   public var preservesRepresentation: Bool { true }
   public var canForwardGuaranteedValues: Bool { true }
@@ -381,12 +387,6 @@ extension SwitchEnumInst : ForwardingInstruction {
 }
 
 extension MarkUnresolvedReferenceBindingInst : ForwardingInstruction {
-  public var preservesRepresentation: Bool { true }
-  public var canForwardGuaranteedValues: Bool { true }
-  public var canForwardOwnedValues: Bool { true }
-}
-
-extension MoveOnlyWrapperToCopyableBoxInst : ForwardingInstruction {
   public var preservesRepresentation: Bool { true }
   public var canForwardGuaranteedValues: Bool { true }
   public var canForwardOwnedValues: Bool { true }

--- a/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
@@ -58,21 +58,6 @@ extension ForwardingInstruction {
   }
 }
 
-// An instruction that forwards a single value to a single result.
-//
-// For legacy reasons, some ForwardingInstructions that fit the
-// SingleValueInstruction and UnaryInstruction requirements are not
-// considered ConversionInstructions because certain routines do not
-// want to see through them (InitExistentialValueInst,
-// DeinitExistentialValueInst, OpenExistentialValueInst,
-// OpenExistentialValueInst). This most likely has to do with
-// type-dependent operands, although any ConversionInstruction should
-// support type-dependent operands.
-public protocol ConversionInstruction : SingleValueInstruction,
-                                        UnaryInstruction,
-                                        ForwardingInstruction
-{}
-
 extension Value {
   // If this value is produced by a ForwardingInstruction, return that instruction. This is convenient for following the forwarded value chain.
   // Unlike definingInstruction, a value's forwardingInstruction is not necessarily a valid insertion point. 
@@ -231,6 +216,18 @@ extension TuplePackExtractInst : ForwardingInstruction {
 
 // -----------------------------------------------------------------------------
 // conversion instructions
+
+/// An instruction that forwards a single value to a single result.
+///
+/// For legacy reasons, some ForwardingInstructions that fit the
+/// SingleValueInstruction and UnaryInstruction requirements are not
+/// considered ConversionInstructions because certain routines do not
+/// want to see through them (InitExistentialValueInst,
+/// DeinitExistentialValueInst, OpenExistentialValueInst,
+/// OpenExistentialValueInst). This most likely has to do with
+/// type-dependent operands, although any ConversionInstruction should
+/// support type-dependent operands.
+public protocol ConversionInstruction : SingleValueInstruction, UnaryInstruction, ForwardingInstruction {}
 
 extension MarkUnresolvedNonCopyableValueInst : ConversionInstruction {
   public var preservesRepresentation: Bool { true }

--- a/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
@@ -397,3 +397,33 @@ extension LinearFunctionExtractInst: ForwardingInstruction {
   public var canForwardGuaranteedValues: Bool { true }
   public var canForwardOwnedValues: Bool { true }
 }
+
+// -----------------------------------------------------------------------------
+// ownership transition instructions
+
+/// An instruction that transfers lifetime dependence from a single operand to a single result. The operand and result
+/// have the same identity, but they are not part of the same forwarded lifetime:
+/// copy_value, move_value, begin_borrow.
+public protocol OwnershipTransitionInstruction: UnaryInstruction {
+  var ownershipResult: Value { get }
+}
+
+extension OwnershipTransitionInstruction where Self: SingleValueInstruction {
+  public var ownershipResult: Value { self }
+}
+
+// CopyingInstruction implies OwnershipTransitionInstruction
+
+extension MoveValueInst: OwnershipTransitionInstruction {}
+
+extension BeginBorrowInst: OwnershipTransitionInstruction {}
+
+extension BeginCOWMutationInst: OwnershipTransitionInstruction {
+  public var ownershipResult: Value { instanceResult }
+}
+
+extension EndCOWMutationInst: OwnershipTransitionInstruction {}
+
+extension EndInitLetRefInst: OwnershipTransitionInstruction {}
+
+extension BeginDeallocRefInst: OwnershipTransitionInstruction {}

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -452,7 +452,7 @@ final public class UnconditionalCheckedCastAddrInst : Instruction {
 final public class EndApplyInst : Instruction, UnaryInstruction {}
 final public class AbortApplyInst : Instruction, UnaryInstruction {}
 
-final public class BeginDeallocRefInst : SingleValueInstruction {
+final public class BeginDeallocRefInst : SingleValueInstruction, UnaryInstruction {
   public var reference: Value { operands[0].value }
   public var allocation: AllocRefInstBase { operands[1].value as! AllocRefInstBase }
 }
@@ -1043,16 +1043,16 @@ final public class ProjectExistentialBoxInst : SingleValueInstruction, UnaryInst
 
 public protocol CopyingInstruction : SingleValueInstruction, UnaryInstruction {}
 
-final public class CopyValueInst : SingleValueInstruction, UnaryInstruction, CopyingInstruction {
+final public class CopyValueInst : SingleValueInstruction, CopyingInstruction {
   public var fromValue: Value { operand.value }
 }
 
-final public class ExplicitCopyValueInst : SingleValueInstruction, UnaryInstruction, CopyingInstruction {
+final public class ExplicitCopyValueInst : SingleValueInstruction, CopyingInstruction {
   public var fromValue: Value { operand.value }
 }
 
-final public class UnownedCopyValueInst : SingleValueInstruction, UnaryInstruction, CopyingInstruction {}
-final public class WeakCopyValueInst : SingleValueInstruction, UnaryInstruction, CopyingInstruction {}
+final public class UnownedCopyValueInst : SingleValueInstruction, CopyingInstruction {}
+final public class WeakCopyValueInst : SingleValueInstruction, CopyingInstruction {}
 
 final public class UncheckedOwnershipConversionInst : SingleValueInstruction {}
 
@@ -1245,8 +1245,7 @@ final public class AllocExistentialBoxInst : SingleValueInstruction, Allocation 
 //                            multi-value instructions
 //===----------------------------------------------------------------------===//
 
-final public class BeginCOWMutationInst : MultipleValueInstruction,
-                                          UnaryInstruction {
+final public class BeginCOWMutationInst : MultipleValueInstruction, UnaryInstruction {
   public var instance: Value { operand.value }
   public var uniquenessResult: Value { return getResult(index: 0) }
   public var instanceResult: Value { return getResult(index: 1) }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1041,7 +1041,7 @@ final public class ProjectBoxInst : SingleValueInstruction, UnaryInstruction {
 
 final public class ProjectExistentialBoxInst : SingleValueInstruction, UnaryInstruction {}
 
-public protocol CopyingInstruction : SingleValueInstruction, UnaryInstruction {}
+public protocol CopyingInstruction : SingleValueInstruction, UnaryInstruction, OwnershipTransitionInstruction {}
 
 final public class CopyValueInst : SingleValueInstruction, CopyingInstruction {
   public var fromValue: Value { operand.value }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -983,12 +983,18 @@ final public class BridgeObjectToRefInst : SingleValueInstruction, UnaryInstruct
 
 final public class BridgeObjectToWordInst : SingleValueInstruction, UnaryInstruction {}
 
-public typealias AccessKind = BridgedInstruction.AccessKind
-
-
 // TODO: add support for begin_unpaired_access
 final public class BeginAccessInst : SingleValueInstruction, UnaryInstruction {
-  public var accessKind: AccessKind { bridged.BeginAccessInst_getAccessKind() }
+  // The raw values must match SILAccessKind.
+  public enum AccessKind: Int {
+    case `init` = 0
+    case read = 1
+    case modify = 2
+    case `deinit` = 3
+  }
+  public var accessKind: AccessKind {
+    AccessKind(rawValue: bridged.BeginAccessInst_getAccessKind())!
+  }
 
   public var isStatic: Bool { bridged.BeginAccessInst_isStatic() }
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1115,8 +1115,7 @@ final public class IsUniqueInst : SingleValueInstruction, UnaryInstruction {}
 
 final public class IsEscapingClosureInst : SingleValueInstruction, UnaryInstruction {}
 
-final public class MarkUnresolvedNonCopyableValueInst
-  : SingleValueInstruction, UnaryInstruction {}
+final public class MarkUnresolvedNonCopyableValueInst: SingleValueInstruction, UnaryInstruction {}
 
 final public class MarkUnresolvedReferenceBindingInst : SingleValueInstruction {}
 
@@ -1125,13 +1124,11 @@ final public class MarkUnresolvedMoveAddrInst : Instruction, SourceDestAddrInstr
   public var isInitializationOfDest: Bool { true }
 }
 
-final public class CopyableToMoveOnlyWrapperValueInst
-  : SingleValueInstruction, UnaryInstruction {}
+final public class CopyableToMoveOnlyWrapperValueInst: SingleValueInstruction, UnaryInstruction {}
 
-final public class MoveOnlyWrapperToCopyableValueInst
-  : SingleValueInstruction, UnaryInstruction {}
+final public class MoveOnlyWrapperToCopyableValueInst: SingleValueInstruction, UnaryInstruction {}
 
-final public class MoveOnlyWrapperToCopyableBoxInst : SingleValueInstruction {}
+final public class MoveOnlyWrapperToCopyableBoxInst: SingleValueInstruction, UnaryInstruction {}
 
 final public class CopyableToMoveOnlyWrapperAddrInst
   : SingleValueInstruction, UnaryInstruction {}

--- a/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
@@ -158,15 +158,15 @@ public enum AccessBase : CustomStringConvertible, Hashable {
     }
   }
 
-  /// True, if the address is immediately produced by an allocation in its function.
+  /// True, if the address is produced by an allocation in its function.
   public var isLocal: Bool {
     switch self {
-      case .box(let pbi):      return pbi.box is AllocBoxInst
-      case .class(let rea):    return rea.instance is AllocRefInstBase
-      case .tail(let rta):     return rta.instance is AllocRefInstBase
-      case .stack:             return true
-      case .global, .argument, .yield, .pointer, .unidentified:
-        return false
+    case .box(let pbi):      return pbi.box.referenceRoot is AllocBoxInst
+    case .class(let rea):    return rea.instance.referenceRoot is AllocRefInstBase
+    case .tail(let rta):     return rta.instance.referenceRoot is AllocRefInstBase
+    case .stack:             return true
+    case .global, .argument, .yield, .pointer, .unidentified:
+      return false
     }
   }
 
@@ -241,7 +241,7 @@ public enum AccessBase : CustomStringConvertible, Hashable {
     // First handle all pairs of the same kind (except `yield` and `pointer`).
     case (.box(let pb), .box(let otherPb)):
       return pb.fieldIndex != otherPb.fieldIndex ||
-             isDifferentAllocation(pb.box, otherPb.box)
+        isDifferentAllocation(pb.box.referenceRoot, otherPb.box.referenceRoot)
     case (.stack(let asi), .stack(let otherAsi)):
       return asi != otherAsi
     case (.global(let global), .global(let otherGlobal)):
@@ -542,7 +542,7 @@ extension Value {
     return .base(walker.result.base)
   }
 
-  /// The root definition of a reference, obtained by skipping casts, etc.
+  /// The root definition of a reference, obtained by skipping ownership forwarding and ownership transition.
   public var referenceRoot: Value {
     var value: Value = self
     while true {

--- a/include/swift/SIL/InstWrappers.h
+++ b/include/swift/SIL/InstWrappers.h
@@ -111,6 +111,8 @@ struct ConversionOperation {
 
   static bool isa(SILInstruction *inst) {
     switch (inst->getKind()) {
+    case SILInstructionKind::MarkUnresolvedNonCopyableValueInst:
+    case SILInstructionKind::MarkUninitializedInst:
     case SILInstructionKind::ConvertFunctionInst:
     case SILInstructionKind::UpcastInst:
     case SILInstructionKind::AddressToPointerInst:
@@ -135,6 +137,9 @@ struct ConversionOperation {
     case SILInstructionKind::RefToUnownedInst:
     case SILInstructionKind::UnmanagedToRefInst:
     case SILInstructionKind::UnownedToRefInst:
+    case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:
+    case SILInstructionKind::MoveOnlyWrapperToCopyableValueInst:
+    case SILInstructionKind::MoveOnlyWrapperToCopyableBoxInst:
       return true;
     default:
       return false;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -811,13 +811,6 @@ struct BridgedInstruction {
     bool hasValue;
   };
 
-  enum class AccessKind {
-    Init,
-    Read,
-    Modify,
-    Deinit
-  };
-
   enum class MarkDependenceKind {
     Unresolved, Escaping, NonEscaping
   };
@@ -887,7 +880,7 @@ struct BridgedInstruction {
   BRIDGED_INLINE SwiftInt AssignInst_getAssignOwnership() const;
   BRIDGED_INLINE MarkDependenceKind MarkDependenceInst_dependenceKind() const;
   BRIDGED_INLINE void MarkDependenceInst_resolveToNonEscaping() const;
-  BRIDGED_INLINE AccessKind BeginAccessInst_getAccessKind() const;
+  BRIDGED_INLINE SwiftInt BeginAccessInst_getAccessKind() const;
   BRIDGED_INLINE bool BeginAccessInst_isStatic() const;
   BRIDGED_INLINE bool CopyAddrInst_isTakeOfSrc() const;
   BRIDGED_INLINE bool CopyAddrInst_isInitializationOfDest() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1134,8 +1134,8 @@ void BridgedInstruction::MarkDependenceInst_resolveToNonEscaping() const {
   getAs<swift::MarkDependenceInst>()->resolveToNonEscaping();
 }
 
-BridgedInstruction::AccessKind BridgedInstruction::BeginAccessInst_getAccessKind() const {
-  return (AccessKind)getAs<swift::BeginAccessInst>()->getAccessKind();
+SwiftInt BridgedInstruction::BeginAccessInst_getAccessKind() const {
+  return (SwiftInt)getAs<swift::BeginAccessInst>()->getAccessKind();
 }
 
 bool BridgedInstruction::BeginAccessInst_isStatic() const {

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -795,7 +795,6 @@ bool swift::isIdentityPreservingRefCast(SingleValueInstruction *svi) {
   return isa<CopyValueInst>(svi) || isa<BeginBorrowInst>(svi) ||
          isa<EndInitLetRefInst>(svi) || isa<BeginDeallocRefInst>(svi) ||
          isa<EndCOWMutationInst>(svi) ||
-         isa<MarkUnresolvedReferenceBindingInst>(svi) ||
          isIdentityAndOwnershipPreservingRefCast(svi);
 }
 
@@ -824,6 +823,7 @@ bool swift::isIdentityAndOwnershipPreservingRefCast(
   // Ignore markers
   case SILInstructionKind::MarkUninitializedInst:
   case SILInstructionKind::MarkDependenceInst:
+  case SILInstructionKind::MarkUnresolvedReferenceBindingInst:
     return true;
   }
 }

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -402,11 +402,6 @@ static_assert((int)BridgedMemoryBehavior::MayWrite == (int)swift::MemoryBehavior
 static_assert((int)BridgedMemoryBehavior::MayReadWrite == (int)swift::MemoryBehavior::MayReadWrite);
 static_assert((int)BridgedMemoryBehavior::MayHaveSideEffects == (int)swift::MemoryBehavior::MayHaveSideEffects);
 
-static_assert((int)BridgedInstruction::AccessKind::Init == (int)swift::SILAccessKind::Init);
-static_assert((int)BridgedInstruction::AccessKind::Read == (int)swift::SILAccessKind::Read);
-static_assert((int)BridgedInstruction::AccessKind::Modify == (int)swift::SILAccessKind::Modify);
-static_assert((int)BridgedInstruction::AccessKind::Deinit == (int)swift::SILAccessKind::Deinit);
-
 BridgedOwnedString BridgedInstruction::getDebugDescription() const {
   std::string str;
   llvm::raw_string_ostream os(str);

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -61,18 +61,18 @@ static llvm::cl::opt<bool> SILViewSILGenCFG(
     "sil-view-silgen-cfg", llvm::cl::init(false),
     llvm::cl::desc("Enable the sil cfg viewer pass before diagnostics"));
 
-llvm::cl::opt<bool> EnableDeinitDevirtualizer(
-    "enable-deinit-devirtualizer", llvm::cl::init(false),
-    llvm::cl::desc("Enable the DeinitDevirtualizer pass."));
+static llvm::cl::opt<bool>
+    EnableDeinitDevirtualizer("enable-deinit-devirtualizer", llvm::cl::init(false),
+                          llvm::cl::desc("Enable the DestroyHoisting pass."));
 
 // Temporary flag until the stdlib builds with ~Escapable
-llvm::cl::opt<bool>
+static llvm::cl::opt<bool>
 EnableLifetimeDependenceInsertion(
   "enable-lifetime-dependence-insertion", llvm::cl::init(false),
   llvm::cl::desc("Enable lifetime dependence insertion."));
 
 // Temporary flag until the stdlib builds with ~Escapable
-llvm::cl::opt<bool>
+static llvm::cl::opt<bool>
 EnableLifetimeDependenceDiagnostics(
   "enable-lifetime-dependence-diagnostics", llvm::cl::init(false),
   llvm::cl::desc("Enable lifetime dependence diagnostics."));


### PR DESCRIPTION
No functional change intended. But this does fix holes in the existing utilities and make the Swift/C++ code base more consistent. That might improve the power of some analyses which could affect SIL patterns.

Namely, AccessUtils/MemAccessUtils now finds the actual reference root consistently.