### PR TITLE
[cxx-interop] Overhaul virtual method support

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -131,6 +131,7 @@ typedef llvm::PointerUnion<const clang::Decl *, const clang::MacroInfo *,
 /// from Clang ASTs over to Swift ASTs.
 class ClangImporter final : public ClangModuleLoader {
   friend class ClangModuleUnit;
+  friend class SwiftDeclSynthesizer;
 
   // Make requests in the ClangImporter zone friends so they can access `Impl`.
 #define SWIFT_REQUEST(Zone, Name, Sig, Caching, LocOptions)                    \

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5062,16 +5062,6 @@ static clang::CXXMethodDecl *synthesizeCxxBaseMethod(
   return newMethod;
 }
 
-// Synthesize a C++ virtual method
-clang::CXXMethodDecl *synthesizeCxxVirtualMethod(
-    swift::ClangImporter &Impl, const clang::CXXRecordDecl *derivedClass,
-    const clang::CXXRecordDecl *baseClass, const clang::CXXMethodDecl *method) {
-  return synthesizeCxxBaseMethod(
-      Impl, derivedClass, baseClass, method,
-      ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
-      false /* forceConstQualifier */, true /* isVirtualCall */);
-}
-
 // Find the base C++ method called by the base function we want to synthesize
 // the derived thunk for.
 // The base C++ method is either the original C++ method that corresponds
@@ -6881,7 +6871,7 @@ static ValueDecl *addThunkForDependentTypes(FuncDecl *oldDecl,
 // are not used in the function signature. We supply the type params as explicit
 // metatype arguments to aid in typechecking, but they shouldn't be forwarded to
 // the corresponding C++ function.
-std::pair<BraceStmt *, bool>
+static std::pair<BraceStmt *, bool>
 synthesizeForwardingThunkBody(AbstractFunctionDecl *afd, void *context) {
   ASTContext &ctx = afd->getASTContext();
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4891,177 +4891,6 @@ MemberRefExpr *getSelfInteropStaticCast(FuncDecl *funcDecl,
   return pointeePropertyRefExpr;
 }
 
-enum class ReferenceReturnTypeBehaviorForBaseMethodSynthesis {
-  KeepReference,
-  RemoveReference,
-  RemoveReferenceIfPointer,
-};
-
-// Synthesize a C++ method that invokes the method from the base
-// class. This lets Clang take care of the cast from the derived class
-// to the base class during the invocation of the method.
-static clang::CXXMethodDecl *synthesizeCxxBaseMethod(
-    ClangImporter &impl, const clang::CXXRecordDecl *derivedClass,
-    const clang::CXXRecordDecl *baseClass, const clang::CXXMethodDecl *method,
-    ReferenceReturnTypeBehaviorForBaseMethodSynthesis
-        referenceReturnTypeBehavior =
-            ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
-    bool forceConstQualifier = false,
-    bool isVirtualCall = false) {
-  auto &clangCtx = impl.getClangASTContext();
-  auto &clangSema = impl.getClangSema();
-  // When emitting symbolic decls, the method might not have a concrete
-  // record type as this type.
-  if (impl.isSymbolicImportEnabled()
-      && !method->getThisType()->getPointeeCXXRecordDecl()) {
-    return nullptr;
-  }
-
-  // Create a new method in the derived class that calls the base method.
-  clang::DeclarationName name = method->getNameInfo().getName();
-  if (name.isIdentifier()) {
-    std::string newName;
-    llvm::raw_string_ostream os(newName);
-    os << (isVirtualCall ? "__synthesizedVirtualCall_" :
-                           "__synthesizedBaseCall_")
-       << name.getAsIdentifierInfo()->getName();
-    name = clang::DeclarationName(
-        &impl.getClangPreprocessor().getIdentifierTable().get(os.str()));
-  } else if (name.getCXXOverloadedOperator() == clang::OO_Subscript) {
-    name = clang::DeclarationName(
-        &impl.getClangPreprocessor().getIdentifierTable().get(
-            (isVirtualCall ? "__synthesizedVirtualCall_operatorSubscript" :
-                             "__synthesizedBaseCall_operatorSubscript")));
-  } else if (name.getCXXOverloadedOperator() == clang::OO_Star) {
-    name = clang::DeclarationName(
-        &impl.getClangPreprocessor().getIdentifierTable().get(
-            (isVirtualCall ? "__synthesizedVirtualCall_operatorStar" :
-                             "__synthesizedBaseCall_operatorStar")));
-  }
-  auto methodType = method->getType();
-  // Check if we need to drop the reference from the return type
-  // of the new method. This is needed when a synthesized `operator []`
-  // derived-to-base call is invoked from Swift's subscript getter.
-  if (referenceReturnTypeBehavior !=
-      ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference) {
-    if (const auto *fpt = methodType->getAs<clang::FunctionProtoType>()) {
-      auto retType = fpt->getReturnType();
-      if (retType->isReferenceType() &&
-          (referenceReturnTypeBehavior ==
-               ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
-                   RemoveReference ||
-           (referenceReturnTypeBehavior ==
-                ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
-                    RemoveReferenceIfPointer &&
-            retType->getPointeeType()->isPointerType()))) {
-        methodType = clangCtx.getFunctionType(retType->getPointeeType(),
-                                              fpt->getParamTypes(),
-                                              fpt->getExtProtoInfo());
-      }
-    }
-  }
-  // Check if this method requires an additional `const` qualifier.
-  // This might needed when a non-const synthesized `operator []`
-  // derived-to-base call is invoked from Swift's subscript getter.
-  bool castThisToNonConstThis = false;
-  if (forceConstQualifier) {
-    if (const auto *fpt = methodType->getAs<clang::FunctionProtoType>()) {
-      auto info = fpt->getExtProtoInfo();
-      if (!info.TypeQuals.hasConst()) {
-        info.TypeQuals.addConst();
-        castThisToNonConstThis = true;
-        methodType = clangCtx.getFunctionType(fpt->getReturnType(),
-                                              fpt->getParamTypes(), info);
-      }
-    }
-  }
-  auto newMethod = clang::CXXMethodDecl::Create(
-      clangCtx, const_cast<clang::CXXRecordDecl *>(derivedClass),
-      method->getSourceRange().getBegin(),
-      clang::DeclarationNameInfo(name, clang::SourceLocation()), methodType,
-      method->getTypeSourceInfo(), method->getStorageClass(),
-      method->UsesFPIntrin(), /*isInline=*/true, method->getConstexprKind(),
-      method->getSourceRange().getEnd());
-  newMethod->setImplicit();
-  newMethod->setImplicitlyInline();
-  newMethod->setAccess(clang::AccessSpecifier::AS_public);
-  if (method->hasAttr<clang::CFReturnsRetainedAttr>()) {
-    // Return an FRT field at +1 if the base method also follows this
-    // convention.
-    newMethod->addAttr(clang::CFReturnsRetainedAttr::CreateImplicit(clangCtx));
-  }
-
-  llvm::SmallVector<clang::ParmVarDecl *, 4> params;
-  for (size_t i = 0; i < method->getNumParams(); ++i) {
-    const auto &param = *method->getParamDecl(i);
-    params.push_back(clang::ParmVarDecl::Create(
-        clangCtx, newMethod, param.getSourceRange().getBegin(),
-        param.getLocation(), param.getIdentifier(), param.getType(),
-        param.getTypeSourceInfo(), param.getStorageClass(),
-        /*DefExpr=*/nullptr));
-  }
-  newMethod->setParams(params);
-
-  // Create a new Clang diagnostic pool to capture any diagnostics
-  // emitted during the construction of the method.
-  clang::sema::DelayedDiagnosticPool diagPool{
-      clangSema.DelayedDiagnostics.getCurrentPool()};
-  auto diagState = clangSema.DelayedDiagnostics.push(diagPool);
-
-  // Construct the method's body.
-  clang::Expr *thisExpr = new (clangCtx) clang::CXXThisExpr(
-      clang::SourceLocation(), newMethod->getThisType(), /*IsImplicit=*/false);
-  if (castThisToNonConstThis) {
-    auto baseClassPtr =
-        clangCtx.getPointerType(clangCtx.getRecordType(derivedClass));
-    clang::CastKind Kind;
-    clang::CXXCastPath Path;
-    clangSema.CheckPointerConversion(thisExpr, baseClassPtr, Kind, Path,
-                                     /*IgnoreBaseAccess=*/false,
-                                     /*Diagnose=*/true);
-    auto conv = clangSema.ImpCastExprToType(thisExpr, baseClassPtr, Kind,
-                                            clang::VK_PRValue, &Path);
-    if (!conv.isUsable())
-      return nullptr;
-    thisExpr = conv.get();
-  }
-
-  auto memberExpr = clangSema.BuildMemberExpr(
-      thisExpr, /*isArrow=*/true, clang::SourceLocation(),
-      clang::NestedNameSpecifierLoc(), clang::SourceLocation(),
-      const_cast<clang::CXXMethodDecl *>(method),
-      clang::DeclAccessPair::make(const_cast<clang::CXXMethodDecl *>(method),
-                                  clang::AS_public),
-      /*HadMultipleCandidates=*/false, method->getNameInfo(),
-      clangCtx.BoundMemberTy, clang::VK_PRValue, clang::OK_Ordinary);
-  llvm::SmallVector<clang::Expr *, 4> args;
-  for (size_t i = 0; i < newMethod->getNumParams(); ++i) {
-    auto *param = newMethod->getParamDecl(i);
-    auto type = param->getType();
-    if (type->isReferenceType())
-      type = type->getPointeeType();
-    args.push_back(new (clangCtx) clang::DeclRefExpr(
-        clangCtx, param, false, type, clang::ExprValueKind::VK_LValue,
-        clang::SourceLocation()));
-  }
-  auto memberCall = clangSema.BuildCallToMemberFunction(
-      nullptr, memberExpr, clang::SourceLocation(), args,
-      clang::SourceLocation());
-  if (!memberCall.isUsable())
-    return nullptr;
-  auto returnStmt = clang::ReturnStmt::Create(clangCtx, clang::SourceLocation(),
-                                              memberCall.get(), nullptr);
-
-  // Check if there were any Clang errors during the construction
-  // of the method body.
-  clangSema.DelayedDiagnostics.popWithoutEmitting(diagState);
-  if (!diagPool.empty())
-    return nullptr;
-
-  newMethod->setBody(returnStmt);
-  return newMethod;
-}
-
 // Find the base C++ method called by the base function we want to synthesize
 // the derived thunk for.
 // The base C++ method is either the original C++ method that corresponds
@@ -5117,9 +4946,11 @@ FuncDecl *synthesizeBaseFunctionDeclCall(ClangImporter &impl, ASTContext &ctx,
   auto *cxxMethod = getCalledBaseCxxMethod(baseMember);
   if (!cxxMethod)
     return nullptr;
-  auto *newClangMethod = synthesizeCxxBaseMethod(
-      impl, cast<clang::CXXRecordDecl>(derivedStruct->getClangDecl()),
-      cast<clang::CXXRecordDecl>(baseStruct->getClangDecl()), cxxMethod);
+  auto *newClangMethod =
+      SwiftDeclSynthesizer(&impl).synthesizeCXXForwardingMethod(
+          cast<clang::CXXRecordDecl>(derivedStruct->getClangDecl()),
+          cast<clang::CXXRecordDecl>(baseStruct->getClangDecl()), cxxMethod,
+          ForwardingMethodKind::Base);
   if (!newClangMethod)
     return nullptr;
   return cast_or_null<FuncDecl>(
@@ -5378,19 +5209,22 @@ synthesizeBaseClassFieldGetterOrAddressGetterBody(AbstractFunctionDecl *afd,
   if (auto *md = dyn_cast_or_null<clang::CXXMethodDecl>(baseClangDecl)) {
     // Subscript operator, or `.pointee` wrapper is represented through a
     // generated C++ method call that calls the base operator.
-    baseGetterCxxMethod = synthesizeCxxBaseMethod(
-        *static_cast<ClangImporter *>(ctx.getClangModuleLoader()),
-        cast<clang::CXXRecordDecl>(derivedStruct->getClangDecl()),
-        cast<clang::CXXRecordDecl>(baseStruct->getClangDecl()), md,
-        getterDecl->getResultInterfaceType()->isForeignReferenceType()
-            ? ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
-                  RemoveReferenceIfPointer
-            : (kind != AccessorKind::Get
-                   ? ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
-                         KeepReference
-                   : ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
-                         RemoveReference),
-        /*forceConstQualifier=*/kind != AccessorKind::MutableAddress);
+    baseGetterCxxMethod =
+        SwiftDeclSynthesizer(
+            static_cast<ClangImporter *>(ctx.getClangModuleLoader()))
+            .synthesizeCXXForwardingMethod(
+                cast<clang::CXXRecordDecl>(derivedStruct->getClangDecl()),
+                cast<clang::CXXRecordDecl>(baseStruct->getClangDecl()), md,
+                ForwardingMethodKind::Base,
+                getterDecl->getResultInterfaceType()->isForeignReferenceType()
+                    ? ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
+                          RemoveReferenceIfPointer
+                    : (kind != AccessorKind::Get
+                           ? ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
+                                 KeepReference
+                           : ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
+                                 RemoveReference),
+                /*forceConstQualifier=*/kind != AccessorKind::MutableAddress);
   } else if (auto *fd = dyn_cast_or_null<clang::FieldDecl>(baseClangDecl)) {
     ValueDecl *retainOperationFn = nullptr;
     // Check if this field getter is returning a retainable FRT.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3754,38 +3754,9 @@ namespace {
       }
 
       if (decl->isVirtual() && isa_and_nonnull<ValueDecl>(method)) {
-        if (Impl.isCxxInteropCompatVersionAtLeast(6)) {
-          if (auto dc = method->getDeclContext();
-              !decl->isPure() &&
-              isa_and_nonnull<NominalTypeDecl>(dc->getAsDecl())) {
-
-            // generates the __synthesizedVirtualCall_ C++ thunk
-            clang::CXXMethodDecl *cxxThunk = synthesizeCxxVirtualMethod(
-                *static_cast<ClangImporter *>(
-                    dc->getASTContext().getClangModuleLoader()),
-                decl->getParent(), decl->getParent(), decl);
-
-            // call the __synthesizedVirtualCall_ C++ thunk from a Swift thunk
-            if (Decl *swiftThunk =
-                    cxxThunk ? VisitCXXMethodDecl(cxxThunk) : nullptr;
-                isa_and_nonnull<FuncDecl>(swiftThunk)) {
-              // synthesize the body of the Swift method to call the swiftThunk
-              synthesizeForwardingThunkBody(cast<FuncDecl>(method),
-                                            cast<FuncDecl>(swiftThunk));
-              return method;
-            }
-          }
-
-          Impl.markUnavailable(
-              cast<ValueDecl>(method),
-              decl->isPure() ? "virtual function is not available in Swift "
-                               "because it is pure"
-                             : "virtual function is not available in Swift");
-        } else {
-          Impl.markUnavailable(
-              cast<ValueDecl>(method),
-              "virtual functions are not yet available in Swift");
-        }
+        Impl.markUnavailable(
+            cast<ValueDecl>(method),
+            "virtual functions are not yet available in Swift");
       }
 
       if (Impl.SwiftContext.LangOpts.CxxInteropGettersSettersAsProperties ||

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2258,6 +2258,14 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
         baseName = newName;
       }
     }
+    if (method->isImplicit() &&
+        baseName.starts_with("__synthesizedVirtualCall_")) {
+      // If this is a thunk for a virtual method of a C++ reference type, we
+      // strip away the underscored prefix. This method should be visible and
+      // callable from Swift.
+      newName = baseName.substr(StringRef("__synthesizedVirtualCall_").size());
+      baseName = newName;
+    }
   }
 
   // swift_newtype-ed declarations may have common words with the type name

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -2024,14 +2024,4 @@ bool isViewType(const clang::CXXRecordDecl *decl);
 }
 }
 
-// Forwards to synthesizeCxxBasicMethod(), producing a thunk that calls a
-// virtual function.
-clang::CXXMethodDecl *synthesizeCxxVirtualMethod(
-    swift::ClangImporter &Impl, const clang::CXXRecordDecl *derivedClass,
-    const clang::CXXRecordDecl *baseClass, const clang::CXXMethodDecl *method);
-
-// Exposed to produce a Swift method body for calling a Swift thunk.
-std::pair<swift::BraceStmt *, bool>
-synthesizeForwardingThunkBody(swift::AbstractFunctionDecl *afd, void *context);
-
 #endif

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "SwiftDeclSynthesizer.h"
-#include "clang/AST/Mangle.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Builtins.h"
 #include "swift/AST/Expr.h"
@@ -19,6 +18,8 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/Stmt.h"
 #include "swift/ClangImporter/CXXMethodBridging.h"
+#include "clang/AST/Mangle.h"
+#include "clang/Sema/DelayedDiagnostic.h"
 
 using namespace swift;
 using namespace importer;
@@ -1999,6 +2000,171 @@ synthesizeOperatorMethodBody(AbstractFunctionDecl *afd, void *context) {
   auto body = BraceStmt::create(ctx, SourceLoc(), {returnStmt}, SourceLoc(),
                                 /*implicit*/ true);
   return {body, /*isTypeChecked*/ true};
+}
+
+clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
+    const clang::CXXRecordDecl *derivedClass,
+    const clang::CXXRecordDecl *baseClass, const clang::CXXMethodDecl *method,
+    ForwardingMethodKind forwardingMethodKind,
+    ReferenceReturnTypeBehaviorForBaseMethodSynthesis
+        referenceReturnTypeBehavior,
+    bool forceConstQualifier) {
+
+  auto &clangCtx = ImporterImpl.getClangASTContext();
+  auto &clangSema = ImporterImpl.getClangSema();
+  // When emitting symbolic decls, the method might not have a concrete
+  // record type as this type.
+  if (ImporterImpl.importSymbolicCXXDecls &&
+      !method->getThisType()->getPointeeCXXRecordDecl())
+    return nullptr;
+
+  // Create a new method in the derived class that calls the base method.
+  clang::DeclarationName name = method->getNameInfo().getName();
+  if (name.isIdentifier()) {
+    std::string newName;
+    llvm::raw_string_ostream os(newName);
+    os << (forwardingMethodKind == ForwardingMethodKind::Virtual
+               ? "__synthesizedVirtualCall_"
+               : "__synthesizedBaseCall_")
+       << name.getAsIdentifierInfo()->getName();
+    name = clang::DeclarationName(
+        &ImporterImpl.getClangPreprocessor().getIdentifierTable().get(
+            os.str()));
+  } else if (name.getCXXOverloadedOperator() == clang::OO_Subscript) {
+    name = clang::DeclarationName(
+        &ImporterImpl.getClangPreprocessor().getIdentifierTable().get(
+            (forwardingMethodKind == ForwardingMethodKind::Virtual
+                 ? "__synthesizedVirtualCall_operatorSubscript"
+                 : "__synthesizedBaseCall_operatorSubscript")));
+  } else if (name.getCXXOverloadedOperator() == clang::OO_Star) {
+    name = clang::DeclarationName(
+        &ImporterImpl.getClangPreprocessor().getIdentifierTable().get(
+            (forwardingMethodKind == ForwardingMethodKind::Virtual
+                 ? "__synthesizedVirtualCall_operatorStar"
+                 : "__synthesizedBaseCall_operatorStar")));
+  }
+  auto methodType = method->getType();
+  // Check if we need to drop the reference from the return type
+  // of the new method. This is needed when a synthesized `operator []`
+  // derived-to-base call is invoked from Swift's subscript getter.
+  if (referenceReturnTypeBehavior !=
+      ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference) {
+    if (const auto *fpt = methodType->getAs<clang::FunctionProtoType>()) {
+      auto retType = fpt->getReturnType();
+      if (retType->isReferenceType() &&
+          (referenceReturnTypeBehavior ==
+               ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
+                   RemoveReference ||
+           (referenceReturnTypeBehavior ==
+                ReferenceReturnTypeBehaviorForBaseMethodSynthesis::
+                    RemoveReferenceIfPointer &&
+            retType->getPointeeType()->isPointerType()))) {
+        methodType = clangCtx.getFunctionType(retType->getPointeeType(),
+                                              fpt->getParamTypes(),
+                                              fpt->getExtProtoInfo());
+      }
+    }
+  }
+  // Check if this method requires an additional `const` qualifier.
+  // This might needed when a non-const synthesized `operator []`
+  // derived-to-base call is invoked from Swift's subscript getter.
+  bool castThisToNonConstThis = false;
+  if (forceConstQualifier) {
+    if (const auto *fpt = methodType->getAs<clang::FunctionProtoType>()) {
+      auto info = fpt->getExtProtoInfo();
+      if (!info.TypeQuals.hasConst()) {
+        info.TypeQuals.addConst();
+        castThisToNonConstThis = true;
+        methodType = clangCtx.getFunctionType(fpt->getReturnType(),
+                                              fpt->getParamTypes(), info);
+      }
+    }
+  }
+  auto newMethod = clang::CXXMethodDecl::Create(
+      clangCtx, const_cast<clang::CXXRecordDecl *>(derivedClass),
+      method->getSourceRange().getBegin(),
+      clang::DeclarationNameInfo(name, clang::SourceLocation()), methodType,
+      method->getTypeSourceInfo(), method->getStorageClass(),
+      method->UsesFPIntrin(), /*isInline=*/true, method->getConstexprKind(),
+      method->getSourceRange().getEnd());
+  newMethod->setImplicit();
+  newMethod->setImplicitlyInline();
+  newMethod->setAccess(clang::AccessSpecifier::AS_public);
+  if (method->hasAttr<clang::CFReturnsRetainedAttr>()) {
+    // Return an FRT field at +1 if the base method also follows this
+    // convention.
+    newMethod->addAttr(clang::CFReturnsRetainedAttr::CreateImplicit(clangCtx));
+  }
+
+  llvm::SmallVector<clang::ParmVarDecl *, 4> params;
+  for (size_t i = 0; i < method->getNumParams(); ++i) {
+    const auto &param = *method->getParamDecl(i);
+    params.push_back(clang::ParmVarDecl::Create(
+        clangCtx, newMethod, param.getSourceRange().getBegin(),
+        param.getLocation(), param.getIdentifier(), param.getType(),
+        param.getTypeSourceInfo(), param.getStorageClass(),
+        /*DefExpr=*/nullptr));
+  }
+  newMethod->setParams(params);
+
+  // Create a new Clang diagnostic pool to capture any diagnostics
+  // emitted during the construction of the method.
+  clang::sema::DelayedDiagnosticPool diagPool{
+      clangSema.DelayedDiagnostics.getCurrentPool()};
+  auto diagState = clangSema.DelayedDiagnostics.push(diagPool);
+
+  // Construct the method's body.
+  clang::Expr *thisExpr = new (clangCtx) clang::CXXThisExpr(
+      clang::SourceLocation(), newMethod->getThisType(), /*IsImplicit=*/false);
+  if (castThisToNonConstThis) {
+    auto baseClassPtr =
+        clangCtx.getPointerType(clangCtx.getRecordType(derivedClass));
+    clang::CastKind Kind;
+    clang::CXXCastPath Path;
+    clangSema.CheckPointerConversion(thisExpr, baseClassPtr, Kind, Path,
+                                     /*IgnoreBaseAccess=*/false,
+                                     /*Diagnose=*/true);
+    auto conv = clangSema.ImpCastExprToType(thisExpr, baseClassPtr, Kind,
+                                            clang::VK_PRValue, &Path);
+    if (!conv.isUsable())
+      return nullptr;
+    thisExpr = conv.get();
+  }
+
+  auto memberExpr = clangSema.BuildMemberExpr(
+      thisExpr, /*isArrow=*/true, clang::SourceLocation(),
+      clang::NestedNameSpecifierLoc(), clang::SourceLocation(),
+      const_cast<clang::CXXMethodDecl *>(method),
+      clang::DeclAccessPair::make(const_cast<clang::CXXMethodDecl *>(method),
+                                  clang::AS_public),
+      /*HadMultipleCandidates=*/false, method->getNameInfo(),
+      clangCtx.BoundMemberTy, clang::VK_PRValue, clang::OK_Ordinary);
+  llvm::SmallVector<clang::Expr *, 4> args;
+  for (size_t i = 0; i < newMethod->getNumParams(); ++i) {
+    auto *param = newMethod->getParamDecl(i);
+    auto type = param->getType();
+    if (type->isReferenceType())
+      type = type->getPointeeType();
+    args.push_back(new (clangCtx) clang::DeclRefExpr(
+        clangCtx, param, false, type, clang::ExprValueKind::VK_LValue,
+        clang::SourceLocation()));
+  }
+  auto memberCall = clangSema.BuildCallToMemberFunction(
+      nullptr, memberExpr, clang::SourceLocation(), args,
+      clang::SourceLocation());
+  if (!memberCall.isUsable())
+    return nullptr;
+  auto returnStmt = clang::ReturnStmt::Create(clangCtx, clang::SourceLocation(),
+                                              memberCall.get(), nullptr);
+
+  // Check if there were any Clang errors during the construction
+  // of the method body.
+  clangSema.DelayedDiagnostics.popWithoutEmitting(diagState);
+  if (!diagPool.empty())
+    return nullptr;
+
+  newMethod->setBody(returnStmt);
+  return newMethod;
 }
 
 FuncDecl *

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2235,6 +2235,26 @@ SwiftDeclSynthesizer::makeOperator(FuncDecl *operatorMethod,
   return topLevelStaticFuncDecl;
 }
 
+// MARK: C++ virtual methods
+
+FuncDecl *SwiftDeclSynthesizer::makeVirtualMethod(
+    const clang::CXXMethodDecl *clangMethodDecl) {
+  auto clangDC = clangMethodDecl->getParent();
+  auto &ctx = ImporterImpl.SwiftContext;
+
+  assert(!clangMethodDecl->isStatic() &&
+         "C++ virtual functions cannot be static");
+
+  auto newMethod = synthesizeCXXForwardingMethod(
+      clangDC, clangDC, clangMethodDecl, ForwardingMethodKind::Virtual,
+      ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
+      /*forceConstQualifier*/ false);
+
+  auto result = dyn_cast_or_null<FuncDecl>(
+      ctx.getClangModuleLoader()->importDeclDirectly(newMethod));
+  return result;
+}
+
 // MARK: C++ properties
 
 static std::pair<BraceStmt *, bool>

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -315,6 +315,10 @@ public:
               ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
       bool forceConstQualifier = false);
 
+  /// Given an overload of a C++ virtual method on a reference type, create a
+  /// method that dispatches the call dynamically.
+  FuncDecl *makeVirtualMethod(const clang::CXXMethodDecl *clangMethodDecl);
+
   VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
                                               FuncDecl *setter);
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.h
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.h
@@ -44,6 +44,14 @@ inline AccessLevel getOverridableAccessLevel(const DeclContext *dc) {
   return (dc->getSelfClassDecl() ? AccessLevel::Open : AccessLevel::Public);
 }
 
+enum class ReferenceReturnTypeBehaviorForBaseMethodSynthesis {
+  KeepReference,
+  RemoveReference,
+  RemoveReferenceIfPointer,
+};
+
+enum class ForwardingMethodKind { Base, Virtual };
+
 class SwiftDeclSynthesizer {
 private:
   ClangImporter::Implementation &ImporterImpl;
@@ -51,6 +59,8 @@ private:
 public:
   explicit SwiftDeclSynthesizer(ClangImporter::Implementation &Impl)
       : ImporterImpl(Impl) {}
+  explicit SwiftDeclSynthesizer(ClangImporter *importer)
+      : ImporterImpl(importer->Impl) {}
 
   /// Create a typedpattern(namedpattern(decl))
   static Pattern *createTypedNamedPattern(VarDecl *decl);
@@ -292,6 +302,18 @@ public:
 
   FuncDecl *makeOperator(FuncDecl *operatorMethod,
                          clang::OverloadedOperatorKind opKind);
+  
+  // Synthesize a C++ method that invokes the method from the base
+  // class. This lets Clang take care of the cast from the derived class
+  // to the base class during the invocation of the method.
+  clang::CXXMethodDecl *synthesizeCXXForwardingMethod(
+      const clang::CXXRecordDecl *derivedClass,
+      const clang::CXXRecordDecl *baseClass, const clang::CXXMethodDecl *method,
+      ForwardingMethodKind forwardingMethodKind,
+      ReferenceReturnTypeBehaviorForBaseMethodSynthesis
+          referenceReturnTypeBehavior =
+              ReferenceReturnTypeBehaviorForBaseMethodSynthesis::KeepReference,
+      bool forceConstQualifier = false);
 
   VarDecl *makeComputedPropertyFromCXXMethods(FuncDecl *getter,
                                               FuncDecl *setter);

--- a/test/Interop/Cxx/class/Inputs/protocol-conformance.h
+++ b/test/Interop/Cxx/class/Inputs/protocol-conformance.h
@@ -68,4 +68,8 @@ struct HasOperatorPlusEqual {
 
 using HasOperatorPlusEqualInt = HasOperatorPlusEqual<int>;
 
+struct HasVirtualMethod {
+  virtual int return42() { return 42; } 
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_PROTOCOL_CONFORMANCE_H

--- a/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
@@ -1,4 +1,4 @@
-extern "C" void puts(const char *);
+extern "C" void puts(const char *_Null_unspecified);
 
 inline void testFunctionCollected() {
   puts("test\n");
@@ -38,3 +38,50 @@ using UnusedInt = Unused<int>;
 struct VirtualNonAbstractBase {
   virtual void nonAbstractMethod() const;
 };
+
+struct CallsPureMethod {
+  virtual int getPureInt() const = 0;
+  int getInt() const { return getPureInt() + 1; }
+};
+
+struct DerivedFromCallsPureMethod : CallsPureMethod {
+  int getPureInt() const override { return 789; }
+};
+
+struct DerivedFromDerivedFromCallsPureMethod : DerivedFromCallsPureMethod {};
+
+// MARK: Reference Types:
+
+#define IMMORTAL_FRT                                                           \
+  __attribute__((swift_attr("import_reference")))                              \
+  __attribute__((swift_attr("retain:immortal")))                               \
+  __attribute__((swift_attr("release:immortal")))
+
+struct IMMORTAL_FRT ImmortalBase {
+  int value = 0;
+
+  virtual int get42() const { return 42; }
+  virtual int getOverridden42() const { return 123; }
+  virtual int getIntValue() const { return value; }
+};
+
+struct IMMORTAL_FRT Immortal : public ImmortalBase {
+  static Immortal *_Nonnull create() { return new Immortal(); }
+
+  virtual int getOverridden42() const override { return 42; }
+  virtual void setIntValue(int newValue) { this->value = newValue; }
+};
+
+struct IMMORTAL_FRT DerivedFromImmortal : public Immortal {
+  static DerivedFromImmortal *_Nonnull create() { return new DerivedFromImmortal(); }
+};
+
+inline const ImmortalBase *_Nonnull castToImmortalBase(
+    const Immortal *_Nonnull immortal) {
+  return static_cast<const ImmortalBase *>(immortal);
+}
+
+inline const Immortal *_Nonnull castToImmortal(
+    const DerivedFromImmortal *_Nonnull immortal) {
+  return static_cast<const Immortal *>(immortal);
+}

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-module-interface.swift
@@ -24,3 +24,12 @@
 // CHECK: struct VirtualNonAbstractBase {
 // CHECK-NEXT:  init()
 // CHECK-NEXT:  func nonAbstractMethod()
+
+// CHECK: class ImmortalBase {
+// CHECK:  func get42() -> Int32
+// CHECK:  func getOverridden42() -> Int32
+// CHECK: }
+// CHECK: class Immortal {
+// CHECK:  func getOverridden42() -> Int32
+// CHECK:  func get42() -> Int32
+// CHECK: }

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-typechecker.swift
@@ -13,3 +13,26 @@ let _ = Derived4()
 let _ = DerivedFromDerived2()
 
 VirtualNonAbstractBase().nonAbstractMethod()
+
+@available(macOS 13.3, *)
+func takesImmortalBase(_ i: ImmortalBase) {
+  let _ = i.get42()
+  let _ = i.getOverridden42()
+  let _ = i.getIntValue()
+}
+
+@available(macOS 13.3, *)
+func takesImmortal(_ i: Immortal) {
+  let _ = i.get42()
+  let _ = i.getOverridden42()
+  let _ = i.getIntValue()
+  i.setIntValue(1)
+}
+
+@available(macOS 13.3, *)
+func takesDerivedFromImmortal(_ i: DerivedFromImmortal) {
+  let _ = i.get42()
+  let _ = i.getOverridden42()
+  let _ = i.getIntValue()
+  i.setIntValue(1)
+}

--- a/test/Interop/Cxx/class/inheritance/virtual-methods.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods.swift
@@ -1,0 +1,55 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import VirtualMethods
+
+var VirtualMethodsTestSuite = TestSuite("Virtual Methods")
+
+VirtualMethodsTestSuite.test("value type") {
+  var d2 = Derived2()
+  expectEqual(42, d2.f())
+
+  var d3 = Derived3()
+  expectEqual(42, d3.f())
+
+  var d4 = Derived4()
+  expectEqual(24, d4.f())
+
+  let d5 = DerivedFromCallsPureMethod()
+  expectEqual(790, d5.getInt())
+  expectEqual(789, d5.getPureInt())
+
+  let d6 = DerivedFromDerivedFromCallsPureMethod()
+  expectEqual(790, d6.getInt())
+  expectEqual(789, d6.getPureInt())
+}
+
+if #available(macOS 13.3, *) {
+  VirtualMethodsTestSuite.test("immortal reference type") {
+    let i = Immortal.create()
+    expectEqual(42, i.get42())
+    expectEqual(0, i.getIntValue())
+
+    let base = castToImmortalBase(i)
+    expectEqual(42, base.get42())
+    expectEqual(42, base.getOverridden42())
+    expectEqual(0, base.getIntValue())
+
+    i.setIntValue(566)
+    expectEqual(566, i.getIntValue())
+    expectEqual(566, base.getIntValue())
+
+    let d = DerivedFromImmortal.create()
+    expectEqual(42, d.get42())
+    expectEqual(42, d.getOverridden42())
+    d.setIntValue(321)
+    expectEqual(321, d.getIntValue())
+    let base2 = castToImmortalBase(castToImmortal(d))
+    expectEqual(321, base2.getIntValue())
+  }
+}
+
+runAllTests()

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -1,6 +1,8 @@
 // Tests that a C++ class can conform to a Swift protocol.
 
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -D VIRTUAL_METHODS -cxx-interoperability-mode=swift-6
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -D VIRTUAL_METHODS -cxx-interoperability-mode=upcoming-swift
 
 import ProtocolConformance
 
@@ -9,6 +11,10 @@ protocol HasReturn42 {
 }
 
 extension ConformsToProtocol : HasReturn42 {}
+
+#if VIRTUAL_METHODS
+extension HasVirtualMethod : HasReturn42 {}
+#endif
 
 extension DoesNotConformToProtocol : HasReturn42 {} // expected-error {{'DoesNotConformToProtocol' does not conform to protocol}}
 


### PR DESCRIPTION
This adds a new implementation of virtual method dispatch that handles reference types correctly.

Previously, for all C++ types an invocation of a virtual method would actually get dispatched statically. For value types this is expected and matches what C++ does because of slicing. For reference types, however, this is incorrect, we should do dynamic dispatch.

rdar://123852577