### PR TITLE
[CSDiagnostics] Produce a diagnostic for patterns with extraneous ele…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5984,6 +5984,18 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
     return true;
   }
 
+  if (auto *pattern = getAsPattern<EnumElementPattern>(anchor)) {
+    if (isa<TuplePattern>(pattern->getSubPattern())) {
+      auto paramTuple = FunctionType::composeTuple(
+          getASTContext(), ContextualType->getParams(),
+          ParameterFlagHandling::IgnoreNonEmpty);
+
+      emitDiagnostic(diag::tuple_pattern_length_mismatch,
+                     paramTuple);
+      return true;
+    }
+  }
+
   if (isContextualMismatch()) {
     auto *locator = getLocator();
     emitDiagnostic(locator->isLastElement<LocatorPathElt::ContextualType>()

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -774,3 +774,20 @@ func issue66750(_ x: Result<String, Error>) {
     break
   }
 }
+
+// rdar://123466496 - `type of expression is ambiguous without a type annotation` with extra elements
+do {
+  enum E {
+  case test(a: Int, b: String)
+  }
+
+  func test(_: (E) -> Void) {
+  }
+
+  test {
+    switch $0 {
+    case .test(a: 42, b: "", c: 0.0): break
+      // expected-error@-1 {{tuple pattern has the wrong length for tuple type '(Int, String)'}}
+    }
+  }
+}

--- a/test/Constraints/rdar107724970.swift
+++ b/test/Constraints/rdar107724970.swift
@@ -5,12 +5,11 @@ enum E {
   case e(Int)
 }
 func foo(_ x: E) {
-  // FIXME: We need to handle pattern arguments in a bunch of places in argument
-  // list diagnostic logic.
   // https://github.com/apple/swift/issues/65062
-  let fn = { // expected-error {{unable to infer closure type without a type annotation}}
+  let fn = {
     switch x {
     case E.e(_, _):
+      // expected-error@-1 {{tuple pattern has the wrong length for tuple type 'Int'}}
       break
     }
   }


### PR DESCRIPTION
…ments

Extend `ExtraneousArgumentsFailure` to handle enum element pattern mismatches.

Resolves: rdar://123466496

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
