### PR TITLE
Don't infer empty availability attributes

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -109,6 +109,12 @@ static AvailableAttr *createAvailableAttr(PlatformKind Platform,
                                           StringRef Rename,
                                           ValueDecl *RenameDecl,
                                           ASTContext &Context) {
+  // If there is no information that would go into the availability attribute,
+  // don't create one.
+  if (!Inferred.Introduced && !Inferred.Deprecated && !Inferred.Obsoleted &&
+      Message.empty() && Rename.empty() && !RenameDecl)
+    return nullptr;
+
   llvm::VersionTuple Introduced =
       Inferred.Introduced.value_or(llvm::VersionTuple());
   llvm::VersionTuple Deprecated =
@@ -189,7 +195,8 @@ void AvailabilityInference::applyInferredAvailableAttrs(
     auto *Attr = createAvailableAttr(Pair.first, Pair.second, Message,
                                      Rename, RenameDecl, Context);
 
-    Attrs.add(Attr);
+    if (Attr)
+      Attrs.add(Attr);
   }
 }
 

--- a/test/ModuleInterface/Inputs/assoc_type_inference_tvos/assoc.h
+++ b/test/ModuleInterface/Inputs/assoc_type_inference_tvos/assoc.h
@@ -1,0 +1,3 @@
+__attribute__((availability(ios,introduced=2.0)))
+@interface TheColor
+@end

--- a/test/ModuleInterface/Inputs/assoc_type_inference_tvos/module.modulemap
+++ b/test/ModuleInterface/Inputs/assoc_type_inference_tvos/module.modulemap
@@ -1,0 +1,3 @@
+module CAssoc {
+  header "assoc.h"
+}

--- a/test/ModuleInterface/assoc_type_inference_tvos.swift
+++ b/test/ModuleInterface/assoc_type_inference_tvos.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// RUN: %target-swift-emit-module-interface(%t/assoc_type_inference_tvos.swiftinterface) %s %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/assoc_type_inference_tvos
+// RUN: %FileCheck --input-file %t/assoc_type_inference_tvos.swiftinterface %s
+// RUN: %target-swift-typecheck-module-from-interface(%t/assoc_type_inference_tvos.swiftinterface) %clang-importer-sdk -F %clang-importer-sdk-path/frameworks -I %S/Inputs/assoc_type_inference_tvos
+
+// REQUIRES: objc_interop
+
+import CAssoc
+
+extension TheColor {
+  // This checks for the absence of an @available(tvOS) on an associated type
+  // that is inferred to have tvOS availability based on its enclosing type
+  // having iOS availability that predates the introduction of tvOS.
+
+  // CHECK: public init?(rawValue: Swift.String)
+  // CHECK-NOT: @available(tvOS
+  // CHECK: public typealias RawValue = Swift.String
+  public enum StaticNamedColor: String {
+    case black
+  }
+}


### PR DESCRIPTION
Due to the mapping of iOS platform availability to tvOS platform availability, we were ending up inferring an availability attribute `@available(tvOS)` for an associated type, which does not parse properly. Suppress the creation of inferred availability attributes when they convey no information (e.g., because they have no introduced/deprecated/obsoleted/etc. in them).

Fixes rdar://123545422.
