### PR TITLE
Turn off lifetime dependence inference on builtins temporarily

### DIFF
--- a/lib/Sema/LifetimeDependence.cpp
+++ b/lib/Sema/LifetimeDependence.cpp
@@ -360,6 +360,15 @@ LifetimeDependenceInfo::infer(AbstractFunctionDecl *afd, Type resultType) {
     return std::nullopt;
   }
   if (!candidateParam && !hasParamError) {
+    // Explicitly turn off error messages for builtins, since some of are
+    // ~Escapable currently.
+    // TODO: rdar://123555720: Remove this check after another round of
+    // surveying builtins
+    if (auto *fd = dyn_cast<FuncDecl>(afd)) {
+      if (fd->isImplicit()) {
+        return std::nullopt;
+      }
+    }
     diags.diagnose(returnLoc,
                    diag::lifetime_dependence_cannot_infer_no_candidates);
     return std::nullopt;


### PR DESCRIPTION
Some builtin results are still incorrectly ~Escapable leading to errors with lifetime dependence inference. Turn off inference for implicit FuncDecl to avoid this issue temporarily. 