### PR TITLE
[Parse] Fix a couple of SourceRanges

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1506,7 +1506,7 @@ bool Parser::parseExternAttribute(DeclAttributes &Attributes,
     return false;
   }
 
-  auto AttrRange = SourceRange(Loc, Tok.getLoc());
+  auto AttrRange = SourceRange(Loc, rParenLoc);
 
   // Reject duplicate attributes with the same kind.
   if (ExternAttr::find(Attributes, kind)) {
@@ -2329,7 +2329,7 @@ bool Parser::parseBackDeployedAttribute(DeclAttributes &Attributes,
   }
 
   assert(!PlatformAndVersions.empty());
-  auto AttrRange = SourceRange(Loc, Tok.getLoc());
+  auto AttrRange = SourceRange(Loc, RightLoc);
   for (auto &Item : PlatformAndVersions) {
     Attributes.add(new (Context) BackDeployedAttr(AtLoc, AttrRange, Item.first,
                                                   Item.second,

--- a/test/SourceKit/Misc/rdar123405070.swift
+++ b/test/SourceKit/Misc/rdar123405070.swift
@@ -1,0 +1,10 @@
+// RUN: %sourcekitd-test -req=open %s -- %s
+// Test that this doesn't crash sourcekitd
+
+@_backDeploy(before: macOS 14.0)
+@inline(never)
+public func foo() {}
+
+@_extern(wasm, module: "b", name: "c")
+@_extern(c)
+private func bar()


### PR DESCRIPTION
These should point to the last token of the attribute, not the token that follows.

rdar://123405070