### PR TITLE
build: Respect `native-*-tools-path` when building Wasm stdlib

### DIFF
--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -147,7 +147,7 @@ class CMake(object):
             define("CMAKE_CXX_COMPILER_LAUNCHER:PATH", args.cmake_cxx_launcher)
 
         if self.prefer_just_built_toolchain and product:
-            toolchain_path = product.install_toolchain_path(args.host_target)
+            toolchain_path = product.native_toolchain_path(args.host_target)
             cmake_swiftc_path = os.getenv('CMAKE_Swift_COMPILER',
                                           os.path.join(toolchain_path, 'bin', 'swiftc'))
             define("CMAKE_C_COMPILER:PATH", os.path.join(toolchain_path,

--- a/utils/swift_build_support/swift_build_support/cmake.py
+++ b/utils/swift_build_support/swift_build_support/cmake.py
@@ -97,13 +97,16 @@ class CMakeOptions(object):
 
 class CMake(object):
 
-    def __init__(self, args, toolchain, prefer_just_built_toolchain=False):
-        """If prefer_just_built_toolchain is set to True, we set the clang, clang++,
-        and Swift compilers from the installed toolchain.
+    def __init__(self, args, toolchain, prefer_native_toolchain=False):
+        """If prefer_native_toolchain is set to True, we set the clang, clang++,
+        and Swift compilers from the toolchain explicitly specified by the
+        native-*-tools-path options or just installed toolchain if the options
+        are not specified. If prefer_native_toolchain is set to False, we use
+        system defaults.
         """
         self.args = args
         self.toolchain = toolchain
-        self.prefer_just_built_toolchain = prefer_just_built_toolchain
+        self.prefer_native_toolchain = prefer_native_toolchain
 
     def common_options(self, product=None):
         """Return options used for all products, including LLVM/Clang
@@ -146,7 +149,7 @@ class CMake(object):
         if args.cmake_cxx_launcher:
             define("CMAKE_CXX_COMPILER_LAUNCHER:PATH", args.cmake_cxx_launcher)
 
-        if self.prefer_just_built_toolchain and product:
+        if self.prefer_native_toolchain and product:
             toolchain_path = product.native_toolchain_path(args.host_target)
             cmake_swiftc_path = os.getenv('CMAKE_Swift_COMPILER',
                                           os.path.join(toolchain_path, 'bin', 'swiftc'))

--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -24,11 +24,11 @@ class CMakeProduct(product.Product):
         return self.args.verbose_build
 
     def build_with_cmake(self, build_targets, build_type, build_args,
-                         prefer_just_built_toolchain=False):
+                         prefer_native_toolchain=False):
         assert self.toolchain.cmake is not None
         cmake_build = []
         _cmake = cmake.CMake(self.args, self.toolchain,
-                             prefer_just_built_toolchain)
+                             prefer_native_toolchain)
 
         if self.toolchain.distcc_pump:
             cmake_build.append(self.toolchain.distcc_pump)

--- a/utils/swift_build_support/swift_build_support/products/minimalstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/minimalstdlib.py
@@ -174,7 +174,7 @@ class MinimalStdlib(cmake_product.CMakeProduct):
 
         # Build!
         self.build_with_cmake(["swift-stdlib-freestanding"], build_variant, [],
-                              prefer_just_built_toolchain=True)
+                              prefer_native_toolchain=True)
 
     def should_test(self, host_target):
         return False

--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -45,7 +45,10 @@ class WASILibc(product.Product):
 
     def build(self, host_target):
         build_root = os.path.dirname(self.build_dir)
-        llvm_build_dir = os.path.join('..', build_root, '%s-%s' % ('llvm', host_target))
+        llvm_build_bin_dir = os.path.join(
+            '..', build_root, '%s-%s' % ('llvm', host_target), 'bin')
+        llvm_tools_path = self.args.native_llvm_tools_path or llvm_build_bin_dir
+        clang_tools_path = self.args.native_clang_tools_path or llvm_build_bin_dir
         build_jobs = self.args.build_jobs or multiprocessing.cpu_count()
 
         sysroot_build_dir = WASILibc.sysroot_build_path(build_root, host_target)
@@ -66,9 +69,9 @@ class WASILibc(product.Product):
             'OBJDIR=' + os.path.join(self.build_dir, 'obj'),
             'SYSROOT=' + sysroot_build_dir,
             'INSTALL_DIR=' + WASILibc.sysroot_install_path(build_root),
-            'CC=' + os.path.join(llvm_build_dir, 'bin', 'clang'),
-            'AR=' + os.path.join(llvm_build_dir, 'bin', 'llvm-ar'),
-            'NM=' + os.path.join(llvm_build_dir, 'bin', 'llvm-nm'),
+            'CC=' + os.path.join(clang_tools_path, 'clang'),
+            'AR=' + os.path.join(llvm_tools_path, 'llvm-ar'),
+            'NM=' + os.path.join(llvm_tools_path, 'llvm-nm'),
         ])
 
     @classmethod
@@ -119,7 +122,10 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
 
     def build(self, host_target):
         build_root = os.path.dirname(self.build_dir)
-        llvm_build_dir = os.path.join('..', build_root, '%s-%s' % ('llvm', host_target))
+        llvm_build_bin_dir = os.path.join(
+            '..', build_root, '%s-%s' % ('llvm', host_target), 'bin')
+        llvm_tools_path = self.args.native_llvm_tools_path or llvm_build_bin_dir
+        clang_tools_path = self.args.native_clang_tools_path or llvm_build_bin_dir
 
         self.cmake_options.define('CMAKE_SYSROOT:PATH',
                                   WASILibc.sysroot_build_path(build_root, host_target))
@@ -144,13 +150,13 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
         self.cmake_options.define('CMAKE_SYSTEM_NAME:STRING', 'WASI')
         self.cmake_options.define('CMAKE_SYSTEM_PROCESSOR:STRING', 'wasm32')
         self.cmake_options.define('CMAKE_AR:FILEPATH',
-                                  os.path.join(llvm_build_dir, 'bin', 'llvm-ar'))
+                                  os.path.join(llvm_tools_path, 'llvm-ar'))
         self.cmake_options.define('CMAKE_RANLIB:FILEPATH',
-                                  os.path.join(llvm_build_dir, 'bin', 'llvm-ranlib'))
+                                  os.path.join(llvm_tools_path, 'llvm-ranlib'))
         self.cmake_options.define('CMAKE_C_COMPILER:FILEPATH',
-                                  os.path.join(llvm_build_dir, 'bin', 'clang'))
+                                  os.path.join(clang_tools_path, 'clang'))
         self.cmake_options.define('CMAKE_CXX_COMPILER:STRING',
-                                  os.path.join(llvm_build_dir, 'bin', 'clang++'))
+                                  os.path.join(clang_tools_path, 'clang++'))
         # Explicitly disable exceptions even though it's usually implicitly disabled by
         # LIBCXX_ENABLE_EXCEPTIONS because the CMake feature check fails to detect
         # -fno-exceptions support in clang due to missing compiler-rt while configuring

--- a/utils/swift_build_support/swift_build_support/products/wasisysroot.py
+++ b/utils/swift_build_support/swift_build_support/products/wasisysroot.py
@@ -194,7 +194,7 @@ class WasmLLVMRuntimeLibs(cmake_product.CMakeProduct):
         self.cmake_options.define('UNIX:BOOL', 'TRUE')
 
         self.build_with_cmake([], self.args.build_variant, [],
-                              prefer_just_built_toolchain=True)
+                              prefer_native_toolchain=True)
         self.install_with_cmake(
             ["install"], WASILibc.sysroot_install_path(build_root))
 

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -117,7 +117,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
 
         # Configure with WebAssembly target variant, and build with just-built toolchain
         self.build_with_cmake([], self._build_variant, [],
-                              prefer_just_built_toolchain=True)
+                              prefer_native_toolchain=True)
 
     def test(self, host_target):
         build_root = os.path.dirname(self.build_dir)

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -44,7 +44,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
             'SWIFT_STDLIB_BUILD_TYPE:STRING', self._build_variant)
 
         # Toolchain configuration
-        toolchain_path = self.install_toolchain_path(host_target)
+        toolchain_path = self.native_toolchain_path(host_target)
         # Explicitly set the CMake AR and RANLIB to force it to use llvm-ar/llvm-ranlib
         # instead of the system ar/ranlib, which usually don't support WebAssembly
         # object files.


### PR DESCRIPTION
This change allows the Wasm stdlib to be built using the prebuilt Swift toolchain instead of just built from source without building compiler tools. For example, I'm using the following build preset on my local.

```
skip-build-llvm
skip-build-swift
skip-build-cmark
skip-build-benchmarks
skip-early-swift-driver

build-wasm-stdlib

native-swift-tools-path=/path/to/swift-source/install/usr/bin
native-clang-tools-path=/path/to/swift-source/install/usr/bin
native-llvm-tools-path=/path/to/swift-source/install/usr/bin
```