### PR TITLE
Propagate function subtype conversion information down to closure emission

### DIFF
--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -44,10 +44,13 @@ public:
     BridgeResultFromObjC,
 
     /// An erasure to Any (possibly wrapped in optional conversions).
-    /// This is sortof a bridging conversion.
+    /// This is sortof a bridging conversion?  Really it's more of a
+    /// subtype conversion, but we're calling it out separately here,
+    /// and that's easier.
     AnyErasure,
 
-    LastBridgingKind = AnyErasure,
+    /// A subtype conversion.
+    Subtype,
 
     /// An orig-to-subst conversion.
     OrigToSubst,
@@ -57,12 +60,37 @@ public:
   };
 
   static bool isBridgingKind(KindTy kind) {
-    return kind <= LastBridgingKind;
+    switch (kind) {
+    case BridgeToObjC:
+    case ForceAndBridgeToObjC:
+    case BridgeFromObjC:
+    case BridgeResultFromObjC:
+    case AnyErasure:
+    case Subtype:
+      return true;
+
+    case OrigToSubst:
+    case SubstToOrig:
+      return false;
+    }
+    llvm_unreachable("bad kind");
   }
   
   static bool isReabstractionKind(KindTy kind) {
-    // Update if we end up with more kinds!
-    return !isBridgingKind(kind);
+    switch (kind) {
+    case OrigToSubst:
+    case SubstToOrig:
+      return true;
+
+    case BridgeToObjC:
+    case ForceAndBridgeToObjC:
+    case BridgeFromObjC:
+    case BridgeResultFromObjC:
+    case AnyErasure:
+    case Subtype:
+      return false;
+    }
+    llvm_unreachable("bad kind");
   }
 
 private:
@@ -76,8 +104,11 @@ private:
   };
 
   struct ReabstractionTypes {
+    // Whether this abstraction pattern applies to the input or output
+    // substituted type is determined by the kind.
     AbstractionPattern OrigType;
-    CanType SubstType;
+    CanType SubstSourceType;
+    CanType SubstResultType;
     SILType LoweredResultType;
   };
 
@@ -90,6 +121,7 @@ private:
     case BridgeFromObjC:
     case BridgeResultFromObjC:
     case AnyErasure:
+    case Subtype:
       return Members::indexOf<BridgingTypes>();
 
     case OrigToSubst:
@@ -110,24 +142,32 @@ private:
                                           loweredResultTy, isExplicit);
   }
 
-  Conversion(KindTy kind, AbstractionPattern origType, CanType substType,
-             SILType loweredResultTy)
+  Conversion(KindTy kind, AbstractionPattern origType, CanType substSourceType,
+             CanType substResultType, SILType loweredResultTy)
       : Kind(kind) {
-    Types.emplaceAggregate<ReabstractionTypes>(kind, origType, substType,
-                                               loweredResultTy);
+    Types.emplaceAggregate<ReabstractionTypes>(kind, origType, substSourceType,
+                                               substResultType, loweredResultTy);
   }
 
 public:
   static Conversion getOrigToSubst(AbstractionPattern origType,
                                    CanType substType,
                                    SILType loweredResultTy) {
-    return Conversion(OrigToSubst, origType, substType, loweredResultTy);
+    return Conversion(OrigToSubst, origType, substType, substType, loweredResultTy);
   }
 
   static Conversion getSubstToOrig(AbstractionPattern origType,
                                    CanType substType,
                                    SILType loweredResultTy) {
-    return Conversion(SubstToOrig, origType, substType, loweredResultTy);
+    return Conversion(SubstToOrig, origType, substType, substType, loweredResultTy);
+  }
+
+  static Conversion getSubstToOrig(CanType inputSubstType,
+                                   AbstractionPattern outputOrigType,
+                                   CanType outputSubstType,
+                                   SILType loweredResultTy) {
+    return Conversion(SubstToOrig, outputOrigType, inputSubstType,
+                      outputSubstType, loweredResultTy);
   }
 
   static Conversion getBridging(KindTy kind, CanType origType,
@@ -135,6 +175,11 @@ public:
                                 bool isExplicit = false) {
     assert(isBridgingKind(kind));
     return Conversion(kind, origType, resultType, loweredResultTy, isExplicit);
+  }
+
+  static Conversion getSubtype(CanType origType, CanType substType,
+                               SILType loweredResultTy) {
+    return getBridging(Subtype, origType, substType, loweredResultTy);
   }
 
   KindTy getKind() const {
@@ -153,8 +198,12 @@ public:
     return Types.get<ReabstractionTypes>(Kind).OrigType;
   }
 
-  CanType getReabstractionSubstType() const {
-    return Types.get<ReabstractionTypes>(Kind).SubstType;
+  CanType getReabstractionSubstSourceType() const {
+    return Types.get<ReabstractionTypes>(Kind).SubstSourceType;
+  }
+
+  CanType getReabstractionSubstResultType() const {
+    return Types.get<ReabstractionTypes>(Kind).SubstResultType;
   }
 
   SILType getReabstractionLoweredResultType() const {
@@ -206,7 +255,11 @@ public:
     BridgeToAnyObject,
 
     /// The value just needs to undergo a subtype conversion.
-    Subtype
+    Subtype,
+
+    /// The inner conversion is a subtype conversion and can be done implicitly
+    /// as part of the outer conversion.
+    SubtypeIntoSubstToOrig,
   };
 
 private:
@@ -234,8 +287,8 @@ canPeepholeConversions(SILGenFunction &SGF, const Conversion &outerConversion,
 /// the value before completing the initialization.
 ///
 /// Value generators may call getAsConversion() to check whether an
-/// Initialization is one of these.  If so, they may call either
-/// tryPeephole or setConvertedValue.
+/// Initialization is one of these.  This adds initWithConvertedValue
+/// to the normal set of ways to receive an initializing value.
 class ConvertingInitialization final : public Initialization {
 private:
   enum StateTy {
@@ -301,27 +354,49 @@ public:
 
   // The three ways to perform this initialization:
 
-  /// Set the unconverted value for this initialization.
+  /// Set the converted value for this initialization.
+  ///
+  /// If the converted value has been emitted into the final context, you
+  /// can pass ManagedValue::forInContext() to this function.  In this
+  /// case, you must call finishInitialization on the final initialization
+  /// yourself prior to calling this.  finishEmission will return
+  /// ManagedValue::forInContext().
+  ///
+  /// Otherwise, if the final context exists, this will forward the value
+  /// into it and finish it.  finishEmission will return
+  /// ManagedValue::forInContext().
+  ///
+  /// Otherwise, this will store the value internally, and finishEmission
+  /// will return it.
+  ///
+  /// You must call finishInitialization after calling this.
+  void initWithConvertedValue(SILGenFunction &SGF, SILLocation loc,
+                              ManagedValue value);
+
+  /// Set the unconverted value for this initialization.  The value will
+  /// first be converted.  If the final context has an initialization,
+  /// the converted value will be forwarded into it, and finishEmission
+  /// will return ManagedValue::forInContext().  Otherwise, finishEmission
+  /// will return the converted value.
+  ///
+  /// You must call finishInitialization after calling this.
   void copyOrInitValueInto(SILGenFunction &SGF, SILLocation loc,
                            ManagedValue value, bool isInit) override;
 
   /// Given that the result of the given expression needs to sequentially
   /// undergo the given conversion and then this conversion, attempt to
-  /// peephole the result.  If successful, the value will be set in this
-  /// initialization.  The initialization will not yet be finished.
+  /// peephole the result.
+  ///
+  /// If this returns true, this initialization will have been initialized
+  /// as if initWithConvertedValue has been called.  You must call
+  /// finishInitialization in this path.
+  ///
+  /// Otherwise, there is no state change for the conversion.
   bool tryPeephole(SILGenFunction &SGF, Expr *E, Conversion innerConversion);
   bool tryPeephole(SILGenFunction &SGF, SILLocation loc,
                    Conversion innerConversion, ValueProducerRef producer);
   bool tryPeephole(SILGenFunction &SGF, SILLocation loc, ManagedValue value,
                    Conversion innerConversion);
-
-  /// Set the converted value for this initialization.
-  void setConvertedValue(ManagedValue value) {
-    assert(getState() == Uninitialized);
-    assert(!value.isInContext() || FinalContext.getEmitInto());
-    Value = value;
-    State = Initialized;
-  }
 
   /// Given that an emitter was able to adjust the conversion when
   /// emitting into this initialization, continue emission into the
@@ -348,9 +423,6 @@ public:
     return this;
   }
   
-  // Get the abstraction pattern, if any, the value is converted to.
-  std::optional<AbstractionPattern> getAbstractionPattern() const override;
-
   // Bookkeeping.
   void finishInitialization(SILGenFunction &SGF) override {
     if (getState() == PackExpanding) {

--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -205,16 +205,6 @@ public:
                      "uninitialized");
   }
 
-  /// The preferred abstraction pattern to initialize with.
-  ///
-  /// Returning something other than None here gives expression emission the
-  /// opportunity to generate the initial value directly at the proper
-  /// abstraction level, avoiding the need for a conversion in some
-  /// circumstances.
-  virtual std::optional<AbstractionPattern> getAbstractionPattern() const {
-    return std::nullopt;
-  }
-
 protected:
   bool EmitDebugValueOnInit = true;
 

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -235,6 +235,11 @@ public:
   SILValue getUnmanagedSingleValue(SILGenFunction &SGF, SILLocation l) const &;
 
   ManagedValue getScalarValue() && {
+    if (isInContext()) {
+      makeUsed();
+      return ManagedValue::forInContext();
+    }
+
     assert(!isa<TupleType>(type) && "getScalarValue of a tuple rvalue");
     assert(values.size() == 1);
     auto value = values[0];

--- a/lib/SILGen/SGFContext.h
+++ b/lib/SILGen/SGFContext.h
@@ -167,14 +167,6 @@ public:
 
     return SGFContext();
   }
-  
-  /// Return the abstraction pattern of the context we're emitting into.
-  std::optional<AbstractionPattern> getAbstractionPattern() const {
-    if (auto *init = getEmitInto()) {
-      return init->getAbstractionPattern();
-    }
-    return std::nullopt;
-  }
 };
 
 using ValueProducerRef =

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -305,7 +305,9 @@ public:
 
   /// Generates code for the given closure expression and adds the
   /// SILFunction to the current SILModule under the name SILDeclRef(ce).
-  SILFunction *emitClosure(AbstractClosureExpr *ce);
+  SILFunction *emitClosure(AbstractClosureExpr *ce,
+                           const FunctionTypeInfo &closureInfo);
+
   /// Generates code for the given ConstructorDecl and adds
   /// the SILFunction to the current SILModule under the name SILDeclRef(decl).
   void emitConstructor(ConstructorDecl *decl);

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1170,6 +1170,22 @@ emitPeepholedConversions(SILGenFunction &SGF, SILLocation loc,
   case ConversionPeepholeHint::Identity:
     return produceValue(C);
 
+  case ConversionPeepholeHint::SubtypeIntoSubstToOrig: {
+    assert(!hint.isForced());
+    assert(innerConversion.getKind() == Conversion::Subtype);
+    assert(outerConversion.getKind() == Conversion::SubstToOrig);
+    // The outer conversion's source type is somewhere between
+    // the inner conversion's source type and the outer conversion's result
+    // type, but subtyping is not path-dependent (right?) so we shouldn't
+    // have to preserve it.
+    auto newConversion = Conversion::getSubstToOrig(
+      innerConversion.getBridgingSourceType(),
+      outerConversion.getReabstractionOrigType(),
+      outerConversion.getReabstractionSubstResultType(),
+      outerConversion.getReabstractionLoweredResultType());
+    return SGF.emitConvertedRValue(loc, newConversion, C, produceOrigValue);
+  }
+
   case ConversionPeepholeHint::BridgeToAnyObject: {
     auto value = produceValue(SGFContext());
     return SGF.emitNativeToBridgedValue(loc, value, getBridgingSourceType(),
@@ -1181,6 +1197,7 @@ emitPeepholedConversions(SILGenFunction &SGF, SILLocation loc,
     // Otherwise, emit and convert.
     // TODO: if the context allows +0, use it in more situations.
     auto value = produceValue(SGFContext());
+
     SILType loweredResultTy = getBridgingLoweredResultType();
 
     // Nothing to do if the value already has the right representation.
@@ -1225,16 +1242,7 @@ bool ConvertingInitialization::tryPeephole(SILGenFunction &SGF, SILLocation loc,
   ManagedValue value = emitPeepholedConversions(SGF, loc, outerConversion,
                                                 innerConversion, *hint,
                                                 FinalContext, produceValue);
-  
-  // The callers to tryPeephole assume that the initialization is ready to be
-  // finalized after returning. If this conversion sits on top of another
-  // initialization, forward the value into the underlying initialization and
-  // report the value as emitted in context.
-  if (FinalContext.getEmitInto() && !value.isInContext()) {
-    value.ensurePlusOne(SGF, loc).forwardInto(SGF, loc, FinalContext.getEmitInto());
-    value = ManagedValue::forInContext();
-  }
-  setConvertedValue(value);
+  initWithConvertedValue(SGF, loc, value);
   return true;
 }
 
@@ -1246,14 +1254,28 @@ void ConvertingInitialization::copyOrInitValueInto(SILGenFunction &SGF,
 
   // TODO: take advantage of borrowed inputs?
   if (!isInit) formalValue = formalValue.copy(SGF, loc);
-  State = Initialized;
-  
-  Value = TheConversion.emit(SGF, loc, formalValue, FinalContext);
-  
-  if (FinalContext.getEmitInto() && !Value.isInContext()) {
-    Value.forwardInto(SGF, loc, FinalContext.getEmitInto());
-    Value = ManagedValue::forInContext();
+
+  // Convert the value.
+  auto value = TheConversion.emit(SGF, loc, formalValue, FinalContext);
+
+ initWithConvertedValue(SGF, loc, value);
+}
+
+void ConvertingInitialization::initWithConvertedValue(SILGenFunction &SGF,
+                                                      SILLocation loc,
+                                                      ManagedValue value) {
+  assert(getState() == Uninitialized);
+  auto finalInit = FinalContext.getEmitInto();
+  if (value.isInContext()) {
+    assert(finalInit);
+  } else if (finalInit) {
+    value.ensurePlusOne(SGF, loc).forwardInto(SGF, loc, finalInit);
+    value = ManagedValue::forInContext();
   }
+
+  assert(value.isInContext() == (finalInit != nullptr));
+  Value = value;
+  State = Initialized;
 }
 
 ManagedValue
@@ -1264,23 +1286,16 @@ ConvertingInitialization::emitWithAdjustedConversion(SILGenFunction &SGF,
   ConvertingInitialization init(adjustedConversion, getFinalContext());
   auto result = produceValue(SGF, loc, SGFContext(&init));
   result = init.finishEmission(SGF, loc, result);
-  setConvertedValue(result);
+  initWithConvertedValue(SGF, loc, result);
   finishInitialization(SGF);
   return ManagedValue::forInContext();
-}
-
-std::optional<AbstractionPattern>
-ConvertingInitialization::getAbstractionPattern() const {
-  if (TheConversion.isReabstraction()) {
-    return TheConversion.getReabstractionOrigType();
-  }
-  return std::nullopt;
 }
 
 ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
                               ManagedValue value, SGFContext C) const {
   switch (getKind()) {
   case AnyErasure:
+  case Subtype:
     return SGF.emitTransformedValue(loc, value, getBridgingSourceType(),
                                     getBridgingResultType(), C);
 
@@ -1315,15 +1330,19 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
                                         /*isResult*/ true);
 
   case SubstToOrig:
-    return SGF.emitSubstToOrigValue(loc, value,
+    return SGF.emitTransformedValue(loc, value,
+                 AbstractionPattern(getReabstractionSubstSourceType()),
+                                    getReabstractionSubstSourceType(),
                                     getReabstractionOrigType(),
-                                    getReabstractionSubstType(),
+                                    getReabstractionSubstResultType(),
                                     getReabstractionLoweredResultType(), C);
 
   case OrigToSubst:
-    return SGF.emitOrigToSubstValue(loc, value,
+    return SGF.emitTransformedValue(loc, value,
                                     getReabstractionOrigType(),
-                                    getReabstractionSubstType(),
+                                    getReabstractionSubstSourceType(),
+                 AbstractionPattern(getReabstractionSubstResultType()),
+                                    getReabstractionSubstResultType(),
                                     getReabstractionLoweredResultType(), C);
   }
   llvm_unreachable("bad kind");
@@ -1340,6 +1359,7 @@ Conversion::adjustForInitialOptionalConversions(CanType newSourceType) const {
   case ForceAndBridgeToObjC:
     return std::nullopt;
 
+  case Subtype:
   case AnyErasure:
   case BridgeToObjC:
   case BridgeFromObjC:
@@ -1360,6 +1380,7 @@ std::optional<Conversion> Conversion::adjustForInitialForceValue() const {
   case BridgeFromObjC:
   case BridgeResultFromObjC:
   case ForceAndBridgeToObjC:
+  case Subtype:
     return std::nullopt;
 
   case BridgeToObjC: {
@@ -1384,8 +1405,10 @@ static void printReabstraction(const Conversion &conversion,
                                llvm::raw_ostream &out, StringRef name) {
   out << name << "(orig: ";
   conversion.getReabstractionOrigType().print(out);
-  out << ", subst: ";
-  conversion.getReabstractionSubstType().print(out);
+  out << ", substSource: ";
+  conversion.getReabstractionSubstSourceType().print(out);
+  out << ", substResult: ";
+  conversion.getReabstractionSubstResultType().print(out);
   out << ", loweredResult: ";
   conversion.getReabstractionLoweredResultType().print(out);
   out << ')';
@@ -1408,6 +1431,8 @@ void Conversion::print(llvm::raw_ostream &out) const {
     return printReabstraction(*this, out, "OrigToSubst");
   case AnyErasure:
     return printBridging(*this, out, "AnyErasure");
+  case Subtype:
+    return printBridging(*this, out, "Subtype");
   case BridgeToObjC:
     return printBridging(*this, out, "BridgeToObjC");
   case ForceAndBridgeToObjC:
@@ -1500,6 +1525,8 @@ static bool isMatchedAnyToAnyObjectConversion(CanType from, CanType to) {
   return false;
 }
 
+/// TODO: this would really be a lot cleaner if it just returned a
+/// std::optional<Conversion>.
 std::optional<ConversionPeepholeHint>
 Lowering::canPeepholeConversions(SILGenFunction &SGF,
                                  const Conversion &outerConversion,
@@ -1515,17 +1542,28 @@ Lowering::canPeepholeConversions(SILGenFunction &SGF,
 
       if (innerConversion.getReabstractionOrigType().getCachingKey() !=
           outerConversion.getReabstractionOrigType().getCachingKey() ||
-          innerConversion.getReabstractionSubstType() !=
-          outerConversion.getReabstractionSubstType()) {
+          innerConversion.getReabstractionSubstSourceType() !=
+          outerConversion.getReabstractionSubstResultType()) {
         break;
       }
 
       return ConversionPeepholeHint(ConversionPeepholeHint::Identity, false);
 
+    case Conversion::Subtype:
+      if (outerConversion.getKind() == Conversion::SubstToOrig)
+        return ConversionPeepholeHint(
+                 ConversionPeepholeHint::SubtypeIntoSubstToOrig, false);
+      break;
+
     default:
       break;
     }
 
+    return std::nullopt;
+
+  case Conversion::Subtype:
+    if (innerConversion.getKind() == Conversion::Subtype)
+      return ConversionPeepholeHint(ConversionPeepholeHint::Subtype, false);
     return std::nullopt;
 
   case Conversion::AnyErasure:

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -705,6 +705,12 @@ public:
     return SGM.Types.getConstantInfo(context, constant);
   }
 
+  /// Return the normal local type-lowering information for the given
+  /// formal function type without any special abstraction pattern applied.
+  /// This matches the type that `emitRValue` etc. are expected to produce
+  /// without any contextual overrides.
+  FunctionTypeInfo getFunctionTypeInfo(CanAnyFunctionType fnType);
+
   bool isEmittingTopLevelCode() { return IsEmittingTopLevelCode; }
   void stopEmittingTopLevelCode() { IsEmittingTopLevelCode = false; }
 
@@ -1714,9 +1720,8 @@ public:
   /// given. The result is re-abstracted to the given expected type.
   ManagedValue emitClosureValue(SILLocation loc,
                                 SILDeclRef function,
-                                CanType expectedType,
-                                SubstitutionMap subs,
-                                bool alreadyConverted);
+                                const FunctionTypeInfo &typeContext,
+                                SubstitutionMap subs);
 
   PreparedArguments prepareSubscriptIndices(SILLocation loc,
                                             SubscriptDecl *subscript,

--- a/test/Distributed/Runtime/distributed_actor_localSystem_generic.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_generic.swift
@@ -16,7 +16,7 @@
 
 import Distributed
 
-@available(SwiftStdlib 5.11, *)
+@available(SwiftStdlib 6.0, *)
 distributed actor Worker<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable>, ActorSystem.ActorID: Codable {
   distributed func hi(name: String) {
     print("Hi, \(name)!")
@@ -28,7 +28,7 @@ distributed actor Worker<ActorSystem> where ActorSystem: DistributedActorSystem<
 }
 
 // ==== Execute ----------------------------------------------------------------
-@available(SwiftStdlib 5.11, *)
+@available(SwiftStdlib 6.0, *)
 @main struct Main {
   static func main() async throws {
     let system = LocalTestingDistributedActorSystem()

--- a/test/SILGen/existential_member_accesses_self_assoctype.swift
+++ b/test/SILGen/existential_member_accesses_self_assoctype.swift
@@ -696,19 +696,12 @@ func testCovariantAssocMethod6Constrained(p2: any P2) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype36testCovariantAssocMethod7Constrained2p2yAA2P2_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P2 to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P2) Self
 // CHECK: function_ref thunk for @callee_guaranteed (@guaranteed Class & P) -> ()
-// CHECK-NEXT: [[THUNK1:%[0-9]+]] = function_ref @$s42existential_member_accesses_self_assoctype1P_AA5ClassCXcIgg_1AAaBPQzIegg_AA2P2RzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : P2> (@guaranteed τ_0_0.A, @guaranteed @noescape @callee_guaranteed (@guaranteed any Class & P) -> ()) -> ()
-// CHECK: [[STEP1:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK1]]<@opened([[OPENED_ID]], any P2) Self>
-// CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@guaranteed @opened([[OPENED_ID]], any P2) Self.A) -> () to $@callee_guaranteed @substituted <τ_0_0 where τ_0_0 : _NativeClass> (@guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P2) Self.A>
-// CHECK: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
-// CHECK: [[STEP4:%[0-9]+]] = convert_function [[STEP3]] : $@noescape @callee_guaranteed @substituted <τ_0_0 where τ_0_0 : _NativeClass> (@guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P2) Self.A> to $@noescape @callee_guaranteed (@guaranteed @opened([[OPENED_ID]], any P2) Self.A) -> ()
-// FIXME: 'A.P.A' is a rather weird way to print (@opened P2).A
-// CHECK: function_ref thunk for @callee_guaranteed (@guaranteed A.P.A) -> ()
-// CHECK: [[THUNK2:%[0-9]+]] = function_ref @$s1A42existential_member_accesses_self_assoctype1PPQzIgg_AEIegn_AB2P2RzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0.A, @guaranteed @noescape @callee_guaranteed (@guaranteed τ_0_0.A) -> ()) -> ()
-// CHECK: [[STEP5:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK2]]<@opened([[OPENED_ID]], any P2) Self>([[STEP4]])
-// CHECK: [[STEP6:%[0-9]+]] = convert_function [[STEP5]] : $@callee_guaranteed (@in_guaranteed @opened([[OPENED_ID]], any P2) Self.A) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P2) Self.A>
-// CHECK: [[STEP7:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP6]]
-// CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod7 : <Self where Self : P> (Self) -> ((Self.A) -> ()) -> ()
-// CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>([[STEP7]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0.A>, @in_guaranteed τ_0_0) -> ()
+// CHECK-NEXT: [[THUNK1:%[0-9]+]] = function_ref @$s42existential_member_accesses_self_assoctype1P_AA5ClassCXcIgg_1AAaBPQzIegn_AA2P2RzlTR : $@convention(thin) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0.A, @guaranteed @noescape @callee_guaranteed (@guaranteed any Class & P) -> ()) -> ()
+// CHECK-NEXT: [[STEP1:%[0-9]+]] = partial_apply [callee_guaranteed] [[THUNK1]]<@opened([[OPENED_ID]], any P2) Self>
+// CHECK-NEXT: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] :  $@callee_guaranteed (@in_guaranteed @opened([[OPENED_ID]], any P2) Self.A) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P2) Self.A>
+// CHECK-NEXT: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
+// CHECK-NEXT: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P2) Self, #P.covariantAssocMethod7 : <Self where Self : P> (Self) -> ((Self.A) -> ()) -> ()
+// CHECK-NEXT: apply [[WITNESS]]<@opened([[OPENED_ID]], any P2) Self>([[STEP3]], [[OPENED]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@guaranteed @noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0.A>, @in_guaranteed τ_0_0) -> ()
 func testCovariantAssocMethod7Constrained(p2: any P2) {
   p2.covariantAssocMethod7 { _ in }
 }

--- a/test/SILGen/reabstract.swift
+++ b/test/SILGen/reabstract.swift
@@ -29,10 +29,11 @@ func test0() {
 // CHECK-NEXT: [[T4:%.*]] = partial_apply [callee_guaranteed] [[T3]]([[CVT]])
 // CHECK-NEXT: [[T5:%.*]] = convert_function [[T4]]
 // CHECK-NEXT: [[CVT:%.*]] = convert_escape_to_noescape [not_guaranteed] [[T5]]
-// CHECK: destroy_value [[T5]]
-// CHECK:      [[T0:%.*]] = function_ref @$s10reabstract6takeFn{{[_0-9a-zA-Z]*}}F
+// CHECK-NEXT: // function_ref
+// CHECK-NEXT: [[T0:%.*]] = function_ref @$s10reabstract6takeFn{{[_0-9a-zA-Z]*}}F
 // CHECK-NEXT: apply [[T0]]<Int>([[CVT]])
 // CHECK-NEXT: destroy_value [[CVT]]
+// CHECK-NEXT: destroy_value [[T5]]
 // CHECK-NEXT: tuple ()
 // CHECK-NEXT: return
 // CHECK-NEXT: } // end sil function '$s10reabstract5test0yyF'

--- a/test/SILGen/typed_throws.swift
+++ b/test/SILGen/typed_throws.swift
@@ -290,7 +290,9 @@ func formerReabstractionCrash() {
   // CHECK-LABEL: sil private [ossa] @$s12typed_throws24formerReabstractionCrashyyFAA8MyResultOySSs5Error_pGyXEfU_ : $@convention(thin) () -> @owned MyResult<String, any Error> {
   // CHECK: function_ref @$s12typed_throws24formerReabstractionCrashyyFAA8MyResultOySSs5Error_pGyXEfU_SSyXEfU_ : $@convention(thin) () -> @owned String
   // CHECK-NEXT: thin_to_thick_function
-  // CHECK-NEXT: convert_function {{%.*}} : $@noescape @callee_guaranteed () -> @owned String to $@noescape @callee_guaranteed () -> (@owned String, @error any Error)
+  // CHECK-NEXT: // function_ref thunk
+  // CHECK-NEXT: function_ref @$sSSIgo_SSs5Error_pIegrzr_TR : $@convention(thin) (@guaranteed @noescape @callee_guaranteed () -> @owned String) -> (@out String, @error_indirect any Error)
+  // CHECK-NEXT: partial_apply
   let _: MyResult<String, Error>? = {
     return MyResult{"hello"}
   }()

--- a/test/SILOptimizer/closure_lifetime_fixup.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup.swift
@@ -131,7 +131,7 @@ func useGenericClosureThrowing<T, V>(_ c: (T) throws -> V) throws {
 // CHECK: function_ref @$s22closure_lifetime_fixup17useGenericClosureyyq_xXEr0_lF
 
 // CHECK: partial_apply [callee_guaranteed] [on_stack]
-// CHECK: function_ref @$ss5Error_pIgzo_ytytsAA_pIegnrzo_TR
+// CHECK: function_ref @$sIg_ytyts5Error_pIegnrzo_TR
 // CHECK: partial_apply [callee_guaranteed] [on_stack]
 // CHECK: function_ref @$s22closure_lifetime_fixup25useGenericClosureThrowingyyq_xKXEKr0_l
 public func captureClass(c: C, d: C) throws {
@@ -172,7 +172,7 @@ public protocol DoIt {
 // CHECK: function_ref @$s22closure_lifetime_fixup17useGenericClosureyyq_xXEr0_lF
 
 // CHECK: partial_apply [callee_guaranteed] [on_stack]
-// CHECK: function_ref @$ss5Error_pIgzo_ytytsAA_pIegnrzo_TR
+// CHECK: function_ref @$sIg_ytyts5Error_pIegnrzo_TR
 // CHECK: partial_apply [callee_guaranteed] [on_stack]
 // CHECK: function_ref @$s22closure_lifetime_fixup25useGenericClosureThrowingyyq_xKXEKr0_lF
 public func captureGeneric<C :DoIt,D: DoIt>(c: C, d: D) throws {
@@ -211,7 +211,7 @@ public func captureGeneric<C :DoIt,D: DoIt>(c: C, d: D) throws {
 // CHECK: function_ref @$s22closure_lifetime_fixup17useGenericClosureyyq_xXEr0_lF
 
 // CHECK:  partial_apply [callee_guaranteed] [on_stack]
-// CHECK:  function_ref @$ss5Error_pIgzo_ytytsAA_pIegnrzo_TR
+// CHECK:  function_ref @$sIg_ytyts5Error_pIegnrzo_TR
 // CHECK:  partial_apply [callee_guaranteed] [on_stack]
 // CHECK:  function_ref @$s22closure_lifetime_fixup25useGenericClosureThrowingyyq_xKXEKr0_lF
 public func captureClosure<T, V>(c : (T) ->V, d: (T) -> V, t: T) throws {


### PR DESCRIPTION
 Teach SILGen to try to peephole a function conversion into the emission of a closure expression, then don't actually do it.  The long term plan is to actually do this, which should just be a matter of taking some of the code out of reabstraction thunk emission and using it in prolog/epilog/return emission.  In the short term, the goal is just to get the conversion information down to the closure emitter so that we can see that we're erasing into an `@isolated(any)` type and then actually erase the closure's isolation properly instead of relying on type-based erasure, which can't handle parameter/capture isolation correctly.

Includes the commit from #71832 so that CI might succeed.