### PR TITLE
[Build] Build SwiftRefactor module from swift-syntax

### DIFF
--- a/lib/SwiftSyntax/CMakeLists.txt
+++ b/lib/SwiftSyntax/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SWIFT_SYNTAX_MODULES
   SwiftCompilerPluginMessageHandling
   # Support for LSP
   SwiftIDEUtils
+  SwiftRefactor
 )
 
 # Install shared runtime libraries


### PR DESCRIPTION
sourcekit-lsp will be using this in https://github.com/apple/sourcekit-lsp/pull/1072 and Windows uses the swift-syntax modules from the compiler build for sourcekit-lsp.
