### PR TITLE
Serialization: Error when decoding invalid PlatformKind values

### DIFF
--- a/include/swift/AST/PlatformKind.h
+++ b/include/swift/AST/PlatformKind.h
@@ -42,6 +42,10 @@ StringRef platformString(PlatformKind platform);
 /// or None if such a platform kind does not exist.
 std::optional<PlatformKind> platformFromString(StringRef Name);
 
+/// Safely converts the given unsigned value to a valid \c PlatformKind value or
+/// \c nullopt otherwise.
+std::optional<PlatformKind> platformFromUnsigned(unsigned value);
+
 /// Returns a valid platform string that is closest to the candidate string
 /// based on edit distance. Returns \c None if the closest valid platform
 /// distance is not within a minimum threshold.

--- a/lib/AST/PlatformKind.cpp
+++ b/lib/AST/PlatformKind.cpp
@@ -58,6 +58,17 @@ std::optional<PlatformKind> swift::platformFromString(StringRef Name) {
       .Default(std::optional<PlatformKind>());
 }
 
+std::optional<PlatformKind> swift::platformFromUnsigned(unsigned value) {
+  PlatformKind platform = PlatformKind(value);
+  switch (platform) {
+  case PlatformKind::none:
+#define AVAILABILITY_PLATFORM(X, PrettyName) case PlatformKind::X:
+#include "swift/AST/PlatformKinds.def"
+    return platform;
+  }
+  return std::nullopt;
+}
+
 std::optional<StringRef>
 swift::closestCorrectedPlatformString(StringRef candidate) {
   auto lowerCasedCandidate = candidate.lower();

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -646,6 +646,32 @@ public:
   }
 };
 
+class InvalidEnumValueError
+    : public llvm::ErrorInfo<InvalidEnumValueError, DeclDeserializationError> {
+  friend ErrorInfo;
+  static const char ID;
+  void anchor() override;
+
+  unsigned enumValue;
+  const char *enumDescription;
+
+public:
+  explicit InvalidEnumValueError(unsigned enumValue,
+                                 const char *enumDescription) {
+    this->enumValue = enumValue;
+    this->enumDescription = enumDescription;
+  }
+
+  void log(raw_ostream &OS) const override {
+    OS << "invalid value " << enumValue << " for enumeration "
+       << enumDescription;
+  }
+
+  std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+};
+
 class PrettyStackTraceModuleFile : public llvm::PrettyStackTraceEntry {
   const char *Action;
   const ModuleFile &MF;


### PR DESCRIPTION
Recently, unexpected binary module sharing between compilers that had inconsistent views of the `PlatformKind` enumeration caused me to spend several days debugging undefined behavior in the compiler. We should validate that enumeration values decoded during deserialization are valid, and fail fast when they are not to make debugging this kind of issue less time consuming. This change just validates the `PlatformKind` value decoded for an `AvailableAttr`, but more of deserialization could be updated to do similar validation.

Resolves rdar://123770273
