### PR TITLE
[region-isolation] Only make partial_apply actor derived if we capture an isolated parameter... not just any actor.

### DIFF
--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -100,7 +100,7 @@ public:
     return Value.getPointer().is<OpaqueValueExpr *>();
   }
 
-  /// Returns true if this captured value has a local capture.
+  /// Returns true if this captured value is a local capture.
   ///
   /// NOTE: This implies that the value is not dynamic self metadata, since
   /// values with decls are the only values that are able to be local captures.

--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -100,6 +100,12 @@ public:
     return Value.getPointer().is<OpaqueValueExpr *>();
   }
 
+  /// Returns true if this captured value has a local capture.
+  ///
+  /// NOTE: This implies that the value is not dynamic self metadata, since
+  /// values with decls are the only values that are able to be local captures.
+  bool isLocalCapture() const;
+
   CapturedValue mergeFlags(CapturedValue cv) {
     assert(Value.getPointer() == cv.Value.getPointer() &&
            "merging flags on two different value decls");

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -571,6 +571,16 @@ public:
     return getApplyOptions().contains(ApplyFlags::DoesNotAwait);
   }
 
+  /// Return the SILParameterInfo for this operand in the callee function.
+  SILParameterInfo getArgumentParameterInfo(const Operand &oper) const {
+    assert(!getArgumentConvention(oper).isIndirectOutParameter() &&
+           "Can only be applied to non-out parameters");
+
+    // The ParameterInfo is going to be the parameter in the caller.
+    unsigned calleeArgIndex = getCalleeArgIndex(oper);
+    return getSubstCalleeConv().getParamInfoForSILArg(calleeArgIndex);
+  }
+
   static ApplySite getFromOpaqueValue(void *p) { return ApplySite(p); }
 
   friend bool operator==(ApplySite lhs, ApplySite rhs) {
@@ -799,15 +809,6 @@ public:
     case FullApplySiteKind::BeginApplyInst:
       return cast<BeginApplyInst>(**this)->getIsolationCrossing();
     }
-  }
-
-  SILParameterInfo getArgumentParameterInfo(const Operand &oper) const {
-    assert(!getArgumentConvention(oper).isIndirectOutParameter() &&
-           "Can only be applied to non-out parameters");
-
-    // The ParameterInfo is going to be the parameter in the caller.
-    unsigned calleeArgIndex = getCalleeArgIndex(oper);
-    return getSubstCalleeConv().getParamInfoForSILArg(calleeArgIndex);
   }
 
   static FullApplySite getFromOpaqueValue(void *p) { return FullApplySite(p); }

--- a/lib/AST/CaptureInfo.cpp
+++ b/lib/AST/CaptureInfo.cpp
@@ -88,11 +88,9 @@ VarDecl *CaptureInfo::getIsolatedParamCapture() const {
     return nullptr;
 
   for (const auto &capture : getCaptures()) {
-    // Check for dynamic self metadata before checking if we have a local
-    // capture since dynamic self metadata doesn't have a decl.
-    if (capture.isDynamicSelfMetadata())
-      continue;
-
+    // NOTE: isLocalCapture() returns false if we have dynamic self metadata
+    // since dynamic self metadata is never an isolated capture. So we can just
+    // call isLocalCapture without checking for dynamic self metadata.
     if (!capture.isLocalCapture())
       continue;
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1917,6 +1917,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
   // signature from the AST for that.
   auto origGenericSig = function.getAnyFunctionRef()->getGenericSignature();
   auto loweredCaptures = TC.getLoweredLocalCaptures(function);
+  auto *isolatedParam = loweredCaptures.getIsolatedParamCapture();
 
   for (auto capture : loweredCaptures.getCaptures()) {
     if (capture.isDynamicSelfMetadata()) {
@@ -1955,13 +1956,17 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       continue;
     }
 
-    auto *VD = capture.getDecl();
-    auto type = VD->getInterfaceType();
+    auto *varDecl = capture.getDecl();
+    auto type = varDecl->getInterfaceType();
     auto canType = type->getReducedType(origGenericSig);
+
+    auto options = SILParameterInfo::Options();
+    if (isolatedParam == varDecl)
+      options |= SILParameterInfo::Isolated;
 
     // If we're capturing a parameter pack, wrap it in a tuple.
     if (isa<PackExpansionType>(canType)) {
-      assert(!cast<ParamDecl>(VD)->supportsMutation() &&
+      assert(!cast<ParamDecl>(varDecl)->supportsMutation() &&
              "Cannot capture a pack as an lvalue");
 
       SmallVector<TupleTypeElt, 1> elts;
@@ -1983,7 +1988,7 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       } else {
         convention = ParameterConvention::Direct_Guaranteed;
       }
-      SILParameterInfo param(loweredTy.getASTType(), convention);
+      SILParameterInfo param(loweredTy.getASTType(), convention, options);
       inputs.push_back(param);
       break;
     }
@@ -1995,10 +2000,10 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
               .getLoweredType();
       // Lvalues are captured as a box that owns the captured value.
       auto boxTy = TC.getInterfaceBoxTypeForCapture(
-          VD, minimalLoweredTy.getASTType(),
+          varDecl, minimalLoweredTy.getASTType(),
           /*mutable*/ true);
       auto convention = ParameterConvention::Direct_Guaranteed;
-      auto param = SILParameterInfo(boxTy, convention);
+      auto param = SILParameterInfo(boxTy, convention, options);
       inputs.push_back(param);
       break;
     }
@@ -2009,20 +2014,20 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
                              TypeExpansionContext::minimal())
               .getLoweredType();
       // Lvalues are captured as a box that owns the captured value.
-      auto boxTy =
-          TC.getInterfaceBoxTypeForCapture(VD, minimalLoweredTy.getASTType(),
-                                           /*mutable*/ false);
+      auto boxTy = TC.getInterfaceBoxTypeForCapture(
+          varDecl, minimalLoweredTy.getASTType(),
+          /*mutable*/ false);
       auto convention = ParameterConvention::Direct_Guaranteed;
-      auto param = SILParameterInfo(boxTy, convention);
+      auto param = SILParameterInfo(boxTy, convention, options);
       inputs.push_back(param);
       break;
     }
     case CaptureKind::StorageAddress: {
       // Non-escaping lvalues are captured as the address of the value.
       SILType ty = loweredTy.getAddressType();
-      auto param =
-          SILParameterInfo(ty.getASTType(),
-                           ParameterConvention::Indirect_InoutAliasable);
+      auto param = SILParameterInfo(
+          ty.getASTType(), ParameterConvention::Indirect_InoutAliasable,
+          options);
       inputs.push_back(param);
       break;
     }
@@ -2030,9 +2035,9 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       // 'let' constants that are address-only are captured as the address of
       // the value and will be consumed by the closure.
       SILType ty = loweredTy.getAddressType();
-      auto param =
-          SILParameterInfo(ty.getASTType(),
-                           ParameterConvention::Indirect_In_Guaranteed);
+      auto param = SILParameterInfo(ty.getASTType(),
+                                    ParameterConvention::Indirect_In_Guaranteed,
+                                    options);
       inputs.push_back(param);
       break;
     }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1961,8 +1961,10 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
     auto canType = type->getReducedType(origGenericSig);
 
     auto options = SILParameterInfo::Options();
-    if (isolatedParam == varDecl)
+    if (isolatedParam == varDecl) {
       options |= SILParameterInfo::Isolated;
+      isolatedParam = nullptr;
+    }
 
     // If we're capturing a parameter pack, wrap it in a tuple.
     if (isa<PackExpansionType>(canType)) {
@@ -2043,6 +2045,9 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
     }
     }
   }
+  assert(!isolatedParam &&
+         "If we had an isolated capture, we should have visited it when "
+         "iterating over loweredCaptures.getCaptures().");
 }
 
 static AccessorDecl *

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -195,14 +195,10 @@ func transferNonIsolatedNonAsyncClosureTwice() async {
   var actorCaptureClosure = { print(a) }
   await transferToMain(actorCaptureClosure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'actorCaptureClosure' may cause a race}}
-  // expected-tns-note @-3 {{transferring nonisolated 'actorCaptureClosure' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 
   actorCaptureClosure = { print(a) }
   await transferToMain(actorCaptureClosure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'actorCaptureClosure' may cause a race}}
-  // expected-tns-note @-3 {{transferring nonisolated 'actorCaptureClosure' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 }
 
 extension Actor {
@@ -403,8 +399,6 @@ func testSimpleLetClosureCaptureActor() async {
   let closure = { print(a) }
   await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
-  // expected-tns-note @-3 {{transferring nonisolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 }
 
 #if TYPECHECKER_ONLY
@@ -441,8 +435,6 @@ func testSimpleVarClosureCaptureActor() async {
   closure = { print(a) }
   await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
-  // expected-tns-note @-3 {{transferring nonisolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 }
 
 #if TYPECHECKER_ONLY

--- a/test/SILGen/capture_info_invariants.swift
+++ b/test/SILGen/capture_info_invariants.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -o - -emit-silgen %s
+
+// REQUIRES: concurrency
+
+// READ THIS! This test is meant to test invariants around CaptureInfo usage in
+// SILGen. Only add examples to this if we hit a crasher in capture info and the
+// example makes sure we do not crash again.
+
+class GetIsolatedParamTest {
+  public static var rootType: Any.Type? { nil }
+}
+
+extension GetIsolatedParamTest : CustomDebugStringConvertible {
+    public var debugDescription: String {
+      let description = "\\\(String(describing: Self.rootType!))"
+      let x: Any.Type? = nil
+      // The error is triggered by the ?? autoclosure.
+      var valueType: Any.Type? = x ?? Self.rootType
+      return description
+    }
+}

--- a/test/SILGen/check_executor.swift
+++ b/test/SILGen/check_executor.swift
@@ -47,7 +47,7 @@ public actor MyActor {
     }
   }
 
-  // CHECK-CANONICAL-LABEL: sil private [ossa] @$s4test7MyActorC0A13LocalFunctionyyF5localL_SiyF : $@convention(thin) (@guaranteed MyActor) -> Int
+  // CHECK-CANONICAL-LABEL: sil private [ossa] @$s4test7MyActorC0A13LocalFunctionyyF5localL_SiyF : $@convention(thin) (@sil_isolated @guaranteed MyActor) -> Int
   // CHECK-CANONICAL: [[CAPTURE:%.*]] = copy_value %0 : $MyActor
   // CHECK-CANONICAL-NEXT: [[BORROWED_CAPTURE:%.*]] = begin_borrow [[CAPTURE]] : $MyActor
   // CHECK-CANONICAL-NEXT: [[EXECUTOR:%.*]] = builtin "buildDefaultActorExecutorRef"<MyActor>([[BORROWED_CAPTURE]] : $MyActor) : $Builtin.Executor

--- a/test/SILGen/hop_to_executor.swift
+++ b/test/SILGen/hop_to_executor.swift
@@ -61,7 +61,7 @@ actor MyActor {
   // CHECK: } // end sil function '$s4test7MyActorC0A7ClosureSiyYaF'
 
   ///// closure #1 in MyActor.testClosure()
-  // CHECK-LABEL: sil private [ossa] @$s4test7MyActorC0A7ClosureSiyYaFSiyYaXEfU_ : $@convention(thin) @async (@guaranteed MyActor) -> Int {
+  // CHECK-LABEL: sil private [ossa] @$s4test7MyActorC0A7ClosureSiyYaFSiyYaXEfU_ : $@convention(thin) @async (@sil_isolated @guaranteed MyActor) -> Int {
   // CHECK:        [[COPIED_SELF:%[0-9]+]] = copy_value %0 : $MyActor
   // CHECK:        [[BORROWED_SELF:%[0-9]+]] = begin_borrow [[COPIED_SELF]] : $MyActor
   // CHECK:        hop_to_executor [[BORROWED_SELF]] : $MyActor 

--- a/test/SILGen/isolated_any.swift
+++ b/test/SILGen/isolated_any.swift
@@ -221,7 +221,7 @@ func testEraseInheritingSyncMainActorClosure() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0a19EraseInheritingSyncC7ClosureyyF
 // CHECK:         // function_ref closure #1
-// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test7MyActorC0a19EraseInheritingSyncC7ClosureyyFyycfU_ : $@convention(thin) (@guaranteed Optional<any Actor>, @guaranteed MyActor) -> ()
+// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test7MyActorC0a19EraseInheritingSyncC7ClosureyyFyycfU_ : $@convention(thin) (@guaranteed Optional<any Actor>, @sil_isolated @guaranteed MyActor) -> ()
 // CHECK-NEXT:    [[CAPTURE:%.*]] = copy_value %0 : $MyActor
 // CHECK-NEXT:    [[CAPTURE_FOR_ISOLATION:%.*]] = copy_value [[CAPTURE]] : $MyActor
 // CHECK-NEXT:    [[ISOLATION_OBJECT:%.*]] = init_existential_ref [[CAPTURE_FOR_ISOLATION]] : $MyActor : $MyActor, $any Actor
@@ -332,7 +332,7 @@ func testEraseInheritingAsyncMainActorClosure() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0a20EraseInheritingAsyncC7ClosureyyF
 // CHECK:         // function_ref closure #1
-// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test7MyActorC0a20EraseInheritingAsyncC7ClosureyyFyyYacfU_ : $@convention(thin) @async (@guaranteed Optional<any Actor>, @guaranteed MyActor) -> ()
+// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test7MyActorC0a20EraseInheritingAsyncC7ClosureyyFyyYacfU_ : $@convention(thin) @async (@guaranteed Optional<any Actor>, @sil_isolated @guaranteed MyActor) -> ()
 // CHECK-NEXT:    [[CAPTURE:%.*]] = copy_value %0 : $MyActor
 // CHECK-NEXT:    [[CAPTURE_FOR_ISOLATION:%.*]] = copy_value [[CAPTURE]] : $MyActor
 // CHECK-NEXT:    [[ISOLATION_OBJECT:%.*]] = init_existential_ref [[CAPTURE_FOR_ISOLATION]] : $MyActor : $MyActor, $any Actor
@@ -362,7 +362,7 @@ func takeInheritingAsyncIsolatedAny_optionalResult(@_inheritActorContext fn: @es
 // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0a20EraseInheritingAsyncC18Closure_noPeepholeyyF
 //   We emit the closure itself with just the erasure conversion.
 // CHECK:         // function_ref closure #1
-// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test7MyActorC0a20EraseInheritingAsyncC18Closure_noPeepholeyyFSiyYacfU_ : $@convention(thin) @async (@guaranteed Optional<any Actor>, @guaranteed MyActor) -> Int
+// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test7MyActorC0a20EraseInheritingAsyncC18Closure_noPeepholeyyFSiyYacfU_ : $@convention(thin) @async (@guaranteed Optional<any Actor>, @sil_isolated @guaranteed MyActor) -> Int
 // CHECK-NEXT:    [[CAPTURE:%.*]] = copy_value %0 : $MyActor
 // CHECK-NEXT:    [[CAPTURE_FOR_ISOLATION:%.*]] = copy_value [[CAPTURE]] : $MyActor
 // CHECK-NEXT:    [[ISOLATION_OBJECT:%.*]] = init_existential_ref [[CAPTURE_FOR_ISOLATION]] : $MyActor : $MyActor, $any Actor

--- a/test/SILGen/isolated_self_capture.swift
+++ b/test/SILGen/isolated_self_capture.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -disable-availability-checking -sil-verify-all -swift-version 5 | %FileCheck %s
 
 // REQUIRES: concurrency
 

--- a/test/SILGen/isolated_self_capture.swift
+++ b/test/SILGen/isolated_self_capture.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-silgen %s -module-name test -swift-version 5 | %FileCheck %s
+
+// REQUIRES: concurrency
+
+class NonSendableKlass {}
+
+func useValue<T>(_ t: T) {}
+
+@MainActor func transferToMain<T>(_ t: T) async {}
+
+actor MyActor {
+  var ns = NonSendableKlass()
+
+  // CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC19passSelfIntoClosureyyYaF : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> () {
+  // CHECK: bb0([[ARG:%.*]] : @guaranteed $
+  // CHECK:   [[COPY:%.*]] = copy_value [[ARG]]
+  // CHECK:   [[PAI:%.*]] = partial_apply [callee_guaranteed] {{.*}}([[COPY]]) : $@convention(thin) (@sil_isolated @guaranteed MyActor) -> ()
+  // CHECK: } // end sil function '$s4test7MyActorC19passSelfIntoClosureyyYaF'
+  func passSelfIntoClosure() async {
+    let closure = { useValue(self.ns) }
+    await transferToMain(closure) 
+  }
+}


### PR DESCRIPTION
Before I couldn't do this since, @sil_isolated was not represented on partial_applies. In the first commit in this commit series, I added support to the frontend so that we now emit partial_applies with sil_isolated parameters.

In the second commit, I use this information to restrict when the partial_apply is considered to be "actor derived" to if the partial_apply parameter is @sil_isolated.

rdar://123881277

