### PR TITLE
Revert `-disable-target-os-checking` workaround for ASTGen/SwiftCompilerSources

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -102,7 +102,6 @@ function(add_swift_compiler_modules_library name)
       "-color-diagnostics"
       "-Xfrontend" "-validate-tbd-against-ir=none"
       "-Xfrontend" "-enable-experimental-cxx-interop"
-      "-Xfrontend" "-disable-target-os-checking"
       "-Xcc" "-std=c++17"
       "-Xcc" "-DCOMPILED_WITH_SWIFT" "-Xcc" "-DSWIFT_TARGET"
       "-Xcc" "-UIBOutlet" "-Xcc" "-UIBAction" "-Xcc" "-UIBInspectable")

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -107,9 +107,6 @@ set(compile_options
   "SHELL: ${cxx_interop_flag}"
   "SHELL: -Xcc -std=c++17 -Xcc -DCOMPILED_WITH_SWIFT"
 
-  # FIXME: Needed to work around an availability issue with CxxStdlib
-  "SHELL: -Xfrontend -disable-target-os-checking"
-
   # Necessary to avoid treating IBOutlet and IBAction as keywords
   "SHELL:-Xcc -UIBOutlet -Xcc -UIBAction -Xcc -UIBInspectable"
 

--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -31,9 +31,6 @@ let swiftSetttings: [SwiftSetting] = [
     "-Xcc", "-I../../../build/Default/swift/include",
     "-Xcc", "-I../../../build/Default/llvm/include",
     "-Xcc", "-I../../../build/Default/llvm/tools/clang/include",
-
-    // FIXME: Needed to work around an availability issue with CxxStdlib
-    "-Xfrontend", "-disable-target-os-checking",
   ]),
 ]
 


### PR DESCRIPTION
rdar://117849149
