### PR TITLE
[DebugInfo] Simplify test for DynamicSelfLocation

### DIFF
--- a/test/DebugInfo/DynamicSelfLocation.swift
+++ b/test/DebugInfo/DynamicSelfLocation.swift
@@ -21,4 +21,4 @@ class Model {
 // CHECK-NEXT: entry:
 // CHECK-NEXT:   %2 = load ptr, ptr %[[Self]]
 // CHECK-NOT:    !dbg
-// CHECK-NEXT:   call void @llvm.dbg.declare
+// CHECK-SAME:  {{$}}


### PR DESCRIPTION
We only want to check that there is no "!dbg" until the next line, we can accomplish this by checking-same on the end-of-line regex marker.