### PR TITLE
Introduce suppressible features so that the newer _Concurrency interface file can be handled by older compilers

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -372,6 +372,10 @@ struct PrintOptions {
   /// Whether to suppress printing of custom attributes that are expanded macros.
   bool SuppressExpandedMacros = true;
 
+  /// Whether we're supposed to slap a @rethrows on `AsyncSequence` /
+  /// `AsyncIteratorProtocol` for backward-compatibility reasons.
+  bool AsyncSequenceRethrows = false;
+
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {
       DeclAttrKind::Transparent, DeclAttrKind::Effects,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -110,6 +110,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes2, 346, "Primary associated 
 SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync")
 SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)")
 SUPPRESSIBLE_LANGUAGE_FEATURE(AssociatedTypeAvailability, 0, "Availability on associated types")
+SUPPRESSIBLE_LANGUAGE_FEATURE(AsyncSequenceFailure, 0, "Failure associated type on AsyncSequence and AsyncIteratorProtocol")
 LANGUAGE_FEATURE(BuiltinIntLiteralAccessors, 368, "Builtin.IntLiteral accessors")
 LANGUAGE_FEATURE(Macros, 0, "Macros")
 LANGUAGE_FEATURE(FreestandingExpressionMacros, 382, "Expression macros")

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -109,6 +109,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(UnsafeInheritExecutor, 0, "@_unsafeInheritExecutor
 SUPPRESSIBLE_LANGUAGE_FEATURE(PrimaryAssociatedTypes2, 346, "Primary associated types")
 SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync")
 SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)")
+SUPPRESSIBLE_LANGUAGE_FEATURE(AssociatedTypeAvailability, 0, "Availability on associated types")
 LANGUAGE_FEATURE(BuiltinIntLiteralAccessors, 368, "Builtin.IntLiteral accessors")
 LANGUAGE_FEATURE(Macros, 0, "Macros")
 LANGUAGE_FEATURE(FreestandingExpressionMacros, 382, "Expression macros")

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3305,6 +3305,20 @@ static bool usesFeatureNoAsyncAvailability(Decl *decl) {
    return decl->getAttrs().getNoAsync(decl->getASTContext()) != nullptr;
 }
 
+static bool usesFeatureAssociatedTypeAvailability(Decl *decl) {
+  return isa<AssociatedTypeDecl>(decl) &&
+      decl->getAttrs().hasAttribute<AvailableAttr>();
+}
+
+static void
+suppressingFeatureAssociatedTypeAvailability(
+    PrintOptions &options, llvm::function_ref<void()> action) {
+  unsigned originalExcludeAttrCount = options.ExcludeAttrList.size();
+  options.ExcludeAttrList.push_back(DeclAttrKind::Available);
+  action();
+  options.ExcludeAttrList.resize(originalExcludeAttrCount);
+}
+
 static bool usesFeatureBuiltinIntLiteralAccessors(Decl *decl) {
   return false;
 }

--- a/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
@@ -20,9 +20,7 @@ extension ASTGenError {
     MessageID(domain: "ASTGen", id: "\(Self.self)")
   }
 
-  var severity: DiagnosticSeverity {
-    .error
-  }
+  var severity: DiagnosticSeverity { .error }
 }
 
 /// An error emitted when a token is of an unexpected kind.

--- a/test/ModuleInterface/associated_type_availability.swift
+++ b/test/ModuleInterface/associated_type_availability.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name assoc
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name assoc
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// REQUIRES: concurrency, objc_interop
+
+// CHECK: public protocol P
+public protocol P {
+  // CHECK: #if compiler(>=5.3) && $AssociatedTypeAvailability
+  // CHECK-NEXT: @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  // CHECK-NEXT: associatedtype AT = Self
+  // CHECK-NEXT: #else
+  // CHECK-NEXT: associatedtype AT = Self
+  // CHECK-NEXT: #endif
+  @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+  associatedtype AT = Self
+}

--- a/test/ModuleInterface/async_sequence_rethrows.swift
+++ b/test/ModuleInterface/async_sequence_rethrows.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name _Concurrency -disable-implicit-concurrency-module-import
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name _Concurrency -disable-implicit-concurrency-module-import
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// REQUIRES: concurrency
+
+// CHECK: @rethrows
+// CHECK-NEXT: public protocol AsyncIteratorProtocol
+public protocol AsyncIteratorProtocol {
+}


### PR DESCRIPTION
We need two new suppressible features:
* `AssociatedTypeAvailability` for availability attributes on associated types
* `AsyncSequenceFailure` for the compiler support needed for the introduction of the `Failure` associated type into `AsyncSequence` and `AsyncIteratorProtocol`

Fixes rdar://123782658.