### PR TITLE
[CS] Invalidate VarDecls in targets that fail to type-check

### DIFF
--- a/include/swift/Sema/SyntacticElementTarget.h
+++ b/include/swift/Sema/SyntacticElementTarget.h
@@ -887,6 +887,10 @@ public:
     llvm_unreachable("invalid target type");
   }
 
+  /// Marks the target as invalid, filling in ErrorTypes for the AST it
+  /// represents.
+  void markInvalid() const;
+
   /// Walk the contents of the application target.
   std::optional<SyntacticElementTarget> walk(ASTWalker &walker) const;
 };

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -136,6 +136,10 @@ enum class TypeCheckExprFlags {
 
   /// Don't expand macros.
   DisableMacroExpansions = 0x08,
+
+  /// If set, typeCheckExpression will avoid invalidating the AST if
+  /// type-checking fails. Do not add new uses of this.
+  AvoidInvalidatingAST = 0x10,
 };
 
 using TypeCheckExprOptions = OptionSet<TypeCheckExprFlags>;

--- a/test/Constraints/type_inference_from_default_closure.swift
+++ b/test/Constraints/type_inference_from_default_closure.swift
@@ -1,0 +1,6 @@
+// NOTE: This intentionally doesn't use %target-typecheck-verify, this should
+// compile without any errors since we're testing the ASTVerifier is happy.
+// RUN: %target-swift-frontend -typecheck %s
+
+// Make sure we don't prematurely mark 'x' as invalid.
+func testInferenceFromClosureVar<T>(x: T = { var x: Int = 0; return x }()) {}

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -266,3 +266,6 @@ do {
   // expected-warning@-1 {{dictionary literal of type '[String : Int]' has duplicate entries for string literal key 'a'}}
   // expected-note@-2 2 {{duplicate key declared here}}
 }
+
+func testInferenceFromClosureVarInvalid<T>(x: T = { let x = "" as Int; return x }()) {}
+// expected-error@-1 {{cannot convert value of type 'String' to type 'Int' in coercion}}

--- a/test/Index/rdar120012473.swift
+++ b/test/Index/rdar120012473.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck %s -index-store-path %t
+
+let k = ""
+
+// Make sure we don't crash here (rdar://120012473).
+func foo() {
+  _ = {
+    let x = switch 1 {
+    case k:
+      return false
+    }
+    return true
+  }
+
+  for x in [0] where ({
+    let x = switch 1 {
+    case k:
+      return false
+    }
+    return true
+  }()) {}
+}
+
+@resultBuilder
+struct Builder {
+  static func buildBlock<T>(_ components: T...) -> T {
+    fatalError()
+  }
+}
+
+@Builder
+func bar() -> Bool {
+  let fn = {
+    let x = switch 1 {
+    case k:
+      return false
+    }
+    return true
+  }
+  fn()
+}
+
+func baz(x: () -> Bool = {
+  let x = switch 1 {
+  case k:
+    return false
+  }
+  return true
+}) {}


### PR DESCRIPTION
This avoids a crash that could occur when attempting to query their interface type later, which could cause us to attempt to type-check the Decl separately from its enclosing closure.

Eventually we also ought to use this to fill in ErrorTypes for expressions (since type-checking ought to only produce typed AST), but I'm leaving that as future work for now.

rdar://120012473