### PR TITLE
[sil] Ensure that all SILValues have a parent function by making it so that SILUndef is uniqued at the function instead of module level.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LetPropertyLowering.swift
@@ -99,7 +99,8 @@ private func insertEndInitInstructions(
   atEndOf initRegion: InstructionRange,
   _ context: FunctionPassContext
 ) {
-  var ssaUpdater = SSAUpdater(type: markUninitialized.type, ownership: .owned, context)
+  var ssaUpdater = SSAUpdater(function: markUninitialized.parentFunction,
+                              type: markUninitialized.type, ownership: .owned, context)
   ssaUpdater.addAvailableValue(markUninitialized, in: markUninitialized.parentBlock)
 
   for endInst in initRegion.ends {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/RedundantLoadElimination.swift
@@ -236,7 +236,8 @@ private extension LoadInst {
 }
 
 private func replace(load: LoadInst, with availableValues: [AvailableValue], _ context: FunctionPassContext) {
-  var ssaUpdater = SSAUpdater(type: load.type, ownership: load.ownership, context)
+  var ssaUpdater = SSAUpdater(function: load.parentFunction,
+                              type: load.type, ownership: load.ownership, context)
 
   for availableValue in availableValues {
     let block = availableValue.instruction.parentBlock

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/SSAUpdater.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/SSAUpdater.swift
@@ -17,9 +17,11 @@ import OptimizerBridging
 struct SSAUpdater<Context: MutatingContext> {
   let context: Context
 
-  init(type: Type, ownership: Ownership, _ context: Context) {
+  init(function: Function, type: Type, ownership: Ownership,
+       _ context: Context) {
     self.context = context
-    context._bridged.SSAUpdater_initialize(type.bridged, ownership._bridged)
+    context._bridged.SSAUpdater_initialize(function.bridged, type.bridged,
+                                           ownership._bridged)
   }
 
   mutating func addAvailableValue(_ value: Value, in block: BasicBlock) {

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -200,7 +200,11 @@ public:
     assert(F && "cannot create this instruction without a function context");
     return *F;
   }
-  
+
+  /// If this SILBuilder is inserting into a function, return that function. If
+  /// we are inserting into a global, this returns nullptr.
+  SILFunction *maybeGetFunction() const { return F; }
+
   bool isInsertingIntoGlobal() const { return F == nullptr; }
 
   TypeExpansionContext getTypeExpansionContext() const {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -593,7 +593,7 @@ SILCloner<ImplClass>::getMappedValue(SILValue Value) {
   if (auto *U = dyn_cast<SILUndef>(Value)) {
     auto type = getOpType(U->getType());
     ValueBase *undef =
-      (type == U->getType() ? U : SILUndef::get(type, Builder.getFunction()));
+        (type == U->getType() ? U : SILUndef::get(Builder.getFunction(), type));
     return SILValue(undef);
   }
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -40,6 +40,7 @@ class BasicBlockBitfield;
 class NodeBitfield;
 class OperandBitfield;
 class CalleeCache;
+class SILUndef;
 
 namespace Lowering {
 class TypeLowering;
@@ -211,6 +212,7 @@ private:
   friend class BasicBlockBitfield;
   friend class NodeBitfield;
   friend class OperandBitfield;
+  friend SILUndef;
 
   /// Module - The SIL module that the function belongs to.
   SILModule &Module;
@@ -328,6 +330,9 @@ private:
   Purpose specialPurpose = Purpose::None;
 
   PerformanceConstraints perfConstraints = PerformanceConstraints::None;
+
+  /// This is the set of undef values we've created, for uniquing purposes.
+  llvm::DenseMap<SILType, SILUndef *> undefValues;
 
   /// This is the number of uses of this SILFunction inside the SIL.
   /// It does not include references from debug scopes.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -332,7 +332,11 @@ private:
   PerformanceConstraints perfConstraints = PerformanceConstraints::None;
 
   /// This is the set of undef values we've created, for uniquing purposes.
-  llvm::DenseMap<SILType, SILUndef *> undefValues;
+  ///
+  /// We use a SmallDenseMap since in most functions, we will have only one type
+  /// of undef if we have any at all. In that case, by staying small we avoid
+  /// needing a heap allocation.
+  llvm::SmallDenseMap<SILType, SILUndef *, 1> undefValues;
 
   /// This is the number of uses of this SILFunction inside the SIL.
   /// It does not include references from debug scopes.
@@ -1562,6 +1566,12 @@ public:
   ///
   /// This is a fast subset of the checks performed in the SILVerifier.
   void verifyCriticalEdges() const;
+
+  /// Validate that all SILUndefs stored in the function's type -> SILUndef map
+  /// have this function as their parent function.
+  ///
+  /// Please only call this from the SILVerifier.
+  void verifySILUndefMap() const;
 
   /// Pretty-print the SILFunction.
   void dump(bool Verbose) const;

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -108,7 +108,6 @@ class FuncDecl;
 class IRGenOptions;
 class KeyPathPattern;
 class ModuleDecl;
-class SILUndef;
 class SourceFile;
 class SerializedSILLoader;
 class SILFunctionBuilder;
@@ -192,7 +191,6 @@ private:
   friend SILType;
   friend SILVTable;
   friend SILProperty;
-  friend SILUndef;
   friend SILWitnessTable;
   friend SILMoveOnlyDeinit;
   friend Lowering::SILGenModule;
@@ -314,9 +312,6 @@ private:
 
   /// This is a cache of builtin Function declarations to numeric ID mappings.
   llvm::DenseMap<Identifier, BuiltinInfo> BuiltinIDCache;
-
-  /// This is the set of undef values we've created, for uniquing purposes.
-  llvm::DenseMap<SILType, SILUndef *> UndefValues;
 
   llvm::DenseMap<std::pair<Decl *, VarDecl *>, unsigned> fieldIndices;
   llvm::DenseMap<EnumElementDecl *, unsigned> enumCaseIndices;

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -409,12 +409,13 @@ public:
   /// otherwise return null.
   SILBasicBlock *getParentBlock() const;
 
-  /// If this is a SILArgument or a SILInstruction get its parent function,
-  /// otherwise return null.
+  /// Returns the parent function of this value.
+  ///
+  /// Only returns nullptr if the given value's parent is a sil global variable
+  /// initializer.
   SILFunction *getFunction() const;
 
-  /// If this is a SILArgument or a SILInstruction get its parent module,
-  /// otherwise return null.
+  /// Return the parent module of this value.
   SILModule *getModule() const;
   
   /// Pretty-print the node.  If the node is an instruction, the output

--- a/include/swift/SIL/SILUndef.h
+++ b/include/swift/SIL/SILUndef.h
@@ -23,28 +23,36 @@ class SILInstruction;
 class SILModule;
 
 class SILUndef : public ValueBase {
-  SILUndef(SILType type);
+  /// A back pointer to the function that this SILUndef is uniqued by.
+  SILFunction *parent;
+
+  SILUndef(SILFunction *parent, SILType type);
 
 public:
   void operator=(const SILArgument &) = delete;
   void operator delete(void *, size_t) = delete;
 
-  static SILUndef *get(SILType ty, SILModule &m);
-
   /// Return a SILUndef with the same type as the passed in value.
   static SILUndef *get(SILValue value) {
-    return SILUndef::get(value->getType(), *value->getModule());
+    return SILUndef::get(value->getFunction(), value->getType());
   }
 
-  static SILUndef *get(SILType ty, const SILFunction &f);
+  static SILUndef *get(SILFunction *f, SILType ty);
+  static SILUndef *get(SILFunction &f, SILType ty) {
+    return SILUndef::get(&f, ty);
+  }
 
+  /// This is an API only used by SILSSAUpdater... please do not use it anywhere
+  /// else.
   template <class OwnerTy>
-  static SILUndef *getSentinelValue(SILType type, OwnerTy owner) {
+  static SILUndef *getSentinelValue(SILFunction *fn, OwnerTy owner,
+                                    SILType type) {
     // Ownership kind isn't used here, the value just needs to have a unique
     // address.
-    return new (*owner) SILUndef(type);
+    return new (*owner) SILUndef(fn, type);
   }
 
+  SILFunction *getParent() const { return parent; }
   ValueOwnershipKind getOwnershipKind() const { return OwnershipKind::None; }
 
   static bool classof(const SILArgument *) = delete;

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1592,15 +1592,19 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, SILValue V) {
 
 /// Used internally in e.g. the SIL parser and deserializer to handle forward-
 /// referenced values.
+///
 /// A PlaceholderValue must not appear in valid SIL.
 class PlaceholderValue : public ValueBase {
+  SILFunction *parentFunction;
   static int numPlaceholderValuesAlive;
 
 public:
-  PlaceholderValue(SILType type);
+  PlaceholderValue(SILFunction *parentFunction, SILType type);
   ~PlaceholderValue();
 
   static int getNumPlaceholderValuesAlive() { return numPlaceholderValuesAlive; }
+
+  SILFunction *getParent() const { return parentFunction; }
 
   static bool classof(const SILArgument *) = delete;
   static bool classof(const SILInstruction *) = delete;

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -307,7 +307,9 @@ struct BridgedPassContext {
 
   // SSAUpdater
 
-  BRIDGED_INLINE void SSAUpdater_initialize(BridgedType type, BridgedValue::Ownership ownership) const;
+  BRIDGED_INLINE void
+  SSAUpdater_initialize(BridgedFunction function, BridgedType type,
+                        BridgedValue::Ownership ownership) const;
   BRIDGED_INLINE void SSAUpdater_addAvailableValue(BridgedBasicBlock block, BridgedValue value) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue SSAUpdater_getValueAtEndOfBlock(BridgedBasicBlock block) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedValue SSAUpdater_getValueInMiddleOfBlock(BridgedBasicBlock block) const;

--- a/include/swift/SILOptimizer/OptimizerBridgingImpl.h
+++ b/include/swift/SILOptimizer/OptimizerBridgingImpl.h
@@ -229,7 +229,7 @@ void BridgedPassContext::moveInstructionBefore(BridgedInstruction inst, BridgedI
 }
 
 BridgedValue BridgedPassContext::getSILUndef(BridgedType type) const {
-  return {swift::SILUndef::get(type.unbridged(), *invocation->getFunction())};
+  return {swift::SILUndef::get(invocation->getFunction(), type.unbridged())};
 }
 
 bool BridgedPassContext::optimizeMemoryAccesses(BridgedFunction f) const {
@@ -410,8 +410,10 @@ bool BridgedPassContext::continueWithNextSubpassRun(OptionalBridgedInstruction i
       inst.unbridged(), invocation->getFunction(), invocation->getTransform());
 }
 
-void BridgedPassContext::SSAUpdater_initialize(BridgedType type, BridgedValue::Ownership ownership) const {
-  invocation->initializeSSAUpdater(type.unbridged(),
+void BridgedPassContext::SSAUpdater_initialize(
+    BridgedFunction function, BridgedType type,
+    BridgedValue::Ownership ownership) const {
+  invocation->initializeSSAUpdater(function.getFunction(), type.unbridged(),
                                    BridgedValue::castToOwnership(ownership));
 }
 

--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -160,10 +160,11 @@ public:
   void setNeedFixStackNesting(bool newValue) { needFixStackNesting = newValue; }
   bool getNeedFixStackNesting() const { return needFixStackNesting; }
 
-  void initializeSSAUpdater(SILType type, ValueOwnershipKind ownership) {
+  void initializeSSAUpdater(SILFunction *fn, SILType type,
+                            ValueOwnershipKind ownership) {
     if (!ssaUpdater)
       ssaUpdater = new SILSSAUpdater;
-    ssaUpdater->initialize(type, ownership);
+    ssaUpdater->initialize(fn, type, ownership);
   }
 
   SILSSAUpdater *getSSAUpdater() const {

--- a/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
+++ b/include/swift/SILOptimizer/Utils/SILSSAUpdater.h
@@ -79,7 +79,8 @@ public:
   }
 
   /// Initialize for a use of a value of type and ownershipKind
-  void initialize(SILType type, ValueOwnershipKind ownershipKind);
+  void initialize(SILFunction *fn, SILType type,
+                  ValueOwnershipKind ownershipKind);
 
   bool hasValueForBlock(SILBasicBlock *block) const;
   void addAvailableValue(SILBasicBlock *block, SILValue value);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2809,7 +2809,7 @@ void IRGenSILFunction::visitDifferentiableFunctionInst(
         i->getModule().Types,
         LookUpConformanceInModule(i->getModule().getSwiftModule()));
     auto *undef = SILUndef::get(
-        SILType::getPrimitiveObjectType(derivativeFnType), *i->getFunction());
+        i->getFunction(), SILType::getPrimitiveObjectType(derivativeFnType));
     return getLoweredExplosion(undef);
   };
   auto jvpExp = getDerivativeExplosion(AutoDiffDerivativeFunctionKind::JVP);

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -1383,7 +1383,7 @@ void LoadableStorageAllocation::allocateLoadableStorage() {
 SILArgument *LoadableStorageAllocation::replaceArgType(SILBuilder &argBuilder,
                                                        SILArgument *arg,
                                                        SILType newSILType) {
-  SILValue undef = SILUndef::get(newSILType, *pass.F);
+  SILValue undef = SILUndef::get(pass.F, newSILType);
   SmallVector<Operand *, 8> useList(arg->use_begin(), arg->use_end());
   for (auto *use : useList) {
     use->set(undef);
@@ -1459,7 +1459,7 @@ void LoadableStorageAllocation::convertIndirectFunctionArgs() {
 
 static void convertBBArgType(SILBuilder &argBuilder, SILType newSILType,
                              SILArgument *arg) {
-  SILValue undef = SILUndef::get(newSILType, argBuilder.getFunction());
+  SILValue undef = SILUndef::get(argBuilder.getFunction(), newSILType);
   SmallVector<Operand *, 8> useList(arg->use_begin(), arg->use_end());
   for (auto *use : useList) {
     use->set(undef);

--- a/lib/SIL/IR/SILBasicBlock.cpp
+++ b/lib/SIL/IR/SILBasicBlock.cpp
@@ -232,7 +232,7 @@ SILPhiArgument *SILBasicBlock::replacePhiArgumentAndReplaceAllUses(
   // replacePhiArgument() expects the replaced argument to not have
   // any uses.
   SmallVector<Operand *, 16> operands;
-  SILValue undef = SILUndef::get(ty, *getParent());
+  SILValue undef = SILUndef::get(getParent(), ty);
   SILArgument *arg = getArgument(i);
   while (!arg->use_empty()) {
     Operand *use = *arg->use_begin();

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -680,7 +680,8 @@ SILValue SILModule::getRootLocalArchetypeDef(CanLocalArchetypeType archetype,
   SILValue &def = RootLocalArchetypeDefs[{archetype, inFunction}];
   if (!def) {
     numUnresolvedLocalArchetypes++;
-    def = ::new PlaceholderValue(SILType::getPrimitiveAddressType(archetype));
+    def = ::new PlaceholderValue(inFunction,
+                                 SILType::getPrimitiveAddressType(archetype));
   }
 
   return def;

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -760,6 +760,12 @@ void SILModule::notifyAddedInstruction(SILInstruction *inst) {
 
 void SILModule::notifyMovedInstruction(SILInstruction *inst,
                                        SILFunction *fromFunction) {
+  for (auto &op : inst->getAllOperands()) {
+    if (auto *undef = dyn_cast<SILUndef>(op.get())) {
+      op.set(SILUndef::get(inst->getFunction(), undef->getType()));
+    }
+  }
+
   inst->forEachDefinedLocalArchetype([&](CanLocalArchetypeType archeTy,
                                          SILValue dependency) {
     LocalArchetypeKey key = {archeTy, fromFunction};

--- a/lib/SIL/IR/SILUndef.cpp
+++ b/lib/SIL/IR/SILUndef.cpp
@@ -15,16 +15,12 @@
 
 using namespace swift;
 
-SILUndef::SILUndef(SILType type)
-    : ValueBase(ValueKind::SILUndef, type) {}
+SILUndef::SILUndef(SILFunction *parent, SILType type)
+    : ValueBase(ValueKind::SILUndef, type), parent(parent) {}
 
-SILUndef *SILUndef::get(SILType ty, SILModule &m) {
-  SILUndef *&entry = m.UndefValues[ty];
+SILUndef *SILUndef::get(SILFunction *fn, SILType ty) {
+  SILUndef *&entry = fn->undefValues[ty];
   if (entry == nullptr)
-    entry = new (m) SILUndef(ty);
+    entry = new (fn->getModule()) SILUndef(fn, ty);
   return entry;
-}
-
-SILUndef *SILUndef::get(SILType ty, const SILFunction &f) {
-  return SILUndef::get(ty, f.getModule());
 }

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -62,7 +62,7 @@ void ValueBase::replaceAllUsesWithUndef() {
   }
   while (!use_empty()) {
     Operand *Op = *use_begin();
-    Op->set(SILUndef::get(Op->get()->getType(), *F));
+    Op->set(SILUndef::get(F, Op->get()->getType()));
   }
 }
 
@@ -213,16 +213,21 @@ SILBasicBlock *SILNode::getParentBlock() const {
 }
 
 SILFunction *SILNode::getFunction() const {
-  if (auto *parentBlock = getParentBlock())
-    return parentBlock->getParent();
+  if (auto *parentBlock = getParentBlock()) {
+    // This can return nullptr if the block's parent is a global variable
+    // initializer.
+    if (auto *parentFunction = parentBlock->getParent()) {
+      return parentFunction;
+    }
+  }
+
+  if (auto *undef = dyn_cast<SILUndef>(this))
+    return undef->getParent();
+
   return nullptr;
 }
 
-SILModule *SILNode::getModule() const {
-  if (SILFunction *func = getFunction())
-    return &func->getModule();
-  return nullptr;
-}
+SILModule *SILNode::getModule() const { return &getFunction()->getModule(); }
 
 /// Get a location for this value.
 SILLocation SILValue::getLoc() const {

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -224,6 +224,9 @@ SILFunction *SILNode::getFunction() const {
   if (auto *undef = dyn_cast<SILUndef>(this))
     return undef->getParent();
 
+  if (auto *placeHolder = dyn_cast<PlaceholderValue>(this))
+    return placeHolder->getParent();
+
   return nullptr;
 }
 
@@ -540,8 +543,8 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &os,
 
 int PlaceholderValue::numPlaceholderValuesAlive = 0;
 
-PlaceholderValue::PlaceholderValue(SILType type)
-      : ValueBase(ValueKind::PlaceholderValue, type) {
+PlaceholderValue::PlaceholderValue(SILFunction *fn, SILType type)
+    : ValueBase(ValueKind::PlaceholderValue, type), parentFunction(fn) {
   numPlaceholderValuesAlive++;
 }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -376,7 +376,7 @@ SILValue SILParser::getLocalValue(UnresolvedValueName Name, SILType Type,
   // it until we see a real definition.
   ForwardRefLocalValues[Name.Name] = Name.NameLoc;
 
-  Entry = ::new PlaceholderValue(Type);
+  Entry = ::new PlaceholderValue(&B.getFunction(), Type);
   return Entry;
 }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -188,7 +188,8 @@ bool SILParser::parseVerbatim(StringRef name) {
 SILParser::~SILParser() {
   for (auto &Entry : ForwardRefLocalValues) {
     if (ValueBase *dummyVal = LocalValues[Entry.first()]) {
-      dummyVal->replaceAllUsesWith(SILUndef::get(dummyVal->getType(), SILMod));
+      dummyVal->replaceAllUsesWith(
+          SILUndef::get(dummyVal->getFunction(), dummyVal->getType()));
       ::delete cast<PlaceholderValue>(dummyVal);
     }
   }
@@ -351,7 +352,7 @@ bool SILParser::parseGlobalName(Identifier &Name) {
 SILValue SILParser::getLocalValue(UnresolvedValueName Name, SILType Type,
                                   SILLocation Loc, SILBuilder &B) {
   if (Name.isUndef())
-    return SILUndef::get(Type, B.getFunction());
+    return SILUndef::get(B.getFunction(), Type);
 
   // Check to see if this is already defined.
   ValueBase *&Entry = LocalValues[Name.Name];
@@ -365,7 +366,7 @@ SILValue SILParser::getLocalValue(UnresolvedValueName Name, SILType Type,
       P.diagnose(Name.NameLoc, diag::sil_value_use_type_mismatch, Name.Name,
                  EntryTy.getRawASTType(), Type.getRawASTType());
       // Make sure to return something of the requested type.
-      return SILUndef::get(Type, B.getFunction());
+      return SILUndef::get(B.getFunction(), Type);
     }
 
     return SILValue(Entry);

--- a/lib/SIL/Utils/Projection.cpp
+++ b/lib/SIL/Utils/Projection.cpp
@@ -1244,7 +1244,7 @@ ProjectionTree::computeExplodedArgumentValueInner(SILBuilder &Builder,
     if (Iter != LeafValues.end())
       return Iter->second;
     // Return undef for dead node.
-    return SILUndef::get(Node->getType(), Builder.getFunction());
+    return SILUndef::get(Builder.getFunction(), Node->getType());
   }
 
   // This is an aggregate node, construct its value from its children

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1552,8 +1552,8 @@ SILFunction *SILGenFunction::emitNativeAsyncToForeignThunk(SILDeclRef thunk) {
   scope.pop();
   
   // Return void to the immediate caller.
-  B.createReturn(loc, SILUndef::get(SGM.Types.getEmptyTupleType(), F));
-  
+  B.createReturn(loc, SILUndef::get(&F, SGM.Types.getEmptyTupleType()));
+
   return closure;
 }
 
@@ -1855,7 +1855,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     }
     
     // The immediate function result is an empty tuple.
-    return SILUndef::get(SGM.Types.getEmptyTupleType(), F);
+    return SILUndef::get(&F, SGM.Types.getEmptyTupleType());
   };
     
   if (!substTy->hasErrorResult()) {
@@ -1966,7 +1966,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
           auto paramTy = param.getSILStorageInterfaceType();
           if (paramTy.isTrivial(F)) {
             // If it's trivial, the value passed doesn't matter.
-            completionHandlerArgs.push_back(SILUndef::get(paramTy, F.getModule()));
+            completionHandlerArgs.push_back(SILUndef::get(&F, paramTy));
           } else {
             // If it's not trivial, it must be a nullable class type. Pass
             // nil.
@@ -2002,7 +2002,7 @@ void SILGenFunction::emitNativeToForeignThunk(SILDeclRef thunk) {
     if (foreignAsync) {
       // After invoking the completion handler, our immediate return value is
       // void.
-      result = SILUndef::get(SGM.Types.getEmptyTupleType(), F);
+      result = SILUndef::get(&F, SGM.Types.getEmptyTupleType());
     } else {
       result = contBB->createPhiArgument(objcResultTy, OwnershipKind::Owned);
     }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -6939,6 +6939,6 @@ ManagedValue SILGenFunction::emitUndef(Type type) {
 }
 
 ManagedValue SILGenFunction::emitUndef(SILType type) {
-  SILValue undef = SILUndef::get(type, F);
+  SILValue undef = SILUndef::get(F, type);
   return ManagedValue::forRValueWithoutOwnership(undef);
 }

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -185,7 +185,7 @@ emitBridgeErrorForForeignError(SILLocation loc,
   case ForeignErrorConvention::NilResult:
     return B.createOptionalNone(loc, bridgedResultType);
   case ForeignErrorConvention::NonNilError:
-    return SILUndef::get(bridgedResultType, F);
+    return SILUndef::get(F, bridgedResultType);
   }
   llvm_unreachable("bad foreign error convention kind");
 }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1876,7 +1876,7 @@ void SILGenFunction::emitAssignOrInit(SILLocation loc, ManagedValue selfValue,
     setterFRef = emitApplyOfSetterToBase(loc, SILDeclRef(setter), selfValue,
                                          substitutions);
   } else {
-    setterFRef = SILUndef::get(initFRef->getType(), F);
+    setterFRef = SILUndef::get(F, initFRef->getType());
   }
 
   auto isValueSelf = !selfValue.getType().getASTType()->mayHaveSuperclass();

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3707,7 +3707,7 @@ LValue SILGenLValue::visitPackElementExpr(PackElementExpr *e,
   SGF.SGM.diagnose(refExpr, diag::not_implemented,
                    "emission of 'each' for this kind of expression");
   auto loweredTy = SGF.getLoweredType(substFormalType).getAddressType();
-  auto fakeAddr = ManagedValue::forLValue(SILUndef::get(loweredTy, SGF.F));
+  auto fakeAddr = ManagedValue::forLValue(SILUndef::get(SGF.F, loweredTy));
   return LValue::forAddress(
       accessKind, fakeAddr, /*access enforcement*/ std::nullopt,
       AbstractionPattern(substFormalType), substFormalType);

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2207,7 +2207,7 @@ void PatternMatchEmission::emitEnumElementObjectDispatch(
         }
 
         return ConsumableManagedValue::forUnmanaged(
-            SILUndef::get(SGF.SGM.Types.getEmptyTupleType(), SGF.F));
+            SILUndef::get(SGF.F, SGF.SGM.Types.getEmptyTupleType()));
       }();
 
       // Okay, specialize on the argument.
@@ -2392,7 +2392,7 @@ void PatternMatchEmission::emitEnumElementDispatch(
       if (hasNonAny) {
         result = SGF.emitEmptyTuple(loc);
       } else {
-        result = SILUndef::get(SGF.SGM.Types.getEmptyTupleType(), SGF.F);
+        result = SILUndef::get(&SGF.F, SGF.SGM.Types.getEmptyTupleType());
       }
       origCMV = ConsumableManagedValue::forUnmanaged(result);
       eltCMV = origCMV;
@@ -2611,8 +2611,7 @@ emitBoolDispatch(ArrayRef<RowToSpecialize> rows, ConsumableManagedValue src,
     // We're in conditionally-executed code; enter a scope.
     Scope scope(SGF.Cleanups, CleanupLocation(loc));
 
-    SILValue result
-      = SILUndef::get(SGF.SGM.Types.getEmptyTupleType(), SGF.F);
+    SILValue result = SILUndef::get(&SGF.F, SGF.SGM.Types.getEmptyTupleType());
     ConsumableManagedValue CMV =
       ConsumableManagedValue::forUnmanaged(result);
 

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -196,7 +196,7 @@ SILGenFunction::emitGlobalFunctionRef(SILLocation loc, SILDeclRef constant,
       isa<BuiltinUnit>(constant.getDecl()->getDeclContext())) {
     SGM.diagnose(loc.getSourceLoc(), diag::not_implemented,
                  "delayed application of builtin");
-    return SILUndef::get(constantInfo.getSILType(), F);
+    return SILUndef::get(&F, constantInfo.getSILType());
   }
   
   // If the constant is a thunk we haven't emitted yet, emit it.
@@ -224,7 +224,7 @@ SILGenFunction::emitGlobalFunctionRef(SILLocation loc, SILDeclRef constant,
                    existingType, constantFnTypeInContext);
       SGM.diagnose(f->getLocation().getSourceLoc(),
                    diag::function_declared_here);
-      return SILUndef::get(constantInfo.getSILType(), F);
+      return SILUndef::get(&F, constantInfo.getSILType());
     };
 
     // If we have a distributed thunk, see if we only differ by isolation.
@@ -604,8 +604,8 @@ SILFunction *SILGenModule::getOrCreateForeignAsyncCompletionHandlerImplFunction(
       }
     }
 
-    SGF.B.createReturn(loc,
-                       SILUndef::get(SGF.SGM.Types.getEmptyTupleType(), SGF.F));
+    SGF.B.createReturn(
+        loc, SILUndef::get(&SGF.F, SGF.SGM.Types.getEmptyTupleType()));
   }
   
   return F;

--- a/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
@@ -528,7 +528,7 @@ protected:
       return;
 
     // Update SSA form.
-    SSAUp.initialize(V->getType(), V->getOwnershipKind());
+    SSAUp.initialize(V->getFunction(), V->getType(), V->getOwnershipKind());
     SSAUp.addAvailableValue(OrigBB, V);
     SILValue NewVal = getMappedValue(V);
     SSAUp.addAvailableValue(getOpBasicBlock(OrigBB), NewVal);

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -1394,7 +1394,8 @@ hoistLoadsAndStores(AccessPath accessPath, SILLoop *loop) {
 
       if (!storeAddr) {
         storeAddr = SI->getDest();
-        ssaUpdater.initialize(storeAddr->getType().getObjectType(),
+        ssaUpdater.initialize(storeAddr->getFunction(),
+                              storeAddr->getType().getObjectType(),
                               storeAddr->getOwnershipKind());
       } else if (SI->getDest()->getType() != storeAddr->getType()) {
         // This transformation assumes that the values of all stores in the loop

--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -151,7 +151,8 @@ static void updateSSAForUseOfValue(
   assert(Res->getType() == MappedValue->getType() && "The types must match");
 
   insertedPhis.clear();
-  updater.initialize(Res->getType(), Res->getOwnershipKind());
+  updater.initialize(MappedValue->getFunction(), Res->getType(),
+                     Res->getOwnershipKind());
   updater.addAvailableValue(Header, Res);
   updater.addAvailableValue(EntryCheckBlock, MappedValue);
 

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -392,7 +392,6 @@ static bool tryToUnrollLoop(SILLoop *Loop) {
   auto *Preheader = Loop->getLoopPreheader();
   if (!Preheader)
     return false;
-  SILModule &M = Preheader->getParent()->getModule();
 
   auto *Latch = Loop->getLoopLatch();
   if (!Latch)

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -361,7 +361,7 @@ void LoopCloner::collectLoopLiveOutValues(
 }
 
 static void
-updateSSA(SILModule &M, SILLoop *Loop,
+updateSSA(SILFunction *Fn, SILLoop *Loop,
           DenseMap<SILValue, SmallVector<SILValue, 8>> &LoopLiveOutValues) {
   SILSSAUpdater SSAUp;
   for (auto &MapEntry : LoopLiveOutValues) {
@@ -372,7 +372,7 @@ updateSSA(SILModule &M, SILLoop *Loop,
       if (!Loop->contains(Use->getUser()->getParent()))
         UseList.push_back(UseWrapper(Use));
     // Update SSA of use with the available values.
-    SSAUp.initialize(OrigValue->getType(), OrigValue->getOwnershipKind());
+    SSAUp.initialize(Fn, OrigValue->getType(), OrigValue->getOwnershipKind());
     SSAUp.addAvailableValue(OrigValue->getParentBlock(), OrigValue);
     for (auto NewValue : MapEntry.second)
       SSAUp.addAvailableValue(NewValue->getParentBlock(), NewValue);
@@ -471,7 +471,7 @@ static bool tryToUnrollLoop(SILLoop *Loop) {
   }
 
   // Fixup SSA form for loop values used outside the loop.
-  updateSSA(M, Loop, LoopLiveOutValues);
+  updateSSA(Loop->getFunction(), Loop, LoopLiveOutValues);
   return true;
 }
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -645,7 +645,7 @@ static void convertDirectToIndirectFunctionArgs(AddressLoweringState &pass) {
       SILArgument *arg = pass.function->getArgument(argIdx);
       SILType addrType = arg->getType().getAddressType();
       auto loc = SILValue(arg).getLoc();
-      SILValue undefAddress = SILUndef::get(addrType, *pass.function);
+      SILValue undefAddress = SILUndef::get(pass.function, addrType);
       SingleValueInstruction *load;
       if (addrType.isTrivial(*pass.function)) {
         load = argBuilder.createLoad(loc, undefAddress,
@@ -2803,7 +2803,7 @@ void ApplyRewriter::rewriteTryApply(ArrayRef<SILValue> newCallArgs) {
   // Temporarily redirect all uses to Undef. They will be fixed in
   // replaceDirectResults().
   replaceTermResult(
-      SILUndef::get(resultArg->getType().getAddressType(), *pass.function));
+      SILUndef::get(pass.function, resultArg->getType().getAddressType()));
 }
 
 // Replace all formally direct results by rewriting the destructure_tuple.
@@ -3436,7 +3436,7 @@ protected:
   void visitBranchInst(BranchInst *) {
     pass.getPhiRewriter().materializeOperand(use);
 
-    use->set(SILUndef::get(use->get()->getType(), *pass.function));
+    use->set(SILUndef::get(use->get()));
   }
 
   // Copy from an opaque source operand.

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -295,7 +295,8 @@ static void extendLifetimeToEndOfFunction(SILFunction &fn,
 
   auto fixupSILForLifetimeExtension = [&](SILValue value, SILValue entryValue) {
     // Use SSAUpdater to find insertion points for lifetime ends.
-    updater.initialize(optionalEscapingClosureTy, value->getOwnershipKind());
+    updater.initialize(value->getFunction(), optionalEscapingClosureTy,
+                       value->getOwnershipKind());
     SmallVector<SILPhiArgument *, 8> insertedPhis;
     updater.setInsertedPhis(&insertedPhis);
 
@@ -1303,9 +1304,9 @@ static bool fixupCopyBlockWithoutEscaping(CopyBlockWithoutEscapingInst *cb,
 
   SmallVector<SILPhiArgument *, 8> insertedPhis;
   SILSSAUpdater updater(&insertedPhis);
-  updater.initialize(optionalEscapingClosureTy, fn.hasOwnership()
-                                                    ? OwnershipKind::Owned
-                                                    : OwnershipKind::None);
+  updater.initialize(&fn, optionalEscapingClosureTy,
+                     fn.hasOwnership() ? OwnershipKind::Owned
+                                       : OwnershipKind::None);
 
   // Create the Optional.none as the beginning available value.
   SILValue entryBlockOptionalNone;

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -1507,11 +1507,10 @@ bool DataflowState::cleanupAllDestroyAddr(
           SILBuilderWithScope dbgValueInsertBuilder(dvi);
           dbgValueInsertBuilder.setCurrentDebugScope(
               addressDebugInst->getDebugScope());
-          dbgValueInsertBuilder.createDebugValue(
-              (*addressDebugInst)->getLoc(),
-              SILUndef::get(address->getType(), dvi->getModule()), *varInfo,
-              false,
-              /*was moved*/ true);
+          dbgValueInsertBuilder.createDebugValue((*addressDebugInst)->getLoc(),
+                                                 SILUndef::get(address),
+                                                 *varInfo, false,
+                                                 /*was moved*/ true);
         }
       }
       useState.destroys.insert(dvi);
@@ -1793,10 +1792,9 @@ bool DataflowState::process(
         if (auto varInfo = addressDebugInst.getVarInfo()) {
           SILBuilderWithScope undefBuilder(builder);
           undefBuilder.setCurrentDebugScope(addressDebugInst->getDebugScope());
-          undefBuilder.createDebugValue(
-              addressDebugInst->getLoc(),
-              SILUndef::get(address->getType(), builder.getModule()), *varInfo,
-              false /*poison*/, true /*was moved*/);
+          undefBuilder.createDebugValue(addressDebugInst->getLoc(),
+                                        SILUndef::get(address), *varInfo,
+                                        false /*poison*/, true /*was moved*/);
         }
       }
 
@@ -2090,11 +2088,9 @@ bool ConsumeOperatorCopyableAddressesChecker::performSingleBasicBlockAnalysis(
       if (auto varInfo = addressDebugInst.getVarInfo()) {
         SILBuilderWithScope undefBuilder(builder);
         undefBuilder.setCurrentDebugScope(addressDebugInst->getDebugScope());
-        undefBuilder.createDebugValue(
-            addressDebugInst->getLoc(),
-            SILUndef::get(address->getType(), builder.getModule()), *varInfo,
-            false,
-            /*was moved*/ true);
+        undefBuilder.createDebugValue(addressDebugInst->getLoc(),
+                                      SILUndef::get(address), *varInfo, false,
+                                      /*was moved*/ true);
       }
       addressDebugInst.markAsMoved();
     }
@@ -2201,11 +2197,9 @@ bool ConsumeOperatorCopyableAddressesChecker::performSingleBasicBlockAnalysis(
         {
           SILBuilderWithScope undefBuilder(builder);
           undefBuilder.setCurrentDebugScope(addressDebugInst->getDebugScope());
-          undefBuilder.createDebugValue(
-              addressDebugInst->getLoc(),
-              SILUndef::get(address->getType(), builder.getModule()), *varInfo,
-              false,
-              /*was moved*/ true);
+          undefBuilder.createDebugValue(addressDebugInst->getLoc(),
+                                        SILUndef::get(address), *varInfo, false,
+                                        /*was moved*/ true);
         }
         {
           // Make sure at the reinit point to create a new debug value after the
@@ -2253,11 +2247,9 @@ bool ConsumeOperatorCopyableAddressesChecker::performSingleBasicBlockAnalysis(
       if (auto varInfo = addressDebugInst.getVarInfo()) {
         SILBuilderWithScope undefBuilder(builder);
         undefBuilder.setCurrentDebugScope(addressDebugInst->getDebugScope());
-        undefBuilder.createDebugValue(
-            addressDebugInst->getLoc(),
-            SILUndef::get(address->getType(), builder.getModule()), *varInfo,
-            false,
-            /*was moved*/ true);
+        undefBuilder.createDebugValue(addressDebugInst->getLoc(),
+                                      SILUndef::get(address), *varInfo, false,
+                                      /*was moved*/ true);
       }
       addressDebugInst.markAsMoved();
     }

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -436,7 +436,6 @@ bool ConsumeOperatorCopyableValuesChecker::check() {
              << "Found at least one value to check, performing checking.\n");
   auto valuesToProcess =
       llvm::ArrayRef(valuesToCheck.begin(), valuesToCheck.end());
-  auto &mod = fn->getModule();
 
   // If we do not emit any diagnostics, we need to put in a break after each dbg
   // info carrying inst for a lexical value that we find a move on. This ensures

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -493,10 +493,9 @@ bool ConsumeOperatorCopyableValuesChecker::check() {
             // scope as our original so that the backend treats them as
             // referring to the same "debug entity".
             builder.setCurrentDebugScope(dbgVarInst->getDebugScope());
-            builder.createDebugValue(
-                dbgVarInst->getLoc(),
-                SILUndef::get(mvi->getOperand()->getType(), mod), *varInfo,
-                false /*poison*/, true /*moved*/);
+            builder.createDebugValue(dbgVarInst->getLoc(),
+                                     SILUndef::get(mvi->getOperand()), *varInfo,
+                                     false /*poison*/, true /*moved*/);
           }
         }
         foundMove = true;

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -667,7 +667,7 @@ static void setOutsideBlockUsesToUndef(SILInstruction *I) {
 
   for (auto *Use : Uses)
     if (Use->getUser()->getParent() != BB)
-      Use->set(SILUndef::get(Use->get()->getType(), *F));
+      Use->set(SILUndef::get(Use->get()));
 }
 
 static SILInstruction *getAsCallToNoReturn(SILInstruction *I) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -658,7 +658,6 @@ static void setOutsideBlockUsesToUndef(SILInstruction *I) {
     return;
 
   SILBasicBlock *BB = I->getParent();
-  auto *F = BB->getParent();
 
   // Replace all uses outside of I's basic block by undef.
   llvm::SmallVector<Operand *, 16> Uses;

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -1221,7 +1221,7 @@ SILValue DifferentiationTransformer::promoteToLinearFunction(
       parameterIndices, context.getTypeConverter(),
       LookUpConformanceInModule(builder.getModule().getSwiftModule()));
   auto transposeType = SILType::getPrimitiveObjectType(transposeFnType);
-  auto transposeFn = SILUndef::get(transposeType, builder.getFunction());
+  auto transposeFn = SILUndef::get(builder.getFunction(), transposeType);
   auto *newLinearFn = context.createLinearFunction(
       builder, loc, parameterIndices, origFnOperand, SILValue(transposeFn));
   context.getLinearFunctionInstWorklist().push_back(lfi);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2979,9 +2979,8 @@ void MoveOnlyAddressCheckerPImpl::insertDestroysOnBoundary(
   // referring to the same debug variable as the original definition, we have to
   // use the same debug scope and location as the original debug var.
   auto insertUndefDebugValue = [&debugVar](SILInstruction *insertPt) {
-    insertDebugValueBefore(insertPt, debugVar, [&]{
-      return SILUndef::get(debugVar.getOperandForDebugValueClone()->getType(),
-                           insertPt->getModule());
+    insertDebugValueBefore(insertPt, debugVar, [&] {
+      return SILUndef::get(debugVar.getOperandForDebugValueClone());
     });
   };
 

--- a/lib/SILOptimizer/Mandatory/MovedAsyncVarDebugInfoPropagator.cpp
+++ b/lib/SILOptimizer/Mandatory/MovedAsyncVarDebugInfoPropagator.cpp
@@ -93,8 +93,7 @@ static DebugVarCarryingInst
 cloneDebugValueMakeUndef(DebugVarCarryingInst original, SILBasicBlock *block) {
   SILBuilderWithScope builder(&block->front());
   builder.setCurrentDebugScope(original->getDebugScope());
-  auto *undef = SILUndef::get(
-      original.getOperandForDebugValueClone()->getType(), block->getModule());
+  auto *undef = SILUndef::get(original.getOperandForDebugValueClone());
   return builder.createDebugValue(original->getLoc(), undef,
                                   *original.getVarInfo(), false,
                                   true /*was moved*/);
@@ -105,9 +104,7 @@ cloneDebugValueMakeUndef(DebugVarCarryingInst original,
                          SILInstruction *insertPt) {
   SILBuilderWithScope builder(std::next(insertPt->getIterator()));
   builder.setCurrentDebugScope(original->getDebugScope());
-  auto *undef =
-      SILUndef::get(original.getOperandForDebugValueClone()->getType(),
-                    insertPt->getModule());
+  auto *undef = SILUndef::get(original.getOperandForDebugValueClone());
   return builder.createDebugValue(original->getLoc(), undef,
                                   *original.getVarInfo(), false,
                                   true /*was moved*/);

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -688,8 +688,9 @@ AvailableValueAggregator::aggregateFullyAvailableValue(SILType loadTy,
   // have multiple insertion points if we are storing exactly the same value
   // implying that we can just copy firstVal at each insertion point.
   SILSSAUpdater updater(&insertedPhiNodes);
-  updater.initialize(loadTy, B.hasOwnership() ? OwnershipKind::Owned
-                                              : OwnershipKind::None);
+  updater.initialize(&B.getFunction(), loadTy,
+                     B.hasOwnership() ? OwnershipKind::Owned
+                                      : OwnershipKind::None);
 
   std::optional<SILValue> singularValue;
   for (auto *insertPt : insertPts) {
@@ -865,8 +866,9 @@ SILValue AvailableValueAggregator::handlePrimitiveValue(SILType loadTy,
   // never have the same value along all paths unless we have a trivial value
   // meaning the SSA updater given a non-trivial value must /always/ be used.
   SILSSAUpdater updater(&insertedPhiNodes);
-  updater.initialize(loadTy, B.hasOwnership() ? OwnershipKind::Owned
-                                              : OwnershipKind::None);
+  updater.initialize(&B.getFunction(), loadTy,
+                     B.hasOwnership() ? OwnershipKind::Owned
+                                      : OwnershipKind::None);
 
   std::optional<SILValue> singularValue;
   for (auto *i : insertPts) {

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -183,7 +183,7 @@ private:
       auto *next = inst->getSingleUse();
       assert(next);
       assert(rest.empty() || bool(next->getUser() == rest.back()));
-      next->set(SILUndef::get(next->get()->getType(), inst->getModule()));
+      next->set(SILUndef::get(next->get()));
       SC.eraseInstFromFunction(*inst);
     }
   }

--- a/lib/SILOptimizer/SemanticARC/OwnershipPhiOperand.h
+++ b/lib/SILOptimizer/SemanticARC/OwnershipPhiOperand.h
@@ -73,9 +73,7 @@ public:
 
   unsigned getOperandNumber() const { return op->getOperandNumber(); }
 
-  void markUndef() & {
-    op->set(SILUndef::get(getType(), *op->getUser()->getFunction()));
-  }
+  void markUndef() & { op->set(SILUndef::get(getValue())); }
 
   SILInstruction *getInst() const { return op->getUser(); }
 

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -588,7 +588,7 @@ static void hoistMarkUnresolvedNonCopyableValueInsts(
     loc = RegularLocation::getDiagnosticsOnlyLocation(loc, next->getModule());
   SILBuilderWithScope builder(next);
 
-  auto *undef = SILUndef::get(stackBox->getType(), *stackBox->getModule());
+  auto *undef = SILUndef::get(stackBox);
 
   auto *mmci =
       builder.createMarkUnresolvedNonCopyableValueInst(loc, undef, checkKind);

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -860,7 +860,7 @@ static void updateBasicBlockArgTypes(SILBasicBlock *BB,
       OriginalArgUses.push_back(ArgUse);
     }
     // Then replace all uses by an undef.
-    Arg->replaceAllUsesWith(SILUndef::get(Arg->getType(), *BB->getParent()));
+    Arg->replaceAllUsesWith(SILUndef::get(Arg));
     // Replace the type of the BB argument.
     auto *NewArg = BB->replacePhiArgument(Arg->getIndex(), NewArgType,
                                           Arg->getOwnershipKind(),

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -271,8 +271,7 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
     }
     assert(ArgUser == SEI);
     // We delete the SEI later anyway. Just get rid of the Arg use.
-    ArgUse->set(SILUndef::get(SEI->getOperand()->getType(),
-                              *getFunction()));
+    ArgUse->set(SILUndef::get(SEI->getOperand()));
   }
 
   // Redirect the predecessors of the condition's merging block to the

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -551,7 +551,7 @@ void DCE::replaceBranchWithJump(SILInstruction *Inst, SILBasicBlock *Block) {
     auto E = Block->args_end();
     for (auto A = Block->args_begin(); A != E; ++A) {
       assert(!LiveArguments.contains(*A) && "Unexpected live block argument!");
-      Args.push_back(SILUndef::get((*A)->getType(), *(*A)->getFunction()));
+      Args.push_back(SILUndef::get(*A));
     }
     Branch =
         SILBuilderWithScope(Inst).createBranch(Inst->getLoc(), Block, Args);

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -724,7 +724,8 @@ static void insertReleases(ArrayRef<StoreInst*> Stores,
   assert(!Stores.empty());
   SILValue StVal = Stores.front()->getSrc();
 
-  SSAUp.initialize(StVal->getType(), StVal->getOwnershipKind());
+  SSAUp.initialize(StVal->getFunction(), StVal->getType(),
+                   StVal->getOwnershipKind());
 
   for (auto *Store : Stores)
     SSAUp.addAvailableValue(Store->getParent(), Store->getSrc());

--- a/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/SILCodeMotion.cpp
@@ -1238,7 +1238,7 @@ static bool sinkArgument(EnumCaseDataflowContext &Context, SILBasicBlock *BB, un
     Clones.push_back(SI);
   }
 
-  auto *Undef = SILUndef::get(FSI->getType(), *BB->getParent());
+  auto *Undef = SILUndef::get(FSI);
 
   // Delete the debug info of the instruction that we are about to sink.
   deleteAllDebugUses(FSI);

--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -269,7 +269,7 @@ static void
 prepareForDeletion(SILInstruction *inst,
                    SmallVectorImpl<SILInstruction *> &instructionsToDelete) {
   for (auto &operand : inst->getAllOperands()) {
-    operand.set(SILUndef::get(operand.get()->getType(), *inst->getFunction()));
+    operand.set(SILUndef::get(operand.get()));
   }
   instructionsToDelete.push_back(inst);
 }
@@ -713,7 +713,7 @@ static SILValue createEmptyAndUndefValue(SILType ty,
     SILBuilderWithScope builder(insertionPoint, ctx);
     return builder.createStruct(insertionPoint->getLoc(), ty, elements);
   } else {
-    return SILUndef::get(ty, *insertionPoint->getFunction());
+    return SILUndef::get(insertionPoint->getFunction(), ty);
   }
 }
 
@@ -1310,7 +1310,7 @@ LiveValues StackAllocationPromoter::getEffectiveLiveOutValues(
   if (auto values = getLiveOutValues(phiBlocks, startBlock)) {
     return *values;
   }
-  auto *undef = SILUndef::get(asi->getElementType(), *asi->getFunction());
+  auto *undef = SILUndef::get(asi->getFunction(), asi->getElementType());
   return LiveValues::forOwned(undef, undef);
 }
 
@@ -1345,7 +1345,7 @@ LiveValues StackAllocationPromoter::getEffectiveLiveInValues(
   if (auto values = getLiveInValues(phiBlocks, block)) {
     return *values;
   }
-  auto *undef = SILUndef::get(asi->getElementType(), *asi->getFunction());
+  auto *undef = SILUndef::get(asi->getFunction(), asi->getElementType());
   // TODO: Add another kind of LiveValues for undef.
   return LiveValues::forOwned(undef, undef);
 }

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3740,7 +3740,7 @@ bool SimplifyCFG::simplifyArgument(SILBasicBlock *BB, unsigned i) {
   // Okay, we'll replace the BB arg with one with the right type, replace
   // the uses in this block, and then rewrite the branch operands.
   LLVM_DEBUG(llvm::dbgs() << "unwrap argument:" << *A);
-  A->replaceAllUsesWith(SILUndef::get(A->getType(), *BB->getParent()));
+  A->replaceAllUsesWith(SILUndef::get(A));
   auto *NewArg = BB->replacePhiArgument(i, proj->getType(),
                                         BB->getArgument(i)->getOwnershipKind());
   proj->replaceAllUsesWith(NewArg);

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -147,7 +147,7 @@ class BugReducerTester : public SILFunctionTransform {
           // the next instruction and then replace its current value
           // with undef.
           auto *Inst = cast<SingleValueInstruction>(&*II);
-          Inst->replaceAllUsesWith(SILUndef::get(Inst->getType(), *getFunction()));
+          Inst->replaceAllUsesWith(SILUndef::get(Inst));
           Inst->eraseFromParent();
 
           // Mark that we found the miscompile and return so we do not try to
@@ -170,7 +170,7 @@ class BugReducerTester : public SILFunctionTransform {
 
         auto *Inst = cast<SingleValueInstruction>(&*II);
         ++II;
-        Inst->replaceAllUsesWith(SILUndef::get(Inst->getType(), *getFunction()));
+        Inst->replaceAllUsesWith(SILUndef::get(Inst));
         Inst->eraseFromParent();
 
         CausedError = true;

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -172,7 +172,8 @@ void BasicBlockCloner::updateSSAAfterCloning() {
     for (auto *use : inst->getUses())
       useList.push_back(UseWrapper(use));
 
-    ssaUpdater.initialize(inst->getType(), inst->getOwnershipKind());
+    ssaUpdater.initialize(inst->getFunction(), inst->getType(),
+                          inst->getOwnershipKind());
     ssaUpdater.addAvailableValue(origBB, inst);
     ssaUpdater.addAvailableValue(getNewBB(), newResult);
 

--- a/lib/SILOptimizer/Utils/CFGOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/CFGOptUtils.cpp
@@ -81,7 +81,7 @@ static void deleteTriviallyDeadOperandsOfDeadArgument(
   auto *i = op.get()->getDefiningInstruction();
   if (!i)
     return;
-  op.set(SILUndef::get(op.get()->getType(), *i->getFunction()));
+  op.set(SILUndef::get(op.get()));
   eliminateDeadInstruction(i, callbacks);
 }
 

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -1065,7 +1065,7 @@ CastOptimizer::simplifyCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
         CastedValue =
             emitSuccessfulScalarUnconditionalCast(Builder, Loc, dynamicCast);
       } else {
-        CastedValue = SILUndef::get(TargetLoweredType, *F);
+        CastedValue = SILUndef::get(F, TargetLoweredType);
       }
       if (!CastedValue)
         CastedValue =

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -652,7 +652,7 @@ extendOverBorrowScopeAndConsume(SILValue ownedValue) {
   InstructionDeleter deleter(std::move(tempCallbacks));
 
   // Generate and map the phis with undef operands first, in case of recursion.
-  auto undef = SILUndef::get(ownedValue->getType(), *ownedValue->getFunction());
+  auto undef = SILUndef::get(ownedValue);
   for (PhiValue reborrowedPhi : reborrowedPhis) {
     auto *phiBlock = reborrowedPhi.phiBlock;
     auto *ownedPhi = phiBlock->createPhiArgument(ownedValue->getType(),

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -245,8 +245,7 @@ public:
 
       // Replace all the yielded values in the callee with undef.
       for (auto calleeYield : BeginApply->getYieldedValues()) {
-        calleeYield->replaceAllUsesWith(
-            SILUndef::get(calleeYield->getType(), Builder->getFunction()));
+        calleeYield->replaceAllUsesWith(SILUndef::get(calleeYield));
       }
     }
 

--- a/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
+++ b/lib/SILOptimizer/Utils/SILSSAUpdater.cpp
@@ -40,12 +40,13 @@ SILSSAUpdater::SILSSAUpdater(SmallVectorImpl<SILPhiArgument *> *phis)
 
 SILSSAUpdater::~SILSSAUpdater() = default;
 
-void SILSSAUpdater::initialize(SILType inputType, ValueOwnershipKind kind) {
+void SILSSAUpdater::initialize(SILFunction *fn, SILType inputType,
+                               ValueOwnershipKind kind) {
   type = inputType;
   ownershipKind = kind;
 
   phiSentinel = std::unique_ptr<SILUndef, void (*)(SILUndef *)>(
-      SILUndef::getSentinelValue(inputType, this),
+      SILUndef::getSentinelValue(fn, this, inputType),
       SILSSAUpdater::deallocateSentinel);
 
   if (!blockToAvailableValueMap)
@@ -225,7 +226,7 @@ SILValue SILSSAUpdater::getValueInMiddleOfBlock(SILBasicBlock *block) {
 
   // Return undef for blocks without predecessor.
   if (predVals.empty())
-    return SILUndef::get(type, *block->getParent());
+    return SILUndef::get(block->getParent(), type);
 
   if (singularValue)
     return singularValue;
@@ -325,7 +326,7 @@ public:
   }
 
   static SILValue GetUndefVal(SILBasicBlock *block, SILSSAUpdater *ssaUpdater) {
-    return SILUndef::get(ssaUpdater->type, *block->getParent());
+    return SILUndef::get(block->getParent(), ssaUpdater->type);
   }
 
   /// Add an Argument to the basic block.

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -319,7 +319,7 @@ SILValue SILDeserializer::getLocalValue(SILFunction *inContext, ValueID Id,
   if (!Entry) {
     // Otherwise, this is a forward reference.  Create a dummy node to represent
     // it until we see a real definition.
-    Entry = ::new PlaceholderValue(Type);
+    Entry = ::new PlaceholderValue(inContext, Type);
   }
   // If this value was already defined, check it to make sure types match.
   assert(Entry->getType() == Type && "Value Type mismatch?");

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -301,11 +301,15 @@ void SILDeserializer::setLocalValue(ValueBase *Value, ValueID Id) {
   Entry = Value;
 }
 
-SILValue SILDeserializer::getLocalValue(ValueID Id,
+SILValue SILDeserializer::getLocalValue(SILFunction *inContext, ValueID Id,
                                         SILType Type) {
   // The first two IDs are special undefined values.
-  if (Id == 0)
-    return SILUndef::get(Type, SILMod);
+  if (Id == 0) {
+    assert(inContext &&
+           "Should never have a SILUndef in a global variable initializer?!");
+    return SILUndef::get(*inContext, Type);
+  }
+
   assert(Id != 1 && "This used to be for SILUndef with OwnershipKind::Owned... "
                     "but we don't support that anymore. Make sure no one "
                     "changes that without updating this code if needed");
@@ -1423,11 +1427,13 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::GetAsyncContinuationAddrInst:
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND
            && "Layout should be OneTypeOneOperand.");
-    ResultInst = Builder.createGetAsyncContinuationAddr(Loc,
-      getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                      (SILValueCategory)TyCategory2, Fn)),
-      MF->getType(TyID)->getCanonicalType(),
-      /*throws*/ Attr != 0);
+    ResultInst = Builder.createGetAsyncContinuationAddr(
+        Loc,
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
+        MF->getType(TyID)->getCanonicalType(),
+        /*throws*/ Attr != 0);
     break;
 
 #define ONETYPE_ONEOPERAND_INST(ID)                                            \
@@ -1436,8 +1442,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            "Layout should be OneTypeOneOperand.");                             \
     ResultInst = Builder.create##ID(                                           \
         Loc, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn),  \
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),                    \
-                                        (SILValueCategory)TyCategory2, Fn)));  \
+        getLocalValue(Builder.maybeGetFunction(), ValID,                       \
+                      getSILType(MF->getType(TyID2),                           \
+                                 (SILValueCategory)TyCategory2, Fn)));         \
     break;
     ONETYPE_ONEOPERAND_INST(ValueMetatype)
     ONETYPE_ONEOPERAND_INST(ExistentialMetatype)
@@ -1447,17 +1454,18 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
     ResultInst = Builder.createDeallocBox(
-        Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)));
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
+                           getSILType(MF->getType(TyID2),
+                                      (SILValueCategory)TyCategory2, Fn)));
     break;
   case SILInstructionKind::OpenExistentialAddrInst:
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
     ResultInst = Builder.createOpenExistentialAddr(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn),
         Attr == 0 ? OpenedExistentialAccess::Immutable
                   : OpenedExistentialAccess::Mutable);
@@ -1467,15 +1475,16 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            "Layout should be OneTypeOneOperand.");
     ResultInst = Builder.createAllocVector(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     break;
   case SILInstructionKind::DynamicPackIndexInst: {
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
-    auto indexOperand =
-      getLocalValue(ValID,
+    auto indexOperand = getLocalValue(
+        Builder.maybeGetFunction(), ValID,
         getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn));
     auto packType = cast<PackType>(MF->getType(TyID)->getCanonicalType());
     ResultInst = Builder.createDynamicPackIndex(Loc, indexOperand, packType);
@@ -1484,8 +1493,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::PackPackIndexInst: {
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
-    auto indexOperand =
-      getLocalValue(ValID,
+    auto indexOperand = getLocalValue(
+        Builder.maybeGetFunction(), ValID,
         getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn));
     auto packType = cast<PackType>(MF->getType(TyID)->getCanonicalType());
     ResultInst =
@@ -1500,8 +1509,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   }
   case SILInstructionKind::OpenPackElementInst: {
     assert(RecordKind == SIL_OPEN_PACK_ELEMENT && "Layout should be OpenPackElement");
-    auto index = getLocalValue(ValID,
-        getSILType(MF->getType(TyID), (SILValueCategory) TyCategory, Fn));
+    auto index = getLocalValue(
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     auto env = MF->getGenericEnvironmentChecked(Attr);
     if (!env) MF->fatal(env.takeError());
     ResultInst = Builder.createOpenPackElement(Loc, index, *env);
@@ -1513,9 +1523,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                                   (SILValueCategory) TyCategory, Fn);
     auto packType = getSILType(MF->getType(TyID2),
                                (SILValueCategory) TyCategory2, Fn);
-    auto pack = getLocalValue(ValID2, packType);
+    auto pack = getLocalValue(Builder.maybeGetFunction(), ValID2, packType);
     auto indexType = SILType::getPackIndexType(MF->getContext());
-    auto index = getLocalValue(ValID3, indexType);
+    auto index = getLocalValue(Builder.maybeGetFunction(), ValID3, indexType);
     ResultInst = Builder.createPackElementGet(Loc, index, pack, elementType);
     break;
   }
@@ -1523,12 +1533,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(RecordKind == SIL_PACK_ELEMENT_SET);
     auto elementType = getSILType(MF->getType(TyID),
                                   (SILValueCategory) TyCategory, Fn);
-    auto value = getLocalValue(ValID, elementType);
+    auto value = getLocalValue(Builder.maybeGetFunction(), ValID, elementType);
     auto packType = getSILType(MF->getType(TyID2),
                                (SILValueCategory) TyCategory2, Fn);
-    auto pack = getLocalValue(ValID2, packType);
+    auto pack = getLocalValue(Builder.maybeGetFunction(), ValID2, packType);
     auto indexType = SILType::getPackIndexType(MF->getContext());
-    auto index = getLocalValue(ValID3, indexType);
+    auto index = getLocalValue(Builder.maybeGetFunction(), ValID3, indexType);
     ResultInst = Builder.createPackElementSet(Loc, value, index, pack);
     break;
   }
@@ -1538,9 +1548,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
                                   (SILValueCategory) TyCategory, Fn);
     auto tupleType = getSILType(MF->getType(TyID2),
                                (SILValueCategory) TyCategory2, Fn);
-    auto tuple = getLocalValue(ValID2, tupleType);
+    auto tuple = getLocalValue(Builder.maybeGetFunction(), ValID2, tupleType);
     auto indexType = SILType::getPackIndexType(MF->getContext());
-    auto index = getLocalValue(ValID3, indexType);
+    auto index = getLocalValue(Builder.maybeGetFunction(), ValID3, indexType);
     ResultInst = Builder.createTuplePackElementAddr(Loc, index, tuple,
                                                     elementType);
     break;
@@ -1551,9 +1561,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     auto tupleType =
         getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn);
-    auto tuple = getLocalValue(ValID2, tupleType);
+    auto tuple = getLocalValue(Builder.maybeGetFunction(), ValID2, tupleType);
     auto indexType = SILType::getPackIndexType(MF->getContext());
-    auto index = getLocalValue(ValID3, indexType);
+    auto index = getLocalValue(Builder.maybeGetFunction(), ValID3, indexType);
     ResultInst = Builder.createTuplePackExtract(Loc, index, tuple, elementType);
     break;
   }
@@ -1564,8 +1574,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            "Layout should be OneTypeOneOperand.");                             \
     ResultInst = Builder.create##ID(                                           \
         Loc,                                                                   \
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),                    \
-                                        (SILValueCategory)TyCategory2, Fn)),   \
+        getLocalValue(Builder.maybeGetFunction(), ValID,                       \
+                      getSILType(MF->getType(TyID2),                           \
+                                 (SILValueCategory)TyCategory2, Fn)),          \
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));      \
     break;
     ONEOPERAND_ONETYPE_INST(OpenExistentialRef)
@@ -1600,10 +1611,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            "Layout should be OneTypeOneOperand.");
     ResultInst = Builder.createAddressToPointer(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn),
-        /*needsStackProtection=*/ Attr != 0);
+        /*needsStackProtection=*/Attr != 0);
     break;
   }
   case SILInstructionKind::ProjectBoxInst: {
@@ -1611,8 +1623,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            "Layout should be OneTypeOneOperand.");
     ResultInst = Builder.createProjectBox(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
         TyID);
     break;
   }
@@ -1622,8 +1635,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool isLifetimeGuaranteed = Attr & 0x01;
     ResultInst = Builder.createConvertEscapeToNoEscape(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn),
         isLifetimeGuaranteed);
     break;
@@ -1634,8 +1648,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool withoutActuallyEscaping = Attr & 0x01;
     ResultInst = Builder.createConvertFunction(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn),
         withoutActuallyEscaping);
     break;
@@ -1648,8 +1663,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool isInvariant = Attr & 0x200;
     ResultInst = Builder.createPointerToAddress(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn),
         isStrict, isInvariant, alignment);
     break;
@@ -1659,8 +1675,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            "Layout should be OneTypeOneOperand.");
     ResultInst = Builder.createDeallocExistentialBox(
         Loc, MF->getType(TyID)->getCanonicalType(),
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)));
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)));
     break;
 
   }
@@ -1668,10 +1685,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::RefToBridgeObjectInst: {
     auto RefTy =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
-    auto Ref = getLocalValue(ValID, RefTy);
+    auto Ref = getLocalValue(Builder.maybeGetFunction(), ValID, RefTy);
     auto BitsTy =
         getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn);
-    auto Bits = getLocalValue(ValID2, BitsTy);
+    auto Bits = getLocalValue(Builder.maybeGetFunction(), ValID2, BitsTy);
 
     ResultInst = Builder.createRefToBridgeObject(Loc, Ref, Bits);
     break;
@@ -1697,8 +1714,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       ConcreteTy = MF->getType(ConcreteTyID)->getCanonicalType();
     SILValue operand;
     if (OpCode != SILInstructionKind::AllocExistentialBoxInst)
-      operand = getLocalValue(
-          ValID, getSILType(Ty2, (SILValueCategory)TyCategory2, Fn));
+      operand =
+          getLocalValue(Builder.maybeGetFunction(), ValID,
+                        getSILType(Ty2, (SILValueCategory)TyCategory2, Fn));
 
     SmallVector<ProtocolConformanceRef, 2> conformances;
     for (auto conformanceID: ListOfValues) {
@@ -1753,14 +1771,16 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       TailTypes.push_back(TailType);
       SILType CountType = getSILType(MF->getType(ListOfValues[i + 2]),
                                      SILValueCategory::Object, Fn);
-      SILValue CountVal = getLocalValue(ListOfValues[i+1], CountType);
+      SILValue CountVal = getLocalValue(Builder.maybeGetFunction(),
+                                        ListOfValues[i + 1], CountType);
       Counts.push_back(CountVal);
     }
     if (OpCode == SILInstructionKind::AllocRefDynamicInst) {
       assert(i + 2 == NumVals);
       SILType MetadataType = getSILType(MF->getType(ListOfValues[i+1]),
                                         SILValueCategory::Object, Fn);
-      SILValue MetadataOp = getLocalValue(ListOfValues[i], MetadataType);
+      SILValue MetadataOp = getLocalValue(Builder.maybeGetFunction(),
+                                          ListOfValues[i], MetadataType);
       ResultInst = Builder.createAllocRefDynamic(Loc, MetadataOp, ClassTy,
                                                  isObjC, canAllocOnStack,
                                                  TailTypes, Counts);
@@ -1787,7 +1807,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            && "Argument number mismatch in ApplyInst.");
     SmallVector<SILValue, 4> Args;
     for (unsigned I = 0, E = ListOfValues.size(); I < E; ++I)
-      Args.push_back(getLocalValue(ListOfValues[I],
+      Args.push_back(getLocalValue(Builder.maybeGetFunction(), ListOfValues[I],
                                    substConventions.getSILArgumentType(
                                        I, Builder.getTypeExpansionContext())));
     SubstitutionMap Substitutions = MF->getSubstitutionMap(NumSubs);
@@ -1800,13 +1820,13 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     }
 
     if (OpCode == SILInstructionKind::ApplyInst) {
-      ResultInst =
-          Builder.createApply(Loc, getLocalValue(ValID, FnTy), Substitutions,
-                              Args, ApplyOpts, nullptr, IsolationCrossing);
+      ResultInst = Builder.createApply(
+          Loc, getLocalValue(Builder.maybeGetFunction(), ValID, FnTy),
+          Substitutions, Args, ApplyOpts, nullptr, IsolationCrossing);
     } else {
-      ResultInst = Builder.createBeginApply(Loc, getLocalValue(ValID, FnTy),
-                                            Substitutions, Args, ApplyOpts,
-                                            nullptr, IsolationCrossing);
+      ResultInst = Builder.createBeginApply(
+          Loc, getLocalValue(Builder.maybeGetFunction(), ValID, FnTy),
+          Substitutions, Args, ApplyOpts, nullptr, IsolationCrossing);
     }
     break;
   }
@@ -1831,7 +1851,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            && "Argument number mismatch in ApplyInst.");
     SmallVector<SILValue, 4> Args;
     for (unsigned I = 0, E = ListOfValues.size(); I < E; ++I)
-      Args.push_back(getLocalValue(ListOfValues[I],
+      Args.push_back(getLocalValue(Builder.maybeGetFunction(), ListOfValues[I],
                                    substConventions.getSILArgumentType(
                                        I, Builder.getTypeExpansionContext())));
     SubstitutionMap Substitutions = MF->getSubstitutionMap(NumSubs);
@@ -1843,9 +1863,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       IsolationCrossing = {caller, callee};
     }
 
-    ResultInst = Builder.createTryApply(Loc, getLocalValue(ValID, FnTy),
-                                        Substitutions, Args, normalBB, errorBB,
-                                        ApplyOpts, nullptr, IsolationCrossing);
+    ResultInst = Builder.createTryApply(
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID, FnTy),
+        Substitutions, Args, normalBB, errorBB, ApplyOpts, nullptr,
+        IsolationCrossing);
     break;
   }
   case SILInstructionKind::PartialApplyInst: {
@@ -1868,12 +1889,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(numArgs >= ListOfValues.size()
            && "Argument number mismatch in PartialApplyInst.");
 
-    SILValue FnVal = getLocalValue(ValID, FnTy);
+    SILValue FnVal = getLocalValue(Builder.maybeGetFunction(), ValID, FnTy);
     SmallVector<SILValue, 4> Args;
     unsigned unappliedArgs = numArgs - ListOfValues.size();
     for (unsigned I = 0, E = ListOfValues.size(); I < E; ++I)
       Args.push_back(getLocalValue(
-          ListOfValues[I],
+          Builder.maybeGetFunction(), ListOfValues[I],
           fnConv.getSILArgumentType(I + unappliedArgs,
                                     Builder.getTypeExpansionContext())));
     auto onStack = closureTy->isNoEscape()
@@ -1894,7 +1915,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       auto ArgASTTy = MF->getType(ListOfValues[i+1]);
       auto ArgTy = getSILType(
           ArgASTTy, (SILValueCategory)(unsigned)ListOfValues[i + 2], Fn);
-      Args.push_back(getLocalValue(ListOfValues[i], ArgTy));
+      Args.push_back(
+          getLocalValue(Builder.maybeGetFunction(), ListOfValues[i], ArgTy));
     }
     SubstitutionMap Substitutions = MF->getSubstitutionMap(NumSubs);
     Identifier Name = MF->getIdentifier(ValID);
@@ -1944,8 +1966,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
            "Type of a global variable does not match GlobalAddr.");
     (void)Ty;
     (void)expectedType;
-    SILValue token = ValID2 == 0 ? SILValue()
-          : getLocalValue(ValID2, SILType::getSILTokenType(MF->getContext()));
+    SILValue token =
+        ValID2 == 0 ? SILValue()
+                    : getLocalValue(Builder.maybeGetFunction(), ValID2,
+                                    SILType::getSILTokenType(MF->getContext()));
     ResultInst = Builder.createGlobalAddr(Loc, g, token);
     break;
   }
@@ -1957,29 +1981,29 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::DeallocStackInst: {
     auto Ty = MF->getType(TyID);
     ResultInst = Builder.createDeallocStack(
-        Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
+                           getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
   }
   case SILInstructionKind::DeallocStackRefInst: {
     auto Ty = MF->getType(TyID);
     ResultInst = Builder.createDeallocStackRef(
-        Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
+                           getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
   }
   case SILInstructionKind::DeallocPackInst: {
     auto Ty = MF->getType(TyID);
     ResultInst = Builder.createDeallocPack(
-        Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
+                           getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
   }
   case SILInstructionKind::DeallocRefInst: {
     auto Ty = MF->getType(TyID);
     ResultInst = Builder.createDeallocRef(
-        Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
+                           getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
   }
   case SILInstructionKind::DeallocPartialRefInst: {
@@ -1987,8 +2011,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty2 = MF->getType(TyID2);
     ResultInst = Builder.createDeallocPartialRef(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        getLocalValue(ValID2,
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
                       getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)));
     break;
   }
@@ -2027,8 +2052,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty2 = MF->getType(TyID2);
     ResultInst = Builder.createMarkDependence(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        getLocalValue(ValID2,
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
                       getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)),
         MarkDependenceKind(Attr));
     break;
@@ -2038,8 +2064,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty2 = MF->getType(TyID2);
     ResultInst = Builder.createBeginDeallocRef(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        getLocalValue(ValID2, getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)));
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
+                      getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)));
     break;
   }
   case SILInstructionKind::CopyBlockWithoutEscapingInst: {
@@ -2047,8 +2075,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty2 = MF->getType(TyID2);
     ResultInst = Builder.createCopyBlockWithoutEscaping(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        getLocalValue(ValID2,
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
                       getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)));
     break;
   }
@@ -2057,10 +2086,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty2 = MF->getType(TyID2);
     ResultInst = Builder.createIndexAddr(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        getLocalValue(ValID2,
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
                       getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)),
-        /*needsStackProtection=*/ Attr != 0);
+        /*needsStackProtection=*/Attr != 0);
     break;
   }
   case SILInstructionKind::TailAddrInst: {
@@ -2069,8 +2099,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto ResultTy = MF->getType(TyID3);
     ResultInst = Builder.createTailAddr(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, SILValueCategory::Address, Fn)),
-        getLocalValue(ValID2, getSILType(Ty2, SILValueCategory::Object, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, SILValueCategory::Address, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
+                      getSILType(Ty2, SILValueCategory::Object, Fn)),
         getSILType(ResultTy, SILValueCategory::Address, Fn));
     break;
   }
@@ -2079,8 +2111,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty2 = MF->getType(TyID2);
     ResultInst = Builder.createIndexRawPointer(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        getLocalValue(ValID2,
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
                       getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)));
     break;
   }
@@ -2133,7 +2166,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   }
   case SILInstructionKind::CondFailInst: {
     SILValue Op = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     StringRef StringVal = MF->getIdentifierText(ValID2);
     ResultInst = Builder.createCondFail(Loc, Op, StringVal);
     break;
@@ -2145,7 +2179,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     for (unsigned I = 0, E = ListOfValues.size(); I < E; I += 3) {
       auto EltTy = MF->getType(ListOfValues[I]);
       OpList.push_back(getLocalValue(
-          ListOfValues[I + 2],
+          Builder.maybeGetFunction(), ListOfValues[I + 2],
           getSILType(EltTy, (SILValueCategory)ListOfValues[I + 1], Fn)));
     }
     ResultInst = Builder.createMarkFunctionEscape(Loc, OpList);
@@ -2155,7 +2189,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::UnconditionalCheckedCastInst: {
     SILType srcLoweredType = getSILType(MF->getType(ListOfValues[1]),
                                         (SILValueCategory)ListOfValues[2], Fn);
-    SILValue src = getLocalValue(ListOfValues[0], srcLoweredType);
+    SILValue src = getLocalValue(Builder.maybeGetFunction(), ListOfValues[0],
+                                 srcLoweredType);
 
     SILType targetLoweredType =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
@@ -2170,9 +2205,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::ID##Inst:                                           \
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");   \
     ResultInst = Builder.create##ID(                                           \
-        Loc,                                                                   \
-        getLocalValue(ValID, getSILType(MF->getType(TyID),                     \
-                                        (SILValueCategory)TyCategory, Fn)));   \
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID,                  \
+                           getSILType(MF->getType(TyID),                       \
+                                      (SILValueCategory)TyCategory, Fn)));     \
     break;
 
 #define REFCOUNTING_INSTRUCTION(ID)                                            \
@@ -2180,8 +2215,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");   \
     ResultInst = Builder.create##ID(                                           \
         Loc,                                                                   \
-        getLocalValue(ValID, getSILType(MF->getType(TyID),                     \
-                                        (SILValueCategory)TyCategory, Fn)),    \
+        getLocalValue(                                                         \
+            Builder.maybeGetFunction(), ValID,                                 \
+            getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn)),  \
         (Atomicity)Attr);                                                      \
     break;
 
@@ -2238,8 +2274,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool isFixed = (Attr >> 3) & 0x1;
     ResultInst = Builder.createBeginBorrow(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID),
-                                        (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn)),
         isLexical, hasPointerEscape, fromVarDecl, isFixed);
     break;
   }
@@ -2249,8 +2286,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     unsigned verificationType = Attr;
     ResultInst = Builder.createIsEscapingClosure(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID),
-                                        (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn)),
         verificationType);
     break;
   }
@@ -2260,8 +2298,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     unsigned mandatory = Attr;
     ResultInst = Builder.createHopToExecutor(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID),
-                                        (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn)),
         mandatory != 0);
     break;
   }
@@ -2270,8 +2309,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     unsigned poisonRefs = Attr;
     ResultInst = Builder.createDestroyValue(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID),
-                                        (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn)),
         poisonRefs != 0);
     break;
   }
@@ -2281,8 +2321,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     unsigned isNative = Attr;
     ResultInst = Builder.createBeginCOWMutation(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID),
-                                        (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn)),
         isNative != 0);
     break;
   }
@@ -2292,8 +2333,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     unsigned keepUnique = Attr;
     ResultInst = Builder.createEndCOWMutation(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID),
-                                        (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn)),
         keepUnique != 0);
     break;
   }
@@ -2301,14 +2343,16 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::DestructureTupleInst: {
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
     SILValue Operand = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     ResultInst = Builder.createDestructureTuple(Loc, Operand);
     break;
   }
   case SILInstructionKind::DestructureStructInst: {
     assert(RecordKind == SIL_ONE_OPERAND && "Layout should be OneOperand.");
     SILValue Operand = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     ResultInst = Builder.createDestructureStruct(Loc, Operand);
     break;
   }
@@ -2317,7 +2361,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto ResultKind = decodeValueOwnership(Attr);
     ResultInst = Builder.createUncheckedOwnershipConversion(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         ResultKind);
     break;
   }
@@ -2330,7 +2375,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool IsFromVarDecl = (Attr >> 3) & 0x1;
     auto *MVI = Builder.createMoveValue(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         IsLexical, IsEscaping, IsFromVarDecl);
     MVI->setAllowsDiagnostics(AllowsDiagnostics);
     ResultInst = MVI;
@@ -2340,8 +2386,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::DropDeinitInst: {
     auto Ty = MF->getType(TyID);
     ResultInst = Builder.createDropDeinit(
-        Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
+                           getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
   }
 
@@ -2351,7 +2397,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto kind = Kind(Attr);
     ResultInst = Builder.createMarkUnresolvedReferenceBindingInst(
         Loc,
-        getLocalValue(ValID, getSILType(ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(ty, (SILValueCategory)TyCategory, Fn)),
         kind);
     break;
   }
@@ -2361,11 +2408,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool isOwned = bool(Attr);
     if (isOwned)
       ResultInst = Builder.createOwnedMoveOnlyWrapperToCopyableValue(
-          Loc, getLocalValue(ValID,
+          Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
                              getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     else
       ResultInst = Builder.createGuaranteedMoveOnlyWrapperToCopyableValue(
-          Loc, getLocalValue(ValID,
+          Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
                              getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
   }
@@ -2375,11 +2422,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool isOwned = bool(Attr);
     if (isOwned)
       ResultInst = Builder.createOwnedCopyableToMoveOnlyWrapperValue(
-          Loc, getLocalValue(ValID,
+          Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
                              getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     else
       ResultInst = Builder.createGuaranteedCopyableToMoveOnlyWrapperValue(
-          Loc, getLocalValue(ValID,
+          Loc, getLocalValue(Builder.maybeGetFunction(), ValID,
                              getSILType(Ty, (SILValueCategory)TyCategory, Fn)));
     break;
   }
@@ -2389,7 +2436,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Qualifier = LoadOwnershipQualifier(Attr);
     ResultInst = Builder.createLoad(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         Qualifier);
     break;
   }
@@ -2398,8 +2446,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::Load##Name##Inst: {                                 \
     auto Ty = MF->getType(TyID);                                               \
     bool isTake = (Attr > 0);                                                  \
-    auto Val = getLocalValue(                                                  \
-        ValID, getSILType(Ty, SILValueCategory(TyCategory), Fn));              \
+    auto Val =                                                                 \
+        getLocalValue(Builder.maybeGetFunction(), ValID,                       \
+                      getSILType(Ty, SILValueCategory(TyCategory), Fn));       \
     ResultInst = Builder.createLoad##Name(Loc, Val, IsTake_t(isTake));         \
     break;                                                                     \
   }                                                                            \
@@ -2409,16 +2458,17 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto refType = addrType.castTo<Name##StorageType>();                       \
     auto ValType = SILType::getPrimitiveObjectType(refType.getReferentType()); \
     bool isInit = (Attr > 0);                                                  \
-    ResultInst = Builder.createStore##Name(Loc, getLocalValue(ValID, ValType), \
-                                           getLocalValue(ValID2, addrType),    \
-                                           IsInitialization_t(isInit));        \
+    ResultInst = Builder.createStore##Name(                                    \
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID, ValType),        \
+        getLocalValue(Builder.maybeGetFunction(), ValID2, addrType),           \
+        IsInitialization_t(isInit));                                           \
     break;                                                                     \
   }
 #include "swift/AST/ReferenceStorage.def"
   case SILInstructionKind::MarkUninitializedInst: {
     auto Ty = getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     auto Kind = (MarkUninitializedInst::Kind)Attr;
-    auto Val = getLocalValue(ValID, Ty);
+    auto Val = getLocalValue(Builder.maybeGetFunction(), ValID, Ty);
     ResultInst = Builder.createMarkUninitialized(Loc, Val, Kind);
     break;
   }
@@ -2431,7 +2481,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       : MarkUnresolvedNonCopyableValueInst::IsNotStrict;
     ResultInst = Builder.createMarkUnresolvedNonCopyableValueInst(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         CKind, Strict);
     break;
   }
@@ -2440,22 +2491,24 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory, Fn);
     SILType ValType = addrType.getObjectType();
     auto Qualifier = StoreOwnershipQualifier(Attr);
-    ResultInst =
-        Builder.createStore(Loc, getLocalValue(ValID, ValType),
-                            getLocalValue(ValID2, addrType), Qualifier);
+    ResultInst = Builder.createStore(
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID, ValType),
+        getLocalValue(Builder.maybeGetFunction(), ValID2, addrType), Qualifier);
     break;
   }
   case SILInstructionKind::StoreBorrowInst: {
     auto Ty = MF->getType(TyID);
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory, Fn);
     SILType ValType = addrType.getObjectType();
-    ResultInst = Builder.createStoreBorrow(Loc, getLocalValue(ValID, ValType),
-                                           getLocalValue(ValID2, addrType));
+    ResultInst = Builder.createStoreBorrow(
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID, ValType),
+        getLocalValue(Builder.maybeGetFunction(), ValID2, addrType));
     break;
   }
   case SILInstructionKind::BeginAccessInst: {
     SILValue op = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     auto accessKind = SILAccessKind(Attr & 0x3);
     auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x07);
     bool noNestedConflict = (Attr >> 5) & 0x01;
@@ -2467,37 +2520,42 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::MoveOnlyWrapperToCopyableAddrInst: {
     assert(RecordKind == SIL_ONE_OPERAND);
     SILValue op = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     ResultInst = Builder.createMoveOnlyWrapperToCopyableAddr(Loc, op);
     break;
   }
   case SILInstructionKind::MoveOnlyWrapperToCopyableBoxInst: {
     assert(RecordKind == SIL_ONE_OPERAND);
     SILValue op = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     ResultInst = Builder.createMoveOnlyWrapperToCopyableBox(Loc, op);
     break;
   }
   case SILInstructionKind::CopyableToMoveOnlyWrapperAddrInst: {
     assert(RecordKind == SIL_ONE_OPERAND);
     SILValue op = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     ResultInst = Builder.createCopyableToMoveOnlyWrapperAddr(Loc, op);
     break;
   }
   case SILInstructionKind::EndAccessInst: {
     SILValue op = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     bool aborted = Attr & 0x1;
     ResultInst = Builder.createEndAccess(Loc, op, aborted);
     break;
   }
   case SILInstructionKind::BeginUnpairedAccessInst: {
     SILValue source = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
-    SILValue buffer =
-        getLocalValue(ValID2, getSILType(MF->getType(TyID2),
-                                         (SILValueCategory)TyCategory2, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+    SILValue buffer = getLocalValue(
+        Builder.maybeGetFunction(), ValID2,
+        getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn));
     auto accessKind = SILAccessKind(Attr & 0x3);
     auto enforcement = SILAccessEnforcement((Attr >> 2) & 0x07);
     bool noNestedConflict = (Attr >> 5) & 0x01;
@@ -2509,7 +2567,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   }
   case SILInstructionKind::EndUnpairedAccessInst: {
     SILValue op = getLocalValue(
-        ValID, getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+        Builder.maybeGetFunction(), ValID,
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     bool aborted = Attr & 0x1;
     auto enforcement = SILAccessEnforcement((Attr >> 1) & 0x07);
     bool fromBuiltin = (Attr >> 4) & 0x01;
@@ -2523,7 +2582,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool isInit = (Attr & 0x2) > 0;
     bool isTake = (Attr & 0x1) > 0;
     ResultInst = Builder.createCopyAddr(
-        Loc, getLocalValue(ValID, addrType), getLocalValue(ValID2, addrType),
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID, addrType),
+        getLocalValue(Builder.maybeGetFunction(), ValID2, addrType),
         IsTake_t(isTake), IsInitialization_t(isInit));
     break;
   }
@@ -2533,7 +2593,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     bool isInit = (Attr & 0x2) > 0;
     bool isTake = (Attr & 0x1) > 0;
     ResultInst = Builder.createExplicitCopyAddr(
-        Loc, getLocalValue(ValID, addrType), getLocalValue(ValID2, addrType),
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID, addrType),
+        getLocalValue(Builder.maybeGetFunction(), ValID2, addrType),
         IsTake_t(isTake), IsInitialization_t(isInit));
     break;
   }
@@ -2542,7 +2603,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty = MF->getType(TyID);
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory, Fn);
     ResultInst = Builder.createMarkUnresolvedMoveAddr(
-        Loc, getLocalValue(ValID, addrType), getLocalValue(ValID2, addrType));
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID, addrType),
+        getLocalValue(Builder.maybeGetFunction(), ValID2, addrType));
     break;
   }
 
@@ -2551,9 +2613,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType addrType = getSILType(Ty, (SILValueCategory)TyCategory, Fn);
     SILType valType = addrType.getObjectType();
     auto qualifier = AssignOwnershipQualifier(Attr);
-    ResultInst =
-        Builder.createAssign(Loc, getLocalValue(ValID, valType),
-                             getLocalValue(ValID2, addrType), qualifier);
+    ResultInst = Builder.createAssign(
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID, valType),
+        getLocalValue(Builder.maybeGetFunction(), ValID2, addrType), qualifier);
     break;
   }
   case SILInstructionKind::AssignByWrapperInst:
@@ -2565,10 +2627,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty = MF->getType(TyID);   // BoundTy
     ResultInst = Builder.createBindMemory(
         Loc,
-        getLocalValue(ListOfValues[2],
+        getLocalValue(Builder.maybeGetFunction(), ListOfValues[2],
                       getSILType(MF->getType(ListOfValues[0]),
                                  (SILValueCategory)ListOfValues[1], Fn)),
-        getLocalValue(ListOfValues[5],
+        getLocalValue(Builder.maybeGetFunction(), ListOfValues[5],
                       getSILType(MF->getType(ListOfValues[3]),
                                  (SILValueCategory)ListOfValues[4], Fn)),
         getSILType(Ty, (SILValueCategory)TyCategory, Fn));
@@ -2580,8 +2642,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty2 = MF->getType(TyID2);
     ResultInst = Builder.createRebindMemory(
         Loc,
-        getLocalValue(ValID, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
-        getLocalValue(ValID2,
+        getLocalValue(Builder.maybeGetFunction(), ValID,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
                       getSILType(Ty2, (SILValueCategory)TyCategory2, Fn)));
     break;
   }
@@ -2590,8 +2653,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // Use SILOneValueOneOperandLayout.
     VarDecl *Field = cast<VarDecl>(MF->getDecl(ValID));
     auto Ty = MF->getType(TyID);
-    auto Val =
-        getLocalValue(ValID2, getSILType(Ty, (SILValueCategory)TyCategory, Fn));
+    auto Val = getLocalValue(Builder.maybeGetFunction(), ValID2,
+                             getSILType(Ty, (SILValueCategory)TyCategory, Fn));
     auto ResultTy = Val->getType().getFieldType(
         Field, SILMod, Builder.getTypeExpansionContext());
     if (OpCode == SILInstructionKind::StructElementAddrInst)
@@ -2610,7 +2673,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     for (unsigned I = 0, E = ListOfValues.size(); I < E; I += 3) {
       auto EltTy = MF->getType(ListOfValues[I]);
       OpList.push_back(getLocalValue(
-          ListOfValues[I + 2],
+          Builder.maybeGetFunction(), ListOfValues[I + 2],
           getSILType(EltTy, (SILValueCategory)ListOfValues[I + 1], Fn)));
     }
     ResultInst = Builder.createStruct(
@@ -2629,12 +2692,12 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     default: llvm_unreachable("Out of sync with parent switch");
     case SILInstructionKind::TupleElementAddrInst:
       ResultInst = Builder.createTupleElementAddr(
-          Loc, getLocalValue(ValID, ST), TyID,
+          Loc, getLocalValue(Builder.maybeGetFunction(), ValID, ST), TyID,
           getSILType(ResultTy, SILValueCategory::Address, Fn));
       break;
     case SILInstructionKind::TupleExtractInst:
       ResultInst = Builder.createTupleExtract(
-          Loc, getLocalValue(ValID, ST), TyID,
+          Loc, getLocalValue(Builder.maybeGetFunction(), ValID, ST), TyID,
           getSILType(ResultTy, SILValueCategory::Object, Fn));
       break;
     }
@@ -2650,8 +2713,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     for (unsigned I = 0, E = ListOfValues.size(); I < E; ++I) {
       Type EltTy = TT->getElement(I).getType();
       OpList.push_back(
-        getLocalValue(ListOfValues[I],
-                      getSILType(EltTy, SILValueCategory::Object, Fn)));
+          getLocalValue(Builder.maybeGetFunction(), ListOfValues[I],
+                        getSILType(EltTy, SILValueCategory::Object, Fn)));
     }
     ResultInst = Builder.createTuple(
         Loc, getSILType(Ty, (SILValueCategory)TyCategory, Fn), OpList);
@@ -2677,7 +2740,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       uint32_t count = value & 0x7FFFFFFF;
       SILValueCategory category = value & 0x80000000 ? SILValueCategory::Address
                                                      : SILValueCategory::Object;
-      return getLocalValue(count, getSILType(type, category, Fn));
+      return getLocalValue(Builder.maybeGetFunction(), count,
+                           getSILType(type, category, Fn));
     };
 
     SILValue DestAddr = getValue(TT, ListOfValues[0]);
@@ -2707,7 +2771,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     for (unsigned i = 1; i < NumVals; i += 2) {
       SILType elementType = getSILType(MF->getType(ListOfValues[i + 1]),
                                        SILValueCategory::Object, Fn);
-      SILValue elementVal = getLocalValue(ListOfValues[i], elementType);
+      SILValue elementVal = getLocalValue(Builder.maybeGetFunction(),
+                                          ListOfValues[i], elementType);
       elements.push_back(elementVal);
     }
     ResultInst = Builder.createObject(Loc, ClassTy, elements, numBaseElements);
@@ -2718,8 +2783,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SmallVector<SILValue, 4> OpList;
     for (unsigned I = 0, E = ListOfValues.size(); I < E; ++I) {
       OpList.push_back(
-        getLocalValue(ListOfValues[I],
-                      getSILType(EltTy, SILValueCategory::Object, Fn)));
+          getLocalValue(Builder.maybeGetFunction(), ListOfValues[I],
+                        getSILType(EltTy, SILValueCategory::Object, Fn)));
     }
     ResultInst = Builder.createVector(Loc, OpList);
     break;
@@ -2729,7 +2794,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SmallVector<SILValue, 4> Args;
     for (unsigned I = 0, E = ListOfValues.size(); I < E; I += 3)
       Args.push_back(
-          getLocalValue(ListOfValues[I + 2],
+          getLocalValue(Builder.maybeGetFunction(), ListOfValues[I + 2],
                         getSILType(MF->getType(ListOfValues[I]),
                                    (SILValueCategory)ListOfValues[I + 1], Fn)));
 
@@ -2743,7 +2808,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // false basic block ID, number of true arguments, and a list of true|false
     // arguments.
     SILValue Cond = getLocalValue(
-        ListOfValues[0],
+        Builder.maybeGetFunction(), ListOfValues[0],
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
 
     unsigned NumTrueArgs = ListOfValues[3];
@@ -2752,14 +2817,14 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SmallVector<SILValue, 4> TrueArgs;
     for (unsigned I = StartOfTrueArg, E = StartOfFalseArg; I < E; I += 3)
       TrueArgs.push_back(
-          getLocalValue(ListOfValues[I + 2],
+          getLocalValue(Builder.maybeGetFunction(), ListOfValues[I + 2],
                         getSILType(MF->getType(ListOfValues[I]),
                                    (SILValueCategory)ListOfValues[I + 1], Fn)));
 
     SmallVector<SILValue, 4> FalseArgs;
     for (unsigned I = StartOfFalseArg, E = ListOfValues.size(); I < E; I += 3)
       FalseArgs.push_back(
-          getLocalValue(ListOfValues[I + 2],
+          getLocalValue(Builder.maybeGetFunction(), ListOfValues[I + 2],
                         getSILType(MF->getType(ListOfValues[I]),
                                    (SILValueCategory)ListOfValues[I + 1], Fn)));
 
@@ -2771,9 +2836,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::AwaitAsyncContinuationInst: {
     // Format: continuation, resume block ID, error block ID if given
     SILValue Cont = getLocalValue(
-              ListOfValues[0],
-              getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
-    
+        Builder.maybeGetFunction(), ListOfValues[0],
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
+
     SILBasicBlock *resultBB = getBBForReference(Fn, ListOfValues[1]);
     SILBasicBlock *errorBB = nullptr;
     if (ListOfValues.size() >= 3) {
@@ -2790,7 +2855,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // for condition, the list has value for condition, hasDefault, default
     // basic block ID, a list of (DeclID, BasicBlock ID).
     SILValue Cond = getLocalValue(
-        ListOfValues[0],
+        Builder.maybeGetFunction(), ListOfValues[0],
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
 
     SILBasicBlock *DefaultBB = nullptr;
@@ -2818,9 +2883,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // for condition, the list has value for condition, result type,
     //   hasDefault, default
     // basic block ID, a list of (DeclID, BasicBlock ID).
-    SILValue Cond = getLocalValue(ListOfValues[0],
-                                  getSILType(MF->getType(TyID),
-                                             (SILValueCategory)TyCategory, Fn));
+    SILValue Cond = getLocalValue(
+        Builder.maybeGetFunction(), ListOfValues[0],
+        getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
 
     Type ResultLoweredTy = MF->getType(ListOfValues[1]);
     SILValueCategory ResultCategory = (SILValueCategory)ListOfValues[2];
@@ -2828,11 +2893,13 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 
     SILValue DefaultVal = nullptr;
     if (ListOfValues[3])
-      DefaultVal = getLocalValue(ListOfValues[4], ResultTy);
+      DefaultVal =
+          getLocalValue(Builder.maybeGetFunction(), ListOfValues[4], ResultTy);
 
     SmallVector<std::pair<EnumElementDecl*, SILValue>, 4> CaseVals;
     for (unsigned I = 5, E = ListOfValues.size(); I < E; I += 2) {
-      auto Value = getLocalValue(ListOfValues[I+1], ResultTy);
+      auto Value = getLocalValue(Builder.maybeGetFunction(),
+                                 ListOfValues[I + 1], ResultTy);
       CaseVals.push_back({cast<EnumElementDecl>(MF->getDecl(ListOfValues[I])),
                          Value});
     }
@@ -2852,7 +2919,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType ResultTy = getSILType(MF->getType(TyID),
                                              (SILValueCategory)TyCategory, Fn);
     SILValue Cond = getLocalValue(
-        ListOfValues[0],
+        Builder.maybeGetFunction(), ListOfValues[0],
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
 
     SILBasicBlock *DefaultBB = nullptr;
@@ -2861,7 +2928,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 
     SmallVector<std::pair<SILValue, SILBasicBlock*>, 4> CaseBBs;
     for (unsigned I = 3, E = ListOfValues.size(); I < E; I += 2) {
-      auto value = getLocalValue(ListOfValues[I], ResultTy);
+      auto value =
+          getLocalValue(Builder.maybeGetFunction(), ListOfValues[I], ResultTy);
       CaseBBs.push_back( {value, getBBForReference(Fn, ListOfValues[I+1])} );
     }
     ResultInst = Builder.createSwitchValue(Loc, Cond, DefaultBB, CaseBBs);
@@ -2872,9 +2940,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // (DeclID + hasOperand), and an operand.
     SILValue Operand;
     if (Attr)
-      Operand =
-          getLocalValue(ValID2, getSILType(MF->getType(TyID2),
-                                           (SILValueCategory)TyCategory2, Fn));
+      Operand = getLocalValue(
+          Builder.maybeGetFunction(), ValID2,
+          getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn));
     ResultInst = Builder.createEnum(
         Loc, Operand, cast<EnumElementDecl>(MF->getDecl(ValID)),
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
@@ -2888,7 +2956,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType ResultTy = OperandTy.getEnumElementType(
         Elt, SILMod, Builder.getTypeExpansionContext());
     ResultInst = Builder.createInitEnumDataAddr(
-        Loc, getLocalValue(ValID2, OperandTy), Elt, ResultTy);
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID2, OperandTy), Elt,
+        ResultTy);
     break;
   }
   case SILInstructionKind::UncheckedEnumDataInst: {
@@ -2899,7 +2968,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType ResultTy = OperandTy.getEnumElementType(
         Elt, SILMod, Builder.getTypeExpansionContext());
     ResultInst = Builder.createUncheckedEnumData(
-        Loc, getLocalValue(ValID2, OperandTy), Elt, ResultTy);
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID2, OperandTy), Elt,
+        ResultTy);
     break;
   }
   case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
@@ -2910,7 +2980,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     SILType ResultTy = OperandTy.getEnumElementType(
         Elt, SILMod, Builder.getTypeExpansionContext());
     ResultInst = Builder.createUncheckedTakeEnumDataAddr(
-        Loc, getLocalValue(ValID2, OperandTy), Elt, ResultTy);
+        Loc, getLocalValue(Builder.maybeGetFunction(), ValID2, OperandTy), Elt,
+        ResultTy);
     break;
   }
   case SILInstructionKind::InjectEnumAddrInst: {
@@ -2919,7 +2990,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     auto Ty = MF->getType(TyID);
     ResultInst = Builder.createInjectEnumAddr(
         Loc,
-        getLocalValue(ValID2, getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
+        getLocalValue(Builder.maybeGetFunction(), ValID2,
+                      getSILType(Ty, (SILValueCategory)TyCategory, Fn)),
         Elt);
     break;
   }
@@ -2927,7 +2999,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // Use SILOneValueOneOperandLayout.
     VarDecl *Field = cast<VarDecl>(MF->getDecl(ValID));
     auto Ty = MF->getType(TyID);
-    auto Val = getLocalValue(ValID2,
+    auto Val = getLocalValue(Builder.maybeGetFunction(), ValID2,
                              getSILType(Ty, (SILValueCategory)TyCategory, Fn));
     auto ResultTy = Val->getType().getFieldType(
         Field, SILMod, Builder.getTypeExpansionContext());
@@ -2941,8 +3013,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     assert((SILValueCategory)TyCategory == SILValueCategory::Address);
     ResultInst = Builder.createRefTailAddr(
         Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)),
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
         getSILType(MF->getType(TyID), SILValueCategory::Address, Fn),
         /*Immutable*/ Attr & 0x1);
     break;
@@ -2968,23 +3041,31 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     default: llvm_unreachable("Out of sync with parent switch");
     case SILInstructionKind::ClassMethodInst:
       ResultInst = Builder.createClassMethod(
-          Loc, getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef,
-          Ty);
+          Loc,
+          getLocalValue(Builder.maybeGetFunction(),
+                        ListOfValues[NextValueIndex], operandTy),
+          DRef, Ty);
       break;
     case SILInstructionKind::SuperMethodInst:
       ResultInst = Builder.createSuperMethod(
-          Loc, getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef,
-          Ty);
+          Loc,
+          getLocalValue(Builder.maybeGetFunction(),
+                        ListOfValues[NextValueIndex], operandTy),
+          DRef, Ty);
       break;
     case SILInstructionKind::ObjCMethodInst:
       ResultInst = Builder.createObjCMethod(
-          Loc, getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef,
-          Ty);
+          Loc,
+          getLocalValue(Builder.maybeGetFunction(),
+                        ListOfValues[NextValueIndex], operandTy),
+          DRef, Ty);
       break;
     case SILInstructionKind::ObjCSuperMethodInst:
       ResultInst = Builder.createObjCSuperMethod(
-          Loc, getLocalValue(ListOfValues[NextValueIndex], operandTy), DRef,
-          Ty);
+          Loc,
+          getLocalValue(Builder.maybeGetFunction(),
+                        ListOfValues[NextValueIndex], operandTy),
+          DRef, Ty);
       break;
     }
     break;
@@ -3006,7 +3087,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       SILType ExistentialOperandTy =
           getSILType(MF->getType(TyID3), (SILValueCategory)TyCategory3, Fn);
       if (ValID3)
-        ExistentialOperand = getLocalValue(ValID3, ExistentialOperandTy);
+        ExistentialOperand = getLocalValue(Builder.maybeGetFunction(), ValID3,
+                                           ExistentialOperandTy);
     }
     ResultInst =
         Builder.createWitnessMethod(Loc, Ty, Conformance, DRef, OperandTy);
@@ -3022,7 +3104,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     ResultInst = Builder.createDynamicMethodBranch(
         Loc,
         getLocalValue(
-            ListOfValues[0],
+            Builder.maybeGetFunction(), ListOfValues[0],
             getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn)),
         DRef, getBBForReference(Fn, ListOfValues[NextValueIndex]),
         getBBForReference(Fn, ListOfValues[NextValueIndex + 1]));
@@ -3035,7 +3117,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     CanType sourceFormalType = MF->getType(ListOfValues[1])->getCanonicalType();
     SILType opTy = getSILType(MF->getType(ListOfValues[3]),
                               (SILValueCategory)ListOfValues[4], Fn);
-    SILValue op = getLocalValue(ListOfValues[2], opTy);
+    SILValue op =
+        getLocalValue(Builder.maybeGetFunction(), ListOfValues[2], opTy);
     SILType targetLoweredType =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
     CanType targetFormalType = MF->getType(ListOfValues[5])->getCanonicalType();
@@ -3054,12 +3137,14 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     CanType srcFormalType = MF->getType(ListOfValues[0])->getCanonicalType();
     SILType srcLoweredType = getSILType(MF->getType(ListOfValues[2]),
                                        (SILValueCategory)ListOfValues[3], Fn);
-    SILValue src = getLocalValue(ListOfValues[1], srcLoweredType);
+    SILValue src = getLocalValue(Builder.maybeGetFunction(), ListOfValues[1],
+                                 srcLoweredType);
 
     CanType targetFormalType = MF->getType(ListOfValues[4])->getCanonicalType();
     SILType targetLoweredType =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
-    SILValue dest = getLocalValue(ListOfValues[5], targetLoweredType);
+    SILValue dest = getLocalValue(Builder.maybeGetFunction(), ListOfValues[5],
+                                  targetLoweredType);
 
     ResultInst = Builder.createUnconditionalCheckedCastAddr(
         Loc, src, srcFormalType, dest, targetFormalType);
@@ -3071,13 +3156,15 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     CanType srcFormalType = MF->getType(ListOfValues[1])->getCanonicalType();
     SILType srcLoweredType = getSILType(MF->getType(ListOfValues[3]),
                                         (SILValueCategory)ListOfValues[4], Fn);
-    SILValue src = getLocalValue(ListOfValues[2], srcLoweredType);
+    SILValue src = getLocalValue(Builder.maybeGetFunction(), ListOfValues[2],
+                                 srcLoweredType);
 
     CanType targetFormalType =
         MF->getType(ListOfValues[5])->getCanonicalType();
     SILType targetLoweredType =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
-    SILValue dest = getLocalValue(ListOfValues[6], targetLoweredType);
+    SILValue dest = getLocalValue(Builder.maybeGetFunction(), ListOfValues[6],
+                                  targetLoweredType);
 
     auto *successBB = getBBForReference(Fn, ListOfValues[7]);
     auto *failureBB = getBBForReference(Fn, ListOfValues[8]);
@@ -3089,9 +3176,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::UncheckedRefCastInst: {
     assert(RecordKind == SIL_ONE_TYPE_ONE_OPERAND &&
            "Layout should be OneTypeOneOperand.");
-    auto *urc = Builder.createUncheckedRefCast(Loc,
-        getLocalValue(ValID, getSILType(MF->getType(TyID2),
-                                        (SILValueCategory)TyCategory2, Fn)),
+    auto *urc = Builder.createUncheckedRefCast(
+        Loc,
+        getLocalValue(
+            Builder.maybeGetFunction(), ValID,
+            getSILType(MF->getType(TyID2), (SILValueCategory)TyCategory2, Fn)),
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn));
     urc->setForwardingOwnershipKind(decodeValueOwnership(Attr));
     ResultInst = urc;
@@ -3102,12 +3191,14 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     // ignore attr.
     SILType srcAddrTy = getSILType(MF->getType(ListOfValues[2]),
                                    (SILValueCategory)ListOfValues[3], Fn);
-    SILValue src = getLocalValue(ListOfValues[1], srcAddrTy);
+    SILValue src =
+        getLocalValue(Builder.maybeGetFunction(), ListOfValues[1], srcAddrTy);
 
     CanType targetType = MF->getType(ListOfValues[4])->getCanonicalType();
     SILType destAddrTy =
         getSILType(MF->getType(TyID), (SILValueCategory)TyCategory, Fn);
-    SILValue dest = getLocalValue(ListOfValues[5], destAddrTy);
+    SILValue dest =
+        getLocalValue(Builder.maybeGetFunction(), ListOfValues[5], destAddrTy);
 
     ResultInst = Builder.createUncheckedRefCastAddr(Loc, src, sourceType, dest,
                                                     targetType);
@@ -3121,14 +3212,14 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
 
     SILType storageTy = getSILType(MF->getType(ListOfValues[1]),
                                    SILValueCategory::Address, Fn);
-    SILValue storage
-      = getLocalValue(ListOfValues[0], storageTy);
+    SILValue storage =
+        getLocalValue(Builder.maybeGetFunction(), ListOfValues[0], storageTy);
 
     SILType invokeTy =
         getSILType(MF->getType(ListOfValues[3]), SILValueCategory::Object, Fn);
-    SILValue invoke
-      = getLocalValue(ListOfValues[2], invokeTy);
-    
+    SILValue invoke =
+        getLocalValue(Builder.maybeGetFunction(), ListOfValues[2], invokeTy);
+
     auto SubMap = MF->getSubstitutionMap(ListOfValues[4]);
 
     ResultInst = Builder.createInitBlockStorageHeader(Loc, storage, invoke,
@@ -3157,8 +3248,9 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
     for (unsigned I = 0, E = ListOfValues.size(); I < E; I += 3) {
       auto valueTy = MF->getType(ListOfValues[I]);
       auto valueCategory = (SILValueCategory) ListOfValues[I+1];
-      yieldedValues.push_back(getLocalValue(
-          ListOfValues[I + 2], getSILType(valueTy, valueCategory, Fn)));
+      yieldedValues.push_back(
+          getLocalValue(Builder.maybeGetFunction(), ListOfValues[I + 2],
+                        getSILType(valueTy, valueCategory, Fn)));
     }
 
     ResultInst = Builder.createYield(Loc, yieldedValues, resumeBB, unwindBB);
@@ -3211,7 +3303,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
       auto opValue = ListOfValues[nextValue++];
       auto opTy = MF->getType(ListOfValues[nextValue++]);
       auto opCat = (SILValueCategory)ListOfValues[nextValue++];
-      operands.push_back(getLocalValue(opValue, getSILType(opTy, opCat, Fn)));
+      operands.push_back(getLocalValue(Builder.maybeGetFunction(), opValue,
+                                       getSILType(opTy, opCat, Fn)));
     }
 
     ResultInst = Builder.createKeyPath(Loc, pattern, subMap, operands, kpTy);
@@ -3242,7 +3335,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
          i < numParamIndices + numOperands * 3; i += 3) {
       auto astTy = MF->getType(ListOfValues[i]);
       auto silTy = getSILType(astTy, (SILValueCategory)ListOfValues[i + 1], Fn);
-      operands.push_back(getLocalValue(ListOfValues[i + 2], silTy));
+      operands.push_back(getLocalValue(Builder.maybeGetFunction(),
+                                       ListOfValues[i + 2], silTy));
     }
     std::optional<std::pair<SILValue, SILValue>> derivativeFunctions =
         std::nullopt;
@@ -3268,7 +3362,8 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
          i < numParamIndices + numOperands * 3; i += 3) {
       auto astTy = MF->getType(ListOfValues[i]);
       auto silTy = getSILType(astTy, (SILValueCategory)ListOfValues[i+1], Fn);
-      operands.push_back(getLocalValue(ListOfValues[i+2], silTy));
+      operands.push_back(getLocalValue(Builder.maybeGetFunction(),
+                                       ListOfValues[i + 2], silTy));
     }
     std::optional<SILValue> transposeFunction = std::nullopt;
     if (hasLinearFunction)
@@ -3280,7 +3375,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::DifferentiableFunctionExtractInst: {
     auto astTy = MF->getType(TyID);
     auto silTy = getSILType(astTy, SILValueCategory::Object, Fn);
-    auto val = getLocalValue(ValID, silTy);
+    auto val = getLocalValue(Builder.maybeGetFunction(), ValID, silTy);
     NormalDifferentiableFunctionTypeComponent extractee(Attr);
     std::optional<SILType> explicitExtracteeType = std::nullopt;
     if (Attr2) {
@@ -3295,7 +3390,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   case SILInstructionKind::LinearFunctionExtractInst: {
     auto astTy = MF->getType(TyID);
     auto silTy = getSILType(astTy, SILValueCategory::Object, Fn);
-    auto val = getLocalValue(ValID, silTy);
+    auto val = getLocalValue(Builder.maybeGetFunction(), ValID, silTy);
     LinearDifferentiableFunctionTypeComponent extractee(Attr);
     ResultInst = Builder.createLinearFunctionExtract(Loc, extractee, val);
     break;

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -132,8 +132,12 @@ namespace swift {
     /// When an instruction or block argument is defined, this method is used to
     /// register it and update our symbol table.
     void setLocalValue(ValueBase *Value, serialization::ValueID Id);
+
     /// Get a reference to a local value with the specified ID and type.
-    SILValue getLocalValue(serialization::ValueID Id,
+    ///
+    /// NOTE: \p inContext is expected to be nullptr if we are inserting into a
+    /// global variable initializer.
+    SILValue getLocalValue(SILFunction *inContext, serialization::ValueID Id,
                            SILType Type);
 
     SILType getSILType(Type ty, SILValueCategory category,


### PR DESCRIPTION
For years, optimizer engineers have been hitting a common bug caused by passes
assuming all SILValues have a parent function only to be surprised by SILUndef.
Generally we see SILUndef not that often so we see this come up later in
testing. This patch eliminates that problem by making SILUndef uniqued at the
function level instead of the module level. This ensures that it makes sense for
SILUndef to have a parent function, eliminating this possibility since we can
define an API to get its parent function.

rdar://123484595

