### PR TITLE
[build-script] Avoid stripping clang builtin .a libraries when extracting dSYMs on Darwin

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3230,20 +3230,21 @@ for host in "${ALL_HOSTS[@]}"; do
             printJSONStartTimestamp dsymutil
             (cd "${host_symroot}" &&
              find ./"${CURRENT_PREFIX}" -perm -0111 -type f -not -name "*.a" -not -name "*.py" -print | \
-               xargs -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path})
+               xargs -t -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path})
             printJSONEndTimestamp dsymutil
 
             # Strip executables, shared libraries and static libraries in
-            # `host_install_destdir`.
+            # `host_install_destdir`. Avoid touching clang builtins .a files.
             find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
               '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
-              xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
+              grep_that_allows_no_matches -v "/clang/lib/darwin/" | \
+              xargs -t -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
 
             # Codesign dylibs and executables in usr/bin after strip tool
             # rdar://45388785
             find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
               '(' '(' -path "*/usr/bin/*" -and -perm -0111 ')' -or -name "*.dylib" ')' -type f -print | \
-              xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool codesign) -f -s -
+              xargs -t -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool codesign) -f -s -
         fi
 
         { set +x; } 2>/dev/null

--- a/validation-test/BuildSystem/dsymutil_jobs.test
+++ b/validation-test/BuildSystem/dsymutil_jobs.test
@@ -8,5 +8,5 @@
 
 # CHECK: --- Extracting symbols ---
 # CHECK: { "command": "dsymutil", "start": "
-# CHECK: xargs -n 1 -P 5 {{.*}}dsymutil
+# CHECK: xargs -t -n 1 -P 5 {{.*}}dsymutil
 # CHECK: { "command": "dsymutil", "end": "


### PR DESCRIPTION
Clang builtins (.a libraries inside lib/swift/clang/lib/darwin) are sometimes problematic to strip (because stripping .a/.o files involves calling the linker) and it's somewhat wrong to strip them in the first place (because they get consumed into linked products which might want to still extract dSYMs but if the .a is already stripped, then debug info for the .a content is already lost). Let's avoid stripping Clang builtins.

rdar://123844745