### PR TITLE
 Fix metadata availability testing for parameterized existentials and implement it for @isolated(any) function types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6609,6 +6609,11 @@ ERROR(availability_parameterized_protocol_only_version_newer, none,
       "%0 %1 or newer",
       (StringRef, llvm::VersionTuple))
 
+ERROR(availability_isolated_any_only_version_newer, none,
+      "runtime support for @isolated(any) function types is only available in "
+      "%0 %1 or newer",
+      (StringRef, llvm::VersionTuple))
+
 ERROR(availability_variadic_type_only_version_newer, none,
       "parameter packs in generic types are only available in %0 %1 or newer",
       (StringRef, llvm::VersionTuple))

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -18,6 +18,13 @@
 /// FEATURE(N, V)
 ///   N - The name of the feature (in UpperCamelCase).
 ///   V - The Swift version number, as a tuple, or FUTURE.
+///
+/// The feature Foo turns into two methods on ASTContext:
+/// getFooRuntimeAvailability(), which returns the exact version provided
+/// here, and getFooAvailability(), which maps that version into a version
+/// of the target OS.  Because both of these methods exist, it is a bad idea
+/// to use a feature name that ends in "Runtime", or people might get very
+/// confused.
 #ifndef FEATURE
 #define FEATURE(N, V)
 #endif
@@ -48,7 +55,8 @@ FEATURE(Concurrency,                                    (5, 5))
 FEATURE(MultiPayloadEnumTagSinglePayload,               (5, 6))
 FEATURE(ObjCIsUniquelyReferenced,                       (5, 6))
 
-FEATURE(ParameterizedExistentialRuntime,                (5, 7))
+// Metadata and casting support for parameterized existential types
+FEATURE(ParameterizedExistential,                       (5, 7))
 
 FEATURE(VariadicGenericType,                            (5, 9))
 FEATURE(SignedConformsToProtocol,                       (5, 9))

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -68,6 +68,8 @@ FEATURE(ObjCSymbolicReferences,                         (5, 11))
 FEATURE(TypedThrows,                                    (5, 11))
 FEATURE(StaticReadOnlyArrays,                           (5, 11))
 FEATURE(SwiftExceptionPersonality,                      (5, 11))
+// Metadata support for @isolated(any) function types
+FEATURE(IsolatedAny,                                    (5, 11))
 
 FEATURE(TaskExecutor,                                   FUTURE)
 FEATURE(Differentiation,                                FUTURE)

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -176,60 +176,65 @@ public:
 
 std::optional<llvm::VersionTuple>
 getRuntimeVersionThatSupportsDemanglingType(CanType type) {
-  // The Swift 6.0 runtime is the first version able to demangle types
-  // that involve typed throws.
-  bool usesTypedThrows = type.findIf([](CanType t) -> bool {
+  enum VersionRequirement {
+    None,
+    Swift_5_2,
+    Swift_5_5,
+    Swift_6_0,
+
+    // Short-circuit if we find this requirement.
+    Latest = Swift_6_0
+  };
+
+  VersionRequirement latestRequirement = None;
+  auto addRequirement = [&](VersionRequirement req) -> bool {
+    if (req > latestRequirement) {
+      latestRequirement = req;
+      return req == Latest;
+    }
+    return false;
+  };
+
+  (void) type.findIf([&](CanType t) -> bool {
     if (auto fn = dyn_cast<AnyFunctionType>(t)) {
-      if (!fn.getThrownError().isNull())
-        return true;
+      // The Swift 6.0 runtime is the first version able to demangle types
+      // that involve typed throws or @isolated(any), or for that matter
+      // represent them at all at runtime.
+      if (!fn.getThrownError().isNull() || fn->getIsolation().isErased())
+        return addRequirement(Swift_6_0);
+
+      // The Swift 5.5 runtime is the first version able to demangle types
+      // related to concurrency.
+      if (fn->isAsync() || fn->isSendable() ||
+          !fn->getIsolation().isNonIsolated())
+        return addRequirement(Swift_5_5);
+
+      return false;
+    }
+
+    if (auto opaqueArchetype = dyn_cast<OpaqueTypeArchetypeType>(t)) {
+      // Associated types of opaque types weren't mangled in a usable
+      // form by the Swift 5.1 runtime, so we needed to add a new
+      // mangling in 5.2.
+      if (opaqueArchetype->getInterfaceType()->is<DependentMemberType>())
+        return addRequirement(Swift_5_2);
+
+      // Although opaque types in general were only added in Swift 5.1,
+      // declarations that use them are already covered by availability
+      // guards, so we don't need to limit availability of mangled names
+      // involving them.
     }
 
     return false;
   });
-  if (usesTypedThrows) {
-    return llvm::VersionTuple(6, 0);
+
+  switch (latestRequirement) {
+  case Swift_6_0: return llvm::VersionTuple(6, 0);
+  case Swift_5_5: return llvm::VersionTuple(5, 5);
+  case Swift_5_2: return llvm::VersionTuple(5, 2);
+  case None: return std::nullopt;
   }
-
-  // The Swift 5.5 runtime is the first version able to demangle types
-  // related to concurrency.
-  bool needsConcurrency = type.findIf([](CanType t) -> bool {
-    if (auto fn = dyn_cast<AnyFunctionType>(t)) {
-      if (fn->isAsync() || fn->isSendable() || fn->hasGlobalActor())
-        return true;
-
-      for (const auto &param : fn->getParams()) {
-        if (param.isIsolated())
-          return true;
-      }
-
-      return false;
-    }
-    return false;
-  });
-  if (needsConcurrency) {
-    return llvm::VersionTuple(5, 5);
-  }
-
-  // Associated types of opaque types weren't mangled in a usable form by the
-  // Swift 5.1 runtime, so we needed to add a new mangling in 5.2.
-  if (type->hasOpaqueArchetype()) {
-    auto hasOpaqueAssocType = type.findIf([](CanType t) -> bool {
-      if (auto a = dyn_cast<ArchetypeType>(t)) {
-        return isa<OpaqueTypeArchetypeType>(a) &&
-          a->getInterfaceType()->is<DependentMemberType>();
-      }
-      return false;
-    });
-    
-    if (hasOpaqueAssocType)
-      return llvm::VersionTuple(5, 2);
-    // Although opaque types in general were only added in Swift 5.1,
-    // declarations that use them are already covered by availability
-    // guards, so we don't need to limit availability of mangled names
-    // involving them.
-  }
-
-  return std::nullopt;
+  llvm_unreachable("bad kind");
 }
 
 // Produce a fallback mangled type name that uses an open-coded callback

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -960,7 +960,7 @@ namespace RuntimeConstants {
   }
 
   RuntimeAvailability ParameterizedExistentialAvailability(ASTContext &Context) {
-    auto featureAvailability = Context.getParameterizedExistentialRuntimeAvailability();
+    auto featureAvailability = Context.getParameterizedExistentialAvailability();
     if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
       return RuntimeAvailability::ConditionallyAvailable;
     }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2984,7 +2984,7 @@ bool isSubscriptReturningString(const ValueDecl *D, ASTContext &Context) {
   return resultTy->isString();
 }
 
-bool swift::diagnoseParameterizedProtocolAvailability(
+static bool diagnoseParameterizedProtocolAvailability(
     SourceRange ReferenceRange, const DeclContext *ReferenceDC) {
   return TypeChecker::checkAvailability(
       ReferenceRange,
@@ -2993,27 +2993,162 @@ bool swift::diagnoseParameterizedProtocolAvailability(
       ReferenceDC);
 }
 
-static void
-maybeDiagParameterizedExistentialErasure(ErasureExpr *EE,
-                                         const ExportContext &Where) {
-  if (auto *OE = dyn_cast<OpaqueValueExpr>(EE->getSubExpr())) {
-    auto *OAT = OE->getType()->getAs<OpenedArchetypeType>();
-    if (!OAT)
-      return;
+static bool diagnoseIsolatedAnyAvailability(
+    SourceRange ReferenceRange, const DeclContext *ReferenceDC) {
+  return TypeChecker::checkAvailability(
+      ReferenceRange,
+      ReferenceDC->getASTContext().getIsolatedAnyAvailability(),
+      diag::availability_isolated_any_only_version_newer,
+      ReferenceDC);
+}
 
-    auto opened = OAT->getGenericEnvironment()->getOpenedExistentialType();
-    if (!opened || !opened->hasParameterizedExistential())
-      return;
+static bool checkTypeMetadataAvailabilityInternal(CanType type,
+                                                  SourceRange refLoc,
+                                                  const DeclContext *refDC) {
+  return type.findIf([&](CanType type) {
+    if (isa<ParameterizedProtocolType>(type)) {
+      return diagnoseParameterizedProtocolAvailability(refLoc, refDC);
+    } else if (auto fnType = dyn_cast<AnyFunctionType>(type)) {
+      auto isolation = fnType->getIsolation();
+      if (isolation.isErased())
+        return diagnoseIsolatedAnyAvailability(refLoc, refDC);
+    }
+    return false;
+  });
+}
 
-    (void)diagnoseParameterizedProtocolAvailability(EE->getLoc(),
-                                                    Where.getDeclContext());
+/// Check whether type metadata is available for the given type (and its
+/// component types).
+bool swift::checkTypeMetadataAvailability(Type type,
+                                          SourceRange refLoc,
+                                          const DeclContext *refDC) {
+  if (!type) return false;
+  return checkTypeMetadataAvailabilityInternal(type->getCanonicalType(),
+                                               refLoc, refDC);
+}
+
+/// Check whether type metadata is available for the given type, given that
+/// it is the operand of a dynamic cast or existential conversion.
+static bool checkTypeMetadataAvailabilityForConverted(Type refType,
+                                                      SourceRange refLoc,
+                                                      const DeclContext *refDC) {
+  if (!refType) return false;
+
+  auto type = refType->getCanonicalType();
+
+  // SILGen emits these conversions by opening the outermost level of
+  // existential, so we never need to emit type metadata for an
+  // existential in such a position.  We necessarily have type metadata
+  // for the dynamic type of the existential, so there's nothing to check
+  // there.
+  if (type.isAnyExistentialType()) return false;
+
+  return checkTypeMetadataAvailabilityInternal(type, refLoc, refDC);
+}
+
+namespace {
+
+class CheckConversionAvailability {
+  SourceRange refLoc;
+  const DeclContext *refDC;
+
+public:
+  CheckConversionAvailability(SourceRange refLoc, const DeclContext *refDC)
+    : refLoc(refLoc), refDC(refDC) {}
+
+  void check(CanType srcType, CanType destType);
+  void checkFunction(CanAnyFunctionType srcType, CanAnyFunctionType destType);
+
+private:
+  void checkTuple(CanTupleType srcType, CanTupleType destType);
+};
+
+} // end anonymous namespace
+
+void CheckConversionAvailability::check(CanType srcType, CanType destType) {
+  if (srcType == destType)
+    return;
+
+  // We care about specific optionality structure here: converting
+  // `(any P<T>)?` to `Any?` doesn't require metadata for `any P<T>`,
+  // but converting `(any P<T>)?` to non-optional `Any` does.
+  if (auto destObjectType = destType.getOptionalObjectType()) {
+    // optional -> optional conversion
+    if (auto srcObjectType = srcType.getOptionalObjectType()) {
+      check(srcObjectType, destObjectType);
+    // optional injection
+    } else {
+      check(srcType, destObjectType);
+    }
+
+  // Conversions to existential types require type metadata for the
+  // source type, except that we look into existentials.
+  } else if (destType.isAnyExistentialType()) {
+    checkTypeMetadataAvailabilityForConverted(srcType, refLoc, refDC);
+
+  // Conversions between function types perform a bunch of recursive
+  // conversions.
+  } else if (auto destFnType = dyn_cast<AnyFunctionType>(destType)) {
+    if (auto srcFnType = dyn_cast<AnyFunctionType>(srcType)) {
+      checkFunction(srcFnType, destFnType);
+    }
+
+  // Conversions between tuple types perform a bunch of recursive
+  // conversions.
+  } else if (auto destTupleType = dyn_cast<TupleType>(destType)) {
+    if (auto srcTupleType = dyn_cast<TupleType>(srcType)) {
+      checkTuple(srcTupleType, destTupleType);
+    }
+
+  // Conversions of things containing pack expansions convert the
+  // expansion patterns.  We won't print the types we get here, so
+  // we can ignore them.
+  } else if (auto destExpType = dyn_cast<PackExpansionType>(destType)) {
+    if (auto srcExpType = dyn_cast<PackExpansionType>(srcType)) {
+      check(srcExpType.getPatternType(), destExpType.getPatternType());
+    }
   }
+}
 
-  if (EE->getType() &&
-      EE->getType()->isAny() &&
-      EE->getSubExpr()->getType()->hasParameterizedExistential()) {
-    (void)diagnoseParameterizedProtocolAvailability(EE->getLoc(),
-                                                    Where.getDeclContext());
+void CheckConversionAvailability::checkFunction(CanAnyFunctionType srcType,
+                                                CanAnyFunctionType destType) {
+  // Results are covariantly converted.
+  check(srcType.getResult(), destType.getResult());
+
+  // Defensively ignored invalid conversion structure.
+  if (srcType->getNumParams() != destType->getNumParams())
+    return;
+
+  // Parameters are contravariantly converted.
+  for (auto i : range(srcType->getNumParams())) {
+    const auto &srcParam = srcType.getParams()[i];
+    const auto &destParam = destType.getParams()[i];
+
+    // Note the reversal for contravariance.
+    check(destParam.getParameterType(), srcParam.getParameterType());
+  }
+}
+
+void CheckConversionAvailability::checkTuple(CanTupleType srcType,
+                                             CanTupleType destType) {
+  // Handle invalid structure appropriately.
+  if (srcType->getNumElements() != destType->getNumElements())
+    return;
+
+  for (auto i : range(srcType->getNumElements())) {
+    check(srcType.getElementType(i), destType.getElementType(i));
+  }
+}
+
+static void checkFunctionConversionAvailability(Type srcType, Type destType,
+                                                SourceRange refLoc,
+                                                const DeclContext *refDC) {
+  if (srcType && destType) {
+    auto srcFnType = cast<AnyFunctionType>(srcType->getCanonicalType());
+    auto destFnType = cast<AnyFunctionType>(destType->getCanonicalType());
+
+    CheckConversionAvailability(refLoc, refDC)
+      .checkFunction(srcFnType, destFnType);
   }
 }
 
@@ -3236,16 +3371,11 @@ public:
       diagnoseDeclRefAvailability(CE->getInitializer(), CE->getSourceRange());
     }
 
-    if (auto *EE = dyn_cast<ErasureExpr>(E)) {
-      maybeDiagParameterizedExistentialErasure(EE, Where);
-    }
-    if (auto *CC = dyn_cast<ExplicitCastExpr>(E)) {
-      if (!isa<CoerceExpr>(CC) && CC->getCastType() &&
-          CC->getCastType()->hasParameterizedExistential()) {
-        SourceLoc loc = CC->getCastTypeRepr() ? CC->getCastTypeRepr()->getLoc()
-                                              : E->getLoc();
-        diagnoseParameterizedProtocolAvailability(loc, Where.getDeclContext());
-      }
+    if (auto *FCE = dyn_cast<FunctionConversionExpr>(E)) {
+      checkFunctionConversionAvailability(FCE->getSubExpr()->getType(),
+                                          FCE->getType(),
+                                          FCE->getLoc(),
+                                          Where.getDeclContext());
     }
     if (auto KP = dyn_cast<KeyPathExpr>(E)) {
       maybeDiagKeyPath(KP);
@@ -3274,19 +3404,31 @@ public:
                                : nullptr,
                                CE->getResultType(), E->getLoc(), Where);
     }
-    if (auto CE = dyn_cast<ExplicitCastExpr>(E)) {
-      diagnoseTypeAvailability(CE->getCastTypeRepr(), CE->getCastType(),
-                               E->getLoc(), Where);
-    }
-
     if (AbstractClosureExpr *closure = dyn_cast<AbstractClosureExpr>(E)) {
       if (shouldWalkIntoClosure(closure)) {
         walkAbstractClosure(closure);
         return Action::SkipChildren(E);
       }
     }
+
+    if (auto CE = dyn_cast<ExplicitCastExpr>(E)) {
+      if (!isa<CoerceExpr>(CE)) {
+        SourceLoc loc = CE->getCastTypeRepr() ? CE->getCastTypeRepr()->getLoc()
+                                              : E->getLoc();
+        checkTypeMetadataAvailability(CE->getCastType(), loc,
+                                      Where.getDeclContext());
+        checkTypeMetadataAvailabilityForConverted(CE->getSubExpr()->getType(),
+                                                  loc, Where.getDeclContext());
+      }
+
+      diagnoseTypeAvailability(CE->getCastTypeRepr(), CE->getCastType(),
+                               E->getLoc(), Where);
+    }
     
     if (auto EE = dyn_cast<ErasureExpr>(E)) {
+      checkTypeMetadataAvailability(EE->getSubExpr()->getType(),
+                                    EE->getLoc(), Where.getDeclContext());
+
       for (ProtocolConformanceRef C : EE->getConformances()) {
         diagnoseConformanceAvailability(E->getLoc(), C, Where, Type(), Type(),
                                         /*useConformanceAvailabilityErrorsOpt=*/true);
@@ -3530,6 +3672,17 @@ bool ExprAvailabilityWalker::diagnoseDeclRefAvailability(
   if (!declRef)
     return false;
   const ValueDecl *D = declRef.getDecl();
+
+  // Suppress availability diagnostics for uses of builtins.  We don't
+  // synthesize availability for builtin functions anyway, so this really
+  // means to not check availability for the substitution maps.  This is
+  // abstractly reasonable, since calls to generic builtins usually do not
+  // require metadata for generic arguments the same way that calls to
+  // generic functions might.  More importantly, the stdlib has to get the
+  // availability right anyway, and diagnostics from builtin usage are not
+  // likely to be of significant assistance in that.
+  if (D->getModuleContext()->isBuiltinModule())
+    return false;
 
   if (auto *attr = AvailableAttr::isUnavailable(D)) {
     if (diagnoseIncDecRemoval(D, R, attr))
@@ -4045,19 +4198,6 @@ public:
       }
     }
 
-    if (auto *TT = T->getAs<TupleType>()) {
-      for (auto component : TT->getElementTypes()) {
-        // Let the walker find inner tuple types, we only want to diagnose
-        // non-compound components.
-        if (component->is<TupleType>())
-          continue;
-
-        if (component->hasParameterizedExistential())
-          (void)diagnoseParameterizedProtocolAvailability(
-              Loc, Where.getDeclContext());
-      }
-    }
-
     return TypeDeclFinder::walkToTypePost(T);
   }
 };
@@ -4198,10 +4338,8 @@ swift::diagnoseSubstitutionMapAvailability(SourceLoc loc,
     return hadAnyIssues;
 
   for (auto replacement : subs.getReplacementTypes()) {
-    if (replacement->hasParameterizedExistential())
-      if (diagnoseParameterizedProtocolAvailability(loc,
-                                                    where.getDeclContext()))
-        hadAnyIssues = true;
+    if (checkTypeMetadataAvailability(replacement, loc, where.getDeclContext()))
+      hadAnyIssues = true;
   }
   return hadAnyIssues;
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2988,7 +2988,7 @@ bool swift::diagnoseParameterizedProtocolAvailability(
     SourceRange ReferenceRange, const DeclContext *ReferenceDC) {
   return TypeChecker::checkAvailability(
       ReferenceRange,
-      ReferenceDC->getASTContext().getParameterizedExistentialRuntimeAvailability(),
+      ReferenceDC->getASTContext().getParameterizedExistentialAvailability(),
       diag::availability_parameterized_protocol_only_version_newer,
       ReferenceDC);
 }

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -275,10 +275,12 @@ bool diagnoseExplicitUnavailability(
     const ExportContext &where,
     bool warnIfConformanceUnavailablePreSwift6 = false);
 
-/// Diagnose uses of the runtime features of parameterized protools. Returns
-/// \c true if a diagnostic was emitted.
-bool diagnoseParameterizedProtocolAvailability(SourceRange loc,
-                                               const DeclContext *DC);
+/// Diagnose uses of the runtime support of the given type, such as
+/// type metadata and dynamic casting.
+///
+/// Returns \c true if a diagnostic was emitted.
+bool checkTypeMetadataAvailability(Type type, SourceRange loc,
+                                   const DeclContext *DC);
 
 /// Check if \p decl has a introduction version required by -require-explicit-availability
 void checkExplicitAvailability(Decl *decl);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4853,11 +4853,11 @@ static void ensureRequirementsAreSatisfied(ASTContext &ctx,
     }
 
     // Make sure any associated type witnesses don't make reference to a
-    // parameterized existential type, or we're going to have trouble at
+    // type we can't emit metadata for, or we're going to have trouble at
     // runtime.
-    if (type->hasParameterizedExistential())
-      (void)diagnoseParameterizedProtocolAvailability(typeDecl->getLoc(),
-                                                      where.getDeclContext());
+    checkTypeMetadataAvailability(type, typeDecl->getLoc(),
+                                  where.getDeclContext());
+
     return false;
   });
 

--- a/test/IRGen/isolated_any.sil
+++ b/test/IRGen/isolated_any.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir %s | %IRGenFileCheck %s
+// RUN: %target-swift-frontend -emit-ir %s -enable-experimental-feature IsolatedAny | %IRGenFileCheck %s
 
 // REQUIRES: concurrency
 

--- a/test/IRGen/isolated_any_metadata.sil
+++ b/test/IRGen/isolated_any_metadata.sil
@@ -1,0 +1,24 @@
+// RUN: %swift -emit-ir %s -enable-experimental-feature IsolatedAny -target x86_64-apple-macosx10.10 -disable-legacy-type-info -parse-stdlib | %IRGenFileCheck %s -check-prefix=CHECK-ACCESSOR
+// RUN: %swift -emit-ir %s -enable-experimental-feature IsolatedAny -target x86_64-unknown-linux-gnu -disable-legacy-type-info -parse-stdlib | %IRGenFileCheck %s -check-prefix=CHECK-DEMANGLE
+
+// REQUIRES: concurrency
+
+sil_stage canonical
+
+// CHECK-LABEL:        define{{.*}} swiftcc ptr @get_metadata
+// CHECK:              entry:
+// CHECK-ACCESSOR-NEXT:  [[T0:%.*]] = call swiftcc %swift.metadata_response @"$syyYAcMa"([[INT]] 0)
+// CHECK-ACCESSOR-NEXT:  [[METADATA:%.]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-DEMANGLE:       [[METADATA:%.*]] = call ptr @__swift_instantiateConcreteTypeFromMangledName(ptr @"$syyYAcMD")
+// CHECK-NEXT:           ret ptr [[METADATA]]
+sil @get_metadata : $() -> @thick Any.Type {
+entry:
+  %type = metatype $@thick (@isolated(any) () -> ()).Type
+  %result = init_existential_metatype %type : $@thick (@isolated(any) () -> ()).Type, $@thick Any.Type
+  return %result : $@thick Any.Type
+}
+
+// CHECK-ACCESSOR-LABEL: define{{.*}} swiftcc %swift.metadata_response @"$syyYAcMa"
+//   2214592512 == 0x84000000 == (ExtendedFlags | Escaping)
+//   2 == IsolatedAny
+// CHECK-ACCESSOR:         call ptr @swift_getExtendedFunctionTypeMetadata([[INT]] 2214592512, [[INT]] 0, ptr null, ptr null, ptr getelementptr inbounds {{.*}} @"$sytN"{{.*}}), ptr null, i32 2, ptr null)

--- a/test/Parse/isolated_any.swift
+++ b/test/Parse/isolated_any.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature IsolatedAny
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature IsolatedAny -disable-availability-checking
 
 // REQUIRES: asserts
 

--- a/test/Sema/availability_isolated_any.swift
+++ b/test/Sema/availability_isolated_any.swift
@@ -1,0 +1,43 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.50 -enable-experimental-feature IsolatedAny
+
+// REQUIRES: OS=macosx
+
+// Concrete uses of @isolated(any) are fine.
+func expectIsolatedAny(fn: @isolated(any) () -> ()) {}
+
+func testConcrete1(fn: @isolated(any) () -> ()) {
+  expectIsolatedAny(fn: fn)
+}
+func testConcrete2(fn: @isolated(any) () -> ()) {
+  expectIsolatedAny {}
+}
+func testConcrete3(fn: @MainActor () -> ()) {
+  expectIsolatedAny {}
+}
+
+func testErasure(fn: @escaping @isolated(any) () -> ()) -> Any {
+  return fn // expected-error {{runtime support for @isolated(any) function types is only available in}}
+  // expected-note @-2 {{add @available attribute to enclosing global function}}
+  // expected-note @-2 {{add 'if #available' version check}}
+}
+
+func testCovariantErasure(fn: @escaping () -> @isolated(any) () -> Void) -> (() -> Any) {
+  return fn // expected-error {{runtime support for @isolated(any) function types is only available in}}
+  // expected-note @-2 {{add @available attribute to enclosing global function}}
+  // expected-note @-2 {{add 'if #available' version check}}
+}
+
+func testContravariantErasure(fn: @escaping (Any) -> Void) -> ((@escaping @isolated(any) () -> Void) -> Void) {
+  return fn // expected-error {{runtime support for @isolated(any) function types is only available in}}
+  // expected-note @-2 {{add @available attribute to enclosing global function}}
+  // expected-note @-2 {{add 'if #available' version check}}
+}
+
+protocol P {
+  associatedtype A
+}
+
+struct S: P { // expected-note {{add @available attribute to enclosing struct}}
+  typealias A = @isolated(any) () -> () // expected-error {{runtime support for @isolated(any) function types is only available in}}
+  // expected-note @-1 {{add @available attribute to enclosing type alias}}
+}

--- a/test/Sema/availability_parameterized_existential.swift
+++ b/test/Sema/availability_parameterized_existential.swift
@@ -26,9 +26,34 @@ struct Wrapper<T> {}
 func identity<T>(_ x: any P<T>) -> any P<T> { return x } // OK
 func unwrapUnwrap<T>(_ x: (any P<T>)???) -> (any P<T>)? { return x!! } // OK
 
-func erase<T>(_ x: any P<T>) -> Any { return x } // expected-error {{runtime support for parameterized protocol types is only available in}}
+func erase<T>(_ x: any P<T>) -> Any { return x }
+
+func nonerasingFunction<T>(_ f: @escaping (any P<T>) -> ()) -> Any { return 0 }
+
+func eraseFunction<T>(_ f: @escaping (any P<T>) -> ()) -> Any { return f } // expected-error {{runtime support for parameterized protocol types is only available in}}
 // expected-note@-1 {{add @available attribute to enclosing global function}}
 // expected-note@-2 {{add 'if #available' version check}}
+
+// These are okay because we can convert between existentials without metadata.
+func eraseFunctionCovariant<T>(_ f: @escaping () -> any P<T>) -> (() -> Any) {
+  return f
+}
+func eraseFunctionContravariant<T>(_ f: @escaping (Any) -> ()) -> ((any P<T>) -> Any) {
+  return f
+}
+
+// We cannot convert from an optional existential to an existential without
+// metadata.
+func eraseFunctionCovariantOptional<T>(_ f: @escaping () -> (any P<T>)?) -> (() -> Any) {
+  return f // expected-error {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-2 {{add @available attribute to enclosing global function}}
+  // expected-note@-2 {{add 'if #available' version check}}
+}
+func eraseFunctionContravariantOptional<T>(_ f: @escaping (Any) -> ()) -> (((any P<T>)?) -> Any) {
+  return f // expected-error {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-2 {{add @available attribute to enclosing global function}}
+  // expected-note@-2 {{add 'if #available' version check}}
+}
 
 func eraseOptional<T>(_ x: (any P<T>)?) -> Any { return x }
 // expected-note@-1 {{add @available attribute to enclosing global function}}
@@ -44,10 +69,8 @@ func eraseOptional2<T>(_ x: (any P<T>)?) -> Any { return x as Any }
 // expected-error@-2 {{runtime support for parameterized protocol types is only available in}}
 // expected-note@-3 {{add 'if #available' version check}}
 
-func tupleOut<T>() -> (any P<T>, Int) { return tupleOut() } // expected-error {{runtime support for parameterized protocol types is only available in}}
-// expected-note@-1 {{add @available attribute to enclosing global function}}
-func tupleIn<T>(_ xs: (any P<T>, Int)) -> Int { return tupleIn(xs) } // expected-error {{runtime support for parameterized protocol types is only available in}}
-// expected-note@-1 {{add @available attribute to enclosing global function}}
+func tupleOut<T>() -> (any P<T>, Int) { return tupleOut() }
+func tupleIn<T>(_ xs: (any P<T>, Int)) -> Int { return tupleIn(xs) }
 func wrap<T>(_ x: any P<T>) -> Wrapper<any P<T>> { return wrap(x) } // expected-error {{runtime support for parameterized protocol types is only available in}}
 // expected-note@-1 {{add @available attribute to enclosing global function}}
 func optionalWrap<T>(_ x: any P<T>) -> Wrapper<(any P<T>)?> { return optionalWrap(x) } // expected-error {{runtime support for parameterized protocol types is only available in}}
@@ -75,7 +98,7 @@ struct ParameterizedMembers { // expected-note {{add @available attribute to enc
   var broken: Wrapper<(any P<String>)?> // expected-error {{runtime support for parameterized protocol types is only available in}}
 }
 
-func casts() { // expected-note 5 {{add @available attribute to enclosing global function}}
+func casts() { // expected-note 4 {{add @available attribute to enclosing global function}}
   struct Value: P { typealias T = String }
 
   let _ = Value() as any P<String> // OK
@@ -96,8 +119,8 @@ func casts() { // expected-note 5 {{add @available attribute to enclosing global
 
   let _ = Value() as! (any P<String>, Int)
   // expected-warning@-1 {{cast from 'Value' to unrelated type '(any P<String>, Int)' always fails}}
-  // expected-error@-2 2 {{runtime support for parameterized protocol types is only available in}}
-  // expected-note@-3 2 {{add 'if #available' version check}}
+  // expected-error@-2 1 {{runtime support for parameterized protocol types is only available in}}
+  // expected-note@-3 1 {{add 'if #available' version check}}
 }
 
 // FIXME: It's a little aggressive to also ban metatypes.
@@ -109,4 +132,37 @@ func metatypes<T>(_ x: T.Type) {  // expected-note 2 {{add @available attribute 
   metatypes((any P<T>.Type).self)
   // expected-error@-1 {{runtime support for parameterized protocol types is only available in}}
   // expected-note@-2 {{add 'if #available' version check}}
+}
+
+func tupleConversion1<T>(_ tuple: (any P<T>, Int)) {
+  let converted: (any P<T>, Int?) = tuple
+  _ = converted
+}
+func tupleConversion2<T>(_ tuple: (any P<T>, Int)) {
+  let converted: (Any, Int?) = tuple
+  _ = converted
+}
+func tupleConversion3<T>(_ tuple: ((any P<T>)?, Int)) {
+  // expected-note @-1 {{add @available attribute to enclosing global function}}
+
+  let converted: (Any, Int?) = tuple // expected-error {{runtime support for parameterized protocol types is only available in}}
+  // expected-note @-1 {{add 'if #available' version check}}
+
+  // expected-warning @-3 {{expression implicitly coerced from '(any P<T>)?' to 'Any'}}
+  // expected-note @-4 {{explicitly cast to 'Any'}}
+  // expected-note @-5 {{force-unwrap the value}}
+  // expected-note @-6 {{provide a default value}}
+
+  _ = converted
+}
+
+func tupleCovariantConversion1<T>(fn: @escaping () -> (any P<T>, Int)) -> (() -> (Any, Int)) {
+  return fn
+}
+func tupleCovariantConversion2<T>(fn: @escaping () -> ((any P<T>)?, Int)) -> (() -> (Any, Int)) {
+  // expected-note @-1 {{add @available attribute to enclosing global function}}
+
+  return fn // expected-error {{runtime support for parameterized protocol types is only available in}}
+  // expected-note @-1 {{add 'if #available' version check}}
+
 }

--- a/validation-test/IRGen/98995607.swift.gyb
+++ b/validation-test/IRGen/98995607.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swiftgyb
+// RUN: %target-run-simple-swiftgyb(-Xfrontend -disable-availability-checking)
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION

The existing testing was pretty broken: we were diagnosing all sorts of things that don't require type metadata (like using a tuple with an extended existential in a value position in an API signature) and not diagnosing several things that do (like covariant function conversions that erase types).  There's therefore some risk to this patch, but I'm not too worried because needing metadata like this is pretty uncommon, and it's likely that programs won't build correctly anyway --- it'll just get caught by the linker instead of the compiler.
