### PR TITLE
test: Repair isolated_any_metadata.sil for Wasm CI

### DIFF
--- a/test/IRGen/isolated_any_metadata.sil
+++ b/test/IRGen/isolated_any_metadata.sil
@@ -1,5 +1,5 @@
-// RUN: %swift -emit-ir %s -enable-experimental-feature IsolatedAny -target x86_64-apple-macosx10.10 -disable-legacy-type-info -parse-stdlib | %IRGenFileCheck %s -check-prefix=CHECK-ACCESSOR
-// RUN: %swift -emit-ir %s -enable-experimental-feature IsolatedAny -target x86_64-unknown-linux-gnu -disable-legacy-type-info -parse-stdlib | %IRGenFileCheck %s -check-prefix=CHECK-DEMANGLE
+// RUN: %swift -emit-ir %s -enable-experimental-feature IsolatedAny -target x86_64-apple-macosx10.10 -disable-legacy-type-info -parse-stdlib | %FileCheck -DINT=i64 %s -check-prefixes=CHECK,CHECK-ACCESSOR
+// RUN: %swift -emit-ir %s -enable-experimental-feature IsolatedAny -target x86_64-unknown-linux-gnu -disable-legacy-type-info -parse-stdlib | %FileCheck -DINT=i64 %s -check-prefixes=CHECK,CHECK-DEMANGLE
 
 // REQUIRES: concurrency
 


### PR DESCRIPTION
The test was failing on the Wasm CI because `%IRGenFileCheck` is configured for the target platform (in this case wasm32-unknown-wasi), but the test used it to check the output for other platforms. The mismatch was not revealed on the other CI because they are all 64-bit, but the 32-bit Wasm CI revealed it. https://ci.swift.org/job/oss-swift-pr-test-crosscompile-wasm-ubuntu-20_04/66/

Adjust a test case added by https://github.com/apple/swift/pull/71970 to repair Wasm CI