### PR TITLE
[Concurrency] Warn if implied `@unchecked Sendable` conformances are not re-stated.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5640,6 +5640,9 @@ ERROR(sendable_raw_storage,none,
 
 WARNING(unchecked_conformance_not_special,none,
       "@unchecked conformance to %0 has no meaning", (Type))
+WARNING(restate_unchecked_sendable,none,
+        "class %0 must restate inherited '@unchecked Sendable' conformance",
+        (DeclName))
 ERROR(unchecked_not_inheritance_clause,none,
       "'unchecked' attribute only applies in inheritance clauses", ())
 ERROR(unchecked_not_existential,none,

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -5596,6 +5596,55 @@ bool swift::checkSendableConformance(
       return false;
   }
 
+  bool isUnchecked = false;
+  if (auto *normal = conformance->getRootNormalConformance())
+    isUnchecked = normal->isUnchecked();
+
+  if (isUnchecked) {
+    // Warn if inferred or inherited '@unchecked Sendable' is not restated.
+    // Beyond that, '@unchecked Sendable' requires no further checking.
+
+    if (!isa<InheritedProtocolConformance>(conformance))
+      return false;
+
+    auto statesUnchecked =
+      [](InheritedTypes inheritedTypes, DeclContext *dc) -> bool {
+        for (auto i : inheritedTypes.getIndices()) {
+          auto inheritedType =
+              TypeResolution::forInterface(
+                  dc,
+                  TypeResolverContext::Inherited,
+                  /*unboundTyOpener*/ nullptr,
+                  /*placeholderHandler*/ nullptr,
+                  /*packElementOpener*/ nullptr)
+              .resolveType(inheritedTypes.getTypeRepr(i));
+
+          if (!inheritedType || inheritedType->hasError())
+            continue;
+
+          if (inheritedType->getKnownProtocol() != KnownProtocolKind::Sendable)
+            continue;
+
+          if (inheritedTypes.getEntry(i).isUnchecked())
+            return true;
+        }
+
+        return false;
+      };
+
+    if (statesUnchecked(nominal->getInherited(), nominal))
+      return false;
+
+    for (auto *extension : nominal->getExtensions()) {
+      if (statesUnchecked(extension->getInherited(), extension))
+        return false;
+    }
+
+    nominal->diagnose(diag::restate_unchecked_sendable,
+                      nominal->getName());
+    return false;
+  }
+
   auto classDecl = dyn_cast<ClassDecl>(nominal);
   if (classDecl) {
     // Actors implicitly conform to Sendable and protect their state.

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -336,9 +336,20 @@ class C5: @unchecked Sendable {
   var x: Int = 0 // okay
 }
 
+// expected-warning@+1 {{class 'C6' must restate inherited '@unchecked Sendable' conformance}}
 class C6: C5 {
   var y: Int = 0 // still okay, it's unsafe
 }
+
+class C6_Restated: C5, @unchecked Sendable {
+  var y: Int = 0 // still okay, it's unsafe
+}
+
+class C6_Restated_Extension: C5 {
+  var y: Int = 0 // still okay, it's unsafe
+}
+
+extension C6_Restated_Extension: @unchecked Sendable {}
 
 final class C7<T>: Sendable { }
 

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -8,6 +8,7 @@ class MyActorSubclass1: MyActor { }
 // expected-error@-1{{actor types do not support inheritance}}
 // expected-error@-2{{type 'MyActorSubclass1' cannot conform to the 'Actor' protocol}}
 // expected-error@-3{{non-actor type 'MyActorSubclass1' cannot conform to the 'AnyActor' protocol}}
+// expected-warning@-4 {{non-final class 'MyActorSubclass1' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in Swift 6}}
 
 actor MyActorSubclass2: MyActor { } // expected-error{{actor types do not support inheritance}}
 


### PR DESCRIPTION
`@unchecked Sendable` conformances can be inherited through subclassing, making it easy to introduce unprotected mutable state:

```swift
class C1: @unchecked Sendable {}

class C2: C1 {
  var x = 10 // oh no
}
```

This is especially misleading if the subclass states a checked `Sendable` conformance:

```swift
class C1: @unchecked Sendable {}

class C2: C1, Sendable {
  var x = 10 // okay?
}
```

This change emits a warning if an implicit `@unchecked Sendable` conformance is not re-stated.

Resolves: rdar://120867728, rdar://100001263