### PR TITLE
 Allow declarations to opt in to suppressing `@isolated(any)` instead of suppressing the entire declaration

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -481,6 +481,14 @@ BridgedAlignmentAttr_createParsed(BridgedASTContext cContext,
                                   BridgedSourceLoc cAtLoc,
                                   BridgedSourceRange cRange, size_t cValue);
 
+SWIFT_NAME("BridgedAllowFeatureSuppressionAttr.createParsed(_:atLoc:range:features:)")
+BridgedAllowFeatureSuppressionAttr
+BridgedAllowFeatureSuppressionAttr_createParsed(
+                                  BridgedASTContext cContext,
+                                  BridgedSourceLoc cAtLoc,
+                                  BridgedSourceRange cRange,
+                                  BridgedArrayRef cFeatures);
+
 SWIFT_NAME("BridgedCDeclAttr.createParsed(_:atLoc:range:name:)")
 BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,
                                                BridgedSourceLoc cAtLoc,

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -488,7 +488,10 @@ SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
 DECL_ATTR(_distributedThunkTarget, DistributedThunkTarget,
   OnAbstractFunction | UserInaccessible | ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   156)
-LAST_DECL_ATTR(DistributedThunkTarget)
+DECL_ATTR(_allowFeatureSuppression, AllowFeatureSuppression,
+  OnAnyDecl | UserInaccessible | NotSerialized | ABIStableToAdd | APIStableToAdd | ABIStableToRemove | APIStableToRemove,
+  157)
+LAST_DECL_ATTR(AllowFeatureSuppression)
 
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1889,6 +1889,10 @@ ERROR(attr_rawlayout_expected_params,none,
 
 ERROR(attr_extern_expected_label,none,
       "expected %0 argument to @_extern attribute", (StringRef))
+
+ERROR(attr_expected_feature_name,none,
+      "expected feature name in @%0 attribute", (StringRef))
+
 //------------------------------------------------------------------------------
 // MARK: Generics parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -379,7 +379,9 @@ struct PrintOptions {
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {
       DeclAttrKind::Transparent, DeclAttrKind::Effects,
-      DeclAttrKind::FixedLayout, DeclAttrKind::ShowInInterface};
+      DeclAttrKind::FixedLayout, DeclAttrKind::ShowInInterface,
+      DeclAttrKind::AllowFeatureSuppression
+  };
 
   /// List of attribute kinds that should be printed exclusively.
   /// Empty means allow all.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -376,11 +376,13 @@ struct PrintOptions {
   /// `AsyncIteratorProtocol` for backward-compatibility reasons.
   bool AsyncSequenceRethrows = false;
 
+  /// Suppress the @isolated(any) attribute.
+  bool SuppressIsolatedAny = false;
+
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {
       DeclAttrKind::Transparent, DeclAttrKind::Effects,
       DeclAttrKind::FixedLayout, DeclAttrKind::ShowInInterface,
-      DeclAttrKind::AllowFeatureSuppression
   };
 
   /// List of attribute kinds that should be printed exclusively.

--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -35,9 +35,6 @@ constexpr unsigned numFeatures() {
   return NumFeatures;
 }
 
-/// Determine whether the given feature is suppressible.
-bool isSuppressibleFeature(Feature feature);
-
 /// Check whether the given feature is available in production compilers.
 bool isFeatureAvailableInProduction(Feature feature);
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -335,7 +335,7 @@ EXPERIMENTAL_FEATURE(DynamicActorIsolation, false)
 EXPERIMENTAL_FEATURE(BorrowingSwitch, true)
 
 // Enable isolated(any) attribute on function types.
-EXPERIMENTAL_FEATURE(IsolatedAny, true)
+CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedAny, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -34,6 +34,11 @@
 // imply the existence of earlier features.  (This only needs to apply to
 // suppressible features.)
 //
+// If suppressing a feature in general is problematic, but it's okay to
+// suppress it for specific declarations, the feature can be made
+// conditionally suppressible.  Declarations opt in to suppression with
+// the @_allowFeatureSuppression attribute.
+//
 // BASELINE_LANGUAGE_FEATURE is the same as LANGUAGE_FEATURE, but is used
 // for features that can be assumed to be available in any Swift compiler that
 // will be used to process the textual interface files produced by this
@@ -44,9 +49,44 @@
 #  error define LANGUAGE_FEATURE before including Features.def
 #endif
 
+// A feature that's both suppressible and experimental.
+// Delegates to whichever the includer defines.
+#ifndef SUPPRESSIBLE_EXPERIMENTAL_FEATURE
+#  if defined(SUPPRESSIBLE_LANGUAGE_FEATURE) && \
+      defined(EXPERIMENTAL_FEATURE)
+#    error ambiguous defines when including Features.def
+#  elif defined(SUPPRESSIBLE_LANGUAGE_FEATURE)
+#    define SUPPRESSIBLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd) \
+       SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, 0, #FeatureName)
+#  else
+#    define SUPPRESSIBLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd) \
+       EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
+#  endif
+#endif
+
 #ifndef SUPPRESSIBLE_LANGUAGE_FEATURE
-#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description) \
+#  define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description) \
   LANGUAGE_FEATURE(FeatureName, SENumber, Description)
+#endif
+
+// A feature that's both conditionally-suppressible and experimental.
+// Delegates to whichever the includer defines.
+#ifndef CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE
+#  if defined(CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE) && \
+      defined(EXPERIMENTAL_FEATURE)
+#    error ambiguous defines when including Features.def
+#  elif defined(CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE)
+#    define CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd) \
+       CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, 0, #FeatureName)
+#  else
+#    define CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd) \
+       EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
+#  endif
+#endif
+
+#ifndef CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE
+#  define CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description) \
+     LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #endif
 
 #ifndef UPCOMING_FEATURE
@@ -301,5 +341,8 @@ EXPERIMENTAL_FEATURE(IsolatedAny, true)
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
 #undef BASELINE_LANGUAGE_FEATURE
+#undef CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE
+#undef CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE
+#undef SUPPRESSIBLE_EXPERIMENTAL_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE
 #undef LANGUAGE_FEATURE

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -729,28 +729,28 @@ public:
   }
 
 public:
-  InFlightDiagnostic diagnose(SourceLoc Loc, Diagnostic Diag) {
+  InFlightDiagnostic diagnose(SourceLoc Loc, DiagRef Diag) {
     if (Diags.isDiagnosticPointsToFirstBadToken(Diag.getID()) &&
         Loc == Tok.getLoc() && Tok.isAtStartOfLine())
       Loc = getEndOfPreviousLoc();
     return Diags.diagnose(Loc, Diag);
   }
 
-  InFlightDiagnostic diagnose(Token Tok, Diagnostic Diag) {
+  InFlightDiagnostic diagnose(Token Tok, DiagRef Diag) {
     return diagnose(Tok.getLoc(), Diag);
   }
 
   template<typename ...DiagArgTypes, typename ...ArgTypes>
   InFlightDiagnostic diagnose(SourceLoc Loc, Diag<DiagArgTypes...> DiagID,
                               ArgTypes &&...Args) {
-    return diagnose(Loc, Diagnostic(DiagID, std::forward<ArgTypes>(Args)...));
+    return diagnose(Loc, {DiagID, {std::forward<ArgTypes>(Args)...}});
   }
 
   template<typename ...DiagArgTypes, typename ...ArgTypes>
   InFlightDiagnostic diagnose(Token Tok, Diag<DiagArgTypes...> DiagID,
                               ArgTypes &&...Args) {
     return diagnose(Tok.getLoc(),
-                    Diagnostic(DiagID, std::forward<ArgTypes>(Args)...));
+                    {DiagID, {std::forward<ArgTypes>(Args)...}});
   }
     
   /// Add a fix-it to remove the space in consecutive identifiers.
@@ -809,19 +809,19 @@ public:
   /// its name in \p Result.  Otherwise, emit an error.
   ///
   /// \returns false on success, true on error.
-  bool parseIdentifier(Identifier &Result, SourceLoc &Loc, const Diagnostic &D,
+  bool parseIdentifier(Identifier &Result, SourceLoc &Loc, DiagRef D,
                        bool diagnoseDollarPrefix);
 
   /// Consume an identifier with a specific expected name.  This is useful for
   /// contextually sensitive keywords that must always be present.
   bool parseSpecificIdentifier(StringRef expected, SourceLoc &Loc,
-                               const Diagnostic &D);
+                               DiagRef D);
 
   template<typename ...DiagArgTypes, typename ...ArgTypes>
   bool parseIdentifier(Identifier &Result, SourceLoc &L,
                        bool diagnoseDollarPrefix, Diag<DiagArgTypes...> ID,
                        ArgTypes... Args) {
-    return parseIdentifier(Result, L, Diagnostic(ID, Args...),
+    return parseIdentifier(Result, L, {ID, {Args...}},
                            diagnoseDollarPrefix);
   }
   
@@ -829,19 +829,19 @@ public:
   bool parseSpecificIdentifier(StringRef expected,
                                Diag<DiagArgTypes...> ID, ArgTypes... Args) {
     SourceLoc L;
-    return parseSpecificIdentifier(expected, L, Diagnostic(ID, Args...));
+    return parseSpecificIdentifier(expected, L, {ID, {Args...}});
   }
 
   /// Consume an identifier or operator if present and return its name
   /// in \p Result.  Otherwise, emit an error and return true.
   bool parseAnyIdentifier(Identifier &Result, SourceLoc &Loc,
-                          const Diagnostic &D, bool diagnoseDollarPrefix);
+                          DiagRef D, bool diagnoseDollarPrefix);
 
   template<typename ...DiagArgTypes, typename ...ArgTypes>
   bool parseAnyIdentifier(Identifier &Result, bool diagnoseDollarPrefix,
                           Diag<DiagArgTypes...> ID, ArgTypes... Args) {
     SourceLoc L;
-    return parseAnyIdentifier(Result, L, Diagnostic(ID, Args...),
+    return parseAnyIdentifier(Result, L, {ID, {Args...}},
                               diagnoseDollarPrefix);
   }
 
@@ -849,28 +849,28 @@ public:
   /// emit the specified error diagnostic, and a note at the specified note
   /// location.
   bool parseUnsignedInteger(unsigned &Result, SourceLoc &Loc,
-                            const Diagnostic &D);
+                            DiagRef D);
 
   /// The parser expects that \p K is next token in the input.  If so,
   /// it is consumed and false is returned.
   ///
   /// If the input is malformed, this emits the specified error diagnostic.
-  bool parseToken(tok K, SourceLoc &TokLoc, const Diagnostic &D);
+  bool parseToken(tok K, SourceLoc &TokLoc, DiagRef D);
   
   template<typename ...DiagArgTypes, typename ...ArgTypes>
   bool parseToken(tok K, Diag<DiagArgTypes...> ID, ArgTypes... Args) {
     SourceLoc L;
-    return parseToken(K, L, Diagnostic(ID, Args...));
+    return parseToken(K, L, {ID, {Args...}});
   }
   template<typename ...DiagArgTypes, typename ...ArgTypes>
   bool parseToken(tok K, SourceLoc &L,
                   Diag<DiagArgTypes...> ID, ArgTypes... Args) {
-    return parseToken(K, L, Diagnostic(ID, Args...));
+    return parseToken(K, L, {ID, {Args...}});
   }
   
   /// Parse the specified expected token and return its location on success.  On failure, emit the specified
   /// error diagnostic,  a note at the specified note location, and return the location of the previous token.
-  bool parseMatchingToken(tok K, SourceLoc &TokLoc, Diagnostic ErrorDiag,
+  bool parseMatchingToken(tok K, SourceLoc &TokLoc, DiagRef ErrorDiag,
                           SourceLoc OtherLoc);
 
   /// Returns the proper location for a missing right brace, parenthesis, etc.
@@ -903,7 +903,7 @@ public:
 
   /// Parse a comma separated list of some elements.
   ParserStatus parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
-                         bool AllowSepAfterLast, Diag<> ErrorDiag,
+                         bool AllowSepAfterLast, DiagRef RightErrorDiag,
                          llvm::function_ref<ParserStatus()> callback);
 
   void consumeTopLevelDecl(ParserPosition BeginParserPosition,
@@ -1184,7 +1184,7 @@ public:
   /// Parse a version tuple of the form x[.y[.z]]. Returns true if there was
   /// an error parsing.
   bool parseVersionTuple(llvm::VersionTuple &Version, SourceRange &Range,
-                         const Diagnostic &D);
+                         DiagRef D);
 
   bool isParameterSpecifier() {
     if (Tok.is(tok::kw_inout)) return true;
@@ -1832,7 +1832,7 @@ public:
   ///   unqualified-decl-name:
   ///     unqualified-decl-base-name
   ///     unqualified-decl-base-name '(' ((identifier | '_') ':') + ')'
-  DeclNameRef parseDeclNameRef(DeclNameLoc &loc, const Diagnostic &diag,
+  DeclNameRef parseDeclNameRef(DeclNameLoc &loc, DiagRef diag,
                                DeclNameOptions flags);
 
   /// Parse macro expansion.
@@ -1843,7 +1843,7 @@ public:
       SourceLoc &poundLoc, DeclNameLoc &macroNameLoc, DeclNameRef &macroNameRef,
       SourceLoc &leftAngleLoc, SmallVectorImpl<TypeRepr *> &genericArgs,
       SourceLoc &rightAngleLoc, ArgumentList *&argList, bool isExprBasic,
-      const Diagnostic &diag);
+      DiagRef diag);
 
   ParserResult<Expr> parseExprIdentifier(bool allowKeyword);
   Expr *parseExprEditorPlaceholder(Token PlaceholderTok,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1072,6 +1072,14 @@ public:
                          SmallVector<SourceLoc, 4> &NameLocs,
                          bool &IsNullarySelector);
 
+  /// Parse a parenthesized and comma-separated list of attribute arguments.
+  ///
+  /// \returns false on success, true on error.
+  ParserStatus
+  parseAttributeArguments(SourceLoc attrLoc, StringRef attrName,
+                          bool isAttrModifier, SourceRange &parensRange,
+                          llvm::function_ref<ParserStatus()> parseAttr);
+
   /// Parse the @_specialize attribute.
   /// \p closingBrace is the expected closing brace, which can be either ) or ]
   /// \p Attr is where to store the parsed attribute
@@ -1150,6 +1158,9 @@ public:
   bool
   parseDocumentationAttributeArgument(std::optional<StringRef> &Metadata,
                                       std::optional<AccessLevel> &Visibility);
+
+  ParserResult<AllowFeatureSuppressionAttr>
+  parseAllowFeatureSuppressionAttribute(SourceLoc atLoc, SourceLoc loc);
 
   /// Parse the @attached or @freestanding attribute that specifies a macro
   /// role.

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -429,6 +429,18 @@ BridgedAlignmentAttr_createParsed(BridgedASTContext cContext,
       cValue, cAtLoc.unbridged(), cRange.unbridged(), /*Implicit=*/false);
 }
 
+BridgedAllowFeatureSuppressionAttr
+BridgedAllowFeatureSuppressionAttr_createParsed(BridgedASTContext cContext,
+                                                BridgedSourceLoc cAtLoc,
+                                                BridgedSourceRange cRange,
+                                                BridgedArrayRef cFeatures) {
+  SmallVector<Identifier> features;
+  for (auto elem : cFeatures.unbridged<BridgedIdentifier>())
+    features.push_back(elem.unbridged());
+  return AllowFeatureSuppressionAttr::create(cContext.unbridged(),
+      cAtLoc.unbridged(), cRange.unbridged(), /*implicit*/ false, features);
+}
+
 BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,
                                                BridgedSourceLoc cAtLoc,
                                                BridgedSourceRange cRange,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3112,6 +3112,8 @@ static void suppressingFeature(PrintOptions &options, Feature feature,
   case Feature::FeatureName:                                                   \
     suppressingFeature##FeatureName(options, action);                          \
     return;
+#define CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description)      \
+  SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description)
 #include "swift/Basic/Features.def"
   }
   llvm_unreachable("exhaustive switch");

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1918,6 +1918,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_rawLayout";
   case DeclAttrKind::Extern:
     return "_extern";
+  case DeclAttrKind::AllowFeatureSuppression:
+    return "_allowFeatureSuppression";
   }
   llvm_unreachable("bad DeclAttrKind");
 }
@@ -2899,6 +2901,26 @@ StorageRestrictionsAttr::getAccessesProperties(AccessorDecl *attachedTo) const {
                                const_cast<StorageRestrictionsAttr *>(this),
                                attachedTo, getAccessesNames()},
                            {});
+}
+
+AllowFeatureSuppressionAttr::AllowFeatureSuppressionAttr(SourceLoc atLoc,
+                                                         SourceRange range,
+                                                         bool implicit,
+                                              ArrayRef<Identifier> features)
+    : DeclAttribute(DeclAttrKind::AllowFeatureSuppression,
+                    atLoc, range, implicit) {
+  Bits.AllowFeatureSuppressionAttr.NumFeatures = features.size();
+  std::uninitialized_copy(features.begin(), features.end(),
+                          getTrailingObjects<Identifier>());
+}
+
+AllowFeatureSuppressionAttr *
+AllowFeatureSuppressionAttr::create(ASTContext &ctx, SourceLoc atLoc,
+                                    SourceRange range, bool implicit,
+                                    ArrayRef<Identifier> features) {
+  unsigned size = totalSizeToAlloc<Identifier>(features.size());
+  auto *mem = ctx.Allocate(size, alignof(AllowFeatureSuppressionAttr));
+  return new (mem) AllowFeatureSuppressionAttr(atLoc, range, implicit, features);
 }
 
 void swift::simple_display(llvm::raw_ostream &out, const DeclAttribute *attr) {

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -254,6 +254,13 @@ const char *IsolatedTypeAttr::getIsolationKindName(IsolationKind kind) {
 
 void IsolatedTypeAttr::printImpl(ASTPrinter &printer,
                                  const PrintOptions &options) const {
+  // Suppress the attribute if requested.
+  switch (getIsolationKind()) {
+  case IsolationKind::Dynamic:
+    if (options.SuppressIsolatedAny) return;
+    break;
+  }
+
   printer.callPrintStructurePre(PrintStructureKind::BuiltinAttribute);
   printer.printAttrName("@isolated");
   printer << "(" << getIsolationKindName() << ")";
@@ -1252,6 +1259,15 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   case DeclAttrKind::Alignment:
     Printer.printAttrName("@_alignment");
     Printer << "(" << cast<AlignmentAttr>(this)->getValue() << ")";
+    break;
+
+  case DeclAttrKind::AllowFeatureSuppression:
+    Printer.printAttrName("@_allowFeatureSuppression");
+    Printer << "(";
+    interleave(cast<AllowFeatureSuppressionAttr>(this)->getSuppressedFeatures(),
+               [&](Identifier ident) { Printer << ident; },
+               [&] { Printer << ", "; });
+    Printer << ")";
     break;
 
   case DeclAttrKind::SILGenName:

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -677,15 +677,25 @@ static bool usesFeatureIsolatedAny(Decl *decl) {
 
 void FeatureSet::collectRequiredFeature(Feature feature,
                                         InsertOrRemove operation) {
-  assert(!isSuppressibleFeature(feature));
   required.insertOrRemove(feature, operation == Insert);
 }
 
 void FeatureSet::collectSuppressibleFeature(Feature feature,
                                             InsertOrRemove operation) {
-  assert(isSuppressibleFeature(feature));
   suppressible.insertOrRemove(numFeatures() - size_t(feature),
                               operation == Insert);
+}
+
+static bool shouldSuppressFeature(StringRef featureName, Decl *decl) {
+  auto attr = decl->getAttrs().getAttribute<AllowFeatureSuppressionAttr>();
+  if (!attr) return false;
+
+  for (auto suppressedFeature : attr->getSuppressedFeatures()) {
+    if (suppressedFeature.is(featureName))
+      return true;
+  }
+
+  return false;
 }
 
 /// Go through all the features used by the given declaration and
@@ -699,6 +709,13 @@ void FeatureSet::collectFeaturesUsed(Decl *decl, InsertOrRemove operation) {
 #define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description)      \
   if (usesFeature##FeatureName(decl))                                          \
     collectSuppressibleFeature(Feature::FeatureName, operation);
+#define CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description)      \
+  if (usesFeature##FeatureName(decl)) {                                        \
+    if (shouldSuppressFeature(#FeatureName, decl))                             \
+      collectSuppressibleFeature(Feature::FeatureName, operation);             \
+    else                                                                       \
+      collectRequiredFeature(Feature::FeatureName, operation);                 \
+  }
 #include "swift/Basic/Features.def"
 }
 

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -598,19 +598,6 @@ llvm::StringRef swift::getFeatureName(Feature feature) {
   llvm_unreachable("covered switch");
 }
 
-bool swift::isSuppressibleFeature(Feature feature) {
-  switch (feature) {
-#define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \
-  case Feature::FeatureName:                                                   \
-    return false;
-#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description)      \
-  case Feature::FeatureName:                                                   \
-    return true;
-#include "swift/Basic/Features.def"
-  }
-  llvm_unreachable("covered switch");
-}
-
 bool swift::isFeatureAvailableInProduction(Feature feature) {
   switch (feature) {
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description)                   \

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -629,7 +629,7 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
       bool VerArgWasEmpty = VerArg.empty();
       if (parseVersionTuple(
               VerArg.Version, VerArg.Range,
-              Diagnostic(diag::attr_availability_expected_version, AttrName))) {
+              {diag::attr_availability_expected_version, {AttrName}})) {
         AnyArgumentInvalid = true;
         if (peekToken().isAny(tok::r_paren, tok::comma))
           consumeToken();
@@ -2251,7 +2251,7 @@ ParserStatus Parser::parsePlatformVersionInList(StringRef AttrName,
   llvm::VersionTuple VerTuple;
   SourceRange VersionRange;
   if (parseVersionTuple(VerTuple, VersionRange,
-      Diagnostic(diag::attr_availability_expected_version, AttrName))) {
+        {diag::attr_availability_expected_version, {AttrName}})) {
     return makeParserError();
   }
 
@@ -2745,7 +2745,7 @@ Parser::parseMacroRoleAttribute(
 ///          omitted; the identifier written by the user otherwise.
 static std::optional<Identifier> parseSingleAttrOptionImpl(
     Parser &P, SourceLoc Loc, SourceRange &AttrRange, StringRef AttrName,
-    DeclAttrKind DK, bool allowOmitted, Diagnostic nonIdentifierDiagnostic) {
+    DeclAttrKind DK, bool allowOmitted, DiagRef nonIdentifierDiagnostic) {
   SWIFT_DEFER {
     AttrRange = SourceRange(Loc, P.PreviousLoc);
   };
@@ -2793,7 +2793,7 @@ parseSingleAttrOptionIdentifier(Parser &P, SourceLoc Loc,
                                 DeclAttrKind DK, bool allowOmitted = false) {
   return parseSingleAttrOptionImpl(
              P, Loc, AttrRange, AttrName, DK, allowOmitted,
-             { diag::attr_expected_option_identifier, AttrName });
+             {diag::attr_expected_option_identifier, {AttrName}});
 }
 
 /// Parses a (possibly optional) argument for an attribute containing a single identifier from a known set of
@@ -2819,8 +2819,8 @@ parseSingleAttrOption(Parser &P, SourceLoc Loc, SourceRange &AttrRange,
   auto parsedIdentifier = parseSingleAttrOptionImpl(
              P, Loc, AttrRange,AttrName, DK,
              /*allowOmitted=*/valueIfOmitted.has_value(),
-             Diagnostic(diag::attr_expected_option_such_as, AttrName,
-                        options.front().first.str()));
+             {diag::attr_expected_option_such_as,
+              {AttrName, options.front().first.str()}});
   if (!parsedIdentifier)
     return std::nullopt;
 
@@ -4043,7 +4043,7 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
 
 bool Parser::parseVersionTuple(llvm::VersionTuple &Version,
                                SourceRange &Range,
-                               const Diagnostic &D) {
+                               DiagRef D) {
   // A version number is either an integer (8), a float (8.1), or a
   // float followed by a dot and an integer (8.1.0).
   if (!Tok.isAny(tok::integer_literal, tok::floating_literal)) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2275,7 +2275,7 @@ static bool tryParseArgLabelList(Parser &P, Parser::DeclNameOptions flags,
 }
 
 DeclNameRef Parser::parseDeclNameRef(DeclNameLoc &loc,
-                                     const Diagnostic &diag,
+                                     DiagRef diag,
                                      DeclNameOptions flags) {
   // Consume the base name.
   DeclBaseName baseName;
@@ -2338,7 +2338,7 @@ ParserStatus Parser::parseFreestandingMacroExpansion(
     SourceLoc &poundLoc, DeclNameLoc &macroNameLoc, DeclNameRef &macroNameRef,
     SourceLoc &leftAngleLoc, SmallVectorImpl<TypeRepr *> &genericArgs,
     SourceLoc &rightAngleLoc, ArgumentList *&argList, bool isExprBasic,
-    const Diagnostic &diag) {
+    DiagRef diag) {
   SourceLoc poundEndLoc = Tok.getRange().getEnd();
   poundLoc = consumeToken(tok::pound);
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -868,7 +868,7 @@ Parser::StructureMarkerRAII::StructureMarkerRAII(Parser &parser,
 //===----------------------------------------------------------------------===//
 
 bool Parser::parseIdentifier(Identifier &Result, SourceLoc &Loc,
-                             const Diagnostic &D, bool diagnoseDollarPrefix) {
+                             DiagRef D, bool diagnoseDollarPrefix) {
   switch (Tok.getKind()) {
   case tok::kw_self:
   case tok::kw_Self:
@@ -883,7 +883,7 @@ bool Parser::parseIdentifier(Identifier &Result, SourceLoc &Loc,
 }
 
 bool Parser::parseSpecificIdentifier(StringRef expected, SourceLoc &loc,
-                                     const Diagnostic &D) {
+                                     DiagRef D) {
   if (Tok.getText() != expected) {
     diagnose(Tok, D);
     return true;
@@ -895,8 +895,7 @@ bool Parser::parseSpecificIdentifier(StringRef expected, SourceLoc &loc,
 /// parseAnyIdentifier - Consume an identifier or operator if present and return
 /// its name in Result.  Otherwise, emit an error and return true.
 bool Parser::parseAnyIdentifier(Identifier &Result, SourceLoc &Loc,
-                                const Diagnostic &D,
-                                bool diagnoseDollarPrefix) {
+                                DiagRef D, bool diagnoseDollarPrefix) {
   if (Tok.is(tok::identifier)) {
     Loc = consumeIdentifier(Result, diagnoseDollarPrefix);
     return false;
@@ -935,7 +934,7 @@ bool Parser::parseAnyIdentifier(Identifier &Result, SourceLoc &Loc,
 /// consumed and false is returned.
 ///
 /// If the input is malformed, this emits the specified error diagnostic.
-bool Parser::parseToken(tok K, SourceLoc &TokLoc, const Diagnostic &D) {
+bool Parser::parseToken(tok K, SourceLoc &TokLoc, DiagRef D) {
   if (Tok.is(K)) {
     TokLoc = consumeToken(K);
     return false;
@@ -946,7 +945,7 @@ bool Parser::parseToken(tok K, SourceLoc &TokLoc, const Diagnostic &D) {
   return true;
 }
 
-bool Parser::parseMatchingToken(tok K, SourceLoc &TokLoc, Diagnostic ErrorDiag,
+bool Parser::parseMatchingToken(tok K, SourceLoc &TokLoc, DiagRef ErrorDiag,
                                 SourceLoc OtherLoc) {
   Diag<> OtherNote;
   switch (K) {
@@ -966,7 +965,7 @@ bool Parser::parseMatchingToken(tok K, SourceLoc &TokLoc, Diagnostic ErrorDiag,
 }
 
 bool Parser::parseUnsignedInteger(unsigned &Result, SourceLoc &Loc,
-                                  const Diagnostic &D) {
+                                  DiagRef D) {
   auto IntTok = Tok;
   if (parseToken(tok::integer_literal, Loc, D))
     return true;
@@ -1058,7 +1057,7 @@ Parser::parseListItem(ParserStatus &Status, tok RightK, SourceLoc LeftLoc,
 
 ParserStatus
 Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
-                  bool AllowSepAfterLast, Diag<> ErrorDiag,
+                  bool AllowSepAfterLast, DiagRef ErrorDiag,
                   llvm::function_ref<ParserStatus()> callback) {
   if (Tok.is(RightK)) {
     RightLoc = consumeToken(RightK);

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -138,7 +138,7 @@ ParseSILModuleRequest::evaluate(Evaluator &evaluator,
 //===----------------------------------------------------------------------===//
 
 bool SILParser::parseSILIdentifier(Identifier &Result, SourceLoc &Loc,
-                                   const Diagnostic &D) {
+                                   DiagRef D) {
   switch (P.Tok.getKind()) {
   case tok::identifier:
   case tok::dollarident:
@@ -602,7 +602,7 @@ bool SILParser::parseSILQualifier(
   }
   result = parseName(Str);
   if (!result) {
-    P.diagnose(loc, Diagnostic(diag::unrecognized_sil_qualifier));
+    P.diagnose(loc, diag::unrecognized_sil_qualifier);
     return true;
   }
   return false;
@@ -2051,7 +2051,7 @@ parseAssignOrInitAssignments(llvm::SmallVectorImpl<unsigned> &assignments,
 // Returns true on error.
 static bool parseIndexList(Parser &P, StringRef label,
                            SmallVectorImpl<unsigned> &indices,
-                           const Diagnostic &parseIndexDiag) {
+                           DiagRef parseIndexDiag) {
   SourceLoc loc;
   // Parse `[<label> <integer_literal>...]`.
   if (P.parseToken(tok::l_square, diag::sil_autodiff_expected_lsquare,
@@ -7761,7 +7761,7 @@ parseRootProtocolConformance(Parser &P, SILParser &SP, Type ConformingTy,
 
   if (P.parseSpecificIdentifier(
           ModuleKeyword, KeywordLoc,
-          Diagnostic(diag::expected_tok_in_sil_instr, ModuleKeyword)) ||
+          {diag::expected_tok_in_sil_instr, {ModuleKeyword}}) ||
       SP.parseSILIdentifier(ModuleName, Loc, diag::expected_sil_value_name))
     return ProtocolConformanceRef();
 

--- a/lib/SIL/Parser/SILParser.h
+++ b/lib/SIL/Parser/SILParser.h
@@ -141,14 +141,13 @@ public:
   /// \verbatim
   ///   sil-identifier ::= [A-Za-z_0-9]+
   /// \endverbatim
-  bool parseSILIdentifier(Identifier &Result, SourceLoc &Loc,
-                          const Diagnostic &D);
+  bool parseSILIdentifier(Identifier &Result, SourceLoc &Loc, DiagRef D);
 
   template <typename... DiagArgTypes, typename... ArgTypes>
   bool parseSILIdentifier(Identifier &Result, Diag<DiagArgTypes...> ID,
                           ArgTypes... Args) {
     SourceLoc L;
-    return parseSILIdentifier(Result, L, Diagnostic(ID, Args...));
+    return parseSILIdentifier(Result, L, {ID, {Args...}});
   }
 
   template <typename T, typename... DiagArgTypes, typename... ArgTypes>
@@ -156,13 +155,13 @@ public:
                                 Diag<DiagArgTypes...> ID, ArgTypes... Args) {
     Identifier TmpResult;
     SourceLoc L;
-    if (parseSILIdentifier(TmpResult, L, Diagnostic(ID, Args...))) {
+    if (parseSILIdentifier(TmpResult, L, {ID, {Args...}})) {
       return true;
     }
 
     auto Iter = std::find(Strings.begin(), Strings.end(), TmpResult.str());
     if (Iter == Strings.end()) {
-      P.diagnose(P.Tok, Diagnostic(ID, Args...));
+      P.diagnose(P.Tok, ID, Args...);
       return true;
     }
 
@@ -173,7 +172,7 @@ public:
   template <typename... DiagArgTypes, typename... ArgTypes>
   bool parseSILIdentifier(Identifier &Result, SourceLoc &L,
                           Diag<DiagArgTypes...> ID, ArgTypes... Args) {
-    return parseSILIdentifier(Result, L, Diagnostic(ID, Args...));
+    return parseSILIdentifier(Result, L, {ID, {Args...}});
   }
 
   template <typename T>
@@ -184,7 +183,7 @@ public:
   bool parseVerbatim(StringRef identifier);
 
   template <typename T>
-  bool parseInteger(T &Result, const Diagnostic &D) {
+  bool parseInteger(T &Result, DiagRef D) {
     if (!P.Tok.is(tok::integer_literal)) {
       P.diagnose(P.Tok, D);
       return true;

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -165,6 +165,7 @@ public:
   IGNORED_ATTR(Documentation)
   IGNORED_ATTR(LexicalLifetimes)
   IGNORED_ATTR(DistributedThunkTarget)
+  IGNORED_ATTR(AllowFeatureSuppression)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1559,6 +1559,7 @@ namespace  {
     UNINTERESTING_ATTR(PrivateImport)
     UNINTERESTING_ATTR(MainType)
     UNINTERESTING_ATTR(Preconcurrency)
+    UNINTERESTING_ATTR(AllowFeatureSuppression)
 
     // Differentiation-related attributes.
     UNINTERESTING_ATTR(Differentiable)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6006,6 +6006,22 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
+      case decls_block::AllowFeatureSuppression_DECL_ATTR: {
+        bool isImplicit;
+        ArrayRef<uint64_t> featureIds;
+        serialization::decls_block::AllowFeatureSuppressionDeclAttrLayout
+                     ::readRecord(scratch, isImplicit, featureIds);
+
+        SmallVector<Identifier, 4> features;
+        for (auto id : featureIds)
+          features.push_back(MF.getIdentifier(id));
+
+        Attr = AllowFeatureSuppressionAttr::create(ctx, SourceLoc(),
+                                                   SourceRange(), isImplicit,
+                                                   features);
+        break;
+      }
+
       case decls_block::UnavailableFromAsync_DECL_ATTR: {
         bool isImplicit;
         serialization::decls_block::UnavailableFromAsyncDeclAttrLayout::

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 859; // channel check
+const uint16_t SWIFTMODULE_VERSION_MINOR = 860; // AllowFeatureSuppressionAttr
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -2133,6 +2133,12 @@ namespace decls_block {
     BCVBR<5>,     // 0 for a simple name, otherwise the number of parameter name
                   // components plus one
     BCArray<IdentifierIDField> // name components
+  >;
+
+  using AllowFeatureSuppressionDeclAttrLayout = BCRecordLayout<
+    AllowFeatureSuppression_DECL_ATTR,
+    BCFixed<1>,   // implicit flag
+    BCArray<IdentifierIDField>  // feature names
   >;
 
   using SPIAccessControlDeclAttrLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2752,6 +2752,20 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DeclAttrKind::AllowFeatureSuppression: {
+      auto *theAttr = cast<AllowFeatureSuppressionAttr>(DA);
+      auto abbrCode =
+        S.DeclTypeAbbrCodes[AllowFeatureSuppressionDeclAttrLayout::Code];
+
+      SmallVector<IdentifierID> ids;
+      for (auto id : theAttr->getSuppressedFeatures())
+        ids.push_back(S.addUniquedStringRef(id.str()));
+
+      AllowFeatureSuppressionDeclAttrLayout::emitRecord(
+          S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(), ids);
+      return;
+    }
+
     case DeclAttrKind::SPIAccessControl: {
       auto theAttr = cast<SPIAccessControlAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[SPIAccessControlDeclAttrLayout::Code];

--- a/test/ModuleInterface/isolated_any_suppression.swift
+++ b/test/ModuleInterface/isolated_any_suppression.swift
@@ -1,0 +1,22 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -module-name isolated_any -emit-module -o %t/isolated_any.swiftmodule -emit-module-interface-path -  -enable-experimental-feature IsolatedAny %s | %FileCheck %s
+
+// CHECK:      #if compiler(>=5.3) && $IsolatedAny
+// CHECK-NEXT: {{^}}public func test1(fn: @isolated(any) () -> ())
+// CHECK-NEXT: #endif
+public func test1(fn: @isolated(any) () -> ()) {}
+
+// CHECK-NEXT: #if compiler(>=5.3) && $IsolatedAny
+// CHECK-NEXT: {{^}}public func test2(fn: @isolated(any) () -> ())
+// CHECK-NEXT: #endif
+@_allowFeatureSuppression(XXX)
+public func test2(fn: @isolated(any) () -> ()) {}
+
+// CHECK-NEXT: #if compiler(>=5.3) && $IsolatedAny
+// CHECK-NEXT: {{^}}public func test3(fn: @isolated(any) () -> ())
+// CHECK-NEXT: #else
+// CHECK-NEXT: {{^}}public func test3(fn: () -> ())
+// CHECK-NEXT: #endif
+@_allowFeatureSuppression(IsolatedAny)
+public func test3(fn: @isolated(any) () -> ()) {}


### PR DESCRIPTION
This PR also includes a significant NFC improvement to how we use suspended diagnostics in the parser.