### PR TITLE
[Runtime] Fix generation of .lnk files for static linking.

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -114,39 +114,35 @@ set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/stdlib/include/llvm/Support -I${SWIFT_SOURCE_DIR}/include)
 
-if(SWIFT_BUILD_STATIC_STDLIB)
-  set(static_binary_lnk_file_list)
+set(static_binary_lnk_file_list)
 
-  foreach(sdk ${SWIFT_SDKS})
-    if(NOT "${sdk}" STREQUAL "LINUX" AND NOT "${sdk}" STREQUAL "WASI")
-      continue()
-    endif()
+foreach(sdk ${SWIFT_SDKS})
+  if(NOT SWIFT_SDK_${sdk}_STATIC_LINKING_SUPPORTED)
+    continue()
+  endif()
 
-    string(TOLOWER "${sdk}" lowercase_sdk)
-    set(static_binary_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lowercase_sdk}/static-executable-args.lnk")
+  if(SWIFT_BUILD_STATIC_STDLIB OR SWIFT_SDK_${sdk}_STATIC_ONLY)
+    set(lib_dir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+    set(static_binary_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lib_dir}/static-executable-args.lnk")
 
     # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
-    set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
+    set(linkfile "${lib_dir}/static-executable-args.lnk")
     add_custom_command_target(swift_static_binary_${sdk}_args
       COMMAND
-        "${CMAKE_COMMAND}" -E copy
-        "${static_binary_lnk_src}"
-        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      "${CMAKE_COMMAND}" -E copy
+      "${static_binary_lnk_src}"
+      "${SWIFTSTATICLIB_DIR}/${linkfile}"
       OUTPUT
-        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      "${SWIFTSTATICLIB_DIR}/${linkfile}"
       DEPENDS
-        "${static_binary_lnk_src}")
+      "${static_binary_lnk_src}")
 
     list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
     swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
-                               DESTINATION "lib/swift_static/${lowercase_sdk}"
-                               COMPONENT stdlib)
-  endforeach()
-  if(static_binary_lnk_file_list)
-    add_dependencies(stdlib ${static_binary_lnk_file_list})
-    add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
+      DESTINATION "lib/swift_static/${lib_dir}"
+      COMPONENT stdlib)
   endif()
-endif()
+endforeach()
 
 add_swift_target_library(swiftRuntime OBJECT_LIBRARY
   ${swift_runtime_sources}
@@ -248,7 +244,7 @@ foreach(sdk ${SWIFT_SDKS})
                                   "${static_runtime_registrar}"
                                 DEPENDS
                                   "${swiftrtObject}")
-      if(SWIFT_BUILD_DYNAMIC_STDLIB)
+      if(SWIFT_BUILD_DYNAMIC_STDLIB AND NOT SWIFT_SDK_${sdk}_STATIC_ONLY)
         swift_install_in_component(FILES
                                      "${shared_runtime_registrar}"
                                    DESTINATION
@@ -256,7 +252,7 @@ foreach(sdk ${SWIFT_SDKS})
                                    COMPONENT
                                      stdlib)
       endif()
-      if(SWIFT_BUILD_STATIC_STDLIB)
+      if(SWIFT_BUILD_STATIC_STDLIB OR SWIFT_SDK_${sdk}_STATIC_ONLY)
         swift_install_in_component(FILES
                                      "${static_runtime_registrar}"
                                    DESTINATION
@@ -273,10 +269,26 @@ foreach(sdk ${SWIFT_SDKS})
       add_dependencies(stdlib swift-stdlib-${arch_suffix} swiftImageRegistration-${arch_suffix})
     endif()
 
-    # Generate the static-stdlib-args.lnk file used by -static-stdlib option for
-    # 'GenericUnix' (eg linux)
-    if(SWIFT_SDK_${sdk}_OBJECT_FORMAT STREQUAL "ELF")
-      string(TOLOWER "${sdk}" lowercase_sdk)
+  endforeach()
+
+  # Generate the static-stdlib-args.lnk file used by -static-stdlib option for
+  # 'GenericUnix' (eg linux)
+  if(SWIFT_SDK_${sdk}_OBJECT_FORMAT STREQUAL "ELF")
+    set(lib_dir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+    set(static_stdlib_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lib_dir}/static-stdlib-args.lnk")
+    set(linkfile ${lib_dir}/static-stdlib-args.lnk)
+    if(EXISTS "${static_stdlib_lnk_src}")
+      add_custom_command_target(swift_static_stdlib_${sdk}_args
+        COMMAND
+        "${CMAKE_COMMAND}" -E copy
+        "${static_stdlib_lnk_src}"
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+        OUTPUT
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+        DEPENDS
+        "${static_stdlib_lnk_src}")
+      list(APPEND static_binary_lnk_file_list ${swift_static_stdlib_${sdk}_args})
+    else()
       set(libpthread -lpthread)
       set(concurrency_libs)
       set(android_libraries)
@@ -287,7 +299,6 @@ foreach(sdk ${SWIFT_SDKS})
         set(concurrency_libs "-ldispatch -lBlocksRuntime")
       endif()
 
-      set(linkfile ${lowercase_sdk}/static-stdlib-args.lnk)
       file(WRITE "${SWIFTSTATICLIB_DIR}/${linkfile}" "
 -ldl
 ${libpthread}
@@ -299,10 +310,17 @@ ${concurrency_libs}
 -Xlinker -export-dynamic
 -Xlinker --exclude-libs
 -Xlinker ALL")
-
-      swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
-                                 DESTINATION "lib/swift_static/${lowercase_sdk}"
-                                 COMPONENT stdlib)
     endif()
-  endforeach()
+
+    swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      DESTINATION "lib/swift_static/${lib_dir}"
+      COMPONENT stdlib)
+  endif()
+
 endforeach()
+
+if(static_binary_lnk_file_list)
+  add_dependencies(stdlib ${static_binary_lnk_file_list})
+  add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
+endif()
+


### PR DESCRIPTION
Use the new `SWIFT_SDK_<sdk>_STATIC_LINKING_SUPPORTED` and `_STATIC_ONLY` flags instead of hardcoding support for Linux and WASI.

Also, use the `_LIB_SUBDIR` variable rather than lowercasing the SDK.

rdar://123504757
