### PR TITLE
Reenable BorrowToDestructureTransform during the MoveOnlyAddressChecker.

### DIFF
--- a/test/SILOptimizer/moveonly_borrowing_switch_mode_with_partial_consume.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_mode_with_partial_consume.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -emit-sil -verify -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -parse-as-library %s
+
+func foo() {
+    let node = Node()
+    bar(node.next)
+}
+
+struct Node: ~Copyable {
+    var next: Link
+
+    init() { fatalError() }
+}
+
+struct Link: ~Copyable {}
+
+func bar(_: consuming Link) {}
+
+


### PR DESCRIPTION
The comment stated that this was used to turn switches into consumes (which is no longer relevant), but it looks like it is also necessary for the move-only address checker to be able to properly understand partial consumes of fields in some code patterns. Now that we surround borrowing switches in plenty of opaque accesses to protect them from being pried apart by the move checker, it should be safe to reenable this.