### PR TITLE
[CSApply] Optional chaining forces key path component to be r-value

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5116,7 +5116,8 @@ namespace {
           !componentTy->getWithoutSpecifierType()->isEqual(leafTy)) {
         auto component = KeyPathExpr::Component::forOptionalWrap(leafTy);
         resolvedComponents.push_back(component);
-        componentTy = OptionalType::get(componentTy);
+        // Optional chaining forces the component to be r-value.
+        componentTy = OptionalType::get(componentTy->getWithoutSpecifierType());
       }
 
       // Set the resolved components, and cache their types.

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -652,3 +652,23 @@ struct Test {
   var codingPath: [any CodingKey] { codingStack.map(\.key) }
   // CHECK: keypath $KeyPath<CodingStackEntry, URICoderCodingKey>, (root $CodingStackEntry; stored_property #CodingStackEntry.key : $URICoderCodingKey)
 }
+
+// rdar://123638701 - Make sure that optional chaining forces loads.
+func test_optional_chaining_with_function_conversion() {
+  class Storage {}
+
+  class Elements {
+    var db: Storage = Storage()
+  }
+
+  class Source {
+    var elements: Elements? = nil
+  }
+
+  func test(data: [Source]) {
+    // CHECK: {{.*}} = keypath $KeyPath<Source, Optional<Storage>>
+    _ = data.compactMap(\.elements?.db)
+    // CHECK: {{.*}} = keypath $KeyPath<Source, Storage>
+    _ = data.compactMap(\.elements!.db)
+  }
+}


### PR DESCRIPTION
Key path components with optional chaining unlike other places don't propagate l-value through optionals.

Resolves: rdar://123638701

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
