### PR TITLE
Use the new template deduction guides rather than `makeArrayRef`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1385,14 +1385,6 @@ endif()
 add_subdirectory(include)
 
 if(SWIFT_INCLUDE_TOOLS)
-  # TODO Remove this once release/5.9 is done and we can finish migrating Swift
-  #      off of `llvm::None`/`llvm::Optional`, and `llvm::makeArrayRef`.
-  # This is to silence the avalanche of deprecation warnings from LLVM headers
-  # until we can actually do something about them. This is nasty, but it's
-  # better than losing context due to the sheer number in-actionable deprecation
-  # warnings or the massive number of merge-conflicts we would get otherwise.
-  add_definitions(-DSWIFT_TARGET)
-
   add_subdirectory(lib)
 
   add_subdirectory(SwiftCompilerSources)

--- a/include/swift/ABI/GenericContext.h
+++ b/include/swift/ABI/GenericContext.h
@@ -318,11 +318,11 @@ public:
       PackShapeHeader(packShapeHeader), PackShapeDescriptors(packShapeDescriptors) {}
 
   llvm::ArrayRef<GenericParamDescriptor> getParams() const {
-    return llvm::makeArrayRef(Params, Header.NumParams);
+    return llvm::ArrayRef(Params, Header.NumParams);
   }
 
   llvm::ArrayRef<TargetGenericRequirementDescriptor<Runtime>> getRequirements() const {
-    return llvm::makeArrayRef(Requirements, Header.NumRequirements);
+    return llvm::ArrayRef(Requirements, Header.NumRequirements);
   }
 
   const GenericPackShapeHeader &getGenericPackShapeHeader() const {
@@ -330,7 +330,7 @@ public:
   }
 
   llvm::ArrayRef<GenericPackShapeDescriptor> getGenericPackShapeDescriptors() const {
-    return llvm::makeArrayRef(PackShapeDescriptors, PackShapeHeader.NumPacks);
+    return llvm::ArrayRef(PackShapeDescriptors, PackShapeHeader.NumPacks);
   }
 
   size_t getArgumentLayoutSizeInWords() const {
@@ -379,20 +379,20 @@ class TargetGenericEnvironment
 public:
   /// Retrieve the cumulative generic parameter counts at each level of genericity.
   llvm::ArrayRef<uint16_t> getGenericParameterCounts() const {
-    return llvm::makeArrayRef(this->template getTrailingObjects<uint16_t>(),
-                              Flags.getNumGenericParameterLevels());
+    return llvm::ArrayRef(this->template getTrailingObjects<uint16_t>(),
+                          Flags.getNumGenericParameterLevels());
   }
 
   /// Retrieve the generic parameters descriptors.
   llvm::ArrayRef<GenericParamDescriptor> getGenericParameters() const {
-    return llvm::makeArrayRef(
+    return llvm::ArrayRef(
         this->template getTrailingObjects<GenericParamDescriptor>(),
         getGenericParameterCounts().back());
   }
 
   /// Retrieve the generic requirements.
   llvm::ArrayRef<GenericRequirementDescriptor> getGenericRequirements() const {
-    return llvm::makeArrayRef(
+    return llvm::ArrayRef(
         this->template getTrailingObjects<GenericRequirementDescriptor>(),
         Flags.getNumGenericRequirements());
   }

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -523,7 +523,7 @@ public:
   StringRef AllocateCopy(StringRef Str,
                     AllocationArena arena = AllocationArena::Permanent) const {
     ArrayRef<char> Result =
-        AllocateCopy(llvm::makeArrayRef(Str.data(), Str.size()), arena);
+        AllocateCopy(llvm::ArrayRef(Str.data(), Str.size()), arena);
     return StringRef(Result.data(), Result.size());
   }
 

--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -145,8 +145,7 @@ class CaptureInfo {
       : DynamicSelf(dynamicSelf), OpaqueValue(opaqueValue), Count(count) { }
 
     ArrayRef<CapturedValue> getCaptures() const {
-      return llvm::makeArrayRef(this->getTrailingObjects<CapturedValue>(),
-                                Count);
+      return llvm::ArrayRef(this->getTrailingObjects<CapturedValue>(), Count);
     }
 
     DynamicSelfType *getDynamicSelfType() const {

--- a/include/swift/AST/Comment.h
+++ b/include/swift/AST/Comment.h
@@ -46,7 +46,7 @@ public:
   }
 
   ArrayRef<StringRef> getTags() const {
-    return llvm::makeArrayRef(Parts.Tags.begin(), Parts.Tags.end());
+    return llvm::ArrayRef(Parts.Tags.begin(), Parts.Tags.end());
   }
 
   std::optional<const swift::markup::Paragraph *> getBrief() const {

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -163,16 +163,16 @@ public:
   bool empty() const { return innerResults().empty(); }
 
   ArrayRef<LookupResultEntry> innerResults() const {
-    return llvm::makeArrayRef(Results).take_front(IndexOfFirstOuterResult);
+    return llvm::ArrayRef(Results).take_front(IndexOfFirstOuterResult);
   }
 
   ArrayRef<LookupResultEntry> outerResults() const {
-    return llvm::makeArrayRef(Results).drop_front(IndexOfFirstOuterResult);
+    return llvm::ArrayRef(Results).drop_front(IndexOfFirstOuterResult);
   }
 
   /// \returns An array of both the inner and outer results.
   ArrayRef<LookupResultEntry> allResults() const {
-    return llvm::makeArrayRef(Results);
+    return llvm::ArrayRef(Results);
   }
 
   const LookupResultEntry& operator[](unsigned index) const {

--- a/include/swift/AST/SILLayout.h
+++ b/include/swift/AST/SILLayout.h
@@ -142,7 +142,7 @@ public:
   
   /// Get the fields inside the layout.
   ArrayRef<SILField> getFields() const {
-    return llvm::makeArrayRef(getTrailingObjects<SILField>(), NumFields);
+    return llvm::ArrayRef(getTrailingObjects<SILField>(), NumFields);
   }
   
   /// Produce a profile of this layout, for use in a folding set.

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -302,7 +302,7 @@ public:
   std::optional<ArrayRef<ASTNode>> getCachedTopLevelItems() const {
     if (!Items)
       return std::nullopt;
-    return llvm::makeArrayRef(*Items);
+    return llvm::ArrayRef(*Items);
   }
 
   /// Retrieve the parsing options for the file.

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -514,8 +514,7 @@ public:
                                     bool isUnavailability);
   
   ArrayRef<AvailabilitySpec *> getQueries() const {
-    return llvm::makeArrayRef(getTrailingObjects<AvailabilitySpec *>(),
-                              NumQueries);
+    return llvm::ArrayRef(getTrailingObjects<AvailabilitySpec *>(), NumQueries);
   }
   
   SourceLoc getLParenLoc() const { return LParenLoc; }

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -281,8 +281,8 @@ public:
                                     TypeRepr *ty);
 
   ArrayRef<TypeOrCustomAttr> getAttrs() const {
-    return llvm::makeArrayRef(getTrailingObjects<TypeOrCustomAttr>(),
-                              Bits.AttributedTypeRepr.NumAttributes);
+    return llvm::ArrayRef(getTrailingObjects<TypeOrCustomAttr>(),
+                          Bits.AttributedTypeRepr.NumAttributes);
   }
 
   TypeAttribute *get(TypeAttrKind kind) const;
@@ -871,12 +871,12 @@ public:
   SourceRange getBracesRange() const { return BraceLocs; }
 
   MutableArrayRef<TypeRepr*> getMutableElements() {
-    return llvm::makeMutableArrayRef(getTrailingObjects<TypeRepr*>(),
-                                     Bits.PackTypeRepr.NumElements);
+    return llvm::MutableArrayRef(getTrailingObjects<TypeRepr *>(),
+                                 Bits.PackTypeRepr.NumElements);
   }
   ArrayRef<TypeRepr*> getElements() const {
-    return llvm::makeArrayRef(getTrailingObjects<TypeRepr*>(),
-                              Bits.PackTypeRepr.NumElements);
+    return llvm::ArrayRef(getTrailingObjects<TypeRepr *>(),
+                          Bits.PackTypeRepr.NumElements);
   }
 
   static bool classof(const TypeRepr *T) {

--- a/include/swift/Basic/MultiMapCache.h
+++ b/include/swift/Basic/MultiMapCache.h
@@ -64,9 +64,10 @@ public:
     // If we already have a cached value, just return the cached value.
     if (!iter.second) {
 
-      return swift::transform(iter.first->second,
+      return swift::transform(
+          iter.first->second,
           [&](std::tuple<unsigned, unsigned> startLengthRange) {
-            return llvm::makeArrayRef(data).slice(
+            return llvm::ArrayRef(data).slice(
                 std::get<ArrayStartOffset>(startLengthRange),
                 std::get<ArrayLengthOffset>(startLengthRange));
           });
@@ -88,7 +89,7 @@ public:
     // update the map with the start, length, and return the resulting ArrayRef.
     unsigned length = data.size() - initialOffset;
     iter.first->second = std::make_tuple(initialOffset, length);
-    auto result = llvm::makeArrayRef(data).slice(initialOffset, length);
+    auto result = llvm::ArrayRef(data).slice(initialOffset, length);
     return result;
   }
 };

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -268,7 +268,7 @@ public:
   }
 
   UnwrappedArrayView<const Action> getActions() const {
-    return llvm::makeArrayRef(Actions);
+    return llvm::ArrayRef(Actions);
   }
 
   template <typename SpecificAction, typename... Args>
@@ -278,9 +278,7 @@ public:
     return newAction;
   }
 
-  UnwrappedArrayView<const Job> getJobs() const {
-    return llvm::makeArrayRef(Jobs);
-  }
+  UnwrappedArrayView<const Job> getJobs() const { return llvm::ArrayRef(Jobs); }
 
   /// To send job list to places that don't truck in fancy array views.
   std::vector<const Job *> getJobsSimply() const {

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -56,7 +56,7 @@ ArrayRef<T> copyArray(llvm::BumpPtrAllocator &Allocator,
                             ArrayRef<T> Arr) {
   T *Buffer = Allocator.Allocate<T>(Arr.size());
   std::copy(Arr.begin(), Arr.end(), Buffer);
-  return llvm::makeArrayRef(Buffer, Arr.size());
+  return llvm::ArrayRef(Buffer, Arr.size());
 }
 
 bool isDynamicLookup(Type T);

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -428,7 +428,7 @@ public:
   DeclNameViewer() : DeclNameViewer(StringRef()) {}
   operator bool() const { return !BaseName.empty(); }
   StringRef base() const { return BaseName; }
-  llvm::ArrayRef<StringRef> args() const { return llvm::makeArrayRef(Labels); }
+  llvm::ArrayRef<StringRef> args() const { return llvm::ArrayRef(Labels); }
   unsigned argSize() const { return Labels.size(); }
   unsigned partsCount() const { return 1 + Labels.size(); }
   unsigned commonPartsCount(DeclNameViewer &Other) const;

--- a/include/swift/Markup/Markup.h
+++ b/include/swift/Markup/Markup.h
@@ -53,7 +53,7 @@ public:
 
   StringRef allocateCopy(StringRef Str) {
     ArrayRef<char> Result =
-      allocateCopy(llvm::makeArrayRef(Str.data(), Str.size()));
+        allocateCopy(llvm::ArrayRef(Str.data(), Str.size()));
     return StringRef(Result.data(), Result.size());
   }
 

--- a/include/swift/Runtime/Numeric.h
+++ b/include/swift/Runtime/Numeric.h
@@ -45,8 +45,8 @@ public:
   /// the least-significant chunk.  The value is sign-extended to fill the
   /// final chunk.
   llvm::ArrayRef<UnsignedChunk> getData() const {
-    return llvm::makeArrayRef(Data, (Flags.getBitWidth() + BitsPerChunk - 1) /
-                                        BitsPerChunk);
+    return llvm::ArrayRef(Data, (Flags.getBitWidth() + BitsPerChunk - 1) /
+                                    BitsPerChunk);
   }
 
   /// The flags for this value.

--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -770,13 +770,13 @@ public:
   bool isLeaf() const { return ChildProjections.empty(); }
 
   ArrayRef<unsigned> getChildProjections() const {
-    return llvm::makeArrayRef(ChildProjections);
+    return llvm::ArrayRef(ChildProjections);
   }
 
   std::optional<Projection> &getProjection() { return Proj; }
 
   const ArrayRef<Operand *> getNonProjUsers() const {
-    return llvm::makeArrayRef(NonProjUsers);
+    return llvm::ArrayRef(NonProjUsers);
   }
 
   SILType getType() const { return NodeType; }
@@ -884,7 +884,7 @@ public:
   SILModule &getModule() const { return *Mod; }
 
   llvm::ArrayRef<ProjectionTreeNode *> getProjectionTreeNodes() {
-    return llvm::makeArrayRef(ProjectionTreeNodes);
+    return llvm::ArrayRef(ProjectionTreeNodes);
   }
 
   /// Iterate over all values in the tree. The function should return false if

--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -216,8 +216,8 @@ public:
   /// subcomponent.
   ArrayRef<PathElement> getPath() const {
     // FIXME: Alignment.
-    return llvm::makeArrayRef(reinterpret_cast<const PathElement *>(this + 1),
-                              numPathElements);
+    return llvm::ArrayRef(reinterpret_cast<const PathElement *>(this + 1),
+                          numPathElements);
   }
 
   unsigned getSummaryFlags() const { return summaryFlags; }

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3472,7 +3472,7 @@ public:
   /// path element.
   ConstraintLocator *
   getConstraintLocator(ASTNode anchor, ConstraintLocator::PathElement pathElt) {
-    return getConstraintLocator(anchor, llvm::makeArrayRef(pathElt),
+    return getConstraintLocator(anchor, llvm::ArrayRef(pathElt),
                                 pathElt.getNewSummaryFlags());
   }
 

--- a/include/swift/Sema/SolutionResult.h
+++ b/include/swift/Sema/SolutionResult.h
@@ -23,7 +23,6 @@
 namespace swift {
 
 using llvm::ArrayRef;
-using llvm::makeArrayRef;
 
 namespace constraints {
 

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -328,7 +328,7 @@ ArrayRef<NodeAnnotation> SDKNode::
 getAnnotations(std::vector<NodeAnnotation> &Scratch) const {
   for (auto Ann : Annotations)
     Scratch.push_back(Ann);
-  return llvm::makeArrayRef(Scratch);
+  return llvm::ArrayRef(Scratch);
 }
 
 bool SDKNode::isAnnotatedAs(NodeAnnotation Anno) const {
@@ -380,7 +380,7 @@ KnownTypeKind SDKNodeType::getTypeKind() const {
 }
 
 ArrayRef<TypeAttrKind> SDKNodeType::getTypeAttributes() const {
-  return llvm::makeArrayRef(TypeAttributes.data(), TypeAttributes.size());
+  return llvm::ArrayRef(TypeAttributes.data(), TypeAttributes.size());
 }
 
 void SDKNodeType::addTypeAttribute(TypeAttrKind AttrKind) {
@@ -508,7 +508,7 @@ bool SDKNodeDecl::hasDeclAttribute(DeclAttrKind DAKind) const {
 }
 
 ArrayRef<DeclAttrKind> SDKNodeDecl::getDeclAttributes() const {
-  return llvm::makeArrayRef(DeclAttributes.data(), DeclAttributes.size());
+  return llvm::ArrayRef(DeclAttributes.data(), DeclAttributes.size());
 }
 
 bool SDKNodeDecl::hasAttributeChange(const SDKNodeDecl &Another) const {

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -2451,7 +2451,7 @@ BridgedGenericTypeParamDecl BridgedGenericTypeParamDecl_createParsed(
   if (auto *inheritedType = bridgedInheritedType.unbridged()) {
     auto entry = InheritedEntry(inheritedType);
     ASTContext &context = cContext.unbridged();
-    decl->setInherited(context.AllocateCopy(llvm::makeArrayRef(entry)));
+    decl->setInherited(context.AllocateCopy(llvm::ArrayRef(entry)));
   }
 
   return decl;

--- a/lib/AST/DocComment.cpp
+++ b/lib/AST/DocComment.cpp
@@ -343,8 +343,8 @@ swift::extractCommentParts(swift::markup::MarkupContext &MC,
   }
 
   // Copy BodyNodes and ParamFields into the MarkupContext.
-  Parts.BodyNodes = MC.allocateCopy(llvm::makeArrayRef(BodyNodes));
-  Parts.ParamFields = MC.allocateCopy(llvm::makeArrayRef(ParamFields));
+  Parts.BodyNodes = MC.allocateCopy(llvm::ArrayRef(BodyNodes));
+  Parts.ParamFields = MC.allocateCopy(llvm::ArrayRef(ParamFields));
 
   for (auto Param : Parts.ParamFields) {
     auto ParamParts = extractCommentParts(MC, Param);
@@ -378,7 +378,7 @@ void DocComment::addInheritanceNote(swift::markup::MarkupContext &MC,
   SmallVector<const markup::MarkupASTNode *, 8> BodyNodes{
     Parts.BodyNodes.begin(), Parts.BodyNodes.end()};
   BodyNodes.push_back(note);
-  Parts.BodyNodes = MC.allocateCopy(llvm::makeArrayRef(BodyNodes));
+  Parts.BodyNodes = MC.allocateCopy(llvm::ArrayRef(BodyNodes));
 }
 
 DocComment *swift::getSingleDocComment(swift::markup::MarkupContext &MC,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2824,7 +2824,7 @@ SourceFile::getIfConfigsWithin(SourceRange outer) const {
   }
 
   // First let's find the first #if that is after the outer start loc.
-  auto ranges = llvm::makeArrayRef(IfConfigRanges.Ranges);
+  auto ranges = llvm::ArrayRef(IfConfigRanges.Ranges);
   auto lower = llvm::lower_bound(
       ranges, outer.Start, [&](IfConfigRangeInfo range, SourceLoc loc) {
         return SM.isBeforeInBuffer(range.getStartLoc(), loc);
@@ -2838,7 +2838,7 @@ SourceFile::getIfConfigsWithin(SourceRange outer) const {
       ranges, outer.End, [&](SourceLoc loc, IfConfigRangeInfo range) {
         return SM.isBeforeInBuffer(loc, range.getStartLoc());
       });
-  return llvm::makeArrayRef(lower, upper - lower);
+  return llvm::ArrayRef(lower, upper - lower);
 }
 
 void ModuleDecl::setPackageName(Identifier name) {

--- a/lib/AST/NameLookupRequests.cpp
+++ b/lib/AST/NameLookupRequests.cpp
@@ -322,7 +322,7 @@ ArrayRef<FileUnit *> OperatorLookupDescriptor::getFiles() const {
     return module->getFiles();
 
   // Return an ArrayRef pointing to the FileUnit in the union.
-  return llvm::makeArrayRef(*fileOrModule.getAddrOfPtr1());
+  return llvm::ArrayRef(*fileOrModule.getAddrOfPtr1());
 }
 
 void swift::simple_display(llvm::raw_ostream &out,

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -158,7 +158,7 @@ RawComment RawCommentRequest::evaluate(Evaluator &eval, const Decl *D) const {
       }
 
       if (!SRCs.empty())
-        return RawComment(ctx.AllocateCopy(llvm::makeArrayRef(SRCs)));
+        return RawComment(ctx.AllocateCopy(llvm::ArrayRef(SRCs)));
     }
 
     // Otherwise check to see if we have a comment available in the swiftdoc.

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -785,7 +785,7 @@ getCaseVarDecls(ASTContext &ctx, ArrayRef<CaseLabelItem> labelItems) {
   SmallVector<VarDecl *, 4> tmp;
   labelItems.front().getPattern()->collectVariables(tmp);
   return ctx.AllocateTransform<VarDecl *>(
-      llvm::makeArrayRef(tmp), [&](VarDecl *vOld) -> VarDecl * {
+      llvm::ArrayRef(tmp), [&](VarDecl *vOld) -> VarDecl * {
         auto *vNew = new (ctx) VarDecl(
             /*IsStatic*/ false, vOld->getIntroducer(), vOld->getNameLoc(),
             vOld->getName(), vOld->getDeclContext());

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -527,9 +527,8 @@ SubstitutionMap
 SubstitutionMap::getProtocolSubstitutions(ProtocolDecl *protocol,
                                           Type selfType,
                                           ProtocolConformanceRef conformance) {
-  return get(protocol->getGenericSignature(),
-             llvm::makeArrayRef<Type>(selfType),
-             llvm::makeArrayRef<ProtocolConformanceRef>(conformance));
+  return get(protocol->getGenericSignature(), llvm::ArrayRef<Type>(selfType),
+             llvm::ArrayRef<ProtocolConformanceRef>(conformance));
 }
 
 SubstitutionMap

--- a/lib/AST/SubstitutionMapStorage.h
+++ b/lib/AST/SubstitutionMapStorage.h
@@ -83,8 +83,7 @@ public:
   /// Note that the types may be null, for cases where the generic parameter
   /// is concrete but hasn't been queried yet.
   ArrayRef<Type> getReplacementTypes() const {
-    return llvm::makeArrayRef(getTrailingObjects<Type>(),
-                              getNumReplacementTypes());
+    return llvm::ArrayRef(getTrailingObjects<Type>(), getNumReplacementTypes());
   }
 
   MutableArrayRef<Type> getReplacementTypes() {
@@ -95,8 +94,8 @@ public:
   /// Retrieve the array of protocol conformances, which line up with the
   /// requirements of the generic signature.
   ArrayRef<ProtocolConformanceRef> getConformances() const {
-    return llvm::makeArrayRef(getTrailingObjects<ProtocolConformanceRef>(),
-                              numConformanceRequirements);
+    return llvm::ArrayRef(getTrailingObjects<ProtocolConformanceRef>(),
+                          numConformanceRequirements);
   }
   MutableArrayRef<ProtocolConformanceRef> getConformances() {
     return MutableArrayRef<ProtocolConformanceRef>(

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -105,7 +105,7 @@ set(compile_options
   ${c_include_paths_args}
   "SHELL: -DRESILIENT_SWIFT_SYNTAX"
   "SHELL: ${cxx_interop_flag}"
-  "SHELL: -Xcc -std=c++17 -Xcc -DCOMPILED_WITH_SWIFT -Xcc -DSWIFT_TARGET"
+  "SHELL: -Xcc -std=c++17 -Xcc -DCOMPILED_WITH_SWIFT"
 
   # FIXME: Needed to work around an availability issue with CxxStdlib
   "SHELL: -Xfrontend -disable-target-os-checking"

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -778,7 +778,7 @@ ArrayRef<unsigned> SourceManager::getAncestors(
   // Cache the ancestors in the generated source info record.
   unsigned *ancestorsPtr = new unsigned [ancestors.size()];
   std::copy(ancestors.begin(), ancestors.end(), ancestorsPtr);
-  knownInfo->second.ancestors = llvm::makeArrayRef(ancestorsPtr, ancestors.size());
+  knownInfo->second.ancestors = llvm::ArrayRef(ancestorsPtr, ancestors.size());
   return knownInfo->second.ancestors;
 }
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,10 +23,6 @@ file(GENERATE
 #define COMPILED_WITH_SWIFT
 #endif
 
-#ifndef SWIFT_TARGET
-#define SWIFT_TARGET
-#endif
-
 #include \"swift/Basic/BasicBridging.h\"
 #include \"swift/AST/ASTBridging.h\"
 #include \"swift/IDE/IDEBridging.h\"

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2195,7 +2195,7 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
     // put the Clang AST in a fatal error state if it /doesn't/ exist.
     if (!submodule && component.Item.str() == "Private" &&
         (&component) == (&path.getRaw()[1])) {
-      submodule = loadModule(llvm::makeArrayRef(clangPath).slice(0, 2),
+      submodule = loadModule(llvm::ArrayRef(clangPath).slice(0, 2),
                              clang::Module::Hidden);
     }
 
@@ -4241,7 +4241,7 @@ void ClangModuleUnit::getImportedModulesForLookup(
   }
 
   // Cache our results for use next time.
-  auto importsToCache = llvm::makeArrayRef(imports).slice(firstImport);
+  auto importsToCache = llvm::ArrayRef(imports).slice(firstImport);
   importedModulesForLookup = getASTContext().AllocateCopy(importsToCache);
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7662,7 +7662,7 @@ void SwiftDeclConverter::importNonOverriddenMirroredMethods(DeclContext *dc,
         asyncImports[objcMethod] = imported;
       } else {
         syncImports[objcMethod] = llvm::TinyPtrVector<Decl *>(
-            llvm::makeArrayRef(members).drop_front(start + 1));
+            llvm::ArrayRef(members).drop_front(start + 1));
       }
     }
   }
@@ -9434,9 +9434,8 @@ void ClangImporter::Implementation::insertMembersAndAlternates(
     return true;
   });
 
-  addCompletionHandlerAttribute(asyncImport,
-                                llvm::makeArrayRef(members).drop_front(start),
-                                SwiftContext);
+  addCompletionHandlerAttribute(
+      asyncImport, llvm::ArrayRef(members).drop_front(start), SwiftContext);
 }
 
 void ClangImporter::Implementation::importInheritedConstructors(

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -456,10 +456,9 @@ synthesizeStructDefaultConstructorBody(AbstractFunctionDecl *afd,
   Identifier zeroInitID = ctx.getIdentifier("zeroInitializer");
   auto zeroInitializerFunc =
       cast<FuncDecl>(getBuiltinValueDecl(ctx, zeroInitID));
-  SubstitutionMap subMap =
-      SubstitutionMap::get(zeroInitializerFunc->getGenericSignature(),
-                           llvm::makeArrayRef(selfType),
-                           LookUpConformanceInModule(module));
+  SubstitutionMap subMap = SubstitutionMap::get(
+      zeroInitializerFunc->getGenericSignature(), llvm::ArrayRef(selfType),
+      LookUpConformanceInModule(module));
   ConcreteDeclRef concreteDeclRef(zeroInitializerFunc, subMap);
   auto zeroInitializerRef =
       new (ctx) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1719,7 +1719,7 @@ SwiftLookupTableReader::create(clang::ModuleFileExtension *extension,
         reinterpret_cast<const clang::serialization::DeclID *>(blobData.data());
       unsigned numElements
         = blobData.size() / sizeof(clang::serialization::DeclID);
-      categories = llvm::makeArrayRef(start, numElements);
+      categories = llvm::ArrayRef(start, numElements);
       break;
     }
 

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -623,7 +623,7 @@ void writeJSONValue(llvm::raw_ostream &out, ArrayRef<T> values,
 template <typename T>
 void writeJSONValue(llvm::raw_ostream &out, const std::vector<T> &values,
                     unsigned indentLevel) {
-  writeJSONValue(out, llvm::makeArrayRef(values), indentLevel);
+  writeJSONValue(out, llvm::ArrayRef(values), indentLevel);
 }
 
 /// Write a single JSON field.

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -60,7 +60,7 @@ toolchains::Darwin::findProgramRelativeToSwiftImpl(StringRef name) const {
   }
 
   StringRef paths[] = {swiftBinDir, path};
-  auto pathsRef = llvm::makeArrayRef(paths);
+  auto pathsRef = llvm::ArrayRef(paths);
   if (!hasToolchain)
     pathsRef = pathsRef.drop_back();
 

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -141,5 +141,5 @@ bool swift::driver::getSingleFrontendInvocationFromDriverArguments(
   }
 
   const llvm::opt::ArgStringList &BaseFrontendArgs = Cmd->getArguments();
-  return Action(llvm::makeArrayRef(BaseFrontendArgs).drop_front());
+  return Action(llvm::ArrayRef(BaseFrontendArgs).drop_front());
 }

--- a/lib/DriverTool/driver.cpp
+++ b/lib/DriverTool/driver.cpp
@@ -253,14 +253,14 @@ static int run_driver(StringRef ExecName,
     StringRef FirstArg(argv[1]);
 
     if (FirstArg == "-frontend") {
-      return performFrontend(llvm::makeArrayRef(argv.data()+2,
-                                                argv.data()+argv.size()),
-                             argv[0], (void *)(intptr_t)getExecutablePath);
+      return performFrontend(
+          llvm::ArrayRef(argv.data() + 2, argv.data() + argv.size()), argv[0],
+          (void *)(intptr_t)getExecutablePath);
     }
     if (FirstArg == "-modulewrap") {
-      return modulewrap_main(llvm::makeArrayRef(argv.data()+2,
-                                                argv.data()+argv.size()),
-                             argv[0], (void *)(intptr_t)getExecutablePath);
+      return modulewrap_main(
+          llvm::ArrayRef(argv.data() + 2, argv.data() + argv.size()), argv[0],
+          (void *)(intptr_t)getExecutablePath);
     }
     if (FirstArg == "-sil-opt") {
       return sil_opt_main(eraseFirstArg(argv),
@@ -295,9 +295,9 @@ static int run_driver(StringRef ExecName,
     // without a leading "-frontend".
     if (!FirstArg.startswith("--driver-mode=")
         && ExecName == "swift-frontend") {
-      return performFrontend(llvm::makeArrayRef(argv.data()+1,
-                                                argv.data()+argv.size()),
-                             argv[0], (void *)(intptr_t)getExecutablePath);
+      return performFrontend(
+          llvm::ArrayRef(argv.data() + 1, argv.data() + argv.size()), argv[0],
+          (void *)(intptr_t)getExecutablePath);
     }
 
     if (FirstArg == "repl") {

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -743,7 +743,7 @@ public:
 
     // Create a synthesized ExtensionDecl for the conformance.
     ASTContext &ctx = M->getASTContext();
-    auto inherits = ctx.AllocateCopy(llvm::makeArrayRef(InheritedEntry(
+    auto inherits = ctx.AllocateCopy(llvm::ArrayRef(InheritedEntry(
         TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()), isUnchecked,
         /*isRetroactive=*/false,
         /*isPreconcurrency=*/false)));

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -269,7 +269,7 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
         new (*V.Allocator) ContextFreeCodeCompletionResult(
             kind, associatedKind, opKind, roles, isSystem, isAsync,
             hasAsyncAlternative, string, moduleName, briefDocComment,
-            makeArrayRef(assocUSRs).copy(*V.Allocator),
+            llvm::ArrayRef(assocUSRs).copy(*V.Allocator),
             CodeCompletionResultType(resultTypes), notRecommended, diagSeverity,
             diagMessage, filterName, nameForDiagnostics);
 

--- a/lib/IDE/CodeCompletionContext.cpp
+++ b/lib/IDE/CodeCompletionContext.cpp
@@ -116,8 +116,8 @@ static MutableArrayRef<CodeCompletionResult *> copyCodeCompletionResults(
     targetSink.Results.push_back(contextualResult);
   }
 
-  return llvm::makeMutableArrayRef(targetSink.Results.data() + startSize,
-                                   targetSink.Results.size() - startSize);
+  return llvm::MutableArrayRef(targetSink.Results.data() + startSize,
+                               targetSink.Results.size() - startSize);
 }
 
 void CodeCompletionContext::addResultsFromModules(

--- a/lib/IDE/CodeCompletionResultBuilder.cpp
+++ b/lib/IDE/CodeCompletionResultBuilder.cpp
@@ -69,7 +69,7 @@ copyAssociatedUSRs(llvm::BumpPtrAllocator &Allocator, const Decl *D) {
       });
 
   if (!USRs.empty())
-    return makeArrayRef(USRs).copy(Allocator);
+    return llvm::ArrayRef(USRs).copy(Allocator);
 
   return {};
 }

--- a/lib/IDE/CommentConversion.cpp
+++ b/lib/IDE/CommentConversion.cpp
@@ -297,7 +297,7 @@ void CommentToXMLConverter::visitCommentParts(const swift::markup::CommentParts 
     printThrowsDiscussion(Parts.ThrowsField.value());
 
   if (!Parts.Tags.empty()) {
-    printTagFields(llvm::makeArrayRef(Parts.Tags.begin(), Parts.Tags.end()));
+    printTagFields(llvm::ArrayRef(Parts.Tags.begin(), Parts.Tags.end()));
   }
 
   if (!Parts.BodyNodes.empty()) {

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -639,39 +639,29 @@ private:
     auto UnhandledEffects = getUnhandledEffects({Node});
     OrphanKind Kind = getOrphanKind(ContainedASTNodes);
     if (Node.is<Expr*>())
-      return ResolvedRangeInfo(RangeKind::SingleExpression,
-                               resolveNodeType(Node, RangeKind::SingleExpression),
-                               TokensInRange,
-                               getImmediateContext(),
-                               /*Common Parent Expr*/nullptr,
-                               SingleEntry,
-                               UnhandledEffects, Kind,
-                               llvm::makeArrayRef(ContainedASTNodes),
-                               llvm::makeArrayRef(DeclaredDecls),
-                               llvm::makeArrayRef(ReferencedDecls));
+      return ResolvedRangeInfo(
+          RangeKind::SingleExpression,
+          resolveNodeType(Node, RangeKind::SingleExpression), TokensInRange,
+          getImmediateContext(),
+          /*Common Parent Expr*/ nullptr, SingleEntry, UnhandledEffects, Kind,
+          llvm::ArrayRef(ContainedASTNodes), llvm::ArrayRef(DeclaredDecls),
+          llvm::ArrayRef(ReferencedDecls));
     else if (Node.is<Stmt*>())
-      return ResolvedRangeInfo(RangeKind::SingleStatement,
-                               resolveNodeType(Node, RangeKind::SingleStatement),
-                               TokensInRange,
-                               getImmediateContext(),
-                               /*Common Parent Expr*/nullptr,
-                               SingleEntry,
-                               UnhandledEffects, Kind,
-                               llvm::makeArrayRef(ContainedASTNodes),
-                               llvm::makeArrayRef(DeclaredDecls),
-                               llvm::makeArrayRef(ReferencedDecls));
+      return ResolvedRangeInfo(
+          RangeKind::SingleStatement,
+          resolveNodeType(Node, RangeKind::SingleStatement), TokensInRange,
+          getImmediateContext(),
+          /*Common Parent Expr*/ nullptr, SingleEntry, UnhandledEffects, Kind,
+          llvm::ArrayRef(ContainedASTNodes), llvm::ArrayRef(DeclaredDecls),
+          llvm::ArrayRef(ReferencedDecls));
     else {
       assert(Node.is<Decl*>());
-      return ResolvedRangeInfo(RangeKind::SingleDecl,
-                               ReturnInfo(),
-                               TokensInRange,
-                               getImmediateContext(),
-                               /*Common Parent Expr*/nullptr,
-                               SingleEntry,
-                               UnhandledEffects, Kind,
-                               llvm::makeArrayRef(ContainedASTNodes),
-                               llvm::makeArrayRef(DeclaredDecls),
-                               llvm::makeArrayRef(ReferencedDecls));
+      return ResolvedRangeInfo(
+          RangeKind::SingleDecl, ReturnInfo(), TokensInRange,
+          getImmediateContext(),
+          /*Common Parent Expr*/ nullptr, SingleEntry, UnhandledEffects, Kind,
+          llvm::ArrayRef(ContainedASTNodes), llvm::ArrayRef(DeclaredDecls),
+          llvm::ArrayRef(ReferencedDecls));
     }
   }
 
@@ -722,19 +712,17 @@ public:
   void leave(ASTNode Node) {
     if (!hasResult() && !Node.isImplicit() && nodeContainSelection(Node)) {
       if (auto Parent = Node.is<Expr*>() ? Node.get<Expr*>() : nullptr) {
-        Result = {
-          RangeKind::PartOfExpression,
-          ReturnInfo(),
-          TokensInRange,
-          getImmediateContext(),
-          Parent,
-          hasSingleEntryPoint(ContainedASTNodes),
-          getUnhandledEffects(ContainedASTNodes),
-          getOrphanKind(ContainedASTNodes),
-          llvm::makeArrayRef(ContainedASTNodes),
-          llvm::makeArrayRef(DeclaredDecls),
-          llvm::makeArrayRef(ReferencedDecls)
-        };
+        Result = {RangeKind::PartOfExpression,
+                  ReturnInfo(),
+                  TokensInRange,
+                  getImmediateContext(),
+                  Parent,
+                  hasSingleEntryPoint(ContainedASTNodes),
+                  getUnhandledEffects(ContainedASTNodes),
+                  getOrphanKind(ContainedASTNodes),
+                  llvm::ArrayRef(ContainedASTNodes),
+                  llvm::ArrayRef(DeclaredDecls),
+                  llvm::ArrayRef(ReferencedDecls)};
       }
     }
 
@@ -969,18 +957,15 @@ public:
 
     if (DCInfo.isMultiStatement()) {
       postAnalysis(DCInfo.EndMatches.back());
-      Result = {RangeKind::MultiStatement,
-                /* Last node has the type */
-                resolveNodeType(DCInfo.EndMatches.back(),
-                                RangeKind::MultiStatement),
-                TokensInRange,
-                getImmediateContext(), nullptr,
-                hasSingleEntryPoint(ContainedASTNodes),
-                getUnhandledEffects(ContainedASTNodes),
-                getOrphanKind(ContainedASTNodes),
-                llvm::makeArrayRef(ContainedASTNodes),
-                llvm::makeArrayRef(DeclaredDecls),
-                llvm::makeArrayRef(ReferencedDecls)};
+      Result = {
+          RangeKind::MultiStatement,
+          /* Last node has the type */
+          resolveNodeType(DCInfo.EndMatches.back(), RangeKind::MultiStatement),
+          TokensInRange, getImmediateContext(), nullptr,
+          hasSingleEntryPoint(ContainedASTNodes),
+          getUnhandledEffects(ContainedASTNodes),
+          getOrphanKind(ContainedASTNodes), llvm::ArrayRef(ContainedASTNodes),
+          llvm::ArrayRef(DeclaredDecls), llvm::ArrayRef(ReferencedDecls)};
     }
 
     if (DCInfo.isMultiTypeMemberDecl()) {
@@ -993,9 +978,9 @@ public:
                 /*SinleEntry*/ true,
                 getUnhandledEffects(ContainedASTNodes),
                 getOrphanKind(ContainedASTNodes),
-                llvm::makeArrayRef(ContainedASTNodes),
-                llvm::makeArrayRef(DeclaredDecls),
-                llvm::makeArrayRef(ReferencedDecls)};
+                llvm::ArrayRef(ContainedASTNodes),
+                llvm::ArrayRef(DeclaredDecls),
+                llvm::ArrayRef(ReferencedDecls)};
     }
   }
 
@@ -1253,7 +1238,7 @@ ProvideDefaultImplForRequest::evaluate(Evaluator &eval, ValueDecl* VD) const {
       }
     }
   }
-  return copyToContext(VD->getASTContext(), llvm::makeArrayRef(Results));
+  return copyToContext(VD->getASTContext(), llvm::ArrayRef(Results));
 }
 
 //----------------------------------------------------------------------------//
@@ -1281,7 +1266,7 @@ CollectOverriddenDeclsRequest::evaluate(Evaluator &evaluator,
     }
   }
 
-  return copyToContext(VD->getASTContext(), llvm::makeArrayRef(results));
+  return copyToContext(VD->getASTContext(), llvm::ArrayRef(results));
 }
 
 

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -589,7 +589,7 @@ forEachExtensionMergeGroup(MergeGroupKind Kind, ExtensionGroupOperation Fn) {
       GroupContent.push_back(
           {Member->Ext, Member->EnablingExt, Member->IsSynthesized});
     }
-    Fn(llvm::makeArrayRef(GroupContent));
+    Fn(llvm::ArrayRef(GroupContent));
   }
 }
 

--- a/lib/IRGen/Explosion.h
+++ b/lib/IRGen/Explosion.h
@@ -109,13 +109,13 @@ public:
   ArrayRef<llvm::Value*> getRange(unsigned from, unsigned to) const {
     assert(from <= to);
     assert(to <= Values.size());
-    return llvm::makeArrayRef(begin() + from, to - from);
+    return llvm::ArrayRef(begin() + from, to - from);
   }
 
   /// Return an array containing all of the remaining values.  The values
   /// are not claimed.
   ArrayRef<llvm::Value *> getAll() {
-    return llvm::makeArrayRef(begin(), Values.size() - NextValue);
+    return llvm::ArrayRef(begin(), Values.size() - NextValue);
   }
 
   /// Transfer ownership of the next N values to the given explosion.
@@ -144,7 +144,7 @@ public:
   /// Claim and return the next N values in this explosion.
   ArrayRef<llvm::Value*> claim(unsigned n) {
     assert(NextValue + n <= Values.size());
-    auto array = llvm::makeArrayRef(begin(), n);
+    auto array = llvm::ArrayRef(begin(), n);
     NextValue += n;
     return array;
   }

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1612,8 +1612,8 @@ static ArrayRef<llvm::Type *> expandScalarOrStructTypeToArray(llvm::Type *&ty) {
   ArrayRef<llvm::Type*> expandedTys;
   if (auto expansionTy = dyn_cast<llvm::StructType>(ty)) {
     // Is there any good reason this isn't public API of llvm::StructType?
-    expandedTys = makeArrayRef(expansionTy->element_begin(),
-                               expansionTy->getNumElements());
+    expandedTys = llvm::ArrayRef(expansionTy->element_begin(),
+                                 expansionTy->getNumElements());
   } else {
     expandedTys = ty;
   }
@@ -2935,8 +2935,8 @@ public:
     auto &Builder = IGF.Builder;
 
     auto resultTys =
-        makeArrayRef(suspendResultTy->element_begin() + numAsyncContextParams,
-                     suspendResultTy->element_end());
+        llvm::ArrayRef(suspendResultTy->element_begin() + numAsyncContextParams,
+                       suspendResultTy->element_end());
 
     auto substCalleeType = getCallee().getSubstFunctionType();
     SILFunctionConventions substConv(substCalleeType, IGF.getSILModule());
@@ -4195,7 +4195,7 @@ static void emitDirectForeignParameter(IRGenFunction &IGF, Explosion &in,
   if (AI.isDirect() && AI.getCanBeFlattened() &&
       isa<llvm::StructType>(coercionTy)) {
     const auto *ST = cast<llvm::StructType>(coercionTy);
-    expandedTys = makeArrayRef(ST->element_begin(), ST->getNumElements());
+    expandedTys = llvm::ArrayRef(ST->element_begin(), ST->getNumElements());
   } else if (coercionTy == paramTI.getStorageType()) {
     // Fast-path a really common case.  This check assumes that either
     // the storage type of a type is an llvm::StructType or it has a
@@ -5937,8 +5937,8 @@ void irgen::forwardAsyncCallResult(IRGenFunction &IGF,
   } else {
     auto &Builder = IGF.Builder;
     auto resultTys =
-        makeArrayRef(suspendResultTy->element_begin() + numAsyncContextParams,
-                     suspendResultTy->element_end());
+        llvm::ArrayRef(suspendResultTy->element_begin() + numAsyncContextParams,
+                       suspendResultTy->element_end());
 
     for (unsigned i = 0, e = resultTys.size(); i != e; ++i) {
       llvm::Value *elt =

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -160,7 +160,7 @@ getDynamicCastArguments(IRGenFunction &IGF,
     return argsBuf;
       
   case CheckedCastMode::Conditional:
-    return llvm::makeArrayRef(argsBuf, n-3);
+    return llvm::ArrayRef(argsBuf, n - 3);
     break;
   }
   llvm_unreachable("covered switch");

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1407,7 +1407,7 @@ namespace {
         dataPtr
       };
       auto init = llvm::ConstantStruct::get(IGM.ObjCClassStructTy,
-                                            makeArrayRef(fields));
+                                            llvm::ArrayRef(fields));
       llvm::Constant *uncastMetaclass;
       if (specializedGenericType) {
         uncastMetaclass =

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -469,6 +469,6 @@ void ConstantAggregateBuilderBase::addUniqueHash(StringRef data) {
   llvm::BLAKE3 hasher;
   hasher.update(data);
   auto rawHash = hasher.final();
-  auto truncHash = llvm::makeArrayRef(rawHash).slice(0, NumBytes_UniqueHash);
+  auto truncHash = llvm::ArrayRef(rawHash).slice(0, NumBytes_UniqueHash);
   add(llvm::ConstantDataArray::get(IGM().getLLVMContext(), truncHash));
 }

--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -162,7 +162,7 @@ void IRGenModule::emitCoverageMaps(ArrayRef<const SILCoverageMap *> Mappings) {
 #include "llvm/ProfileData/InstrProfData.inc"
     };
     auto *FunctionRecordTy =
-        llvm::StructType::get(Ctx, makeArrayRef(FunctionRecordTypes),
+        llvm::StructType::get(Ctx, llvm::ArrayRef(FunctionRecordTypes),
                               /*isPacked=*/true);
 
     // Create the function record constant.
@@ -171,7 +171,7 @@ void IRGenModule::emitCoverageMaps(ArrayRef<const SILCoverageMap *> Mappings) {
 #include "llvm/ProfileData/InstrProfData.inc"
     };
     auto *FuncRecordConstant = llvm::ConstantStruct::get(
-        FunctionRecordTy, makeArrayRef(FunctionRecordVals));
+        FunctionRecordTy, llvm::ArrayRef(FunctionRecordVals));
 
     // Create the function record global.
     auto *FuncRecord = new llvm::GlobalVariable(
@@ -196,20 +196,20 @@ void IRGenModule::emitCoverageMaps(ArrayRef<const SILCoverageMap *> Mappings) {
 #include "llvm/ProfileData/InstrProfData.inc"
   };
   auto CovDataHeaderTy =
-      llvm::StructType::get(Ctx, makeArrayRef(CovDataHeaderTypes));
+      llvm::StructType::get(Ctx, llvm::ArrayRef(CovDataHeaderTypes));
   llvm::Constant *CovDataHeaderVals[] = {
 #define COVMAP_HEADER(Type, LLVMType, Name, Init) Init,
 #include "llvm/ProfileData/InstrProfData.inc"
   };
   auto CovDataHeaderVal = llvm::ConstantStruct::get(
-      CovDataHeaderTy, makeArrayRef(CovDataHeaderVals));
+      CovDataHeaderTy, llvm::ArrayRef(CovDataHeaderVals));
 
   // Create the coverage data record
   llvm::Type *CovDataTypes[] = {CovDataHeaderTy, FilenamesVal->getType()};
-  auto CovDataTy = llvm::StructType::get(Ctx, makeArrayRef(CovDataTypes));
+  auto CovDataTy = llvm::StructType::get(Ctx, llvm::ArrayRef(CovDataTypes));
   llvm::Constant *TUDataVals[] = {CovDataHeaderVal, FilenamesVal};
   auto CovDataVal =
-      llvm::ConstantStruct::get(CovDataTy, makeArrayRef(TUDataVals));
+      llvm::ConstantStruct::get(CovDataTy, llvm::ArrayRef(TUDataVals));
   auto CovData = new llvm::GlobalVariable(
       *getModule(), CovDataTy, true, llvm::GlobalValue::PrivateLinkage,
       CovDataVal, llvm::getCoverageMappingVarName());

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1357,11 +1357,9 @@ void IRGenModule::finishEmitAfterTopLevel() {
           { Context.StdlibModuleName, swift::SourceLoc() }
         };
 
-        auto Imp = ImportDecl::create(Context,
-                                      getSwiftModule(),
-                                      SourceLoc(),
+        auto Imp = ImportDecl::create(Context, getSwiftModule(), SourceLoc(),
                                       ImportKind::Module, SourceLoc(),
-                                      llvm::makeArrayRef(moduleName));
+                                      llvm::ArrayRef(moduleName));
         Imp->setModule(TheStdlib);
         DebugInfo->emitImport(Imp);
       }
@@ -4990,7 +4988,7 @@ IRGenModule::getAddrOfGenericTypeMetadataAccessFunction(
     numParams += numGenericArgs;
   }
 
-  auto paramTypes = llvm::makeArrayRef(paramTypesArray, numParams);
+  auto paramTypes = llvm::ArrayRef(paramTypesArray, numParams);
   auto fnType = llvm::FunctionType::get(TypeMetadataResponseTy,
                                         paramTypes, false);
   Signature signature(fnType, llvm::AttributeList(), SwiftCC);
@@ -5022,7 +5020,7 @@ IRGenModule::getAddrOfCanonicalSpecializedGenericTypeMetadataAccessFunction(
   llvm::Type *paramTypesArray[1];
   paramTypesArray[0] = SizeTy; // MetadataRequest
 
-  auto paramTypes = llvm::makeArrayRef(paramTypesArray, 1);
+  auto paramTypes = llvm::ArrayRef(paramTypesArray, 1);
   auto functionType =
       llvm::FunctionType::get(TypeMetadataResponseTy, paramTypes, false);
   Signature signature(functionType, llvm::AttributeList(), SwiftCC);

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1610,7 +1610,7 @@ static const TypeInfo *createExistentialTypeInfo(IRGenModule &IGM, CanType T) {
     fields[1] = reprTy;
 
     // Replace the type metadata pointer with the class instance.
-    auto classFields = llvm::makeArrayRef(fields).slice(1);
+    auto classFields = llvm::ArrayRef(fields).slice(1);
     type->setBody(classFields);
 
     Alignment align = IGM.getPointerAlignment();

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -140,7 +140,7 @@ static llvm::Value *emitAllocatingCall(IRGenFunction &IGF, FunctionPointer fn,
                                        const llvm::Twine &name) {
   auto allocAttrs = IGF.IGM.getAllocAttrs();
   llvm::CallInst *call =
-    IGF.Builder.CreateCall(fn, makeArrayRef(args.begin(), args.size()));
+      IGF.Builder.CreateCall(fn, llvm::ArrayRef(args.begin(), args.size()));
   call->setAttributes(allocAttrs);
   return call;
 }
@@ -244,7 +244,7 @@ llvm::Value *IRGenFunction::emitAllocEmptyBoxCall() {
 static void emitDeallocatingCall(IRGenFunction &IGF, FunctionPointer fn,
                                  std::initializer_list<llvm::Value *> args) {
   llvm::CallInst *call =
-      IGF.Builder.CreateCall(fn, makeArrayRef(args.begin(), args.size()));
+      IGF.Builder.CreateCall(fn, llvm::ArrayRef(args.begin(), args.size()));
   call->setDoesNotThrow();
 }
 
@@ -387,7 +387,7 @@ void IRGenFunction::unimplemented(SourceLoc Loc, StringRef Message) {
 // Debug output for Explosions.
 
 void Explosion::print(llvm::raw_ostream &OS) {
-  for (auto value : makeArrayRef(Values).slice(NextValue)) {
+  for (auto value : llvm::ArrayRef(Values).slice(NextValue)) {
     value->print(OS);
     OS << '\n';
   }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -7687,7 +7687,7 @@ void IRGenSILFunction::visitIncrementProfilerCounterInst(
   llvm::SmallVector<llvm::Value *, 2> indices;
   indices.append(2, llvm::ConstantInt::get(IGM.SizeTy, 0));
   auto *nameGEP = llvm::ConstantExpr::getGetElementPtr(
-      nameVar->getValueType(), nameVar, makeArrayRef(indices));
+      nameVar->getValueType(), nameVar, llvm::ArrayRef(indices));
 
   // Emit the call to the 'llvm.instrprof.increment' LLVM intrinsic.
   llvm::Value *args[] = {

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -1195,12 +1195,11 @@ static Value *createCast(IRBuilder<> &Builder, Value *V, Type *DestTy) {
     assert(SrcTy->getStructNumElements() == DestTy->getStructNumElements());
     Value *Result = UndefValue::get(DestTy);
     for (unsigned int I = 0, E = SrcTy->getStructNumElements(); I < E; ++I) {
-      Value *Element = createCast(
-          Builder, Builder.CreateExtractValue(V, makeArrayRef(I)),
-          DestTy->getStructElementType(I));
+      Value *Element =
+          createCast(Builder, Builder.CreateExtractValue(V, llvm::ArrayRef(I)),
+                     DestTy->getStructElementType(I));
 
-      Result =
-          Builder.CreateInsertValue(Result, Element, makeArrayRef(I));
+      Result = Builder.CreateInsertValue(Result, Element, llvm::ArrayRef(I));
     }
     return Result;
   }

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -128,13 +128,12 @@ public:
                            TypeRepr *SecondChild, bool Optional = false,
                            bool Suffixable = true) {
     TypeRepr *Children[] = {FirstChild, SecondChild};
-    return handleParent(Parent, llvm::makeArrayRef(Children), Optional,
-                        Suffixable);
+    return handleParent(Parent, llvm::ArrayRef(Children), Optional, Suffixable);
   }
 
   FoundResult handleParent(TypeRepr *Parent, TypeRepr *Base,
                            bool Optional = false, bool Suffixable = true) {
-    return handleParent(Parent, llvm::makeArrayRef(Base), Optional, Suffixable);
+    return handleParent(Parent, llvm::ArrayRef(Base), Optional, Suffixable);
   }
 
   FoundResult visitTypeRepr(TypeRepr *T) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6976,7 +6976,7 @@ bool Parser::parseMemberDeclList(SourceLoc &LBLoc, SourceLoc &RBLoc,
         ParseMembersRequest{IDC},
         FingerprintAndMembers{
             membersAndHash.second,
-            Context.AllocateCopy(llvm::makeArrayRef(membersAndHash.first))});
+            Context.AllocateCopy(llvm::ArrayRef(membersAndHash.first))});
 
     if (hadError)
       return true;

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -79,7 +79,7 @@ ParseMembersRequest::evaluate(Evaluator &evaluator,
                                                  declsAndHash.first};
   return FingerprintAndMembers{
       fingerprintAndMembers.fingerprint,
-      ctx.AllocateCopy(llvm::makeArrayRef(fingerprintAndMembers.members))};
+      ctx.AllocateCopy(llvm::ArrayRef(fingerprintAndMembers.members))};
 }
 
 BodyAndFingerprint

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -170,7 +170,7 @@ void printPrimitiveGenericTypeTraits(raw_ostream &os, ASTContext &astContext,
 
       astContext.getIntType(), astContext.getUIntType()};
 
-  auto primTypesArray = llvm::makeArrayRef(supportedPrimitiveTypes);
+  auto primTypesArray = llvm::ArrayRef(supportedPrimitiveTypes);
 
   // Ensure that `long` and `unsigned long` are treated as valid
   // generic Swift types (`Int` and `UInt`) on platforms

--- a/lib/Refactoring/Async/AsyncConverter.cpp
+++ b/lib/Refactoring/Async/AsyncConverter.cpp
@@ -1266,7 +1266,7 @@ void AsyncConverter::addHoistedClosureCallback(
     InlinePatternsToPrint ErrInlinePatterns;
 
     // Always use the ErrParam name if none is bound.
-    prepareNames(Blocks.ErrorBlock, llvm::makeArrayRef(ErrOrResultParam),
+    prepareNames(Blocks.ErrorBlock, llvm::ArrayRef(ErrOrResultParam),
                  ErrInlinePatterns,
                  /*AddIfMissing=*/HandlerDesc.Type != HandlerType::RESULT);
     preparePlaceholdersAndUnwraps(HandlerDesc, CallbackParams,
@@ -1275,7 +1275,7 @@ void AsyncConverter::addHoistedClosureCallback(
     addCatch(ErrOrResultParam);
     convertNodes(Blocks.ErrorBlock.nodesToPrint());
     OS << "\n" << tok::r_brace;
-    clearNames(llvm::makeArrayRef(ErrOrResultParam));
+    clearNames(llvm::ArrayRef(ErrOrResultParam));
   }
 }
 

--- a/lib/Refactoring/Async/AsyncHandlerDesc.cpp
+++ b/lib/Refactoring/Async/AsyncHandlerDesc.cpp
@@ -196,7 +196,7 @@ AsyncHandlerDesc::extractResultArgs(const CallExpr *CE,
                                     bool ReturnErrorArgsIfAmbiguous) const {
   auto *ArgList = CE->getArgs();
   SmallVector<Argument, 2> Scratch(ArgList->begin(), ArgList->end());
-  auto Args = llvm::makeArrayRef(Scratch);
+  auto Args = llvm::ArrayRef(Scratch);
 
   if (Type == HandlerType::PARAMS) {
     bool IsErrorResult;

--- a/lib/Refactoring/Async/CallbackClassifier.cpp
+++ b/lib/Refactoring/Async/CallbackClassifier.cpp
@@ -264,7 +264,7 @@ CallbackClassifier::classifyCallbackCondition(const CallbackCondition &Cond,
     if (auto *BS = dyn_cast<BraceStmt>(ElseStmt)) {
       Nodes = BS->getElements();
     } else {
-      Nodes = llvm::makeArrayRef(ElseNode);
+      Nodes = llvm::ArrayRef(ElseNode);
     }
     if (hasForceUnwrappedErrorParam(Nodes)) {
       // If we also found an unwrap in the success block, we don't know what's

--- a/lib/Refactoring/ContextFinder.h
+++ b/lib/Refactoring/ContextFinder.h
@@ -64,9 +64,7 @@ public:
   bool walkToStmtPre(Stmt *S) override { return contains(S); }
   bool walkToExprPre(Expr *E) override { return contains(E); }
   void resolve() { walk(SF); }
-  ArrayRef<ASTNode> getContexts() const {
-    return llvm::makeArrayRef(AllContexts);
-  }
+  ArrayRef<ASTNode> getContexts() const { return llvm::ArrayRef(AllContexts); }
 };
 
 } // namespace refactoring

--- a/lib/Refactoring/FillProtocolStubs.cpp
+++ b/lib/Refactoring/FillProtocolStubs.cpp
@@ -62,7 +62,7 @@ public:
   getContextFromCursorInfo(ResolvedCursorInfoPtr Tok);
 
   ArrayRef<ValueDecl *> getFillingContents() const {
-    return llvm::makeArrayRef(FillingContents);
+    return llvm::ArrayRef(FillingContents);
   }
 
   DeclContext *getFillingContext() const { return DC; }

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -462,8 +462,8 @@ bool AbstractionPattern::doesTupleContainPackExpansionType() const {
   case Kind::OpaqueDerivativeFunction:
     llvm_unreachable("pattern is not a tuple");
   case Kind::Tuple: {
-    for (auto &elt : llvm::makeArrayRef(OrigTupleElements,
-                                        getNumTupleElements_Stored())) {
+    for (auto &elt :
+         llvm::ArrayRef(OrigTupleElements, getNumTupleElements_Stored())) {
       if (elt.isPackExpansion())
         return true;
     }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -599,8 +599,8 @@ static CanSILFunctionType getAutoDiffDifferentialType(
         GenericSignature::get(substGenericParams, substRequirements)
             .getCanonicalSignature();
     substitutions =
-        SubstitutionMap::get(genericSig, llvm::makeArrayRef(substReplacements),
-                             llvm::makeArrayRef(substConformances));
+        SubstitutionMap::get(genericSig, llvm::ArrayRef(substReplacements),
+                             llvm::ArrayRef(substConformances));
   }
   return SILFunctionType::get(
       GenericSignature(), SILFunctionType::ExtInfo(), SILCoroutineKind::None,
@@ -762,8 +762,8 @@ static CanSILFunctionType getAutoDiffPullbackType(
         GenericSignature::get(substGenericParams, substRequirements)
             .getCanonicalSignature();
     substitutions =
-        SubstitutionMap::get(genericSig, llvm::makeArrayRef(substReplacements),
-                             llvm::makeArrayRef(substConformances));
+        SubstitutionMap::get(genericSig, llvm::ArrayRef(substReplacements),
+                             llvm::ArrayRef(substConformances));
   }
   return SILFunctionType::get(
       GenericSignature(), SILFunctionType::ExtInfo(),
@@ -4364,7 +4364,7 @@ static CanType copyOptionalityFromDerivedToBase(TypeConverter &tc,
                                                      derivedFunc.getResult(),
                                                      baseFunc.getResult());
       return CanAnyFunctionType::get(baseFunc.getOptGenericSignature(),
-                                     llvm::makeArrayRef(params), result,
+                                     llvm::ArrayRef(params), result,
                                      baseFunc->getExtInfo());
     }
   }
@@ -4487,8 +4487,8 @@ CanAnyFunctionType TypeConverter::getBridgedFunctionType(
                                        bridging,
                                        suppressOptional);
 
-    return CanAnyFunctionType::get(genericSig, llvm::makeArrayRef(params),
-                                   result, t->getExtInfo());
+    return CanAnyFunctionType::get(genericSig, llvm::ArrayRef(params), result,
+                                   t->getExtInfo());
   }
   }
   llvm_unreachable("bad calling convention");
@@ -4658,9 +4658,8 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
   }
 
   // Build the curried function type.
-  auto inner =
-    CanFunctionType::get(llvm::makeArrayRef(bridgedParams),
-                         bridgedResultType, innerExtInfo);
+  auto inner = CanFunctionType::get(llvm::ArrayRef(bridgedParams),
+                                    bridgedResultType, innerExtInfo);
 
   auto curried =
     CanAnyFunctionType::get(genericSig, {selfParam}, inner, extInfo);
@@ -4695,11 +4694,8 @@ TypeConverter::getLoweredFormalTypes(SILDeclRef constant,
     bridgedParams.push_back(selfParam);
   }
 
-  auto uncurried =
-    CanAnyFunctionType::get(genericSig,
-                            llvm::makeArrayRef(bridgedParams),
-                            bridgedResultType,
-                            extInfo);
+  auto uncurried = CanAnyFunctionType::get(
+      genericSig, llvm::ArrayRef(bridgedParams), bridgedResultType, extInfo);
 
   return { bridgingFnPattern, uncurried };
 }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3737,8 +3737,7 @@ static CanAnyFunctionType getDestructorInterfaceType(DestructorDecl *dd,
   auto sig = dd->getGenericSignatureOfContext();
   FunctionType::Param args[] = {FunctionType::Param(classType)};
   return CanAnyFunctionType::get(getCanonicalSignatureOrNull(sig),
-                                 llvm::makeArrayRef(args),
-                                 methodTy, extInfo);
+                                 llvm::ArrayRef(args), methodTy, extInfo);
 }
 
 /// Retrieve the type of the ivar initializer or destroyer method for
@@ -3765,8 +3764,7 @@ static CanAnyFunctionType getIVarInitDestroyerInterfaceType(ClassDecl *cd,
   auto sig = cd->getGenericSignature();
   FunctionType::Param args[] = {FunctionType::Param(classType)};
   return CanAnyFunctionType::get(getCanonicalSignatureOrNull(sig),
-                                 llvm::makeArrayRef(args),
-                                 resultType, extInfo);
+                                 llvm::ArrayRef(args), resultType, extInfo);
 }
 
 static CanAnyFunctionType
@@ -3859,8 +3857,8 @@ static CanAnyFunctionType getEntryPointInterfaceType(ASTContext &C) {
                      .withClangFunctionType(clangTy)
                      .build();
 
-  return CanAnyFunctionType::get(/*genericSig*/ nullptr,
-                                 llvm::makeArrayRef(params), Int32Ty, extInfo);
+  return CanAnyFunctionType::get(/*genericSig*/ nullptr, llvm::ArrayRef(params),
+                                 Int32Ty, extInfo);
 }
 
 CanAnyFunctionType TypeConverter::makeConstantInterfaceType(SILDeclRef c) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -7740,7 +7740,7 @@ static CanType parseAssociatedTypePath(Parser &P, SILParser &SP,
 
   SmallString<128> name;
   name += path[0].str();
-  for (auto elt : makeArrayRef(path).slice(1)) {
+  for (auto elt : llvm::ArrayRef(path).slice(1)) {
     name += '.';
     name += elt.str();
   }

--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -672,7 +672,7 @@ RValue RValue::extractElement(unsigned n) && {
     assert(n == 0);
     unsigned to = getRValueSize(type);
     assert(to == values.size());
-    RValue element(nullptr, llvm::makeArrayRef(values).slice(0, to), type);
+    RValue element(nullptr, llvm::ArrayRef(values).slice(0, to), type);
     makeUsed();
     return element;
   }
@@ -687,7 +687,8 @@ RValue RValue::extractElement(unsigned n) && {
   unsigned from = range.first, to = range.second;
 
   CanType eltType = tupleTy.getElementType(n);
-  RValue element(nullptr, llvm::makeArrayRef(values).slice(from, to - from), eltType);
+  RValue element(nullptr, llvm::ArrayRef(values).slice(from, to - from),
+                 eltType);
   makeUsed();
   return element;
 }
@@ -701,7 +702,7 @@ void RValue::extractElements(SmallVectorImpl<RValue> &elements) && {
     assert(to == values.size());
     // We use push_back instead of emplace_back since emplace_back can not
     // invoke the private constructor we are attempting to invoke.
-    elements.push_back({nullptr, llvm::makeArrayRef(values).slice(0, to), type});
+    elements.push_back({nullptr, llvm::ArrayRef(values).slice(0, to), type});
     makeUsed();
     return;
   }
@@ -717,8 +718,8 @@ void RValue::extractElements(SmallVectorImpl<RValue> &elements) && {
     unsigned to = from + getRValueSize(eltType);
     // We use push_back instead of emplace_back since emplace_back can not
     // invoke the private constructor we are attempting to invoke.
-    elements.push_back({nullptr, llvm::makeArrayRef(values).slice(from, to - from),
-                        eltType});
+    elements.push_back(
+        {nullptr, llvm::ArrayRef(values).slice(from, to - from), eltType});
     from = to;
   }
   assert(from == values.size());

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -673,8 +673,8 @@ public:
         eltPlans.push_back(builder.build(eltInit, origEltType,
                                          substEltTypes[0]));
       } else {
-        auto componentInits = llvm::makeArrayRef(eltInits)
-               .slice(elt.getSubstIndex(), substEltTypes.size());
+        auto componentInits = llvm::ArrayRef(eltInits).slice(
+            elt.getSubstIndex(), substEltTypes.size());
         eltPlans.push_back(builder.buildForPackExpansion(componentInits,
                                                          origEltType,
                                                          substEltTypes));

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -278,7 +278,7 @@ FuncDecl *SILGenModule::getUnconditionallyBridgeFromObjectiveCRequirement(
   // Look for _bridgeToObjectiveC().
   auto &ctx = getASTContext();
   DeclName name(ctx, ctx.getIdentifier("_unconditionallyBridgeFromObjectiveC"),
-                llvm::makeArrayRef(Identifier()));
+                llvm::ArrayRef(Identifier()));
   auto *found = dyn_cast_or_null<FuncDecl>(
     proto->getSingleRequirement(name));
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4990,7 +4990,7 @@ SILGenFunction::emitBeginApply(SILLocation loc, ManagedValue fn,
                rawResults, ExecutorBreadcrumb());
 
   auto token = rawResults.pop_back_val();
-  auto yieldValues = llvm::makeArrayRef(rawResults);
+  auto yieldValues = llvm::ArrayRef(rawResults);
 
   // Push a cleanup to end the application.
   // TODO: destroy all the arguments at exactly this point?
@@ -5783,7 +5783,7 @@ RValue SILGenFunction::emitApply(
     assert(unmanagedCopies.empty());
   }
 
-  auto directResultsArray = makeArrayRef(directResults);
+  auto directResultsArray = llvm::ArrayRef(directResults);
   RValue result = resultPlan->finish(*this, loc, directResultsArray,
                                      bridgedForeignError);
   assert(directResultsArray.empty() && "didn't claim all direct results");

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5654,7 +5654,7 @@ void SILGenFunction::emitOptionalEvaluation(SILLocation loc, Type optType,
   SmallVector<SILValue, 4> bbArgs;
   if (!isByAddress)
     bbArgs.push_back(results[0].getValue());
-  for (const auto &result : llvm::makeArrayRef(results).slice(1))
+  for (const auto &result : llvm::ArrayRef(results).slice(1))
     bbArgs.push_back(result.getValue());
 
   // Branch to the continuation block.
@@ -5671,7 +5671,7 @@ void SILGenFunction::emitOptionalEvaluation(SILLocation loc, Type optType,
   } else {
     bbArgs.push_back(getOptionalNoneValue(loc, optTL));
   }
-  for (const auto &result : llvm::makeArrayRef(results).slice(1)) {
+  for (const auto &result : llvm::ArrayRef(results).slice(1)) {
     auto resultTy = result.getType();
     bbArgs.push_back(getOptionalNoneValue(loc, getTypeLowering(resultTy)));
   }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1154,11 +1154,9 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     
     ImportPath::Element UIKitName =
       {ctx.getIdentifier("UIKit"), SourceLoc()};
-    
-    ModuleDecl *UIKit = ctx
-      .getClangModuleLoader()
-      ->loadModule(SourceLoc(),
-                   ImportPath::Module(llvm::makeArrayRef(UIKitName)));
+
+    ModuleDecl *UIKit = ctx.getClangModuleLoader()->loadModule(
+        SourceLoc(), ImportPath::Module(llvm::ArrayRef(UIKitName)));
     assert(UIKit && "couldn't find UIKit objc module?!");
     SmallVector<ValueDecl *, 2> results;
     UIKit->lookupQualified(UIKit,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2232,7 +2232,7 @@ namespace {
       // TODO: build a scalar tuple if possible.
       auto temporary = SGF.emitFormalAccessTemporary(
           loc, SGF.getTypeLowering(getTypeOfRValue()));
-      auto yieldsAsArray = llvm::makeArrayRef(yields);
+      auto yieldsAsArray = llvm::ArrayRef(yields);
       copyBorrowedYieldsIntoTemporary(SGF, loc, yieldsAsArray,
                                       getOrigFormalType(), getSubstFormalType(),
                                       temporary.get());

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -5191,7 +5191,7 @@ void ResultPlanner::execute(SmallVectorImpl<SILValue> &innerDirectResultStack,
 
     case Operation::TupleDirect: {
       auto firstEltIndex = outerDirectResults.size() - op.NumElements;
-      auto elts = makeArrayRef(outerDirectResults).slice(firstEltIndex);
+      auto elts = llvm::ArrayRef(outerDirectResults).slice(firstEltIndex);
       auto tupleType = SGF.F.mapTypeIntoContext(
                           SGF.getSILType(op.OuterResult, CanSILFunctionType()));
       auto tuple = SGF.B.createTuple(Loc, tupleType, elts);

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -614,7 +614,7 @@ public:
       // formal self parameter, but they do not pass an origFnType down,
       // so we can ignore that possibility.
       FormalParamTypes.emplace(SGF.getASTContext(), loweredParams, *origFnType,
-                               llvm::makeArrayRef(substFormalParams),
+                               llvm::ArrayRef(substFormalParams),
                                /*ignore final*/ false);
     }
 

--- a/lib/SILGen/SILGenRequests.cpp
+++ b/lib/SILGen/SILGenRequests.cpp
@@ -70,7 +70,7 @@ ArrayRef<FileUnit *> ASTLoweringDescriptor::getFilesToEmit() const {
 
   // For a single file, we can form an ArrayRef that points at its storage in
   // the union.
-  return llvm::makeArrayRef(*context.getAddrOfPtr1());
+  return llvm::ArrayRef(*context.getAddrOfPtr1());
 }
 
 SourceFile *ASTLoweringDescriptor::getSourceFileToParse() const {

--- a/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/CallerAnalysis.cpp
@@ -147,7 +147,7 @@ bool CallerAnalysis::ApplySiteFinderVisitor::visitFunctionRefBaseInst(
 
   if (result.fullApplySites.size()) {
     iter.first->second.hasFullApply = true;
-    processApplySites(llvm::makeArrayRef(result.fullApplySites));
+    processApplySites(llvm::ArrayRef(result.fullApplySites));
   }
 
   if (result.partialApplySites.size()) {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1524,7 +1524,7 @@ public:
       return;
     }
 
-    auto assignResultsRef = llvm::makeArrayRef(assignResults);
+    auto assignResultsRef = llvm::ArrayRef(assignResults);
     SILValue front = assignResultsRef.front();
     assignResultsRef = assignResultsRef.drop_front();
 
@@ -2216,7 +2216,7 @@ void PartitionOpBuilder::print(llvm::raw_ostream &os) const {
   currentInst->getLoc().getSourceLoc().printLineAndColumn(
       llvm::dbgs(), currentInst->getFunction()->getASTContext().SourceMgr);
 
-  auto ops = llvm::makeArrayRef(currentInstPartitionOps);
+  auto ops = llvm::ArrayRef(currentInstPartitionOps);
 
   // First op on its own line.
   llvm::dbgs() << "\n ├─────╼ ";

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -2496,7 +2496,7 @@ class ConsumeOperatorCopyableAddressesCheckerPass
 
     LLVM_DEBUG(llvm::dbgs() << "Visiting Function: " << fn->getName() << "\n");
     auto addressToProcess =
-        llvm::makeArrayRef(addressesToCheck.begin(), addressesToCheck.end());
+        llvm::ArrayRef(addressesToCheck.begin(), addressesToCheck.end());
 
     SILOptFunctionBuilder funcBuilder(*this);
 

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -435,7 +435,7 @@ bool ConsumeOperatorCopyableValuesChecker::check() {
   LLVM_DEBUG(llvm::dbgs()
              << "Found at least one value to check, performing checking.\n");
   auto valuesToProcess =
-      llvm::makeArrayRef(valuesToCheck.begin(), valuesToCheck.end());
+      llvm::ArrayRef(valuesToCheck.begin(), valuesToCheck.end());
   auto &mod = fn->getModule();
 
   // If we do not emit any diagnostics, we need to put in a break after each dbg

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTester.cpp
@@ -103,8 +103,8 @@ class MoveOnlyBorrowToDestructureTransformPass : public SILFunctionTransform {
     }
 
     diagCount = diagnosticEmitter.getDiagnosticCount();
-    auto introducers = llvm::makeArrayRef(moveIntroducersToProcess.begin(),
-                                          moveIntroducersToProcess.end());
+    auto introducers = llvm::ArrayRef(moveIntroducersToProcess.begin(),
+                                      moveIntroducersToProcess.end());
     if (runTransform(fn, introducers, postOrderAnalysis, diagnosticEmitter)) {
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
@@ -345,8 +345,8 @@ void MoveOnlyObjectCheckerPImpl::check(DominanceInfo *domTree,
 
   unsigned initialDiagCount = diagnosticEmitter.getDiagnosticCount();
 
-  auto moveIntroducers = llvm::makeArrayRef(moveIntroducersToProcess.begin(),
-                                            moveIntroducersToProcess.end());
+  auto moveIntroducers = llvm::ArrayRef(moveIntroducersToProcess.begin(),
+                                        moveIntroducersToProcess.end());
   while (!moveIntroducers.empty()) {
     MarkUnresolvedNonCopyableValueInst *markedValue = moveIntroducers.front();
 

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -147,7 +147,7 @@ OwnershipLiveRange::OwnershipLiveRange(SILValue value)
   llvm::copy(tmpForwardingConsumingUses, std::back_inserter(consumingUses));
   llvm::copy(tmpUnknownConsumingUses, std::back_inserter(consumingUses));
 
-  auto cUseArrayRef = llvm::makeArrayRef(consumingUses);
+  auto cUseArrayRef = llvm::ArrayRef(consumingUses);
   destroyingUses = cUseArrayRef.take_front(tmpDestroyingUses.size());
   ownershipForwardingUses = cUseArrayRef.slice(
       tmpDestroyingUses.size(), tmpForwardingConsumingUses.size());

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -190,7 +190,7 @@ SILDeclRef getBridgeFromObjectiveC(CanType NativeType,
   auto Conformance = ConformanceRef.getConcrete();
   // _unconditionallyBridgeFromObjectiveC
   DeclName Name(Ctx, Ctx.getIdentifier("_unconditionallyBridgeFromObjectiveC"),
-                llvm::makeArrayRef(Identifier()));
+                llvm::ArrayRef(Identifier()));
   auto *Requirement = dyn_cast_or_null<FuncDecl>(
       Proto->getSingleRequirement(Name));
   if (!Requirement)

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -1263,8 +1263,7 @@ OwnershipRAUWHelper::getReplacementAddress() {
   // guaranteedUsePoints?
   BeginBorrowInst *bbi = extender.borrowCopyOverGuaranteedUses(
       base.getReference(), borrowPt,
-      llvm::makeArrayRef(
-        ctx->extraAddressFixupInfo.allAddressUsesFromOldValue));
+      llvm::ArrayRef(ctx->extraAddressFixupInfo.allAddressUsesFromOldValue));
   auto bbiNext = &*std::next(bbi->getIterator());
   auto *refProjection = cast<SingleValueInstruction>(base.getBaseAddress());
   auto *newBase = refProjection->clone(bbiNext);

--- a/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
+++ b/lib/SILOptimizer/Utils/PartialApplyCombiner.cpp
@@ -98,7 +98,7 @@ bool PartialApplyCombiner::copyArgsToTemporaries(
   collectDestroys(pai, paiUses);
 
   ValueLifetimeAnalysis vla(pai,
-                            llvm::makeArrayRef(paiUses.begin(), paiUses.end()));
+                            llvm::ArrayRef(paiUses.begin(), paiUses.end()));
   ValueLifetimeAnalysis::Frontier partialApplyFrontier;
 
   // Computing the frontier may fail if the frontier is located on a critical

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5418,8 +5418,8 @@ namespace {
           // Do not expand macros inside macro arguments. For example for
           // '#stringify(#assert(foo))' when typechecking `#assert(foo)`,
           // we don't want to expand it.
-          llvm::none_of(makeArrayRef(ExprStack).drop_back(1),
-                       [](Expr *E) { return isa<MacroExpansionExpr>(E); })) {
+          llvm::none_of(llvm::ArrayRef(ExprStack).drop_back(1),
+                        [](Expr *E) { return isa<MacroExpansionExpr>(E); })) {
         (void)evaluateOrDefault(cs.getASTContext().evaluator,
                                 ExpandMacroExpansionExprRequest{E},
                                 std::nullopt);
@@ -9947,7 +9947,7 @@ Solution &&SolutionResult::takeSolution() && {
 
 ArrayRef<Solution> SolutionResult::getAmbiguousSolutions() const {
   assert(getKind() == Ambiguous);
-  return makeArrayRef(solutions, numSolutions);
+  return llvm::ArrayRef(solutions, numSolutions);
 }
 
 MutableArrayRef<Solution> SolutionResult::takeAmbiguousSolutions() && {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -5146,7 +5146,7 @@ getBestOverload() const { return Impl->AllDecls[Impl->BestIdx.value()]; }
 
 ArrayRef<ValueDecl*> ResolvedMemberResult::
 getMemberDecls(InterestedMemberKind Kind) {
-  auto Result = llvm::makeArrayRef(Impl->AllDecls);
+  auto Result = llvm::ArrayRef(Impl->AllDecls);
   switch (Kind) {
   case InterestedMemberKind::Viable:
     return Result.slice(Impl->ViableStartIdx);

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -147,7 +147,7 @@ void SplitterStep::computeFollowupSteps(
     // handles all combinations of incoming partial solutions.
     steps.push_back(std::make_unique<DependentComponentSplitterStep>(
         CS, &Components[i], solutionIndex, std::move(components[i]),
-        llvm::makeMutableArrayRef(PartialSolutions.get(), numComponents)));
+        llvm::MutableArrayRef(PartialSolutions.get(), numComponents)));
   }
 
   assert(CS.InactiveConstraints.empty() && "Missed a constraint");
@@ -280,7 +280,7 @@ StepResult DependentComponentSplitterStep::take(bool prevFailed) {
   // Produce all combinations of partial solutions for the inputs.
   SmallVector<std::unique_ptr<SolverStep>, 4> followup;
   SmallVector<unsigned, 2> indices(Component.getDependencies().size(), 0);
-  auto dependsOnSetsRef = llvm::makeArrayRef(dependsOnSets);
+  auto dependsOnSetsRef = llvm::ArrayRef(dependsOnSets);
   do {
     // Form the set of input partial solutions.
     SmallVector<const Solution *, 2> dependsOnSolutions;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1572,7 +1572,7 @@ void ConstraintSystem::recordOpenedTypes(
     = Allocator.Allocate<OpenedType>(replacements.size());
   std::copy(replacements.begin(), replacements.end(), openedTypes);
   OpenedTypes.insert(
-      {locatorPtr, llvm::makeArrayRef(openedTypes, replacements.size())});
+      {locatorPtr, llvm::ArrayRef(openedTypes, replacements.size())});
 }
 
 /// Determine how many levels of argument labels should be removed from the

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -1396,8 +1396,7 @@ void ImportResolver::crossImport(ModuleDecl *M, UnboundImport &I) {
     // declares a cross-import with any previous one.
     auto oldImports =
         // Slice from the start of crossImportableModules up to newImport.
-        llvm::makeArrayRef(crossImportableModules.getArrayRef().data(),
-                           &newImport);
+        llvm::ArrayRef(crossImportableModules.getArrayRef().data(), &newImport);
     findCrossImportsInLists(I, {newImport}, oldImports,
                             /*shouldDiagnoseRedundantCrossImports=*/true);
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5778,7 +5778,7 @@ ProtocolConformance *swift::deriveImplicitSendableConformance(
     if (attrMakingUnavailable) {
       // Conformance availability is currently tied to the declaring extension.
       // FIXME: This is a hack--we should give conformances real availability.
-      auto inherits = ctx.AllocateCopy(makeArrayRef(
+      auto inherits = ctx.AllocateCopy(llvm::ArrayRef(
           InheritedEntry(TypeLoc::withoutLoc(proto->getDeclaredInterfaceType()),
                          /*isUnchecked*/ true, /*isRetroactive=*/false,
                          /*isPreconcurrency=*/false)));

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1898,7 +1898,7 @@ swift::softenIfAccessNote(const Decl *D, const DeclAttribute *attr,
     return std::move(diag);
 
   SmallString<32> attrString;
-  auto attrText = prettyPrintAttrs(VD, makeArrayRef(attr), attrString);
+  auto attrText = prettyPrintAttrs(VD, llvm::ArrayRef(attr), attrString);
 
   ASTContext &ctx = D->getASTContext();
   auto behavior = ctx.LangOpts.getAccessNoteFailureLimit();

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1951,7 +1951,7 @@ public:
 
   /// Peek the unsatisfied requirements collected during conformance checking.
   ArrayRef<ValueDecl*> getUnsatisfiedRequirements() {
-    return llvm::makeArrayRef(UnsatisfiedReqs);
+    return llvm::ArrayRef(UnsatisfiedReqs);
   }
 
   /// Whether this member is "covered" by one of the conformances.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -586,7 +586,7 @@ static void checkLabeledStmtShadowing(
 
   auto activeLabeledStmtsVec = ASTScope::lookupLabeledStmts(
       sourceFile, ls->getStartLoc());
-  auto activeLabeledStmts = llvm::makeArrayRef(activeLabeledStmtsVec);
+  auto activeLabeledStmts = llvm::ArrayRef(activeLabeledStmtsVec);
   for (auto prevLS : activeLabeledStmts.slice(1)) {
     if (prevLS->getLabelInfo().Name == name) {
       ctx.Diags.diagnose(

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -8064,8 +8064,8 @@ public:
 
   ArrayRef<ProtocolConformanceID> claim() {
     // TODO: free the memory here (if it's not used in multiple places?)
-    return llvm::makeArrayRef(getTrailingObjects<ProtocolConformanceID>(),
-                              NumConformances);
+    return llvm::ArrayRef(getTrailingObjects<ProtocolConformanceID>(),
+                          NumConformances);
   }
 };
 } // end anonymous namespace

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -1079,8 +1079,7 @@ void ModuleFile::allocateBuffer(MutableArrayRef<T> &buffer,
     return;
 
   void *rawBuffer = Allocator.Allocate(sizeof(T) * rawData.size(), alignof(T));
-  buffer = llvm::makeMutableArrayRef(static_cast<T *>(rawBuffer),
-                                     rawData.size());
+  buffer = llvm::MutableArrayRef(static_cast<T *>(rawBuffer), rawData.size());
   std::uninitialized_copy(rawData.begin(), rawData.end(), buffer.begin());
 }
 

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -648,8 +648,7 @@ void ModuleFileSharedCore::allocateBuffer(MutableArrayRef<T> &buffer,
     return;
 
   void *rawBuffer = Allocator.Allocate(sizeof(T) * rawData.size(), alignof(T));
-  buffer = llvm::makeMutableArrayRef(static_cast<T *>(rawBuffer),
-                                     rawData.size());
+  buffer = llvm::MutableArrayRef(static_cast<T *>(rawBuffer), rawData.size());
   std::uninitialized_copy(rawData.begin(), rawData.end(), buffer.begin());
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -6535,14 +6535,14 @@ void Serializer::writeAST(ModuleOrSourceFile DC) {
     Scratch.push_back(SF);
     if (auto *synthesizedFile = SF->getSynthesizedFile())
       Scratch.push_back(synthesizedFile);
-    files = llvm::makeArrayRef(Scratch);
+    files = llvm::ArrayRef(Scratch);
   } else {
     for (auto file : M->getFiles()) {
       Scratch.push_back(file);
       if (auto *synthesizedFile = file->getSynthesizedFile())
         Scratch.push_back(synthesizedFile);
     }
-    files = llvm::makeArrayRef(Scratch);
+    files = llvm::ArrayRef(Scratch);
   }
   for (auto nextFile : files) {
     if (nextFile->hasEntryPoint())

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -184,7 +184,7 @@ public:
     for (auto It = Map.begin(); It != Map.end(); ++ It) {
       ViewBuffer.push_back(It->first);
     }
-    return llvm::makeArrayRef(ViewBuffer);
+    return llvm::ArrayRef(ViewBuffer);
   }
 
   bool isEnable() {
@@ -433,7 +433,7 @@ static void writeDeclCommentTable(
   SmallVector<const FileUnit *, 1> Scratch;
   if (SF) {
     Scratch.push_back(SF);
-    files = llvm::makeArrayRef(Scratch);
+    files = llvm::ArrayRef(Scratch);
   } else {
     files = M->getFiles();
   }
@@ -721,8 +721,8 @@ struct BasicDeclLocsTableWriter : public ASTWalker {
     llvm::raw_svector_ostream Out(Buffer);
     endian::Writer Writer(Out, little);
     Writer.write<uint32_t>(FWriter.getTextOffset(AbsolutePath.str()));
-    Writer.write<uint32_t>(DocWriter.getDocRangesOffset(
-        D, llvm::makeArrayRef(RawLocs->DocRanges)));
+    Writer.write<uint32_t>(
+        DocWriter.getDocRangesOffset(D, llvm::ArrayRef(RawLocs->DocRanges)));
     writeRawLoc(RawLocs->Loc, Writer, FWriter);
     writeRawLoc(RawLocs->StartLoc, Writer, FWriter);
     writeRawLoc(RawLocs->EndLoc, Writer, FWriter);

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2045,7 +2045,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(),
         S.addTypeRef(CI->getTargetLoweredType().getRawASTType()),
         (unsigned)CI->getTargetLoweredType().getCategory(),
-        llvm::makeArrayRef(listOfValues));
+        llvm::ArrayRef(listOfValues));
     break;
   }
   case SILInstructionKind::UnconditionalCheckedCastAddrInst: {
@@ -2063,7 +2063,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(),
         S.addTypeRef(CI->getTargetLoweredType().getRawASTType()),
         (unsigned)CI->getTargetLoweredType().getCategory(),
-        llvm::makeArrayRef(listOfValues));
+        llvm::ArrayRef(listOfValues));
     break;
   }
   case SILInstructionKind::UncheckedRefCastAddrInst: {
@@ -2081,7 +2081,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(),
         S.addTypeRef(CI->getTargetLoweredType().getRawASTType()),
         (unsigned)CI->getTargetLoweredType().getCategory(),
-        llvm::makeArrayRef(listOfValues));
+        llvm::ArrayRef(listOfValues));
     break;
   }
 
@@ -2561,7 +2561,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(), ownershipField,
         S.addTypeRef(CBI->getTargetLoweredType().getRawASTType()),
         (unsigned)CBI->getTargetLoweredType().getCategory(),
-        llvm::makeArrayRef(listOfValues));
+        llvm::ArrayRef(listOfValues));
     break;
   }
   case SILInstructionKind::CheckedCastAddrBranchInst: {
@@ -2582,7 +2582,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         (unsigned)SI.getKind(),
         S.addTypeRef(CBI->getTargetLoweredType().getRawASTType()),
         (unsigned)CBI->getTargetLoweredType().getCategory(),
-        llvm::makeArrayRef(listOfValues));
+        llvm::ArrayRef(listOfValues));
     break;
   }
   case SILInstructionKind::InitBlockStorageHeaderInst: {

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -668,7 +668,7 @@ getDeclAttributes(const Decl *D, std::vector<const DeclAttribute*> &Scratch) {
     }
   }
 
-  return llvm::makeArrayRef(Scratch);
+  return llvm::ArrayRef(Scratch);
 }
 
 // Only reports @available.
@@ -1292,9 +1292,8 @@ public:
     std::vector<CategorizedEdits> Results;
     for (unsigned I = 0, N = UIds.size(); I < N; I ++) {
       auto Pair = StartEnds[I];
-      Results.push_back({UIds[I],
-                         llvm::makeArrayRef(AllEdits.data() + Pair.first,
-                                             Pair.second - Pair.first)});
+      Results.push_back({UIds[I], llvm::ArrayRef(AllEdits.data() + Pair.first,
+                                                 Pair.second - Pair.first)});
     }
     Receiver(RequestResult<ArrayRef<CategorizedEdits>>::fromResult(Results));
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1947,8 +1947,7 @@ public:
     // There are multiple trailing closures.
     SmallVector<ClosureInfo, 4> trailingClosures;
     trailingClosures.reserve(params.size() - firstTrailingIndex);
-    for (const auto &param :
-         llvm::makeArrayRef(params).slice(firstTrailingIndex)) {
+    for (const auto &param : llvm::ArrayRef(params).slice(firstTrailingIndex)) {
       trailingClosures.push_back(*param.placeholderClosure);
     }
     MultiClosureCallback(Args, firstTrailingIndex, trailingClosures);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -367,9 +367,9 @@ static bool getModuleInterfaceInfo(
   if (!Group && InterestedUSR) {
     Group = findGroupNameForUSR(Mod, InterestedUSR.value());
   }
-  printModuleInterface(Mod, Group.has_value()
-                         ? llvm::makeArrayRef(Group.value())
-                         : ArrayRef<StringRef>(),
+  printModuleInterface(Mod,
+                       Group.has_value() ? llvm::ArrayRef(Group.value())
+                                         : ArrayRef<StringRef>(),
                        TraversalOptions, Printer, Options,
                        Group.has_value() && SynthesizedExtensions);
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -695,7 +695,7 @@ static bool passCursorInfoForModule(ModuleEntity Mod,
   Symbol.IsSystem = Mod.isNonUserModule();
   if (auto MD = Mod.getAsSwiftModule()) {
     ide::collectModuleGroups(const_cast<ModuleDecl *>(MD), ModuleGroups);
-    Symbol.ModuleGroupArray = llvm::makeArrayRef(ModuleGroups);
+    Symbol.ModuleGroupArray = llvm::ArrayRef(ModuleGroups);
   }
 
   CursorInfoData Data;
@@ -829,7 +829,7 @@ static StringRef copyAndClearString(llvm::BumpPtrAllocator &Allocator,
 template <typename T>
 static ArrayRef<T> copyAndClearArray(llvm::BumpPtrAllocator &Allocator,
                                      SmallVectorImpl<T> &Array) {
-  auto Ref = copyArray(Allocator, llvm::makeArrayRef(Array));
+  auto Ref = copyArray(Allocator, llvm::ArrayRef(Array));
   Array.clear();
   return Ref;
 }
@@ -1031,7 +1031,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
                            Component.Kind,
                            copyAndClearString(Allocator, Buffer));
     };
-    Symbol.ParentContexts = copyArray(Allocator, llvm::makeArrayRef(Parents));
+    Symbol.ParentContexts = copyArray(Allocator, llvm::ArrayRef(Parents));
 
     SmallVector<ReferencedDeclInfo, 8> ReferencedDecls;
     for (auto &FI: FragmentInfos) {
@@ -1063,10 +1063,10 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
           swift::getAccessLevelSpelling(FI.VD->getFormalAccess()), Filename,
           getModuleName(FI.VD, Allocator),
           FI.VD->getModuleContext()->isNonUserModule(), FI.VD->isSPI(),
-          copyArray(Allocator, llvm::makeArrayRef(FIParents)));
+          copyArray(Allocator, llvm::ArrayRef(FIParents)));
     }
-    Symbol.ReferencedSymbols = copyArray(Allocator,
-                                         llvm::makeArrayRef(ReferencedDecls));
+    Symbol.ReferencedSymbols =
+        copyArray(Allocator, llvm::ArrayRef(ReferencedDecls));
   }
 
   Symbol.ModuleName = getModuleName(DInfo.VD, Allocator);
@@ -1326,7 +1326,7 @@ getClangDeclarationName(const clang::NamedDecl *ND, NameTranslatingInfo &Info) {
     if (Info.ArgNames.size() > NumPieces)
       return clang::DeclarationName();
 
-    ArrayRef<StringRef> Args = llvm::makeArrayRef(Info.ArgNames);
+    ArrayRef<StringRef> Args = llvm::ArrayRef(Info.ArgNames);
     std::vector<clang::IdentifierInfo *> Pieces;
     for (unsigned i = 0; i < NumPieces; ++i) {
       if (i >= Info.ArgNames.size() || Info.ArgNames[i].empty()) {
@@ -1362,7 +1362,7 @@ static DeclName getSwiftDeclName(const ValueDecl *VD,
       Args[i] = Ctx.getIdentifier(Arg == "_" ? StringRef() : Arg);
     }
   }
-  return DeclName(Ctx, BaseName, llvm::makeArrayRef(Args));
+  return DeclName(Ctx, BaseName, llvm::ArrayRef(Args));
 }
 
 /// Returns true on success, false on error (and sets `Diagnostic` accordingly).
@@ -1467,7 +1467,7 @@ protected:
   bool CancelOnSubsequentRequest;
 protected:
   ArrayRef<ImmutableTextSnapshotRef> getPreviousASTSnaps() {
-    return llvm::makeArrayRef(PreviousASTSnaps);
+    return llvm::ArrayRef(PreviousASTSnaps);
   }
 
 public:

--- a/tools/SourceKit/tools/complete-test/complete-test.cpp
+++ b/tools/SourceKit/tools/complete-test/complete-test.cpp
@@ -358,7 +358,7 @@ static int skt_main(int argc, const char **argv) {
   KeyUnpopular = sourcekitd_uid_get_from_cstr("key.unpopular");
   KeySubStructure = sourcekitd_uid_get_from_cstr("key.substructure");
 
-  auto Args = llvm::makeArrayRef(argv + 1, argc - 1);
+  auto Args = llvm::ArrayRef(argv + 1, argc - 1);
   TestOptions options;
   std::string error;
   if (!parseOptions(Args, options, error)) {

--- a/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
+++ b/tools/SourceKit/tools/sourcekitd-repl/sourcekitd-repl.cpp
@@ -268,8 +268,7 @@ public:
         CurrentLines.append(indent, ' ');
       }
 
-      convertToUTF8(llvm::makeArrayRef(WLine, WLine + wcslen(WLine)),
-                    CurrentLines);
+      convertToUTF8(llvm::ArrayRef(WLine, WLine + wcslen(WLine)), CurrentLines);
 
       // Special-case backslash for line continuations in the REPL.
       if (CurrentLines.size() > 2 &&
@@ -411,8 +410,8 @@ private:
   }
 
   bool isAtStartOfLine(const LineInfoW *line) {
-    for (wchar_t c : llvm::makeArrayRef(line->buffer,
-                                        line->cursor - line->buffer)) {
+    for (wchar_t c :
+         llvm::ArrayRef(line->buffer, line->cursor - line->buffer)) {
       if (!iswspace(c))
         return false;
     }

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -260,7 +260,7 @@ static void skt_main(skt_args *args) {
   // A test invocation may initialize the options to be used for subsequent
   // invocations.
   TestOptions InitOpts;
-  auto Args = llvm::makeArrayRef(argv+1, argc-1);
+  auto Args = llvm::ArrayRef(argv + 1, argc - 1);
   bool firstInvocation = true;
   while (1) {
     unsigned i = 0;

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -2722,7 +2722,7 @@ static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
     addCursorSymbolInfo(Info.Symbols[0], Elem);
     if (Info.Symbols.size() > 1) {
       auto SecondarySymbols = Elem.setArray(KeySecondarySymbols);
-      for (auto Secondary : makeArrayRef(Info.Symbols).drop_front()) {
+      for (auto Secondary : llvm::ArrayRef(Info.Symbols).drop_front()) {
         auto SecondaryElem = SecondarySymbols.appendDictionary();
         addCursorSymbolInfo(Secondary, SecondaryElem);
       }

--- a/tools/swift-ast-script/swift-ast-script.cpp
+++ b/tools/swift-ast-script/swift-ast-script.cpp
@@ -78,7 +78,7 @@ int main2(int argc, const char *argv[]) {
     return 1;
   }
 
-  Observer observer(llvm::makeArrayRef(argBegin, dashDash));
+  Observer observer(llvm::ArrayRef(argBegin, dashDash));
 
   // Set up the frontend arguments.
   unsigned numFrontendArgs = argEnd - (dashDash + 1);

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4264,7 +4264,7 @@ int main(int argc, char *argv[]) {
   ArrayRef<const char *> CCArgs;
   for (int i = 1; i < argc; ++i) {
     if (StringRef(argv[i]) == "--cc-args") {
-      CCArgs = llvm::makeArrayRef(argv+i+1, argc-i-1);
+      CCArgs = llvm::ArrayRef(argv + i + 1, argc - i - 1);
       argc = i;
     }
   }

--- a/unittests/Basic/EnumMapTest.cpp
+++ b/unittests/Basic/EnumMapTest.cpp
@@ -122,7 +122,7 @@ static const entry globalEntries[] = {
 TEST(EnumMap, Basic) {
   EnumMap<A, size_t> map;
 
-  auto entries = llvm::makeArrayRef(globalEntries);
+  auto entries = llvm::ArrayRef(globalEntries);
 
   for (size_t iteration : range(entries.size())) {
     EXPECT_EQ(iteration, map.size());

--- a/unittests/Basic/ExponentialGrowthAppendingBinaryByteStreamTests.cpp
+++ b/unittests/Basic/ExponentialGrowthAppendingBinaryByteStreamTests.cpp
@@ -79,7 +79,7 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteAtInvalidOffset) {
   EXPECT_EQ(0U, Stream.getLength());
 
   std::vector<uint8_t> InputData = {'T', 'e', 's', 't', 'T', 'e', 's', 't'};
-  auto Test = makeArrayRef(InputData).take_front(4);
+  auto Test = llvm::ArrayRef(InputData).take_front(4);
   // Writing past the end of the stream is an error.
   EXPECT_THAT_ERROR(Stream.writeBytes(4, Test), Failed());
 
@@ -99,7 +99,7 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, InitialSizeZero) {
   auto Stream = ExponentialGrowthAppendingBinaryByteStream();
 
   std::vector<uint8_t> InputData = {'T', 'e', 's', 't'};
-  auto Test = makeArrayRef(InputData).take_front(4);
+  auto Test = llvm::ArrayRef(InputData).take_front(4);
   EXPECT_THAT_ERROR(Stream.writeBytes(0, Test), Succeeded());
   EXPECT_EQ(Test, Stream.data());
 }
@@ -109,7 +109,7 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, GrowMultipleSteps) {
 
   // Test that the buffer can grow multiple steps at once, e.g. 1 -> 2 -> 4
   std::vector<uint8_t> InputData = {'T', 'e', 's', 't'};
-  auto Test = makeArrayRef(InputData).take_front(4);
+  auto Test = llvm::ArrayRef(InputData).take_front(4);
   EXPECT_THAT_ERROR(Stream.writeBytes(0, Test), Succeeded());
   EXPECT_EQ(Test, Stream.data());
 }
@@ -119,25 +119,25 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteIntoMiddle) {
 
   // Test that the stream resizes correctly if we write into its middle
   std::vector<uint8_t> InitialData = {'T', 'e', 's', 't'};
-  auto InitialDataRef = makeArrayRef(InitialData);
+  auto InitialDataRef = llvm::ArrayRef(InitialData);
   EXPECT_THAT_ERROR(Stream.writeBytes(0, InitialDataRef), Succeeded());
   EXPECT_EQ(InitialDataRef, Stream.data());
 
   std::vector<uint8_t> UpdateData = {'u'};
-  auto UpdateDataRef = makeArrayRef(UpdateData);
+  auto UpdateDataRef = llvm::ArrayRef(UpdateData);
   EXPECT_THAT_ERROR(Stream.writeBytes(1, UpdateDataRef), Succeeded());
 
   std::vector<uint8_t> DataAfterUpdate = {'T', 'u', 's', 't'};
-  auto DataAfterUpdateRef = makeArrayRef(DataAfterUpdate);
+  auto DataAfterUpdateRef = llvm::ArrayRef(DataAfterUpdate);
   EXPECT_EQ(DataAfterUpdateRef, Stream.data());
   EXPECT_EQ(4u, Stream.getLength());
 
   std::vector<uint8_t> InsertData = {'e', 'r'};
-  auto InsertDataRef = makeArrayRef(InsertData);
+  auto InsertDataRef = llvm::ArrayRef(InsertData);
   EXPECT_THAT_ERROR(Stream.writeBytes(4, InsertDataRef), Succeeded());
 
   std::vector<uint8_t> DataAfterInsert = {'T', 'u', 's', 't', 'e', 'r'};
-  auto DataAfterInsertRef = makeArrayRef(DataAfterInsert);
+  auto DataAfterInsertRef = llvm::ArrayRef(DataAfterInsert);
   EXPECT_EQ(DataAfterInsertRef, Stream.data());
   EXPECT_EQ(6u, Stream.getLength());
 }
@@ -147,13 +147,13 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteInteger) {
 
   // Test the writeInteger method
   std::vector<uint8_t> InitialData = {'H', 'e', 'l', 'l', 'o'};
-  auto InitialDataRef = makeArrayRef(InitialData);
+  auto InitialDataRef = llvm::ArrayRef(InitialData);
   EXPECT_THAT_ERROR(Stream.writeBytes(0, InitialDataRef), Succeeded());
   EXPECT_EQ(InitialDataRef, Stream.data());
 
   EXPECT_THAT_ERROR(Stream.writeInteger(5, (uint8_t)' '), Succeeded());
   std::vector<uint8_t> AfterFirstInsert = {'H', 'e', 'l', 'l', 'o', ' '};
-  auto AfterFirstInsertRef = makeArrayRef(AfterFirstInsert);
+  auto AfterFirstInsertRef = llvm::ArrayRef(AfterFirstInsert);
   EXPECT_EQ(AfterFirstInsertRef, Stream.data());
   EXPECT_EQ(6u, Stream.getLength());
 
@@ -164,7 +164,7 @@ TEST_F(ExponentialGrowthAppendingBinaryByteStreamTest, WriteInteger) {
   EXPECT_THAT_ERROR(Stream.writeInteger(6, ToInsert), Succeeded());
   std::vector<uint8_t> AfterSecondInsert = {'H', 'e', 'l', 'l', 'o', ' ',
                                             'w', 'o', 'r', 'l'};
-  auto AfterSecondInsertRef = makeArrayRef(AfterSecondInsert);
+  auto AfterSecondInsertRef = llvm::ArrayRef(AfterSecondInsert);
   EXPECT_EQ(AfterSecondInsertRef, Stream.data());
   EXPECT_EQ(10u, Stream.getLength());
 }

--- a/unittests/Basic/SmallMapTest.cpp
+++ b/unittests/Basic/SmallMapTest.cpp
@@ -222,7 +222,7 @@ TEST(SmallMap, Basic) {
   {
     SmallMap<A, A> map;
 
-    auto entries = llvm::makeArrayRef(globalEntries);
+    auto entries = llvm::ArrayRef(globalEntries);
 
     for (size_t iteration : range(entries.size())) {
       EXPECT_EQ(iteration, map.size());

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -180,7 +180,7 @@ TEST(PartitionUtilsTest, Join1) {
 
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
-  Partition p1 = Partition::separateRegions(llvm::makeArrayRef(data1));
+  Partition p1 = Partition::separateRegions(llvm::ArrayRef(data1));
 
   {
     PartitionOpEvaluatorBasic eval(p1, factory);
@@ -192,7 +192,7 @@ TEST(PartitionUtilsTest, Join1) {
                 PartitionOp::Assign(Element(5), Element(2))});
   }
 
-  Partition p2 = Partition::separateRegions(llvm::makeArrayRef(data1));
+  Partition p2 = Partition::separateRegions(llvm::ArrayRef(data1));
   {
     PartitionOpEvaluatorBasic eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
@@ -219,7 +219,7 @@ TEST(PartitionUtilsTest, Join2) {
 
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
-  Partition p1 = Partition::separateRegions(llvm::makeArrayRef(data1));
+  Partition p1 = Partition::separateRegions(llvm::ArrayRef(data1));
 
   {
     PartitionOpEvaluatorBasic eval(p1, factory);
@@ -233,7 +233,7 @@ TEST(PartitionUtilsTest, Join2) {
 
   Element data2[] = {Element(4), Element(5), Element(6),
                      Element(7), Element(8), Element(9)};
-  Partition p2 = Partition::separateRegions(llvm::makeArrayRef(data2));
+  Partition p2 = Partition::separateRegions(llvm::ArrayRef(data2));
   {
     PartitionOpEvaluatorBasic eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(4), Element(4)),
@@ -264,7 +264,7 @@ TEST(PartitionUtilsTest, Join2Reversed) {
 
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
-  Partition p1 = Partition::separateRegions(llvm::makeArrayRef(data1));
+  Partition p1 = Partition::separateRegions(llvm::ArrayRef(data1));
 
   {
     PartitionOpEvaluatorBasic eval(p1, factory);
@@ -278,7 +278,7 @@ TEST(PartitionUtilsTest, Join2Reversed) {
 
   Element data2[] = {Element(4), Element(5), Element(6),
                      Element(7), Element(8), Element(9)};
-  Partition p2 = Partition::separateRegions(llvm::makeArrayRef(data2));
+  Partition p2 = Partition::separateRegions(llvm::ArrayRef(data2));
   {
     PartitionOpEvaluatorBasic eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(4), Element(4)),
@@ -314,7 +314,7 @@ TEST(PartitionUtilsTest, JoinLarge) {
       Element(15), Element(16), Element(17), Element(18), Element(19),
       Element(20), Element(21), Element(22), Element(23), Element(24),
       Element(25), Element(26), Element(27), Element(28), Element(29)};
-  Partition p1 = Partition::separateRegions(llvm::makeArrayRef(data1));
+  Partition p1 = Partition::separateRegions(llvm::ArrayRef(data1));
   {
     PartitionOpEvaluatorBasic eval(p1, factory);
     eval.apply({PartitionOp::Assign(Element(0), Element(29)),
@@ -356,7 +356,7 @@ TEST(PartitionUtilsTest, JoinLarge) {
       Element(30), Element(31), Element(32), Element(33), Element(34),
       Element(35), Element(36), Element(37), Element(38), Element(39),
       Element(40), Element(41), Element(42), Element(43), Element(44)};
-  Partition p2 = Partition::separateRegions(llvm::makeArrayRef(data2));
+  Partition p2 = Partition::separateRegions(llvm::ArrayRef(data2));
   {
     PartitionOpEvaluatorBasic eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(15), Element(31)),

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -404,7 +404,7 @@ TEST_F(CursorInfoTest, CursorInfoMustWaitDueTokenRace) {
   // info, to ensure the ASTManager doesn't try to handle this cursor info with
   // the wrong AST.
   setNeedsSema(true);
-  open(DocName, Contents, llvm::makeArrayRef(Args));
+  open(DocName, Contents, llvm::ArrayRef(Args));
   // Change 'foo' to 'fog' by replacing the last character.
   replaceText(DocName, FooOffs + 2, 1, "g");
   replaceText(DocName, FooRefOffs + 2, 1, "g");
@@ -429,7 +429,7 @@ TEST_F(CursorInfoTest, CursorInfoCancelsPreviousRequest) {
                              "}\n";
   auto SlowOffset = findOffset("x", SlowContents);
   const char *Args[] = {"-parse-as-library"};
-  std::vector<const char *> ArgsForSlow = llvm::makeArrayRef(Args).vec();
+  std::vector<const char *> ArgsForSlow = llvm::ArrayRef(Args).vec();
   ArgsForSlow.push_back(SlowDocName);
 
   const char *FastDocName = "fast.swift";
@@ -437,11 +437,11 @@ TEST_F(CursorInfoTest, CursorInfoCancelsPreviousRequest) {
                              "    let foo = 123\n"
                              "}\n";
   auto FastOffset = findOffset("foo", FastContents);
-  std::vector<const char *> ArgsForFast = llvm::makeArrayRef(Args).vec();
+  std::vector<const char *> ArgsForFast = llvm::ArrayRef(Args).vec();
   ArgsForFast.push_back(FastDocName);
 
-  open(SlowDocName, SlowContents, llvm::makeArrayRef(Args));
-  open(FastDocName, FastContents, llvm::makeArrayRef(Args));
+  open(SlowDocName, SlowContents, llvm::ArrayRef(Args));
+  open(FastDocName, FastContents, llvm::ArrayRef(Args));
 
   // Schedule a cursor info request that takes long to execute. This should be
   // cancelled as the next cursor info (which is faster) gets requested.
@@ -479,10 +479,10 @@ TEST_F(CursorInfoTest, CursorInfoCancellation) {
                              "}\n";
   auto SlowOffset = findOffset("x", SlowContents);
   const char *Args[] = {"-parse-as-library"};
-  std::vector<const char *> ArgsForSlow = llvm::makeArrayRef(Args).vec();
+  std::vector<const char *> ArgsForSlow = llvm::ArrayRef(Args).vec();
   ArgsForSlow.push_back(SlowDocName);
 
-  open(SlowDocName, SlowContents, llvm::makeArrayRef(Args));
+  open(SlowDocName, SlowContents, llvm::ArrayRef(Args));
 
   SourceKitCancellationToken CancellationToken = createCancellationToken();
 

--- a/utils/test-list-merger/TestListMerger.cpp
+++ b/utils/test-list-merger/TestListMerger.cpp
@@ -108,7 +108,7 @@ static std::ostream &operator<<(std::ostream &str, llvm::ArrayRef<T> list) {
 
 template <class T>
 static std::ostream &operator<<(std::ostream &str, const std::vector<T> &list) {
-  return (str << llvm::makeArrayRef(list));
+  return (str << llvm::ArrayRef(list));
 }
 
 static void runInsertAndMergeTest(llvm::ArrayRef<Instruction> values) {


### PR DESCRIPTION
LLVM has removed `make*ArrayRef`, migrate all references to their constructor equivalent.