### PR TITLE
[NFC][Concurrency] Improve the summary documentation for `Sendable`.

### DIFF
--- a/stdlib/public/core/Sendable.swift
+++ b/stdlib/public/core/Sendable.swift
@@ -10,7 +10,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// A type whose values can safely be passed across concurrency domains by copying.
+/// A thread-safe type whose values can be shared across arbitrary concurrent
+/// contexts without introducing a risk of data races. Values of the type may
+/// have no shared mutable state, or they may protect that state with a lock or
+/// by forcing it to only be accessed from a specific actor.
 ///
 /// You can safely pass values of a sendable type
 /// from one concurrency domain to another ---


### PR DESCRIPTION
The old text

> A type whose values can safely be passed across concurrency domains by copying.

Was misleading, especially because soon, `Sendable` will not require `Copyable`. This change improves the opening documentation both by being more descriptive about how types might be `Sendable`, and by using the term of art "thread-safe type" which will be immediately understood by programmers who are conceptually familiar with concurrency.

Thanks to @rjmccall for the new text.