### PR TITLE
SwiftShims: use the correct variable for the behaviour check

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -129,7 +129,7 @@ else()
   set(clang_headers_location "${LLVM_LIBRARY_OUTPUT_INTDIR}/clang/${CLANG_VERSION_MAJOR}")
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
   set(cmake_symlink_option "copy_directory")
 else()
   set(cmake_symlink_option "create_symlink")


### PR DESCRIPTION
We would check the SYSTEM_NAME rather than the HOST_SYSTEM_NAME variable where the former is the host and the latter is the build. The behaviour is concerning the build and so we would behave incorrectly.