### PR TITLE
Revert "[Runtime] Don't use `<sys/errno.h>`."

### DIFF
--- a/stdlib/public/CommandLineSupport/CommandLine.cpp
+++ b/stdlib/public/CommandLineSupport/CommandLine.cpp
@@ -24,7 +24,11 @@
 #include <cstring>
 #include <string>
 
+#if __has_include(<sys/errno.h>)
+#include <sys/errno.h>
+#else
 #include <errno.h>
+#endif
 
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Win32.h"

--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -26,7 +26,11 @@
 #define NOMINMAX
 #include <windows.h>
 #else // defined(_WIN32)
+#if __has_include(<sys/errno.h>)
+#include <sys/errno.h>
+#else
 #include <errno.h>
+#endif
 #if __has_include(<sys/resource.h>)
 #include <sys/resource.h>
 #endif

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -845,10 +845,10 @@ test-installable-package
 toolchain-benchmarks
 
 # Path to the root of the installation filesystem.
-install-destdir=%(install_destdir)s
+install-destdir=/home/build-user/swift-nightly-install
 
 # Path to the .tar.gz package we would create.
-installable-package=%(installable_package)s
+installable-package=/home/build-user/swift-DEVELOPMENT-SNAPSHOT-2024-02-27-a-amazonlinux2.tar.gz
 
 # This ensures the default module cache
 # location is local to this run, allowing
@@ -911,21 +911,21 @@ no-assertions
 
 
 [preset: mixin_buildbot_linux,no_test]
-skip-test-cmark
-skip-test-lldb
-skip-test-swift
-skip-test-llbuild
-skip-test-swiftpm
-skip-test-swift-driver
-skip-test-xctest
-skip-test-foundation
-skip-test-libdispatch
-skip-test-playgroundsupport
-skip-test-libicu
-skip-test-indexstore-db
-skip-test-sourcekit-lsp
-skip-test-swiftdocc
-skip-test-wasm-stdlib
+; skip-test-cmark
+; skip-test-lldb
+; skip-test-swift
+; skip-test-llbuild
+; skip-test-swiftpm
+; skip-test-swift-driver
+; skip-test-xctest
+; skip-test-foundation
+; skip-test-libdispatch
+; skip-test-playgroundsupport
+; skip-test-libicu
+; skip-test-indexstore-db
+; skip-test-sourcekit-lsp
+; skip-test-swiftdocc
+; skip-test-wasm-stdlib
 
 # Linux package with out test
 [preset: buildbot_linux,no_test]


### PR DESCRIPTION
Reverts apple/swift#71846

https://ci.swift.org/job/oss-swift-package-amazon-linux-2/2845/console started failing with the following error. 

```
multiprocessing.pool.MaybeEncodingError: Error sending result: '<lit.Test.Test object at 0x7fd526e8be10>'. Reason: 'OverflowError('cannot serialize a string larger than 4GiB')'
```

PRs since the last successful run were: 
- https://github.com/apple/swift/pull/71814
- https://github.com/apple/swift/pull/71846
- https://github.com/apple/swift/pull/71293
- https://github.com/apple/swift-tools-support-core/pull/470

Let’s see if reverting this one fixes the issue.