### PR TITLE
SILGen: Produce move_values with a fresh cleanup.

### DIFF
--- a/test/SILGen/consume_operator_trivial_value_of_nontrivial_type.swift
+++ b/test/SILGen/consume_operator_trivial_value_of_nontrivial_type.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+// https://github.com/apple/swift/issues/71608
+func f(x:[Int]?)
+{
+}
+func g()
+{
+    let x:[Int]? = nil
+    f(x: consume x)
+}


### PR DESCRIPTION
If the value being moved was a trivial value of a nontrivial type (like nil for Optional<T>) then the lifetime checker would complain that there was no `destroy_value` ending the consumed value's lifetime. Partial fix for #71608.