### PR TITLE
Revert "[Debugging] Use SWIFT_NATIVE_SWIFT_TOOLS_PATH if defined"

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -315,16 +315,8 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Freestand
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Extern")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BitwiseCopyable")
 
-if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
-  set(swift_bin_dir "${CMAKE_BINARY_DIR}/bin")
-  set(swift_lib_dir "${CMAKE_BINARY_DIR}/lib")
-else()
-  set(swift_bin_dir "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}")
-  set(swift_lib_dir "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/../lib")
-endif()
-
 list(APPEND swift_stdlib_compile_flags "-external-plugin-path"
-  "${swift_lib_dir}/swift/host/plugins#${swift_bin_dir}/swift-plugin-server")
+  "${CMAKE_BINARY_DIR}/lib/swift/host/plugins#${CMAKE_BINARY_DIR}/bin/swift-plugin-server")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "SymbolLinkageMarkers")
 
 set(swift_core_incorporate_object_libraries)

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -845,10 +845,10 @@ test-installable-package
 toolchain-benchmarks
 
 # Path to the root of the installation filesystem.
-install-destdir=%(install_destdir)s
+install-destdir=/home/build-user/swift-nightly-install
 
 # Path to the .tar.gz package we would create.
-installable-package=%(installable_package)s
+installable-package=/home/build-user/swift-DEVELOPMENT-SNAPSHOT-2024-02-27-a-amazonlinux2.tar.gz
 
 # This ensures the default module cache
 # location is local to this run, allowing
@@ -911,21 +911,21 @@ no-assertions
 
 
 [preset: mixin_buildbot_linux,no_test]
-skip-test-cmark
-skip-test-lldb
-skip-test-swift
-skip-test-llbuild
-skip-test-swiftpm
-skip-test-swift-driver
-skip-test-xctest
-skip-test-foundation
-skip-test-libdispatch
-skip-test-playgroundsupport
-skip-test-libicu
-skip-test-indexstore-db
-skip-test-sourcekit-lsp
-skip-test-swiftdocc
-skip-test-wasm-stdlib
+; skip-test-cmark
+; skip-test-lldb
+; skip-test-swift
+; skip-test-llbuild
+; skip-test-swiftpm
+; skip-test-swift-driver
+; skip-test-xctest
+; skip-test-foundation
+; skip-test-libdispatch
+; skip-test-playgroundsupport
+; skip-test-libicu
+; skip-test-indexstore-db
+; skip-test-sourcekit-lsp
+; skip-test-swiftdocc
+; skip-test-wasm-stdlib
 
 # Linux package with out test
 [preset: buildbot_linux,no_test]


### PR DESCRIPTION
Reverts apple/swift#71814

https://ci.swift.org/job/oss-swift-package-amazon-linux-2/2845/console started failing with the following error. 

```
multiprocessing.pool.MaybeEncodingError: Error sending result: '<lit.Test.Test object at 0x7fd526e8be10>'. Reason: 'OverflowError('cannot serialize a string larger than 4GiB')'
```

PRs since the last successful run were: 
- https://github.com/apple/swift/pull/71814
- https://github.com/apple/swift/pull/71846
- https://github.com/apple/swift/pull/71293
- https://github.com/apple/swift-tools-support-core/pull/470

Let’s see if reverting this one fixes the issue.