### PR TITLE
ASTGen: Resolve warnings

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -367,6 +367,7 @@ extension ASTGenVisitor {
       return []
     }
 
+    _ = args
     fatalError("unimplemented")
   }
 
@@ -757,6 +758,7 @@ extension ASTGenVisitor {
       return []
     }
 
+    _ = args
     fatalError("unimplemented")
   }
 
@@ -939,6 +941,8 @@ extension ASTGenVisitor {
       // TODO: Diagnose.
       return nil
     }
+
+    _ = args
     fatalError("unimplemented")
   }
 

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -936,7 +936,7 @@ extension ASTGenVisitor {
 
   func generateCustomAttr(attribute node: AttributeSyntax) -> BridgedCustomAttr? {
     guard
-      var args = node.arguments?.as(LabeledExprListSyntax.self)?[...]
+      let args = node.arguments?.as(LabeledExprListSyntax.self)?[...]
     else {
       // TODO: Diagnose.
       return nil

--- a/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
+++ b/lib/ASTGen/Sources/ASTGen/DiagnosticsBridge.swift
@@ -141,7 +141,9 @@ extension DiagnosticSeverity {
     case .note: return .note
     case .warning: return .warning
     case .remark: return .remark
+#if RESILIENT_SWIFT_SYNTAX
     @unknown default: return .error
+#endif
     }
   }
 }

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -317,7 +317,7 @@ extension ASTGenVisitor {
     additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?
   ) -> BridgedArgumentList {
 
-    var bridgedArgs: BridgedArrayRef = {
+    let bridgedArgs: BridgedArrayRef = {
       // Arguments before ')'
       let normalArgs = labeledExprList.lazy.map({ elem in
         let labelInfo = elem.label.map(self.generateIdentifierAndSourceLoc(_:))
@@ -363,7 +363,7 @@ extension ASTGenVisitor {
     // of the normal arguments because we don't have a convenient way to pass
     // Optional to ASTBridging,  ASTBridging can know it's "nil" if
     // bridgedArgs.count == firstTrailingClosureIndex
-    var firstTrailingClosureIndex = labeledExprList.count
+    let firstTrailingClosureIndex = labeledExprList.count
 
     return BridgedArgumentList.createParsed(
       self.ctx,

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -266,6 +266,7 @@ extension ASTGenVisitor {
 
     if let signature = node.signature {
       // FIXME: Translate the signature, capture list, 'in' location, etc.
+      _ = signature
       fatalError("unimplmented")
     } else {
       let lBraceLoc = self.generateSourceLoc(node.leftBrace)

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -270,7 +270,9 @@ class PluginDiagnosticsEngine {
     case .note: bridgedSeverity = .note
     case .warning: bridgedSeverity = .warning
     case .remark: bridgedSeverity = .remark
+#if RESILIENT_SWIFT_SYNTAX
     @unknown default: bridgedSeverity = .error
+#endif
     }
 
     // Emit the diagnostic

--- a/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/TypeAttrs.swift
@@ -31,6 +31,10 @@ extension ASTGenVisitor {
         attrs.add(attr);
       case .ifConfigDecl:
         fatalError("unimplemented")
+#if RESILIENT_SWIFT_SYNTAX
+      @unknown default:
+        fatalError()
+#endif
       }
     }
 


### PR DESCRIPTION
Addresses some `may have additional unknown values`, `was defined but never used`, and `was never mutated` warnings.