### PR TITLE
[Tests] NFC: Add few associated type inference test-cases

### DIFF
--- a/test/decl/protocol/req/rdar123336457.swift
+++ b/test/decl/protocol/req/rdar123336457.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+
+protocol Task1: AnyObject {
+}
+
+protocol Task2: AnyObject {
+}
+
+class TaskImpl : Task2 {
+}
+
+protocol TaskResult {
+  associatedtype Task
+
+  var tasks: [Task] { get }
+
+  func removeMatchedTask(_ task: Task)
+  func match(_ task: Task) -> Bool
+}
+
+extension TaskResult where Task == Task1 {
+  func match(_ task: Task) -> Bool { false }
+}
+
+extension TaskResult where Task: Task2 {
+  func match(_ task: Task) -> Bool { false }
+}
+
+final class Results: TaskResult {
+  var tasks: [TaskImpl] = []
+
+  func removeMatchedTask(_ task: TaskImpl) {}
+}

--- a/test/decl/protocol/req/rdar123357062.swift
+++ b/test/decl/protocol/req/rdar123357062.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-associated-type-inference
+// RUN: %target-typecheck-verify-swift -disable-experimental-associated-type-inference
+
+extension LazySequenceProtocol {
+  @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  func filtering(
+     while predicate: @escaping (Self.Element) -> Bool
+  ) -> some (Sequence<Self.Element> & LazySequenceProtocol) {
+    LazyFilteringSequence(base: self, predicate: predicate)
+  }
+}
+
+struct LazyFilteringSequence<S: Sequence>: LazySequenceProtocol {
+  struct Iterator: IteratorProtocol {
+    var iterator: S.Iterator
+    var predicate: (S.Element) -> Bool
+
+    mutating func next() -> S.Element? {
+      nil
+    }
+  }
+
+  var base: S
+  var predicate: (S.Element) -> Bool
+
+  func makeIterator() -> Iterator {
+    Iterator(iterator: self.base.makeIterator(), predicate: self.predicate)
+  }
+}


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
