### PR TITLE
Move `FullTypedThrows` from "upcoming" to "experimental"

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -140,7 +140,6 @@ UPCOMING_FEATURE(DisableOutwardActorInference, 401, 6)
 UPCOMING_FEATURE(InternalImportsByDefault, 409, 6)
 UPCOMING_FEATURE(IsolatedDefaultValues, 411, 6)
 UPCOMING_FEATURE(GlobalConcurrency, 412, 6)
-UPCOMING_FEATURE(FullTypedThrows, 413, 6)
 UPCOMING_FEATURE(InferSendableFromCaptures, 418, 6)
 UPCOMING_FEATURE(ImplicitOpenExistentials, 352, 6)
 
@@ -153,6 +152,7 @@ EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(CodeItemMacros, false)
 EXPERIMENTAL_FEATURE(BodyMacros, true)
 EXPERIMENTAL_FEATURE(TupleConformances, false)
+EXPERIMENTAL_FEATURE(FullTypedThrows, true)
 
 // Whether to enable @_used and @_section attributes
 EXPERIMENTAL_FEATURE(SymbolLinkageMarkers, true)

--- a/test/stmt/typed_throws.swift
+++ b/test/stmt/typed_throws.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-upcoming-feature FullTypedThrows
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature FullTypedThrows
 
 enum MyError: Error {
 case failed


### PR DESCRIPTION
This feature is not fully implemented, and cannot be considered to be "upcoming" until it is.
