### PR TITLE
RemoteInspection: clean up CMakeLists.txt slightly (NFC)

### DIFF
--- a/stdlib/public/RemoteInspection/CMakeLists.txt
+++ b/stdlib/public/RemoteInspection/CMakeLists.txt
@@ -1,17 +1,17 @@
-set(swiftRemoteInspection_SOURCES
-  MetadataSource.cpp
-  TypeLowering.cpp
-  TypeRef.cpp
-  TypeRefBuilder.cpp)
-
-set(swiftRemoteInspection_C_COMPILE_FLAGS -DswiftCore_EXPORTS)
+set(swiftRemoteInspection_C_COMPILE_FLAGS)
 if(SWIFT_ENABLE_REFLECTION)
   list(APPEND swiftRemoteInspection_C_COMPILE_FLAGS -DSWIFT_ENABLE_REFLECTION)
 endif()
 
 add_swift_target_library(swiftRemoteInspection STATIC
-  ${swiftRemoteInspection_SOURCES}
-  C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS} ${swiftRemoteInspection_C_COMPILE_FLAGS}
+  MetadataSource.cpp
+  TypeLowering.cpp
+  TypeRef.cpp
+  TypeRefBuilder.cpp
+  C_COMPILE_FLAGS
+    ${SWIFT_RUNTIME_CXX_FLAGS}
+    -DswiftCore_EXPORTS
+    ${swiftRemoteInspection_C_COMPILE_FLAGS}
   LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
   INCORPORATE_OBJECT_LIBRARIES
     swiftLLVMSupport swiftDemangling swiftDemanglingCR


### PR DESCRIPTION
Inline single use variable, inline CPP definition, and reflow some text.