### PR TITLE
[DebugInfo] Enable salvageLoadDebugInfo at -O

### DIFF
--- a/include/swift/SILOptimizer/Utils/DebugOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/DebugOptUtils.h
@@ -50,9 +50,6 @@ void salvageDebugInfo(SILInstruction *I);
 
 /// Transfer debug information associated with the result of \p load to the
 /// load's address operand.
-///
-/// TODO: combine this with salvageDebugInfo when it is supported by
-/// optimizations.
 void salvageLoadDebugInfo(LoadOperation load);
 
 /// Create debug_value fragment for a new partial value.

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -320,9 +320,7 @@ splitAggregateLoad(LoadOperation loadInst, CanonicalizeInstruction &pass) {
   }
 
   // Preserve the original load's debug information.
-  if (pass.preserveDebugInfo) {
-    swift::salvageLoadDebugInfo(loadInst);
-  }
+  swift::salvageLoadDebugInfo(loadInst);
   // Remove the now unused borrows.
   for (auto *borrow : borrows)
     nextII = killInstAndIncidentalUses(borrow, nextII, pass);

--- a/lib/SILOptimizer/Utils/InstOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/InstOptUtils.cpp
@@ -1903,6 +1903,10 @@ void swift::salvageDebugInfo(SILInstruction *I) {
         }
       }
   }
+
+  if (auto load = LoadOperation(I)) {
+    salvageLoadDebugInfo(load);
+  }
 }
 
 void swift::salvageLoadDebugInfo(LoadOperation load) {

--- a/test/SILOptimizer/silgen_cleanup_debug.sil
+++ b/test/SILOptimizer/silgen_cleanup_debug.sil
@@ -1,6 +1,5 @@
-// RUN: %target-sil-opt -opt-mode=none -silgen-cleanup -sil-print-debuginfo -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB
-
-// TODO: add -opt-mode=speed after calling salvageLoadDebugInfo() from salvageDebugInfo().
+// RUN: %target-sil-opt -opt-mode=none -silgen-cleanup -sil-print-debuginfo -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-sil-opt -opt-mode=speed -silgen-cleanup -sil-print-debuginfo -sil-verify-all %s | %FileCheck %s --check-prefix=CHECK
 
 import Builtin
 


### PR DESCRIPTION
salvageLoadDebugInfo just creates a debug_value instruction, there is no reason to skip it when optimizations are enabled.

rdar://115676800
