### PR TITLE
[Diagnostics] Clarify the wording of `error_in_future_swift_version`.

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -45,7 +45,7 @@ NOTE(brace_stmt_suggest_do,none,
      "did you mean to use a 'do' statement?", ())
 
 WARNING(error_in_future_swift_version,none,
-        "%0; this is an error in Swift %1",
+        "%0; this is an error in the Swift %1 language mode",
         (DiagnosticInfo *, unsigned))
 
 // Generic disambiguation

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6807,7 +6807,7 @@ WARNING(inlinable_decl_ref_from_hidden_module_warn,
       none, "%kind0 cannot be used in " FRAGILE_FUNC_KIND "1 "
       "because %select{<<ERROR>>|<<ERROR>>|<<ERROR>>|<<ERROR>>|"
       "%2 was not imported by this file}3"
-      "; this is an error in Swift 6",
+      "; this is an error in the Swift 6 language mode",
       (const ValueDecl *, unsigned, Identifier, unsigned))
 
 ERROR(inlinable_typealias_desugars_to_type_from_hidden_module,

--- a/include/swift/AST/EducationalNotes.def
+++ b/include/swift/AST/EducationalNotes.def
@@ -86,5 +86,8 @@ EDUCATIONAL_NOTES(result_builder_missing_build_array,
                   
 EDUCATIONAL_NOTES(multiple_inheritance,
                   "multiple-inheritance.md")
-                  
+
+EDUCATIONAL_NOTES(error_in_future_swift_version,
+                  "error-in-future-swift-version.md")
+
 #undef EDUCATIONAL_NOTES

--- a/test/ClangImporter/objc_async.swift
+++ b/test/ClangImporter/objc_async.swift
@@ -298,7 +298,7 @@ class BarFrame: PictureFrame {
 @available(SwiftStdlib 5.5, *)
 @SomeGlobalActor
 class BazFrame: NotIsolatedPictureFrame {
-// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'BazFrame' has different actor isolation from nonisolated superclass 'NotIsolatedPictureFrame'; this is an error in Swift 6}}
+// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'BazFrame' has different actor isolation from nonisolated superclass 'NotIsolatedPictureFrame'; this is an error in the Swift 6 language mode}}
   init() {
     super.init(size: 0)
   }
@@ -365,7 +365,7 @@ func testSender(
 
   sender.sendAnyArray([sendableObject])
   sender.sendAnyArray([nonSendableObject])
-  // expected-warning@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable; this is an error in Swift 6}}
+  // expected-warning@-1 {{conformance of 'NonSendableClass' to 'Sendable' is unavailable; this is an error in the Swift 6 language mode}}
 
   sender.sendGeneric(sendableGeneric) // no warning
 
@@ -393,7 +393,7 @@ extension SomeWrapper: Sendable where T: Sendable {}
   func makeCall(slowServer: SlowServer) {
     slowServer.doSomethingSlow("churn butter") { (_ : Int) in
       let _ = self.isolatedThing
-      // expected-warning@-1 {{main actor-isolated property 'isolatedThing' can not be referenced from a Sendable closure; this is an error in Swift 6}}
+      // expected-warning@-1 {{main actor-isolated property 'isolatedThing' can not be referenced from a Sendable closure; this is an error in the Swift 6 language mode}}
     }
   }
 }

--- a/test/ClangImporter/objc_async_conformance.swift
+++ b/test/ClangImporter/objc_async_conformance.swift
@@ -87,7 +87,7 @@ class SelectorBothAsync2: NSObject, SelectorBothAsyncProto {
   func hello() async -> Bool // expected-note {{method 'hello()' declared here}}
 
   @objc(helloWithCompletion:)
-  func hello(completion: @escaping (Bool) -> Void) // expected-warning {{method 'hello(completion:)' with Objective-C selector 'helloWithCompletion:' conflicts with method 'hello()' with the same Objective-C selector; this is an error in Swift 6}}
+  func hello(completion: @escaping (Bool) -> Void) // expected-warning {{method 'hello(completion:)' with Objective-C selector 'helloWithCompletion:' conflicts with method 'hello()' with the same Objective-C selector; this is an error in the Swift 6 language mode}}
 }
 
 // additional coverage for situation like C4, where the method names don't

--- a/test/ClangImporter/objc_bridging_custom.swift
+++ b/test/ClangImporter/objc_bridging_custom.swift
@@ -161,7 +161,7 @@ protocol TestProto {
 
   @objc optional subscript(a a: Refrigerator) -> Refrigerator? { get } // expected-note 2 {{here}} {{none}}
   @objc optional subscript(generic a: ManufacturerInfo<NSString>) -> ManufacturerInfo<NSString>? { get } // expected-note {{here}} {{none}}
-  // expected-warning@-1 {{subscript getter with Objective-C selector 'objectForKeyedSubscript:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
+  // expected-warning@-1 {{subscript getter with Objective-C selector 'objectForKeyedSubscript:' conflicts with previous declaration with the same Objective-C selector; this is an error in the Swift 6 language mode}}
 
   @objc optional var prop: Refrigerator? { get } // expected-note {{here}} {{none}}
   @objc optional var propGeneric: ManufacturerInfo<NSString>? { get } // expected-note {{here}} {{none}}

--- a/test/Compatibility/attr_usableFromInline_protocol.swift
+++ b/test/Compatibility/attr_usableFromInline_protocol.swift
@@ -7,8 +7,8 @@ public protocol PublicProtoWithReqs {
 }
 
 @usableFromInline struct UFIAdopter<T> : PublicProtoWithReqs {}
-// expected-warning@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in Swift 5}} {{none}}
-// expected-warning@-2 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in Swift 5}} {{none}}
+// expected-warning@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in the Swift 5 language mode}} {{none}}
+// expected-warning@-2 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in the Swift 5 language mode}} {{none}}
 extension UFIAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}
@@ -18,9 +18,9 @@ extension UFIAdopter {
 
 @usableFromInline struct UFIAdopterAllInOne<T> : PublicProtoWithReqs {
   typealias Assoc = Int
-  // expected-warning@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in Swift 5}} {{none}}
+  // expected-warning@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in the Swift 5 language mode}} {{none}}
   func foo() {}
-  // expected-warning@-1 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in Swift 5}} {{none}}
+  // expected-warning@-1 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'PublicProtoWithReqs'; this is an error in the Swift 5 language mode}} {{none}}
 }
 
 internal struct InternalAdopter<T> : PublicProtoWithReqs {}
@@ -36,8 +36,8 @@ extension InternalAdopter {
 }
 
 public struct PublicAdopter<T> : UFIProtoWithReqs {}
-// expected-warning@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'; this is an error in Swift 5}} {{none}}
-// expected-warning@-2 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'; this is an error in Swift 5}} {{none}}
+// expected-warning@-1 {{type alias 'Assoc' must be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'; this is an error in the Swift 5 language mode}} {{none}}
+// expected-warning@-2 {{instance method 'foo()' must be declared '@usableFromInline' because it matches a requirement in protocol 'UFIProtoWithReqs'; this is an error in the Swift 5 language mode}} {{none}}
 extension PublicAdopter {
   typealias Assoc = Int
   // expected-note@-1 {{'Assoc' declared here}}

--- a/test/Compatibility/ownership_protocol.swift
+++ b/test/Compatibility/ownership_protocol.swift
@@ -4,14 +4,14 @@
 class SomeClass {}
 
 protocol P {
-  // expected-warning@+1 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
+  // expected-warning@+1 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in the Swift 5 language mode}}
   weak var foo: SomeClass? { get set }
-  // expected-warning@+1 {{'unowned' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
+  // expected-warning@+1 {{'unowned' cannot be applied to a property declaration in a protocol; this is an error in the Swift 5 language mode}}
   unowned var foo2: SomeClass { get set }
-  // expected-warning@+2 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
+  // expected-warning@+2 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in the Swift 5 language mode}}
   // expected-error@+1 {{'weak' may only be applied to class and class-bound protocol types, not 'Int'}}
   weak var foo3: Int? { get set }
-  // expected-warning@+2 {{'unowned' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
+  // expected-warning@+2 {{'unowned' cannot be applied to a property declaration in a protocol; this is an error in the Swift 5 language mode}}
   // expected-error@+1 {{'unowned' may only be applied to class and class-bound protocol types, not 'Int'}}
   unowned var foo4: Int { get set }
 }

--- a/test/Concurrency/Inputs/sendable_cycle_other.swift
+++ b/test/Concurrency/Inputs/sendable_cycle_other.swift
@@ -1,3 +1,3 @@
 struct Foo {
-  static let member = Bar() // expected-complete-warning {{static property 'member' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6}}
+  static let member = Bar() // expected-complete-warning {{static property 'member' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in the Swift 6 language mode}}
 }

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -318,7 +318,7 @@ actor ProtectDictionary {
 
   func invalid() async {
     await dict[0].mutate()
-    // expected-warning@-1 {{cannot call mutating async function 'mutate()' on actor-isolated property 'dict'; this is an error in Swift 6}}
+    // expected-warning@-1 {{cannot call mutating async function 'mutate()' on actor-isolated property 'dict'; this is an error in the Swift 6 language mode}}
     // expected-targeted-complete-warning@-2 {{passing argument of non-sendable type 'inout Optional<Int>' outside of actor-isolated context may introduce data races}}
   }
 }

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -12,7 +12,7 @@ import OtherActors // expected-warning{{add '@preconcurrency' to suppress 'Senda
 
 let immutableGlobal: String = "hello"
 
-// expected-warning@+2 {{var 'mutableGlobal' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+// expected-warning@+2 {{var 'mutableGlobal' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
 // expected-note@+1 {{isolate 'mutableGlobal' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 var mutableGlobal: String = "can't touch this" // expected-note 5{{var declared here}}
 
@@ -144,7 +144,7 @@ struct InferredFromContext {
   nonisolated var status: Bool = true // expected-error {{'nonisolated' cannot be applied to mutable stored properties}}{{3-15=}}{{3-15=}}{{14-14=(unsafe)}}
   // expected-note@-1{{convert 'status' to a 'let' constant or consider declaring it 'nonisolated(unsafe)' if manually managing concurrency safety}}
 
-  nonisolated let flag: Bool = false // expected-warning {{'nonisolated' is redundant on struct's stored properties; this is an error in Swift 6}}{{3-15=}}
+  nonisolated let flag: Bool = false // expected-warning {{'nonisolated' is redundant on struct's stored properties; this is an error in the Swift 6 language mode}}{{3-15=}}
 
   subscript(_ i: Int) -> Int { return i }
 
@@ -172,13 +172,13 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
 
 // check for instance members that do not need global-actor protection
 
-// expected-warning@+2 {{memberwise initializer for 'NoGlobalActorValueType' cannot be both nonisolated and global actor 'SomeGlobalActor'-isolated; this is an error in Swift 6}}
+// expected-warning@+2 {{memberwise initializer for 'NoGlobalActorValueType' cannot be both nonisolated and global actor 'SomeGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
 // expected-note@+1 2 {{consider making struct 'NoGlobalActorValueType' conform to the 'Sendable' protocol}}
 struct NoGlobalActorValueType {
-  @SomeGlobalActor var point: Point // expected-warning {{stored property 'point' within struct cannot have a global actor; this is an error in Swift 6}}
+  @SomeGlobalActor var point: Point // expected-warning {{stored property 'point' within struct cannot have a global actor; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{initializer for property 'point' is global actor 'SomeGlobalActor'-isolated}}
 
-  @MainActor let counter: Int // expected-warning {{stored property 'counter' within struct cannot have a global actor; this is an error in Swift 6}}
+  @MainActor let counter: Int // expected-warning {{stored property 'counter' within struct cannot have a global actor; this is an error in the Swift 6 language mode}}
 
   @MainActor static var polygon: [Point] = []
 }
@@ -790,15 +790,15 @@ actor LazyActor {
     lazy var l25: Int = { [unowned self] in self.l }()
 
     nonisolated lazy var l31: Int = { v }()
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l32: Int = v
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l33: Int = { self.v }()
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l34: Int = self.v
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
     nonisolated lazy var l35: Int = { [unowned self] in self.v }()
-    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
+    // expected-warning@-1 {{actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
 
     nonisolated lazy var l41: Int = { l }()
     nonisolated lazy var l42: Int = l
@@ -845,26 +845,26 @@ actor SomeActorWithInits {
     self.mutableState = 42
     self.otherMutableState = 17
 
-    self.isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in Swift 6}}
+    self.isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
     self.nonisolated()
 
     defer {
-      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in Swift 6}}
+      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
       mutableState += 1 // okay through typechecking, since flow-isolation will verify it.
       nonisolated()
     }
 
     func local() {
-      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in Swift 6}}
-      mutableState += 1 // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a non-isolated context; this is an error in Swift 6}}
+      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+      mutableState += 1 // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
       nonisolated()
     }
     local()
 
     let _ = {
       defer {
-        isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in Swift 6}}
-        mutableState += 1  // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a non-isolated context; this is an error in Swift 6}}
+        isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+        mutableState += 1  // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
         nonisolated()
       }
       nonisolated()
@@ -879,14 +879,14 @@ actor SomeActorWithInits {
     self.nonisolated()
   }
 
-  convenience init(i3: Bool) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{3-15=}}
+  convenience init(i3: Bool) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in the Swift 6 language mode}}{{3-15=}}
     self.init(i1: i3)
     _ = mutableState    // expected-error{{actor-isolated property 'mutableState' can not be referenced from a non-isolated context}}
     self.isolated()     // expected-error{{call to actor-isolated instance method 'isolated()' in a synchronous nonisolated context}}
     self.nonisolated()
   }
 
-  convenience init(i4: Bool) async { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{3-15=}}
+  convenience init(i4: Bool) async { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in the Swift 6 language mode}}{{3-15=}}
     self.init(i1: i4)
     _ = mutableState
     self.isolated()
@@ -896,9 +896,9 @@ actor SomeActorWithInits {
   @MainActor init(i5 x: SomeClass) {
     self.mutableState = 42
     self.otherMutableState = 17
-    self.nonSendable = x // expected-warning {{actor-isolated property 'nonSendable' can not be mutated from the main actor; this is an error in Swift 6}}
+    self.nonSendable = x // expected-warning {{actor-isolated property 'nonSendable' can not be mutated from the main actor; this is an error in the Swift 6 language mode}}
 
-    self.isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from the main actor; this is an error in Swift 6}}
+    self.isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
     self.nonisolated()
   }
 
@@ -912,14 +912,14 @@ actor SomeActorWithInits {
     _ = mutableState // will be caught by flow-isolation
   }
 
-  @MainActor convenience init(i7: Bool) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{14-26=}}
+  @MainActor convenience init(i7: Bool) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in the Swift 6 language mode}}{{14-26=}}
     self.init(i1: i7)
     _ = mutableState    // expected-error{{actor-isolated property 'mutableState' can not be referenced from the main actor}}
     self.isolated()     // expected-error{{call to actor-isolated instance method 'isolated()' in a synchronous main actor-isolated context}}
     self.nonisolated()
   }
 
-  @MainActor convenience init(i8: Bool) async { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{14-26=}}
+  @MainActor convenience init(i8: Bool) async { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in the Swift 6 language mode}}{{14-26=}}
     self.init(i1: i8)
     _ = await mutableState
     await self.isolated()
@@ -940,15 +940,15 @@ actor SomeActorWithInits {
     let _ = self.nonSendable // OK only through typechecking, not SIL.
 
     defer {
-      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in Swift 6}}
+      isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
       mutableState += 1 // okay
       nonisolated()
     }
 
     let _ = {
       defer {
-        isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in Swift 6}}
-        mutableState += 1  // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a non-isolated context; this is an error in Swift 6}}
+        isolated() // expected-warning{{actor-isolated instance method 'isolated()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+        mutableState += 1  // expected-warning{{actor-isolated property 'mutableState' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
         nonisolated()
       }
       nonisolated()
@@ -1254,11 +1254,11 @@ actor Counter {
   }
 
   init() {
-    _ = self.next() // expected-warning {{actor-isolated instance method 'next()' can not be referenced from a non-isolated context; this is an error in Swift 6}}
-    defer { _ = self.next() } // expected-warning {{actor-isolated instance method 'next()' can not be referenced from a non-isolated context; this is an error in Swift 6}}
+    _ = self.next() // expected-warning {{actor-isolated instance method 'next()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+    defer { _ = self.next() } // expected-warning {{actor-isolated instance method 'next()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
 
-    _ = computedProp  // expected-warning {{actor-isolated property 'computedProp' can not be referenced from a non-isolated context; this is an error in Swift 6}}
-    computedProp = 1  // expected-warning {{actor-isolated property 'computedProp' can not be mutated from a non-isolated context; this is an error in Swift 6}}
+    _ = computedProp  // expected-warning {{actor-isolated property 'computedProp' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
+    computedProp = 1  // expected-warning {{actor-isolated property 'computedProp' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
 
   }
 
@@ -1273,7 +1273,7 @@ class C2 { }
 
 @SomeGlobalActor
 class C3: C2 { }
-// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'C3' has different actor isolation from nonisolated superclass 'C2'; this is an error in Swift 6}}
+// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'C3' has different actor isolation from nonisolated superclass 'C2'; this is an error in the Swift 6 language mode}}
 
 @GenericGlobalActor<U>
 class GenericSuper<U> { }
@@ -1288,11 +1288,11 @@ class GenericSub2<T>: GenericSuper<[T]> { } // expected-error{{global actor 'Gen
 actor Butterfly {
   var flapsPerSec = 0 // expected-note 3{{mutation of this property is only permitted within the actor}}
 
-  nonisolated init() {} // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
+  nonisolated init() {} // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in the Swift 6 language mode}} {{3-15=}}
 
   nonisolated init(async: Void) async {}
 
-  nonisolated init(icecream: Void) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
+  nonisolated init(icecream: Void) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in the Swift 6 language mode}} {{3-15=}}
     self.init()
     self.flapsPerSec += 1 // expected-error {{actor-isolated property 'flapsPerSec' can not be mutated from a non-isolated context}}
   }
@@ -1416,7 +1416,7 @@ actor DunkTracker {
   private var curry: Int? // expected-note {{property declared here}}
 
   deinit {
-    // expected-warning@+1 {{actor-isolated property 'curry' can not be referenced from a non-isolated autoclosure; this is an error in Swift 6}}
+    // expected-warning@+1 {{actor-isolated property 'curry' can not be referenced from a non-isolated autoclosure; this is an error in the Swift 6 language mode}}
     if lebron != nil || curry != nil {
       
     }
@@ -1453,7 +1453,7 @@ class None {
 // try to add inferred isolation while overriding
 @MainActor
 class MA_None1: None {
-// expected-warning@-1 {{main actor-isolated class 'MA_None1' has different actor isolation from nonisolated superclass 'None'; this is an error in Swift 6}}
+// expected-warning@-1 {{main actor-isolated class 'MA_None1' has different actor isolation from nonisolated superclass 'None'; this is an error in the Swift 6 language mode}}
 
   // FIXME: bad note, since the problem is a mismatch in overridden vs inferred isolation; this wont help.
   // expected-note@+1 {{add '@MainActor' to make instance method 'method()' part of global actor 'MainActor'}}
@@ -1484,7 +1484,7 @@ class None_MADirect: MADirect {
 
 @SomeGlobalActor
 class SGA_MADirect: MADirect {
-// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'SGA_MADirect' has different actor isolation from nonisolated superclass 'MADirect'; this is an error in Swift 6}}
+// expected-warning@-1 {{global actor 'SomeGlobalActor'-isolated class 'SGA_MADirect' has different actor isolation from nonisolated superclass 'MADirect'; this is an error in the Swift 6 language mode}}
 
   // inferred-SomeGlobalActor vs overridden-MainActor = mainactor
   override func method1() { beets_ma() }
@@ -1548,7 +1548,7 @@ protocol NonisolatedProtocol {
 }
 
 actor ActorWithNonSendableLet: NonisolatedProtocol {
-  // expected-warning@+1 {{actor-isolated property 'ns' cannot be used to satisfy nonisolated protocol requirement; this is an error in Swift 6}}
+  // expected-warning@+1 {{actor-isolated property 'ns' cannot be used to satisfy nonisolated protocol requirement; this is an error in the Swift 6 language mode}}
   let ns = NonSendable()
 }
 
@@ -1559,7 +1559,7 @@ actor ProtectNonSendable {
   init() {}
 
   @MainActor init(fromMain: Void) {
-    // expected-warning@+1 {{actor-isolated property 'ns' can not be referenced from the main actor; this is an error in Swift 6}}
+    // expected-warning@+1 {{actor-isolated property 'ns' can not be referenced from the main actor; this is an error in the Swift 6 language mode}}
     _ = self.ns
   }
 }
@@ -1598,6 +1598,6 @@ class MainActorIsolated {
 }
 
 nonisolated func accessAcrossActors() {
-  // expected-warning@+1 {{main actor-isolated static property 'shared' can not be referenced from a non-isolated context; this is an error in Swift 6}}
+  // expected-warning@+1 {{main actor-isolated static property 'shared' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
   let _ = MainActorIsolated.shared
 }

--- a/test/Concurrency/actor_keypath_isolation.swift
+++ b/test/Concurrency/actor_keypath_isolation.swift
@@ -48,7 +48,7 @@ func tryKeyPathsMisc(d : Door) {
 
     // in combination with other key paths
 
-    _ = (\Door.letBox).appending(path:  // expected-warning {{cannot form key path to actor-isolated property 'letBox'; this is an error in Swift 6}}
+    _ = (\Door.letBox).appending(path:  // expected-warning {{cannot form key path to actor-isolated property 'letBox'; this is an error in the Swift 6 language mode}}
                                        \Box?.?.size)
 
     _ = (\Door.varBox).appending(path:  // expected-error {{cannot form key path to actor-isolated property 'varBox'}}
@@ -58,18 +58,18 @@ func tryKeyPathsMisc(d : Door) {
 
 func tryKeyPathsFromAsync() async {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to main actor-isolated property 'unsafeGlobActor_mutable'; this is an error in Swift 6}}
+    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to main actor-isolated property 'unsafeGlobActor_mutable'; this is an error in the Swift 6 language mode}}
 }
 
 func tryNonSendable() {
-    _ = \Door.letDict[0] // expected-warning {{cannot form key path to actor-isolated property 'letDict'; this is an error in Swift 6}}
+    _ = \Door.letDict[0] // expected-warning {{cannot form key path to actor-isolated property 'letDict'; this is an error in the Swift 6 language mode}}
     _ = \Door.varDict[0] // expected-error {{cannot form key path to actor-isolated property 'varDict'}}
-    _ = \Door.letBox!.size // expected-warning {{cannot form key path to actor-isolated property 'letBox'; this is an error in Swift 6}}
+    _ = \Door.letBox!.size // expected-warning {{cannot form key path to actor-isolated property 'letBox'; this is an error in the Swift 6 language mode}}
 }
 
 func tryKeypaths() {
     _ = \Door.unsafeGlobActor_immutable
-    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to main actor-isolated property 'unsafeGlobActor_mutable'; this is an error in Swift 6}}
+    _ = \Door.unsafeGlobActor_mutable // expected-warning {{cannot form key path to main actor-isolated property 'unsafeGlobActor_mutable'; this is an error in the Swift 6 language mode}}
 
     _ = \Door.immutable
     _ = \Door.globActor_immutable
@@ -84,7 +84,7 @@ func tryKeypaths() {
     let _ : PartialKeyPath<Door> = \.mutable // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
     let _ : AnyKeyPath = \Door.mutable  // expected-error{{cannot form key path to actor-isolated property 'mutable'}}
 
-    _ = \Door.globActor_mutable // expected-warning {{cannot form key path to main actor-isolated property 'globActor_mutable'; this is an error in Swift 6}}
+    _ = \Door.globActor_mutable // expected-warning {{cannot form key path to main actor-isolated property 'globActor_mutable'; this is an error in the Swift 6 language mode}}
     _ = \Door.[0] // expected-error{{cannot form key path to actor-isolated subscript 'subscript(_:)'}}
-    _ = \Door.["hello"] // expected-warning {{cannot form key path to main actor-isolated subscript 'subscript(_:)'; this is an error in Swift 6}}
+    _ = \Door.["hello"] // expected-warning {{cannot form key path to main actor-isolated subscript 'subscript(_:)'; this is an error in the Swift 6 language mode}}
 }

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -8,9 +8,9 @@ class GlobalCounter {
   var counter: Int = 0
 }
 
-let rs = GlobalCounter() // expected-warning {{let 'rs' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in Swift 6}}
+let rs = GlobalCounter() // expected-warning {{let 'rs' is not concurrency-safe because it is not either conforming to 'Sendable' or isolated to a global actor; this is an error in the Swift 6 language mode}}
 
-var globalInt = 17 // expected-warning {{var 'globalInt' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+var globalInt = 17 // expected-warning {{var 'globalInt' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
 // expected-note@-1 {{isolate 'globalInt' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 // expected-note@-2 2{{var declared here}}
 

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -232,7 +232,7 @@ func testKeyPaths(dict: [NC: Int], nc: NC) {
 // Sendable restriction on nonisolated declarations.
 // ----------------------------------------------------------------------
 actor ANI {
-  nonisolated let nc = NC() // expected-warning {{'nonisolated' can not be applied to variable with non-'Sendable' type 'NC'; this is an error in Swift 6}}
+  nonisolated let nc = NC() // expected-warning {{'nonisolated' can not be applied to variable with non-'Sendable' type 'NC'; this is an error in the Swift 6 language mode}}
   nonisolated func f() -> NC? { nil }
 }
 
@@ -273,7 +273,7 @@ typealias CF = @Sendable () -> NotConcurrent?
 typealias BadGenericCF<T> = @Sendable () -> T?
 typealias GoodGenericCF<T: Sendable> = @Sendable () -> T? // okay
 
-var concurrentFuncVar: (@Sendable (NotConcurrent) -> Void)? = nil // expected-warning{{var 'concurrentFuncVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+var concurrentFuncVar: (@Sendable (NotConcurrent) -> Void)? = nil // expected-warning{{var 'concurrentFuncVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
 // expected-note@-1 {{isolate 'concurrentFuncVar' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 
 // ----------------------------------------------------------------------

--- a/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis.swift
+++ b/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis.swift
@@ -82,14 +82,14 @@ func testComplexGlobal<U>(_ fn: @escaping @MainActor (U?) -> Void) {
   // CHECK-NEXT: [[SUBST_THUNKED_FN:%.*]] = convert_function [[THUNKED_FN]] : $@callee_guaranteed (@in_guaranteed Optional<U>) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed Optional<τ_0_0>) -> () for <U>
   // CHECK-NEXT: {{.*}} = enum $Optional<@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed Optional<τ_0_0>) -> () for <U>>, #Optional.some!enumelt, [[SUBST_THUNKED_FN]] : $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed Optional<τ_0_0>) -> () for <U>
   compute(fn)
-  // expected-warning@-1 {{converting function value of type '@MainActor (U?) -> Void' to '(U?) -> Void' loses global actor 'MainActor'; this is an error in Swift 6}}
+  // expected-warning@-1 {{converting function value of type '@MainActor (U?) -> Void' to '(U?) -> Void' loses global actor 'MainActor'; this is an error in the Swift 6 language mode}}
 
   // CHECK: [[CLOSURE:%.*]] = function_ref @$s6Client17testComplexGlobalyyyxSgScMYcclFySiScMYccfU_ : $@convention(thin) (Int) -> ()
   // CHECK-NEXT: [[CLOSURE_REF:%.*]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) (Int) -> () to $@callee_guaranteed (Int) -> ()
   // CHECK: [[CLOSURE_THUNK:%.*]] = function_ref @$sSiIegy_SiIegy_TRScMTU : $@convention(thin) (Int, @guaranteed @callee_guaranteed (Int) -> ()) -> ()
   // CHECK-NEXT: {{.*}} = partial_apply [callee_guaranteed] [[CLOSURE_THUNK]]([[CLOSURE_REF]]) : $@convention(thin) (Int, @guaranteed @callee_guaranteed (Int) -> ()) -> ()
   compute { @MainActor (arg: Int) -> Void in
-    // expected-warning@-1 {{converting function value of type '@MainActor (Int) -> Void' to '(Int) -> Void' loses global actor 'MainActor'; this is an error in Swift 6}}
+    // expected-warning@-1 {{converting function value of type '@MainActor (Int) -> Void' to '(Int) -> Void' loses global actor 'MainActor'; this is an error in the Swift 6 language mode}}
   }
 }
 

--- a/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis_objc.swift
+++ b/test/Concurrency/dynamic_checks_for_func_refs_in_preconcurrency_apis_objc.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 install_global_event_handler { @MainActor _ in
-  // expected-warning@-1 {{converting function value of type '@MainActor (Any) -> ()' to 'event_handler' (aka '@convention(c) (Any) -> ()') loses global actor 'MainActor'; this is an error in Swift 6}}
+  // expected-warning@-1 {{converting function value of type '@MainActor (Any) -> ()' to 'event_handler' (aka '@convention(c) (Any) -> ()') loses global actor 'MainActor'; this is an error in the Swift 6 language mode}}
 }
 
 // CHECK-LABEL: sil private [thunk] [ossa] @$s56dynamic_checks_for_func_refs_in_preconcurrency_apis_objcyypScMYccfU_To : $@convention(c) (AnyObject) -> ()

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -48,26 +48,26 @@ actor Bob {
     self.x = 0
     speak()    // expected-note {{after calling instance method 'speak()', only non-isolated properties of 'self' can be accessed from this init}}
     speak()
-    self.x = 1 // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+    self.x = 1 // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     speak()
   }
 
   init(v1 _: Void) {
     self.x = 0
     _ = cherry  // expected-note {{after accessing property 'cherry', only non-isolated properties of 'self' can be accessed from this init}}
-    self.x = 1  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+    self.x = 1  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   init(v2 callBack: (Bob) -> Void) {
     self.x = 0
     callBack(self)  // expected-note {{after a call involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
-    self.x = 1      // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+    self.x = 1      // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   init(v3 _: Void) {
     self.x = 1
     takeBob(self)   // expected-note {{after calling global function 'takeBob', only non-isolated properties of 'self' can be accessed from this init}}
-    self.x = 1  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+    self.x = 1  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
 
@@ -96,7 +96,7 @@ actor Casey {
 
   init() {
     money = Money(dollars: 100)
-    defer { logTransaction(money.euros) } // expected-warning {{cannot access property 'money' here in non-isolated initializer; this is an error in Swift 6}}
+    defer { logTransaction(money.euros) } // expected-warning {{cannot access property 'money' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     self.speak("Yay, I have $\(money.dollars)!") // expected-note {{after calling instance method 'speak', only non-isolated properties of 'self' can be accessed from this init}}
   }
 
@@ -106,14 +106,14 @@ actor Casey {
     if (money.dollars < 0) {
       self.speak("Oh no, I'm in debt!") // expected-note 3 {{after calling instance method 'speak', only non-isolated properties of 'self' can be accessed from this init}}
     }
-    logTransaction(money.euros) // expected-warning {{cannot access property 'money' here in non-isolated initializer; this is an error in Swift 6}}
+    logTransaction(money.euros) // expected-warning {{cannot access property 'money' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
 
-    // expected-warning@+1 2 {{cannot access property 'money' here in non-isolated initializer; this is an error in Swift 6}}
+    // expected-warning@+1 2 {{cannot access property 'money' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     money.dollars = money.dollars + 1
 
     if randomBool() {
       // expected-note@+2 {{after calling instance method 'cashUnderMattress()', only non-isolated properties of 'self' can be accessed from this init}}
-      // expected-warning@+1 {{cannot access property 'money' here in non-isolated initializer; this is an error in Swift 6}}
+      // expected-warning@+1 {{cannot access property 'money' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
       money.dollars += cashUnderMattress()
     }
   }
@@ -128,7 +128,7 @@ actor Demons {
   }
 
   deinit {
-    let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in Swift 6}}
+    let _ = self.ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -152,8 +152,8 @@ actor ExampleFromProposal {
     f() // expected-note 2 {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from this init}}
 
     _ = self.immutableSendable  // ok
-    _ = self.mutableSendable    // expected-warning {{cannot access property 'mutableSendable' here in non-isolated initializer; this is an error in Swift 6}}
-    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' here in non-isolated initializer; this is an error in Swift 6}}
+    _ = self.mutableSendable    // expected-warning {{cannot access property 'mutableSendable' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     _ = self.unsafeNonSendable // ok
   }
 
@@ -161,13 +161,13 @@ actor ExampleFromProposal {
   deinit {
     _ = self.immutableSendable  // ok
     _ = self.mutableSendable    // ok
-    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in Swift 6}}
+    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in the Swift 6 language mode}}
 
     f() // expected-note {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from a deinit}}
 
     _ = self.immutableSendable  // ok
-    _ = self.mutableSendable    // expected-warning {{cannot access property 'mutableSendable' here in deinitializer; this is an error in Swift 6}}
-    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in Swift 6}}
+    _ = self.mutableSendable    // expected-warning {{cannot access property 'mutableSendable' here in deinitializer; this is an error in the Swift 6 language mode}}
+    _ = self.nonSendable        // expected-warning {{cannot access property 'nonSendable' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated func f() {}
@@ -195,13 +195,13 @@ class CheckGAIT1 {
       }
       break
     } while true
-    silly += 2 // expected-warning {{cannot access property 'silly' here in non-isolated initializer; this is an error in Swift 6}}
+    silly += 2 // expected-warning {{cannot access property 'silly' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   deinit {
-    _ = ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in Swift 6}}
+    _ = ns // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType' from non-isolated deinit; this is an error in the Swift 6 language mode}}
     f()     // expected-note {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from a deinit}}
-    _ = silly // expected-warning {{cannot access property 'silly' here in deinitializer; this is an error in Swift 6}}
+    _ = silly // expected-warning {{cannot access property 'silly' here in deinitializer; this is an error in the Swift 6 language mode}}
 
   }
 }
@@ -216,7 +216,7 @@ actor ControlFlowTester {
 
   init(v1: Void) {
     noniso()                 // expected-note {{after calling instance method 'noniso()', only non-isolated properties of 'self' can be accessed from this init}}
-    takeNonSendable(self.ns) // expected-warning {{cannot access property 'ns' here in non-isolated initializer; this is an error in Swift 6}}
+    takeNonSendable(self.ns) // expected-warning {{cannot access property 'ns' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     takeSendable(self.s)
   }
 
@@ -244,16 +244,16 @@ actor ControlFlowTester {
         throw Color.yellow
       }
     } catch Color.blue {
-      count += 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+      count += 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     } catch {
-      count += 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+      count += 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     }
-    count = 42 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+    count = 42 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
 
   init(v4 c: Color) {
-    defer { count += 1 } // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+    defer { count += 1 } // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     noniso() // expected-note 1 {{after calling instance method 'noniso()', only non-isolated properties of 'self' can be accessed from this init}}
   }
 
@@ -267,7 +267,7 @@ actor ControlFlowTester {
     if c == .blue {
       throw c
     }
-    count += 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+    count += 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   init(v5 c: Color?) {
@@ -278,20 +278,20 @@ actor ControlFlowTester {
         count = 0 // OK
         fallthrough
       case .blue:
-        count = 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+        count = 1 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
         fallthrough
       case .yellow:
-        count = 2 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+        count = 2 // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
         break
       }
     }
     switch c {
     case .some(.red):
-      count += 1  // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+      count += 1  // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     case .some(.blue):
-      count += 2  // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+      count += 2  // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     case .some(.yellow):
-      count += 3  // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in Swift 6}}
+      count += 3  // expected-warning {{cannot access property 'count' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     case .none:
       break
     }
@@ -413,28 +413,28 @@ actor MyActor {
 
         Task { self } // expected-note 2 {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
 
-        self.x = randomInt()  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+        self.x = randomInt()  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
 
         callMethod(self) // expected-note 5 {{after calling global function 'callMethod', only non-isolated properties of 'self' can be accessed from this init}}
 
-        passInout(&self.x) // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+        passInout(&self.x) // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
 
         if c {
-          // expected-warning@+2 {{cannot access property 'y' here in non-isolated initializer; this is an error in Swift 6}}
-          // expected-warning@+1 {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+          // expected-warning@+2 {{cannot access property 'y' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+          // expected-warning@+1 {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
           self.x = self.y
         }
 
-        // expected-warning@+2 {{cannot access property 'y' here in non-isolated initializer; this is an error in Swift 6}}
-        // expected-warning@+1 {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+        // expected-warning@+2 {{cannot access property 'y' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
+        // expected-warning@+1 {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
         (_, _) = (self.x, self.y)
-        _ = self.x == 0 // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+        _ = self.x == 0 // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
 
         while c {
-          // expected-warning@+2 {{cannot access property 'hax' here in non-isolated initializer; this is an error in Swift 6}}
+          // expected-warning@+2 {{cannot access property 'hax' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
           // expected-note@+1 2 {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
           self.hax = self
-          _ = self.hax  // expected-warning {{cannot access property 'hax' here in non-isolated initializer; this is an error in Swift 6}}
+          _ = self.hax  // expected-warning {{cannot access property 'hax' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
         }
 
         Task {
@@ -454,7 +454,7 @@ actor MyActor {
 
         callMethod(self)
 
-        passInout(&self.x) // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+        passInout(&self.x) // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     }
 
     init(i3 c:  Bool) async {
@@ -492,7 +492,7 @@ actor MyActor {
 
       callMethod(self)
 
-      passInout(&self.x) // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+      passInout(&self.x) // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     }
 }
 
@@ -505,7 +505,7 @@ actor X {
         self.counter = start
         Task { await self.setCounter(start + 1) } // expected-note {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
 
-        if self.counter != start { // expected-warning {{cannot access property 'counter' here in non-isolated initializer; this is an error in Swift 6}}
+        if self.counter != start { // expected-warning {{cannot access property 'counter' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
             fatalError("where's my protection?")
         }
     }
@@ -521,7 +521,7 @@ struct CardboardBox<T> {
 
 
 @available(SwiftStdlib 5.1, *)
-var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+var globalVar: EscapeArtist? // expected-warning {{var 'globalVar' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
 // expected-note@-1 {{isolate 'globalVar' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 // expected-note@-2 2 {{var declared here}}
 
@@ -539,7 +539,7 @@ actor EscapeArtist {
         // expected-warning@+1 {{reference to var 'globalVar' is not concurrency-safe because it involves shared mutable state}}
         Task { await globalVar!.isolatedMethod() }
 
-        if self.x == 0 {  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+        if self.x == 0 {  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
             fatalError("race detected.")
         }
     }
@@ -551,7 +551,7 @@ actor EscapeArtist {
         let selfUnchained = wrapped!
 
         Task { await selfUnchained.isolatedMethod() }
-        if self.x == 0 {  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+        if self.x == 0 {  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
             fatalError("race detected.")
         }
     }
@@ -602,33 +602,33 @@ actor Ahmad {
   init(v1: Void) {
     Task.detached { self.f() } // expected-note {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
     f()
-    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in Swift 6}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init(v2: Void) async {
     Task.detached { self.f() } // expected-note {{after making a copy of 'self', only non-isolated properties of 'self' can be accessed from this init}}
     f()
-    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in Swift 6}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   nonisolated init(v3: Void) async {
     prop = 10
     f()       // expected-note {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from this init}}
-    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in Swift 6}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor init(v4: Void) async {
     prop = 10
     f()       // expected-note {{after calling instance method 'f()', only non-isolated properties of 'self' can be accessed from this init}}
-    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in Swift 6}}
+    prop += 1 // expected-warning {{cannot access property 'prop' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   deinit {
-    // expected-warning@+2 {{actor-isolated property 'computedProp' can not be referenced from a non-isolated context; this is an error in Swift 6}}
+    // expected-warning@+2 {{actor-isolated property 'computedProp' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
     // expected-note@+1 {{after accessing property 'computedProp', only non-isolated properties of 'self' can be accessed from a deinit}}
     let x = computedProp
 
-    prop = x // expected-warning {{cannot access property 'prop' here in deinitializer; this is an error in Swift 6}}
+    prop = x // expected-warning {{cannot access property 'prop' here in deinitializer; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -640,7 +640,7 @@ actor Rain {
   init(_ hollerBack: (Rain) -> () -> Void) {
     defer { self.f() }
 
-    defer { _ = self.x }  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in Swift 6}}
+    defer { _ = self.x }  // expected-warning {{cannot access property 'x' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
 
     defer { Task { self.f() } }
 
@@ -671,11 +671,11 @@ actor DeinitExceptionForSwift5 {
   }
 
   deinit {
-    // expected-warning@+2 {{actor-isolated instance method 'cleanup()' can not be referenced from a non-isolated context; this is an error in Swift 6}}
+    // expected-warning@+2 {{actor-isolated instance method 'cleanup()' can not be referenced from a non-isolated context; this is an error in the Swift 6 language mode}}
     // expected-note@+1 {{after calling instance method 'cleanup()', only non-isolated properties of 'self' can be accessed from a deinit}}
     cleanup()
 
-    x = 1 // expected-warning {{cannot access property 'x' here in deinitializer; this is an error in Swift 6}}
+    x = 1 // expected-warning {{cannot access property 'x' here in deinitializer; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -688,7 +688,7 @@ actor OhBrother {
 
   init() {
     // expected-note@+2 {{after this closure involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
-    // expected-warning@+1 {{cannot access property 'giver' here in non-isolated initializer; this is an error in Swift 6}}
+    // expected-warning@+1 {{cannot access property 'giver' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     self.giver = { (x: OhBrother) -> Int in Self.DefaultResult }
   }
 
@@ -699,7 +699,7 @@ actor OhBrother {
 
     _ = giver(self) // expected-note {{after a call involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
 
-    whatever = 1 // expected-warning {{cannot access property 'whatever' here in non-isolated initializer; this is an error in Swift 6}}
+    whatever = 1 // expected-warning {{cannot access property 'whatever' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 
   init(v3: Void) {
@@ -710,7 +710,7 @@ actor OhBrother {
 
     _ = blah(self) // expected-note {{after this closure involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
 
-    whatever = 2 // expected-warning {{cannot access property 'whatever' here in non-isolated initializer; this is an error in Swift 6}}
+    whatever = 2 // expected-warning {{cannot access property 'whatever' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -721,8 +721,8 @@ actor OhBrother {
 class CheckDeinitFromClass: AwesomeUIView {
   var ns: NonSendableType?
   deinit {
-    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in Swift 6}}
-    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in Swift 6}}
+    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in the Swift 6 language mode}}
+    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -730,8 +730,8 @@ class CheckDeinitFromClass: AwesomeUIView {
 actor CheckDeinitFromActor {
   var ns: NonSendableType?
   deinit {
-    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in Swift 6}}
-    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in Swift 6}}
+    ns?.f() // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in the Swift 6 language mode}}
+    ns = nil // expected-warning {{cannot access property 'ns' with a non-sendable type 'NonSendableType?' from non-isolated deinit; this is an error in the Swift 6 language mode}}
   }
 }
 
@@ -766,7 +766,7 @@ func testActorWithInitAccessorInit() {
       escapingSelf(self)
 
       self.radians = 0
-      // expected-warning@-1 {{actor-isolated property 'radians' can not be mutated from a non-isolated context; this is an error in Swift 6}}
+      // expected-warning@-1 {{actor-isolated property 'radians' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
     }
   }
 
@@ -791,7 +791,7 @@ func testActorWithInitAccessorInit() {
       // expected-note@-1 {{after this closure involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
 
       self.a = v
-      // expected-warning@-1 {{cannot access property '_a' here in non-isolated initializer; this is an error in Swift 6}}
+      // expected-warning@-1 {{cannot access property '_a' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
     }
   }
 

--- a/test/Concurrency/freestanding_top_level.swift
+++ b/test/Concurrency/freestanding_top_level.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend -concurrency-model=task-to-thread -typecheck  -verify %s
 // RUN: %target-swift-frontend -concurrency-model=task-to-thread -typecheck  -verify -verify-additional-prefix complete- -strict-concurrency=complete %s
 
-// expected-complete-warning@+3 {{var 'global' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in Swift 6}}
+// expected-complete-warning@+3 {{var 'global' is not concurrency-safe because it is non-isolated global shared mutable state; this is an error in the Swift 6 language mode}}
 // expected-complete-note@+2 {{isolate 'global' to a global actor, or convert it to a 'let' constant and conform it to 'Sendable'}}
 // expected-complete-note@+1 {{var declared here}}
 var global = 10
 
-// expected-complete-warning@+1 {{reference to var 'global' is not concurrency-safe because it involves shared mutable state; this is an error in Swift 6}}
+// expected-complete-warning@+1 {{reference to var 'global' is not concurrency-safe because it involves shared mutable state; this is an error in the Swift 6 language mode}}
 print(global)

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -248,7 +248,7 @@ class SuperclassWithGlobalActors {
 
 @GenericGlobalActor<String>
 class SubclassWithGlobalActors : SuperclassWithGlobalActors {
-// expected-warning@-1 {{global actor 'GenericGlobalActor<String>'-isolated class 'SubclassWithGlobalActors' has different actor isolation from nonisolated superclass 'SuperclassWithGlobalActors'; this is an error in Swift 6}}
+// expected-warning@-1 {{global actor 'GenericGlobalActor<String>'-isolated class 'SubclassWithGlobalActors' has different actor isolation from nonisolated superclass 'SuperclassWithGlobalActors'; this is an error in the Swift 6 language mode}}
 
   override func f() { } // okay: inferred to @GenericGlobalActor<Int>
 
@@ -330,7 +330,7 @@ public struct WrapperOnMainActor<Wrapped> {
   public var accessCount: Int
 
   nonisolated public init(wrappedValue: Wrapped) {
-    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context; this is an error in Swift 6}}
+    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
     self.wrappedValue = wrappedValue
   }
 }
@@ -341,7 +341,7 @@ public struct WrapperOnMainActorNonSendable<Wrapped> {
   @MainActor public var wrappedValue: Wrapped
 
   public init(wrappedValue: Wrapped) {
-    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context; this is an error in Swift 6}}
+    // expected-warning@+1 {{main actor-isolated property 'wrappedValue' can not be mutated from a non-isolated context; this is an error in the Swift 6 language mode}}
     self.wrappedValue = wrappedValue
   }
 }
@@ -445,7 +445,7 @@ actor ActorWithWrapper {
   @WrapperOnActor var synced: Int = 0
   // expected-note@-1 3{{property declared here}}
   @WrapperWithMainActorDefaultInit var property: Int // expected-minimal-targeted-error {{call to main actor-isolated initializer 'init()' in a synchronous actor-isolated context}}
-  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a actor-isolated context; this is an error in Swift 6}}
+  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a actor-isolated context; this is an error in the Swift 6 language mode}}
   func f() {
     _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced on a different actor instance}}
     _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced on a different actor instance}}
@@ -562,8 +562,8 @@ struct WrapperOnUnsafeActor<Wrapped> {
 // HasWrapperOnUnsafeActor does not have an inferred global actor attribute,
 // because synced and $synced have different global actors.
 struct HasWrapperOnUnsafeActor {
-// expected-complete-tns-warning@-1 {{memberwise initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in Swift 6}}
-// expected-complete-tns-warning@-2 {{default initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in Swift 6}}
+// expected-complete-tns-warning@-1 {{memberwise initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
+// expected-complete-tns-warning@-2 {{default initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
 
   @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-tns-note 2 {{initializer for property '_synced' is global actor 'OtherGlobalActor'-isolated}}
   // expected-note @-1 3{{property declared here}}
@@ -678,7 +678,7 @@ func replacesDynamicOnMainActor() {
 // Global-actor isolation of stored property initializer expressions
 // ----------------------------------------------------------------------
 
-// expected-complete-tns-warning@+1 {{default initializer for 'Cutter' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
+// expected-complete-tns-warning@+1 {{default initializer for 'Cutter' cannot be both nonisolated and main actor-isolated; this is an error in the Swift 6 language mode}}
 class Cutter {
   // expected-complete-tns-note@+1 {{initializer for property 'x' is main actor-isolated}}
   @MainActor var x = useFooInADefer()
@@ -691,10 +691,10 @@ class Cutter {
 @SomeGlobalActor
 class Butter {
   var a = useFooInADefer() // expected-minimal-targeted-error {{call to main actor-isolated global function 'useFooInADefer()' in a synchronous global actor 'SomeGlobalActor'-isolated context}}
-  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context; this is an error in Swift 6}}
+  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a global actor 'SomeGlobalActor'-isolated context; this is an error in the Swift 6 language mode}}
 
   nonisolated let b = statefulThingy // expected-minimal-targeted-error {{main actor-isolated var 'statefulThingy' can not be referenced from a non-isolated context}}
-  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
+  // expected-complete-tns-warning@-1 {{main actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
 
   var c: Int = {
     return getGlobal7()

--- a/test/Concurrency/import_nsnotificationname_constants_as_nonisolated.swift
+++ b/test/Concurrency/import_nsnotificationname_constants_as_nonisolated.swift
@@ -34,7 +34,7 @@ extern NSNotificationName const TestIsolatedTrigger __attribute__((swift_name("T
 func testAsync() async {
   print(Test.didTrigger) // Ok (property is nonisolated)
   print(Test.isolatedTrigger)
-  // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-2 {{property access is 'async'}}
 }
 

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -42,7 +42,7 @@ class NotSendable {
   // expected-region-isolation-warning @+2 {{transferring 'ns' may cause a race}}
   // expected-region-isolation-note @+1 {{transferring global actor 'MyActor'-isolated 'ns' to global actor 'YourActor'-isolated callee could cause races between global actor 'YourActor'-isolated and global actor 'MyActor'-isolated uses}}
   await { @YourActor in
-    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in Swift 6}}
+    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
 
@@ -63,7 +63,7 @@ class NotSendable {
 
   // FIXME: Region isolation should diagnose this (https://github.com/apple/swift/issues/71533)
   await { @YourActor in
-    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in Swift 6}}
+    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
 
@@ -83,7 +83,7 @@ class NotSendable {
 
   // FIXME: Region isolation should diagnose this (https://github.com/apple/swift/issues/71533)
   await { @YourActor in
-    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in Swift 6}}
+    // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
 

--- a/test/Concurrency/isolated_default_arguments.swift
+++ b/test/Concurrency/isolated_default_arguments.swift
@@ -154,7 +154,7 @@ struct S3 {
 }
 
 struct S4 {
-  // expected-warning@+1 {{main actor-isolated default value in a nonisolated context; this is an error in Swift 6}}
+  // expected-warning@+1 {{main actor-isolated default value in a nonisolated context; this is an error in the Swift 6 language mode}}
   var x: Int = requiresMainActor()
 }
 
@@ -194,7 +194,7 @@ extension A {
   }
 }
 
-// expected-warning@+1 {{default initializer for 'C1' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
+// expected-warning@+1 {{default initializer for 'C1' cannot be both nonisolated and main actor-isolated; this is an error in the Swift 6 language mode}}
 class C1 {
   // expected-note@+1 {{initializer for property 'x' is main actor-isolated}}
   @MainActor var x = requiresMainActor()
@@ -203,7 +203,7 @@ class C1 {
 
 class NonSendable {}
 
-// expected-warning@+1 {{default initializer for 'C2' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
+// expected-warning@+1 {{default initializer for 'C2' cannot be both nonisolated and main actor-isolated; this is an error in the Swift 6 language mode}}
 class C2 {
   // expected-note@+1 {{initializer for property 'x' is main actor-isolated}}
   @MainActor var x = NonSendable()
@@ -231,7 +231,7 @@ func callDefaultInit() async {
   _ = MultipleVars()
 }
 
-// expected-warning@+1 {{default initializer for 'MultipleVarsInvalid' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
+// expected-warning@+1 {{default initializer for 'MultipleVarsInvalid' cannot be both nonisolated and main actor-isolated; this is an error in the Swift 6 language mode}}
 class MultipleVarsInvalid {
   // expected-note@+1 {{initializer for property 'x' is main actor-isolated}}
   @MainActor var (x, y) = (requiresMainActor(), requiresMainActor())
@@ -254,13 +254,13 @@ struct UseRequiresMain {
 }
 
 nonisolated func test() async {
-  // expected-warning@+2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@+2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@+1 {{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}
   _ = UseRequiresMain()
 }
 
-// expected-warning@+2 {{memberwise initializer for 'InitAccessors' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
-// expected-warning@+1 {{default initializer for 'InitAccessors' cannot be both nonisolated and main actor-isolated; this is an error in Swift 6}}
+// expected-warning@+2 {{memberwise initializer for 'InitAccessors' cannot be both nonisolated and main actor-isolated; this is an error in the Swift 6 language mode}}
+// expected-warning@+1 {{default initializer for 'InitAccessors' cannot be both nonisolated and main actor-isolated; this is an error in the Swift 6 language mode}}
 struct InitAccessors {
   private var _a: Int
 

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -19,7 +19,7 @@ extension Actor {
 @available(SwiftStdlib 5.1, *)
 func testA<T: Actor>(
   a: isolated A,  // expected-note{{previous 'isolated' parameter 'a'}}
-  b: isolated T,  // expected-warning{{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+  b: isolated T,  // expected-warning{{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
   c: isolated Int // expected-error {{'isolated' parameter type 'Int' does not conform to 'Actor' or 'DistributedActor'}}
 ) {
   a.f()
@@ -38,7 +38,7 @@ actor Counter {
 
 @available(SwiftStdlib 5.1, *)
 // expected-note@+2 {{previous 'isolated' parameter 'a'}}
-// expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+// expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
 func testDoubleIsolatedParams(a: isolated Counter, b: isolated Other) async {
   a.inc()
   b.inc()
@@ -66,7 +66,7 @@ func globalFuncIsolated(_: isolated A) { // expected-note{{calls to global funct
 }
 
 @available(SwiftStdlib 5.1, *)
-// expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in Swift 6}}{{1-12=}}
+// expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in the Swift 6 language mode}}{{1-12=}}
 @MainActor func testIsolatedParamCalls(a: isolated A, b: A) {
   globalFunc(a)
   globalFunc(b)
@@ -168,7 +168,7 @@ func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-note {{in call to function '
 @available(SwiftStdlib 5.1, *)
 func testTuplingIsolated(
                          _ a: isolated A, // expected-note {{previous 'isolated' parameter 'a'}}
-                         _ b: isolated A  // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+                         _ b: isolated A  // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
                         ) {
   tuplify(testTuplingIsolated)
   // expected-error@-1 {{generic parameter 'Ts' could not be inferred}}
@@ -194,9 +194,9 @@ func testIsolatedClosureInference(one: A, two: A) async {
     a2.f()
   }
 
-  let f: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+  let f: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
       // expected-note@+2 {{previous 'isolated' parameter 'a1'}}
-      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
       { (a1, a2) in
         a1.f()
         a2.f()
@@ -204,9 +204,9 @@ func testIsolatedClosureInference(one: A, two: A) async {
 
   await f(one, two)
 
-  let g: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+  let g: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
       // expected-note@+2 {{previous 'isolated' parameter '$0'}}
-      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
       {
         $0.f()
         $1.f()
@@ -216,12 +216,12 @@ func testIsolatedClosureInference(one: A, two: A) async {
 }
 
 struct CheckIsolatedFunctionTypes {
-  // expected-warning@+2 {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}
-  // expected-warning@+1 {{function type cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+  // expected-warning@+2 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-warning@+1 {{function type cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
   func a(_ f: @MainActor @Sendable (isolated A, isolated A) -> ()) {}
 
   // expected-note@+2 {{calls to parameter 'callback' from outside of its actor context are implicitly asynchronous}}
-  // expected-warning@+1 {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}
+  // expected-warning@+1 {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
   @MainActor func update<R>(_ callback: @Sendable @escaping @MainActor (isolated A) -> R) -> R {
     callback(A()) // expected-error {{call to actor-isolated parameter 'callback' in a synchronous main actor-isolated context}}
   }
@@ -229,21 +229,21 @@ struct CheckIsolatedFunctionTypes {
 
 @available(SwiftStdlib 5.1, *)
 func checkIsolatedAndGlobalClosures(_ a: A) {
-  let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}
+  let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
       = {
     $0.f()
     mainActorFn() // expected-error {{call to main actor-isolated global function 'mainActorFn()' in a synchronous actor-isolated context}}
   }
 
-  let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}
-      = { @MainActor in // expected-warning {{closure with 'isolated' parameter '$0' cannot have a global actor; this is an error in Swift 6}}{{11-22=}}
+  let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in the Swift 6 language mode}}
+      = { @MainActor in // expected-warning {{closure with 'isolated' parameter '$0' cannot have a global actor; this is an error in the Swift 6 language mode}}{{11-22=}}
     $0.f()
     mainActorFn()
   }
 
-  let _ = { @MainActor (a: isolated A, // expected-warning {{closure with 'isolated' parameter 'a' cannot have a global actor; this is an error in Swift 6}}{{13-24=}}
+  let _ = { @MainActor (a: isolated A, // expected-warning {{closure with 'isolated' parameter 'a' cannot have a global actor; this is an error in the Swift 6 language mode}}{{13-24=}}
                                        // expected-note@-1 {{previous 'isolated' parameter 'a'}}
-                        b: isolated A, // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+                        b: isolated A, // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
                         c: isolated A) async in
     a.f()
     mainActorFn()
@@ -268,7 +268,7 @@ extension TestActor {
   func isolatedMethod() { }
   // expected-note@-1{{calls to instance method 'isolatedMethod()' from outside of its actor context are implicitly asynchronous}}
 
-  // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{3-15=}}
+  // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
   nonisolated func isolatedToParameter(_ other: isolated TestActor) {
     isolatedMethod()
     // expected-error@-1{{call to actor-isolated instance method 'isolatedMethod()' in a synchronous actor-isolated context}}
@@ -288,8 +288,8 @@ func isolatedClosures() {
   }
 }
 
-// expected-warning@+2 {{global function with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{12-24=}}
-// expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in Swift 6}}{{1-12=}}
+// expected-warning@+2 {{global function with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{12-24=}}
+// expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in the Swift 6 language mode}}{{1-12=}}
 @MainActor nonisolated func allOfEm(_ a: isolated A) {
   a.f()
 }
@@ -297,7 +297,7 @@ func isolatedClosures() {
 @MainActor class MAClass {
 
   // expected-note@+2 {{previous 'isolated' parameter 'a'}}
-  // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+  // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
   init(_ a: isolated A, _ b: isolated A) {
     // FIXME: wrong isolation. should be isolated to `a` only!
     a.f()
@@ -305,8 +305,8 @@ func isolatedClosures() {
   }
 
   // expected-note@+3 {{previous 'isolated' parameter 'a'}}
-  // expected-warning@+2 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
-  // expected-warning@+1 {{subscript with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{3-15=}}
+  // expected-warning@+2 {{cannot have more than one 'isolated' parameter; this is an error in the Swift 6 language mode}}
+  // expected-warning@+1 {{subscript with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
   nonisolated subscript(_ a: isolated A, _ b: isolated A) -> Int {
     // FIXME: wrong isolation. should be isolated to `a`.
     a.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous actor-isolated context}}
@@ -314,7 +314,7 @@ func isolatedClosures() {
     return 0
   }
 
-  // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{3-15=}}
+  // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in the Swift 6 language mode}}{{3-15=}}
   nonisolated func millionDollars(_ a: isolated A) {
     a.f()
   }

--- a/test/Concurrency/objc_async_overload.swift
+++ b/test/Concurrency/objc_async_overload.swift
@@ -57,7 +57,7 @@ extension Delegate {
   func handle(_ req: Request, with delegate: Delegate) {
     delegate.makeRequest1(req) {
       self.finish()
-      // expected-warning@-1 {{call to main actor-isolated instance method 'finish()' in a synchronous nonisolated context; this is an error in Swift 6}}
+      // expected-warning@-1 {{call to main actor-isolated instance method 'finish()' in a synchronous nonisolated context; this is an error in the Swift 6 language mode}}
     }
   }
 }

--- a/test/Concurrency/preconcurrency_typealias.swift
+++ b/test/Concurrency/preconcurrency_typealias.swift
@@ -31,7 +31,7 @@ func test() {
   var mutableVariable = 0
   preconcurrencyFunc {
     mutableVariable += 1 // no sendable warning unless we have complete
-    // expected-complete-tns-warning @-1 {{mutation of captured var 'mutableVariable' in concurrently-executing code; this is an error in Swift 6}}
+    // expected-complete-tns-warning @-1 {{mutation of captured var 'mutableVariable' in concurrently-executing code; this is an error in the Swift 6 language mode}}
   }
   mutableVariable += 1
 }
@@ -49,7 +49,7 @@ func testAsync() async {
 
   var mutableVariable = 0
   preconcurrencyFunc {
-    mutableVariable += 1 // expected-warning{{mutation of captured var 'mutableVariable' in concurrently-executing code; this is an error in Swift 6}}
+    mutableVariable += 1 // expected-warning{{mutation of captured var 'mutableVariable' in concurrently-executing code; this is an error in the Swift 6 language mode}}
   }
   mutableVariable += 1
 }

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -148,9 +148,9 @@ func testGlobalActorIsolatedReferences() {
   }
 
   let dataKP = \Isolated.data
-  // expected-warning@-1 {{cannot form key path to main actor-isolated property 'data'; this is an error in Swift 6}}
+  // expected-warning@-1 {{cannot form key path to main actor-isolated property 'data'; this is an error in the Swift 6 language mode}}
   let subscriptKP = \Isolated.[42]
-  // expected-warning@-1 {{cannot form key path to main actor-isolated subscript 'subscript(_:)'; this is an error in Swift 6}}
+  // expected-warning@-1 {{cannot form key path to main actor-isolated subscript 'subscript(_:)'; this is an error in the Swift 6 language mode}}
 
   let _: KeyPath<Isolated, Int> & Sendable = dataKP
   // expected-warning@-1 {{type 'WritableKeyPath<Isolated, Int>' does not conform to the 'Sendable' protocol}}
@@ -159,7 +159,7 @@ func testGlobalActorIsolatedReferences() {
 
   func testNonIsolated() {
     _ = \Isolated.data
-    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'data'; this is an error in Swift 6}}
+    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'data'; this is an error in the Swift 6 language mode}}
   }
 
   @MainActor func testIsolated() {
@@ -190,14 +190,14 @@ func testReferencesToDifferentGlobalActorIsolatedMembers() {
   @MainActor func testIsolatedToMain() {
     _ = \Info.name // Ok
     _ = \Isolated.info.name
-    // expected-warning@-1 {{cannot form key path to global actor 'GlobalActor'-isolated property 'info'; this is an error in Swift 6}}
+    // expected-warning@-1 {{cannot form key path to global actor 'GlobalActor'-isolated property 'info'; this is an error in the Swift 6 language mode}}
   }
 
   @GlobalActor func testIsolatedToCustom() {
     _ = \Info.name // Ok
-    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'name'; this is an error in Swift 6}}
+    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'name'; this is an error in the Swift 6 language mode}}
     _ = \Isolated.info.name
-    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'name'; this is an error in Swift 6}}
+    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'name'; this is an error in the Swift 6 language mode}}
   }
 }
 

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -154,7 +154,7 @@ let helloworld:  @Sendable () -> Void = World.greet
 class NonSendableC {
     var x: Int = 0
 
-    @Sendable func inc() { // expected-warning {{instance methods of non-Sendable types cannot be marked as '@Sendable'; this is an error in Swift 6}}
+    @Sendable func inc() { // expected-warning {{instance methods of non-Sendable types cannot be marked as '@Sendable'; this is an error in the Swift 6 language mode}}
         x += 1
     }
 }

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -1026,7 +1026,7 @@ func rdar_59741308() {
 func r60074136() {
   func takesClosure(_ closure: ((Int) -> Void) -> Void) {}
 
-  takesClosure { ((Int) -> Void) -> Void in // expected-warning {{unnamed parameters must be written with the empty name '_'; this is an error in Swift 6}}
+  takesClosure { ((Int) -> Void) -> Void in // expected-warning {{unnamed parameters must be written with the empty name '_'; this is an error in the Swift 6 language mode}}
   }
 }
 

--- a/test/Constraints/common_type_objc.swift
+++ b/test/Constraints/common_type_objc.swift
@@ -7,10 +7,10 @@ import Foundation
 
 @objc protocol P {
   func foo(_ i: Int) -> Double // expected-note {{'foo' previously declared here}}
-  func foo(_ d: Double) -> Double // expected-warning {{method 'foo' with Objective-C selector 'foo:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
+  func foo(_ d: Double) -> Double // expected-warning {{method 'foo' with Objective-C selector 'foo:' conflicts with previous declaration with the same Objective-C selector; this is an error in the Swift 6 language mode}}
 
   @objc optional func opt(_ i: Int) -> Int // expected-note {{'opt' previously declared here}}
-  @objc optional func opt(_ d: Double) -> Int // expected-warning {{method 'opt' with Objective-C selector 'opt:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
+  @objc optional func opt(_ d: Double) -> Int // expected-warning {{method 'opt' with Objective-C selector 'opt:' conflicts with previous declaration with the same Objective-C selector; this is an error in the Swift 6 language mode}}
 }
 
 func testOptional(obj: P) {

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -513,7 +513,7 @@ struct S_24329052<T> { // expected-note {{generic parameter 'T' of generic struc
   // expected-note@+1 {{generic parameter 'T' of instance method 'bar(_:)' declared here}}
   func bar<T>(_ v: T) { foo(v) }
   // expected-error@-1 {{cannot convert value of type 'T' (generic parameter of instance method 'bar(_:)') to expected argument type 'T' (generic parameter of generic struct 'S_24329052')}}
-  // expected-warning@-2 {{generic parameter 'T' shadows generic parameter from outer scope with the same name; this is an error in Swift 6}}
+  // expected-warning@-2 {{generic parameter 'T' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
 }
 
 extension Sequence {

--- a/test/Constraints/overload_filtering_objc.swift
+++ b/test/Constraints/overload_filtering_objc.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @objc protocol P {
   func foo(_ i: Int) -> Int // expected-note {{'foo' previously declared here}}
-  func foo(_ d: Double) -> Int // expected-warning {{method 'foo' with Objective-C selector 'foo:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
+  func foo(_ d: Double) -> Int // expected-warning {{method 'foo' with Objective-C selector 'foo:' conflicts with previous declaration with the same Objective-C selector; this is an error in the Swift 6 language mode}}
 
   @objc optional func opt(_ i: Int) -> Int
   @objc optional func opt(double: Double) -> Int

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -675,7 +675,7 @@ func testExprPatternIsolation() {
   if case .f(0.0, 0) = produceMultiPayload() {}
   if case .f(0, 0.0) = produceMultiPayload() {} // expected-error {{expression pattern of type 'Double' cannot match values of type 'Int'}}
 
-  if case .e(5, nil) = produceMultiPayload() {} // expected-warning {{type 'Int' is not optional, value can never be nil; this is an error in Swift 6}}
+  if case .e(5, nil) = produceMultiPayload() {} // expected-warning {{type 'Int' is not optional, value can never be nil; this is an error in the Swift 6 language mode}}
 
   // FIXME: Bad error (https://github.com/apple/swift/issues/64279)
   if case .e(nil, 0) = produceMultiPayload() {}

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -837,7 +837,7 @@ func test_rdar89742267() {
     @Builder var body: S {
       switch entry {
       case .listen: S()
-      case nil: S() // expected-warning {{type 'Hey' is not optional, value can never be nil; this is an error in Swift 6}}
+      case nil: S() // expected-warning {{type 'Hey' is not optional, value can never be nil; this is an error in the Swift 6 language mode}}
       default: S()
       }
     }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1490,7 +1490,7 @@ do {
   let tuple = (1, (2, 3))
   [tuple].map { (x, (y, z)) -> Int in x + y + z } // expected-note 2 {{'x' declared here}}
   // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{21-27=arg1}} {{39-39=let (y, z) = arg1; }}
-  // expected-warning@-2 {{unnamed parameters must be written with the empty name '_'; this is an error in Swift 6}}  {{21-21=_: }}
+  // expected-warning@-2 {{unnamed parameters must be written with the empty name '_'; this is an error in the Swift 6 language mode}}  {{21-21=_: }}
   // expected-error@-3 {{cannot find 'y' in scope; did you mean 'x'?}}
   // expected-error@-4 {{cannot find 'z' in scope; did you mean 'x'?}}
 }
@@ -1501,7 +1501,7 @@ r31892961_1.forEach { (k, v) in print(k + v) }
 
 let r31892961_2 = [1, 2, 3]
 // expected-error@+2 {{closure tuple parameter does not support destructuring}} {{48-60=arg0}} {{+1:3-3=\n  let (index, val) = arg0\n  }}
-// expected-warning@+1 {{unnamed parameters must be written with the empty name '_'; this is an error in Swift 6}} {{48-48=_: }}
+// expected-warning@+1 {{unnamed parameters must be written with the empty name '_'; this is an error in the Swift 6 language mode}} {{48-48=_: }}
 let _: [Int] = r31892961_2.enumerated().map { ((index, val)) in
   val + 1
   // expected-error@-1 {{cannot find 'val' in scope}}
@@ -1518,13 +1518,13 @@ _ = [r31892961_4].map { x, y in x + y }
 let r31892961_5 = (x: 1, (y: 2, (w: 3, z: 4)))
 [r31892961_5].map { (x: Int, (y: Int, (w: Int, z: Int))) in x + y } // expected-note {{'x' declared here}}
 // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{30-56=arg1}} {{61-61=let (y, (w, z)) = arg1; }}
-// expected-warning@-2 {{unnamed parameters must be written with the empty name '_'; this is an error in Swift 6}} {{30-30=_: }}
+// expected-warning@-2 {{unnamed parameters must be written with the empty name '_'; this is an error in the Swift 6 language mode}} {{30-30=_: }}
 // expected-error@-3{{cannot find 'y' in scope; did you mean 'x'?}}
 
 let r31892961_6 = (x: 1, (y: 2, z: 4))
 [r31892961_6].map { (x: Int, (y: Int, z: Int)) in x + y } // expected-note {{'x' declared here}}
 // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{30-46=arg1}} {{51-51=let (y, z) = arg1; }}
-// expected-warning@-2 {{unnamed parameters must be written with the empty name '_'; this is an error in Swift 6}} {{30-30=_: }}
+// expected-warning@-2 {{unnamed parameters must be written with the empty name '_'; this is an error in the Swift 6 language mode}} {{30-30=_: }}
 // expected-error@-3{{cannot find 'y' in scope; did you mean 'x'?}}
 
 // rdar://problem/32214649 -- these regressed in Swift 4 mode

--- a/test/Distributed/distributed_actor_initialization.swift
+++ b/test/Distributed/distributed_actor_initialization.swift
@@ -55,7 +55,7 @@ distributed actor OK6 {
 
 distributed actor OKMulti {
 
-  convenience init(y: Int, system: FakeActorSystem) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{3-15=}}
+  convenience init(y: Int, system: FakeActorSystem) { // expected-warning{{initializers in actors are not marked with 'convenience'; this is an error in the Swift 6 language mode}}{{3-15=}}
     self.init(actorSystem: system)
   }
 

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -203,16 +203,16 @@ func test_params(
 
 // Actor initializer isolation (through typechecking only!)
 distributed actor DijonMustard {
-  nonisolated init(system: FakeActorSystem) {} // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
+  nonisolated init(system: FakeActorSystem) {} // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in the Swift 6 language mode}} {{3-15=}}
 
-  convenience init(conv: FakeActorSystem) { // expected-warning {{initializers in actors are not marked with 'convenience'; this is an error in Swift 6}}{{3-15=}}
+  convenience init(conv: FakeActorSystem) { // expected-warning {{initializers in actors are not marked with 'convenience'; this is an error in the Swift 6 language mode}}{{3-15=}}
     self.init(system: conv)
     self.f() // expected-error {{call to actor-isolated instance method 'f()' in a synchronous nonisolated context}}
   }
 
   func f() {} // expected-note {{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 
-  nonisolated init(conv2: FakeActorSystem) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in Swift 6}} {{3-15=}}
+  nonisolated init(conv2: FakeActorSystem) { // expected-warning {{'nonisolated' on an actor's synchronous initializer is invalid; this is an error in the Swift 6 language mode}} {{3-15=}}
     self.init(system: conv2)
   }
 }

--- a/test/Distributed/distributed_actor_nonisolated.swift
+++ b/test/Distributed/distributed_actor_nonisolated.swift
@@ -58,7 +58,7 @@ func invalidIsolatedCall<DA: DistributedActor> (
   Task {
     // expected-note@+1 {{let declared here}}
     for await closure in queue {
-      // expected-warning@+1 {{distributed actor-isolated let 'closure' can not be accessed from a non-isolated context; this is an error in Swift 6}}
+      // expected-warning@+1 {{distributed actor-isolated let 'closure' can not be accessed from a non-isolated context; this is an error in the Swift 6 language mode}}
       await closure(actor)
     }
   }

--- a/test/Generics/issue-51472.swift
+++ b/test/Generics/issue-51472.swift
@@ -4,7 +4,7 @@
 // https://github.com/apple/swift/issues/51472
 
 public class OFMAttachment : NativeInserting {
-// expected-warning@-1 {{non-final class 'OFMAttachment' cannot safely conform to protocol 'NativeInserting', which requires that 'Self.SnapshotType.NativeType' is exactly equal to 'Self'; this is an error in Swift 6}}
+// expected-warning@-1 {{non-final class 'OFMAttachment' cannot safely conform to protocol 'NativeInserting', which requires that 'Self.SnapshotType.NativeType' is exactly equal to 'Self'; this is an error in the Swift 6 language mode}}
     public typealias SnapshotType = Message.Attachment
 }
 

--- a/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
+++ b/test/Generics/non_final_class_conforms_same_type_requirement_on_self.swift
@@ -14,7 +14,7 @@ public protocol Q {
 // exactly equal C; since C is not final, this means the conformance
 // is not covariant.
 public class C : P {
-// expected-warning@-1 {{non-final class 'C' cannot safely conform to protocol 'P', which requires that 'Self.A.B' is exactly equal to 'Self'; this is an error in Swift 6}}
+// expected-warning@-1 {{non-final class 'C' cannot safely conform to protocol 'P', which requires that 'Self.A.B' is exactly equal to 'Self'; this is an error in the Swift 6 language mode}}
   public typealias A = D
 }
 
@@ -54,7 +54,7 @@ public protocol ConcreteExampleP {
 }
 
 public class ConcreteExampleC : ConcreteExampleP {
-// expected-warning@-1 {{non-final class 'ConcreteExampleC' cannot safely conform to protocol 'ConcreteExampleP', which requires that 'Self.A.B' is exactly equal to 'G<Self>'; this is an error in Swift 6}}
+// expected-warning@-1 {{non-final class 'ConcreteExampleC' cannot safely conform to protocol 'ConcreteExampleP', which requires that 'Self.A.B' is exactly equal to 'G<Self>'; this is an error in the Swift 6 language mode}}
   public typealias A = ConcreteExampleD
 }
 
@@ -67,7 +67,7 @@ public protocol SuperclassExampleP {
 }
 
 public class SuperclassExampleC : SuperclassExampleP {
-// expected-warning@-1 {{non-final class 'SuperclassExampleC' cannot safely conform to protocol 'SuperclassExampleP', which requires that 'Self.A.B' inherit from 'G<Self>'; this is an error in Swift 6}}
+// expected-warning@-1 {{non-final class 'SuperclassExampleC' cannot safely conform to protocol 'SuperclassExampleP', which requires that 'Self.A.B' inherit from 'G<Self>'; this is an error in the Swift 6 language mode}}
   public typealias A = SuperclassExampleD
 }
 

--- a/test/Generics/rdar80503090.swift
+++ b/test/Generics/rdar80503090.swift
@@ -20,7 +20,7 @@ extension P where T : Q {
 }
 
 class C : P {}
-// expected-warning@-1 {{non-final class 'C' cannot safely conform to protocol 'P', which requires that 'Self.T' is exactly equal to 'Self'; this is an error in Swift 6}}
+// expected-warning@-1 {{non-final class 'C' cannot safely conform to protocol 'P', which requires that 'Self.T' is exactly equal to 'Self'; this is an error in the Swift 6 language mode}}
 
 extension P where T : C {
   // CHECK-LABEL: Generic signature: <Self where Self : C>

--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -322,11 +322,11 @@ func sameTypeConflicts() {
   // expected-error@+1{{no type for 'T.X' can satisfy both 'T.X == G<U.Foo>' and 'T.X == Int'}}
   func fail7<U: Fooable, T: Concrete>(_: U, _: T) where T.X == G<U.Foo> {}
 
-  // expected-warning@+2{{same-type requirement makes generic parameter 'T' non-generic; this is an error in Swift 6}}
+  // expected-warning@+2{{same-type requirement makes generic parameter 'T' non-generic; this is an error in the Swift 6 language mode}}
   // expected-error@+1{{no type for 'T' can satisfy both 'T == G<U.Foo>' and 'T == Int'}}
   func fail8<T, U: Fooable>(_: U, _: T) where T == G<U.Foo>, T == Int {}
 
   // expected-error@+1{{no type for 'T' can satisfy both 'T == G<U.Foo>' and 'T == Int'}}
   func fail9<T, U: Fooable>(_: U, _: T) where T == Int, T == G<U.Foo> {}
-  // expected-warning@-1{{same-type requirement makes generic parameter 'T' non-generic; this is an error in Swift 6}}
+  // expected-warning@-1{{same-type requirement makes generic parameter 'T' non-generic; this is an error in the Swift 6 language mode}}
 }

--- a/test/Generics/shadowed_generic_params.swift
+++ b/test/Generics/shadowed_generic_params.swift
@@ -2,16 +2,16 @@
 
 struct Outer<T, U> { // expected-note 2{{'T' previously declared here}}
   struct Inner<V> { // expected-note 2{{'V' previously declared here}}
-    func foo<T>(_: T) {} // expected-warning {{generic parameter 'T' shadows generic parameter from outer scope with the same name; this is an error in Swift 6}}
-    func bar<V>(_: V) {} // expected-warning {{generic parameter 'V' shadows generic parameter from outer scope with the same name; this is an error in Swift 6}}
+    func foo<T>(_: T) {} // expected-warning {{generic parameter 'T' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
+    func bar<V>(_: V) {} // expected-warning {{generic parameter 'V' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
   }
 }
 
 extension Outer.Inner {
-  func baz<T>(_: T) {} // expected-warning {{generic parameter 'T' shadows generic parameter from outer scope with the same name; this is an error in Swift 6}}
-  func quux<V>(_: V) {} // expected-warning {{generic parameter 'V' shadows generic parameter from outer scope with the same name; this is an error in Swift 6}}
+  func baz<T>(_: T) {} // expected-warning {{generic parameter 'T' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
+  func quux<V>(_: V) {} // expected-warning {{generic parameter 'V' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
 }
 
 extension Sequence {
-  func bing<Self>(_: Self) {} // expected-warning {{generic parameter 'Self' shadows generic parameter from outer scope with the same name; this is an error in Swift 6}}
+  func bing<Self>(_: Self) {} // expected-warning {{generic parameter 'Self' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
 }

--- a/test/ModuleInterface/implicit-import.swift
+++ b/test/ModuleInterface/implicit-import.swift
@@ -54,11 +54,11 @@ import DefinesTypealias
 import DefinesStruct
 
 public func takesQ<T>(_ b: T) where T: Q { }
-// expected-warning @-1 {{'Q' aliases 'DefinesProtocol.P' and cannot be used here because 'DefinesProtocol' was not imported by this file; this is an error in Swift 6}}
+// expected-warning @-1 {{'Q' aliases 'DefinesProtocol.P' and cannot be used here because 'DefinesProtocol' was not imported by this file; this is an error in the Swift 6 language mode}}
 // expected-note @-2 {{The missing import of module 'DefinesProtocol' will be added implicitly}}
 
 @inlinable public func takesC(_ c: C) {
   c.foo()
-  // expected-warning @-1 {{instance method 'foo()' cannot be used in an '@inlinable' function because 'DefinesExtension' was not imported by this file; this is an error in Swift 6}}
+  // expected-warning @-1 {{instance method 'foo()' cannot be used in an '@inlinable' function because 'DefinesExtension' was not imported by this file; this is an error in the Swift 6 language mode}}
   // expected-note @-2 {{The missing import of module 'DefinesExtension' will be added implicitly}}
 }

--- a/test/Parse/attribute_spacing.swift
+++ b/test/Parse/attribute_spacing.swift
@@ -1,11 +1,11 @@
 // RUN: %target-typecheck-verify-swift
 
-@ MainActor  // expected-warning {{extraneous whitespace between '@' and attribute name; this is an error in Swift 6}}
+@ MainActor  // expected-warning {{extraneous whitespace between '@' and attribute name; this is an error in the Swift 6 language mode}}
 class Foo {
-  func funcWithEscapingClosure(_ x: @ escaping () -> Int) {} // expected-warning {{extraneous whitespace between '@' and attribute name; this is an error in Swift 6}}
+  func funcWithEscapingClosure(_ x: @ escaping () -> Int) {} // expected-warning {{extraneous whitespace between '@' and attribute name; this is an error in the Swift 6 language mode}}
 }
 
-@available (*, deprecated) // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in Swift 6}}
+@available (*, deprecated) // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
 func deprecated() {}
 
 @propertyWrapper
@@ -16,18 +16,18 @@ struct MyPropertyWrapper {
 }
 
 struct PropertyWrapperTest {
-  @MyPropertyWrapper (param: 2)  // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in Swift 6}}
+  @MyPropertyWrapper (param: 2)  // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
   var x: Int
 }
 
-let closure1 = { @MainActor (a, b) in // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in Swift 6}}
+let closure1 = { @MainActor (a, b) in // expected-warning {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
 }
 
 let closure2 = { @MainActor
   (a: Int, b: Int) in
 }
 
-// expected-warning@+1{{extraneous whitespace between '@' and attribute name; this is an error in Swift 6}}
+// expected-warning@+1{{extraneous whitespace between '@' and attribute name; this is an error in the Swift 6 language mode}}
 @ 
 MainActor
 func mainActorFunc() {}

--- a/test/Sema/conformance_availability_warn.swift
+++ b/test/Sema/conformance_availability_warn.swift
@@ -25,22 +25,22 @@ extension HasAvailableConformance1 : Horse {}
 // same example but with -swift-version 6.
 
 func passAvailableConformance1(x: HasAvailableConformance1) { // expected-note 6{{add @available attribute to enclosing global function}}
-  takesHorse(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
+  takesHorse(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{add 'if #available' version check}}
 
-  takesHorseExistential(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
+  takesHorseExistential(x) // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{add 'if #available' version check}}
   
-  x.giddyUp() // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
+  x.giddyUp() // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{add 'if #available' version check}}
   
-  _ = x.isGalloping // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
+  _ = x.isGalloping // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{add 'if #available' version check}}
   
-  _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
+  _ = x[keyPath: \.isGalloping] // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{add 'if #available' version check}}
 
-  _ = UsesHorse<HasAvailableConformance1>.self // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in Swift 6}}
+  _ = UsesHorse<HasAvailableConformance1>.self // expected-warning {{conformance of 'HasAvailableConformance1' to 'Horse' is only available in macOS 100 or newer; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{add 'if #available' version check}}
 }
 
@@ -66,7 +66,7 @@ extension HasAvailableConformance2 : Horse {} // expected-note 6 {{conformance o
 
 func passAvailableConformance2(x: HasAvailableConformance2) {
   takesHorse(x) // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}
-  takesHorseExistential(x) // expected-warning {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable; this is an error in Swift 6}}
+  takesHorseExistential(x) // expected-warning {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable; this is an error in the Swift 6 language mode}}
   x.giddyUp() // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}
   _ = x.isGalloping // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}
   _ = x[keyPath: \.isGalloping] // expected-error {{conformance of 'HasAvailableConformance2' to 'Horse' is unavailable}}

--- a/test/Sema/missing-import-inlinable-code.swift
+++ b/test/Sema/missing-import-inlinable-code.swift
@@ -62,13 +62,13 @@ public import libA
 
 @inlinable public func bar() {
   let a = ImportedType()
-  a.implicitlyImportedMethod() // expected-warning {{instance method 'implicitlyImportedMethod()' cannot be used in an '@inlinable' function because 'libB' was not imported by this file; this is an error in Swift 6}}
+  a.implicitlyImportedMethod() // expected-warning {{instance method 'implicitlyImportedMethod()' cannot be used in an '@inlinable' function because 'libB' was not imported by this file; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{The missing import of module 'libB' will be added implicitly}}
 
   // Expected implicit imports are still fine
   a.localModuleMethod()
 
-  conformanceUse(a) // expected-warning {{cannot use conformance of 'ImportedType' to 'SomeProtocol' here; 'libB' was not imported by this file; this is an error in Swift 6}}
+  conformanceUse(a) // expected-warning {{cannot use conformance of 'ImportedType' to 'SomeProtocol' here; 'libB' was not imported by this file; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{The missing import of module 'libB' will be added implicitly}}
 }
 
@@ -83,7 +83,7 @@ public import libA
   // Expected implicit imports are still fine
   a.localModuleMethod()
 
-  conformanceUse(a) // expected-warning {{cannot use conformance of 'ImportedType' to 'SomeProtocol' here; 'libB' was not imported by this file; this is an error in Swift 6}}
+  conformanceUse(a) // expected-warning {{cannot use conformance of 'ImportedType' to 'SomeProtocol' here; 'libB' was not imported by this file; this is an error in the Swift 6 language mode}}
   // expected-note@-1 {{The missing import of module 'libB' will be added implicitly}}
 }
 

--- a/test/Sema/missing-import-typealias.swift
+++ b/test/Sema/missing-import-typealias.swift
@@ -66,27 +66,27 @@ import Aliases
 
 // CHECK-NON-RESILIENT-NOT: was not imported by this file
 
-// expected-warning@+2 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used here because 'Original' was not imported by this file; this is an error in Swift 6}}
+// expected-warning@+2 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used here because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
 // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
 public class InheritsFromClazzAlias: ClazzAlias {}
 
 @inlinable public func inlinableFunc() {
-  // expected-warning@+2 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' was not imported by this file; this is an error in Swift 6}}
+  // expected-warning@+2 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
   // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
   _ = StructAlias.self
 }
 
-// expected-warning@+2 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' was not imported by this file; this is an error in Swift 6}}
+// expected-warning@+2 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
 // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
 public func takesGeneric<T: ProtoAlias>(_ t: T) {}
 
 public struct HasMembers {
-  // expected-warning@+2 {{'WrapperAlias' aliases 'Original.Wrapper' and cannot be used as property wrapper here because 'Original' was not imported by this file; this is an error in Swift 6}}
+  // expected-warning@+2 {{'WrapperAlias' aliases 'Original.Wrapper' and cannot be used as property wrapper here because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
  // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
   @WrapperAlias public var wrapped: Int
 }
 
-// expected-warning@+2 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an extension with public or '@usableFromInline' members because 'Original' was not imported by this file; this is an error in Swift 6}}
+// expected-warning@+2 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an extension with public or '@usableFromInline' members because 'Original' was not imported by this file; this is an error in the Swift 6 language mode}}
 // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}
 extension StructAlias {
   public func someFunc() {}
@@ -99,11 +99,11 @@ import Aliases
 @_implementationOnly import Original
 
 @inlinable public func inlinableFunc() {
-  // expected-warning@+1 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' has been imported as implementation-only; this is an error in Swift 6}}
+  // expected-warning@+1 {{'StructAlias' aliases 'Original.Struct' and cannot be used in an '@inlinable' function because 'Original' has been imported as implementation-only; this is an error in the Swift 6 language mode}}
   _ = StructAlias.self
 }
 
-// expected-warning@+1 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' has been imported as implementation-only; this is an error in Swift 6}}
+// expected-warning@+1 {{'ProtoAlias' aliases 'Original.Proto' and cannot be used here because 'Original' has been imported as implementation-only; this is an error in the Swift 6 language mode}}
 public func takesGeneric<T: ProtoAlias>(_ t: T) {}
 
 

--- a/test/TBD/objc-entry-point.swift
+++ b/test/TBD/objc-entry-point.swift
@@ -12,7 +12,7 @@ import AppKit
 // present in the TBD.
 let globalConstantWithLazyInitializer: String = "hello, world"
 
-@NSApplicationMain // expected-deprecated-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+@NSApplicationMain // expected-deprecated-warning {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain.swift
@@ -5,7 +5,7 @@
 
 import AppKit
 
-@NSApplicationMain // expected-deprecated-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+@NSApplicationMain // expected-deprecated-warning {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_inherited.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_inherited.swift
@@ -7,7 +7,7 @@ import AppKit
 
 class DelegateBase : NSObject, NSApplicationDelegate { }
 
-@NSApplicationMain // expected-deprecated-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+@NSApplicationMain // expected-deprecated-warning {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate : DelegateBase { }
 

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
@@ -11,7 +11,7 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class EvilDelegate: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/delegate.swift
@@ -8,7 +8,7 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multiple.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multiple.swift
@@ -7,19 +7,19 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate1: NSObject, NSApplicationDelegate {
 }
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate2: NSObject, NSApplicationDelegate {
 }
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
-// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate3: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_not_NSApplicationDelegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_not_NSApplicationDelegate.swift
@@ -6,7 +6,7 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' class must conform to the 'NSApplicationDelegate' protocol}}
-// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyNonDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_with_main/delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_with_main/delegate.swift
@@ -8,7 +8,7 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute cannot be used in a module that contains top-level code}}
-// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-@UIApplicationMain // expected-deprecated-warning {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+@UIApplicationMain // expected-deprecated-warning {{'UIApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, UIApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_inherited.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_inherited.swift
@@ -7,7 +7,7 @@ import UIKit
 
 class DelegateBase : NSObject, UIApplicationDelegate { }
 
-@UIApplicationMain // expected-deprecated-warning {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+@UIApplicationMain // expected-deprecated-warning {{'UIApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate : DelegateBase { }
 

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_multiple.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_multiple.swift
@@ -6,19 +6,19 @@
 import UIKit
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute can only apply to one class in a module}}
-// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate1: NSObject, UIApplicationDelegate {
 }
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute can only apply to one class in a module}}
-// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate2: NSObject, UIApplicationDelegate {
 }
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute can only apply to one class in a module}}
-// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate3: NSObject, UIApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_not_UIApplicationDelegate.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_not_UIApplicationDelegate.swift
@@ -6,7 +6,7 @@
 import UIKit
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' class must conform to the 'UIApplicationDelegate' protocol}}
-// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyNonDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_with_main/delegate.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_with_main/delegate.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute cannot be used in a module that contains top-level code}}
-// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-deprecated-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in the Swift 6 language mode}}
 // expected-deprecated-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, UIApplicationDelegate {
 }

--- a/test/attr/attr_availability_noasync.swift
+++ b/test/attr/attr_availability_noasync.swift
@@ -27,7 +27,7 @@ actor IOActor {
 
 @available(SwiftStdlib 5.5, *)
 func asyncFunc() async {
-    // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in Swift 6}}
+    // expected-warning@+1{{global function 'basicNoAsync' is unavailable from asynchronous contexts; this is an error in the Swift 6 language mode}}
     basicNoAsync()
 
     // expected-warning@+1{{global function 'messageNoAsync' is unavailable from asynchronous contexts; a message from the author}}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -368,7 +368,7 @@ protocol subject_containerObjCProtocol2 {
 
   @objc // FIXME: Access notes can't distinguish between init(a:) overloads
   init(a: Double)
-  // expected-warning@-1 {{initializer 'init(a:)' with Objective-C selector 'initWithA:' conflicts with previous declaration with the same Objective-C selector; this is an error in Swift 6}}
+  // expected-warning@-1 {{initializer 'init(a:)' with Objective-C selector 'initWithA:' conflicts with previous declaration with the same Objective-C selector; this is an error in the Swift 6 language mode}}
 
   func func1() -> Int
   @objc // access-note-move{{subject_containerObjCProtocol2.func1_()}}

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -210,7 +210,7 @@ func func_with_unknown_attr3(x: @unknown(Int) -> Int) {} // expected-error {{unk
 func func_with_unknown_attr4(x: @unknown(Int) throws -> Int) {} // expected-error {{unknown attribute 'unknown'}}
 func func_with_unknown_attr5(x: @unknown (x: Int, y: Int)) {} // expected-error {{unknown attribute 'unknown'}}
 func func_with_unknown_attr6(x: @unknown(x: Int, y: Int)) {} // expected-error {{unknown attribute 'unknown'}}
-func func_with_unknown_attr7(x: @unknown (Int) () -> Int) {} // expected-error {{unknown attribute 'unknown'}} expected-warning {{extraneous whitespace between attribute name and '('; this is an error in Swift 6}}
+func func_with_unknown_attr7(x: @unknown (Int) () -> Int) {} // expected-error {{unknown attribute 'unknown'}} expected-warning {{extraneous whitespace between attribute name and '('; this is an error in the Swift 6 language mode}}
 
 func func_type_attribute_with_space(x: @convention(c) () -> Int) {} // OK. Known attributes can have space before its paren.
 

--- a/test/attr/global_actor.swift
+++ b/test/attr/global_actor.swift
@@ -67,7 +67,7 @@ struct OtherGlobalActor {
 }
 
 @GA1 struct X {
-  @GA1 var member: Int // expected-warning {{stored property 'member' within struct cannot have a global actor; this is an error in Swift 6}}
+  @GA1 var member: Int // expected-warning {{stored property 'member' within struct cannot have a global actor; this is an error in the Swift 6 language mode}}
 }
 
 struct Y {

--- a/test/decl/class/actor/basic.swift
+++ b/test/decl/class/actor/basic.swift
@@ -8,7 +8,7 @@ class MyActorSubclass1: MyActor { }
 // expected-error@-1{{actor types do not support inheritance}}
 // expected-error@-2{{type 'MyActorSubclass1' cannot conform to the 'Actor' protocol}}
 // expected-error@-3{{non-actor type 'MyActorSubclass1' cannot conform to the 'AnyActor' protocol}}
-// expected-warning@-4 {{non-final class 'MyActorSubclass1' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in Swift 6}}
+// expected-warning@-4 {{non-final class 'MyActorSubclass1' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode}}
 
 actor MyActorSubclass2: MyActor { } // expected-error{{actor types do not support inheritance}}
 

--- a/test/decl/class/inheritance_across_modules.swift
+++ b/test/decl/class/inheritance_across_modules.swift
@@ -15,6 +15,6 @@ open class MySuperclassA {
 import MyModule
 
 class MySubclassA: MySuperclassA {
-// expected-warning{{'required' initializer 'init()' must be provided by subclass of 'MySuperclassA'; this is an error in Swift 6}}
+// expected-warning{{'required' initializer 'init()' must be provided by subclass of 'MySuperclassA'; this is an error in the Swift 6 language mode}}
   var hi: String
 }

--- a/test/decl/func/functions.swift
+++ b/test/decl/func/functions.swift
@@ -192,8 +192,8 @@ func bogusDestructuring() {
     func registerCallback(_ callback: @escaping (Bar?) -> Void) {}
   }
 
-  Foo().registerCallback { ([Bar]) in } // expected-warning {{unnamed parameters must be written with the empty name '_'; this is an error in Swift 6}} {{29-29=_: }}
-  Foo().registerCallback { ([String: Bar]) in }// expected-warning {{unnamed parameters must be written with the empty name '_'; this is an error in Swift 6}} {{29-29=_: }}
+  Foo().registerCallback { ([Bar]) in } // expected-warning {{unnamed parameters must be written with the empty name '_'; this is an error in the Swift 6 language mode}} {{29-29=_: }}
+  Foo().registerCallback { ([String: Bar]) in }// expected-warning {{unnamed parameters must be written with the empty name '_'; this is an error in the Swift 6 language mode}} {{29-29=_: }}
   Foo().registerCallback { (Bar?) in } // expected-error {{unnamed parameters must be written with the empty name '_'}}
 
 }

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -261,8 +261,8 @@ class C8SubRW2: C8Base {
 
 @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 @objc protocol P9 {
-  @objc(custom:) func f(_: Any) // expected-warning {{method 'f' with Objective-C selector 'custom:' conflicts with method 'h()' with the same Objective-C selector; this is an error in Swift 6}}
-  @objc(custom:) func g(_: Any) // expected-warning {{method 'g' with Objective-C selector 'custom:' conflicts with method 'h()' with the same Objective-C selector; this is an error in Swift 6}}
+  @objc(custom:) func f(_: Any) // expected-warning {{method 'f' with Objective-C selector 'custom:' conflicts with method 'h()' with the same Objective-C selector; this is an error in the Swift 6 language mode}}
+  @objc(custom:) func g(_: Any) // expected-warning {{method 'g' with Objective-C selector 'custom:' conflicts with method 'h()' with the same Objective-C selector; this is an error in the Swift 6 language mode}}
   @objc(custom:) func h() async // expected-note 2 {{method 'h()' declared here}}
 }
 

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -421,7 +421,7 @@ protocol ShouldntCrash {
 
 // rdar://problem/18168866
 protocol FirstProtocol {
-    // expected-warning@+1 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in Swift 5}}
+    // expected-warning@+1 {{'weak' cannot be applied to a property declaration in a protocol; this is an error in the Swift 5 language mode}}
     weak var delegate : SecondProtocol? { get } // expected-error{{'weak' must not be applied to non-class-bound 'any SecondProtocol'; consider adding a protocol conformance that has a class bound}}
 }
 

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -79,7 +79,7 @@ class CodableSuper : Codable {
 
 // expected-note@+1 {{did you mean to override 'init(from:)' and 'encode(to:)'?}}{{+1:1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}\n\noverride func encode(to encoder: Encoder) throws {\n    <#code#>\n\}}}
 class CodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'CodableSubWithoutInitialValue' has no initializers}}
-  // expected-warning{{'required' initializer 'init(from:)' must be provided by subclass of 'CodableSuper'; this is an error in Swift 6}}
+  // expected-warning{{'required' initializer 'init(from:)' must be provided by subclass of 'CodableSuper'; this is an error in the Swift 6 language mode}}
   var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
 }
 
@@ -88,7 +88,7 @@ class CodableSubWithoutInitialValue : CodableSuper { // expected-error {{class '
 //
 // expected-note@+1 {{did you mean to override 'init(from:)'?}}{{+1:1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}}}
 class EncodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'EncodableSubWithoutInitialValue' has no initializers}}
-  // expected-warning{{'required' initializer 'init(from:)' must be provided by subclass of 'CodableSuper'; this is an error in Swift 6}}
+  // expected-warning{{'required' initializer 'init(from:)' must be provided by subclass of 'CodableSuper'; this is an error in the Swift 6 language mode}}
   var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
 
   override func encode(to: Encoder) throws {}
@@ -103,7 +103,7 @@ class GenericCodableSuper<T>: Decodable {}
 class GenericCodableSub<T>: GenericCodableSuper<T> {
 // expected-error@-1 {{class 'GenericCodableSub' has no initializers}}
 // expected-note@-2 {{did you mean to override 'init(from:)'?}}
-// expected-warning@-2 {{'required' initializer 'init(from:)' must be provided by subclass of 'GenericCodableSuper<T>'; this is an error in Swift 6}}
+// expected-warning@-2 {{'required' initializer 'init(from:)' must be provided by subclass of 'GenericCodableSuper<T>'; this is an error in the Swift 6 language mode}}
   var t: T
   // expected-note@-1 {{stored property 't' without initial value prevents synthesized initializers}}
 }

--- a/test/expr/unary/do_expr.swift
+++ b/test/expr/unary/do_expr.swift
@@ -191,7 +191,7 @@ func tryDo4() throws -> Int {
 func tryDo5() throws -> Int {
   return try do { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -200,7 +200,7 @@ func tryDo5() throws -> Int {
 func tryDo6() throws -> Int {
   try do { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -209,7 +209,7 @@ func tryDo6() throws -> Int {
 func tryDo7() throws -> Int {
   let x = try do { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -235,7 +235,7 @@ func tryDo10() throws -> Int {
 func tryDo11() throws -> Int {
   let x = try do { try tryDo4() } catch { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do-catch' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -245,7 +245,7 @@ func tryDo11() throws -> Int {
 func tryDo12() throws -> Int {
   let x = try do { tryDo4() } catch { tryDo4() }
   // expected-warning@-1 {{'try' has no effect on 'do-catch' expression}}
-  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
   // expected-note@-5 2{{did you mean to disable error propagation?}}
@@ -255,13 +255,13 @@ func tryDo12() throws -> Int {
 func tryDo13() throws -> Int {
   let x = try do { // expected-warning {{'try' has no effect on 'do-catch' expression}}
     tryDo4() // expected-warning {{result of call to 'tryDo4()' is unused}}
-    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
 
     _ = tryDo4()
-    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
@@ -483,7 +483,7 @@ func awaitDo10() async -> Int {
 func awaitDo11() async -> Int {
   let x = await do { try await tryAwaitDo1() } catch { awaitDo4() }
   // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -491,7 +491,7 @@ func awaitDo11() async -> Int {
 func awaitDo12() async -> Int {
   let x = await do { try tryAwaitDo1() } catch { awaitDo4() }
   // expected-warning@-1 {{'await' has no effect on 'do-catch' expression}}
-  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
@@ -499,11 +499,11 @@ func awaitDo12() async -> Int {
 func awaitDo13() async throws -> Int {
   let x = await do { // expected-warning {{'await' has no effect on 'do-catch' expression}}
     awaitDo4() // expected-warning {{result of call to 'awaitDo4()' is unused}}
-    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = awaitDo4()
-    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = await awaitDo4() // Okay.
@@ -579,11 +579,11 @@ func tryAwaitDo3() async throws -> Int {
   try await do { tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -591,7 +591,7 @@ func tryAwaitDo4() async throws -> Int {
   try await do { try tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -599,7 +599,7 @@ func tryAwaitDo5() async throws -> Int {
   try await do { await tryAwaitDo2() } as Int
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
@@ -615,11 +615,11 @@ func tryAwaitDo7() async throws -> Int {
   try await do { tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -627,7 +627,7 @@ func tryAwaitDo8() async throws -> Int {
   try await do { try tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -635,7 +635,7 @@ func tryAwaitDo9() async throws -> Int {
   try await do { await tryAwaitDo2() }
   // expected-warning@-1 {{'try' has no effect on 'do' expression}}
   // expected-warning@-2 {{'await' has no effect on 'do' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}

--- a/test/expr/unary/if_expr.swift
+++ b/test/expr/unary/if_expr.swift
@@ -1013,7 +1013,7 @@ func tryIf4() throws -> Int {
 func tryIf5() throws -> Int {
   return try if .random() { tryIf4() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1022,7 +1022,7 @@ func tryIf5() throws -> Int {
 func tryIf6() throws -> Int {
   try if .random() { tryIf4() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1031,7 +1031,7 @@ func tryIf6() throws -> Int {
 func tryIf7() throws -> Int {
   let x = try if .random() { tryIf4() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1057,7 +1057,7 @@ func tryIf10() throws -> Int {
 func tryIf11() throws -> Int {
   let x = try if .random() { try tryIf4() } else { tryIf4() }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1067,7 +1067,7 @@ func tryIf11() throws -> Int {
 func tryIf12() throws -> Int {
   let x = try if .random() { tryIf4() } else { tryIf4() }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
   // expected-note@-5 2{{did you mean to disable error propagation?}}
@@ -1077,13 +1077,13 @@ func tryIf12() throws -> Int {
 func tryIf13() throws -> Int {
   let x = try if .random() { // expected-warning {{'try' has no effect on 'if' expression}}
     tryIf4() // expected-warning {{result of call to 'tryIf4()' is unused}}
-    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
 
     _ = tryIf4()
-    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
@@ -1108,7 +1108,7 @@ func throwsBool() throws -> Bool { true }
 func tryIf14() throws -> Int {
   try if throwsBool() { 0 } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1248,21 +1248,21 @@ func awaitIf4() async -> Int {
 func awaitIf5() async -> Int {
   return await if .random() { awaitIf4() } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf6() async -> Int {
   await if .random() { awaitIf4() } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitIf7() async -> Int {
   let x = await if .random() { awaitIf4() } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1286,7 +1286,7 @@ func awaitIf10() async -> Int {
 func awaitIf11() async -> Int {
   let x = await if .random() { await awaitIf4() } else { awaitIf4() }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1294,7 +1294,7 @@ func awaitIf11() async -> Int {
 func awaitIf12() async -> Int {
   let x = await if .random() { awaitIf4() } else { awaitIf4() }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
@@ -1302,11 +1302,11 @@ func awaitIf12() async -> Int {
 func awaitIf13() async throws -> Int {
   let x = await if .random() { // expected-warning {{'await' has no effect on 'if' expression}}
     awaitIf4() // expected-warning {{result of call to 'awaitIf4()' is unused}}
-    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = awaitIf4()
-    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = await awaitIf4() // Okay.
@@ -1329,7 +1329,7 @@ func asyncBool() async -> Bool { true }
 func awaitIf14() async -> Int {
   await if asyncBool() { 0 } else { 1 }
   // expected-warning@-1 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
@@ -1381,11 +1381,11 @@ func tryAwaitIf3() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1393,7 +1393,7 @@ func tryAwaitIf4() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1401,7 +1401,7 @@ func tryAwaitIf5() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
@@ -1417,11 +1417,11 @@ func tryAwaitIf7() async throws -> Int {
   try await if .random() { tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1429,7 +1429,7 @@ func tryAwaitIf8() async throws -> Int {
   try await if .random() { try tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1437,7 +1437,7 @@ func tryAwaitIf9() async throws -> Int {
   try await if .random() { await tryAwaitIf2() } else { 1 }
   // expected-warning@-1 {{'try' has no effect on 'if' expression}}
   // expected-warning@-2 {{'await' has no effect on 'if' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}

--- a/test/expr/unary/switch_expr.swift
+++ b/test/expr/unary/switch_expr.swift
@@ -1283,7 +1283,7 @@ func trySwitch4() throws -> Int {
 func trySwitch5() throws -> Int {
   return try switch Bool.random() { case true: trySwitch4() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1292,7 +1292,7 @@ func trySwitch5() throws -> Int {
 func trySwitch6() throws -> Int {
   try switch Bool.random() { case true: trySwitch4() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1301,7 +1301,7 @@ func trySwitch6() throws -> Int {
 func trySwitch7() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1327,7 +1327,7 @@ func trySwitch10() throws -> Int {
 func trySwitch11() throws -> Int {
   let x = try switch Bool.random() { case true: try trySwitch4() case false: trySwitch4() }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1337,7 +1337,7 @@ func trySwitch11() throws -> Int {
 func trySwitch12() throws -> Int {
   let x = try switch Bool.random() { case true: trySwitch4() case false: trySwitch4() }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 2{{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 2{{did you mean to use 'try'?}}
   // expected-note@-4 2{{did you mean to handle error as optional value?}}
   // expected-note@-5 2{{did you mean to disable error propagation?}}
@@ -1348,13 +1348,13 @@ func trySwitch13() throws -> Int {
   let x = try switch Bool.random() { // expected-warning {{'try' has no effect on 'switch' expression}}
   case true:
     trySwitch4() // expected-warning {{result of call to 'trySwitch4()' is unused}}
-    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
 
     _ = trySwitch4()
-    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+    // expected-warning@-1 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{did you mean to use 'try'?}}
     // expected-note@-3 {{did you mean to handle error as optional value?}}
     // expected-note@-4 {{did you mean to disable error propagation?}}
@@ -1379,7 +1379,7 @@ func throwsBool() throws -> Bool { true }
 func trySwitch14() throws -> Int {
   try switch throwsBool() { case true: 0 case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-2 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{did you mean to use 'try'?}}
   // expected-note@-4 {{did you mean to handle error as optional value?}}
   // expected-note@-5 {{did you mean to disable error propagation?}}
@@ -1519,21 +1519,21 @@ func awaitSwitch4() async -> Int {
 func awaitSwitch5() async -> Int {
   return await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch6() async -> Int {
   await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
 func awaitSwitch7() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1557,7 +1557,7 @@ func awaitSwitch10() async -> Int {
 func awaitSwitch11() async -> Int {
   let x = await switch Bool.random() { case true: await awaitSwitch4() case false: awaitSwitch4() }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
   return x
 }
@@ -1565,7 +1565,7 @@ func awaitSwitch11() async -> Int {
 func awaitSwitch12() async -> Int {
   let x = await switch Bool.random() { case true: awaitSwitch4() case false: awaitSwitch4() }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 2{{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 2{{call is 'async'}}
   return x
 }
@@ -1574,11 +1574,11 @@ func awaitSwitch13() async throws -> Int {
   let x = await switch Bool.random() { // expected-warning {{'await' has no effect on 'switch' expression}}
   case true:
     awaitSwitch4() // expected-warning {{result of call to 'awaitSwitch4()' is unused}}
-    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = awaitSwitch4()
-    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+    // expected-warning@-1 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
     // expected-note@-2 {{call is 'async'}}
 
     _ = await awaitSwitch4() // Okay.
@@ -1601,7 +1601,7 @@ func asyncBool() async -> Bool { true }
 func awaitSwitch14() async -> Int {
   await switch asyncBool() { case true: 0 case false: 1 }
   // expected-warning@-1 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-2 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-3 {{call is 'async'}}
 }
 
@@ -1653,11 +1653,11 @@ func tryAwaitSwitch3() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1665,7 +1665,7 @@ func tryAwaitSwitch4() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1673,7 +1673,7 @@ func tryAwaitSwitch5() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 } as Int
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
@@ -1689,11 +1689,11 @@ func tryAwaitSwitch7() async throws -> Int {
   try await switch Bool.random() { case true: tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}
-  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-7 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-8 {{call is 'async'}}
 }
 
@@ -1701,7 +1701,7 @@ func tryAwaitSwitch8() async throws -> Int {
   try await switch Bool.random() { case true: try tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in Swift 6}}
+  // expected-warning@-3 {{expression is 'async' but is not marked with 'await'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{call is 'async'}}
 }
 
@@ -1709,7 +1709,7 @@ func tryAwaitSwitch9() async throws -> Int {
   try await switch Bool.random() { case true: await tryAwaitSwitch2() case false: 1 }
   // expected-warning@-1 {{'try' has no effect on 'switch' expression}}
   // expected-warning@-2 {{'await' has no effect on 'switch' expression}}
-  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in Swift 6}}
+  // expected-warning@-3 {{call can throw but is not marked with 'try'; this is an error in the Swift 6 language mode}}
   // expected-note@-4 {{did you mean to use 'try'?}}
   // expected-note@-5 {{did you mean to handle error as optional value?}}
   // expected-note@-6 {{did you mean to disable error propagation?}}

--- a/userdocs/diagnostics/error-in-future-swift-version.md
+++ b/userdocs/diagnostics/error-in-future-swift-version.md
@@ -1,0 +1,10 @@
+# Language mode and tools version
+
+There are two related kinds of "Swift version" that are distinct:
+
+* Swift tools version: the version number of the compiler itself. For example, the Swift 5.6 compiler was introduced in March 2022.
+* Swift language mode version: the language mode version with which we are providing source compatibility. For example, the Swift 5 language mode is the most current language mode version supported by Swift tools version 5.10.
+
+The Swift tools support multiple Swift language modes. All Swift tools versions between 5.0 and 5.10 support three Swift language modes: 4, 4.2, and 5. The Swift 6.0 compiler supports four Swift language modes: 4, 4.2, 5, and 6. Swift language modes are opt-in; when you use a tools version that supports a new language mode, your code will not build with the new language mode until you set that language mode in your build settings with `-swift-version X`.
+
+A warning suffixed with `this is an error in the Swift 6 language mode` means that once you migrate to that language mode in your code, the warning will be promoted to an error. These warnings primarily come from enabling upcoming features that are enabled by default in that language mode version, but errors may also be staged in as warnings until the next language mode to maintain source compatibility when fixing compiler bugs.

--- a/validation-test/Sema/result_builder_buildBlock_resolution.swift
+++ b/validation-test/Sema/result_builder_buildBlock_resolution.swift
@@ -14,11 +14,11 @@ struct ActionLookup<Identifier: ActionIdentifier> {
 
 @resultBuilder
 enum ActionLookupBuilder<Identifier: ActionIdentifier> { // expected-note 3{{'Identifier' previously declared here}}
-  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> ActionLookup<Identifier> { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in Swift 6}}
+  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> ActionLookup<Identifier> { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
     fatalError()
   }
 
-  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> [ActionLookup<Identifier>] { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in Swift 6}}
+  static func buildBlock<Identifier: ActionIdentifier>(_ components: [ActionLookup<Identifier>]...) -> [ActionLookup<Identifier>] { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
     []
   }
 
@@ -26,7 +26,7 @@ enum ActionLookupBuilder<Identifier: ActionIdentifier> { // expected-note 3{{'Id
     []
   }
 
-  static func buildOptional<Identifier: ActionIdentifier>(_ component: [ActionLookup<Identifier>]?) -> [ActionLookup<Identifier>] { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in Swift 6}}
+  static func buildOptional<Identifier: ActionIdentifier>(_ component: [ActionLookup<Identifier>]?) -> [ActionLookup<Identifier>] { // expected-warning {{generic parameter 'Identifier' shadows generic parameter from outer scope with the same name; this is an error in the Swift 6 language mode}}
     []
   }
 }

--- a/validation-test/compiler_crashers_2_fixed/0189-issue-52436.swift
+++ b/validation-test/compiler_crashers_2_fixed/0189-issue-52436.swift
@@ -17,9 +17,9 @@ extension P2 {
 }
 
 class C1 : P1 {
-// expected-warning@-1 {{non-final class 'C1' cannot safely conform to protocol 'P1', which requires that 'Self.A2.A1' is exactly equal to 'Self'; this is an error in Swift 6}}
+// expected-warning@-1 {{non-final class 'C1' cannot safely conform to protocol 'P1', which requires that 'Self.A2.A1' is exactly equal to 'Self'; this is an error in the Swift 6 language mode}}
   class A2 : P2 {
-  // expected-warning@-1 {{non-final class 'C1.A2' cannot safely conform to protocol 'P2', which requires that 'Self.A1.A2' is exactly equal to 'Self'; this is an error in Swift 6}}
+  // expected-warning@-1 {{non-final class 'C1.A2' cannot safely conform to protocol 'P2', which requires that 'Self.A1.A2' is exactly equal to 'Self'; this is an error in the Swift 6 language mode}}
     typealias A1 = C1
   }
 }


### PR DESCRIPTION
Folks are confused about language mode versus compiler version, and this warning does not specify which one it is talking about. Clarify that the warning will become an error in the next major language version, not the tools version. Also, add an educational note explaining tools version versus language mode version.