### PR TITLE
Fix AccessUtils Value.referenceRoot to handle ForwardingInstructions.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
@@ -162,11 +162,11 @@ private func constructLetInitRegion(
       initRegion.insert(inst)
 
     case let beginBorrow as BeginBorrowInst
-         where beginBorrow.borrowedValue.referenceRoot == markUninitialized:
+           where beginBorrow.borrowedValue.isReferenceDerived(from: markUninitialized):
       borrows.append(beginBorrow)
 
     case let storeBorrow as StoreBorrowInst
-         where storeBorrow.source.referenceRoot == markUninitialized:
+           where storeBorrow.source.isReferenceDerived(from: markUninitialized):
       borrows.append(storeBorrow)
 
     default:
@@ -202,10 +202,28 @@ private extension RefElementAddrInst {
 }
 
 private extension Value {
+  func isReferenceDerived(from root: Value) -> Bool {
+    var parent: Value = self
+    while true {
+      if parent == root {
+        return true
+      }
+      if let operand = parent.forwardingInstruction?.singleForwardedOperand {
+        parent = operand.value
+        continue
+      }
+      if let transition = parent.definingInstruction as? OwnershipTransitionInstruction {
+        parent = transition.operand.value
+        continue
+      }
+      return false
+    }
+  }
+
   func isLetFieldAddress(of markUninitialized: MarkUninitializedInst) -> Bool {
     if case .class(let rea) = self.accessBase,
        rea.fieldIsLet,
-       rea.instance.referenceRoot == markUninitialized
+       rea.instance.isReferenceDerived(from: markUninitialized)
     {
       return true
     }

--- a/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/AccessUtils.swift
@@ -546,6 +546,10 @@ extension Value {
   public var referenceRoot: Value {
     var value: Value = self
     while true {
+      if let operand = value.forwardingInstruction?.singleForwardedOperand {
+        value = operand.value
+        continue
+      }
       switch value {
       case is BeginBorrowInst, is CopyValueInst, is MoveValueInst,
            is EndInitLetRefInst,


### PR DESCRIPTION
This fixes all analyses that use AccessUtils in the presence of new forwarding instructions. This is also needed for consistency with the C++ source base. And for general sanity.

Utilities that walk the use-def chain should never hard-code a list of opcodes that happened to work with some specific pass. Passes should never assume that a basic SIL utility handles specific SIL operations a certain way. Instead, the utility needs to be defined in terms of SIL semantics. In this case, the utility is supposed to handle all instructions that semantically forward ownership of a reference.
