### PR TITLE
[lit] Remove unused import.

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -27,7 +27,6 @@ import subprocess
 import sys
 import socket
 import glob
-from distutils.sysconfig import get_python_lib
 
 import lit
 import lit.formats


### PR DESCRIPTION
I normally wouldn't care about this sort of thing, but on my system that import seems to fail and I noticed we aren't actually using it... so it makes sense to just remove it.
