### PR TITLE
[Concurrency] Mark `extractIsolation` as `@_alwaysEmitIntoClient`.

### DIFF
--- a/stdlib/public/Concurrency/Actor.swift
+++ b/stdlib/public/Concurrency/Actor.swift
@@ -86,6 +86,7 @@ public macro isolation<T>() -> T = Builtin.IsolationMacro
 #endif
 
 #if $IsolatedAny
+@_alwaysEmitIntoClient
 @available(SwiftStdlib 5.1, *)
 public func extractIsolation<each Arg, Result>(
   _ fn: @escaping @isolated(any) (repeat each Arg) async throws -> Result

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -264,9 +264,6 @@ Added: _$ss32AsyncThrowingPrefixWhileSequenceV8IteratorV4next9isolation7ElementQ
 // async function pointer to Swift.AsyncThrowingPrefixWhileSequence.Iterator.next(isolation: isolated Swift.Actor?) async throws -> A.Element?
 Added: _$ss32AsyncThrowingPrefixWhileSequenceV8IteratorV4next9isolation7ElementQzSgScA_pSgYi_tYaKFTu
 
-// Swift.extractIsolation<each A, B>(@isolated(any) (repeat A) async throws -> B) -> Swift.Actor?
-Added: _$ss16extractIsolationyScA_pSgq_xxQpYaKYAcRvzr0_lF
-
 Added: _swift_job_run_on_serial_and_task_executor
 Added: _swift_job_run_on_task_executor
 Added: _swift_task_getPreferredTaskExecutor

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -264,9 +264,6 @@ Added: _$ss32AsyncThrowingPrefixWhileSequenceV8IteratorV4next9isolation7ElementQ
 // async function pointer to Swift.AsyncThrowingPrefixWhileSequence.Iterator.next(isolation: isolated Swift.Actor?) async throws -> A.Element?
 Added: _$ss32AsyncThrowingPrefixWhileSequenceV8IteratorV4next9isolation7ElementQzSgScA_pSgYi_tYaKFTu
 
-// Swift.extractIsolation<each A, B>(@isolated(any) (repeat A) async throws -> B) -> Swift.Actor?
-Added: _$ss16extractIsolationyScA_pSgq_xxQpYaKYAcRvzr0_lF
-
 Added: _swift_job_run_on_serial_and_task_executor
 Added: _swift_job_run_on_task_executor
 Added: _swift_task_getPreferredTaskExecutor


### PR DESCRIPTION
Mark `extractIsolation` as `@_alwaysEmitIntoClient` so that it can back deploy to all runtimes that include concurrency.