### PR TITLE
[SymbolGraphGen] Import ObjC forward declarations by default.

### DIFF
--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -142,6 +142,7 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
   }
   Invocation.setClangModuleCachePath(ModuleCachePath);
   Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
+  Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
   Invocation.setDefaultPrebuiltCacheIfNecessary();
 
   if (auto *A = ParsedArgs.getLastArg(OPT_swift_version)) {

--- a/test/SymbolGraph/ClangImporter/ImportForwardDeclarationsTest.swift
+++ b/test/SymbolGraph/ClangImporter/ImportForwardDeclarationsTest.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/ForwardDeclarations/ForwardDeclarations.framework %t
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/ForwardDeclarations.framework/Modules/ForwardDeclarations.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name ForwardDeclarations -disable-objc-attr-requires-foundation-module %s -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/ForwardDeclarations.framework/Modules/ForwardDeclarations.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name ForwardDeclarations -disable-objc-attr-requires-foundation-module %s
 // RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name ForwardDeclarations -F %t -output-dir %t -pretty-print -v
 // RUN: %FileCheck %s --input-file %t/ForwardDeclarations.symbols.json
 

--- a/test/SymbolGraph/ClangImporter/ImportForwardDeclarationsTest.swift
+++ b/test/SymbolGraph/ClangImporter/ImportForwardDeclarationsTest.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/ForwardDeclarations/ForwardDeclarations.framework %t
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module-path %t/ForwardDeclarations.framework/Modules/ForwardDeclarations.swiftmodule/%target-swiftmodule-name -import-underlying-module -F %t -module-name ForwardDeclarations -disable-objc-attr-requires-foundation-module %s -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %target-swift-symbolgraph-extract -sdk %clang-importer-sdk -module-name ForwardDeclarations -F %t -output-dir %t -pretty-print -v
+// RUN: %FileCheck %s --input-file %t/ForwardDeclarations.symbols.json
+
+// REQUIRES: objc_interop
+
+// CHECK: "preciseIdentifier": "c:objc(cs)ForwardDeclaration"

--- a/test/SymbolGraph/ClangImporter/Inputs/ForwardDeclarations/ForwardDeclarations.framework/Headers/ForwardDeclaredInterfaceFoo.h
+++ b/test/SymbolGraph/ClangImporter/Inputs/ForwardDeclarations/ForwardDeclarations.framework/Headers/ForwardDeclaredInterfaceFoo.h
@@ -1,0 +1,9 @@
+@import Foundation;
+
+@class ForwardDeclaration;
+
+@interface Foo : NSObject
+
+@property ForwardDeclaration *foo;
+
+@end

--- a/test/SymbolGraph/ClangImporter/Inputs/ForwardDeclarations/ForwardDeclarations.framework/Modules/module.modulemap
+++ b/test/SymbolGraph/ClangImporter/Inputs/ForwardDeclarations/ForwardDeclarations.framework/Modules/module.modulemap
@@ -1,0 +1,3 @@
+framework module ForwardDeclarations {
+    header "ForwardDeclaredInterfaceFoo.h"
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This pull request configures `ImportForwardDeclarations` to true, enabling the Clang Importer in the Swift SymbolGraph Extractor to generate placeholder types for representing forward declarations in Swift.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves rdar://123279176

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
