### PR TITLE
[CommandLine][Linux] Don't read argv from /proc/self/cmdline.

### DIFF
--- a/stdlib/public/CommandLineSupport/CommandLine.cpp
+++ b/stdlib/public/CommandLineSupport/CommandLine.cpp
@@ -166,7 +166,204 @@ static char **swift::getUnsafeArgvArgc(int *outArgLen) {
 
 template <typename F>
 static void swift::enumerateUnsafeArgv(const F& body) { }
-#elif defined(__linux__) || defined(__CYGWIN__)
+#elif defined(__linux__)
+// On Linux, there is no easy way to get the argument vector pointer outside
+// of the main() function.  However, the ABI specifications dictate the layout
+// of the process's initial stack, which looks something like:
+//
+// stack top ----> ┌────────────────────────┐
+//                 │ Unspecified            │
+//                 ┊                        ┊
+//                 ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 │ Information block      │
+//                 │ (argument strings,     │
+//                 │ environment strings,   │
+//                 │ auxiliary information) │
+//                 ┊                        ┊
+//                 ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 │ Unspecified            │
+//                 ┊                        ┊
+//                 ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 │ NULL                   │
+//                 ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 │ Auxiliary Vector       │
+//                 ┊                        ┊
+//                 ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 │ NULL                   │
+//                 ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 │ Environment Pointers   │
+//                 ┊                        ┊
+// environ ------> ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 │ NULL                   │
+//                 ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 │ Argument Pointers      │
+//                 ┊                        ┊
+//                 ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 │ Argument Count         │
+//                 ├┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┈┤
+//                 ┊                        ┊
+//
+//                 See https://gitlab.com/x86-psABIs/x86-64-ABI,
+//                     https://gitlab.com/x86-psABIs/i386-ABI
+//
+// The upshot is that if we can get hold of `environ` before anything has
+// had a chance to change it, we can find the `argv` array and also the
+// argument count, `argc`, by walking back up the stack.
+//
+// (Note that Linux uses this same layout for all platforms, not just x86-based
+// ones.  It also has a fixed layout for the data at the top of the stack, but
+// we don't need to take advantage of that here and can stick to things that
+// are defined in the ABI specs.)
+
+#include <unistd.h>
+
+#define DEBUG_ARGVGRABBER 0
+#if DEBUG_ARGVGRABBER
+#define ARGVDEBUG(...) fprintf(stderr, __VA_ARGS__)
+#else
+#define ARGVDEBUG(...)
+#endif
+
+namespace {
+
+struct ArgvGrabber {
+  char **argv;
+  int argc;
+
+  ArgvGrabber();
+
+private:
+  struct stack {
+    void *base;
+    void *top;
+
+    stack() : base(nullptr), top(nullptr) {}
+    stack(void *b, void *t) : base(b), top(t) {}
+  };
+
+  stack findStack();
+  void findArgv(stack s);
+};
+
+// Find the stack by looking at /proc/self/maps
+ArgvGrabber::stack ArgvGrabber::findStack(void) {
+  FILE *maps = fopen("/proc/self/maps", "r");
+  if (!maps) {
+    ARGVDEBUG("unable to open maps - %d\n", errno);
+    return stack();
+  }
+
+  char line[256];
+  void *base = NULL, *top = NULL;
+  bool found = false;
+  while (fgets(line, sizeof(line), maps)) {
+    // line is on the stack, so we know we're looking at the right
+    // region if line is between base and top.
+    //
+    // Note that we can't look for [stack], because Rosetta and qemu
+    // set up a separate stack for the emulated code.
+    //
+    // We also need to glom on extra VM ranges after the first one
+    // we find, because *sometimes* we end up with an extra range.
+    void *lo, *hi;
+    if (sscanf(line, "%p-%p", &lo, &hi) == 2) {
+      if ((void *)line >= lo && (void *)line < hi) {
+        base = lo;
+        top = hi;
+        found = true;
+      } else if (found && top == lo) {
+        top = hi;
+      }
+    }
+  }
+
+  fclose(maps);
+
+  if (!found) {
+    ARGVDEBUG("stack not found in maps\n");
+    return stack();
+  }
+
+  return stack(base, top);
+}
+
+#if DEBUG_ARGVGRABBER
+void printMaps() {
+  FILE *maps = fopen("/proc/self/maps", "r");
+  if (!maps) {
+    fprintf(stderr, "unable to open maps - %d\n", errno);
+    return;
+  }
+
+  char line[256];
+  while (fgets(line, sizeof(line), maps)) {
+    fputs(line, stderr);
+  }
+
+  fclose(maps);
+}
+#endif
+
+// Find argv by walking backwards from environ
+void ArgvGrabber::findArgv(ArgvGrabber::stack stack) {
+  if (!stack.base) {
+    ARGVDEBUG("no stack\n");
+    return;
+  }
+
+  // Check that environ points to the stack
+  char **envp = environ;
+  if ((void *)envp < stack.base || (void *)envp >= stack.top) {
+    ARGVDEBUG("envp = %p, stack is from %p to %p\n",
+              envp, stack.base, stack.top);
+#if DEBUG_ARGVGRABBER
+    printMaps();
+#endif
+    return;
+  }
+
+  char **ptr = envp - 1;
+
+  // We're now pointing at the NULL that terminates argv.  Keep going back
+  // while we're seeing pointers (values greater than envp).
+  while ((void *)(ptr - 1) > stack.base) {
+    --ptr;
+
+    // The first thing less than envp must be the argc value
+    if ((void *)*ptr < (void *)envp) {
+      argc = (int)(intptr_t)*ptr++;
+      argv = ptr;
+      return;
+    }
+  }
+
+  ARGVDEBUG("didn't find argc\n");
+}
+
+ArgvGrabber::ArgvGrabber() : argv(nullptr), argc(0) {
+  ARGVDEBUG("***GRABBING ARGV for %d***\n", getpid());
+  findArgv(findStack());
+#if DEBUG_ARGVGRABBER
+  fprintf(stderr, "ARGV is at %p with count %d\n", argv, argc);
+  for (int i = 0; i < argc; ++i) {
+    fprintf(stderr, "  argv[%d] = \"%s\"\n", i, argv[i]);
+  }
+  fprintf(stderr, "***ARGV GRABBED***\n");
+#endif
+}
+
+ArgvGrabber argvGrabber;
+
+} // namespace
+
+static char **swift::getUnsafeArgvArgc(int *outArgLen) {
+  *outArgLen = argvGrabber.argc;
+  return argvGrabber.argv;
+}
+
+template <typename F>
+static void swift::enumerateUnsafeArgv(const F& body) { }
+#elif defined(__CYGWIN__)
 static char **swift::getUnsafeArgvArgc(int *outArgLen) {
   return nullptr;
 }


### PR DESCRIPTION
Instead of reading from `/proc/self/cmdline`, take advantage of the fact that the initial stack layout is ABI specified, and that we already have a pointer into it (`environ`).  This lets us walk up the stack until we find `argc`, at which point we also know where `argv` is.

We do this from a static initializer because a `setenv()` or `putenv()` can change `environ` (if you add a new environment variable), and it's even permissible to just outright change `environ` yourself too.  It seems reasonable to suggest to people that they shouldn't be doing those things from a static initializer, and as long as they don't, they won't run before we've had a chance to find `argv`.

Just in case someone _does_ do this, we also check that `environ` points into the stack.  If it doesn't, they won't get any arguments, so if that happens, that's a clue that they're messing with `environ` too early.

This works around a problem (#69658) with Docker Desktop 4.25.0 and Rosetta, wherein we end up with an extra argument visible in `/proc/self/cmdline`, and also avoids allocating memory for the command line arguments.

rdar://117963394
