### PR TITLE
[DebugInfo] Fix bound generic types debug info generation

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1184,11 +1184,10 @@ private:
       return OpaqueType;
     }
 
-    auto *opaqueType = createOpaqueStructWithSizedContainer(
-        Scope, Decl ? Decl->getNameStr() : "", File, Line, SizeInBits,
-        AlignInBits, Flags, MangledName, collectGenericParams(Type),
-        UnsubstitutedType);
-    return opaqueType;
+    auto *OpaqueType = createOpaqueStruct(
+        Scope, "", File, Line, SizeInBits, AlignInBits, Flags, MangledName,
+        collectGenericParams(Type), UnsubstitutedType);
+    return OpaqueType;
   }
 
   /// Create debug information for an enum with a raw type (enum E : Int {}).
@@ -1624,12 +1623,19 @@ private:
   llvm::DICompositeType *
   createOpaqueStruct(llvm::DIScope *Scope, StringRef Name, llvm::DIFile *File,
                      unsigned Line, unsigned SizeInBits, unsigned AlignInBits,
-                     llvm::DINode::DIFlags Flags, StringRef MangledName) {
-    return DBuilder.createStructType(
+                     llvm::DINode::DIFlags Flags, StringRef MangledName,
+                     llvm::DINodeArray BoundParams = {},
+                     llvm::DIType *SpecificationOf = nullptr) {
+
+    auto StructType = DBuilder.createStructType(
         Scope, Name, File, Line, SizeInBits, AlignInBits, Flags,
         /* DerivedFrom */ nullptr,
         DBuilder.getOrCreateArray(ArrayRef<llvm::Metadata *>()),
-        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName);
+        llvm::dwarf::DW_LANG_Swift, nullptr, MangledName, SpecificationOf);
+
+    if (BoundParams)
+      DBuilder.replaceArrays(StructType, nullptr, BoundParams);
+    return StructType;
   }
 
   bool shouldCacheDIType(llvm::DIType *DITy, DebugTypeInfo &DbgTy) {
@@ -2012,11 +2018,9 @@ private:
         // Force the creation of the unsubstituted type, don't create it
         // directly so it goes through all the caching/verification logic.
         auto unsubstitutedDbgTy = getOrCreateType(DbgTy);
-        DBuilder.retainType(unsubstitutedDbgTy);
-        return createOpaqueStructWithSizedContainer(
-            Scope, Decl->getName().str(), L.File, FwdDeclLine, SizeInBits,
-            AlignInBits, Flags, MangledName, collectGenericParams(EnumTy),
-            unsubstitutedDbgTy);
+        return createOpaqueStruct(
+            Scope, "", L.File, FwdDeclLine, SizeInBits, AlignInBits, Flags,
+            MangledName, collectGenericParams(EnumTy), unsubstitutedDbgTy);
       }
       return createOpaqueStructWithSizedContainer(
           Scope, Decl->getName().str(), L.File, FwdDeclLine, SizeInBits,

--- a/test/DebugInfo/BoundGenericStruct.swift
+++ b/test/DebugInfo/BoundGenericStruct.swift
@@ -13,8 +13,11 @@ public let s = S<Int>(t: 0)
 // CHECK: ![[INT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$sSiD",
 
 
-// DWARF: !DICompositeType(tag: DW_TAG_structure_type, name: "$s18BoundGenericStruct1SVySiGD",
+// DWARF: !DICompositeType(tag: DW_TAG_structure_type,
 // DWARF-SAME:             templateParams: ![[PARAMS:[0-9]+]]
+// DWARF-SAME:             identifier: "$s18BoundGenericStruct1SVySiGD"
+// DWARF-SAME:             specification_of:
+
 // DWARF: ![[PARAMS]] = !{![[INTPARAM:[0-9]+]]}
 // DWARF: ![[INTPARAM]] = !DITemplateTypeParameter(type: ![[INT:[0-9]+]])
 // DWARF: ![[INT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Int", {{.*}}identifier: "$sSiD"


### PR DESCRIPTION
When generating full debug info for generic types, emit the specification type as an opaque struct with the collection of substituted generic parameters.

