### PR TITLE
Windows: add WER module to WinSDK

### DIFF
--- a/stdlib/public/Platform/winsdk.modulemap
+++ b/stdlib/public/Platform/winsdk.modulemap
@@ -468,6 +468,11 @@ module WinSDK [system] {
     link "User32.Lib"
   }
 
+  module WER {
+    header "WerApi.h"
+    export *
+  }
+
   module WIC {
     header "wincodec.h"
     export *


### PR DESCRIPTION
This adds the Windows Error Reporting module to the WinSDK to make it available to Swift.