### PR TITLE
[Runtime][ELF] Mark metadata sections as retained.

### DIFF
--- a/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF-WASM.cpp
@@ -36,7 +36,7 @@ static const void *__backtraceRef __attribute__((used))
 // by the linker.  Otherwise, we may end up with undefined symbol references as
 // the linker table section was never constructed.
 #if defined(__ELF__)
-# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"a\"\n");
+# define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"aR\"\n");
 #elif defined(__wasm__)
 # define DECLARE_EMPTY_METADATA_SECTION(name) __asm__("\t.section " #name ",\"R\",@\n");
 #endif


### PR DESCRIPTION
If section garbage collection is turned on in the linker, the metadata sections may be dropped as there are no external references to them.

To fix this, we need to mark them as retained (add an 'R' to the declaration).

rdar://123504095
