### PR TITLE
[Concurrency] Downgrade newly diagnosed distributed actor isolation violation as a warning until Swift 6.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3186,6 +3186,20 @@ namespace {
               /*setThrows*/ !explicitlyThrowing,
               /*isDistributedThunk=*/true);
         }
+
+        // In compiler versions <=5.10, the compiler did not diagnose cases
+        // where a non-isolated distributed actor value was passed to a VarDecl
+        // with a function type type that has an isolated distributed actor
+        // parameter, e.g. `(isolated DA) -> Void`. Stage in the error as a
+        // warning until Swift 6.
+        if (var->getTypeInContext()->getAs<FunctionType>()) {
+          ctx.Diags.diagnose(declLoc,
+                             diag::distributed_actor_isolated_non_self_reference,
+                             decl)
+            .warnUntilSwiftVersion(6);
+          noteIsolatedActorMember(decl, context);
+          return std::nullopt;
+        }
       }
 
       // FIXME: Subscript?

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -50,3 +50,16 @@ distributed actor DA {
   }
 
 }
+
+func invalidIsolatedCall<DA: DistributedActor> (
+  to actor: DA,
+  queue: AsyncStream<@Sendable (isolated DA) async -> Void>
+) {
+  Task {
+    // expected-note@+1 {{let declared here}}
+    for await closure in queue {
+      // expected-warning@+1 {{distributed actor-isolated let 'closure' can not be accessed from a non-isolated context; this is an error in Swift 6}}
+      await closure(actor)
+    }
+  }
+}


### PR DESCRIPTION
In compiler versions <=5.10, the compiler did not diagnose cases where a non-isolated distributed actor value was passed to a VarDecl with a function type type that has an isolated distributed actor parameter, e.g. `(isolated DA) -> Void`. This code is problematic because the actor value is not known to be local, so only `distributed` functions may be called on it. This change stages in the error as a warning until Swift 6.

Resolves: rdar://123536432