### PR TITLE
[test] Add extractIsolation to concurrency ABI

### DIFF
--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -264,6 +264,9 @@ Added: _$ss32AsyncThrowingPrefixWhileSequenceV8IteratorV4next9isolation7ElementQ
 // async function pointer to Swift.AsyncThrowingPrefixWhileSequence.Iterator.next(isolation: isolated Swift.Actor?) async throws -> A.Element?
 Added: _$ss32AsyncThrowingPrefixWhileSequenceV8IteratorV4next9isolation7ElementQzSgScA_pSgYi_tYaKFTu
 
+// Swift.extractIsolation<each A, B>(@isolated(any) (repeat A) async throws -> B) -> Swift.Actor?
+Added: _$ss16extractIsolationyScA_pSgq_xxQpYaKYAcRvzr0_lF
+
 Added: _swift_job_run_on_serial_and_task_executor
 Added: _swift_job_run_on_task_executor
 Added: _swift_task_getPreferredTaskExecutor

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -264,6 +264,9 @@ Added: _$ss32AsyncThrowingPrefixWhileSequenceV8IteratorV4next9isolation7ElementQ
 // async function pointer to Swift.AsyncThrowingPrefixWhileSequence.Iterator.next(isolation: isolated Swift.Actor?) async throws -> A.Element?
 Added: _$ss32AsyncThrowingPrefixWhileSequenceV8IteratorV4next9isolation7ElementQzSgScA_pSgYi_tYaKFTu
 
+// Swift.extractIsolation<each A, B>(@isolated(any) (repeat A) async throws -> B) -> Swift.Actor?
+Added: _$ss16extractIsolationyScA_pSgq_xxQpYaKYAcRvzr0_lF
+
 Added: _swift_job_run_on_serial_and_task_executor
 Added: _swift_job_run_on_task_executor
 Added: _swift_task_getPreferredTaskExecutor


### PR DESCRIPTION
This was recently introduced in https://github.com/apple/swift/pull/71906, but it raced with the addition of the concurrency ABI test.