### PR TITLE
CI: Include stdlib build for Wasm in the Linux buildbot

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -836,6 +836,9 @@ build-swift-static-stdlib
 build-swift-static-sdk-overlay
 build-swift-stdlib-unittest-extra
 
+wasmkit
+build-wasm-stdlib
+
 # Executes the lit tests for the installable package that is created
 # Assumes the swift-integration-tests repo is checked out
 


### PR DESCRIPTION
This makes the WebAssembly stdlib build mandatory as part of PR testing.


