### PR TITLE
SILGen: Borrow any move-only or borrow-expr'ed accessor base.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3734,12 +3734,6 @@ static bool shouldEmitSelfAsRValue(AccessorDecl *fn, CanType selfType,
     return false;
   case SelfAccessKind::Borrowing:
   case SelfAccessKind::NonMutating:
-    // If the accessor is a coroutine, we may want to access the projected
-    // value through a borrow of the base. But if it's a regular get/set then
-    // there isn't any real benefit to doing so.
-    if (!fn->isCoroutine()) {
-      return true;
-    }
     // Normally we'll copy the base to minimize accesses. But if the base
     // is noncopyable, or we're accessing it in a `borrow` expression, then
     // we want to keep the access nested on the original base.

--- a/test/SILOptimizer/moveonly_borrowing_switch.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch.swift
@@ -342,3 +342,10 @@ extension ChonkyList {
         }
     }
 }
+
+// https://github.com/apple/swift/issues/71598
+struct RangeHolder:~Copyable
+{
+    var r:Range<Int> { fatalError() }
+    var y:Int { self.r.upperBound }
+}


### PR DESCRIPTION
Following up from #71795, we must borrow the base of any non-copyable `borrowing`/`nonmutating` accessor, and we want to borrow the base of any accessor appearing in a `borrow` expr. Fixes #71606.