### PR TITLE
Concurrency: ignore `-Wgnu-offsetof-extensions`

### DIFF
--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -43,10 +43,17 @@ struct MinimalDispatchObjectHeader {
 static_assert(
     offsetof(Job, metadata) == offsetof(MinimalDispatchObjectHeader, VTable),
     "Job Metadata field must match location of Dispatch VTable field.");
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgnu-offsetof-extensions"
+#endif
 static_assert(offsetof(Job, SchedulerPrivate[Job::DispatchLinkageIndex]) ==
                   offsetof(MinimalDispatchObjectHeader, Linkage),
               "Dispatch Linkage field must match Job "
               "SchedulerPrivate[DispatchLinkageIndex].");
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
 /// The function passed to dispatch_async_f to execute a job.
 static void __swift_run_job(void *_job) {


### PR DESCRIPTION
When building for android against a newer SDK, we would encounter the following:

```
stdlib/public/Concurrency/DispatchGlobalExecutor.inc:46:45: error: using an array subscript expression within 'offsetof' is a Clang extension [-Werror,-Wgnu-offsetof-extensions]
static_assert(offsetof(Job, SchedulerPrivate[Job::DispatchLinkageIndex]) ==
```

Use some pragmas to avoid the warning for the particular case to prevent further use of the extension.