### PR TITLE
Fix ASTPrinting of lifetime dependence

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4920,7 +4920,15 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
 
       Printer.printDeclResultTypePre(decl, ResultTyLoc);
       Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
-
+      {
+        if (auto *typeRepr = dyn_cast_or_null<LifetimeDependentReturnTypeRepr>(
+                decl->getResultTypeRepr())) {
+          for (auto &dep : typeRepr->getLifetimeDependencies()) {
+            Printer << " " << dep.getLifetimeDependenceKindString() << "(";
+            Printer << dep.getParamString() << ") ";
+          }
+        }
+      }
       {
         auto fnTy = decl->getInterfaceType();
         bool hasTransferring = false;
@@ -5152,6 +5160,17 @@ void PrintAST::visitConstructorDecl(ConstructorDecl *decl) {
 
       printGenericDeclGenericParams(decl);
       printFunctionParameters(decl);
+      if (decl->hasLifetimeDependentReturn()) {
+        Printer << " -> ";
+        auto *typeRepr =
+            cast<LifetimeDependentReturnTypeRepr>(decl->getResultTypeRepr());
+        for (auto &dep : typeRepr->getLifetimeDependencies()) {
+          Printer << dep.getLifetimeDependenceKindString() << "(";
+          Printer << dep.getParamString() << ") ";
+        }
+        // TODO: Handle failable initializers with lifetime dependent returns
+        Printer << "Self";
+      }
     });
 
   printDeclGenericRequirements(decl);
@@ -7441,6 +7460,13 @@ public:
    }
 
     Printer << " -> ";
+
+    if (T->hasLifetimeDependenceInfo()) {
+      auto lifetimeDependenceInfo = T->getExtInfo().getLifetimeDependenceInfo();
+      assert(!lifetimeDependenceInfo.empty());
+      Printer << lifetimeDependenceInfo.getString() << " ";
+    }
+
     Printer.callPrintStructurePre(PrintStructureKind::FunctionReturnType);
     T->getResult().print(Printer, Options);
     Printer.printStructurePost(PrintStructureKind::FunctionReturnType);

--- a/test/ModuleInterface/Inputs/lifetime_dependence.swift
+++ b/test/ModuleInterface/Inputs/lifetime_dependence.swift
@@ -1,0 +1,53 @@
+public struct AnotherView : ~Escapable {
+  @usableFromInline let _ptr: UnsafeRawBufferPointer
+  @usableFromInline let _count: Int
+  @_unsafeNonescapableResult
+  internal init(_ ptr: UnsafeRawBufferPointer, _ count: Int) {
+    self._ptr = ptr
+    self._count = count
+  }
+}
+
+public struct BufferView : ~Escapable {
+  @usableFromInline let _ptr: UnsafeRawBufferPointer
+  @usableFromInline let _count: Int
+  @_unsafeNonescapableResult
+  @usableFromInline 
+  internal init(_ ptr: UnsafeRawBufferPointer, _ count: Int) {
+    self._ptr = ptr
+    self._count = count
+  }
+
+  @inlinable
+  internal init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) -> _borrow(a) Self {
+    self.init(ptr, a.count)
+    return self
+  }
+  @inlinable
+  internal init(_ ptr: UnsafeRawBufferPointer, _ a: consuming AnotherView) -> _consume(a) Self {
+    self.init(ptr, a._count)
+    return self
+  }
+}
+
+@inlinable
+public func derive(_ x: consuming BufferView) -> _consume(x) BufferView {
+  return BufferView(x._ptr, x._count)
+}
+
+@inlinable
+public func use(_ x: consuming BufferView) {}
+
+@inlinable
+public func consumeAndCreate(_ view: consuming BufferView) -> _consume(view) BufferView {
+  return BufferView(view._ptr, view._count)
+}
+
+@inlinable
+public func deriveThisOrThat(_ this: consuming BufferView, _ that: consuming BufferView) -> _consume(this, that) BufferView {
+  if (Int.random(in: 1..<100) == 0) {
+    return BufferView(this._ptr, this._count)
+  }
+  return BufferView(that._ptr, that._count)
+}
+

--- a/test/ModuleInterface/lifetime_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_dependence_test.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
+// RUN:     -disable-experimental-parser-round-trip \
+// RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature NonescapableTypes \
+// RUN:     -o %t/lifetime_dependence.swiftmodule \
+// RUN:     -emit-module-interface-path %t/lifetime_dependence.swiftinterface \
+// RUN:     %S/Inputs/lifetime_dependence.swift
+// REQUIRES: asserts
+
+// Check the interfaces
+
+// RUN: %FileCheck %s < %t/lifetime_dependence.swiftinterface
+
+// See if we can compile a module through just the interface and typecheck using it.
+
+// RUN: %target-swift-frontend -compile-module-from-interface \
+// RUN:    -disable-experimental-parser-round-trip \
+// RUN:    -enable-experimental-feature NoncopyableGenerics \
+// RUN:    -enable-experimental-feature NonescapableTypes \
+// RUN:    %t/lifetime_dependence.swiftinterface -o %t/lifetime_dependence.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck -I %t %s \
+// RUN:    -disable-experimental-parser-round-trip \
+// RUN:    -enable-experimental-feature NoncopyableGenerics \
+// RUN:    -enable-experimental-feature NonescapableTypes
+
+import lifetime_dependence
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK: @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: borrowing Swift.Array<Swift.Int>) -> _borrow(a) Self {
+// CHECK: @inlinable internal init(_ ptr: Swift.UnsafeRawBufferPointer, _ a: consuming lifetime_dependence.AnotherView) -> _consume(a) Self {
+// CHECK: #endif
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK: @inlinable public func derive(_ x: consuming lifetime_dependence.BufferView) ->  _consume(x) lifetime_dependence.BufferView {
+// CHECK: #endif
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK: @inlinable public func consumeAndCreate(_ view: consuming lifetime_dependence.BufferView) ->  _consume(view) lifetime_dependence.BufferView {
+// CHECK: #endif
+
+// CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK: @inlinable public func deriveThisOrThat(_ this: consuming lifetime_dependence.BufferView, _ that: consuming lifetime_dependence.BufferView) ->  _consume(this)  _consume(that) lifetime_dependence.BufferView {
+// CHECK: #endif


### PR DESCRIPTION
This fixes the errors while compiling functions with lifetime dependence in the textual interface files.

Also fixes rdar://122573346

