### PR TITLE
Add workaround flag for lazy import-as-member

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -144,6 +144,7 @@ public:
   virtual clang::Sema &getClangSema() const = 0;
   virtual const clang::CompilerInstance &getClangInstance() const = 0;
   virtual void printStatistics() const = 0;
+  virtual void dumpSwiftLookupTables() const = 0;
 
   /// Returns the module that contains imports and declarations from all loaded
   /// Objective-C header files.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -377,6 +377,11 @@ namespace swift {
     /// Enable experimental eager Clang module diagnostics.
     bool EnableExperimentalEagerClangModuleDiagnostics = false;
 
+    /// Force ClangImporter's import-as-member extensions to load thier members
+    /// immediately, bypassing their SwiftLookupTables. This emulates an
+    /// implementation quirk of previous compilers.
+    bool DisableNamedLazyImportAsMemberLoading = false;
+
     /// Enable inference of Sendable conformances for public types.
     bool EnableInferPublicSendable = false;
 

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -535,7 +535,7 @@ public:
   void printStatistics() const override;
 
   /// Dump Swift lookup tables.
-  void dumpSwiftLookupTables();
+  void dumpSwiftLookupTables() const override;
 
   /// Given the path of a Clang module, collect the names of all its submodules.
   /// Calling this function does not load the module.

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -280,6 +280,10 @@ public:
   /// termination.
   bool PrintClangStats = false;
 
+  /// Indicates whether or not the Clang importer should dump lookup tables
+  /// upon termination.
+  bool DumpClangLookupTables = false;
+
   /// Indicates whether standard help should be shown.
   bool PrintHelp = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -372,7 +372,13 @@ def debug_constraints_on_line_EQ : Joined<["-"], "debug-constraints-on-line=">,
   Alias<debug_constraints_on_line>;
 
 def disable_named_lazy_member_loading : Flag<["-"], "disable-named-lazy-member-loading">,
-  HelpText<"Disable per-name lazy member loading">;
+  HelpText<"Disable per-name lazy member loading (obsolete)">;
+
+def disable_named_lazy_import_as_member_loading :
+  Flag<["-"], "disable-named-lazy-import-as-member-loading">,
+  HelpText<"Import all of a type's import-as-member globals together, as Swift "
+           "5.10 and earlier did; temporary workaround for modules that are "
+           "sensitive to this change">;
 
 def dump_requirement_machine : Flag<["-"], "dump-requirement-machine">,
   HelpText<"Enables dumping rewrite systems from the generics implementation">;

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -580,6 +580,10 @@ def stack_promotion_limit : Separate<["-"], "stack-promotion-limit">,
 def dump_clang_diagnostics : Flag<["-"], "dump-clang-diagnostics">,
   HelpText<"Dump Clang diagnostics to stderr">;
 
+def dump_clang_lookup_tables : Flag<["-"], "dump-clang-lookup-tables">,
+  HelpText<"Dump the importer's Swift-name-to-Clang-name lookup tables to "
+           "stderr">;
+
 def disable_modules_validate_system_headers : Flag<["-"], "disable-modules-validate-system-headers">,
   HelpText<"Disable validating system headers in the Clang importer">;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6432,7 +6432,7 @@ EffectiveClangContext ClangImporter::Implementation::getEffectiveClangContext(
   return EffectiveClangContext();
 }
 
-void ClangImporter::dumpSwiftLookupTables() {
+void ClangImporter::dumpSwiftLookupTables() const {
   Impl.dumpSwiftLookupTables();
 }
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -166,6 +166,8 @@ bool ArgsToFrontendOptionsConverter::convert(
   computeDebugTimeOptions();
   computeTBDOptions();
 
+  Opts.DumpClangLookupTables |= Args.hasArg(OPT_dump_clang_lookup_tables);
+
   Opts.CheckOnoneSupportCompleteness = Args.hasArg(OPT_check_onone_completeness);
 
   Opts.ParseStdlib |= Args.hasArg(OPT_parse_stdlib);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -623,6 +623,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
       !Args.hasArg(OPT_disable_experimental_clang_importer_diagnostics) &&
       Args.hasArg(OPT_enable_experimental_eager_clang_module_diagnostics);
 
+  Opts.DisableNamedLazyImportAsMemberLoading |=
+      Args.hasArg(OPT_disable_named_lazy_import_as_member_loading);
+
   Opts.DisableImplicitConcurrencyModuleImport |=
     Args.hasArg(OPT_disable_implicit_concurrency_module_import);
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1117,6 +1117,9 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   if (auto *stats = ctx.Stats)
     countASTStats(*stats, Instance);
 
+  if (opts.DumpClangLookupTables && ctx.getClangModuleLoader())
+    ctx.getClangModuleLoader()->dumpSwiftLookupTables();
+
   // Report mangling stats if there was no error.
   if (!ctx.hadError())
     Mangle::printManglingStats();

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -1,5 +1,9 @@
-// RUN: %target-swift-ide-test -dump-importer-lookup-table -source-filename %s -import-objc-header %S/Inputs/swift_name.h -I %S/Inputs/custom-modules > %t.log 2>&1
-// RUN: %FileCheck %s < %t.log
+// RUN: %target-swift-ide-test -dump-importer-lookup-table -source-filename %s -import-objc-header %S/Inputs/swift_name.h -I %S/Inputs/custom-modules > %t.ide-test.log 2>&1
+// RUN: %FileCheck %s < %t.ide-test.log
+
+// RUN: %target-typecheck-verify-swift -dump-clang-lookup-tables -import-objc-header %S/Inputs/swift_name.h -I %S/Inputs/custom-modules > %t.frontend.log 2>&1
+// RUN: %FileCheck %s < %t.frontend.log
+// RUN: false
 
 // REQUIRES: objc_interop
 import ImportAsMember

--- a/test/IDE/dump_swift_lookup_tables.swift
+++ b/test/IDE/dump_swift_lookup_tables.swift
@@ -3,7 +3,6 @@
 
 // RUN: %target-typecheck-verify-swift -dump-clang-lookup-tables -import-objc-header %S/Inputs/swift_name.h -I %S/Inputs/custom-modules > %t.frontend.log 2>&1
 // RUN: %FileCheck %s < %t.frontend.log
-// RUN: false
 
 // REQUIRES: objc_interop
 import ImportAsMember

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -1,5 +1,8 @@
-// RUN: %target-swift-ide-test -dump-importer-lookup-table -source-filename %s -import-objc-header %S/Inputs/swift_name_objc.h > %t.log 2>&1
-// RUN: %FileCheck %s < %t.log
+// RUN: %target-swift-ide-test -dump-importer-lookup-table -source-filename %s -import-objc-header %S/Inputs/swift_name_objc.h > %t.ide-test.log 2>&1
+// RUN: %FileCheck %s < %t.ide-test.log
+
+// RUN: %target-typecheck-verify-swift -dump-clang-lookup-tables -import-objc-header %S/Inputs/swift_name_objc.h > %t.frontend.log 2>&1
+// RUN: %FileCheck %s < %t.frontend.log
 
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx

--- a/test/NameLookup/Inputs/NamedLazyMembers/NamedLazyMembers.h
+++ b/test/NameLookup/Inputs/NamedLazyMembers/NamedLazyMembers.h
@@ -138,3 +138,6 @@
 
 @interface PrivateDoer(Category) <PrivateMethods>
 @end
+
+typedef NSString * const SimpleDoerMode NS_TYPED_ENUM NS_SWIFT_NAME(SimpleDoer.Mode);
+typedef NSString * const SimpleDoerKind NS_TYPED_ENUM NS_SWIFT_NAME(SimpleDoer.Kind);

--- a/test/NameLookup/named_lazy_member_loading_import_as_member.swift
+++ b/test/NameLookup/named_lazy_member_loading_import_as_member.swift
@@ -1,0 +1,16 @@
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t/stats-lazy)
+// RUN: %empty-directory(%t/stats-eager)
+
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers %s -stats-output-dir %t/stats-lazy
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers %s -stats-output-dir %t/stats-eager -disable-named-lazy-import-as-member-loading
+
+// stats-lazy should only have imported SimpleDoer.Mode; stats-eager should also
+// have imported SimpleDoer.Kind
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities == 1' %t/stats-lazy %t/stats-eager
+
+import NamedLazyMembers
+
+func fn(_: SimpleDoer.Mode) {}


### PR DESCRIPTION
In rdar://123649082, a project failed to build because of the lazy import-as-member loading changes in #71320. That project was configured in a way that broke modularization and the correct solution is to fix it, but out of an abundance of caution, add a `-disable-named-lazy-import-as-member-loading` frontend flag in case a project needs to temporarily restore the old behavior.

As a bonus, this lets us write a test to verify that lazy import-as-member loading has positive performance impact.

This PR also includes a frontend flag that dumps ClangImporter's SwiftLookupTables on frontend process termination; this was previously possibly only with a debugger or using swift-ide-test.

Fixes rdar://124228983.