### PR TITLE
[android] Update `memcmp()` declaration for nullability annotations added in NDK 26

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/LibcShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/LibcShims.h
@@ -61,7 +61,7 @@ SWIFT_READONLY
 static inline int _swift_stdlib_memcmp(const void *s1, const void *s2,
                                        __swift_size_t n) {
 // FIXME: Is there a way to identify Glibc specifically?
-#if defined(__gnu_linux__)
+#if defined(__gnu_linux__) || defined(__ANDROID__)
   extern int memcmp(const void * _Nonnull, const void * _Nonnull, __swift_size_t);
 #else
   extern int memcmp(const void * _Null_unspecified, const void * _Null_unspecified, __swift_size_t);


### PR DESCRIPTION
I checked again if this builds with NDK 25c and the stdlib built fine, so I enabled it for both NDK 25 and 26 on my Android CI, finagolfin/swift-android-sdk#132, and saw that [it only breaks building with swift-corelibs-foundation for 25c](https://github.com/finagolfin/swift-android-sdk/actions/runs/8090901505/job/22109144765#step:6:4037). I had seen that this is a breaking change for earlier Android NDKs, so I spun this off from #69908 so it wouldn't break the community Android CI that uses the previous NDK 25, but that CI only builds the Android stdlib so it may be fine.

@drodriguez, let me know what you think about getting this in now, as the community Android CI has been broken because of the swift-syntax issues anyway.