### PR TITLE
[DebugInfo] Fix dynamic self debug loc

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1845,6 +1845,9 @@ llvm::Value *IRGenFunction::getDynamicSelfMetadata() {
                             cast<llvm::Instruction>(SelfValue)))
                       : CurFn->getEntryBlock().begin();
   Builder.SetInsertPoint(&CurFn->getEntryBlock(), insertPt);
+  // Do not inherit the debug location of this insertion point, it could be
+  // anything (e.g. the location of a dbg.declare).
+  Builder.SetCurrentDebugLocation(llvm::DebugLoc());
 
   switch (SelfKind) {
   case SwiftMetatype:

--- a/test/DebugInfo/DynamicSelfLocation.swift
+++ b/test/DebugInfo/DynamicSelfLocation.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-irgen -g -o - | %FileCheck %s
+// REQUIRES: concurrency
+
+func some_func(_: () -> Void) async {}
+
+class Model {
+  static func SelfFunction() {}
+
+  func foo() async -> () {
+    let somevar = 10
+
+    return await some_func {
+      Self.SelfFunction()
+    }
+  }
+}
+
+// Check that the load of DynamicSelf in foo does not have any debug information, as
+// this is hoisted to the start of the function.
+// CHECK: define {{.*}} @"$s19DynamicSelfLocation5ModelC3fooyyYaF"({{.*}}, ptr swiftself %[[Self:.*]])
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   %2 = load ptr, ptr %[[Self]]
+// CHECK-NOT:    !dbg
+// CHECK-NEXT:   call void @llvm.dbg.declare


### PR DESCRIPTION
The instructions related to producing DynamicSelf metadata are always placed at the start of the function. This creates an issue: which debug location should be used in order to preserve a sane line table? The current implementation just uses w/e debug location is present in the new insertion point, which could, for example, be a debug_declare whose location is not suitable for these purposes.

This patch addresses the issue by removing the debug location of instructions associated with producing DynamicSelfMetadata.

rdar://120408665