### PR TITLE
[Explicit Module Builds] Serialize --target= flag instead of -triple

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -230,8 +230,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     serializationOpts.ExtraClangOptions = getClangImporterOptions().ExtraArgs;
   }
   if (LangOpts.ClangTarget) {
-    serializationOpts.ExtraClangOptions.push_back("-triple");
-    serializationOpts.ExtraClangOptions.push_back(LangOpts.ClangTarget->str());
+    serializationOpts.ExtraClangOptions.push_back("-target=" +
+                                                  LangOpts.ClangTarget->str());
   }
 
   serializationOpts.PluginSearchOptions =

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -230,7 +230,7 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
     serializationOpts.ExtraClangOptions = getClangImporterOptions().ExtraArgs;
   }
   if (LangOpts.ClangTarget) {
-    serializationOpts.ExtraClangOptions.push_back("-target=" +
+    serializationOpts.ExtraClangOptions.push_back("--target=" +
                                                   LangOpts.ClangTarget->str());
   }
 

--- a/test/Serialization/clang-target-option.swift
+++ b/test/Serialization/clang-target-option.swift
@@ -6,5 +6,5 @@
 // RUN: %FileCheck %s < %t/has_clang_target.swiftmodule.txt
 
 // CHECK-LABEL: <OPTIONS_BLOCK
-// CHECK:      <XCC abbrevid={{[0-9]+}}/> blob data = '-target=arm64e-apple-macos12.12'
+// CHECK:      <XCC abbrevid={{[0-9]+}}/> blob data = '--target=arm64e-apple-macos12.12'
 // CHECK: </OPTIONS_BLOCK>

--- a/test/Serialization/clang-target-option.swift
+++ b/test/Serialization/clang-target-option.swift
@@ -6,6 +6,5 @@
 // RUN: %FileCheck %s < %t/has_clang_target.swiftmodule.txt
 
 // CHECK-LABEL: <OPTIONS_BLOCK
-// CHECK:      <XCC abbrevid={{[0-9]+}}/> blob data = '-triple'
-// CHECK-NEXT: <XCC abbrevid={{[0-9]+}}/> blob data = 'arm64e-apple-macos12.12'
+// CHECK:      <XCC abbrevid={{[0-9]+}}/> blob data = '-target=arm64e-apple-macos12.12'
 // CHECK: </OPTIONS_BLOCK>


### PR DESCRIPTION
Serialize a `--target=` flag (a driver option) instead of `-triple` (a frontend option). The `XCC` values are passed as driver flags, where `-triple` is not defined.

The target is passed as a joined flag and value, which is more convenient for lldb to consume.