### PR TITLE
[test] Mark test using _Differentiation as needing differentiable_programming

### DIFF
--- a/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
@@ -2,6 +2,7 @@
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
+// REQUIRES: differentiable_programming
 
 sil_stage raw
 


### PR DESCRIPTION
The test was trying to import the module, but it will not be available unless the build system has been setup for differentiable programming.
