### PR TITLE
[Runtime] Don't shrink class InstanceStart when initing field offset vectors.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3514,9 +3514,14 @@ static void initClassFieldOffsetVector(ClassMetadata *self,
   //
   // The rodata may be in read-only memory if the compiler knows that the size
   // it generates is already definitely correct. Don't write to this value
-  // unless it's necessary.
-  if (rodata->InstanceStart != size)
+  // unless it's necessary. We'll grow the space for the superclass if needed,
+  // but not shrink it, as the compiler may write an unaligned size that's less
+  // than our aligned InstanceStart.
+  if (rodata->InstanceStart < size)
     rodata->InstanceStart = size;
+  else
+    size = rodata->InstanceStart;
+
 #endif
 
   // Okay, now do layout.

--- a/test/Runtime/subclass_instance_start_adjustment.swift
+++ b/test/Runtime/subclass_instance_start_adjustment.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/subclass_instance_start_adjustment
+// RUN: %target-codesign %t/subclass_instance_start_adjustment
+// RUN: %target-run %t/subclass_instance_start_adjustment | %FileCheck %s
+
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// Make sure we get the InstanceStart adjustment right for concrete subclasses
+// of generic classes with different sizes, and especially with an unaligned
+// size.
+
+class GenericSuperclassWithAlignedSize<T> {
+  var field = 42
+}
+
+class SubclassOfGenericSuperclassWithAlignedSize: GenericSuperclassWithAlignedSize<Int> {
+  var subfield = 43
+}
+
+do {
+  let obj = SubclassOfGenericSuperclassWithAlignedSize()
+  print(obj, obj.field, obj.subfield)
+  // CHECK: SubclassOfGenericSuperclassWithAlignedSize 42 43
+}
+
+class GenericSuperclassWithMisalignedSize<T> {
+  var field = true
+}
+
+class SubclassOfGenericSuperclassWithMisalignedSize: GenericSuperclassWithMisalignedSize<Int> {
+  var subfield = 44
+}
+
+do {
+  let obj = SubclassOfGenericSuperclassWithMisalignedSize()
+  print(obj, obj.field, obj.subfield)
+  // CHECK: SubclassOfGenericSuperclassWithMisalignedSize true 44
+}
+
+#if canImport(Foundation)
+import Foundation
+
+class GenericSuperclassWithURLField<T> {
+  var field: URL?
+}
+
+class SubclassOfGenericSuperclassWithURLField: GenericSuperclassWithURLField<Int> {
+  var subfield = 45
+}
+
+do {
+  let obj = SubclassOfGenericSuperclassWithURLField()
+  print(obj, obj.field as Any, obj.subfield)
+  // CHECK: SubclassOfGenericSuperclassWithURLField nil 45
+}
+#else
+// Simulate the expected output.
+print("SubclassOfGenericSuperclassWithURLField nil 45")
+#endif


### PR DESCRIPTION
When ObjC interop is enabled, we emit what we think will be the class's InstanceStart and InstanceSize based on what we know about the superclass. We then fix up those values at runtime if they don't match. The compiler will emit this data into read-only memory if it knows they will always match, and then the runtime avoids writing to these fields if they already contain the correct value.

However, the compiler aligns the InstanceStart, but instance size is not aligned. For example:

```
class Super<T> { var bool = true }
class Sub: Super<Int> { var obj: AnyObject? }
```

Super's InstanceSize is 17 (on 64-bit) but Sub's InstanceStart is 24. The compiler sees a fixed layout and emits Sub's rodata into constant memory. The runtime sees that 24 does not equal 17 and tries to update it, but we don't want it to.

Instead, only update InstanceStart if it's too small to accommodate the superclass's InstanceSize. If it's overlay large then we'll just leave it alone. The compiler underestimates InstanceStart when it doesn't know the superclass's size so this should only happen due to alignment.

rdar://123695998