### PR TITLE
[Sema] Fix a syntax error when building without Swift Syntax

### DIFF
--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1034,7 +1034,7 @@ static bool checkExpressionMacroDefaultValueRestrictions(ParamDecl *param) {
       &ctx.Diags, SF->getExportedSourceFile(),
       initExpr->getLoc().getOpaquePointerValue());
 #else
-  ctx.Diags.diagnose(initExpr->getLoc(), diag::macro_unsupported));
+  ctx.Diags.diagnose(initExpr->getLoc(), diag::macro_unsupported);
   return false;
 #endif
 }


### PR DESCRIPTION
There was a mismatched brace in a build where `SWIFT_BUILD_SWIFT_SYNTAX` is `OFF`.