### PR TITLE
Fix a test to use SwiftStdlib 6.0 instead of 5.11

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_localSystem_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_generic.swift
@@ -16,7 +16,7 @@
 
 import Distributed
 
-@available(SwiftStdlib 5.11, *)
+@available(SwiftStdlib 6.0, *)
 distributed actor Worker<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable>, ActorSystem.ActorID: Codable {
   distributed func hi(name: String) {
     print("Hi, \(name)!")
@@ -28,7 +28,7 @@ distributed actor Worker<ActorSystem> where ActorSystem: DistributedActorSystem<
 }
 
 // ==== Execute ----------------------------------------------------------------
-@available(SwiftStdlib 5.11, *)
+@available(SwiftStdlib 6.0, *)
 @main struct Main {
   static func main() async throws {
     let system = LocalTestingDistributedActorSystem()


### PR DESCRIPTION
More fallout from the crossed wires with #71796.  CC @xedin.