### PR TITLE
SIL: More accurate for type lowering whether a type is trivial based on conditional Copyable requirements.

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -846,6 +846,7 @@ public:
                                            bool allowMissing = false);
 
   /// Global conformance lookup, checks conditional requirements.
+  /// Requires a contextualized type.
   ///
   /// \param type The type for which we are computing conformance. Must not
   /// contain type parameters.
@@ -859,8 +860,32 @@ public:
   /// \returns An invalid conformance if the search failed, otherwise an
   /// abstract, concrete or pack conformance, depending on the lookup type.
   ProtocolConformanceRef checkConformance(Type type, ProtocolDecl *protocol,
-                                          // Note: different default than above
-                                          bool allowMissing = true);
+                              // Note: different default from lookupConformance
+                              bool allowMissing = true);
+
+  /// Global conformance lookup, checks conditional requirements.
+  /// Accepts interface types without context. If the conformance cannot be
+  /// definitively established without the missing context, returns \c nullopt.
+  ///
+  /// \param type The type for which we are computing conformance. Must not
+  /// contain type parameters.
+  ///
+  /// \param protocol The protocol to which we are computing conformance.
+  ///
+  /// \param allowMissing When \c true, the resulting conformance reference
+  /// might include "missing" conformances, which are synthesized for some
+  /// protocols as an error recovery mechanism.
+  ///
+  /// \returns An invalid conformance if the search definitively failed. An
+  /// abstract, concrete or pack conformance, depending on the lookup type,
+  /// if the search succeeded. `std::nullopt` if the type could have
+  /// conditionally conformed depending on the context of the interface types.
+  std::optional<ProtocolConformanceRef>
+  checkConformanceWithoutContext(Type type,
+                                 ProtocolDecl *protocol,
+                                 // Note: different default from lookupConformance
+                                 bool allowMissing = true);
+
 
   /// Look for the conformance of the given existential type to the given
   /// protocol.

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -223,6 +223,12 @@ enum class CheckRequirementsResult : uint8_t {
 /// not contain any type parameters.
 CheckRequirementsResult checkRequirements(ArrayRef<Requirement> requirements);
 
+/// Check if each substituted requirement is satisfied. If the requirement
+/// contains type parameters, and the answer would depend on the context of
+/// those type parameters, then `nullopt` is returned.
+std::optional<CheckRequirementsResult>
+checkRequirementsWithoutContext(ArrayRef<Requirement> requirements);
+
 /// Check if each requirement is satisfied after applying the given
 /// substitutions. The substitutions must replace all type parameters that
 /// appear in the requirement with concrete types or archetypes.

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1014,6 +1014,7 @@ public:
 
   bool requiresClass() const;
   LayoutConstraint getLayoutConstraint() const;
+  bool isNoncopyable(CanType substTy) const;
 
   /// Return the Swift type which provides structure for this
   /// abstraction pattern.

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2353,7 +2353,7 @@ namespace {
 
       return handleReference(classType, properties);
     }
-
+    
     // WARNING: when the specification of trivial types changes, also update
     // the isValueTrivial() API used by SILCombine.
     TypeLowering *visitAnyStructType(CanType structType,
@@ -2433,7 +2433,7 @@ namespace {
       properties =
           applyLifetimeAnnotation(D->getLifetimeAnnotation(), properties);
 
-      if (D->canBeCopyable() != TypeDecl::CanBeInvertible::Always) {
+      if (origType.isNoncopyable(structType)) {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
         if (properties.isAddressOnly())
@@ -2530,7 +2530,7 @@ namespace {
       properties =
           applyLifetimeAnnotation(D->getLifetimeAnnotation(), properties);
 
-      if (D->canBeCopyable() != TypeDecl::CanBeInvertible::Always) {
+      if (origType.isNoncopyable(enumType)) {
         properties.setNonTrivial();
         properties.setLexical(IsLexical);
         if (properties.isAddressOnly())

--- a/test/SILGen/typelowering_inverses.swift
+++ b/test/SILGen/typelowering_inverses.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -disable-availability-checking -module-name main %s | %FileCheck %s
 
-
-
 struct NC: ~Copyable {}
 
 struct RudeStruct<T: ~Copyable>: Copyable {
@@ -34,13 +32,13 @@ func check(_ t: RudeEnum<Int>) {}
 // CHECK: sil hidden [ossa] @$s4main5checkyyAA8RudeEnumOyAA2NCVGF : $@convention(thin) (RudeEnum<NC>) -> () {
 func check(_ t: RudeEnum<NC>) {}
 
-// CHECK: sil hidden [ossa] @$s4main5checkyyAA18CondCopyableStructVySiGF : $@convention(thin) (@guaranteed CondCopyableStruct<Int>) -> () {
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA18CondCopyableStructVySiGF : $@convention(thin) (CondCopyableStruct<Int>) -> () {
 func check(_ t: CondCopyableStruct<Int>) {}
 
 // CHECK: sil hidden [ossa] @$s4main5checkyyAA18CondCopyableStructVyAA2NCVGF : $@convention(thin) (@guaranteed CondCopyableStruct<NC>) -> () {
 func check(_ t: borrowing CondCopyableStruct<NC>) {}
 
-// CHECK: sil hidden [ossa] @$s4main5checkyyAA16CondCopyableEnumOySiGF : $@convention(thin) (@guaranteed CondCopyableEnum<Int>) -> () {
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA16CondCopyableEnumOySiGF : $@convention(thin) (CondCopyableEnum<Int>) -> () {
 func check(_ t: CondCopyableEnum<Int>) {}
 
 // CHECK: sil hidden [ossa] @$s4main5checkyyAA16CondCopyableEnumOyAA2NCVGF : $@convention(thin) (@guaranteed CondCopyableEnum<NC>) -> () {
@@ -51,3 +49,51 @@ func check<T>(_ t: CondCopyableEnum<T>) {}
 
 // CHECK: sil hidden [ossa] @$s4main13check_noClashyyAA16CondCopyableEnumOyxGlF : $@convention(thin) <U where U : ~Copyable> (@in_guaranteed CondCopyableEnum<U>) -> () {
 func check_noClash<U: ~Copyable>(_ t: borrowing CondCopyableEnum<U>) {}
+
+struct MyStruct<T: ~Copyable>: ~Copyable {
+    var x: T
+}
+
+extension MyStruct: Copyable where T: Copyable {}
+
+enum MyEnum<T: ~Copyable>: ~Copyable {
+    case x(T)
+    case knoll
+}
+
+extension MyEnum: Copyable where T: Copyable {}
+
+enum Trivial {
+    case a, b, c
+}
+
+// CHECK-LABEL: sil{{.*}} @{{.*}}13trivialStruct
+func trivialStruct() -> Int {
+    // CHECK: [[ALLOC:%.*]] = alloc_stack $MyStruct<Trivial>
+    // CHECK-NOT: destroy_addr [[ALLOC]] :
+    // CHECK: dealloc_stack [[ALLOC]] :
+     return MemoryLayout.size(ofValue: MyStruct(x: Trivial.a))
+}
+// CHECK-LABEL: sil{{.*}} @{{.*}}11trivialEnum
+func trivialEnum() -> Int {
+    // CHECK: [[ALLOC:%.*]] = alloc_stack $MyEnum<Trivial>
+    // CHECK-NOT: destroy_addr [[ALLOC]] :
+    // CHECK: dealloc_stack [[ALLOC]] :
+     return MemoryLayout.size(ofValue: MyEnum.x(Trivial.a))
+}
+
+struct MyAssortment {
+    var a: MyStruct<Trivial>
+    var b: MyEnum<Trivial>
+}
+
+// CHECK-LABEL: sil{{.*}} @{{.*}}4frob
+func frob(x: MyAssortment) -> Int {
+    // CHECK: [[ALLOC:%.*]] = alloc_stack $MyAssortment
+    // CHECK-NOT: destroy_addr [[ALLOC]] :
+    // CHECK: dealloc_stack [[ALLOC]] :
+    return MemoryLayout.size(ofValue: x)
+}
+
+extension MyEnum: _BitwiseCopyable
+    where T: Copyable & _BitwiseCopyable {}


### PR DESCRIPTION
We want a conditionally-copyable type to still be classified as trivial in cases where it's bitwise-copyable, has a trivial deinit, and is Copyable. The previous implementation here only checked at the declaration level whether a type was Copyable or not; get a more accurate answer by consulting the combination of information in the substituted type and abstraction pattern we have available during type lowering so that we classify definitely-copyable substitutions of a conditionally-copyable type as trivial. Should fix rdar://123654553 and rdar://123658878.