### PR TITLE
cmake: avoiding generating ABI baseline files when building stdlib

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -583,6 +583,11 @@ function(_compile_swift_files
     list(APPEND swift_flags "-swift-version" "5")
   endif()
 
+  # Avoiding emiting ABI descriptor files while building stdlib.
+  if (SWIFTFILE_IS_STDLIB)
+    list(APPEND swift_flags "-Xfrontend" "-empty-abi-descriptor")
+  endif()
+
   if(SWIFTFILE_IS_SDK_OVERLAY)
     list(APPEND swift_flags "-autolink-force-load")
   endif()


### PR DESCRIPTION
We have a regression test checked-in the compiler repository to detect ABI breakages as the stdlib evolves, therefore we don't need to generate these side car files for ABI checking purposes that could be potentially done externally.

Related to: rdar://118465899
