### PR TITLE
[Sema] Add global actor attribute to type interface

### DIFF
--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -696,6 +696,11 @@ public:
              lifetimeDependenceInfo);
   }
 
+  [[nodiscard]]
+  ASTExtInfoBuilder withGlobalActorIsolation(Type globalActor) const {
+    return withIsolation(FunctionTypeIsolation::forGlobalActor(globalActor));
+  }
+
   void Profile(llvm::FoldingSetNodeID &ID) const {
     ID.AddInteger(bits);
     ID.AddPointer(clangTypeInfo.getType());

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -543,6 +543,9 @@ void AccessControlCheckerBase::checkGlobalActorAccess(const Decl *D) {
                               : typeAccessScope.requiredAccessForDiagnostics();
         auto diag = D->diagnose(diag::global_actor_access, declAccess, VD,
                                 typeAccess, globalActorDecl->getName());
+        if (auto func = dyn_cast<FuncDecl>(VD)) {
+          diag.limitBehaviorUntilSwiftVersion(DiagnosticBehavior::Warning, 6);
+        }
         highlightOffendingType(diag, complainRepr);
         noteLimitingImport(D->getASTContext(), importLimit, complainRepr);
       });

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4628,8 +4628,8 @@ static ActorIsolation getActorIsolationFromWrappedProperty(VarDecl *var) {
   return ActorIsolation::forUnspecified();
 }
 
-static std::optional<ActorIsolation>
-getActorIsolationForMainFuncDecl(FuncDecl *fnDecl) {
+std::optional<ActorIsolation>
+swift::getActorIsolationForMainFuncDecl(FuncDecl *fnDecl) {
   // Ensure that the base type that this function is declared in has @main
   // attribute
   NominalTypeDecl *declContext =
@@ -4867,7 +4867,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
 
   // If this declaration has an isolated parameter, it's isolated to that
   // parameter.
-  if (auto paramIdx = getIsolatedParamIndex(value)) { // might need to add this to interface request
+  if (auto paramIdx = getIsolatedParamIndex(value)) {
     checkDeclWithIsolatedParameter(value);
 
     ParamDecl *param = getParameterList(value)->get(*paramIdx);
@@ -4926,7 +4926,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
     return isolation;
   };
 
-  auto isolationFromAttr = getIsolationFromAttributes(value);      // add to interface request
+  // Look for explicit annotions to determine isolation
+  auto isolationFromAttr = getIsolationFromAttributes(value);
   if (isolationFromAttr && isolationFromAttr->preconcurrency() &&
       !value->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
     auto preconcurrency =
@@ -4934,21 +4935,15 @@ ActorIsolation ActorIsolationRequest::evaluate(
     value->getAttrs().add(preconcurrency);
   }
 
-  if (FuncDecl *fd = dyn_cast<FuncDecl>(value)) { // add to interface request
+  if (FuncDecl *fd = dyn_cast<FuncDecl>(value)) {
     // Main.main() and Main.$main are implicitly MainActor-protected.
     // Any other isolation is an error.
     std::optional<ActorIsolation> mainIsolation =
         getActorIsolationForMainFuncDecl(fd);
-    if (mainIsolation) {
-      if (isolationFromAttr && isolationFromAttr->isGlobalActor()) {
-        if (!areTypesEqual(isolationFromAttr->getGlobalActor(),
-                           mainIsolation->getGlobalActor())) {
-          fd->getASTContext().Diags.diagnose(
-              fd->getLoc(), diag::main_function_must_be_mainActor);
-        }
-      }
+    
+    if (mainIsolation)
       return *mainIsolation;
-    }
+    
   }
   // If this declaration has one of the actor isolation attributes, report
   // that.
@@ -4962,8 +4957,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
     return checkGlobalIsolation(*isolationFromAttr);
   }
 
-  // Determine the default isolation for this declaration, which may still be
-  // overridden by other inference rules.
+  // If no explicit annotation is provided, determine the default isolation
+  // for this declaration, which may still be overridden by other inference rules.
   ActorIsolation defaultIsolation = ActorIsolation::forUnspecified();
 
   if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {
@@ -4974,7 +4969,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
   }
 
   // When no other isolation applies, an actor's non-async init is independent
-  if (auto nominal = value->getDeclContext()->getSelfNominalTypeDecl()) // some member , add to interface request
+  if (auto nominal = value->getDeclContext()->getSelfNominalTypeDecl())
     if (nominal->isAnyActor())
       if (auto ctor = dyn_cast<ConstructorDecl>(value))
         if (!ctor->hasAsync())

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4940,10 +4940,9 @@ ActorIsolation ActorIsolationRequest::evaluate(
     // Any other isolation is an error.
     std::optional<ActorIsolation> mainIsolation =
         getActorIsolationForMainFuncDecl(fd);
-    
+
     if (mainIsolation)
       return *mainIsolation;
-    
   }
   // If this declaration has one of the actor isolation attributes, report
   // that.
@@ -4958,7 +4957,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
   }
 
   // If no explicit annotation is provided, determine the default isolation
-  // for this declaration, which may still be overridden by other inference rules.
+  // for this declaration, which may still be overridden by other inference
+  // rules.
   ActorIsolation defaultIsolation = ActorIsolation::forUnspecified();
 
   if (auto func = dyn_cast<AbstractFunctionDecl>(value)) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4232,7 +4232,6 @@ static bool hasExplicitIsolationAttribute(const Decl *decl) {
     if (!globalActorAttr->first->isImplicit())
       return true;
   }
-
   return false;
 }
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4262,7 +4262,7 @@ swift::getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose,
   if (numIsolationAttrs == 0)
     return std::nullopt;
 
-  // Only one such attribute is valid, but we only actually care of one of
+  // Only one such attribute is valid, but we only actually care if one of
   // them is a global actor.
   if (numIsolationAttrs > 1 && globalActorAttr && shouldDiagnose) {
     decl->diagnose(diag::actor_isolation_multiple_attr, decl,
@@ -4294,7 +4294,7 @@ swift::getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose,
     // Handle @<global attribute type>(unsafe).
     auto *attr = globalActorAttr->first;
     bool isUnsafe = attr->isArgUnsafe();
-    if (attr->hasArgs()) {
+    if (attr->hasArgs() && shouldDiagnose) {
       if (isUnsafe) {
         SourceFile *file = decl->getDeclContext()->getParentSourceFile();
         bool inSwiftinterface =

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -4241,9 +4241,9 @@ static bool hasExplicitIsolationAttribute(const Decl *decl) {
 /// \returns the actor isolation determined from attributes alone (with no
 /// inference rules). Returns \c None if there were no attributes on this
 /// declaration.
-static std::optional<ActorIsolation>
-getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
-                           bool onlyExplicit = false) {
+std::optional<ActorIsolation>
+swift::getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose,
+                           bool onlyExplicit) {
   // Look up attributes on the declaration that can affect its actor isolation.
   // If any of them are present, use that attribute.
   auto nonisolatedAttr = decl->getAttrs().getAttribute<NonisolatedAttr>();
@@ -4867,7 +4867,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
 
   // If this declaration has an isolated parameter, it's isolated to that
   // parameter.
-  if (auto paramIdx = getIsolatedParamIndex(value)) {
+  if (auto paramIdx = getIsolatedParamIndex(value)) { // might need to add this to interface request
     checkDeclWithIsolatedParameter(value);
 
     ParamDecl *param = getParameterList(value)->get(*paramIdx);
@@ -4926,7 +4926,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
     return isolation;
   };
 
-  auto isolationFromAttr = getIsolationFromAttributes(value);
+  auto isolationFromAttr = getIsolationFromAttributes(value);      // add to interface request
   if (isolationFromAttr && isolationFromAttr->preconcurrency() &&
       !value->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
     auto preconcurrency =
@@ -4934,7 +4934,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
     value->getAttrs().add(preconcurrency);
   }
 
-  if (FuncDecl *fd = dyn_cast<FuncDecl>(value)) {
+  if (FuncDecl *fd = dyn_cast<FuncDecl>(value)) { // add to interface request
     // Main.main() and Main.$main are implicitly MainActor-protected.
     // Any other isolation is an error.
     std::optional<ActorIsolation> mainIsolation =
@@ -4974,7 +4974,7 @@ ActorIsolation ActorIsolationRequest::evaluate(
   }
 
   // When no other isolation applies, an actor's non-async init is independent
-  if (auto nominal = value->getDeclContext()->getSelfNominalTypeDecl())
+  if (auto nominal = value->getDeclContext()->getSelfNominalTypeDecl()) // some member , add to interface request
     if (nominal->isAnyActor())
       if (auto ctor = dyn_cast<ConstructorDecl>(value))
         if (!ctor->hasAsync())

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -498,6 +498,8 @@ void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
 std::optional<std::pair<CustomAttr *, NominalTypeDecl *>>
 checkGlobalActorAttributes(SourceLoc loc, DeclContext *dc,
                            ArrayRef<CustomAttr *> attrs);
+std::optional<ActorIsolation>
+getActorIsolationForMainFuncDecl(FuncDecl *fnDecl);
 
 /// Get the explicit global actor specified for a closure.
 Type getExplicitGlobalActor(ClosureExpr *closure);

--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -353,6 +353,8 @@ enum class SendableCheck {
   ImplicitForExternallyVisible,
 };
 
+std::optional<ActorIsolation> getIsolationFromAttributes(const Decl *decl, bool shouldDiagnose = true,
+                           bool onlyExplicit = false);
 /// Whether this sendable check is implicit.
 static inline bool isImplicitSendableCheck(SendableCheck check) {
   switch (check) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2562,7 +2562,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       // Any other isolation is an error.
       if (FuncDecl *fd = dyn_cast<FuncDecl>(AFD)) {
         std::optional<ActorIsolation> mainIsolation =
-        getActorIsolationForMainFuncDecl(fd);
+            getActorIsolationForMainFuncDecl(fd);
         if (mainIsolation) {
           if (isolationFromAttr && isolationFromAttr->isGlobalActor()) {
             if (!areTypesEqual(isolationFromAttr->getGlobalActor(),
@@ -2570,7 +2570,8 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
               fd->getASTContext().Diags.diagnose(
                   fd->getLoc(), diag::main_function_must_be_mainActor);
             }
-            auto isolation  = FunctionTypeIsolation::forGlobalActor(mainIsolation->getGlobalActor());
+            auto isolation = FunctionTypeIsolation::forGlobalActor(
+                mainIsolation->getGlobalActor());
             infoBuilder = infoBuilder.withIsolation(isolation);
           }
         }
@@ -2623,7 +2624,6 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
         funcTy = FunctionType::get({selfParam}, funcTy, selfInfo);
       }
     }
-
     return funcTy;
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2555,23 +2555,31 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
       auto &ctx = AFD->getASTContext();
 
+      // Check for explicit global actor attribute
       auto isolationFromAttr = getIsolationFromAttributes(AFD);
-      if (isolationFromAttr && isolationFromAttr->preconcurrency() &&
-          !AFD->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
-        auto preconcurrency =
-            new (ctx) PreconcurrencyAttr(/*isImplicit*/true);
-        AFD->getAttrs().add(preconcurrency);
-      }
 
-      if (isolationFromAttr) {
-        // Global actors should be added to interface type.
-        if (isolationFromAttr->isGlobalActor()) {
-          auto isolation  = FunctionTypeIsolation::forGlobalActor(isolationFromAttr->getGlobalActor());
-          infoBuilder = infoBuilder.withIsolation(isolation);
+      // Main.main() and Main.$main are implicitly MainActor-protected.
+      // Any other isolation is an error.
+      if (FuncDecl *fd = dyn_cast<FuncDecl>(AFD)) {
+        std::optional<ActorIsolation> mainIsolation =
+        getActorIsolationForMainFuncDecl(fd);
+        if (mainIsolation) {
+          if (isolationFromAttr && isolationFromAttr->isGlobalActor()) {
+            if (!areTypesEqual(isolationFromAttr->getGlobalActor(),
+                               mainIsolation->getGlobalActor())) {
+              fd->getASTContext().Diags.diagnose(
+                  fd->getLoc(), diag::main_function_must_be_mainActor);
+            }
+            auto isolation  = FunctionTypeIsolation::forGlobalActor(mainIsolation->getGlobalActor());
+            infoBuilder = infoBuilder.withIsolation(isolation);
+          }
         }
       }
-      infoBuilder = infoBuilder.withAsync(AFD->hasAsync());
+
+      // TO-DO: If no isolation attribute provided, compute inferred isolation
+
       infoBuilder = infoBuilder.withConcurrent(AFD->isSendable());
+      infoBuilder = infoBuilder.withAsync(AFD->hasAsync());
       // 'throws' only applies to the innermost function.
       infoBuilder = infoBuilder.withThrows(AFD->hasThrows(), thrownTy);
       // Defer bodies must not escape.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2570,9 +2570,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
               fd->getASTContext().Diags.diagnose(
                   fd->getLoc(), diag::main_function_must_be_mainActor);
             }
-            auto isolation = FunctionTypeIsolation::forGlobalActor(
-                mainIsolation->getGlobalActor());
-            infoBuilder = infoBuilder.withIsolation(isolation);
+            infoBuilder = infoBuilder.withGlobalActorIsolation(mainIsolation->getGlobalActor());
           }
         }
       }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2556,7 +2556,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       auto &ctx = AFD->getASTContext();
 
       // Check for explicit global actor attribute
-      auto isolationFromAttr = getIsolationFromAttributes(AFD);
+      auto isolationFromAttr = getIsolationFromAttributes(AFD, false);
 
       // Main.main() and Main.$main are implicitly MainActor-protected.
       // Any other isolation is an error.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2552,6 +2552,24 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
       AFD->getParameters()->getParams(argTy);
 
       maybeAddParameterIsolation(infoBuilder, argTy);
+
+      auto &ctx = AFD->getASTContext();
+
+      auto isolationFromAttr = getIsolationFromAttributes(AFD);
+      if (isolationFromAttr && isolationFromAttr->preconcurrency() &&
+          !AFD->getAttrs().hasAttribute<PreconcurrencyAttr>()) {
+        auto preconcurrency =
+            new (ctx) PreconcurrencyAttr(/*isImplicit*/true);
+        AFD->getAttrs().add(preconcurrency);
+      }
+
+      if (isolationFromAttr) {
+        // Global actors should be added to interface type.
+        if (isolationFromAttr->isGlobalActor()) {
+          auto isolation  = FunctionTypeIsolation::forGlobalActor(isolationFromAttr->getGlobalActor());
+          infoBuilder = infoBuilder.withIsolation(isolation);
+        }
+      }
       infoBuilder = infoBuilder.withAsync(AFD->hasAsync());
       infoBuilder = infoBuilder.withConcurrent(AFD->isSendable());
       // 'throws' only applies to the innermost function.

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -113,6 +113,7 @@ struct SomeStruct {
   @MainActor init(asyncMainActor: Int) async {}
   @MainActor init(mainActor: Int) {} // expected-note {{calls to initializer 'init(mainActor:)' from outside of its actor context are implicitly asynchronous}}
 
+  // expected-complete-and-tns-warning@+2 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
   // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
   @MainActor(unsafe) init(asyncMainActorUnsafe: Int) async {}
 

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -113,7 +113,6 @@ struct SomeStruct {
   @MainActor init(asyncMainActor: Int) async {}
   @MainActor init(mainActor: Int) {} // expected-note {{calls to initializer 'init(mainActor:)' from outside of its actor context are implicitly asynchronous}}
 
-  // expected-complete-and-tns-warning@+2 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
   // expected-warning@+1 {{'(unsafe)' global actors are deprecated; use '@preconcurrency' instead}}
   @MainActor(unsafe) init(asyncMainActorUnsafe: Int) async {}
 

--- a/test/attr/attr_inlinable_global_actor.swift
+++ b/test/attr/attr_inlinable_global_actor.swift
@@ -5,6 +5,7 @@
 @available(SwiftStdlib 5.1, *)
 @globalActor
 private struct PrivateGA { // expected-note 2 {{type declared here}}
+  // expected-note@-1 {{struct 'PrivateGA' is not '@usableFromInline' or public}}
   actor Actor {}
   static let shared = Actor()
 }
@@ -12,6 +13,7 @@ private struct PrivateGA { // expected-note 2 {{type declared here}}
 @available(SwiftStdlib 5.1, *)
 @globalActor
 internal struct InternalGA { // expected-note {{type declared here}}
+  // expected-note@-1 {{struct 'InternalGA' is not '@usableFromInline' or public}}
   actor Actor {}
   static let shared = Actor()
 }
@@ -43,10 +45,10 @@ public struct PublicGA {
 
 @available(SwiftStdlib 5.1, *)
 @inlinable public func testNestedFuncs() {
-  // FIXME: Functions isolated to non-resilient global actors nested in
+  // Functions isolated to non-resilient global actors nested in
   //        inlinable functions should be diagnosed.
-  @PrivateGA func inlineFuncPrivateGA() {}
-  @InternalGA func inlineFuncInternalGA() {}
+  @PrivateGA func inlineFuncPrivateGA() {} // expected-error {{struct 'PrivateGA' is private and cannot be referenced from an '@inlinable' function}}
+  @InternalGA func inlineFuncInternalGA() {} // expected-error {{struct 'InternalGA' is internal and cannot be referenced from an '@inlinable' function}}
   @UFIGA func inlineFuncUFIGA() {}
   @PublicGA func inlineFuncPublicGA() {}
 }

--- a/test/attr/attr_inlinable_global_actor.swift
+++ b/test/attr/attr_inlinable_global_actor.swift
@@ -32,7 +32,6 @@ public struct PublicGA {
   public actor Actor {}
   public static let shared = Actor()
 }
-
 // expected-error@+2 {{internal struct 'UFIStructPrivateGA' cannot have private global actor 'PrivateGA'}}
 @available(SwiftStdlib 5.1, *)
 @PrivateGA @usableFromInline internal struct UFIStructPrivateGA {} // expected-error {{global actor for struct 'UFIStructPrivateGA' must be '@usableFromInline' or public}}

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -107,13 +107,13 @@ extension SomeActor {
 // -----------------------------------------------------------------------
 
 @globalActor
-private struct PrivateGA { // expected-note 3 {{type declared here}}
+private struct PrivateGA { // expected-note 5 {{type declared here}}
   actor Actor {}
   static let shared = Actor()
 }
 
 @globalActor
-internal struct InternalGA { // expected-note 2 {{type declared here}}
+internal struct InternalGA { // expected-note 3 {{type declared here}}
   actor Actor {}
   static let shared = Actor()
 }
@@ -205,4 +205,37 @@ do {
       @GA1 set { } // expected-warning {{setter cannot have a global actor}} {{7-12=}}
     }
   }
+}
+
+internal struct TestInternalMethods {
+  func fn() {}
+  @InternalGA internal func internalGAMethod() {}
+  @PrivateGA internal func privateGAMethod() {}
+  // expected-warning@-1  {{internal instance method 'privateGAMethod()' cannot have private global actor 'PrivateGA'}}
+  @PublicGA internal func publicGAMethod() {}
+  @PrivateGA internal var privateGAVar : Int {
+    get { return 1 }
+    set {}
+  }
+}
+
+public struct TestPublicMethods {
+    @InternalGA public func internalGAMethod() {}
+    // expected-warning@-1 {{public instance method 'internalGAMethod()' cannot have internal global actor 'InternalGA'}}
+    @PrivateGA public func privateGAMethod() {}
+    // expected-warning@-1 {{public instance method 'privateGAMethod()' cannot have private global actor 'PrivateGA'}}
+    @PublicGA public func publicActorMethod()  {}
+    @InternalGA public var privateGAVar : Int {
+      get { return 1 }
+      set {}
+    }
+}
+
+@InternalGA public var fn : ()  = TestInternalMethods().fn()
+@PrivateGA public var fn2 : ()  = TestInternalMethods().fn()
+@PrivateGA internal var fn3 : ()  = TestInternalMethods().fn()
+
+public actor D {
+  @InternalGA public var fn: (@Sendable () -> Void)? = nil
+  @PrivateGA public var fn2: (@Sendable () -> Void)? = nil
 }


### PR DESCRIPTION
Add global actor attribute to type interface when there is an explicit attribute on a declaration. Follow up pull requests will include inferred isolation in the type interface as well. This will help avoid adjusting function types later on during type checking which is prone to errors.
