### PR TITLE
[SourceKit] Print compilerargs and sourcetext keys last

### DIFF
--- a/test/SourceKit/CodeComplete/complete_annotateddescription.swift.result
+++ b/test/SourceKit/CodeComplete/complete_annotateddescription.swift.result
@@ -3,84 +3,84 @@
     {
       key.kind: source.lang.swift.decl.function.subscript,
       key.name: "[:]",
-      key.sourcetext: "[<#T##param: Int##Int#>]",
       key.description: "[<callarg><callarg.label>_</callarg.label> <callarg.param>param</callarg.param>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>]",
       key.typename: "<typeid.sys>Int</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructVyS2icip",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: "[<#T##param: Int##Int#>]"
     },
     {
       key.kind: source.lang.swift.decl.function.subscript,
       key.name: "[label:]",
-      key.sourcetext: "[label: <#T##Int#>]",
       key.description: "[<callarg><callarg.label>label</callarg.label> <callarg.param>param</callarg.param>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>]",
       key.typename: "<typeid.sys>Int</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructV5labelS2i_tcip",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: "[label: <#T##Int#>]"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "labelName(label:)",
-      key.sourcetext: ".labelName(label: <#T##(@autoclosure () -> Int) -> Int#>)",
       key.description: "<name>labelName</name>(<callarg><callarg.label>label</callarg.label>: <callarg.type>(<attribute>@autoclosure</attribute> () -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Int</typeid.sys></callarg.type></callarg>)",
       key.typename: "<typeid.sys>Void</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructV9labelName0E0yS2iyXKXE_tF",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: ".labelName(label: <#T##(@autoclosure () -> Int) -> Int#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "labelNameParamName(label:)",
-      key.sourcetext: ".labelNameParamName(label: <#T##(inout Int) throws -> MyStruct#>)",
       key.description: "<name>labelNameParamName</name>(<callarg><callarg.label>label</callarg.label> <callarg.param>param</callarg.param>: <callarg.type>(<keyword>inout</keyword> <typeid.sys>Int</typeid.sys>) <keyword>throws</keyword> -&gt; <typeid.user>MyStruct</typeid.user></callarg.type></callarg>) <keyword>rethrows</keyword>",
       key.typename: "<typeid.sys>Void</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructV014labelNameParamF00E0yACSizKXE_tKF",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: ".labelNameParamName(label: <#T##(inout Int) throws -> MyStruct#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "paramName(:)",
-      key.sourcetext: ".paramName(<#T##param: Int##Int#>)",
       key.description: "<name>paramName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>param</callarg.param>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>)",
       key.typename: "<typeid.sys>Void</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructV9paramNameyySiF",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: ".paramName(<#T##param: Int##Int#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "sameName(label:)",
-      key.sourcetext: ".sameName(label: <#T##Int#>)",
       key.description: "<name>sameName</name>(<callarg><callarg.label>label</callarg.label>: <callarg.type><typeid.sys>Int</typeid.sys></callarg.type></callarg>)",
       key.typename: "<typeid.sys>Void</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructV8sameName5labelySi_tF",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: ".sameName(label: <#T##Int#>)"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "self",
-      key.sourcetext: ".self",
       key.description: "<keyword>self</keyword>",
       key.typename: "<typeid.user>MyStruct</typeid.user>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: ".self"
     }
   ],
   key.annotated.typename: 1
@@ -90,82 +90,82 @@
     {
       key.kind: source.lang.swift.decl.function.constructor,
       key.name: "init()",
-      key.sourcetext: "init()",
       key.description: "<name>init</name>()",
       key.typename: "<typeid.user>MyStruct</typeid.user>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructVACycfc",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: "init()"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "labelName(:)",
-      key.sourcetext: "labelName(<#T##self: MyStruct##MyStruct#>)",
       key.description: "<name>labelName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>)",
       key.typename: "(label: (<attribute>@autoclosure</attribute> () -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructV9labelName0E0yS2iyXKXE_tF",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: "labelName(<#T##self: MyStruct##MyStruct#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "labelNameParamName(:)",
-      key.sourcetext: "labelNameParamName(<#T##self: MyStruct##MyStruct#>)",
       key.description: "<name>labelNameParamName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>)",
       key.typename: "(label: (<keyword>inout</keyword> <typeid.sys>Int</typeid.sys>) <keyword>throws</keyword> -&gt; <typeid.user>MyStruct</typeid.user>) -&gt; <typeid.sys>Void</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructV014labelNameParamF00E0yACSizKXE_tKF",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: "labelNameParamName(<#T##self: MyStruct##MyStruct#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "paramName(:)",
-      key.sourcetext: "paramName(<#T##self: MyStruct##MyStruct#>)",
       key.description: "<name>paramName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>)",
       key.typename: "(<typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructV9paramNameyySiF",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: "paramName(<#T##self: MyStruct##MyStruct#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "sameName(:)",
-      key.sourcetext: "sameName(<#T##self: MyStruct##MyStruct#>)",
       key.description: "<name>sameName</name>(<callarg><callarg.label>_</callarg.label> <callarg.param>self</callarg.param>: <callarg.type><typeid.user>MyStruct</typeid.user></callarg.type></callarg>)",
       key.typename: "(label: <typeid.sys>Int</typeid.sys>) -&gt; <typeid.sys>Void</typeid.sys>",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:29complete_annotateddescription8MyStructV8sameName5labelySi_tF",
-      key.modulename: "complete_annotateddescription"
+      key.modulename: "complete_annotateddescription",
+      key.sourcetext: "sameName(<#T##self: MyStruct##MyStruct#>)"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "self",
-      key.sourcetext: "self",
       key.description: "<keyword>self</keyword>",
       key.typename: "<typeid.user>MyStruct</typeid.user>.Type",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: "self"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "Type",
-      key.sourcetext: "Type",
       key.description: "<keyword>Type</keyword>",
       key.typename: "<typeid.user>MyStruct</typeid.user>.Type",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: "Type"
     }
   ],
   key.reusingastcontext: 1,

--- a/test/SourceKit/CodeComplete/complete_big_array.swift
+++ b/test/SourceKit/CodeComplete/complete_big_array.swift
@@ -1,6 +1,6 @@
 // RUN: %sourcekitd-test -req=complete -pos=45:1 %S/../Inputs/big_array.swift -- %S/../Inputs/big_array.swift | %FileCheck %s
 // CHECK: key.kind: source.lang.swift.decl.var.global
 // CHECK: key.name: "gCubeVertexData"
-// CHECK: key.sourcetext: "gCubeVertexData"
 // CHECK: key.description: "gCubeVertexData"
 // CHECK: key.typename: "[Float]"
+// CHECK: key.sourcetext: "gCubeVertexData"

--- a/test/SourceKit/CodeComplete/complete_cache.swift
+++ b/test/SourceKit/CodeComplete/complete_cache.swift
@@ -26,22 +26,22 @@ func test2() {
   for i in 1...#^VOID_2,fooFunc^# {}
 }
 // VOID_1: key.name: "fooFuncNoreturn1()",
-// VOID_1-NEXT: key.sourcetext:
 // VOID_1-NEXT: key.description:
 // VOID_1-NEXT: key.typename: "Never",
 // VOID_1-NEXT: key.context: source.codecompletion.context.othermodule,
 // VOID_1-NEXT: key.moduleimportdepth: 1,
 // VOID_1-NEXT: key.num_bytes_to_erase: 0,
 // VOID_1-NEXT: key.substructure:
+// VOID_1: key.sourcetext:
 
 // VOID_1: key.name: "fooHelperSubFunc1(:)",
-// VOID_1-NEXT: key.sourcetext:
 // VOID_1-NEXT: key.description:
 // VOID_1-NEXT: key.typename: "Int32",
 // VOID_1-NEXT: key.context: source.codecompletion.context.othermodule,
 // VOID_1-NEXT: key.moduleimportdepth: 2,
 // VOID_1-NEXT: key.num_bytes_to_erase: 0,
 // VOID_1-NEXT: key.substructure:
+// VOID_1: key.sourcetext:
 
 func test3() {
   #^VOID_3,fooFunc^# {}

--- a/test/SourceKit/CodeComplete/complete_constructor.swift.response
+++ b/test/SourceKit/CodeComplete/complete_constructor.swift.response
@@ -3,14 +3,14 @@
     {
       key.kind: source.lang.swift.decl.function.constructor,
       key.name: "arg1:arg2:",
-      key.sourcetext: "arg1: <#T##Int#>, arg2: <#T##Int#>",
       key.description: "(arg1: Int, arg2: Int)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:20complete_constructor3FooC4arg14arg2ACSi_Sitcfc",
-      key.modulename: "complete_constructor"
+      key.modulename: "complete_constructor",
+      key.sourcetext: "arg1: <#T##Int#>, arg2: <#T##Int#>"
     }
   ]
 }

--- a/test/SourceKit/CodeComplete/complete_docbrief_1.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_1.swift
@@ -30,7 +30,6 @@ func test() {
 // CHECK-NEXT:     {
 // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
 // CHECK-NEXT:       key.name: "bar()",
-// CHECK-NEXT:       key.sourcetext: "bar()",
 // CHECK-NEXT:       key.description: "bar()",
 // CHECK-NEXT:       key.typename: "Void",
 // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.bar",
@@ -38,12 +37,12 @@ func test() {
 // CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // CHECK-NEXT:       key.num_bytes_to_erase: 0,
 // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1PPAAE3baryyF",
-// CHECK-NEXT:       key.modulename: "DocBriefTest"
+// CHECK-NEXT:       key.modulename: "DocBriefTest",
+// CHECK-NEXT:       key.sourcetext: "bar()"
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
 // CHECK-NEXT:       key.name: "foo()",
-// CHECK-NEXT:       key.sourcetext: "foo()",
 // CHECK-NEXT:       key.description: "foo()",
 // CHECK-NEXT:       key.typename: "Void",
 // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
@@ -51,5 +50,6 @@ func test() {
 // CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // CHECK-NEXT:       key.num_bytes_to_erase: 0,
 // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
-// CHECK-NEXT:       key.modulename: "DocBriefTest"
+// CHECK-NEXT:       key.modulename: "DocBriefTest",
+// CHECK-NEXT:       key.sourcetext: "foo()"
 // CHECK-NEXT:     }

--- a/test/SourceKit/CodeComplete/complete_docbrief_2.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_2.swift
@@ -32,7 +32,6 @@ func test() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
   // CHECK-NEXT:       key.name: "foo()",
-  // CHECK-NEXT:       key.sourcetext: "foo()",
   // CHECK-NEXT:       key.description: "foo()",
   // CHECK-NEXT:       key.typename: "Void",
   // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
@@ -40,6 +39,7 @@ func test() {
   // CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
   // CHECK-NEXT:       key.num_bytes_to_erase: 0,
   // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefUser1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
-  // CHECK-NEXT:       key.modulename: "DocBriefUser"
+  // CHECK-NEXT:       key.modulename: "DocBriefUser",
+  // CHECK-NEXT:       key.sourcetext: "foo()"
   // CHECK-NEXT:     }
 }

--- a/test/SourceKit/CodeComplete/complete_docbrief_3.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_3.swift
@@ -33,7 +33,6 @@ func test() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
   // CHECK-NEXT:       key.name: "foo()",
-  // CHECK-NEXT:       key.sourcetext: "foo()",
   // CHECK-NEXT:       key.description: "foo()",
   // CHECK-NEXT:       key.typename: "Void",
   // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
@@ -41,6 +40,7 @@ func test() {
   // CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
   // CHECK-NEXT:       key.num_bytes_to_erase: 0,
   // CHECK-NEXT:       key.associated_usrs: "s:12DocBriefTest1SV3fooyyF s:12DocBriefTest1PP3fooyyF",
-  // CHECK-NEXT:       key.modulename: "DocBriefTest"
+  // CHECK-NEXT:       key.modulename: "DocBriefTest",
+  // CHECK-NEXT:       key.sourcetext: "foo()"
   // CHECK-NEXT:     }
 }

--- a/test/SourceKit/CodeComplete/complete_docbrief_package.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_package.swift
@@ -35,9 +35,9 @@ func test() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
   // CHECK-NEXT:       key.name: "foo()",
-  // CHECK-NEXT:       key.sourcetext: "foo()",
   // CHECK-NEXT:       key.description: "foo()",
   // CHECK-NEXT:       key.typename: "Void",
   // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+  // CHECK:            key.sourcetext: "foo()"
   // CHECK:          }
 }

--- a/test/SourceKit/CodeComplete/complete_docbrief_spi.swift
+++ b/test/SourceKit/CodeComplete/complete_docbrief_spi.swift
@@ -36,9 +36,9 @@ func test() {
   // CHECK-NEXT:     {
   // CHECK-NEXT:       key.kind: source.lang.swift.decl.function.method.instance,
   // CHECK-NEXT:       key.name: "foo()",
-  // CHECK-NEXT:       key.sourcetext: "foo()",
   // CHECK-NEXT:       key.description: "foo()",
   // CHECK-NEXT:       key.typename: "Void",
   // CHECK-NEXT:       key.doc.brief: "This is a doc comment of P.foo",
+  // CHECK:            key.sourcetext: "foo()"
   // CHECK:          }
 }

--- a/test/SourceKit/CodeComplete/complete_from_clang_module.swift
+++ b/test/SourceKit/CodeComplete/complete_from_clang_module.swift
@@ -4,7 +4,6 @@ import Foo
 // RUN: %sourcekitd-test -req=complete -pos=2:1 %s -- -F %S/../Inputs/libIDE-mock-sdk %s | %FileCheck %s
 
 // CHECK-LABEL:      key.name: "fooIntVar",
-// CHECK-NEXT:       key.sourcetext: "fooIntVar",
 // CHECK-NEXT:       key.description: "fooIntVar",
 // CHECK-NEXT:       key.typename: "Int32",
 // CHECK-NEXT:       key.doc.brief: "Aaa.  fooIntVar.  Bbb.",
@@ -12,6 +11,7 @@ import Foo
 // CHECK-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // CHECK-NEXT:       key.num_bytes_to_erase: 0,
 // CHECK-NEXT:       key.associated_usrs: "c:@fooIntVar",
-// CHECK-NEXT:       key.modulename: "Foo"
+// CHECK-NEXT:       key.modulename: "Foo",
+// CHECK-NEXT:       key.sourcetext: "fooIntVar"
 // CHECK-NEXT:     },
 

--- a/test/SourceKit/CodeComplete/complete_member.swift
+++ b/test/SourceKit/CodeComplete/complete_member.swift
@@ -47,14 +47,14 @@ func testOverrideUSR() {
 // CHECK-OPTIONAL:     {
 // CHECK-OPTIONAL:       key.kind: source.lang.swift.decl.function.method.instance,
 // CHECK-OPTIONAL:       key.name: "fooInstanceFunc0()",
-// CHECK-OPTIONAL-LABEL:       key.sourcetext: "?.fooInstanceFunc1(<#T##a: Int##Int#>)",
-// CHECK-OPTIONAL-NEXT:       key.description: "fooInstanceFunc1(a: Int)",
+// CHECK-OPTIONAL-LABEL:       key.description: "fooInstanceFunc1(a: Int)",
 // CHECK-OPTIONAL-NEXT:       key.typename: "Double",
 // CHECK-OPTIONAL-NEXT:       key.context: source.codecompletion.context.thisclass,
 // CHECK-OPTIONAL-NEXT:       key.typerelation: source.codecompletion.typerelation.unknown,
 // CHECK-OPTIONAL-NEXT:       key.num_bytes_to_erase: 1,
 // CHECK-OPTIONAL-NEXT:       key.associated_usrs: "s:15complete_member11FooProtocolP16fooInstanceFunc1ySdSiF",
-// CHECK-OPTIONAL-NEXT:       key.modulename: "complete_member"
+// CHECK-OPTIONAL-NEXT:       key.modulename: "complete_member",
+// CHECK-OPTIONAL-NEXT:       key.sourcetext: "?.fooInstanceFunc1(<#T##a: Int##Int#>)"
 // CHECK-OPTIONAL-NEXT:     },
 
 // RUN: %sourcekitd-test -req=complete.open -pos=19:5 %s -- %s | %FileCheck %s -check-prefix=CHECK-OPTIONAL-OPEN
@@ -69,12 +69,12 @@ func testOverrideUSR() {
 // CHECK-OVERRIDE_USR:      {
 // CHECK-OVERRIDE_USR:          key.kind: source.lang.swift.decl.function.method.instance,
 // CHECK-OVERRIDE_USR-NEXT:     key.name: "foo()",
-// CHECK-OVERRIDE_USR-NEXT:     key.sourcetext: "foo()",
 // CHECK-OVERRIDE_USR-NEXT:     key.description: "foo()",
 // CHECK-OVERRIDE_USR-NEXT:     key.typename: "Void",
 // CHECK-OVERRIDE_USR-NEXT:     key.context: source.codecompletion.context.thisclass,
 // CHECK-OVERRIDE_USR-NEXT:     key.typerelation: source.codecompletion.typerelation.unknown,
 // CHECK-OVERRIDE_USR-NEXT:     key.num_bytes_to_erase: 0,
 // CHECK-OVERRIDE_USR-NEXT:     key.associated_usrs: "s:15complete_member7DerivedC3fooyyF s:15complete_member4BaseC3fooyyF",
-// CHECK-OVERRIDE_USR-NEXT:     key.modulename: "complete_member"
+// CHECK-OVERRIDE_USR-NEXT:     key.modulename: "complete_member",
+// CHECK-OVERRIDE_USR-NEXT:     key.sourcetext: "foo()"
 // CHECK-OVERRIDE_USR-NEXT: }

--- a/test/SourceKit/CodeComplete/complete_member.swift.response
+++ b/test/SourceKit/CodeComplete/complete_member.swift.response
@@ -3,31 +3,30 @@
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "fooInstanceFunc0()",
-      key.sourcetext: "fooInstanceFunc0()",
       key.description: "fooInstanceFunc0()",
       key.typename: "Double",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:15complete_member11FooProtocolP16fooInstanceFunc0SdyF",
-      key.modulename: "complete_member"
+      key.modulename: "complete_member",
+      key.sourcetext: "fooInstanceFunc0()"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "fooInstanceFunc1(:)",
-      key.sourcetext: "fooInstanceFunc1(<#T##a: Int##Int#>)",
       key.description: "fooInstanceFunc1(a: Int)",
       key.typename: "Double",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:15complete_member11FooProtocolP16fooInstanceFunc1ySdSiF",
-      key.modulename: "complete_member"
+      key.modulename: "complete_member",
+      key.sourcetext: "fooInstanceFunc1(<#T##a: Int##Int#>)"
     },
     {
       key.kind: source.lang.swift.decl.var.instance,
       key.name: "fooInstanceVar",
-      key.sourcetext: "fooInstanceVar",
       key.description: "fooInstanceVar",
       key.typename: "Int",
       key.doc.brief: "fooInstanceVar Aaa. Bbb.",
@@ -35,17 +34,18 @@
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:15complete_member11FooProtocolP14fooInstanceVarSivp",
-      key.modulename: "complete_member"
+      key.modulename: "complete_member",
+      key.sourcetext: "fooInstanceVar"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "self",
-      key.sourcetext: "self",
       key.description: "self",
       key.typename: "any FooProtocol",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: "self"
     }
   ]
 }

--- a/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
+++ b/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
@@ -11,7 +11,6 @@ func test() {
 
 // Swift == 1
 // CHECK-LABEL:  key.name: "abs(:)",
-// CHECK-NEXT:   key.sourcetext: "abs(<#T##x: Comparable & SignedNumeric##Comparable & SignedNumeric#>)",
 // CHECK-NEXT:   key.description: "abs(x: Comparable & SignedNumeric)",
 // CHECK-NEXT:   key.typename: "Comparable & SignedNumeric",
 // CHECK-NEXT:   key.doc.brief: "Returns the absolute value of the given number.",
@@ -20,11 +19,11 @@ func test() {
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
 // CHECK-NOT:    key.modulename
 // CHECK:        key.modulename: "Swift"
+// CHECK-NEXT:   key.sourcetext: "abs(<#T##x: Comparable & SignedNumeric##Comparable & SignedNumeric#>)"
 // CHECK-NEXT: },
 
 // FooHelper.FooHelperExplicit == 1
 // CHECK-LABEL:  key.name: "fooHelperExplicitFrameworkFunc1(:)",
-// CHECK-NEXT:   key.sourcetext: "fooHelperExplicitFrameworkFunc1(<#T##a: Int32##Int32#>)",
 // CHECK-NEXT:   key.description: "fooHelperExplicitFrameworkFunc1(a: Int32)",
 // CHECK-NEXT:   key.typename: "Int32",
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
@@ -32,11 +31,11 @@ func test() {
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
 // CHECK-NOT:    key.modulename
 // CHECK:        key.modulename: "FooHelper.FooHelperExplicit"
+// CHECK-NEXT:   key.sourcetext: "fooHelperExplicitFrameworkFunc1(<#T##a: Int32##Int32#>)"
 // CHECK-NEXT: },
 
 // ImportsImportsFoo == 1
 // CHECK-LABEL:  key.name: "importsImportsFoo()",
-// CHECK-NEXT:   key.sourcetext: "importsImportsFoo()",
 // CHECK-NEXT:   key.description: "importsImportsFoo()",
 // CHECK-NEXT:   key.typename: "Void",
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
@@ -44,11 +43,11 @@ func test() {
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
 // CHECK-NOT:    key.modulename
 // CHECK:        key.modulename: "ImportsImportsFoo"
+// CHECK-NEXT:   key.sourcetext: "importsImportsFoo()"
 // CHECK-NEXT: },
 
 // Bar == 2
 // CHECK-LABEL:  key.name: "BarForwardDeclaredClass",
-// CHECK-NEXT:   key.sourcetext: "BarForwardDeclaredClass",
 // CHECK-NEXT:   key.description: "BarForwardDeclaredClass",
 // CHECK-NEXT:   key.typename: "BarForwardDeclaredClass",
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
@@ -56,11 +55,11 @@ func test() {
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
 // CHECK-NOT:    key.modulename
 // CHECK:        key.modulename: "Bar"
+// CHECK-NEXT:   key.sourcetext: "BarForwardDeclaredClass"
 // CHECK-NEXT: },
 
 // ImportsFoo == 2
 // CHECK-LABEL:  key.name: "importsFoo()",
-// CHECK-NEXT:   key.sourcetext: "importsFoo()",
 // CHECK-NEXT:   key.description: "importsFoo()",
 // CHECK-NEXT:   key.typename: "Void",
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
@@ -68,11 +67,11 @@ func test() {
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
 // CHECK-NOT:    key.modulename
 // CHECK:        key.modulename: "ImportsFoo"
+// CHECK-NEXT:   key.sourcetext: "importsFoo()"
 // CHECK-NEXT: },
 
 // Foo == FooSub == 3
 // CHECK-LABEL:  key.name: "FooClassBase",
-// CHECK-NEXT:   key.sourcetext: "FooClassBase",
 // CHECK-NEXT:   key.description: "FooClassBase",
 // CHECK-NEXT:   key.typename: "FooClassBase",
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
@@ -80,10 +79,10 @@ func test() {
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
 // CHECK-NOT:    key.modulename
 // CHECK:        key.modulename: "Foo"
+// CHECK-NEXT:   key.sourcetext: "FooClassBase"
 // CHECK-NEXT: },
 
 // CHECK-LABEL:  key.name: "FooSubEnum1",
-// CHECK-NEXT:   key.sourcetext: "FooSubEnum1",
 // CHECK-NEXT:   key.description: "FooSubEnum1",
 // CHECK-NEXT:   key.typename: "FooSubEnum1",
 // CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
@@ -91,13 +90,13 @@ func test() {
 // CHECK-NEXT:   key.num_bytes_to_erase: 0,
 // CHECK-NOT:    key.modulename
 // CHECK:        key.modulename: "Foo.FooSub"
+// CHECK-NEXT:   key.sourcetext: "FooSubEnum1"
 // CHECK-NEXT: },
 
 // FooHelper == 4
 // FIXME: rdar://problem/20230030
 // We're picking up the implicit import of FooHelper used to attach FooHelperExplicit to.
 // xCHECK-LABEL:  key.name: "FooHelperUnnamedEnumeratorA2",
-// xCHECK-NEXT:   key.sourcetext: "FooHelperUnnamedEnumeratorA2",
 // xCHECK-NEXT:   key.description: "FooHelperUnnamedEnumeratorA2",
 // xCHECK-NEXT:   key.typename: "Int",
 // xCHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
@@ -105,4 +104,5 @@ func test() {
 // xCHECK-NEXT:   key.num_bytes_to_erase: 0,
 // xCHECK-NOT:    key.modulename
 // xCHECK:        key.modulename: "FooHelper"
+// xCHECK-NEXT:   key.sourcetext: "FooHelperUnnamedEnumeratorA2"
 // xCHECK-NEXT: },

--- a/test/SourceKit/CodeComplete/complete_object_literals.swift
+++ b/test/SourceKit/CodeComplete/complete_object_literals.swift
@@ -13,28 +13,28 @@ func test(color: String) {
 // CHECK1:     {
 // CHECK1:       key.kind: source.lang.swift.literal.color,
 // CHECK1:       key.name: "#colorLiteral(red:green:blue:alpha:)",
-// CHECK1:       key.sourcetext: "#colorLiteral(red: <#T##Float#>, green: <#T##Float#>, blue: <#T##Float#>, alpha: <#T##Float#>)",
 // CHECK1:       key.description: "#colorLiteral(red: Float, green: Float, blue: Float, alpha: Float)",
+// CHECK1:       key.sourcetext: "#colorLiteral(red: <#T##Float#>, green: <#T##Float#>, blue: <#T##Float#>, alpha: <#T##Float#>)"
 // CHECK1:     },
 // CHECK1:     {
 // CHECK1:       key.kind: source.lang.swift.literal.image,
 // CHECK1:       key.name: "#imageLiteral(resourceName:)",
-// CHECK1:       key.sourcetext: "#imageLiteral(resourceName: <#T##String#>)",
 // CHECK1:       key.description: "#imageLiteral(resourceName: String)",
+// CHECK1:       key.sourcetext: "#imageLiteral(resourceName: <#T##String#>)"
 // CHECK1:     },
 
 // CHECK1-LABEL: key.results: [
 // CHECK1:     {
 // CHECK1:       key.kind: source.lang.swift.literal.color,
 // CHECK1:       key.name: "#colorLiteral(red:green:blue:alpha:)",
-// CHECK1:       key.sourcetext: "#colorLiteral(red: <#T##Float#>, green: <#T##Float#>, blue: <#T##Float#>, alpha: <#T##Float#>)",
 // CHECK1:       key.description: "#colorLiteral(red: Float, green: Float, blue: Float, alpha: Float)",
+// CHECK1:       key.sourcetext: "#colorLiteral(red: <#T##Float#>, green: <#T##Float#>, blue: <#T##Float#>, alpha: <#T##Float#>)"
 // CHECK1:     },
 // CHECK1:     {
 // CHECK1:       key.kind: source.lang.swift.literal.image,
 // CHECK1:       key.name: "#imageLiteral(resourceName:)",
-// CHECK1:       key.sourcetext: "#imageLiteral(resourceName: <#T##String#>)",
 // CHECK1:       key.description: "#imageLiteral(resourceName: String)",
+// CHECK1:       key.sourcetext: "#imageLiteral(resourceName: <#T##String#>)"
 // CHECK1:     },
 
 // CHECK1-LABEL: key.results: [
@@ -47,12 +47,12 @@ func test(color: String) {
 // CHECK1:     {
 // CHECK1:       key.kind: source.lang.swift.literal.color,
 // CHECK1:       key.name: "#colorLiteral(red:green:blue:alpha:)",
-// CHECK1:       key.sourcetext: "#colorLiteral(red: <#T##Float#>, green: <#T##Float#>, blue: <#T##Float#>, alpha: <#T##Float#>)",
 // CHECK1:       key.description: "#colorLiteral(red: Float, green: Float, blue: Float, alpha: Float)",
+// CHECK1:       key.sourcetext: "#colorLiteral(red: <#T##Float#>, green: <#T##Float#>, blue: <#T##Float#>, alpha: <#T##Float#>)"
 // CHECK1:     },
 // CHECK1:     {
 // CHECK1:       key.kind: source.lang.swift.literal.image,
 // CHECK1:       key.name: "#imageLiteral(resourceName:)",
-// CHECK1:       key.sourcetext: "#imageLiteral(resourceName: <#T##String#>)",
 // CHECK1:       key.description: "#imageLiteral(resourceName: String)",
+// CHECK1:       key.sourcetext: "#imageLiteral(resourceName: <#T##String#>)"
 // CHECK1:     },

--- a/test/SourceKit/CodeComplete/complete_operators.swift
+++ b/test/SourceKit/CodeComplete/complete_operators.swift
@@ -37,22 +37,22 @@ func test2(x: inout MyInt) {
 // RAW: {
 // RAW:   key.kind: source.lang.swift.decl.function.operator.infix,
 // RAW:   key.name: "!=",
-// RAW:   key.sourcetext: " != <#T##MyInt#>",
 // RAW:   key.description: "!=",
 // RAW:   key.typename: "Bool",
+// RAW:   key.sourcetext: " != <#T##MyInt#>"
 // RAW: {
 // RAW:   key.kind: source.lang.swift.decl.function.operator.infix,
 // RAW:   key.name: "+",
-// RAW:   key.sourcetext: " + <#T##MyInt#>",
 // RAW:   key.description: "+",
 // RAW:   key.typename: "MyInt",
+// RAW:   key.sourcetext: " + <#T##MyInt#>"
 // RAW: },
 // RAW: {
 // RAW:   key.kind: source.lang.swift.decl.function.operator.postfix,
 // RAW:   key.name: "++",
-// RAW:   key.sourcetext: "++",
 // RAW:   key.description: "++",
 // RAW:   key.typename: "MyInt",
+// RAW:   key.sourcetext: "++"
 // RAW: },
 
 struct MyBool {

--- a/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
+++ b/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
@@ -3,24 +3,24 @@
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "optionalMethod()",
-      key.sourcetext: "optionalMethod?()",
       key.description: "optionalMethod?()",
       key.typename: "Int",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "c:@M@complete_optionalmethod@objc(pl)Proto(im)optionalMethod",
-      key.modulename: "complete_optionalmethod"
+      key.modulename: "complete_optionalmethod",
+      key.sourcetext: "optionalMethod?()"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "self",
-      key.sourcetext: "self",
       key.description: "self",
       key.typename: "T",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: "self"
     }
   ]
 }

--- a/test/SourceKit/CodeComplete/complete_sort_order.swift
+++ b/test/SourceKit/CodeComplete/complete_sort_order.swift
@@ -191,11 +191,11 @@ func test6() {
 // VOID_1: ]
 
 // VOID_1_RAW: key.name: "foo1()",
-// VOID_1_RAW-NEXT: key.sourcetext: "foo1()",
 // VOID_1_RAW-NEXT: key.description: "foo1()",
 // VOID_1_RAW-NEXT: key.typename: "Void",
 // VOID_1_RAW-NEXT: key.context: source.codecompletion.context.local,
 // VOID_1_RAW-NEXT: key.num_bytes_to_erase: 0,
+// VOID_1_RAW: key.sourcetext: "foo1()"
 
 
 

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift.convertible.response
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift.convertible.response
@@ -3,55 +3,54 @@
     {
       key.kind: source.lang.swift.decl.enumelement,
       key.name: "bar()",
-      key.sourcetext: "bar(<#T##Int#>)",
       key.description: "bar(Int)",
       key.typename: "MyEnum",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO3baryACSicACmF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "bar(<#T##Int#>)"
     },
     {
       key.kind: source.lang.swift.decl.enumelement,
       key.name: "foo",
-      key.sourcetext: "foo",
       key.description: "foo",
       key.typename: "MyEnum",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO3fooyA2CmF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "foo"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "intanceReturnMyEnum(:)",
-      key.sourcetext: "intanceReturnMyEnum(<#T##self: MyEnum##MyEnum#>)",
       key.description: "intanceReturnMyEnum(self: MyEnum)",
       key.typename: "() -> MyEnum",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO013intanceReturncD0ACyF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "intanceReturnMyEnum(<#T##self: MyEnum##MyEnum#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "intanceReturnVoid(:)",
-      key.sourcetext: "intanceReturnVoid(<#T##self: MyEnum##MyEnum#>)",
       key.description: "intanceReturnVoid(self: MyEnum)",
       key.typename: "() -> Void",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.invalid,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO17intanceReturnVoidyyF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "intanceReturnVoid(<#T##self: MyEnum##MyEnum#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "intanceReturnVoidDeprecated(:)",
-      key.sourcetext: "intanceReturnVoidDeprecated(<#T##self: MyEnum##MyEnum#>)",
       key.description: "intanceReturnVoidDeprecated(self: MyEnum)",
       key.typename: "() -> Void",
       key.context: source.codecompletion.context.thisclass,
@@ -59,51 +58,52 @@
       key.num_bytes_to_erase: 0,
       key.not_recommended: 1,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO27intanceReturnVoidDeprecatedyyF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "intanceReturnVoidDeprecated(<#T##self: MyEnum##MyEnum#>)"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "self",
-      key.sourcetext: "self",
       key.description: "self",
       key.typename: "MyEnum.Type",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: "self"
     },
     {
       key.kind: source.lang.swift.decl.function.method.class,
       key.name: "staticReturnMyEnum()",
-      key.sourcetext: "staticReturnMyEnum()",
       key.description: "staticReturnMyEnum()",
       key.typename: "MyEnum",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO012staticReturncD0ACyFZ",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "staticReturnMyEnum()"
     },
     {
       key.kind: source.lang.swift.decl.function.method.class,
       key.name: "staticReturnVoid()",
-      key.sourcetext: "staticReturnVoid()",
       key.description: "staticReturnVoid()",
       key.typename: "Void",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.invalid,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO16staticReturnVoidyyFZ",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "staticReturnVoid()"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "Type",
-      key.sourcetext: "Type",
       key.description: "Type",
       key.typename: "MyEnum.Type",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: "Type"
     }
   ]
 }

--- a/test/SourceKit/CodeComplete/complete_typerelation.swift.identical.response
+++ b/test/SourceKit/CodeComplete/complete_typerelation.swift.identical.response
@@ -3,55 +3,54 @@
     {
       key.kind: source.lang.swift.decl.enumelement,
       key.name: "bar()",
-      key.sourcetext: "bar(<#T##Int#>)",
       key.description: "bar(Int)",
       key.typename: "MyEnum",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO3baryACSicACmF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "bar(<#T##Int#>)"
     },
     {
       key.kind: source.lang.swift.decl.enumelement,
       key.name: "foo",
-      key.sourcetext: "foo",
       key.description: "foo",
       key.typename: "MyEnum",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO3fooyA2CmF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "foo"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "intanceReturnMyEnum(:)",
-      key.sourcetext: "intanceReturnMyEnum(<#T##self: MyEnum##MyEnum#>)",
       key.description: "intanceReturnMyEnum(self: MyEnum)",
       key.typename: "() -> MyEnum",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unrelated,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO013intanceReturncD0ACyF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "intanceReturnMyEnum(<#T##self: MyEnum##MyEnum#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "intanceReturnVoid(:)",
-      key.sourcetext: "intanceReturnVoid(<#T##self: MyEnum##MyEnum#>)",
       key.description: "intanceReturnVoid(self: MyEnum)",
       key.typename: "() -> Void",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.invalid,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO17intanceReturnVoidyyF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "intanceReturnVoid(<#T##self: MyEnum##MyEnum#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "intanceReturnVoidDeprecated(:)",
-      key.sourcetext: "intanceReturnVoidDeprecated(<#T##self: MyEnum##MyEnum#>)",
       key.description: "intanceReturnVoidDeprecated(self: MyEnum)",
       key.typename: "() -> Void",
       key.context: source.codecompletion.context.thisclass,
@@ -59,51 +58,52 @@
       key.num_bytes_to_erase: 0,
       key.not_recommended: 1,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO27intanceReturnVoidDeprecatedyyF",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "intanceReturnVoidDeprecated(<#T##self: MyEnum##MyEnum#>)"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "self",
-      key.sourcetext: "self",
       key.description: "self",
       key.typename: "MyEnum.Type",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: "self"
     },
     {
       key.kind: source.lang.swift.decl.function.method.class,
       key.name: "staticReturnMyEnum()",
-      key.sourcetext: "staticReturnMyEnum()",
       key.description: "staticReturnMyEnum()",
       key.typename: "MyEnum",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO012staticReturncD0ACyFZ",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "staticReturnMyEnum()"
     },
     {
       key.kind: source.lang.swift.decl.function.method.class,
       key.name: "staticReturnVoid()",
-      key.sourcetext: "staticReturnVoid()",
       key.description: "staticReturnVoid()",
       key.typename: "Void",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.invalid,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:21complete_typerelation6MyEnumO16staticReturnVoidyyFZ",
-      key.modulename: "complete_typerelation"
+      key.modulename: "complete_typerelation",
+      key.sourcetext: "staticReturnVoid()"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "Type",
-      key.sourcetext: "Type",
       key.description: "Type",
       key.typename: "MyEnum.Type",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: "Type"
     }
   ]
 }

--- a/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
+++ b/test/SourceKit/CodeComplete/complete_unresolvedmember.swift.response
@@ -3,86 +3,86 @@
     {
       key.kind: source.lang.swift.decl.function.method.class,
       key.name: "create()",
-      key.sourcetext: "create()",
       key.description: "create()",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO6createACyFZ",
-      key.modulename: "complete_unresolvedmember"
+      key.modulename: "complete_unresolvedmember",
+      key.sourcetext: "create()"
     },
     {
       key.kind: source.lang.swift.decl.enumelement,
       key.name: "east",
-      key.sourcetext: "east",
       key.description: "east",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO4eastyA2CmF",
-      key.modulename: "complete_unresolvedmember"
+      key.modulename: "complete_unresolvedmember",
+      key.sourcetext: "east"
     },
     {
       key.kind: source.lang.swift.decl.function.constructor,
       key.name: "init(i:)",
-      key.sourcetext: "init(i: <#T##Int#>)",
       key.description: "init(i: Int)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO1iACSi_tcfc",
-      key.modulename: "complete_unresolvedmember"
+      key.modulename: "complete_unresolvedmember",
+      key.sourcetext: "init(i: <#T##Int#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.constructor,
       key.name: "init(s:)",
-      key.sourcetext: "init(s: <#T##String#>)",
       key.description: "init(s: String)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO1sACSS_tcfc",
-      key.modulename: "complete_unresolvedmember"
+      key.modulename: "complete_unresolvedmember",
+      key.sourcetext: "init(s: <#T##String#>)"
     },
     {
       key.kind: source.lang.swift.decl.var.class,
       key.name: "instance",
-      key.sourcetext: "instance",
       key.description: "instance",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO8instanceACvpZ",
-      key.modulename: "complete_unresolvedmember"
+      key.modulename: "complete_unresolvedmember",
+      key.sourcetext: "instance"
     },
     {
       key.kind: source.lang.swift.decl.enumelement,
       key.name: "other()",
-      key.sourcetext: "other(<#T##String#>)",
       key.description: "other(String)",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO5otheryACSScACmF",
-      key.modulename: "complete_unresolvedmember"
+      key.modulename: "complete_unresolvedmember",
+      key.sourcetext: "other(<#T##String#>)"
     },
     {
       key.kind: source.lang.swift.decl.enumelement,
       key.name: "west",
-      key.sourcetext: "west",
       key.description: "west",
       key.typename: "Foo",
       key.context: source.codecompletion.context.exprspecific,
       key.typerelation: source.codecompletion.typerelation.convertible,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:25complete_unresolvedmember3FooO4westyA2CmF",
-      key.modulename: "complete_unresolvedmember"
+      key.modulename: "complete_unresolvedmember",
+      key.sourcetext: "west"
     }
   ],
   key.kind: source.lang.swift.completion.unresolvedmember

--- a/test/SourceKit/CodeComplete/complete_with_closure_param.swift
+++ b/test/SourceKit/CodeComplete/complete_with_closure_param.swift
@@ -10,11 +10,11 @@ C().
 
 // CHECK:      key.kind: source.lang.swift.decl.function.method.instance,
 // CHECK-NEXT: key.name: "foo(:)",
-// CHECK-NEXT: key.sourcetext: "foo(<#T##x: (Int) -> Int##(Int) -> Int#>)",
 // CHECK-NEXT: key.description: "foo(x: (Int) -> Int)",
 // CHECK-NEXT: key.typename: "Void",
+// CHECK: key.sourcetext: "foo(<#T##x: (Int) -> Int##(Int) -> Int#>)"
 
 // CHECK:      key.kind: source.lang.swift.decl.function.method.instance,
 // CHECK-NEXT: key.name: "foo2(:)",
-// CHECK-NEXT: key.sourcetext: "foo2(<#T##x: (Int) -> Int##(Int) -> Int#>)",
 // CHECK-NEXT: key.description: "foo2(x: (Int) -> Int)",
+// CHECK: key.sourcetext: "foo2(<#T##x: (Int) -> Int##(Int) -> Int#>)"

--- a/test/SourceKit/CodeComplete/multiple_trailing_closure_signatures.swift
+++ b/test/SourceKit/CodeComplete/multiple_trailing_closure_signatures.swift
@@ -20,10 +20,10 @@ func func1(
 // CHECK: key.results: [
 // CHECK-DAG: key.sourcetext: "fn2: {\n<#code#>\n}"
 // CHECK-DAG: key.sourcetext: "fn3: { <#Int#> in\n<#code#>\n}"
-// CHECK-DAG: key.sourcetext: "fn4: { <#Int#>, <#String#> in\n<#code#>\n}",
-// CHECK-DAG: key.sourcetext: "fn5: { <#Int#>, <#String#> in\n<#code#>\n}",
-// CHECK-DAG: key.sourcetext: "fn7: { <#inout Int#> in\n<#code#>\n}",
-// CHECK-DAG: key.sourcetext: "fn8: { <#Int...#> in\n<#code#>\n}",
+// CHECK-DAG: key.sourcetext: "fn4: { <#Int#>, <#String#> in\n<#code#>\n}"
+// CHECK-DAG: key.sourcetext: "fn5: { <#Int#>, <#String#> in\n<#code#>\n}"
+// CHECK-DAG: key.sourcetext: "fn7: { <#inout Int#> in\n<#code#>\n}"
+// CHECK-DAG: key.sourcetext: "fn8: { <#Int...#> in\n<#code#>\n}"
 // CHECK: ]
 
 // DESCRIPTION-NOT: key.description: "fn{{[0-9]*}}: {

--- a/test/SourceKit/ConformingMethods/basic.swift.response
+++ b/test/SourceKit/ConformingMethods/basic.swift.response
@@ -4,17 +4,17 @@
   key.members: [
     {
       key.name: "methodForTarget1()",
-      key.sourcetext: "methodForTarget1()",
       key.description: "methodForTarget1()",
       key.typename: "ConcreteTarget1",
-      key.typeusr: "$s8MyModule15ConcreteTarget1VD"
+      key.typeusr: "$s8MyModule15ConcreteTarget1VD",
+      key.sourcetext: "methodForTarget1()"
     },
     {
       key.name: "methodForTarget2()",
-      key.sourcetext: "methodForTarget2()",
       key.description: "methodForTarget2()",
       key.typename: "ConcreteTarget2",
-      key.typeusr: "$s8MyModule15ConcreteTarget2VD"
+      key.typeusr: "$s8MyModule15ConcreteTarget2VD",
+      key.sourcetext: "methodForTarget2()"
     }
   ]
 }
@@ -24,17 +24,17 @@
   key.members: [
     {
       key.name: "methodForTarget1()",
-      key.sourcetext: "methodForTarget1()",
       key.description: "methodForTarget1()",
       key.typename: "ConcreteTarget1",
-      key.typeusr: "$s8MyModule15ConcreteTarget1VD"
+      key.typeusr: "$s8MyModule15ConcreteTarget1VD",
+      key.sourcetext: "methodForTarget1()"
     },
     {
       key.name: "methodForTarget2()",
-      key.sourcetext: "methodForTarget2()",
       key.description: "methodForTarget2()",
       key.typename: "ConcreteTarget2",
-      key.typeusr: "$s8MyModule15ConcreteTarget2VD"
+      key.typeusr: "$s8MyModule15ConcreteTarget2VD",
+      key.sourcetext: "methodForTarget2()"
     }
   ],
   key.reusingastcontext: 1

--- a/test/SourceKit/ConformingMethods/generics.swift.response.1
+++ b/test/SourceKit/ConformingMethods/generics.swift.response.1
@@ -4,31 +4,31 @@
   key.members: [
     {
       key.name: "methodForProto1(x:)",
-      key.sourcetext: "methodForProto1(x: <#T##T#>)",
       key.description: "methodForProto1(x: T)",
       key.typename: "ConcreteProto",
-      key.typeusr: "$s8MyModule13ConcreteProtoVD"
+      key.typeusr: "$s8MyModule13ConcreteProtoVD",
+      key.sourcetext: "methodForProto1(x: <#T##T#>)"
     },
     {
       key.name: "methodForProto2(x:)",
-      key.sourcetext: "methodForProto2(x: <#T##U#>)",
       key.description: "methodForProto2(x: U)",
       key.typename: "ConcreteProtoGen<U>",
-      key.typeusr: "$s8MyModule16ConcreteProtoGenVyqd__GD"
+      key.typeusr: "$s8MyModule16ConcreteProtoGenVyqd__GD",
+      key.sourcetext: "methodForProto2(x: <#T##U#>)"
     },
     {
       key.name: "methodForProto3(x:)",
-      key.sourcetext: "methodForProto3(x: <#T##S<T>#>)",
       key.description: "methodForProto3(x: S<T>)",
       key.typename: "ConcreteProtoGen<T>",
-      key.typeusr: "$s8MyModule16ConcreteProtoGenVyxGD"
+      key.typeusr: "$s8MyModule16ConcreteProtoGenVyxGD",
+      key.sourcetext: "methodForProto3(x: <#T##S<T>#>)"
     },
     {
       key.name: "methodForProto4()",
-      key.sourcetext: "methodForProto4()",
       key.description: "methodForProto4()",
       key.typename: "S<T>",
-      key.typeusr: "$s8MyModule1SVyxGD"
+      key.typeusr: "$s8MyModule1SVyxGD",
+      key.sourcetext: "methodForProto4()"
     }
   ]
 }

--- a/test/SourceKit/ConformingMethods/generics.swift.response.2
+++ b/test/SourceKit/ConformingMethods/generics.swift.response.2
@@ -4,31 +4,31 @@
   key.members: [
     {
       key.name: "methodForProto1(x:)",
-      key.sourcetext: "methodForProto1(x: <#T##X#>)",
       key.description: "methodForProto1(x: X)",
       key.typename: "ConcreteProto",
-      key.typeusr: "$s8MyModule13ConcreteProtoVD"
+      key.typeusr: "$s8MyModule13ConcreteProtoVD",
+      key.sourcetext: "methodForProto1(x: <#T##X#>)"
     },
     {
       key.name: "methodForProto2(x:)",
-      key.sourcetext: "methodForProto2(x: <#T##U#>)",
       key.description: "methodForProto2(x: U)",
       key.typename: "ConcreteProtoGen<U>",
-      key.typeusr: "$s8MyModule16ConcreteProtoGenVyqd__GD"
+      key.typeusr: "$s8MyModule16ConcreteProtoGenVyqd__GD",
+      key.sourcetext: "methodForProto2(x: <#T##U#>)"
     },
     {
       key.name: "methodForProto3(x:)",
-      key.sourcetext: "methodForProto3(x: <#T##S<X>#>)",
       key.description: "methodForProto3(x: S<X>)",
       key.typename: "ConcreteProtoGen<X>",
-      key.typeusr: "$s8MyModule16ConcreteProtoGenVyxGD"
+      key.typeusr: "$s8MyModule16ConcreteProtoGenVyxGD",
+      key.sourcetext: "methodForProto3(x: <#T##S<X>#>)"
     },
     {
       key.name: "methodForProto4()",
-      key.sourcetext: "methodForProto4()",
       key.description: "methodForProto4()",
       key.typename: "S<X>",
-      key.typeusr: "$s8MyModule1SVyxGD"
+      key.typeusr: "$s8MyModule1SVyxGD",
+      key.sourcetext: "methodForProto4()"
     }
   ]
 }

--- a/test/SourceKit/Misc/mixed_completion_sequence.swift.response
+++ b/test/SourceKit/Misc/mixed_completion_sequence.swift.response
@@ -3,84 +3,84 @@
     {
       key.kind: source.lang.swift.decl.function.operator.infix,
       key.name: "!==",
-      key.sourcetext: " !== <#T##AnyObject?#>",
       key.description: "!==",
       key.typename: "Bool",
       key.context: source.codecompletion.context.othermodule,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.is_system: 1,
-      key.modulename: "Swift"
+      key.modulename: "Swift",
+      key.sourcetext: " !== <#T##AnyObject?#>"
     },
     {
       key.kind: source.lang.swift.decl.function.operator.infix,
       key.name: "===",
-      key.sourcetext: " === <#T##AnyObject?#>",
       key.description: "===",
       key.typename: "Bool",
       key.context: source.codecompletion.context.othermodule,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.is_system: 1,
-      key.modulename: "Swift"
+      key.modulename: "Swift",
+      key.sourcetext: " === <#T##AnyObject?#>"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "instanceMethod(x:)",
-      key.sourcetext: ".instanceMethod(x: <#T##MyEnum#>)",
       key.description: "instanceMethod(x: MyEnum)",
       key.typename: "C",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:8MyModule1CC14instanceMethod1xAcA0A4EnumO_tF",
-      key.modulename: "MyModule"
+      key.modulename: "MyModule",
+      key.sourcetext: ".instanceMethod(x: <#T##MyEnum#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "methodForTarget1()",
-      key.sourcetext: ".methodForTarget1()",
       key.description: "methodForTarget1()",
       key.typename: "ConcreteTarget1",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:8MyModule1CC16methodForTarget1AA08ConcreteE0VyF",
-      key.modulename: "MyModule"
+      key.modulename: "MyModule",
+      key.sourcetext: ".methodForTarget1()"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "methodForTarget2()",
-      key.sourcetext: ".methodForTarget2()",
       key.description: "methodForTarget2()",
       key.typename: "ConcreteTarget2",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:8MyModule1CC16methodForTarget2AA08ConcreteE0VyF",
-      key.modulename: "MyModule"
+      key.modulename: "MyModule",
+      key.sourcetext: ".methodForTarget2()"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "protocolMethod(asc:)",
-      key.sourcetext: ".protocolMethod(asc: <#T##String#>)",
       key.description: "protocolMethod(asc: String)",
       key.typename: "C",
       key.context: source.codecompletion.context.superclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:8MyModule1PPAAE14protocolMethod3ascx5AssocQz_tF",
-      key.modulename: "MyModule"
+      key.modulename: "MyModule",
+      key.sourcetext: ".protocolMethod(asc: <#T##String#>)"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "self",
-      key.sourcetext: ".self",
       key.description: "self",
       key.typename: "C",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: ".self"
     }
   ]
 }
@@ -90,17 +90,17 @@
   key.members: [
     {
       key.name: "methodForTarget1()",
-      key.sourcetext: "methodForTarget1()",
       key.description: "methodForTarget1()",
       key.typename: "ConcreteTarget1",
-      key.typeusr: "$s8MyModule15ConcreteTarget1VD"
+      key.typeusr: "$s8MyModule15ConcreteTarget1VD",
+      key.sourcetext: "methodForTarget1()"
     },
     {
       key.name: "methodForTarget2()",
-      key.sourcetext: "methodForTarget2()",
       key.description: "methodForTarget2()",
       key.typename: "ConcreteTarget2",
-      key.typeusr: "$s8MyModule15ConcreteTarget2VD"
+      key.typeusr: "$s8MyModule15ConcreteTarget2VD",
+      key.sourcetext: "methodForTarget2()"
     }
   ],
   key.reusingastcontext: 1
@@ -113,13 +113,13 @@
       key.implicitmembers: [
         {
           key.name: "foo",
-          key.sourcetext: "foo",
-          key.description: "foo"
+          key.description: "foo",
+          key.sourcetext: "foo"
         },
         {
           key.name: "bar",
-          key.sourcetext: "bar",
-          key.description: "bar"
+          key.description: "bar",
+          key.sourcetext: "bar"
         }
       ]
     }
@@ -131,84 +131,84 @@
     {
       key.kind: source.lang.swift.decl.function.operator.infix,
       key.name: "!==",
-      key.sourcetext: " !== <#T##AnyObject?#>",
       key.description: "!==",
       key.typename: "Bool",
       key.context: source.codecompletion.context.othermodule,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.is_system: 1,
-      key.modulename: "Swift"
+      key.modulename: "Swift",
+      key.sourcetext: " !== <#T##AnyObject?#>"
     },
     {
       key.kind: source.lang.swift.decl.function.operator.infix,
       key.name: "===",
-      key.sourcetext: " === <#T##AnyObject?#>",
       key.description: "===",
       key.typename: "Bool",
       key.context: source.codecompletion.context.othermodule,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.is_system: 1,
-      key.modulename: "Swift"
+      key.modulename: "Swift",
+      key.sourcetext: " === <#T##AnyObject?#>"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "instanceMethod(x:)",
-      key.sourcetext: ".instanceMethod(x: <#T##MyEnum#>)",
       key.description: "instanceMethod(x: MyEnum)",
       key.typename: "C",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:8MyModule1CC14instanceMethod1xAcA0A4EnumO_tF",
-      key.modulename: "MyModule"
+      key.modulename: "MyModule",
+      key.sourcetext: ".instanceMethod(x: <#T##MyEnum#>)"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "methodForTarget1()",
-      key.sourcetext: ".methodForTarget1()",
       key.description: "methodForTarget1()",
       key.typename: "ConcreteTarget1",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:8MyModule1CC16methodForTarget1AA08ConcreteE0VyF",
-      key.modulename: "MyModule"
+      key.modulename: "MyModule",
+      key.sourcetext: ".methodForTarget1()"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "methodForTarget2()",
-      key.sourcetext: ".methodForTarget2()",
       key.description: "methodForTarget2()",
       key.typename: "ConcreteTarget2",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:8MyModule1CC16methodForTarget2AA08ConcreteE0VyF",
-      key.modulename: "MyModule"
+      key.modulename: "MyModule",
+      key.sourcetext: ".methodForTarget2()"
     },
     {
       key.kind: source.lang.swift.decl.function.method.instance,
       key.name: "protocolMethod(asc:)",
-      key.sourcetext: ".protocolMethod(asc: <#T##String#>)",
       key.description: "protocolMethod(asc: String)",
       key.typename: "C",
       key.context: source.codecompletion.context.superclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
       key.num_bytes_to_erase: 0,
       key.associated_usrs: "s:8MyModule1PPAAE14protocolMethod3ascx5AssocQz_tF",
-      key.modulename: "MyModule"
+      key.modulename: "MyModule",
+      key.sourcetext: ".protocolMethod(asc: <#T##String#>)"
     },
     {
       key.kind: source.lang.swift.keyword,
       key.name: "self",
-      key.sourcetext: ".self",
       key.description: "self",
       key.typename: "C",
       key.context: source.codecompletion.context.thisclass,
       key.typerelation: source.codecompletion.typerelation.unknown,
-      key.num_bytes_to_erase: 0
+      key.num_bytes_to_erase: 0,
+      key.sourcetext: ".self"
     }
   ],
   key.reusingastcontext: 1

--- a/test/SourceKit/TypeContextInfo/typecontext_basic.swift.response
+++ b/test/SourceKit/TypeContextInfo/typecontext_basic.swift.response
@@ -6,23 +6,23 @@
       key.implicitmembers: [
         {
           key.name: "east",
-          key.sourcetext: "east",
-          key.description: "east"
+          key.description: "east",
+          key.sourcetext: "east"
         },
         {
           key.name: "west",
-          key.sourcetext: "west",
-          key.description: "west"
+          key.description: "west",
+          key.sourcetext: "west"
         },
         {
           key.name: "vector(x:y:)",
-          key.sourcetext: "vector(x: <#T##Int#>, y: <#T##Int#>)",
-          key.description: "vector(x: Int, y: Int)"
+          key.description: "vector(x: Int, y: Int)",
+          key.sourcetext: "vector(x: <#T##Int#>, y: <#T##Int#>)"
         },
         {
           key.name: "distance(_:)",
-          key.sourcetext: "distance(<#T##Int#>)",
-          key.description: "distance(Int)"
+          key.description: "distance(Int)",
+          key.sourcetext: "distance(<#T##Int#>)"
         }
       ]
     },
@@ -32,27 +32,27 @@
       key.implicitmembers: [
         {
           key.name: "me",
-          key.sourcetext: "me",
           key.description: "me",
-          key.doc.brief: "Mine."
+          key.doc.brief: "Mine.",
+          key.sourcetext: "me"
         },
         {
           key.name: "you",
-          key.sourcetext: "you",
           key.description: "you",
-          key.doc.brief: "Yours."
+          key.doc.brief: "Yours.",
+          key.sourcetext: "you"
         },
         {
           key.name: "them",
-          key.sourcetext: "them",
           key.description: "them",
-          key.doc.brief: "Theirs."
+          key.doc.brief: "Theirs.",
+          key.sourcetext: "them"
         },
         {
           key.name: "all",
-          key.sourcetext: "all",
           key.description: "all",
-          key.doc.brief: "One for all."
+          key.doc.brief: "One for all.",
+          key.sourcetext: "all"
         }
       ]
     }
@@ -66,23 +66,23 @@
       key.implicitmembers: [
         {
           key.name: "east",
-          key.sourcetext: "east",
-          key.description: "east"
+          key.description: "east",
+          key.sourcetext: "east"
         },
         {
           key.name: "west",
-          key.sourcetext: "west",
-          key.description: "west"
+          key.description: "west",
+          key.sourcetext: "west"
         },
         {
           key.name: "vector(x:y:)",
-          key.sourcetext: "vector(x: <#T##Int#>, y: <#T##Int#>)",
-          key.description: "vector(x: Int, y: Int)"
+          key.description: "vector(x: Int, y: Int)",
+          key.sourcetext: "vector(x: <#T##Int#>, y: <#T##Int#>)"
         },
         {
           key.name: "distance(_:)",
-          key.sourcetext: "distance(<#T##Int#>)",
-          key.description: "distance(Int)"
+          key.description: "distance(Int)",
+          key.sourcetext: "distance(<#T##Int#>)"
         }
       ]
     },
@@ -92,27 +92,27 @@
       key.implicitmembers: [
         {
           key.name: "me",
-          key.sourcetext: "me",
           key.description: "me",
-          key.doc.brief: "Mine."
+          key.doc.brief: "Mine.",
+          key.sourcetext: "me"
         },
         {
           key.name: "you",
-          key.sourcetext: "you",
           key.description: "you",
-          key.doc.brief: "Yours."
+          key.doc.brief: "Yours.",
+          key.sourcetext: "you"
         },
         {
           key.name: "them",
-          key.sourcetext: "them",
           key.description: "them",
-          key.doc.brief: "Theirs."
+          key.doc.brief: "Theirs.",
+          key.sourcetext: "them"
         },
         {
           key.name: "all",
-          key.sourcetext: "all",
           key.description: "all",
-          key.doc.brief: "One for all."
+          key.doc.brief: "One for all.",
+          key.sourcetext: "all"
         }
       ]
     }

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.2
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.2
@@ -6,8 +6,8 @@
       key.implicitmembers: [
         {
           key.name: "instance",
-          key.sourcetext: "instance",
-          key.description: "instance"
+          key.description: "instance",
+          key.sourcetext: "instance"
         }
       ]
     }

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.3
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.3
@@ -6,8 +6,8 @@
       key.implicitmembers: [
         {
           key.name: "instance",
-          key.sourcetext: "instance",
-          key.description: "instance"
+          key.description: "instance",
+          key.sourcetext: "instance"
         }
       ]
     }

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.5
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.5
@@ -6,8 +6,8 @@
       key.implicitmembers: [
         {
           key.name: "instance",
-          key.sourcetext: "instance",
-          key.description: "instance"
+          key.description: "instance",
+          key.sourcetext: "instance"
         }
       ]
     }

--- a/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.6
+++ b/test/SourceKit/TypeContextInfo/typecontext_generics.swift.response.6
@@ -6,8 +6,8 @@
       key.implicitmembers: [
         {
           key.name: "instance",
-          key.sourcetext: "instance",
-          key.description: "instance"
+          key.description: "instance",
+          key.sourcetext: "instance"
         }
       ]
     }

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -45,12 +45,10 @@ UID_KEYS = [
     KEY('FilePath', 'key.filepath'),
     KEY('ModuleInterfaceName', 'key.module_interface_name'),
     KEY('Hash', 'key.hash'),
-    KEY('CompilerArgs', 'key.compilerargs'),
     KEY('Severity', 'key.severity'),
     KEY('Offset', 'key.offset'),
     KEY('Length', 'key.length'),
     KEY('SourceFile', 'key.sourcefile'),
-    KEY('SourceText', 'key.sourcetext'),
     KEY('PrimaryFile', 'key.primary_file'),
     KEY('EnableSyntaxMap', 'key.enablesyntaxmap'),
     KEY('EnableStructure', 'key.enablesubstructure'),
@@ -222,6 +220,16 @@ UID_KEYS = [
     KEY('IncludeSystemModules', 'key.include_system_modules'),
     KEY('IgnoreStdlib', 'key.ignore_stdlib'),
     KEY('DisableImplicitModules', 'key.disable_implicit_modules'),
+
+    KEY('CompilerArgs', 'key.compilerargs'),
+    KEY('SourceText', 'key.sourcetext'),
+
+    # IMPORTANT: Add any new keys before CompilerArgs and SourceText.
+    # Always keep CompilerArgs and SourceText as the last keys so that printing
+    # a request dictionary has those as the last entries. That way, when the
+    # request gets truncated by os_log in sourcekit-lsp, we see most of the
+    # request. Most likely the sourcetext and the compiler args wouldn't have
+    # made it into the log message completely anyway.
 ]
 
 


### PR DESCRIPTION
That way, when the request gets truncated by os_log in sourcekit-lsp, we see most of the request. Most likely the sourcetext and the compiler args wouldn't have made it into the log message completely anyway.

rdar://121322828
