### PR TITLE
[AST] Special handling for existentials with superclass and marker pr…

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6050,6 +6050,10 @@ public:
     return Bits.ProtocolCompositionType.HasExplicitAnyObject;
   }
 
+  /// Produce a new type (potentially not be a protoocl composition)
+  /// which drops all of the marker protocol types associated with this one.
+  Type withoutMarkerProtocols() const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::ProtocolComposition;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1468,6 +1468,13 @@ void ASTMangler::appendType(Type type, GenericSignature sig,
 
     case TypeKind::ProtocolComposition: {
       auto *PCT = cast<ProtocolCompositionType>(tybase);
+
+      if (!AllowMarkerProtocols) {
+        auto strippedTy = PCT->withoutMarkerProtocols();
+        if (!strippedTy->isEqual(PCT))
+          return appendType(strippedTy, sig, forDecl);
+      }
+
       if (PCT->hasParameterizedExistential()
           || (PCT->hasInverse() && AllowInverses))
         return appendConstrainedExistential(PCT, sig, forDecl);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3704,6 +3704,20 @@ Type ProtocolCompositionType::getInverseOf(const ASTContext &C,
                                       /*HasExplicitAnyObject=*/false);
 }
 
+Type ProtocolCompositionType::withoutMarkerProtocols() const {
+  SmallVector<Type, 4> newMembers;
+  llvm::copy_if(getMembers(), std::back_inserter(newMembers), [](Type member) {
+    auto *P = member->getAs<ProtocolType>();
+    return !(P && P->getDecl()->isMarkerProtocol());
+  });
+
+  if (newMembers.size() == getMembers().size())
+    return Type(const_cast<ProtocolCompositionType *>(this));
+
+  return ProtocolCompositionType::get(getASTContext(), newMembers,
+                                      getInverses(), hasExplicitAnyObject());
+}
+
 Type ProtocolCompositionType::get(const ASTContext &C,
                                   ArrayRef<Type> Members,
                                   InvertibleProtocolSet Inverses,

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -697,6 +697,9 @@ protected:
                          llvm::function_ref<void ()> body);
 
   std::string mangleTypeSymbol(Type type, const char *Op) {
+    llvm::SaveAndRestore<bool> savedAllowMarkerProtocols(AllowMarkerProtocols,
+                                                         false);
+
     beginMangling();
     appendType(type, nullptr);
     appendOperator(Op);

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -546,3 +546,34 @@ _ = P_61517(false) // expected-error{{type 'any P_61517' cannot be instantiated}
 
 _ = P_61517.init() // expected-error{{type 'any P_61517' cannot be instantiated}}
 _ = P_61517.init(false) // expected-error{{type 'any P_61517' cannot be instantiated}}
+
+@_marker
+protocol Marker {}
+
+do {
+  class C : Fooable, Error {
+    func foo() {}
+  }
+
+  struct Other {}
+
+  func overloaded() -> C & Marker {
+    fatalError()
+  }
+
+  func overloaded() -> Other {
+    fatalError()
+  }
+
+  func isFooable<T: Fooable>(_: T) {}
+
+  isFooable(overloaded()) // Ok
+
+  func isError<T: Error>(_: T) {}
+
+  isError(overloaded()) // Ok
+
+  func isFooableError<T: Fooable & Error>(_: T) {}
+
+  isFooableError(overloaded()) // Ok
+}

--- a/test/IRGen/marker_protocol.swift
+++ b/test/IRGen/marker_protocol.swift
@@ -14,7 +14,7 @@ extension Int: P { }
 extension Array: P where Element: P { }
 
 // No mention of the marker protocol for runtime type instantiation.
-// CHECK-LABEL: @"$sSS_15marker_protocol1P_ptMD" =
+// CHECK-LABEL: @"$sSS_yptMD" =
 // CHECK-SAME: @"symbolic SS_ypt"
 
 // CHECK-LABEL: @"$s15marker_protocol1QMp" = {{(dllexport |protected )?}}constant
@@ -47,7 +47,7 @@ struct HasMarkers {
 
 // Note: no mention of marker protocols when forming a dictionary.
 // CHECK-LABEL: define{{.*}}@"$s15marker_protocol0A12InDictionaryypyF"
-// CHECK: call ptr @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSS_15marker_protocol1P_ptMD")
+// CHECK: call ptr @__swift_instantiateConcreteTypeFromMangledName({{.*}} @"$sSS_yptMD")
 public func markerInDictionary() -> Any {
   let dict: [String: P] = ["answer" : 42]
   return dict
@@ -85,3 +85,15 @@ protocol P2 {
 
 // CHECK: define{{.*}}$s15marker_protocol3fooyy3FooQz_xtAA1PRzAA2P2RzlF
 func foo<T: P & P2>(_: T.Foo, _: T) { }
+
+class C {}
+
+let v1 = (any C & P).self
+let v2 = C.self
+
+// CHECK-LABEL: define hidden swiftcc void @"$s15marker_protocol23testProtocolCompositionyyF"()
+// CHECK: [[V1:%.*]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$s15marker_protocol1CCMD")
+// CHECK: [[V2:%.*]] = load ptr, ptr @"$s15marker_protocol2v2AA1CCmvp"
+func testProtocolComposition() {
+  print(v1 == v2)
+}

--- a/test/IRGen/marker_protocol_backdeploy.swift
+++ b/test/IRGen/marker_protocol_backdeploy.swift
@@ -20,8 +20,8 @@ protocol R { }
 // Suppress marker protocols when forming existentials at runtime
 public func takeAnyType<T>(_: T.Type) { }
 
-// CHECK-LABEL: define {{.*}}@"$ss8Sendable_26marker_protocol_backdeploy1QAB1RpMa"
-// CHECK: ss8Sendable_26marker_protocol_backdeploy1QAB1RpML
+// CHECK-LABEL: define {{.*}}@"$s26marker_protocol_backdeploy1Q_AA1RpMa"
+// CHECK: $s26marker_protocol_backdeploy1Q_AA1RpML
 // CHECK-NOT: Sendable
 // CHECK: s26marker_protocol_backdeploy1QMp
 // CHECK-NOT: Sendable

--- a/test/Interpreter/protocol_composition_with_markers.swift
+++ b/test/Interpreter/protocol_composition_with_markers.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+protocol P {
+  init()
+  func f()
+}
+class C: P {
+  required init() {}
+  func f() { print("C.f") }
+}
+struct G<T: P> {
+  func f() { T().f() }
+}
+
+G<any (C & Sendable)>().f()
+// CHECK: C.f
+
+do {
+  let v1 = (any C & Sendable).self
+  let v2 = C.self
+
+  print(v1)
+  // CHECK: C
+  print(v2)
+  // CHECK: C
+  print(v1 == v2)
+  // CHECK: true
+}


### PR DESCRIPTION
…otocols

Even if protocol is not self-conforming it should be okay to produce a conformance based on superclass
if protocol bounds of the existential are all marker protocols.

Superclass concrete conformance is wrapped into an inherited conformance in such cases to 
reference the existential.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
