### PR TITLE
Test existing behavior of default arguments in protocol extensions

### DIFF
--- a/test/Interpreter/protocol_extensions.swift
+++ b/test/Interpreter/protocol_extensions.swift
@@ -374,3 +374,25 @@ extension String: Addable {}
 ProtocolExtensionTestSuite.test("MarkerProtocolExtensions") {
     expectTrue("hello".increment(this: 11) == 111)
 }
+
+protocol DefaultArgumentsInExtension {
+    func foo(a: Int, b: Int) -> (Int, Int)
+}
+extension DefaultArgumentsInExtension {
+    func foo(a: Int, b: Int = 1) -> (Int, Int) {
+        self.foo(a: a * 10, b: b * 10)
+    }
+}
+struct DefaultArgumentsInExtensionImpl: DefaultArgumentsInExtension {
+    func foo(a: Int, b: Int) -> (Int, Int) {
+        (a * 2, b * 2)
+    }
+}
+
+ProtocolExtensionTestSuite.test("DefaultArgumentsInExtension") {
+    let instance = DefaultArgumentsInExtensionImpl()
+    expectEqual((4, 6), instance.foo(a: 2, b: 3))
+    expectEqual((4, 6), (instance as any DefaultArgumentsInExtension).foo(a: 2, b: 3))
+    expectEqual((40, 20), instance.foo(a: 2))
+    expectEqual((40, 20), (instance as any DefaultArgumentsInExtension).foo(a: 2))
+}


### PR DESCRIPTION
This is load-bearing behavior for existing code in the wild, and it doesn't look like there's an existing test specifically for it. (I confess to being a bit lazy by adding it as an execution test rather than a SIL test, which could also confirm the overload choices currently being made. Feel free to just take the test case from me if you want to put it somewhere else.)