### PR TITLE
Update canTriviallyDeleteOSSAEndScopeInst and a related assertion

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -128,6 +128,8 @@ bool isInstructionTriviallyDeletable(SILInstruction *inst);
 /// This routine only examines the state of the instruction at hand.
 bool isInstructionTriviallyDead(SILInstruction *inst);
 
+bool canTriviallyDeleteOSSAEndScopeInst(SILInstruction *inst);
+
 /// Return true if this is a release instruction that's not going to
 /// free the object.
 bool isIntermediateRelease(SILInstruction *inst, EpilogueARCFunctionInfo *erfi);

--- a/lib/SILOptimizer/Utils/InstructionDeleter.cpp
+++ b/lib/SILOptimizer/Utils/InstructionDeleter.cpp
@@ -180,7 +180,9 @@ bool InstructionDeleter::trackIfDead(SILInstruction *inst) {
   bool fixLifetime = inst->getFunction()->hasOwnership();
   if (isInstructionTriviallyDead(inst)
       || isScopeAffectingInstructionDead(inst, fixLifetime)) {
-    assert(!isIncidentalUse(inst) && !isa<DestroyValueInst>(inst) &&
+    assert(!isIncidentalUse(inst) &&
+           (!isa<DestroyValueInst>(inst) ||
+            canTriviallyDeleteOSSAEndScopeInst(inst)) &&
            "Incidental uses cannot be removed in isolation. "
            "They would be removed iff the operand is dead");
     getCallbacks().notifyWillBeDeleted(inst);

--- a/test/SILOptimizer/simplify_cfg_ossa_jump_threading.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_jump_threading.sil
@@ -275,3 +275,46 @@ bb6:
   %t = tuple ()
   return %t : $()
 }
+
+sil @_swift_stdlib_isNSString : $@convention(c) (AnyObject) -> UInt8
+
+// Ensure no crash in compiler
+sil hidden [ossa] @test_clone_destroy_none : $@convention(thin) (@guaranteed AnyObject) -> Bool {
+bb0(%0 : @guaranteed $AnyObject):
+  %3 = enum $Optional<(utf16Length: Int, asciiContentsPointer: UnsafePointer<UInt8>, untaggedCocoa: AnyObject)>, #Optional.none!enumelt
+  %4 = begin_borrow %3 : $Optional<(utf16Length: Int, asciiContentsPointer: UnsafePointer<UInt8>, untaggedCocoa: AnyObject)>
+  switch_enum %4 : $Optional<(utf16Length: Int, asciiContentsPointer: UnsafePointer<UInt8>, untaggedCocoa: AnyObject)>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1(%6 : @guaranteed $(utf16Length: Int, asciiContentsPointer: UnsafePointer<UInt8>, untaggedCocoa: AnyObject)):
+  end_borrow %4 : $Optional<(utf16Length: Int, asciiContentsPointer: UnsafePointer<UInt8>, untaggedCocoa: AnyObject)>
+  %8 = integer_literal $Builtin.Int1, -1
+  br bb3(%8 : $Builtin.Int1)
+
+bb2:
+  end_borrow %4 : $Optional<(utf16Length: Int, asciiContentsPointer: UnsafePointer<UInt8>, untaggedCocoa: AnyObject)>
+  %11 = integer_literal $Builtin.Int1, 0
+  br bb3(%11 : $Builtin.Int1)
+
+bb3(%13 : $Builtin.Int1):
+  destroy_value %3 : $Optional<(utf16Length: Int, asciiContentsPointer: UnsafePointer<UInt8>, untaggedCocoa: AnyObject)>
+  cond_br %13, bb4, bb5
+
+bb4:
+  %16 = integer_literal $Builtin.Int1, -1
+  %17 = struct $Bool (%16 : $Builtin.Int1)
+  br bb6(%17 : $Bool)
+
+bb5:
+  %19 = function_ref @_swift_stdlib_isNSString : $@convention(c) (AnyObject) -> UInt8
+  %20 = apply %19(%0) : $@convention(c) (AnyObject) -> UInt8
+  %21 = integer_literal $Builtin.Int8, 0
+  %22 = struct_extract %20 : $UInt8, #UInt8._value
+  %23 = builtin "cmp_eq_Int8"(%22 : $Builtin.Int8, %21 : $Builtin.Int8) : $Builtin.Int1
+  %24 = integer_literal $Builtin.Int1, -1
+  %25 = builtin "xor_Int1"(%23 : $Builtin.Int1, %24 : $Builtin.Int1) : $Builtin.Int1
+  %26 = struct $Bool (%25 : $Builtin.Int1)
+  br bb6(%26 : $Bool)
+
+bb6(%28 : $Bool):
+  return %28 : $Bool
+}


### PR DESCRIPTION
A destroy_value of Optional.none can be deleted.

A move-only struct with deinit has a non trivial SILType but OwnershipKind::None, such values cannot be deleted.

