### PR TITLE
SwiftCompilerSources: support `Undef.parentFunction` and `PlaceholderValue.parentFunction`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -185,7 +185,7 @@ struct LifetimeDependence : CustomStringConvertible {
   var parentValue: Value { scope.parentValue }
 
   var function: Function {
-    dependentValue.parentFunction // dependentValue can't be undef
+    dependentValue.parentFunction
   }
 
   var description: String {

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -414,6 +414,8 @@ struct BridgedValue {
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE OptionalBridgedOperand getFirstUse() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedType getType() const;
   BRIDGED_INLINE Ownership getOwnership() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedFunction SILUndef_getParentFunction() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedFunction PlaceholderValue_getParentFunction() const;
 
   bool findPointerEscape() const;
 };

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -418,6 +418,14 @@ BridgedValue::Ownership BridgedValue::getOwnership() const {
   return castOwnership(getSILValue()->getOwnershipKind());
 }
 
+BridgedFunction BridgedValue::SILUndef_getParentFunction() const {
+  return {llvm::cast<swift::SILUndef>(getSILValue())->getParent()};
+}
+
+BridgedFunction BridgedValue::PlaceholderValue_getParentFunction() const {
+  return {llvm::cast<swift::PlaceholderValue>(getSILValue())->getParent()};
+}
+
 //===----------------------------------------------------------------------===//
 //                                BridgedOperand
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -592,9 +592,7 @@ SILCloner<ImplClass>::getMappedValue(SILValue Value) {
   // If we have undef, just remap the type.
   if (auto *U = dyn_cast<SILUndef>(Value)) {
     auto type = getOpType(U->getType());
-    ValueBase *undef =
-        (type == U->getType() ? U : SILUndef::get(Builder.getFunction(), type));
-    return SILValue(undef);
+    return SILUndef::get(Builder.getFunction(), type);
   }
 
   llvm_unreachable("Unmapped value while cloning?");

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -209,6 +209,10 @@ SILBasicBlock *SILNode::getParentBlock() const {
   if (auto *MVR = dyn_cast<MultipleValueInstructionResult>(this)) {
     return MVR->getParent()->getParent();
   }
+  if (auto *undef = dyn_cast<SILUndef>(this)) {
+    // By convention, undefs are considered to be defined at the entry of the function.
+    return undef->getParent()->getEntryBlock();
+  }
   return nullptr;
 }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -1263,6 +1263,10 @@ public:
                 "instruction isn't dominated by its bb argument operand");
       }
 
+      if (auto *undef = dyn_cast<SILUndef>(operand.get())) {
+        require(undef->getParent() == BB->getParent(), "SILUndef in wrong function");
+      }
+
       require(operand.getUser() == I,
               "instruction's operand's owner isn't the instruction");
       require(isOperandInValueUses(&operand), "operand value isn't used by operand");

--- a/test/SILOptimizer/simplify_cfg_args.sil
+++ b/test/SILOptimizer/simplify_cfg_args.sil
@@ -745,14 +745,14 @@ enum ThreeWay {
 
 // CHECK-LABEL: sil hidden [noinline] @testUnwrapEnumArg : $@convention(thin) () -> () {
 // CHECK: bb0:
-// CHECK:   br bb1(undef : $Builtin.Int64, %{{.*}} : $Payload)
-// CHECK: bb1(%{{.*}} : $Builtin.Int64, %{{.*}} : $Payload):
+// CHECK:   br bb1(%{{.*}} : $Payload)
+// CHECK: bb1(%{{.*}} : $Payload):
 // CHECK:   alloc_stack $Payload
 // CHECK:   switch_enum undef : $ThreeWay, case #ThreeWay.one!enumelt: bb4, case #ThreeWay.two!enumelt: bb2, case #ThreeWay.three!enumelt: bb3
 // CHECK: bb2:
 // CHECK:   [[P2:%.*]] = load %{{.*}} : $*Payload
 // CHECK:   dealloc_stack %{{.*}} : $*Payload
-// CHECK:   br bb1(undef : $Builtin.Int64, [[P2]] : $Payload)
+// CHECK:   br bb1([[P2]] : $Payload)
 // CHECK: bb3:
 // CHECK:   [[P3:%.*]] = load %{{.*}} : $*Payload
 // CHECK:   dealloc_stack %{{.*}} : $*Payload
@@ -764,7 +764,7 @@ enum ThreeWay {
 // CHECK: bb5:
 // CHECK:   br bb7
 // CHECK: bb6:
-// CHECK:   br bb1(undef : $Builtin.Int64, [[P4]] : $Payload)
+// CHECK:   br bb1([[P4]] : $Payload)
 // CHECK: bb7:
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'testUnwrapEnumArg'

--- a/test/SILOptimizer/simplify_cfg_args_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_args_ossa.sil
@@ -723,14 +723,14 @@ enum ThreeWay {
 
 // CHECK-LABEL: sil hidden [noinline] [ossa] @testUnwrapEnumArg : $@convention(thin) () -> () {
 // CHECK: bb0:
-// CHECK:   br bb1(undef : $Builtin.Int64, %{{.*}} : $Payload)
-// CHECK: bb1(%{{.*}} : $Builtin.Int64, %{{.*}} : $Payload):
+// CHECK:   br bb1(%{{.*}} : $Payload)
+// CHECK: bb1(%{{.*}} : $Payload):
 // CHECK:   alloc_stack $Payload
 // CHECK:   switch_enum undef : $ThreeWay, case #ThreeWay.one!enumelt: bb4, case #ThreeWay.two!enumelt: bb2, case #ThreeWay.three!enumelt: bb3
 // CHECK: bb2:
 // CHECK:   [[P2:%.*]] = load [trivial] %{{.*}} : $*Payload
 // CHECK:   dealloc_stack %{{.*}} : $*Payload
-// CHECK:   br bb1(undef : $Builtin.Int64, [[P2]] : $Payload)
+// CHECK:   br bb1([[P2]] : $Payload)
 // CHECK: bb3:
 // CHECK:   [[P3:%.*]] = load [trivial] %{{.*}} : $*Payload
 // CHECK:   dealloc_stack %{{.*}} : $*Payload
@@ -740,7 +740,7 @@ enum ThreeWay {
 // CHECK:   dealloc_stack %{{.*}} : $*Payload
 // CHECK:   cond_br undef, bb6, bb5
 // CHECK: bb5:
-// CHECK:   br bb1(undef : $Builtin.Int64, [[P4]] : $Payload)
+// CHECK:   br bb1([[P4]] : $Payload)
 // CHECK: bb6:
 // CHECK:   br bb7
 // CHECK: bb7:


### PR DESCRIPTION
After support in the C++ SIL (https://github.com/apple/swift/pull/71879), we can implement parentFunction for those values in swift, too. It simplifies a few things.
