### PR TITLE
[ExternalGenericMetadataBuilder] Fix install invocation. Add dependency.

### DIFF
--- a/lib/ExternalGenericMetadataBuilder/CMakeLists.txt
+++ b/lib/ExternalGenericMetadataBuilder/CMakeLists.txt
@@ -13,9 +13,9 @@ target_link_libraries(swiftGenericMetadataBuilder
                       swiftDemangling)
 
 swift_install_in_component(TARGETS swiftGenericMetadataBuilder
+  COMPONENT compiler
   LIBRARY
     DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
-    COMPONENT compiler
   ARCHIVE
-    DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
-    COMPONENT compiler)
+    DESTINATION "lib${LLVM_LIBDIR_SUFFIX}")
+add_dependencies(compiler swiftGenericMetadataBuilder)


### PR DESCRIPTION
The call `swift_install_in_component` does not support multiple component depending on the `TARGET` pieces, so providing it several times is only confusing for humans. Deduplicate the repeated component and move it outside of the `ARCHIVE` and `LIBRARY` pieces.

Additionally, `add_swift_host_library` does not provide a `INSTALL_IN_COMPONENT` like `add_swift_target_library` does, so there is a missing dependency between the `compiler` component and the library. This is not a problem with `build-script` because the target is part of `all`, but it is a problem when using `ninja compiler`, for example.`
