### PR TITLE
SwiftPrivateLibcExtras: explicitly unwrap the fildes array

### DIFF
--- a/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
+++ b/stdlib/private/SwiftPrivateLibcExtras/SwiftPrivateLibcExtras.swift
@@ -132,7 +132,7 @@ public func _stdlib_pipe() -> (readEnd: CInt, writeEnd: CInt, error: CInt) {
 #elseif os(WASI)
     preconditionFailure("No pipes available on WebAssembly/WASI")
 #else
-    return pipe(unsafeFds.baseAddress)
+    return pipe(unsafeFds.baseAddress!)
 #endif
   }
   return (readEnd: fds[0], writeEnd: fds[1], error: ret)


### PR DESCRIPTION
When building on newer Android NDKs, the `pipe` function is marked as having a non-nullable type parameter. Explicitly unwrap the parameter so that it works for both nullable and non-nullable attributed `pipe` declarations.