### PR TITLE
[Test] Add another C++ stdlib symbol to the Linux symbol visibility test

### DIFF
--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -508,6 +508,7 @@
 // RUN:             -e _ZNSt10_HashtableImSt4pairIKmSt8optionalINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEESaISA_ENSt8__detail10_Select1stESt8equal_toImESt4hashImENSC_18_Mod_range_hashingENSC_20_Default_ranged_hashENSC_20_Prime_rehash_policyENSC_17_Hashtable_traitsILb0ELb0ELb1EEEE13_M_rehash_auxEmSt17integral_constantIbLb1EE \
 // RUN:             -e _ZNSt6vectorISt8optionalISt4pairINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEbEESaIS9_EE17_M_realloc_insertIJRKS9_EEEvN9__gnu_cxx17__normal_iteratorIPS9_SB_EEDpOT_ \
 // RUN:             -e _ZSt7nullopt \
+// RUN:             -e _ZNSt6vectorISt8optionalISt4pairISsbEESaIS3_EE17_M_realloc_insertIJRKS3_EEEvN9__gnu_cxx17__normal_iteratorIPS3_S5_EEDpOT_ \
 // RUN:   > %t/swiftRemoteMirror-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftRemoteMirror) > %t/swiftRemoteMirror-no-weak.txt
 // RUN: diff -u %t/swiftRemoteMirror-all.txt %t/swiftRemoteMirror-no-weak.txt


### PR DESCRIPTION
`_ZNSt6vectorISt8optionalISt4pairISsbEESaIS3_EE17_M_realloc_insertIJRKS3_EEEvN9__gnu_cxx17__normal_iteratorIPS3_S5_EEDpOT_`

```
void std::vector<std::optional<std::pair<std::string, bool> >, std::allocator<std::optional<std::pair<std::string, bool> > > >::_M_realloc_insert<std::optional<std::pair<std::string, bool> > const&>(__gnu_cxx::__normal_iterator<std::optional<std::pair<std::string, bool> >*, std::vector<std::optional<std::pair<std::string, bool> >, std::allocator<std::optional<std::pair<std::string, bool> > > > >, std::optional<std::pair<std::string, bool> > const&)
```