### PR TITLE
Fix hash/isEqual interop conditionals, update tests

### DIFF
--- a/stdlib/public/runtime/Bincompat.cpp
+++ b/stdlib/public/runtime/Bincompat.cpp
@@ -20,6 +20,7 @@
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Threading/Once.h"
 #include "swift/shims/RuntimeShims.h"
+#include "swift/shims/Target.h"
 #include <stdint.h>
 
 // If this is an Apple OS, use the Apple binary compatibility rules
@@ -248,7 +249,7 @@ bool useLegacySwiftObjCHashing() {
 #if BINARY_COMPATIBILITY_APPLE
   return true; // For now, legacy behavior on Apple OSes
 #elif SWIFT_TARGET_OS_DARWIN
-  return true; // For now, legacy behavior on open-source builds for Apple OSes
+  return true; // For now, use legacy behavior on open-source builds for Apple platforms
 #else
   return false; // Always use the new behavior on non-Apple OSes
 #endif

--- a/stdlib/public/runtime/Bincompat.cpp
+++ b/stdlib/public/runtime/Bincompat.cpp
@@ -247,6 +247,8 @@ bool useLegacySwiftValueUnboxingInCasting() {
 bool useLegacySwiftObjCHashing() {
 #if BINARY_COMPATIBILITY_APPLE
   return true; // For now, legacy behavior on Apple OSes
+#elif SWIFT_TARGET_OS_DARWIN
+  return true; // For now, legacy behavior on open-source builds for Apple OSes
 #else
   return false; // Always use the new behavior on non-Apple OSes
 #endif

--- a/stdlib/public/runtime/SwiftValue.mm
+++ b/stdlib/public/runtime/SwiftValue.mm
@@ -464,7 +464,7 @@ swift::findSwiftValueConformances(const ExistentialTypeMetadata *existentialType
 	    selfHeader->type, hashableConformance);
   }
 
-  if (!runtime::bincompat::useLegacySwiftObjCHashing()) {
+  if (runtime::bincompat::useLegacySwiftObjCHashing()) {
     // Legacy behavior doesn't honor Equatable conformance, only Hashable
     return (NSUInteger)self;
   }

--- a/test/stdlib/BridgeEquatableToObjC.swift
+++ b/test/stdlib/BridgeEquatableToObjC.swift
@@ -32,7 +32,12 @@ BridgeEquatableToObjC.test("Bridge equatable struct") {
   let objcResult = objcA.isEqual(objcB)
 
   expectEqual(swiftResult, true)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  // Apple platforms use old semantics for now...
+  expectEqual(objcResult, false)
+#else
   expectEqual(objcResult, true)
+#endif
 }
 
 BridgeEquatableToObjC.test("Bridge non-equatable struct") {

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -124,8 +124,7 @@ func TestEquatableHash(_ e: AnyObject)
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
   // Legacy behavior: Equatable in Swift => ObjC hashes with identity
   TestSwiftObjectNSObjectDefaultHashValue(e)
-  let msg = "Obj-C `-hash` ... type `SwiftObjectNSObject.\(type(of: e))` ... Equatable but not Hashable\n"
-  fputs(msg, stderr)
+  fakeEquatableWarning(e)
 #else
   // New behavior: These should have a constant hash value
   TestSwiftObjectNSObjectHashValue(e, 1)
@@ -143,10 +142,18 @@ func TestNonEquatableHash(_ e: AnyObject)
 // CHECK-NEXT: d ##SwiftObjectNSObject.D##
 // CHECK-NEXT: S ##{{.*}}SwiftObject##
 
-// Full message is longer, but this is the essential part...
+// Verify that the runtime emits the warning that we expected...
 // CHECK-NEXT: Obj-C `-hash` {{.*}} type `SwiftObjectNSObject.E` {{.*}} Equatable but not Hashable
 // CHECK-NEXT: Obj-C `-hash` {{.*}} type `SwiftObjectNSObject.E1` {{.*}} Equatable but not Hashable
 // CHECK-NEXT: Obj-C `-hash` {{.*}} type `SwiftObjectNSObject.E2` {{.*}} Equatable but not Hashable
+
+// If we're checking legacy behavior or unsupported platform, then
+// the warning above won't be emitted.  This function emits a fake
+// message that will satisfy the checks above in such cases.
+func fakeEquatableWarning(e: AnyObject) {
+  let msg = "Obj-C `-hash` ... type `SwiftObjectNSObject.\(type(of: e))` ... Equatable but not Hashable\n"
+  fputs(msg, stderr)
+}
 
 // Temporarily disable this test on older OSes until we have time to
 // look into why it's failing there. rdar://problem/47870743
@@ -213,7 +220,7 @@ if #available(OSX 10.12, iOS 10.0, *) {
   fputs("c ##SwiftObjectNSObject.C##\n", stderr)
   fputs("d ##SwiftObjectNSObject.D##\n", stderr)
   fputs("S ##Swift._SwiftObject##\n", stderr)
-  fputs("Obj-C `-hash` ... type `SwiftObjectNSObject.E` ... Equatable but not Hashable", stderr)
-  fputs("Obj-C `-hash` ... type `SwiftObjectNSObject.E1` ... Equatable but not Hashable", stderr)
-  fputs("Obj-C `-hash` ... type `SwiftObjectNSObject.E2` ... Equatable but not Hashable", stderr)
+  fakeEquatableWarning(E(i:1))
+  fakeEquatableWarning(E1(i:1))
+  fakeEquatableWarning(E2(i:1))
 }

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -150,7 +150,7 @@ func TestNonEquatableHash(_ e: AnyObject)
 // If we're checking legacy behavior or unsupported platform, then
 // the warning above won't be emitted.  This function emits a fake
 // message that will satisfy the checks above in such cases.
-func fakeEquatableWarning(e: AnyObject) {
+func fakeEquatableWarning(_ e: AnyObject) {
   let msg = "Obj-C `-hash` ... type `SwiftObjectNSObject.\(type(of: e))` ... Equatable but not Hashable\n"
   fputs(msg, stderr)
 }

--- a/test/stdlib/SwiftValueNSObject.swift
+++ b/test/stdlib/SwiftValueNSObject.swift
@@ -77,9 +77,25 @@ func TestSwiftValueNSObjectDefaultHashValue(_: AnyObject)
 func TestSwiftValueNSObjectAssertNoErrors()
 
 // Verify that Obj-C isEqual: provides same answer as Swift ==
-func TestEquatableEquals<T: Equatable>(_ e1: T, _ e2: T) {
+// This has been true for a long time for Hashable value types
+func TestHashableEquals<T: Equatable>(_ e1: T, _ e2: T) {
   if e1 == e2 {
     TestSwiftValueNSObjectEquals(e1 as AnyObject, e2 as AnyObject)
+  } else {
+    TestSwiftValueNSObjectNotEquals(e1 as AnyObject, e2 as AnyObject)
+  }
+}
+
+// Verify that Obj-C isEqual: provides same answer as Swift ==
+// This has not always been true for Equatable value types
+func TestEquatableEquals<T: Equatable>(_ e1: T, _ e2: T) {
+  if e1 == e2 {
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    // Legacy: Swift Equatable is not used in ObjC
+    TestSwiftValueNSObjectNotEquals(e1 as AnyObject, e2 as AnyObject)
+#else
+    TestSwiftValueNSObjectEquals(e1 as AnyObject, e2 as AnyObject)
+#endif
   } else {
     TestSwiftValueNSObjectNotEquals(e1 as AnyObject, e2 as AnyObject)
   }
@@ -143,9 +159,9 @@ if #available(OSX 10.12, iOS 10.0, *) {
   TestNonEquatableHash(D())
 
   // Hashable types are also Equatable
-  TestEquatableEquals(H(i:1), H(i:1))
-  TestEquatableEquals(H(i:1), H(i:2))
-  TestEquatableEquals(H(i:2), H(i:1))
+  TestHashableEquals(H(i:1), H(i:1))
+  TestHashableEquals(H(i:1), H(i:2))
+  TestHashableEquals(H(i:2), H(i:1))
 
   // Verify Obj-C hash value agrees with Swift
   TestHashable(H(i:1))


### PR DESCRIPTION
Github PR #71620 mixed up one of the bincompat conditionals. It also had some errors in the tests for ObjC interop.

For now, this leaves the legacy behavior in place for all Apple platforms.

Resolves rdar://123422591