### PR TITLE
Fix accidental ABI break with AsyncSequence.flatMap

### DIFF
--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -40,6 +40,7 @@ extension AsyncSequence {
   /// - Returns: A single, flattened asynchronous sequence that contains all
   ///   elements in all the asynchronous sequences produced by `transform`.
   @usableFromInline
+  @preconcurrency
   __consuming func flatMap<SegmentOfResult: AsyncSequence>(
     _ transform: @Sendable @escaping (Element) async -> SegmentOfResult
   ) -> AsyncFlatMapSequence<Self, SegmentOfResult> {

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -52,7 +52,6 @@
 // UNSUPPORTED: swift_evolve
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
-Func AsyncSequence.flatMap(_:) has mangled name changing from '(extension in _Concurrency):Swift.AsyncSequence.flatMap<A where A1: Swift.AsyncSequence>((A.Element) async -> A1) -> _Concurrency.AsyncFlatMapSequence<A, A1>' to '(extension in _Concurrency):Swift.AsyncSequence.flatMap<A where A1: Swift.AsyncSequence>(@Sendable (A.Element) async -> A1) -> _Concurrency.AsyncFlatMapSequence<A, A1>'
 Func MainActor.run(resultType:body:) has generic signature change from <T where T : Swift.Sendable> to <T>
 Func MainActor.run(resultType:body:) has mangled name changing from 'static Swift.MainActor.run<A where A: Swift.Sendable>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A' to 'static Swift.MainActor.run<A>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A'
 Func _asyncLet_get(_:_:) has mangled name changing from '_Concurrency._asyncLet_get(Builtin.RawPointer, Builtin.RawPointer) async -> Builtin.RawPointer' to '_Concurrency._asyncLet_get(Builtin.RawPointer, Builtin.RawPointer) async -> ()'


### PR DESCRIPTION
At the type that I introduced type throws into AsyncSequence and its algorithms, I accidentally dropped a `@preconcurrency` on the ABI entrypoint, leading to a mangled name change.

Fixes rdar://123639030.

