### PR TITLE
[overlay] magic-symbols-for-install-name conflicts with @_originallyDefinedIn

### DIFF
--- a/stdlib/public/ClangOverlays/CMakeLists.txt
+++ b/stdlib/public/ClangOverlays/CMakeLists.txt
@@ -2,8 +2,6 @@ add_swift_target_library(swift_Builtin_float
     ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
     IS_SDK_OVERLAY
 
-    "${SWIFT_SOURCE_DIR}/stdlib/linker-support/magic-symbols-for-install-name.c"
-
     GYB_SOURCES
       float.swift.gyb
 

--- a/stdlib/public/ClangOverlays/float.swift.gyb
+++ b/stdlib/public/ClangOverlays/float.swift.gyb
@@ -13,6 +13,8 @@
 @_exported import _Builtin_float
 
 @available(swift, deprecated: 3.0, message: "Please use 'T.radix' to get the radix of a FloatingPoint type 'T'.")
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
+@_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
 public let FLT_RADIX = Double.radix
 
 %for type, prefix in [('Float', 'FLT'), ('Double', 'DBL'), ('Float80', 'LDBL')]:
@@ -22,7 +24,7 @@ public let FLT_RADIX = Double.radix
 //  Where does the 1 come from? C counts the usually-implicit leading
 //  significand bit, but Swift does not. Neither is really right or wrong.
 @available(swift, deprecated: 3.0, message: "Please use '${type}.significandBitCount + 1'.")
-@available(macOS 10.9, iOS 7.0, tvOS 7.0, watchOS 2.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
 public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
 
@@ -31,32 +33,32 @@ public let ${prefix}_MANT_DIG = ${type}.significandBitCount + 1
 //  significand to be in [1, 2). This rationale applies to ${prefix}_MIN_EXP
 //  as well.
 @available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude.exponent + 1'.")
-@available(macOS 10.9, iOS 7.0, tvOS 7.0, watchOS 2.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
 public let ${prefix}_MAX_EXP = ${type}.greatestFiniteMagnitude.exponent + 1
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude.exponent + 1'.")
-@available(macOS 10.9, iOS 7.0, tvOS 7.0, watchOS 2.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
 public let ${prefix}_MIN_EXP = ${type}.leastNormalMagnitude.exponent + 1
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.greatestFiniteMagnitude' or '.greatestFiniteMagnitude'.")
-@available(macOS 10.9, iOS 7.0, tvOS 7.0, watchOS 2.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
 public let ${prefix}_MAX = ${type}.greatestFiniteMagnitude
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.ulpOfOne' or '.ulpOfOne'.")
-@available(macOS 10.9, iOS 7.0, tvOS 7.0, watchOS 2.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
 public let ${prefix}_EPSILON = ${type}.ulpOfOne
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNormalMagnitude' or '.leastNormalMagnitude'.")
-@available(macOS 10.9, iOS 7.0, tvOS 7.0, watchOS 2.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
 public let ${prefix}_MIN = ${type}.leastNormalMagnitude
 
 @available(swift, deprecated: 3.0, message: "Please use '${type}.leastNonzeroMagnitude' or '.leastNonzeroMagnitude'.")
-@available(macOS 10.9, iOS 7.0, tvOS 7.0, watchOS 2.0, *)
+@available(macOS 10.9, iOS 7.0, watchOS 2.0, tvOS 9.0, *)
 @_originallyDefinedIn(module: "Darwin", macOS 9999, iOS 9999, watchOS 9999, tvOS 9999)
 public let ${prefix}_TRUE_MIN = ${type}.leastNonzeroMagnitude
 


### PR DESCRIPTION
The _Builtin_float interfaces were defined in $@rpath/lib/libswiftDarwin.dylib until macOS 10.14.4 and then in usr/lib/swift/libswiftDarwin.dylib after that. We were trying to use magic-symbols-for-install-name for the first one and @_originallyDefinedIn for the second one. However, `@_originallyDefinedIn` uses the `@available` introduced version as the first bound for $ld$previous$ which conflicts with the magic-symbols-for-install-name $ld$install_name$. Eventually `@_originallyDefinedIn` will need to support multiple install names, but until then just use it as-is and stop using magic-symbols-for-install-name.

Add the missing `@_originallyDefinedIn` on FLT_RADIX, and match the watchOS/tvOS order between `@_originallyDefinedIn` and `@available`.
There was no tvOS 7.0, the first one was 9.0.

rdar://122351557