### PR TITLE
[Tests] NFC: Disable `@preconcurrency` conformances executable test o…

### DIFF
--- a/test/Interpreter/preconcurrency_conformances.swift
+++ b/test/Interpreter/preconcurrency_conformances.swift
@@ -35,6 +35,9 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 
+// rdar://123810657
+// UNSUPPORTED: back_deployment_runtime
+
 //--- Interface.swift
 public protocol P {
   init()


### PR DESCRIPTION
…n backdeployment runtime

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
