### PR TITLE
Some create_benchmark.py script enhancements.

### DIFF
--- a/benchmark/scripts/Template.swift
+++ b/benchmark/scripts/Template.swift
@@ -1,8 +1,8 @@
-//===--- {name}.swift -------------------------------------------===//
+//===--- {name}.swift {padding}----===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) {year} Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,7 +12,7 @@
 
 import TestsUtils
 
-public let {name} = [
+public let benchmarks = [
   BenchmarkInfo(name: "{name}", runFunction: run_{name}, tags: [.validation, .api]),
 ]
 

--- a/benchmark/scripts/Template.swift
+++ b/benchmark/scripts/Template.swift
@@ -1,4 +1,4 @@
-//===--- {name}.swift {padding}----===//
+//===--- {name}.swift {padding}---===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/benchmark/scripts/create_benchmark.py
+++ b/benchmark/scripts/create_benchmark.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import datetime
 import os
 import re
 
@@ -47,17 +48,22 @@ def create_benchmark_file(name):
     """
 
     template_path = create_relative_path("Template.swift")
-    benchmark_template = ""
+    file_text = ""
+    
     with open(template_path, "r") as f:
-        benchmark_template = "".join(f.readlines())
+        file_text = "".join(f.readlines())
 
-    # fill in template with benchmark name.
-    formatted_template = benchmark_template.format(name=name)
-
-    relative_path = create_relative_path("../single-source/")
-    source_file_path = os.path.join(relative_path, name + ".swift")
-    with open(source_file_path, "w") as f:
-        f.write(formatted_template)
+    # fill in missing template details
+    file_text = file_text.format(
+        name = name,
+        padding = "-" * (55 - len(name)),
+        year = datetime.date.today().year
+    )
+    
+    file_path_prefix = create_relative_path("../single-source/")
+    file_path = os.path.join(file_path_prefix, name + ".swift")
+    with open(file_path, "w") as f:
+        f.write(file_text)
 
 
 def add_import_benchmark(name):
@@ -119,9 +125,9 @@ def add_register_benchmark(name):
 
     file_new_contents = insert_line_alphabetically(
         name,
-        "registerBenchmark(" + name + ")\n",
+        "register(" + name + ".benchmarks)\n",
         file_contents,
-        r"registerBenchmark\(([a-zA-Z]+)\)",
+        r"register\(([a-zA-Z]+)\.benchmarks\)",
     )
     with open(relative_path, "w") as f:
         for line in file_new_contents:

--- a/benchmark/scripts/create_benchmark.py
+++ b/benchmark/scripts/create_benchmark.py
@@ -56,7 +56,7 @@ def create_benchmark_file(name):
     # fill in missing template details
     file_text = file_text.format(
         name = name,
-        padding = "-" * (55 - len(name)),
+        padding = "-" * (56 - len(name)),
         year = datetime.date.today().year
     )
     

--- a/benchmark/scripts/create_benchmark.py
+++ b/benchmark/scripts/create_benchmark.py
@@ -47,19 +47,18 @@ def create_benchmark_file(name):
     and places it in the `single-source` directory.
     """
 
-    template_path = create_relative_path("Template.swift")
     file_text = ""
-    
+    template_path = create_relative_path("Template.swift")
     with open(template_path, "r") as f:
         file_text = "".join(f.readlines())
 
     # fill in missing template details
     file_text = file_text.format(
-        name = name,
-        padding = "-" * (56 - len(name)),
-        year = datetime.date.today().year
+        name=name,
+        padding="-" * (56 - len(name)),
+        year=datetime.date.today().year
     )
-    
+
     file_path_prefix = create_relative_path("../single-source/")
     file_path = os.path.join(file_path_prefix, name + ".swift")
     with open(file_path, "w") as f:


### PR DESCRIPTION
This patch addresses some trials and tribulations I encountered in (#71786). It:

1. fixes the auto-registration regex
2. fixes the auto-generated array's name
3. generates the current year for the license header
4. generates some dashes for the license header

#### Short how-to per README.md

```
swift-source$ ./swift/benchmark/scripts/create_benchmark.py YourTestNameHere
```