### PR TITLE
[ConstraintSystem] Skip sendability check for static members

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2806,7 +2806,9 @@ ConstraintSystem::getTypeOfMemberReference(
     FunctionType::ExtInfo info;
 
     if (Context.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
-      if (isPartialApplication(locator) && baseOpenedTy->isSendableType()) {
+      if (isPartialApplication(locator) &&
+          (resolvedBaseTy->is<AnyMetatypeType>() ||
+           baseOpenedTy->isSendableType())) {
         // Add @Sendable to functions without conditional conformances
         functionType =
             functionType

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -29,8 +29,8 @@ func testInAsync(x: X) async {
   let _: Int = unsafelyMainActorClosure // expected-error{{type '@Sendable (@MainActor () -> Void) -> ()'}}
   let _: Int = unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
-  let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (X) -> (@MainActor @Sendable () -> Void) -> ()'}}
-  let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (X) -> @Sendable (@MainActor @Sendable () -> Void) -> ()'}}
+  let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
 
   let _: Int = x.sendableVar // expected-error{{type '@Sendable () -> Void'}}
   let _: Int = x.mainActorVar // expected-error{{type '@MainActor () -> Void'}}
@@ -44,8 +44,8 @@ func testElsewhere(x: X) {
   let _: Int = unsafelyMainActorClosure // expected-error{{type '@Sendable (@MainActor () -> Void) -> ()'}}
   let _: Int = unsafelyDoEverythingClosure // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
   let _: Int = x.unsafelyDoEverythingClosure // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
-  let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (X) -> (@MainActor @Sendable () -> Void) -> ()'}}
-  let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '(@MainActor @Sendable () -> Void) -> ()'}}
+  let _: Int = X.unsafelyDoEverythingClosure // expected-error{{type '@Sendable (X) -> @Sendable (@MainActor @Sendable () -> Void) -> ()'}}
+  let _: Int = (X.unsafelyDoEverythingClosure)(x) // expected-error{{type '@Sendable (@MainActor @Sendable () -> Void) -> ()'}}
 
   let _: Int = x.sendableVar // expected-error{{type '@Sendable () -> Void'}}
   let _: Int = x.mainActorVar // expected-error{{type '@MainActor () -> Void'}}

--- a/test/Concurrency/sendable_functions.swift
+++ b/test/Concurrency/sendable_functions.swift
@@ -46,3 +46,19 @@ extension S: Sendable where T: Sendable {
 
 @available(SwiftStdlib 5.1, *)
 @MainActor @Sendable func globalActorFuncAsync() async { }
+
+func test_initializer_ref() {
+  func test<T>(_: @Sendable (T, T) -> Array<T>) {
+  }
+
+  // Type of `initRef` should be @Sendable but due to implicitly injected autoclosure it isn't
+  let initRef = Array.init as (Int, Int) -> Array<Int>
+
+  // FIXME: incorrect non-Sendable diagnostic is produced due to `autoclosure` wrapping `Array.init`
+  test(initRef)
+  // expected-warning@-1 {{converting non-sendable function value to '@Sendable (Int, Int) -> Array<Int>' may introduce data races}}
+
+  // FIXME: Same here
+  test(Array.init as (Int, Int) -> Array<Int>)
+  // expected-warning@-1 {{converting non-sendable function value to '@Sendable (Int, Int) -> Array<Int>' may introduce data races}}
+}


### PR DESCRIPTION
Such members only capture base metatatypes which are themselves always sendable.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
