### PR TITLE
Add support to the compiler for musl and the LINUX_STATIC SDK.

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -231,7 +231,17 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   case llvm::Triple::XROS:
     return getPlatformNameForDarwin(getDarwinPlatformKind(triple));
   case llvm::Triple::Linux:
-    return triple.isAndroid() ? "android" : "linux";
+    if (triple.isAndroid())
+      return "android";
+    else if (triple.isMusl()) {
+      // The triple for linux-static is <arch>-swift-linux-musl, to distinguish
+      // it from a "normal" musl set-up (ala Alpine).
+      if (triple.getVendor() == llvm::Triple::Swift)
+        return "linux-static";
+      else
+        return "musl";
+    } else
+      return "linux";
   case llvm::Triple::FreeBSD:
     return "freebsd";
   case llvm::Triple::OpenBSD:

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -646,7 +646,7 @@ void importer::getNormalInvocationArguments(
     // using Glibc or a libc that respects that flag. This will cause some
     // source breakage however (specifically with strerror_r()) on Linux
     // without a workaround.
-    if (triple.isOSFuchsia() || triple.isAndroid()) {
+    if (triple.isOSFuchsia() || triple.isAndroid() || triple.isMusl()) {
       // Many of the modern libc features are hidden behind feature macros like
       // _GNU_SOURCE or _XOPEN_SOURCE.
       invocationArgStrs.insert(invocationArgStrs.end(), {

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -530,11 +530,32 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
 
   const llvm::Triple &triple = ctx.LangOpts.Target;
 
+  // For modulemaps that have all the C standard library headers together in
+  // a single module, we end up with module cycles with the clang _Builtin_
+  // modules.  e.g. <inttypes.h> includes <stdint.h> on these platforms. The
+  // clang builtin <stdint.h> include-nexts <stdint.h>. When both of those
+  // platform headers are in the SwiftLibc module, there's a module cycle
+  // SwiftLibc -> _Builtin_stdint -> SwiftLibc (i.e. inttypes.h (platform) ->
+  // stdint.h (builtin) -> stdint.h (platform)).
+  //
+  // Until these modulemaps can be fixed, the builtin headers need to join
+  // the system modules to avoid the cycle.
+  //
+  // Note that this does nothing to fix the same problem with C++ headers,
+  // and that this is generally a fragile solution.
+  //
+  // We start by assuming we do *not* need to do this, then enable it for
+  // affected modulemaps.
+  result.requiresBuiltinHeadersInSystemModules = false;
+
   SmallVector<std::pair<std::string, std::string>, 2> libcFileMapping;
   if (triple.isOSWASI()) {
     // WASI Mappings
     libcFileMapping =
         getLibcFileMapping(ctx, "wasi-libc.modulemap", std::nullopt, vfs);
+
+    // WASI's module map needs fixing
+    result.requiresBuiltinHeadersInSystemModules = true;
   } else if (triple.isMusl()) {
     libcFileMapping =
         getLibcFileMapping(ctx, "musl.modulemap", StringRef("SwiftMusl.h"), vfs);
@@ -542,21 +563,11 @@ ClangInvocationFileMapping swift::getClangInvocationFileMapping(
     // Android/BSD/Linux Mappings
     libcFileMapping = getLibcFileMapping(ctx, "glibc.modulemap",
                                          StringRef("SwiftGlibc.h"), vfs);
+
+    // glibc.modulemap needs fixing
+    result.requiresBuiltinHeadersInSystemModules = true;
   }
   result.redirectedFiles.append(libcFileMapping);
-  // Both libc module maps have the C standard library headers all together in a
-  // SwiftLibc module. That leads to module cycles with the clang _Builtin_
-  // modules. e.g. <inttypes.h> includes <stdint.h> on these platforms. The
-  // clang builtin <stdint.h> include-nexts <stdint.h>. When both of those
-  // platform headers are in the SwiftLibc module, there's a module cycle
-  // SwiftLibc -> _Builtin_stdint -> SwiftLibc (i.e. inttypes.h (platform) ->
-  // stdint.h (builtin) -> stdint.h (platform)). Until this can be fixed in
-  // these module maps, the clang builtin headers need to join the "system"
-  // modules (SwiftLibc). i.e. when the clang builtin stdint.h is in the
-  // SwiftLibc module too, the cycle goes away. Note that
-  // -fbuiltin-headers-in-system-modules does nothing to fix the same problem
-  // with C++ headers, and is generally fragile.
-  result.requiresBuiltinHeadersInSystemModules = !libcFileMapping.empty();
 
   if (ctx.LangOpts.EnableCXXInterop)
     getLibStdCxxFileMapping(result, ctx, vfs);

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -127,7 +127,9 @@ bool isAmazonLinux2023Host() {
     }
 
 std::string toolchains::GenericUnix::getDefaultLinker() const {
-  if (getTriple().isAndroid() || isAmazonLinux2023Host())
+  if (getTriple().isAndroid() || isAmazonLinux2023Host()
+      || (getTriple().isMusl()
+          && getTriple().getVendor() == llvm::Triple::Swift))
     return "lld";
 
   switch (getTriple().getArch()) {
@@ -285,7 +287,8 @@ toolchains::GenericUnix::constructInvocation(const DynamicLinkJobAction &job,
   }
 
   SmallString<128> SharedResourceDirPath;
-  getResourceDirPath(SharedResourceDirPath, context.Args, /*Shared=*/true);
+  getResourceDirPath(SharedResourceDirPath, context.Args,
+                     /*Shared=*/!(staticExecutable || staticStdlib));
 
   SmallString<128> swiftrtPath = SharedResourceDirPath;
   llvm::sys::path::append(swiftrtPath,

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -114,39 +114,35 @@ set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/stdlib/include/llvm/Support -I${SWIFT_SOURCE_DIR}/include)
 
-if(SWIFT_BUILD_STATIC_STDLIB)
-  set(static_binary_lnk_file_list)
+set(static_binary_lnk_file_list)
 
-  foreach(sdk ${SWIFT_SDKS})
-    if(NOT "${sdk}" STREQUAL "LINUX" AND NOT "${sdk}" STREQUAL "WASI")
-      continue()
-    endif()
+foreach(sdk ${SWIFT_SDKS})
+  if(NOT SWIFT_SDK_${sdk}_STATIC_LINKING_SUPPORTED)
+    continue()
+  endif()
 
-    string(TOLOWER "${sdk}" lowercase_sdk)
-    set(static_binary_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lowercase_sdk}/static-executable-args.lnk")
+  if(SWIFT_BUILD_STATIC_STDLIB OR SWIFT_SDK_${sdk}_STATIC_ONLY)
+    set(lib_dir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+    set(static_binary_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lib_dir}/static-executable-args.lnk")
 
     # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
-    set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
+    set(linkfile "${lib_dir}/static-executable-args.lnk")
     add_custom_command_target(swift_static_binary_${sdk}_args
       COMMAND
-        "${CMAKE_COMMAND}" -E copy
-        "${static_binary_lnk_src}"
-        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      "${CMAKE_COMMAND}" -E copy
+      "${static_binary_lnk_src}"
+      "${SWIFTSTATICLIB_DIR}/${linkfile}"
       OUTPUT
-        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      "${SWIFTSTATICLIB_DIR}/${linkfile}"
       DEPENDS
-        "${static_binary_lnk_src}")
+      "${static_binary_lnk_src}")
 
     list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
     swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
-                               DESTINATION "lib/swift_static/${lowercase_sdk}"
-                               COMPONENT stdlib)
-  endforeach()
-  if(static_binary_lnk_file_list)
-    add_dependencies(stdlib ${static_binary_lnk_file_list})
-    add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
+      DESTINATION "lib/swift_static/${lib_dir}"
+      COMPONENT stdlib)
   endif()
-endif()
+endforeach()
 
 add_swift_target_library(swiftRuntime OBJECT_LIBRARY
   ${swift_runtime_sources}
@@ -248,7 +244,7 @@ foreach(sdk ${SWIFT_SDKS})
                                   "${static_runtime_registrar}"
                                 DEPENDS
                                   "${swiftrtObject}")
-      if(SWIFT_BUILD_DYNAMIC_STDLIB)
+      if(SWIFT_BUILD_DYNAMIC_STDLIB AND NOT SWIFT_SDK_${sdk}_STATIC_ONLY)
         swift_install_in_component(FILES
                                      "${shared_runtime_registrar}"
                                    DESTINATION
@@ -256,7 +252,7 @@ foreach(sdk ${SWIFT_SDKS})
                                    COMPONENT
                                      stdlib)
       endif()
-      if(SWIFT_BUILD_STATIC_STDLIB)
+      if(SWIFT_BUILD_STATIC_STDLIB OR SWIFT_SDK_${sdk}_STATIC_ONLY)
         swift_install_in_component(FILES
                                      "${static_runtime_registrar}"
                                    DESTINATION
@@ -273,10 +269,26 @@ foreach(sdk ${SWIFT_SDKS})
       add_dependencies(stdlib swift-stdlib-${arch_suffix} swiftImageRegistration-${arch_suffix})
     endif()
 
-    # Generate the static-stdlib-args.lnk file used by -static-stdlib option for
-    # 'GenericUnix' (eg linux)
-    if(SWIFT_SDK_${sdk}_OBJECT_FORMAT STREQUAL "ELF")
-      string(TOLOWER "${sdk}" lowercase_sdk)
+  endforeach()
+
+  # Generate the static-stdlib-args.lnk file used by -static-stdlib option for
+  # 'GenericUnix' (eg linux)
+  if(SWIFT_SDK_${sdk}_OBJECT_FORMAT STREQUAL "ELF")
+    set(lib_dir "${SWIFT_SDK_${sdk}_LIB_SUBDIR}")
+    set(static_stdlib_lnk_src "${SWIFT_SOURCE_DIR}/stdlib/public/Resources/${lib_dir}/static-stdlib-args.lnk")
+    set(linkfile ${lib_dir}/static-stdlib-args.lnk)
+    if(EXISTS "${static_stdlib_lnk_src}")
+      add_custom_command_target(swift_static_stdlib_${sdk}_args
+        COMMAND
+        "${CMAKE_COMMAND}" -E copy
+        "${static_stdlib_lnk_src}"
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+        OUTPUT
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+        DEPENDS
+        "${static_stdlib_lnk_src}")
+      list(APPEND static_binary_lnk_file_list ${swift_static_stdlib_${sdk}_args})
+    else()
       set(libpthread -lpthread)
       set(concurrency_libs)
       set(android_libraries)
@@ -287,7 +299,6 @@ foreach(sdk ${SWIFT_SDKS})
         set(concurrency_libs "-ldispatch -lBlocksRuntime")
       endif()
 
-      set(linkfile ${lowercase_sdk}/static-stdlib-args.lnk)
       file(WRITE "${SWIFTSTATICLIB_DIR}/${linkfile}" "
 -ldl
 ${libpthread}
@@ -299,10 +310,17 @@ ${concurrency_libs}
 -Xlinker -export-dynamic
 -Xlinker --exclude-libs
 -Xlinker ALL")
-
-      swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
-                                 DESTINATION "lib/swift_static/${lowercase_sdk}"
-                                 COMPONENT stdlib)
     endif()
-  endforeach()
+
+    swift_install_in_component(FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      DESTINATION "lib/swift_static/${lib_dir}"
+      COMPONENT stdlib)
+  endif()
+
 endforeach()
+
+if(static_binary_lnk_file_list)
+  add_dependencies(stdlib ${static_binary_lnk_file_list})
+  add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
+endif()
+


### PR DESCRIPTION
This is really just about setting appropriate defaults (such as making sure that the static Linux triple causes us to use `lld`).

rdar://123506306