### PR TITLE
[EscapeAnalysis] Handle atomic instructions in escape analysis

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -420,6 +420,41 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
           return .continueWalk
         }
         return isEscaping
+
+      case .AtomicLoad:
+        // Treat atomic loads as regular loads and just walk down their uses.
+        if !followLoads(at: path) {
+          return .continueWalk
+        }
+
+        // Even when analyzing atomics, a loaded trivial value can be ignored.
+        if hasRelevantType(bi, at: path.projectionPath) {
+          return .continueWalk
+        }
+
+        return walkDownUses(ofValue: bi, path: path.with(knownType: nil))
+
+      case .AtomicStore, .AtomicRMW:
+        // If we shouldn't follow the store, then we can keep walking.
+        if !path.followStores {
+          return .continueWalk
+        }
+
+        // Be conservative and just say the store is escaping.
+        return isEscaping
+
+      case .CmpXChg:
+        // If we have to follow loads or stores of a cmpxchg, then just bail.
+        if followLoads(at: path) || path.followStores {
+          return isEscaping
+        }
+
+        return .continueWalk
+
+      case .Fence:
+        // Fences do not affect escape analysis.
+        return .continueWalk
+
       default:
         return isEscaping
       }

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -1100,6 +1100,131 @@ bb0:
   return %4 : $()
 }
 
+// CHECK-LABEL: @test_builtin_zeroInitializer_atomicload
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %0 = alloc_stack
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %1 = alloc_stack
+// CHECK-NEXT:    r=0,w=1
+sil @test_builtin_zeroInitializer_atomicload : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %0 = alloc_stack $C
+  %1 = alloc_stack $C
+  %2 = builtin "zeroInitializer"<C>(%1 : $*C) : $()
+  %3 = apply undef<C>(%1) : $@convention(thin) <C> () -> @out C
+  copy_addr [take] %1 to [init] %0 : $*C
+  dealloc_stack %1 : $*C
+  %4 = address_to_pointer %0 : $*C to $Builtin.RawPointer
+  %5 = builtin "atomicload_monotonic_Int64"(%4 : $Builtin.RawPointer) : $Builtin.Int64
+  destroy_addr %0 : $*C
+  dealloc_stack %0 : $*C
+  return %5 : $Builtin.Int64
+}
+
+// CHECK-LABEL: @test_builtin_zeroInitializer_atomicstore
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %0 = alloc_stack
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %1 = alloc_stack
+// CHECK-NEXT:    r=0,w=1
+sil @test_builtin_zeroInitializer_atomicstore : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $C
+  %1 = alloc_stack $C
+  %2 = builtin "zeroInitializer"<C>(%1 : $*C) : $()
+  %3 = apply undef<C>(%1) : $@convention(thin) <C> () -> @out C
+  copy_addr [take] %1 to [init] %0 : $*C
+  dealloc_stack %1 : $*C
+  %4 = address_to_pointer %0 : $*C to $Builtin.RawPointer
+  %5 = integer_literal $Builtin.Int64, 1
+  %6 = builtin "atomicstore_monotonic_Int64"(%4 : $Builtin.RawPointer, %5 : $Builtin.Int64) : $()
+  destroy_addr %0 : $*C
+  dealloc_stack %0 : $*C
+  %7 = tuple ()
+  return %7 : $()
+}
+
+// CHECK-LABEL: @test_builtin_zeroInitializer_atomicrmw
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %0 = alloc_stack
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %1 = alloc_stack
+// CHECK-NEXT:    r=0,w=1
+sil @test_builtin_zeroInitializer_atomicrmw : $@convention(thin) () -> (Builtin.Int64, Builtin.Int64) {
+bb0:
+  %0 = alloc_stack $C
+  %1 = alloc_stack $C
+  %2 = builtin "zeroInitializer"<C>(%1 : $*C) : $()
+  %3 = apply undef<C>(%1) : $@convention(thin) <C> () -> @out C
+  copy_addr [take] %1 to [init] %0 : $*C
+  dealloc_stack %1 : $*C
+  %4 = address_to_pointer %0 : $*C to $Builtin.RawPointer
+  %5 = integer_literal $Builtin.Int64, 1
+  %6 = builtin "atomicrmw_xchg_monotonic_Int64"(%4 : $Builtin.RawPointer, %5 : $Builtin.Int64) : $Builtin.Int64
+  %7 = builtin "atomicrmw_add_monotonic_Int64"(%4 : $Builtin.RawPointer, %5 : $Builtin.Int64) : $Builtin.Int64
+  destroy_addr %0 : $*C
+  dealloc_stack %0 : $*C
+  %8 = tuple (%6 : $Builtin.Int64, %7 : $Builtin.Int64)
+  return %8 : $(Builtin.Int64, Builtin.Int64)
+}
+
+// CHECK-LABEL: @test_builtin_zeroInitializer_cmpxchg
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %0 = alloc_stack
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %1 = alloc_stack
+// CHECK-NEXT:    r=0,w=1
+sil @test_builtin_zeroInitializer_cmpxchg : $@convention(thin) () -> (Builtin.Int64, Builtin.Int1) {
+bb0:
+  %0 = alloc_stack $C
+  %1 = alloc_stack $C
+  %2 = builtin "zeroInitializer"<C>(%1 : $*C) : $()
+  %3 = apply undef<C>(%1) : $@convention(thin) <C> () -> @out C
+  copy_addr [take] %1 to [init] %0 : $*C
+  dealloc_stack %1 : $*C
+  %4 = address_to_pointer %0 : $*C to $Builtin.RawPointer
+  %5 = integer_literal $Builtin.Int64, 1
+  %6 = builtin "cmpxchg_monotonic_monotonic_Int64"(%4 : $Builtin.RawPointer, %5 : $Builtin.Int64) : $(Builtin.Int64, Builtin.Int1)
+  destroy_addr %0 : $*C
+  dealloc_stack %0 : $*C
+  return %6 : $(Builtin.Int64, Builtin.Int1)
+}
+
+// CHECK-LABEL: @test_builtin_zeroInitializer_fence
+// CHECK:       PAIR #0.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %0 = alloc_stack
+// CHECK-NEXT:    r=0,w=0
+// CHECK:       PAIR #1.
+// CHECK-NEXT:      %2 = builtin "zeroInitializer"<C>(%1 : $*C)
+// CHECK-NEXT:      %1 = alloc_stack
+// CHECK-NEXT:    r=0,w=1
+sil @test_builtin_zeroInitializer_fence : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $C
+  %1 = alloc_stack $C
+  %2 = builtin "zeroInitializer"<C>(%1 : $*C) : $()
+  %3 = apply undef<C>(%1) : $@convention(thin) <C> () -> @out C
+  copy_addr [take] %1 to [init] %0 : $*C
+  dealloc_stack %1 : $*C
+  %5 = builtin "fence_release"() : $()
+  destroy_addr %0 : $*C
+  dealloc_stack %0 : $*C
+  return %5 : $()
+}
+
 // CHECK-LABEL: @test_stored_pointer
 // CHECK:       PAIR #3.
 // CHECK-NEXT:      %5 = apply %4(%2) : $@convention(thin) (@in Builtin.RawPointer) -> ()

--- a/test/SILOptimizer/templvalueopt.sil
+++ b/test/SILOptimizer/templvalueopt.sil
@@ -264,6 +264,16 @@ bb0(%ret_addr : $*T):
   apply undef<T>(%temporary) : $@convention(thin) <T> () -> @out T
   copy_addr [take] %temporary to [init] %ret_addr : $*T
   dealloc_stack %temporary : $*T
+
+  // Ensure that the following builtin instructions don't interfere with
+  // temp l value from getting rid of the temporary.
+  %empty = builtin "fence_release"() : $()
+  %ptr = address_to_pointer %ret_addr : $*T to $Builtin.RawPointer
+  %load = builtin "atomicload_monotonic_Int64"(%ptr : $Builtin.RawPointer) : $Builtin.Int64
+  %onetwoeight = integer_literal $Builtin.Int64, 128
+  %empty2 = builtin "atomicstore_monotonic_Int64"(%ptr : $Builtin.RawPointer, %onetwoeight : $Builtin.Int64) : $()
+  %add = builtin "atomicrmw_add_monotonic_Int64"(%ptr : $Builtin.RawPointer, %onetwoeight : $Builtin.Int64) : $Builtin.Int64
+  %cmpxchg = builtin "cmpxchg_monotonic_monotonic_Int64"(%ptr : $Builtin.RawPointer, %onetwoeight : $Builtin.Int64, %onetwoeight : $Builtin.Int64) : $(Builtin.Int64, Builtin.Int1)
   %15 = tuple ()
   return %15 : $()
 }


### PR DESCRIPTION
Given the following simple use of the new `Atomic` type:
```swift
func something() -> Int {
  let x = Atomic(0)
  return x.load(ordering: .relaxed)
}
```
we generate the following SIL:
```swift
// something()
sil hidden @something: $@convention(thin) () -> Int {
[global: read,write,copy,destroy,allocate,deinit_barrier]
bb0:
  %0 = alloc_stack [lexical] $Atomic<Int>, let, name "x" // users: %7, %9, %12, %13
  %1 = integer_literal $Builtin.Int64, 0          // user: %4
  %2 = alloc_stack $Atomic<Int>                   // users: %5, %8, %7, %3
  %3 = builtin "zeroInitializer"<Atomic<Int>>(%2 : $*Atomic<Int>) : $()
  %4 = struct $_Atomic64BitStorage (%1 : $Builtin.Int64) // user: %6
  %5 = unchecked_addr_cast %2 : $*Atomic<Int> to $*_Atomic64BitStorage // user: %6
  store %4 to %5 : $*_Atomic64BitStorage          // id: %6
  copy_addr [take] %2 to [init] %0 : $*Atomic<Int> // id: %7
  dealloc_stack %2 : $*Atomic<Int>                // id: %8
  %9 = address_to_pointer %0 : $*Atomic<Int> to $Builtin.RawPointer // user: %10
  %10 = builtin "atomicload_monotonic_Int64"(%9 : $Builtin.RawPointer) : $Builtin.Int64 // user: %11
  %11 = struct $Int (%10 : $Builtin.Int64)        // user: %14
  destroy_addr %0 : $*Atomic<Int>                 // id: %12
  dealloc_stack %0 : $*Atomic<Int>                // id: %13
  return %11 : $Int                               // id: %14
} // end sil function '$s4main8testLoadSiyF'
```

TempLValueOpt is unable to eliminate the temporary because of the atomic builtin instruction acting as a barrier for escape analysis to determine if the zero initializer escapes the lexical alloc stack instruction. Handle them by walking down their result uses.

This results in the following new SIL:
```swift
// something
sil hidden @something : $@convention(thin) () -> Int {
[global: read,write,copy,destroy,allocate,deinit_barrier]
bb0:
  %0 = alloc_stack [lexical] $Atomic<Int>, let, name "x" // users: %4, %2, %6, %9, %10
  %1 = integer_literal $Builtin.Int64, 0          // user: %3
  %2 = builtin "zeroInitializer"<Atomic<Int>>(%0 : $*Atomic<Int>) : $()
  %3 = struct $_Atomic64BitStorage (%1 : $Builtin.Int64) // user: %5
  %4 = unchecked_addr_cast %0 : $*Atomic<Int> to $*_Atomic64BitStorage // user: %5
  store %3 to %4 : $*_Atomic64BitStorage          // id: %5
  %6 = address_to_pointer %0 : $*Atomic<Int> to $Builtin.RawPointer // user: %7
  %7 = builtin "atomicload_monotonic_Int64"(%6 : $Builtin.RawPointer) : $Builtin.Int64 // user: %8
  %8 = struct $Int (%7 : $Builtin.Int64)          // user: %11
  destroy_addr %0 : $*Atomic<Int>                 // id: %9
  dealloc_stack %0 : $*Atomic<Int>                // id: %10
  return %8 : $Int                                // id: %11
} // end sil function 'something'
```

Now, we should be able to optimize away the zero initializer entirely, but that's work for a different optimization pass.