### PR TITLE
Create mark_dependence for array allocation in OSLogOptimization

### DIFF
--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -529,6 +529,8 @@ static SILValue emitCodeForConstantArray(ArrayRef<SILValue> elements,
       builder.createDestructureTuple(loc, applyInst);
   SILValue arraySIL = destructureInst->getResults()[0];
   SILValue storagePointerSIL = destructureInst->getResults()[1];
+  storagePointerSIL = builder.createMarkDependence(
+      loc, storagePointerSIL, arraySIL, MarkDependenceKind::Escaping);
 
   if (elements.empty()) {
     // Nothing more to be done if we are creating an empty array.

--- a/test/SILOptimizer/OSLogMandatoryOptTest.sil
+++ b/test/SILOptimizer/OSLogMandatoryOptTest.sil
@@ -407,7 +407,8 @@ bb0:
     // CHECK: [[ALLOCATORREF:%[0-9]+]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
     // CHECK: [[TUPLE:%[0-9]+]] = apply [[ALLOCATORREF]]<Int64>([[NUMELEMS]])
     // CHECK: ([[ARRAY:%[0-9]+]], [[STORAGEPTR:%[0-9]+]]) = destructure_tuple [[TUPLE]]
-    // CHECK: [[STORAGEADDR:%[0-9]+]] = pointer_to_address [[STORAGEPTR]] : $Builtin.RawPointer to [strict] $*Int64
+    // CHECK: [[MDI:%.*]] = mark_dependence [[STORAGEPTR]] : $Builtin.RawPointer on [[ARRAY]] : $Array<Int64>
+    // CHECK: [[STORAGEADDR:%[0-9]+]] = pointer_to_address [[MDI]] : $Builtin.RawPointer to [strict] $*Int64
     // CHECK: store [[ELEM1INT]] to [trivial] [[STORAGEADDR]] : $*Int64
     // CHECK: [[INDEX1:%[0-9]+]] = integer_literal $Builtin.Word, 1
     // CHECK: [[INDEXADDR1:%[0-9]+]] = index_addr [[STORAGEADDR]] : $*Int64, [[INDEX1]] : $Builtin.Word
@@ -539,7 +540,8 @@ bb0:
     // CHECK: [[ALLOCATORREF:%[0-9]+]] = function_ref @$ss27_allocateUninitializedArrayySayxG_BptBwlF
     // CHECK: [[TUPLE:%[0-9]+]] = apply [[ALLOCATORREF]]<String>([[NUMELEMS]])
     // CHECK: ([[ARRAY:%[0-9]+]], [[STORAGEPTR:%[0-9]+]]) = destructure_tuple [[TUPLE]]
-    // CHECK: [[STORAGEADDR:%[0-9]+]] = pointer_to_address [[STORAGEPTR]] : $Builtin.RawPointer to [strict] $*String
+    // CHECK: [[MDI:%.*]] = mark_dependence [[STORAGEPTR]] : $Builtin.RawPointer on [[ARRAY]] : $Array<String>
+    // CHECK: [[STORAGEADDR:%[0-9]+]] = pointer_to_address [[MDI]] : $Builtin.RawPointer to [strict] $*String
     // CHECK: store [[STRINGCONST]] to [init] [[STORAGEADDR]] : $*String
     // CHECK: [[FINALIZEREF:%[0-9]+]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
     // CHECK: [[FINALIZED:%[0-9]+]] = apply [[FINALIZEREF]]<String>([[ARRAY]])


### PR DESCRIPTION
With #70242 mark_dependence was added while emitting uninitialized array allocation between the unsafe pointer and the array value returned. Without it, we can end up with use after free of the unsafe pointer if the array's lifetime is shortened. Along with this change, pattern matching of all array optimizations was updated to include mark_dependence.

This change adds mark_dependence for uninitialized array allocation in OSLogOptimization which was left out previously. With this, potential use-after-free of the unsafe pointer is prevented and all updated array optimizations apply to the array created by OSLogOptimization.

Fixes rdar://122922902
