### PR TITLE
[DebugInfo] Emit mangled name of opaque container for debug info

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1463,9 +1463,9 @@ private:
     llvm::Metadata *Elements[] = {DBuilder.createMemberType(
         Scope, "", File, 0, SizeInBits, AlignInBits, 0, Flags, UniqueType)};
     return DBuilder.createStructType(
-        Scope, "", File, Line, SizeInBits, AlignInBits, Flags,
+        Scope, Name, File, Line, SizeInBits, AlignInBits, Flags,
         /* DerivedFrom */ nullptr, DBuilder.getOrCreateArray(Elements),
-        llvm::dwarf::DW_LANG_Swift, nullptr, "", SpecificationOf, 0);
+        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName, SpecificationOf, 0);
   }
 
   llvm::DIType *


### PR DESCRIPTION
With the new SpecifiedOf attribute, consumers of debug info will follow the specification link and copy over any attribute that are not specified in the current type. For this reason, emit the opaque container's mangled name as well, as it may have a different name from the type it specifies.
