### PR TITLE
Move diagnostic about `@_weakLinked` not working for COFF into the type checker

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2873,14 +2873,6 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     DiscardAttribute = true;
   }
 
-  if (Context.LangOpts.Target.isOSBinFormatCOFF()) {
-    if (DK == DeclAttrKind::WeakLinked) {
-      diagnose(Loc, diag::attr_unsupported_on_target, AttrName,
-               Context.LangOpts.Target.str());
-      DiscardAttribute = true;
-    }
-  }
-
   if (DK == DeclAttrKind::ResultDependsOnSelf &&
       !Context.LangOpts.hasFeature(Feature::NonescapableTypes)) {
     diagnose(Loc, diag::requires_experimental_feature, AttrName, true,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7343,10 +7343,11 @@ void AttributeChecker::visitStaticExclusiveOnlyAttr(
 }
 
 void AttributeChecker::visitWeakLinkedAttr(WeakLinkedAttr *attr) {
-  if (Ctx.LangOpts.Target.isOSBinFormatCOFF()) {
-    diagnoseAndRemoveAttr(attr, diag::attr_unsupported_on_target,
-                          attr->getAttrName(), Ctx.LangOpts.Target.str());
-  }
+  if (!Ctx.LangOpts.Target.isOSBinFormatCOFF())
+    return;
+
+  diagnoseAndRemoveAttr(attr, diag::attr_unsupported_on_target,
+                        attr->getAttrName(), Ctx.LangOpts.Target.str());
 }
 
 namespace {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -147,7 +147,6 @@ public:
   IGNORED_ATTR(StaticInitializeObjCMetadata)
   IGNORED_ATTR(SynthesizedProtocol)
   IGNORED_ATTR(Testable)
-  IGNORED_ATTR(WeakLinked)
   IGNORED_ATTR(PrivateImport)
   IGNORED_ATTR(DisfavoredOverload)
   IGNORED_ATTR(ProjectedValueProperty)
@@ -368,6 +367,7 @@ public:
   void visitUnsafeNonEscapableResultAttr(UnsafeNonEscapableResultAttr *attr);
 
   void visitStaticExclusiveOnlyAttr(StaticExclusiveOnlyAttr *attr);
+  void visitWeakLinkedAttr(WeakLinkedAttr *attr);
 };
 
 } // end anonymous namespace
@@ -7339,6 +7339,13 @@ void AttributeChecker::visitStaticExclusiveOnlyAttr(
 
   if (structDecl->canBeCopyable() != TypeDecl::CanBeInvertible::Never) {
     diagnoseAndRemoveAttr(attr, diag::attr_static_exclusive_only_noncopyable);
+  }
+}
+
+void AttributeChecker::visitWeakLinkedAttr(WeakLinkedAttr *attr) {
+  if (Ctx.LangOpts.Target.isOSBinFormatCOFF()) {
+    diagnoseAndRemoveAttr(attr, diag::attr_unsupported_on_target,
+                          attr->getAttrName(), Ctx.LangOpts.Target.str());
   }
 }
 

--- a/test/attr/attr_weaklinked.swift
+++ b/test/attr/attr_weaklinked.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift
+
+#if !os(Windows)
+@_weakLinked public func f() { }
+#endif
+


### PR DESCRIPTION
This allows us to use `@_weakLinked` inside of a `#if` properly.
