### PR TITLE
Remove -D_LIBCPP_DISABLE_AVAILABILITY from tests

### DIFF
--- a/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
+++ b/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
@@ -1,15 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++14 -Xcc -fmodules-cache-path=%t
 // RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++17 -Xcc -fmodules-cache-path=%t
-// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t -Xcc -D_LIBCPP_DISABLE_AVAILABILITY
+// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t
 
 // RUN: find %t | %FileCheck %s
 
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++17 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
-// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB -Xcc -D_LIBCPP_DISABLE_AVAILABILITY
-// FIXME: remove _LIBCPP_DISABLE_AVAILABILITY above (https://github.com/apple/swift/issues/67841)
+// RUN: %target-swift-frontend %s -c -enable-experimental-cxx-interop -Xcc -std=c++20 -Xcc -fmodules-cache-path=%t -DADD_CXXSTDLIB
 
 // REQUIRES: OS=macosx || OS=linux-gnu
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -18,8 +18,7 @@
 // Check that the generated header can be
 // built with Clang modules enabled in C++.
 
-// RUN: %target-interop-build-clangxx -fsyntax-only -x c++-header %t/full-cxx-swift-cxx-bridging.h -std=gnu++17 -c -fmodules -fcxx-modules -I %t -D_LIBCPP_DISABLE_AVAILABILITY
-// FIXME: remove _LIBCPP_DISABLE_AVAILABILITY above (https://github.com/apple/swift/issues/67841)
+// RUN: %target-interop-build-clangxx -fsyntax-only -x c++-header %t/full-cxx-swift-cxx-bridging.h -std=gnu++17 -c -fmodules -fcxx-modules -I %t 
 // FIXME: test c++20 (rdar://117419434)
 
 // XFAIL: OS=linux-android, OS=linux-androideabi

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-objcxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-objcxx.swift
@@ -10,5 +10,4 @@
 
 // REQUIRES: objc_interop
 
-// RUN: %target-interop-build-clangxx -fsyntax-only -x objective-c++-header %t/full-cxx-swift-cxx-bridging.h -std=gnu++20 -c -fmodules -fcxx-modules -I %t -D_LIBCPP_DISABLE_AVAILABILITY
-// FIXME: remove _LIBCPP_DISABLE_AVAILABILITY above (https://github.com/apple/swift/issues/67841)
+// RUN: %target-interop-build-clangxx -fsyntax-only -x objective-c++-header %t/full-cxx-swift-cxx-bridging.h -std=gnu++20 -c -fmodules -fcxx-modules -I %t 


### PR DESCRIPTION
<!-- What's in this pull request? -->
As I understand it from https://github.com/apple/swift/issues/67841 these flags can be dropped when using llvm-17. As of https://github.com/apple/swift/commit/7f220e0928c206ccdec8b6952331e29efb11ffee the `main` branch uses llvm-17.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #67841

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
