### PR TITLE
[Explicit Module Builds] Explicit interface verification sub-invocations must always inherit `-Xcc` flags from the parent instance.

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1813,7 +1813,10 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
         clangImporterOpts.getReducedExtraArgsForSwiftModuleDependency();
     genericSubInvocation.getFrontendOptions()
         .DependencyScanningSubInvocation = true;
-  } else if (LoaderOpts.strictImplicitModuleContext) {
+  } else if (LoaderOpts.strictImplicitModuleContext ||
+             // Explicit module Interface verification jobs still spawn a sub-instance
+             // and we must ensure this sub-instance gets all of the Xcc flags.
+             LoaderOpts.disableImplicitSwiftModule) {
     // If the compiler has been asked to be strict with ensuring downstream
     // dependencies get the parent invocation's context, inherit the extra Clang
     // arguments also. Inherit any clang-specific state of the compilation

--- a/test/ScanDependencies/verify-interface-inherit-xcc.swift
+++ b/test/ScanDependencies/verify-interface-inherit-xcc.swift
@@ -1,0 +1,28 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/inputs)
+// RUN: %target-swift-emit-pcm -module-name SwiftShims %swift-lib-dir/swift/shims/module.modulemap -o %t/inputs/SwiftShims.pcm -Xcc -fobjc-disable-direct-methods-for-testing
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftShims\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%swift-lib-dir/swift/shims/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModulePath\": \"%t/inputs/SwiftShims.pcm\"" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: split-file %s %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/inputs/Foo.swiftinterface) -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -disable-implicit-swift-modules -explicit-swift-module-map-file %t/inputs/map.json -explicit-interface-module-build -Xcc -fobjc-disable-direct-methods-for-testing
+
+//--- inputs/Foo.swiftinterface
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name Foo
+public func foo() {}


### PR DESCRIPTION
Otherwise they may be unable to use the explicit module dependencies which were built in the same driver invocation using those `-Xcc` flags.

Resolves rdar://123648621