### PR TITLE
SILGen: Make FormalEvaluationScope destructor tolerate running from unreachable code.

### DIFF
--- a/lib/SILGen/FormalEvaluation.cpp
+++ b/lib/SILGen/FormalEvaluation.cpp
@@ -145,7 +145,9 @@ void FormalEvaluationScope::popImpl() {
     access.setFinished();
 
     // Deactivate the cleanup.
-    SGF.Cleanups.setCleanupState(access.getCleanup(), CleanupState::Dead);
+    if (SGF.B.hasValidInsertionPoint()) {
+      SGF.Cleanups.setCleanupState(access.getCleanup(), CleanupState::Dead);
+    }
 
     // Attempt to diagnose problems where obvious aliasing introduces illegal
     // code. We do a simple N^2 comparison here to detect this because it is
@@ -168,8 +170,10 @@ void FormalEvaluationScope::popImpl() {
     //
     // This evaluates arbitrary code, so it's best to be paranoid
     // about iterators on the context.
-    DiverseValueBuffer<FormalAccess> copiedAccess(access);
-    copiedAccess.getCopy().finish(SGF);
+    if (SGF.B.hasValidInsertionPoint()) {
+      DiverseValueBuffer<FormalAccess> copiedAccess(access);
+      copiedAccess.getCopy().finish(SGF);
+    }
 
   } while (i != endDepth);
 

--- a/test/SILGen/borrowing_switch_return_on_all_paths.swift
+++ b/test/SILGen/borrowing_switch_return_on_all_paths.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -verify %s
+
+struct Box<Wrapped: ~Copyable>: ~Copyable {
+    var wrapped: Wrapped {
+        _read { fatalError() }
+        _modify { fatalError() }
+    }
+}
+
+struct NoncopyableList<Element>: ~Copyable {
+    struct Node: ~Copyable {
+        var element: Element
+        var next: Link
+    }
+
+    enum Link: ~Copyable {
+        case empty
+        case more(Box<Node>)
+    }
+
+    var head: Link = .empty
+}
+
+extension NoncopyableList.Link {
+    func find(where predicate: (Element)->Bool) -> Maybe<Element> {
+        switch self {
+        case .empty: return .none
+        case .more(_borrowing box):
+            if predicate(box.wrapped.element) { return .some(box.wrapped.element) }
+            return box.wrapped.next.find(where: predicate)
+        }
+    }
+}
+
+
+enum Maybe<Element: ~Copyable>: ~Copyable {
+    case none
+    case some(Element)
+}


### PR DESCRIPTION
This can happen now in a borrowing `switch` that nonlocal exits on all paths.
