### PR TITLE
[test] Mark IsolatedAny tests as requiring asserts compiler

### DIFF
--- a/test/Concurrency/isolated_any.swift
+++ b/test/Concurrency/isolated_any.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature IsolatedAny -enable-upcoming-feature InferSendableFromCaptures %s
 
+// REQUIRES: asserts
+
 func globalNonisolatedFunction() {}
 @MainActor func globalMainActorFunction() {}
 

--- a/test/Parse/isolated_any.swift
+++ b/test/Parse/isolated_any.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature IsolatedAny
 
+// REQUIRES: asserts
+
 typealias FnType = @isolated(any) () -> ()
 
 func testInParameter(function: @isolated(any) () -> ()) {}

--- a/test/SILGen/isolated_any.swift
+++ b/test/SILGen/isolated_any.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature IsolatedAny %s -module-name test -swift-version 5 -disable-availability-checking | %FileCheck %s
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 // CHECK-LABEL: sil hidden [ossa] @$s4test8callSync2fnyyyYAXE_tYaF
 // CHECK:         [[NIL_EXECUTOR:%.*]] = enum $Optional<Builtin.Executor>, #Optional.none


### PR DESCRIPTION
IsolatedAny is an experimental feature, so the tests require an asserts compiler to pass.

