### PR TITLE
Fix test for tvOS

### DIFF
--- a/test/ModuleInterface/assoc_type_inference_tvos.swift
+++ b/test/ModuleInterface/assoc_type_inference_tvos.swift
@@ -19,7 +19,7 @@ extension TheColor {
   // having iOS availability that predates the introduction of tvOS.
 
   // CHECK: public init?(rawValue: Swift.String)
-  // CHECK-NOT: @available(tvOS
+  // CHECK-NOT: @available(tvOS)
   // CHECK: public typealias RawValue = Swift.String
   public enum StaticNamedColor: String {
     case black


### PR DESCRIPTION
It's fine for tvOS to print "2.0", it's the unversioned `@available(tvOS)` that was wrong.