### PR TITLE
Soften objcImpl selector conflict errors

### DIFF
--- a/lib/Sema/TypeCheckDeclObjC.cpp
+++ b/lib/Sema/TypeCheckDeclObjC.cpp
@@ -2551,6 +2551,12 @@ bool swift::diagnoseObjCMethodConflicts(SourceFile &sf) {
                                      conflict.selector);
       diag.warnUntilSwiftVersionIf(breakingInSwift5, 6);
 
+      // Temporarily soften selector conflicts in objcImpl extensions; we're
+      // seeing some that are caused by ObjCImplementationChecker improvements.
+      if (conflictingDecl->getDeclContext()->getImplementedObjCContext()
+            != conflictingDecl->getDeclContext())
+        diag.wrapIn(diag::wrap_objc_implementation_will_become_error);
+
       auto objcAttr = getObjCAttrIfFromAccessNote(conflictingDecl);
       swift::softenIfAccessNote(conflictingDecl, objcAttr, diag);
       if (objcAttr)

--- a/test/decl/ext/Inputs/objc_implementation_class_extension.h
+++ b/test/decl/ext/Inputs/objc_implementation_class_extension.h
@@ -1,0 +1,21 @@
+@import Foundation;
+
+@interface ObjCClass : NSObject
+
+- (void)methodFromHeader1:(int)param;
+- (void)methodFromHeader2:(int)param;
+
+@property (readwrite) int propertyFromHeader1;
+@property (readwrite) int propertyFromHeader2;
+
+@end
+
+@interface ObjCClass ()
+
+- (void)extensionMethodFromHeader1:(int)param;
+- (void)extensionMethodFromHeader2:(int)param;
+
+@property (readwrite) int extensionPropertyFromHeader1;
+@property (readwrite) int extensionPropertyFromHeader2;
+
+@end

--- a/test/decl/ext/Inputs/objc_implementation_class_extension.modulemap
+++ b/test/decl/ext/Inputs/objc_implementation_class_extension.modulemap
@@ -1,0 +1,9 @@
+module objc_implementation_class_extension {
+  header "objc_implementation_class_extension.h"
+  export *
+}
+
+module objc_implementation_class_extension_internal {
+  header "objc_implementation_class_extension_internal.h"
+  export *
+}

--- a/test/decl/ext/Inputs/objc_implementation_class_extension_internal.h
+++ b/test/decl/ext/Inputs/objc_implementation_class_extension_internal.h
@@ -1,0 +1,11 @@
+#import "objc_implementation_class_extension.h"
+
+@interface ObjCClass ()
+
+- (void)otherModuleExtensionMethodFromHeader1:(int)param;
+- (void)otherModuleExtensionMethodFromHeader2:(int)param;
+
+@property (readwrite) int otherModuleExtensionPropertyFromHeader1;
+@property (readwrite) int otherModuleExtensionPropertyFromHeader2;
+
+@end

--- a/test/decl/ext/objc_implementation_class_extension.swift
+++ b/test/decl/ext/objc_implementation_class_extension.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -import-underlying-module -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_class_extension.modulemap
+// REQUIRES: objc_interop
+
+@_implementationOnly import objc_implementation_class_extension_internal
+
+@_objcImplementation extension ObjCClass {
+  // expected-warning@-1 {{extension for main class interface should provide implementation for instance method 'method(fromHeader2:)'}}
+  // expected-warning@-2 {{extension for main class interface should provide implementation for property 'propertyFromHeader2'}}
+  // expected-warning@-3 {{extension for main class interface should provide implementation for instance method 'otherModuleExtensionMethod(fromHeader2:)'}}
+  // expected-warning@-4 {{extension for main class interface should provide implementation for property 'otherModuleExtensionPropertyFromHeader2'}}
+  // expected-warning@-5 {{extension for main class interface should provide implementation for instance method 'extensionMethod(fromHeader2:)'}}
+  // expected-warning@-6 {{extension for main class interface should provide implementation for property 'extensionPropertyFromHeader2'}}
+
+  @objc func method(fromHeader1: CInt) {}
+  @objc private func method(fromHeader2: CInt) {}
+
+  @objc var propertyFromHeader1: CInt = 1
+  @objc private var propertyFromHeader2: CInt = 2
+
+  @objc func extensionMethod(fromHeader1: CInt) {}
+  @objc private func extensionMethod(fromHeader2: CInt) {}
+
+  @objc var extensionPropertyFromHeader1: CInt = 1
+  @objc private var extensionPropertyFromHeader2: CInt = 2
+
+  @objc func otherModuleExtensionMethod(fromHeader1: CInt) {}
+  @objc private func otherModuleExtensionMethod(fromHeader2: CInt) {}
+
+  @objc var otherModuleExtensionPropertyFromHeader1: CInt = 1
+  @objc private var otherModuleExtensionPropertyFromHeader2: CInt = 2
+  // expected-warning@-1 {{getter for 'otherModuleExtensionPropertyFromHeader2' with Objective-C selector 'otherModuleExtensionPropertyFromHeader2' conflicts with previous declaration with the same Objective-C selector}}
+  // expected-warning@-2 {{setter for 'otherModuleExtensionPropertyFromHeader2' with Objective-C selector 'setOtherModuleExtensionPropertyFromHeader2:' conflicts with previous declaration with the same Objective-C selector}}
+}


### PR DESCRIPTION
The recent change to make objcImpl examine class extensions has collided with a workaround some projects were employing where they declared class extension member implementations `private`. Now that we’re checking class extensions in objcImpl extensions, this workaround is creating selector conflict errors in some circumstances. Soften selector conflict errors in objcImpl extensions to warnings so the affected projects continue to build.

Fixes rdar://123347290.