### PR TITLE
[build-script] Fix the LLDB redecl completion filter that we pass to llvm-lit

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2764,10 +2764,7 @@ for host in "${ALL_HOSTS[@]}"; do
                              "${lldb_build_dir}/test/API" \
                              ${LLVM_LIT_ARGS} \
                              --param dotest-args="--setting plugin.typesystem.clang.experimental-redecl-completion=true" \
-                             --filter="lang" \
-                             --filter="functionalities" \
-                             --filter="types" \
-                             --filter="commands"
+                             --filter="lang|functionalities|types|commands"
 
                     # FIXME: run shell-tests with new setting. LLDB doesn't support that yet.
                  fi


### PR DESCRIPTION
In the presence of multiple `--filter` options, `llvm-lit` will only pick the last one. Which means we only ever ran the tests under `commands/`.

This patch turns the multiple filters into a regex.