### PR TITLE
[Build] Tweak Libdispatch.cmake for static linking support.

### DIFF
--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -84,105 +84,107 @@ foreach(sdk ${DISPATCH_SDKS})
       set(SWIFT_LIBDISPATCH_SYSTEM_PROCESSOR  -DCMAKE_SYSTEM_PROCESSOR=${arch})
     endif()
 
-    ExternalProject_Add("${LIBDISPATCH_VARIANT_NAME}"
-                        SOURCE_DIR
-                          "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}"
-                        CMAKE_ARGS
-                          -DCMAKE_AR=${CMAKE_AR}
-                          -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-                          ${SWIFT_LIBDISPATCH_COMPILER_CMAKE_ARGS}
-                          ${SWIFT_LIBDISPATCH_COMPILER_TRIPLE_CMAKE_ARGS}
-                          -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-                          -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-                          -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}
-                          -DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}
-                          -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
-                          -DCMAKE_INSTALL_LIBDIR=lib
-                          -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-                          -DCMAKE_LINKER=${CMAKE_LINKER}
-                          -DCMAKE_MT=${CMAKE_MT}
-                          -DCMAKE_RANLIB=${CMAKE_RANLIB}
-                          -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-                          -DCMAKE_SYSTEM_NAME=${SWIFT_SDK_${sdk}_NAME}
-                          ${SWIFT_LIBDISPATCH_SYSTEM_PROCESSOR}
-                          "${SWIFT_LIBDISPATCH_ANDROID_NDK}"
-                          -DCMAKE_ANDROID_ARCH_ABI=${SWIFT_SDK_ANDROID_ARCH_${arch}_ABI}
-                          -DCMAKE_ANDROID_API=${SWIFT_ANDROID_API_LEVEL}
-                          -DBUILD_SHARED_LIBS=YES
-                          -DENABLE_SWIFT=NO
-                          -DBUILD_TESTING=NO
-                        INSTALL_COMMAND
-                          # NOTE(compnerd) provide a custom install command to
-                          # ensure that we strip out the DESTDIR environment
-                          # from the sub-build
-                          ${CMAKE_COMMAND} -E env --unset=DESTDIR ${CMAKE_COMMAND} --build . --target install
-                        COMMAND
-                          ${CMAKE_COMMAND} -E copy
-                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                          ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                        COMMAND
-                          ${CMAKE_COMMAND} -E copy
-                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                          ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                        COMMAND
-                          ${CMAKE_COMMAND} -E copy
-                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                          ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                        COMMAND
-			  ${CMAKE_COMMAND} -E copy
-                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                          ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                        STEP_TARGETS
-                          install
-                        BUILD_BYPRODUCTS
-                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                          <INSTALL_DIR>/lib/${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_SUFFIX}
-                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                          <INSTALL_DIR>/lib/${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_SUFFIX}
-                        BUILD_ALWAYS
-                          1)
+    if(NOT SWIFT_SDK_${sdk}_STATIC_ONLY)
+      ExternalProject_Add("${LIBDISPATCH_VARIANT_NAME}"
+        SOURCE_DIR
+        "${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}"
+        CMAKE_ARGS
+        -DCMAKE_AR=${CMAKE_AR}
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        ${SWIFT_LIBDISPATCH_COMPILER_CMAKE_ARGS}
+        ${SWIFT_LIBDISPATCH_COMPILER_TRIPLE_CMAKE_ARGS}
+        -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+        -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}
+        -DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}
+        -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
+        -DCMAKE_INSTALL_LIBDIR=lib
+        -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+        -DCMAKE_LINKER=${CMAKE_LINKER}
+        -DCMAKE_MT=${CMAKE_MT}
+        -DCMAKE_RANLIB=${CMAKE_RANLIB}
+        -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+        -DCMAKE_SYSTEM_NAME=${SWIFT_SDK_${sdk}_NAME}
+        ${SWIFT_LIBDISPATCH_SYSTEM_PROCESSOR}
+        "${SWIFT_LIBDISPATCH_ANDROID_NDK}"
+        -DCMAKE_ANDROID_ARCH_ABI=${SWIFT_SDK_ANDROID_ARCH_${arch}_ABI}
+        -DCMAKE_ANDROID_API=${SWIFT_ANDROID_API_LEVEL}
+        -DBUILD_SHARED_LIBS=YES
+        -DENABLE_SWIFT=NO
+        -DBUILD_TESTING=NO
+        INSTALL_COMMAND
+        # NOTE(compnerd) provide a custom install command to
+        # ensure that we strip out the DESTDIR environment
+        # from the sub-build
+        ${CMAKE_COMMAND} -E env --unset=DESTDIR ${CMAKE_COMMAND} --build . --target install
+        COMMAND
+        ${CMAKE_COMMAND} -E copy
+        <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        COMMAND
+        ${CMAKE_COMMAND} -E copy
+        <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        COMMAND
+        ${CMAKE_COMMAND} -E copy
+        <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        COMMAND
+	${CMAKE_COMMAND} -E copy
+        <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        STEP_TARGETS
+        install
+        BUILD_BYPRODUCTS
+        <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        <INSTALL_DIR>/lib/${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_SUFFIX}
+        <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        <INSTALL_DIR>/lib/${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_SUFFIX}
+        BUILD_ALWAYS
+        1)
 
-    ExternalProject_Get_Property("${LIBDISPATCH_VARIANT_NAME}" install_dir)
+      ExternalProject_Get_Property("${LIBDISPATCH_VARIANT_NAME}" install_dir)
 
-    if(NOT SWIFT_BUILT_STANDALONE AND NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-      add_dependencies("${LIBDISPATCH_VARIANT_NAME}" clang)
+      if(NOT SWIFT_BUILT_STANDALONE AND NOT "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+        add_dependencies("${LIBDISPATCH_VARIANT_NAME}" clang)
+      endif()
+
+      # CMake does not like the addition of INTERFACE_INCLUDE_DIRECTORIES without
+      # the directory existing.  Just create the location which will be populated
+      # during the installation.
+      file(MAKE_DIRECTORY ${install_dir}/include)
+
+      set(DISPATCH_VARIANT_NAME "dispatch-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+      add_library("${DISPATCH_VARIANT_NAME}" SHARED IMPORTED GLOBAL)
+      set_target_properties("${DISPATCH_VARIANT_NAME}"
+        PROPERTIES
+        IMPORTED_LOCATION
+        ${install_dir}/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        IMPORTED_IMPLIB
+        ${install_dir}/lib/${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_SUFFIX}
+        INTERFACE_INCLUDE_DIRECTORIES
+        ${install_dir}/include
+        IMPORTED_NO_SONAME
+        1)
+
+      set(BLOCKS_RUNTIME_VARIANT_NAME "BlocksRuntime-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
+      add_library("${BLOCKS_RUNTIME_VARIANT_NAME}" SHARED IMPORTED GLOBAL)
+      set_target_properties("${BLOCKS_RUNTIME_VARIANT_NAME}"
+        PROPERTIES
+        IMPORTED_LOCATION
+        ${install_dir}/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
+        IMPORTED_IMPLIB
+        ${install_dir}/lib/${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_SUFFIX}
+        INTERFACE_INCLUDE_DIRECTORIES
+        ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime
+        IMPORTED_NO_SONAME
+        1)
+
+      add_dependencies("${DISPATCH_VARIANT_NAME}" "${LIBDISPATCH_VARIANT_NAME}-install")
+      add_dependencies("${BLOCKS_RUNTIME_VARIANT_NAME}" "${LIBDISPATCH_VARIANT_NAME}-install")
     endif()
 
-    # CMake does not like the addition of INTERFACE_INCLUDE_DIRECTORIES without
-    # the directory existing.  Just create the location which will be populated
-    # during the installation.
-    file(MAKE_DIRECTORY ${install_dir}/include)
-
-    set(DISPATCH_VARIANT_NAME "dispatch-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
-    add_library("${DISPATCH_VARIANT_NAME}" SHARED IMPORTED GLOBAL)
-    set_target_properties("${DISPATCH_VARIANT_NAME}"
-                          PROPERTIES
-                            IMPORTED_LOCATION
-                              ${install_dir}/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                            IMPORTED_IMPLIB
-                              ${install_dir}/lib/${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_SUFFIX}
-                            INTERFACE_INCLUDE_DIRECTORIES
-                              ${install_dir}/include
-                            IMPORTED_NO_SONAME
-                              1)
-
-    set(BLOCKS_RUNTIME_VARIANT_NAME "BlocksRuntime-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}")
-    add_library("${BLOCKS_RUNTIME_VARIANT_NAME}" SHARED IMPORTED GLOBAL)
-    set_target_properties("${BLOCKS_RUNTIME_VARIANT_NAME}"
-                          PROPERTIES
-                            IMPORTED_LOCATION
-                              ${install_dir}/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                            IMPORTED_IMPLIB
-                              ${install_dir}/lib/${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_SUFFIX}
-                            INTERFACE_INCLUDE_DIRECTORIES
-                              ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime
-                            IMPORTED_NO_SONAME
-                              1)
-
-    add_dependencies("${DISPATCH_VARIANT_NAME}" "${LIBDISPATCH_VARIANT_NAME}-install")
-    add_dependencies("${BLOCKS_RUNTIME_VARIANT_NAME}" "${LIBDISPATCH_VARIANT_NAME}-install")
-
-    if(SWIFT_BUILD_STATIC_STDLIB)
+    if(SWIFT_BUILD_STATIC_STDLIB OR SWIFT_SDK_${sdk}_STATIC_ONLY)
       set(LIBDISPATCH_STATIC_VARIANT_NAME "libdispatch-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch}-static")
       ExternalProject_Add("${LIBDISPATCH_STATIC_VARIANT_NAME}"
                           SOURCE_DIR

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -15,6 +15,9 @@ function(_report_sdk prefix)
   message(STATUS "  Swift Standard Library Path: ${SWIFT_SDK_${prefix}_LIB_SUBDIR}")
   message(STATUS "  Threading Package: ${SWIFT_SDK_${prefix}_THREADING_PACKAGE}")
 
+  message(STATUS "  Static linking supported: ${SWIFT_SDK_${prefix}_STATIC_LINKING_SUPPORTED}")
+  message(STATUS "  Static link only: ${SWIFT_SDK_${prefix}_STATIC_ONLY}")
+
   if("${prefix}" STREQUAL "WINDOWS")
     message(STATUS "  UCRT Version: ${UCRTVersion}")
     message(STATUS "  UCRT SDK Path: ${UniversalCRTSdkDir}")
@@ -148,20 +151,23 @@ endfunction()
 # This macro attempts to configure a given SDK. When successful, it
 # defines a number of variables:
 #
-#   SWIFT_SDK_${prefix}_NAME                    Display name for the SDK
-#   SWIFT_SDK_${prefix}_VERSION                 SDK version number (e.g., 10.9, 7.0)
-#   SWIFT_SDK_${prefix}_BUILD_NUMBER            SDK build number (e.g., 14A389a)
-#   SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION      Deployment version (e.g., 10.9, 7.0)
-#   SWIFT_SDK_${prefix}_LIB_SUBDIR              Library subdir for this SDK
-#   SWIFT_SDK_${prefix}_TRIPLE_NAME             Triple name for this SDK
-#   SWIFT_SDK_${prefix}_OBJECT_FORMAT           The object file format (e.g. MACHO)
-#   SWIFT_SDK_${prefix}_USE_ISYSROOT            Whether to use -isysroot
-#   SWIFT_SDK_${prefix}_SHARED_LIBRARY_PREFIX   Shared library prefix for this SDK (e.g. 'lib')
-#   SWIFT_SDK_${prefix}_SHARED_LIBRARY_SUFFIX   Shared library suffix for this SDK (e.g. 'dylib')
-#   SWIFT_SDK_${prefix}_ARCHITECTURES           Architectures (as a list)
-#   SWIFT_SDK_${prefix}_IS_SIMULATOR            Whether this is a simulator target.
-#   SWIFT_SDK_${prefix}_ARCH_${ARCH}_TRIPLE     Triple name
-#   SWIFT_SDK_${prefix}_ARCH_${ARCH}_MODULE     Module triple name for this SDK
+#   SWIFT_SDK_${prefix}_NAME                      Display name for the SDK
+#   SWIFT_SDK_${prefix}_VERSION                   SDK version number (e.g., 10.9, 7.0)
+#   SWIFT_SDK_${prefix}_BUILD_NUMBER              SDK build number (e.g., 14A389a)
+#   SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION        Deployment version (e.g., 10.9, 7.0)
+#   SWIFT_SDK_${prefix}_LIB_SUBDIR                Library subdir for this SDK
+#   SWIFT_SDK_${prefix}_TRIPLE_NAME               Triple name for this SDK
+#   SWIFT_SDK_${prefix}_OBJECT_FORMAT             The object file format (e.g. MACHO)
+#   SWIFT_SDK_${prefix}_USE_ISYSROOT              Whether to use -isysroot
+#   SWIFT_SDK_${prefix}_SHARED_LIBRARY_PREFIX     Shared library prefix for this SDK (e.g. 'lib')
+#   SWIFT_SDK_${prefix}_SHARED_LIBRARY_SUFFIX     Shared library suffix for this SDK (e.g. 'dylib')
+#   SWIFT_SDK_${prefix}_STATIC_LINKING_SUPPORTED  Whether static linking is supported for this SDK
+#   SWIFT_SDK_${prefix}_STATIC_ONLY               Whether to build *only* static libraries
+
+#   SWIFT_SDK_${prefix}_ARCHITECTURES             Architectures (as a list)
+#   SWIFT_SDK_${prefix}_IS_SIMULATOR              Whether this is a simulator target.
+#   SWIFT_SDK_${prefix}_ARCH_${ARCH}_TRIPLE       Triple name
+#   SWIFT_SDK_${prefix}_ARCH_${ARCH}_MODULE       Module triple name for this SDK
 macro(configure_sdk_darwin
     prefix name deployment_version xcrun_name
     triple_name module_name architectures)
@@ -206,6 +212,8 @@ macro(configure_sdk_darwin
   set(SWIFT_SDK_${prefix}_STATIC_LIBRARY_SUFFIX ".a")
   set(SWIFT_SDK_${prefix}_IMPORT_LIBRARY_PREFIX "")
   set(SWIFT_SDK_${prefix}_IMPORT_LIBRARY_SUFFIX "")
+  set(SWIFT_SDK_${prefix}_STATIC_LINKING_SUPPORTED FALSE)
+  set(SWIFT_SDK_${prefix}_STATIC_ONLY FALSE)
   get_threading_package(${prefix} "darwin" SWIFT_SDK_${prefix}_THREADING_PACKAGE)
 
   set(SWIFT_SDK_${prefix}_ARCHITECTURES ${architectures})
@@ -279,6 +287,7 @@ macro(configure_sdk_unix name architectures)
 
   string(TOUPPER ${name} prefix)
   string(TOLOWER ${name} platform)
+  string(REPLACE "_" "-" platform "${platform}")
 
   set(SWIFT_SDK_${prefix}_NAME "${name}")
   set(SWIFT_SDK_${prefix}_LIB_SUBDIR "${platform}")
@@ -309,6 +318,14 @@ macro(configure_sdk_unix name architectures)
     set(SWIFT_SDK_${prefix}_IMPORT_LIBRARY_SUFFIX "")
   endif()
   set(SWIFT_SDK_${prefix}_USE_ISYSROOT FALSE)
+
+  # Static linking is suported on Linux and WASI
+  if("${prefix}" STREQUAL "LINUX"
+      OR "${prefix}" STREQUAL "WASI")
+    set(SWIFT_SDK_${prefix}_STATIC_LINKING_SUPPORTED TRUE)
+  else()
+    set(SWIFT_SDK_${prefix}_STATIC_LINKING_SUPPORTED FALSE)
+  endif()
 
   # GCC on Linux is usually located under `/usr`.
   # However, Ubuntu 20.04 ships with another GCC installation under `/`, which
@@ -456,6 +473,8 @@ macro(configure_sdk_windows name environment architectures)
   set(SWIFT_SDK_${prefix}_STATIC_LIBRARY_SUFFIX ".lib")
   set(SWIFT_SDK_${prefix}_IMPORT_LIBRARY_PREFIX "")
   set(SWIFT_SDK_${prefix}_IMPORT_LIBRARY_SUFFIX ".lib")
+  set(SWIFT_SDK_${prefix}_STATIC_LINKING_SUPPORTED FALSE)
+  set(SWIFT_SDK_${prefix}_STATIC_ONLY FALSE)
   get_threading_package(${prefix} "win32" SWIFT_SDK_${prefix}_THREADING_PACKAGE)
 
   foreach(arch ${architectures})
@@ -523,6 +542,8 @@ function(configure_target_variant prefix name sdk build_config lib_subdir)
   set(SWIFT_VARIANT_${prefix}_STATIC_LIBRARY_SUFFIX ${SWIFT_SDK_${sdk}_STATIC_LIBRARY_SUFFIX})
   set(SWIFT_VARIANT_${prefix}_IMPORT_LIBRARY_PREFIX ${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_PREFIX})
   set(SWIFT_VARIANT_${prefix}_IMPORT_LIBRARY_SUFFIX ${SWIFT_SDK_${sdk}_IMPORT_LIBRARY_SUFFIX})
+  set(SWIFT_VARIANT_${prefix}_STATIC_LINKING_SUPPORTED ${SWIFT_SDK_${sdk}_STATIC_LINKING_SUPPORTED})
+  set(SWIFT_VARIANT_${prefix}_STATIC_ONLY ${SWIFT_SDK_${sdk}_STATIC_ONLY})
   get_threading_package(${prefix} ${SWIFT_SDK_${sdk}_THREADING_PACKAGE} SWIFT_VARIANT_${prefix}_THREADING_PACKAGE)
 endfunction()
 


### PR DESCRIPTION
Don't try to build dynamic libraries if the SDK only supports static linking.  Also, *do* build static libraries if the SDK only supports static linking.

rdar://123503191
