### PR TITLE
[Concurrency] Add an API in the Concurrency library for extracting isolation from a dynamically isolated function value.

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/ForwardingInstruction.swift
@@ -347,6 +347,13 @@ extension DestructureStructInst : ForwardingInstruction {
   public var canForwardOwnedValues: Bool { true }
 }
 
+extension FunctionExtractIsolationInst : ForwardingInstruction {
+  public var preservesIdentity: Bool { false }
+  public var preservesRepresentation: Bool { true }
+  public var canForwardGuaranteedValues: Bool { true }
+  public var canForwardOwnedValues: Bool { false }
+}
+
 extension InitExistentialRefInst : ForwardingInstruction {
   public var preservesIdentity: Bool { false }
   public var preservesRepresentation: Bool { true }

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -290,7 +290,7 @@ EXPERIMENTAL_FEATURE(DynamicActorIsolation, false)
 EXPERIMENTAL_FEATURE(BorrowingSwitch, true)
 
 // Enable isolated(any) attribute on function types.
-EXPERIMENTAL_FEATURE(IsolatedAny, false)
+EXPERIMENTAL_FEATURE(IsolatedAny, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Mandatory/OwnershipModelEliminator.cpp
@@ -219,6 +219,7 @@ struct OwnershipModelEliminatorVisitor
   HANDLE_FORWARDING_INST(LinearFunctionExtract)
   HANDLE_FORWARDING_INST(DifferentiableFunctionExtract)
   HANDLE_FORWARDING_INST(MarkUninitialized)
+  HANDLE_FORWARDING_INST(FunctionExtractIsolation)
 #undef HANDLE_FORWARDING_INST
 };
 

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -196,6 +196,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   FORWARDING_INST(LinearFunction)
   FORWARDING_INST(DifferentiableFunctionExtract)
   FORWARDING_INST(LinearFunctionExtract)
+  FORWARDING_INST(FunctionExtractIsolation)
 #undef FORWARDING_INST
 
   bool processWorklist();

--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -85,3 +85,11 @@ internal func _enqueueOnMain(_ job: UnownedJob)
 public macro isolation<T>() -> T = Builtin.IsolationMacro
 #endif
 
+#if $IsolatedAny
+@available(SwiftStdlib 5.1, *)
+public func extractIsolation<each Arg, Result>(
+  _ fn: @escaping @isolated(any) (repeat each Arg) async throws -> Result
+) -> (any Actor)? {
+  return Builtin.extractFunctionIsolation(fn)
+}
+#endif

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -60,6 +60,10 @@ else()
   list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS "-fswift-async-fp=never")
 endif()
 
+list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
+  "-enable-experimental-feature"
+  "IsolatedAny"
+)
 
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS
   "-D__STDC_WANT_LIB_EXT1__=1")

--- a/test/Concurrency/isolated_any.swift
+++ b/test/Concurrency/isolated_any.swift
@@ -7,6 +7,9 @@ func globalNonisolatedFunction() {}
 
 actor A {
   func actorFunction() {}
+  func asyncActorFunction() async {}
+  func asyncThrowsActorFunction() async throws {}
+  func actorFunctionWithArgs(value: Int) async -> String { "" }
 }
 
 func testBasic_sync() {
@@ -70,4 +73,13 @@ func requireSendableGlobalActor(_ fn: @Sendable @MainActor () -> ()) {}
 func testConvertIsolatedAnyToMainActor(fn: @Sendable @isolated(any) () -> ()) {
   // expected-error @+1 {{cannot convert value of type '@isolated(any) @Sendable () -> ()' to expected argument type '@MainActor @Sendable () -> ()'}}
   requireSendableGlobalActor(fn)
+}
+
+func extractFunctionIsolation(_ fn: @isolated(any) @escaping () async -> Void) {
+  let _: (any Actor)? = extractIsolation(fn)
+
+  let myActor = A()
+  let _: (any Actor)? = extractIsolation(myActor.asyncActorFunction)
+  let _: (any Actor)? = extractIsolation(myActor.asyncThrowsActorFunction)
+  let _: (any Actor)? = extractIsolation(myActor.actorFunctionWithArgs(value:))
 }


### PR DESCRIPTION
Extracting the isolation value from a function whose type is `@isolated(any)` needs a surface syntax. There's already a builtin, so for now I've exposed this with the following function in the Concurrency library, copied from the _Concurrency swiftinterface in my local build to demonstrate availability and compiler feature guards:

```swift
#if compiler(>=5.3) && $ParameterPacks && $IsolatedAny
@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
public func extractIsolation<each Arg, Result>(_ fn: @escaping @isolated(any) (repeat each Arg) async throws -> Result) -> (any _Concurrency.Actor)?
#endif
```

Note that I needed to fix a few small issues in the mandatory SILOptimizer passes, as this change introduces the first use of `Builtin.extractFunctionIsolation` / `FunctionExtractIsolationInst`.