### PR TITLE
Android: always build libraries as PIC

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1237,6 +1237,9 @@ function(add_swift_target_library_single target name)
         PROPERTIES
         INSTALL_RPATH "$ORIGIN")
     endif()
+
+    set_target_properties(${target} PROPERTIES
+      POSITION_INDEPENDENT_CODE YES)
   elseif("${SWIFTLIB_SINGLE_SDK}" STREQUAL "OPENBSD")
     set_target_properties("${target}"
       PROPERTIES


### PR DESCRIPTION
This adjusts the stdlib bits to be built as position independent. As we build a single instance of the code and then create static and dynamic runtimes, simply pay a penalty when performing static linking of the runtime to make the dynamic case work properly. This repairs part of the runtime build on Android where we would previously see when building SwiftRemoteMirror:

```
ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'vtable for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'vtable for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'construction vtable for std::__ndk1::basic_istream<char, std::__ndk1::char_traits<char>>-in-std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'construction vtable for std::__ndk1::basic_istream<char, std::__ndk1::char_traits<char>>-in-std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'vtable for std::__ndk1::basic_stringbuf<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'vtable for std::__ndk1::basic_stringbuf<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'vtable for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'vtable for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'vtable for std::__ndk1::basic_stringbuf<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'vtable for std::__ndk1::basic_stringbuf<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'VTT for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'VTT for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(swift::reflection::TypeRefBuilder::ReflectionTypeDescriptorFinder::collectFieldTypes(std::__ndk1::optional<std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>>)) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'vtable for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>::~basic_stringstream()) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'vtable for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>::~basic_stringstream()) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'vtable for std::__ndk1::basic_stringbuf<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>::~basic_stringstream()) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'vtable for std::__ndk1::basic_stringbuf<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>::~basic_stringstream()) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'VTT for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>::~basic_stringstream()) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'VTT for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>::~basic_stringstream()) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADR_PREL_PG_HI21 cannot be used against symbol 'vtable for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(non-virtual thunk to std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>::~basic_stringstream()) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: relocation R_AARCH64_ADD_ABS_LO12_NC cannot be used against symbol 'vtable for std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>'; recompile with -fPIC
>>> defined in lib/swift/android/aarch64/libswiftRemoteInspection.a(TypeRefBuilder.cpp.o)
>>> referenced by TypeRefBuilder.cpp
>>>               TypeRefBuilder.cpp.o:(non-virtual thunk to std::__ndk1::basic_stringstream<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>>::~basic_stringstream()) in archive lib/swift/android/aarch64/libswiftRemoteInspection.a

ld.lld: error: too many errors emitted, stopping now (use --error-limit=0 to see all errors)
```