### PR TITLE
test: Fix IRGen/moveonly_value_functions.swift for 32-bit targets

### DIFF
--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -3,7 +3,7 @@
 // RUN:     -disable-type-layout                             \
 // RUN:     %s                                               \
 // RUN: |                                                    \
-// RUN: %FileCheck %s
+// RUN: %IRGenFileCheck %s
 
 @_silgen_name("external_symbol")
 func external_symbol()
@@ -138,7 +138,7 @@ public func takeOuterNC_1<T>(_ o: consuming OuterNC_1<T>) {
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
 // CHECK:         [[RESPONSE:%[^,]+]] = call{{.*}} @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"(
-// CHECK-SAME:        i64 0,
+// CHECK-SAME:        [[INT]] 0,
 // CHECK-SAME:        ptr %T)
 // CHECK:         [[INNER_DEINITING_DESTRUCTABLE_NC_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]]
 // CHECK:         call{{.*}} @"$s24moveonly_value_functions9OuterNC_2VyxGlWOh"(


### PR DESCRIPTION
https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-20.04-webassembly/1969/
```
/home/buildbot/jenkins/workspace/oss-swift-RA-linux-ubuntu-20.04-webassembly/swift/test/IRGen/moveonly_value_functions.swift:141:16: error: CHECK-SAME: expected string not found in input
// CHECK-SAME: i64 0,
               ^
<stdin>:650:110: note: scanning from here
 %1 = call swiftcc %swift.metadata_response @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"(i32 0, ptr %T) #15
                                                                                                             ^

Input file: <stdin>
Check file: /home/buildbot/jenkins/workspace/oss-swift-RA-linux-ubuntu-20.04-webassembly/swift/test/IRGen/moveonly_value_functions.swift

-dump-input=help explains the following input dump.

Input was:
<<<<<<
          .
          .
          .
        645: } 
        646:  
        647: define swiftcc void @"$s24moveonly_value_functions13takeOuterNC_2yyAA0eF2_2VyxGnlF"(ptr noalias %0, ptr %T) #0 { 
        648: entry: 
        649:  call swiftcc void @external_symbol() #16 
        650:  %1 = call swiftcc %swift.metadata_response @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"(i32 0, ptr %T) #15 
same:141                                                                                                                  X~~~~~~~~~~~~~~~~~~ error: no match found
        651:  %2 = extractvalue %swift.metadata_response %1, 0 
same:141     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        652:  %3 = call swiftcc %swift.metadata_response @"$s24moveonly_value_functions9OuterNC_2VMa"(i32 0, ptr %T) #15 
same:141     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        653:  %4 = extractvalue %swift.metadata_response %3, 0 
same:141     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        654:  %5 = call ptr @"$s24moveonly_value_functions9OuterNC_2VyxGlWOh"(ptr %0, ptr %T, ptr %2, ptr %4) 
same:141     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        655:  ret void 
same:141     ~~~~~~~~~~
```