### PR TITLE
utils: update swift-collections to 1.0.5

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -154,7 +154,7 @@
                 "swiftpm": "release/5.10",
                 "swift-argument-parser": "1.2.3",
                 "swift-atomics": "1.0.2",
-                "swift-collections": "1.0.1",
+                "swift-collections": "1.0.5",
                 "swift-crypto": "3.0.0",
                 "swift-certificates": "1.0.1",
                 "swift-asn1": "1.0.0",


### PR DESCRIPTION
The 1.0.5 release contains the CMake changes required to support Windows ARM64 builds.