### PR TITLE
[DebugInfo] Emit embedded swift into DW_AT_APPLE_flags

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -602,7 +602,8 @@ public:
   }
 
   std::string getDebugFlags(StringRef PrivateDiscriminator,
-                            bool EnableCXXInterop) const {
+                            bool EnableCXXInterop,
+                            bool EnableEmbeddedSwift) const {
     std::string Flags = DebugFlags;
     if (!PrivateDiscriminator.empty()) {
       if (!Flags.empty())
@@ -614,6 +615,12 @@ public:
         Flags += " ";
       Flags += "-enable-experimental-cxx-interop";
     }
+    if (EnableEmbeddedSwift) {
+      if (!Flags.empty())
+        Flags += " ";
+      Flags += "-enable-embedded-swift";
+    }
+
     return Flags;
   }
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2357,9 +2357,12 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
 
   bool EnableCXXInterop =
       IGM.getSILModule().getASTContext().LangOpts.EnableCXXInterop;
+  bool EnableEmbeddedSwift =
+      IGM.getSILModule().getASTContext().LangOpts.hasFeature(Feature::Embedded);
   TheCU = DBuilder.createCompileUnit(
       Lang, MainFile, Producer, Opts.shouldOptimize(),
-      Opts.getDebugFlags(PD, EnableCXXInterop), MajorRuntimeVersion, SplitName,
+      Opts.getDebugFlags(PD, EnableCXXInterop, EnableEmbeddedSwift),
+      MajorRuntimeVersion, SplitName,
       Opts.DebugInfoLevel > IRGenDebugInfoLevel::LineTables
           ? llvm::DICompileUnit::FullDebug
           : llvm::DICompileUnit::LineTablesOnly,

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -122,14 +122,16 @@ static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
     CGO.DebugCompilationDir = Opts.DebugCompilationDir;
     CGO.DwarfVersion = Opts.DWARFVersion;
     CGO.DwarfDebugFlags =
-        Opts.getDebugFlags(PD, Context.LangOpts.EnableCXXInterop);
+        Opts.getDebugFlags(PD, Context.LangOpts.EnableCXXInterop,
+                           Context.LangOpts.hasFeature(Feature::Embedded));
     break;
   case IRGenDebugInfoFormat::CodeView:
     CGO.EmitCodeView = true;
     CGO.DebugCompilationDir = Opts.DebugCompilationDir;
     // This actually contains the debug flags for codeview.
     CGO.DwarfDebugFlags =
-        Opts.getDebugFlags(PD, Context.LangOpts.EnableCXXInterop);
+        Opts.getDebugFlags(PD, Context.LangOpts.EnableCXXInterop,
+                           Context.LangOpts.hasFeature(Feature::Embedded));
     break;
   }
   if (!Opts.TrapFuncName.empty()) {

--- a/test/DebugInfo/embedded.swift
+++ b/test/DebugInfo/embedded.swift
@@ -1,0 +1,10 @@
+// Check that the "-enable-embedded-swift" is stored as a flag in the 
+// Compile Unit.
+
+// RUN: %target-swift-frontend -emit-ir -enable-experimental-feature Embedded -g %s -o - | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+// CHECK:          !DICompileUnit({{.*}}flags: "-enable-embedded-swift"


### PR DESCRIPTION
To properly initialize the compiler instance on LLDB when debugging embedded Swift programs, emit "-enable-embedded-swift" into the DW_AT_APPLE_flags attribute of the compile unit.
