### PR TITLE
Sema: Fix checkTypeWitness() for Objective-C protocol compositions

### DIFF
--- a/test/decl/protocol/req/associated_type_inference_objc_existential.swift
+++ b/test/decl/protocol/req/associated_type_inference_objc_existential.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol P1 {
+  associatedtype A: NSObject
+}
+
+@objc protocol P2 {}
+
+struct S: P1 {
+  typealias A = NSObject & P2
+}
+
+let x: (any NSObject & P2).Type = S.A.self


### PR DESCRIPTION
I forgot that a protocol composition `(C & P)` can satisfy a superclass requirement `[T : D]` in one narrow case implemented in TypeBase::isExactSuperclassOf():

- D is a superclass of C
- P is an @objc protocol
- C is declared in Objective-C

This case was ruled out here because the code assumed the type witness had to be a concrete class or archetype to satisfy a superclass requirement.

Fixes rdar://problem/123543200.
