### PR TITLE
Always infer AsyncSequence.Failure from AsyncIteratorProtocol.Failure

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6374,6 +6374,32 @@ void Decl::printInherited(ASTPrinter &Printer, const PrintOptions &Opts) const {
   printer.printInherited(this);
 }
 
+/// Determine whether this typealias is an inferred typealias "Failure" that
+/// would conflict with another entity named failure in the same type.
+static bool isConflictingFailureTypeWitness(
+    const TypeAliasDecl *typealias) {
+  if (!typealias->isImplicit())
+    return false;
+
+  ASTContext &ctx = typealias->getASTContext();
+  if (typealias->getName() != ctx.Id_Failure)
+    return false;
+
+  auto nominal = typealias->getDeclContext()->getSelfNominalTypeDecl();
+  if (!nominal)
+    return false;
+
+  // Look for another entity with the same name.
+  auto lookupResults = nominal->lookupDirect(
+      typealias->getName(), typealias->getLoc());
+  for (auto found : lookupResults) {
+    if (found != typealias)
+      return true;
+  }
+
+  return false;
+}
+
 bool Decl::shouldPrintInContext(const PrintOptions &PO) const {
   // Skip getters/setters. They are part of the variable or subscript.
   if (isa<AccessorDecl>(this))
@@ -6411,6 +6437,14 @@ bool Decl::shouldPrintInContext(const PrintOptions &PO) const {
 
   if (isa<IfConfigDecl>(this)) {
     return PO.PrintIfConfig;
+  }
+
+  // Prior to Swift 6, we shouldn't print the inferred associated type
+  // witness for AsyncSequence.Failure. It is always determined from the
+  // AsyncIteratorProtocol witness.
+  if (auto typealias = dyn_cast<TypeAliasDecl>(this)) {
+    if (isConflictingFailureTypeWitness(typealias))
+      return false;
   }
 
   // Print everything else.

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -99,3 +99,23 @@ func forTryAwaitReturningExistentialType() async throws {
   for try await _ in S().seq() { // Ok
   }
 }
+
+@available(SwiftStdlib 5.1, *)
+public struct ReaderSeq: AsyncSequence, Sendable {
+  public enum Failure: Error {
+    case x
+  }
+
+  public typealias Element = Int
+
+  public func makeAsyncIterator() -> Reader {}
+
+  public actor Reader: AsyncIteratorProtocol {
+    public func next() async throws -> Element? {}
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func test1() -> Error {
+  return ReaderSeq.Failure.x
+}

--- a/test/ModuleInterface/async_sequence_conformance.swift
+++ b/test/ModuleInterface/async_sequence_conformance.swift
@@ -25,3 +25,30 @@ public struct SequenceAdapter<Base: AsyncSequence>: AsyncSequence {
   // CHECK: @available(
   // CHECK-NEXT: public typealias Failure = Base.Failure
 }
+
+// CHECK: @available(
+// CHECK-NEXT: public struct OtherSequenceAdapte
+@available(SwiftStdlib 5.1, *)
+public struct OtherSequenceAdapter<Base: AsyncSequence>: AsyncSequence {
+  // CHECK: public typealias Element = Base.Element
+  // CHECK-NOT: public typealias Failure
+  // CHECK: public struct Failure
+
+  // CHECK-LABEL: public struct AsyncIterator
+  // CHECK: @available{{.*}}macOS 10.15
+  // CHECK: @available(
+  // CHECK-NEXT: public typealias Failure = Base.Failure
+  public typealias Element = Base.Element
+
+  public struct Failure: Error { }
+
+  // CHECK-NOT: public typealias Failure
+  public struct AsyncIterator: AsyncIteratorProtocol {
+    public mutating func next() async rethrows -> Base.Element? { nil }
+  }
+
+  // CHECK: public func makeAsyncIterator
+  public func makeAsyncIterator() -> AsyncIterator { AsyncIterator() }
+
+  // CHECK-NOT: public typealias Failure
+}


### PR DESCRIPTION
The newly-introduced associated type `AsyncSequence.Failure` must always be equivalent to the `Failure` type of the
`AsyncIteratorProtocol`. If the `AsyncSequence` type itself defines a nested `Failure` type (say, for another purpose), associated type inference would pick it and reject the `AsyncSequence`, causing a source compatibility problem.

Work around the issue in two ways. First, always infer the type witness for `AsyncSequence.Failure` from the type witness for `AsyncIteratorProtocol.Failure`, so they can't be out of sync. This means that we'll never even consider a nested `Failure` type in the `AsyncSequence`-conforming type. This hack only applies prior to Swift 6.

Second, when we have inferred a `Failure` type and there is already something else called `Failure` within that same nominal type, don't print the inferred typelias into a module interface because it will cause a conflict.

Fixes rdar://123543633.
