### PR TITLE
Ensure that proper default visibility is set for compatibility archives

### DIFF
--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -46,6 +46,10 @@ endif()
 # runtime being patched only through public ABI.
 list(APPEND CXX_COMPILE_FLAGS "-DSWIFT_COMPATIBILITY_LIBRARY=1")
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
+
 if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   add_subdirectory(legacy_layouts)
   add_subdirectory(Compatibility50)

--- a/stdlib/toolchain/Compatibility56/CMakeLists.txt
+++ b/stdlib/toolchain/Compatibility56/CMakeLists.txt
@@ -2,10 +2,6 @@ set(library_name "swiftCompatibility56")
 
 include_directories("include/" "${SWIFT_STDLIB_SOURCE_DIR}")
 
-set(CMAKE_C_VISIBILITY_PRESET hidden)
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
-
 add_compile_definitions(SWIFT_COMPATIBILITY56)
 add_swift_target_library("${library_name}" STATIC
   Overrides.cpp

--- a/stdlib/toolchain/CompatibilityPacks/CMakeLists.txt
+++ b/stdlib/toolchain/CompatibilityPacks/CMakeLists.txt
@@ -2,10 +2,6 @@ set(library_name "swiftCompatibilityPacks")
 
 include_directories("include/" "${SWIFT_STDLIB_SOURCE_DIR}")
 
-set(CMAKE_C_VISIBILITY_PRESET hidden)
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
-
 add_compile_definitions(SWIFT_COMPATIBILITY_PACKS)
 add_swift_target_library("${library_name}" STATIC
   Metadata.cpp


### PR DESCRIPTION
This is set to hidden in `stdlib/CMakeLists.txt`, but in some Apple internal configurations we build the compatibility archives by directly importing `stdlib/toolchain`, thus skipping these directives and
 causing some symbols to become unexpected visible.

Addresses rdar://73709695