### PR TITLE
MoveOnlyAddressChecker: Treat opaque accesses consistently in CopiedLoadBorrowEliminationVisitor.

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1726,8 +1726,7 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
           // Begin a new binding scope, which is popped when the next innermost debug
           // scope ends. The cleanup location loc isn't the perfect source location
           // but it's close enough.
-          B.getSILGenFunction().enterDebugScope(loc,
-                                                      /*isBindingScope=*/true);
+          B.getSILGenFunction().enterDebugScope(loc, /*isBindingScope=*/true);
         InitializationPtr initialization =
           emitPatternBindingInitialization(elt.getPattern(), FalseDest);
 

--- a/test/SILOptimizer/moveonly_borrowing_switch_load_borrow.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_load_borrow.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -emit-sil -verify %s
+
+struct Box<Wrapped: ~Copyable>: ~Copyable {
+    init(_ element: consuming Wrapped) { }
+}
+
+struct Tree<Element>: ~Copyable {
+    struct Node: ~Copyable { }
+    
+    enum Branch: ~Copyable {
+        case empty
+        case more(Box<Node>)
+    }
+    var root: Branch = .empty
+}
+
+extension Tree {
+    mutating func insert(_ element: consuming Element) {
+        root =
+            switch root {
+            case .empty:
+                    .more(Box(Node()))
+            case .more:
+                fatalError()
+            }
+    }
+}


### PR DESCRIPTION
Don't prepare loads from inside an opaque access that the checker isn't going to visit. Fixes rdar://123601728.
