### PR TITLE
[Runtime] Don't use `<sys/errno.h>`.

### DIFF
--- a/stdlib/public/CommandLineSupport/CommandLine.cpp
+++ b/stdlib/public/CommandLineSupport/CommandLine.cpp
@@ -24,11 +24,7 @@
 #include <cstring>
 #include <string>
 
-#if __has_include(<sys/errno.h>)
-#include <sys/errno.h>
-#else
 #include <errno.h>
-#endif
 
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Win32.h"

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -26,11 +26,7 @@
 #define NOMINMAX
 #include <windows.h>
 #else // defined(_WIN32)
-#if __has_include(<sys/errno.h>)
-#include <sys/errno.h>
-#else
 #include <errno.h>
-#endif
 #if __has_include(<sys/resource.h>)
 #include <sys/resource.h>
 #endif


### PR DESCRIPTION
We should always be using `<errno.h>`, not `<sys/errno.h>`.  The former is part of the C standard.  The latter is a non-standard header that happens to be present on some systems.

rdar://123507361
