### PR TITLE
[build-presets] Test SourceKit-LSP in the swift-syntax macOS job

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1878,6 +1878,7 @@ swiftsyntax-lint
 swiftformat
 skstresstester
 sourcekit-lsp
+test-sourcekit-lsp
 install-swiftformat
 skip-test-swift=false
 


### PR DESCRIPTION
SourceKit-LSP depends on swift-syntax sufficiently much that changed runtime behavior of swift-syntax can make sourcekit-lsp fail, as it happened in https://github.com/apple/sourcekit-lsp/pull/1110.

Only testing sourcekit-lsp on macOS, not Linux for now. Testing on one platform should be sufficient.
