### PR TITLE
FlattenSequence/distance(from:to:) untrapping Int.min

### DIFF
--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -289,12 +289,12 @@ extension FlattenCollection: Collection {
 
   @inlinable // lazy-performance
   public func distance(from start: Index, to end: Index) -> Int {
-    let minus = start > end
+    let distanceIsNegative = start > end
     
     // The following check ensures that distance(from:to:) is invoked on
     // the _base at least once, to trigger a _precondition in forward only
     // collections.
-    if minus {
+    if distanceIsNegative {
       _ = _base.distance(from: _base.endIndex, to: _base.startIndex)
     }
     
@@ -310,20 +310,20 @@ extension FlattenCollection: Collection {
     let lowerBound: Index
     let upperBound: Index
     
-    if minus {
+    if distanceIsNegative {
+      step = -1
       lowerBound = end
       upperBound = start
-      step = -1
     } else {
+      step = 01
       lowerBound = start
       upperBound = end
-      step = 01
     }
-        
+    
     // This always unwraps because start._outer != end._outer.
     if let inner = lowerBound._inner {
       let collection = _base[lowerBound._outer]
-      distance += minus
+      distance += distanceIsNegative
       ? collection.distance(from: collection.endIndex, to: inner)
       : collection.distance(from: inner, to: collection.endIndex)
     }
@@ -341,7 +341,7 @@ extension FlattenCollection: Collection {
     /// This unwraps if start != endIndex and end != endIndex.
     if let inner = upperBound._inner {
       let collection = _base[upperBound._outer]
-      distance += minus
+      distance += distanceIsNegative
       ? collection.distance(from: inner, to: collection.startIndex)
       : collection.distance(from: collection.startIndex, to: inner)
     }

--- a/test/stdlib/FlattenDistanceFromTo.swift
+++ b/test/stdlib/FlattenDistanceFromTo.swift
@@ -1,0 +1,144 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// RUN: %target-run-simple-swift(-parse-as-library)
+// REQUIRES: executable_test
+// REQUIRES: reflection
+// UNSUPPORTED: use_os_stdlib
+// END.
+//
+//===----------------------------------------------------------------------===//
+
+import StdlibUnittest
+
+@main
+final class FlattenDistanceFromToTests {
+
+  static func main() {
+    let tests = FlattenDistanceFromToTests()
+    let suite = TestSuite("FlattenDistanceFromToTests")
+    suite.test("EachIndexPair", tests.testEachIndexPair)
+    runAllTests()
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: - Each Index Pair
+//===----------------------------------------------------------------------===//
+
+extension FlattenDistanceFromToTests {
+  
+  /// Performs one `action` per lane size case through `limits`.
+  ///
+  ///     limits: [0,1,2,3]
+  ///     ─────────────────
+  ///     [][ ][   ][     ]
+  ///     [][1][   ][     ]
+  ///     [][ ][2  ][     ]
+  ///     [][1][   ][     ]
+  ///     [][ ][2,2][     ]
+  ///     [][1][2,2][     ]
+  ///     [][ ][   ][3    ]
+  ///     ─────────────────
+  ///     [][1][2,2][3,3,3]
+  ///
+  func forEachLaneSizeCase(
+    through limits: [Int],
+    perform action: ([[Int]]) -> Void
+  ) {
+    var array = Array(repeating: [Int](), count: limits.count)
+    var index = array.startIndex
+    while index < limits.endIndex {
+      action(array)
+      
+      if array[index].count < limits[index] {
+        array[index].append(index)
+        continue
+      }
+      
+      while index < limits.endIndex, array[index].count == limits[index] {
+        array.formIndex(after: &index)
+      }
+      
+      if index < limits.endIndex {
+        array[index].append(index)
+        
+        while index > array.startIndex {
+          array.formIndex(before: &index)
+          array[index].removeAll(keepingCapacity: true)
+        }
+      }
+    }
+  }
+  
+  /// Performs one `action` per offset-index pair in `collection`.
+  ///
+  ///     collection: [[0],[1,2]].joined()
+  ///     ────────────────────────────────
+  ///     offset: 0, index: 0,0
+  ///     offset: 1, index: 1,0
+  ///     offset: 2, index: 1,1
+  ///     offset: 3, index: 2
+  ///
+  func forEachEnumeratedIndexIncludingEndIndex<T: Collection>(
+    in collection: T,
+    perform action: ((offset: Int, index: T.Index)) -> Void
+  ) {
+    var state = (offset: 0, index: collection.startIndex)
+    while true {
+      action(state)
+      
+      if state.index == collection.endIndex {
+        return
+      }
+      
+      state.offset += 1
+      collection.formIndex(after: &state.index)
+    }
+  }
+  
+  /// Checks the distance between each index pair in various cases.
+  ///
+  /// You need three lanes to exercise the first, the middle, the last region.
+  /// The past-the-end index is a separate lane, so the middle region contains
+  /// one additional lane when the past-the-end index is selected.
+  ///
+  func testEachIndexPair() {
+    var invocations = 0 as Int
+    
+    for lanes in 0 ... 3 {
+      let limits = Array(repeating: 3, count: lanes)
+      
+      forEachLaneSizeCase(through: limits) { base in
+        let collection: FlattenSequence = base.joined()
+        
+        forEachEnumeratedIndexIncludingEndIndex(in: collection) { start in
+          forEachEnumeratedIndexIncludingEndIndex(in: collection) { end in
+            let pair = (from: start.offset, to: end.offset)
+            
+            invocations += 1
+            
+            expectEqual(
+              collection.distance(from: start.index, to: end.index),
+              end.offset - start.offset,
+              """
+              index distance != offset distance for \(pair) in \(base).joined()
+              """
+            )
+          }
+        }
+      }
+    }
+    
+    expectEqual(invocations, 2502, "unexpected workload")
+  }
+}

--- a/test/stdlib/FlattenDistanceFromTo.swift
+++ b/test/stdlib/FlattenDistanceFromTo.swift
@@ -12,8 +12,6 @@
 //
 // RUN: %target-run-simple-swift(-parse-as-library)
 // REQUIRES: executable_test
-// REQUIRES: reflection
-// UNSUPPORTED: use_os_stdlib
 // END.
 //
 //===----------------------------------------------------------------------===//
@@ -27,6 +25,7 @@ final class FlattenDistanceFromToTests {
     let tests = FlattenDistanceFromToTests()
     let suite = TestSuite("FlattenDistanceFromToTests")
     suite.test("EachIndexPair", tests.testEachIndexPair)
+    suite.test("MinMaxOutputs", tests.testMinMaxOutputs)
     runAllTests()
   }
 }
@@ -140,5 +139,36 @@ extension FlattenDistanceFromToTests {
     }
     
     expectEqual(invocations, 2502, "unexpected workload")
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// MARK: - Min Max Outputs
+//===----------------------------------------------------------------------===//
+
+extension FlattenDistanceFromToTests {
+  
+  /// Checks some `Int.min` and `Int.max` distances.
+  ///
+  /// - Note: A distance of `Int.min` requires more than `Int.max` elements.
+  ///
+  func testMinMaxOutputs() {
+    for s: FlattenSequence in [
+      
+      [-1..<Int.max/1],
+      [00..<Int.max/1, 00..<000000001],
+      [00..<000000001, 01..<Int.max/1, 00..<000000001],
+      [00..<000000001, 00..<Int.max/2, 00..<Int.max/2, 00..<000000001]
+      
+    ].map({ $0.joined() }) {
+      
+      let a = s.startIndex, b = s.endIndex
+      
+      expectEqual(Int.min, s.distance(from: b, to: s.index(a, offsetBy: 00)))
+      expectEqual(Int.max, s.distance(from: s.index(a, offsetBy: 01), to: b))
+      
+      expectEqual(Int.min, s.distance(from: s.index(b, offsetBy: 00), to: a))
+      expectEqual(Int.max, s.distance(from: a, to: s.index(b, offsetBy: -1)))
+    }
   }
 }


### PR DESCRIPTION
This patch makes it so FlattenSequence/distance(from:to:) can return `Int.min` without trapping. The (#71648) version traps `Int.min` because `0...Int.max ~= count`. I have double-checked, however, and Range/distance(from:to:) (etc.) can return `Int.min` without trapping:

```swift
(Int.min ..< Int.max).distance(from: 0, to: Int.min) // Int.min
```

I don't believe there are stdlib tests for this, as those would have been too slow before, but perhaps I could add some. But, I haven't yet had time to look at `StdlibUnittest`.