### PR TITLE
[test] guard a behavioral change

### DIFF
--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -852,9 +852,12 @@ tests.test("Strideable") {
   expectEqual(dist(UInt8.max, UInt8.min), -255)
   expectEqual(dist(Int8.min, Int8.max), 255)
   expectEqual(dist(Int8.max, Int8.min), -255)
-  
-  expectEqual(Int8.min.advanced(by: Int(Int8.max)+1), 0)
-  expectEqual(UInt.max.advanced(by: Int.min), UInt.max / 2)
+
+  if #available(SwiftStdlib 6.0, *) {
+    // Edge cases fixed in Swift 6.0
+    expectEqual(Int8.min.advanced(by: Int(Int8.max)+1), 0)
+    expectEqual(UInt.max.advanced(by: Int.min), UInt.max / 2)
+  }
 }
 
 tests.test("signum/generic") {


### PR DESCRIPTION
These two edge cases were fixed in https://github.com/apple/swift/pull/71369, and fail when run against an older standard library. Ensure they run only against a Swift 6.0 or newer stdlib

Addresses rdar://123810713