### PR TITLE
wasm: Add `pthread.h` to the WASI libc modulemap

### DIFF
--- a/stdlib/public/Platform/wasi-libc.modulemap
+++ b/stdlib/public/Platform/wasi-libc.modulemap
@@ -88,3 +88,8 @@ module wasi_emulated_signal {
   link "wasi-emulated-signal"
   export *
 }
+
+module wasi_pthread {
+  header "pthread.h"
+  export *
+}


### PR DESCRIPTION
Recent wasi-libc has added `pthread.h` to its headers. This patch adds it to the modulemap.

