### PR TITLE
Fix a use-after-free in `getPackageInterfacePathIfInSamePackage`

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -611,7 +611,7 @@ SerializedModuleBaseName::getPackageInterfacePathIfInSamePackage(
 
   if (fs.exists(packagePath)) {
     // Read the interface file and extract its package-name argument value
-    StringRef result;
+    std::string result;
     if (auto packageFile = llvm::MemoryBuffer::getFile(packagePath)) {
       llvm::BumpPtrAllocator alloc;
       llvm::StringSaver argSaver(alloc);


### PR DESCRIPTION
Fix a use-after-free bug in package-name extraction code, where the BumpPtrAllcoator is destroyed before a StringRef that uses the allocated name is used.
