### PR TITLE
Fix grammar in `starts(with:)` docs

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -213,7 +213,7 @@ extension Sequence  {
   /// sequence are equivalent to the elements in another sequence, using
   /// the given predicate as the equivalence test.
   ///
-  /// The predicate must be a *equivalence relation* over the elements. That
+  /// The predicate must be an *equivalence relation* over the elements. That
   /// is, for any elements `a`, `b`, and `c`, the following conditions must
   /// hold:
   ///
@@ -297,7 +297,7 @@ extension Sequence {
   ///
   /// At least one of the sequences must be finite.
   ///
-  /// The predicate must be a *equivalence relation* over the elements. That
+  /// The predicate must be an *equivalence relation* over the elements. That
   /// is, for any elements `a`, `b`, and `c`, the following conditions must
   /// hold:
   ///
@@ -407,7 +407,7 @@ extension Sequence {
   public func lexicographicallyPrecedes<OtherSequence: Sequence>(
     _ other: OtherSequence,
     by areInIncreasingOrder: (Element, Element) throws -> Bool
-  ) rethrows -> Bool 
+  ) rethrows -> Bool
   where OtherSequence.Element == Element {
     var iter1 = self.makeIterator()
     var iter2 = other.makeIterator()
@@ -632,7 +632,7 @@ extension Sequence {
     }
     return accumulator
   }
-  
+
   /// Returns the result of combining the elements of the sequence using the
   /// given closure.
   ///


### PR DESCRIPTION
Just a small typo discovered in apple/swift-algorithms#224