### PR TITLE
[IRGen] Outlined consume functions call noncopyable deinits.

### DIFF
--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -48,6 +48,7 @@
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
 #include "IRGenModule.h"
+#include "LocalTypeData.h"
 #include "MetadataRequest.h"
 #include "Outlining.h"
 #include "ProtocolInfo.h"
@@ -75,6 +76,25 @@ irgen::emitArchetypeTypeMetadataRef(IRGenFunction &IGF,
       return emitOpaqueTypeMetadataRef(IGF, opaque, request);
   }
 
+#ifndef NDEBUG
+  if (!archetype->getParent()) {
+    llvm::errs() << "Metadata for archetype not bound in function.\n"
+                 << "  The metadata could be missing entirely because it needs "
+                    "to be passed to the function.\n"
+                 << "  Or the metadata is present and not bound in which case "
+                    "setScopedLocalTypeMetadata or similar must be called.\n";
+    llvm::errs() << "Archetype without metadata: " << archetype << "\n";
+    archetype->dump(llvm::errs());
+    llvm::errs() << "Function:\n";
+    IGF.CurFn->print(llvm::errs());
+    if (auto localTypeData = IGF.getLocalTypeData()) {
+      llvm::errs() << "LocalTypeData:\n";
+      localTypeData->dump();
+    } else {
+      llvm::errs() << "No LocalTypeDataCache for this function!\n";
+    }
+  }
+#endif
   // If there's no local or opaque metadata, it must be a nested type.
   assert(archetype->getParent() && "Not a nested archetype");
 

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -135,7 +135,7 @@ public:
   void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                    SILType T) const override {
     // We'll need formal type metadata for this archetype.
-    collector.collectTypeMetadataForLayout(T);
+    collector.collectTypeMetadata(T);
   }
 
   TypeLayoutEntry

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -631,7 +631,7 @@ namespace {
         return;
       getSingleton()->collectMetadataForOutlining(collector,
                                         getSingletonType(collector.IGF.IGM, T));
-      collector.collectTypeMetadataForLayout(T);
+      collector.collectTypeMetadata(T);
     }
 
     void reexplode(Explosion &src, Explosion &dest)
@@ -3239,7 +3239,7 @@ namespace {
         auto payloadT = getPayloadType(IGM, T);
         getPayloadTypeInfo().collectMetadataForOutlining(collector, payloadT);
       }
-      collector.collectTypeMetadataForLayout(T);
+      collector.collectTypeMetadata(T);
     }
 
     void storeTag(IRGenFunction &IGF,
@@ -5134,7 +5134,7 @@ namespace {
         auto &payloadTI = *payloadCasePair.ti;
         payloadTI.collectMetadataForOutlining(collector, payloadT);
       }
-      collector.collectTypeMetadataForLayout(T);
+      collector.collectTypeMetadata(T);
     }
 
     void destroy(IRGenFunction &IGF, Address addr, SILType T,
@@ -6051,7 +6051,7 @@ namespace {
 
     void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                      SILType T) const override {
-      collector.collectTypeMetadataForLayout(T);
+      collector.collectTypeMetadata(T);
     }
 
     void destroy(IRGenFunction &IGF, Address addr, SILType T,

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -253,7 +253,7 @@ namespace {
         asDerived().emitValueAssignWithCopy(IGF, destValue, srcValue);
         emitCopyOfTables(IGF, dest, src);
       } else {
-        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+        OutliningMetadataCollector collector(T, IGF, LayoutIsNeeded,
                                              DeinitIsNotNeeded);
         collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                          IsNotInitialization, IsNotTake);
@@ -268,7 +268,7 @@ namespace {
         asDerived().emitValueInitializeWithCopy(IGF, destValue, srcValue);
         emitCopyOfTables(IGF, dest, src);
       } else {
-        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+        OutliningMetadataCollector collector(T, IGF, LayoutIsNeeded,
                                              DeinitIsNotNeeded);
         collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                          IsInitialization, IsNotTake);
@@ -283,7 +283,7 @@ namespace {
         asDerived().emitValueAssignWithTake(IGF, destValue, srcValue);
         emitCopyOfTables(IGF, dest, src);
       } else {
-        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+        OutliningMetadataCollector collector(T, IGF, LayoutIsNeeded,
                                              DeinitIsNotNeeded);
         collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                          IsNotInitialization, IsTake);
@@ -298,7 +298,7 @@ namespace {
         asDerived().emitValueInitializeWithTake(IGF, destValue, srcValue);
         emitCopyOfTables(IGF, dest, src);
       } else {
-        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+        OutliningMetadataCollector collector(T, IGF, LayoutIsNeeded,
                                              DeinitIsNotNeeded);
         collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                          IsInitialization, IsTake);
@@ -311,7 +311,7 @@ namespace {
         Address valueAddr = projectValue(IGF, existential);
         asDerived().emitValueDestroy(IGF, valueAddr);
       } else {
-        OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+        OutliningMetadataCollector collector(T, IGF, LayoutIsNeeded,
                                              DeinitIsNeeded);
         collector.emitCallToOutlinedDestroy(existential, T, *this);
       }
@@ -968,7 +968,7 @@ public:
                                                srcBuffer);
     } else {
       // Create an outlined function to avoid explosion
-      OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+      OutliningMetadataCollector collector(T, IGF, LayoutIsNeeded,
                                            DeinitIsNotNeeded);
       collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                        IsInitialization, IsNotTake);
@@ -985,7 +985,7 @@ public:
       IGF.emitMemCpy(dest, src, getLayout().getSize(IGF.IGM));
     } else {
       // Create an outlined function to avoid explosion
-      OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+      OutliningMetadataCollector collector(T, IGF, LayoutIsNeeded,
                                            DeinitIsNotNeeded);
       collector.emitCallToOutlinedCopy(dest, src, T, *this,
                                        IsInitialization, IsTake);

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -492,7 +492,7 @@ public:
       auto fType = field.getType(collector.IGF.IGM, T);
       field.getTypeInfo().collectMetadataForOutlining(collector, fType);
     }
-    collector.collectTypeMetadataForLayout(T);
+    collector.collectTypeMetadata(T);
   }
 };
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -184,7 +184,7 @@ void LoadableTypeInfo::initializeWithCopy(IRGenFunction &IGF, Address destAddr,
     loadAsCopy(IGF, srcAddr, copy);
     initialize(IGF, copy, destAddr, true);
   } else {
-    OutliningMetadataCollector collector(IGF, LayoutIsNeeded,
+    OutliningMetadataCollector collector(T, IGF, LayoutIsNeeded,
                                          DeinitIsNotNeeded);
     // No need to collect anything because we assume loadable types can be
     // loaded without enums.

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -76,7 +76,7 @@ public:
   OptimizationMode OptMode;
   bool isPerformanceConstraint;
 
-  llvm::Function *CurFn;
+  llvm::Function *const CurFn;
   ModuleDecl *getSwiftModule() const;
   SILModule &getSILModule() const;
   Lowering::TypeConverter &getSILTypes() const;

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -792,6 +792,9 @@ public:
   llvm::Value *getDynamicSelfMetadata();
   void setDynamicSelfMetadata(CanType selfBaseTy, bool selfIsExact,
                               llvm::Value *value, DynamicSelfKind kind);
+#ifndef NDEBUG
+  LocalTypeDataCache const *getLocalTypeData() { return LocalTypeData; }
+#endif
 
 private:
   LocalTypeDataCache &getOrCreateLocalTypeData();

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -193,7 +193,7 @@ public:
   void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                    SILType T) const override {
     // We'll need formal type metadata for this archetype.
-    collector.collectTypeMetadataForLayout(T);
+    collector.collectTypeMetadata(T);
   }
 
   TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM, SILType T,

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -32,6 +32,11 @@
 using namespace swift;
 using namespace irgen;
 
+OutliningMetadataCollector::OutliningMetadataCollector(
+    IRGenFunction &IGF, LayoutIsNeeded_t needsLayout,
+    DeinitIsNeeded_t needsDeinitTypes)
+    : IGF(IGF), needsLayout(needsLayout), needsDeinit(needsDeinitTypes) {}
+
 void OutliningMetadataCollector::collectTypeMetadata(SILType ty) {
   // If the type has no archetypes, we can emit it from scratch in the callee.
   if (!ty.hasArchetype()) {

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -32,7 +32,7 @@
 using namespace swift;
 using namespace irgen;
 
-void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType ty) {
+void OutliningMetadataCollector::collectTypeMetadata(SILType ty) {
   // If the type has no archetypes, we can emit it from scratch in the callee.
   if (!ty.hasArchetype()) {
     return;

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -33,9 +33,9 @@ using namespace swift;
 using namespace irgen;
 
 OutliningMetadataCollector::OutliningMetadataCollector(
-    IRGenFunction &IGF, LayoutIsNeeded_t needsLayout,
+    SILType T, IRGenFunction &IGF, LayoutIsNeeded_t needsLayout,
     DeinitIsNeeded_t needsDeinitTypes)
-    : IGF(IGF), needsLayout(needsLayout), needsDeinit(needsDeinitTypes) {}
+    : T(T), IGF(IGF), needsLayout(needsLayout), needsDeinit(needsDeinitTypes) {}
 
 void OutliningMetadataCollector::collectTypeMetadata(SILType ty) {
   // If the type has no archetypes, we can emit it from scratch in the callee.
@@ -180,7 +180,7 @@ bool TypeInfo::withWitnessableMetadataCollector(
   }
 
   if (needsCollector) {
-    OutliningMetadataCollector collector(IGF, needsLayout, needsDeinit);
+    OutliningMetadataCollector collector(T, IGF, needsLayout, needsDeinit);
     if (needsDeinit || needsLayout) {
       // Only collect if anything would be collected.
       collectMetadataForOutlining(collector, T);
@@ -479,7 +479,8 @@ llvm::Constant *IRGenModule::getOrCreateRetainFunction(const TypeInfo &ti,
 
 void TypeInfo::callOutlinedRelease(IRGenFunction &IGF, Address addr, SILType T,
                                    Atomicity atomicity) const {
-  OutliningMetadataCollector collector(IGF, LayoutIsNotNeeded, DeinitIsNeeded);
+  OutliningMetadataCollector collector(T, IGF, LayoutIsNotNeeded,
+                                       DeinitIsNeeded);
   collectMetadataForOutlining(collector, T);
   collector.emitCallToOutlinedRelease(addr, T, *this, atomicity);
 }

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -73,14 +73,14 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType ty) {
   collectRepresentationTypeMetadata(ty);
 }
 
-void OutliningMetadataCollector::collectFormalTypeMetadata(CanType type) {
+void OutliningMetadataCollector::collectFormalTypeMetadata(CanType ty) {
   // If the type has no archetypes, we can emit it from scratch in the callee.
-  assert(type->hasArchetype());
+  assert(ty->hasArchetype());
 
-  auto key = LocalTypeDataKey(type, LocalTypeDataKind::forFormalTypeMetadata());
+  auto key = LocalTypeDataKey(ty, LocalTypeDataKind::forFormalTypeMetadata());
   if (Values.count(key)) return;
 
-  auto metadata = IGF.emitTypeMetadataRef(type);
+  auto metadata = IGF.emitTypeMetadataRef(ty);
   Values.insert({key, metadata});
 }
 

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -150,7 +150,7 @@ irgen::getTypeAndGenericSignatureForManglingOutlineFunction(SILType type) {
           env->getGenericSignature().getCanonicalSignature()};
 }
 
-bool TypeInfo::withMetadataCollector(
+bool TypeInfo::withWitnessableMetadataCollector(
     IRGenFunction &IGF, SILType T, LayoutIsNeeded_t needsLayout,
     DeinitIsNeeded_t needsDeinit,
     llvm::function_ref<void(OutliningMetadataCollector &)> invocation) const {
@@ -177,11 +177,11 @@ bool TypeInfo::withMetadataCollector(
 void TypeInfo::callOutlinedCopy(IRGenFunction &IGF, Address dest, Address src,
                                 SILType T, IsInitialization_t isInit,
                                 IsTake_t isTake) const {
-  if (withMetadataCollector(IGF, T, LayoutIsNeeded, DeinitIsNotNeeded,
-                            [&](auto collector) {
-                              collector.emitCallToOutlinedCopy(
-                                  dest, src, T, *this, isInit, isTake);
-                            })) {
+  if (withWitnessableMetadataCollector(
+          IGF, T, LayoutIsNeeded, DeinitIsNotNeeded, [&](auto collector) {
+            collector.emitCallToOutlinedCopy(dest, src, T, *this, isInit,
+                                             isTake);
+          })) {
     return;
   }
 
@@ -376,7 +376,7 @@ void TypeInfo::callOutlinedDestroy(IRGenFunction &IGF,
   if (IGF.IGM.getTypeLowering(T).isTrivial())
     return;
 
-  if (withMetadataCollector(
+  if (withWitnessableMetadataCollector(
           IGF, T, LayoutIsNeeded, DeinitIsNeeded, [&](auto collector) {
             collector.emitCallToOutlinedDestroy(addr, T, *this);
           })) {

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -52,9 +52,15 @@ void OutliningMetadataCollector::collectTypeMetadata(SILType ty) {
     }
   }
 
-  if (!needsLayout) {
+  collectTypeMetadataForLayout(ty);
+}
+
+void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType ty) {
+  if (!needsLayout)
     return;
-  }
+
+  auto astType = ty.getASTType();
+  auto &ti = IGF.IGM.getTypeInfoForLowered(astType);
 
   // We don't need the metadata for fixed size types or types that are not ABI
   // accessible. Outlining will call the value witness of the enclosing type of

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -90,6 +90,7 @@ public:
                                  Explosion &params) const;
 
 private:
+  void collectTypeMetadataForLayout(SILType type);
   void collectFormalTypeMetadata(CanType type);
   void collectRepresentationTypeMetadata(SILType ty);
 };

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -73,7 +73,7 @@ public:
                              DeinitIsNeeded_t needsDeinitTypes)
       : IGF(IGF), needsLayout(needsLayout), needsDeinit(needsDeinitTypes) {}
 
-  void collectTypeMetadataForLayout(SILType type);
+  void collectTypeMetadata(SILType type);
 
   void emitCallToOutlinedCopy(Address dest, Address src,
                               SILType T, const TypeInfo &ti,

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -19,7 +19,9 @@
 
 #include "IRGen.h"
 #include "LocalTypeDataKind.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/IRGen/GenericRequirement.h"
 #include "swift/SIL/SILType.h"
 #include "llvm/ADT/MapVector.h"
 
@@ -69,6 +71,8 @@ public:
 
 private:
   llvm::MapVector<LocalTypeDataKey, llvm::Value *> Values;
+  llvm::MapVector<GenericRequirement, llvm::Value *> Requirements;
+  std::optional<SubstitutionMap> Subs;
   friend class IRGenModule;
 
 public:
@@ -94,6 +98,7 @@ public:
 
 private:
   void collectTypeMetadataForLayout(SILType type);
+  void collectTypeMetadataForDeinit(SILType type);
   void collectFormalTypeMetadata(CanType type);
   void collectRepresentationTypeMetadata(SILType ty);
 };

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -70,8 +70,7 @@ private:
 
 public:
   OutliningMetadataCollector(IRGenFunction &IGF, LayoutIsNeeded_t needsLayout,
-                             DeinitIsNeeded_t needsDeinitTypes)
-      : IGF(IGF), needsLayout(needsLayout), needsDeinit(needsDeinitTypes) {}
+                             DeinitIsNeeded_t needsDeinitTypes);
 
   void collectTypeMetadata(SILType type);
 

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -83,10 +83,11 @@ public:
   void emitCallToOutlinedRelease(Address addr, SILType T, const TypeInfo &ti,
                                  Atomicity atomicity) const;
 
-  void addMetadataArguments(SmallVectorImpl<llvm::Value *> &args) const ;
-  void addMetadataParameterTypes(SmallVectorImpl<llvm::Type *> &paramTys) const;
-  void bindMetadataParameters(IRGenFunction &helperIGF,
-                              Explosion &params) const;
+  void addPolymorphicArguments(SmallVectorImpl<llvm::Value *> &args) const;
+  void
+  addPolymorphicParameterTypes(SmallVectorImpl<llvm::Type *> &paramTys) const;
+  void bindPolymorphicParameters(IRGenFunction &helperIGF,
+                                 Explosion &params) const;
 
 private:
   void collectFormalTypeMetadata(CanType type);

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file defines interfaces for outlining value witnesses.
+// This file defines interfaces for outlined value witnesses.
 //
 //===----------------------------------------------------------------------===//
 

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -83,14 +83,14 @@ public:
   void emitCallToOutlinedRelease(Address addr, SILType T, const TypeInfo &ti,
                                  Atomicity atomicity) const;
 
-private:
-  void collectFormalTypeMetadata(CanType type);
-  void collectRepresentationTypeMetadata(SILType ty);
-
   void addMetadataArguments(SmallVectorImpl<llvm::Value *> &args) const ;
   void addMetadataParameterTypes(SmallVectorImpl<llvm::Type *> &paramTys) const;
   void bindMetadataParameters(IRGenFunction &helperIGF,
                               Explosion &params) const;
+
+private:
+  void collectFormalTypeMetadata(CanType type);
+  void collectRepresentationTypeMetadata(SILType ty);
 };
 
 std::pair<CanType, CanGenericSignature>

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -80,6 +80,9 @@ public:
                              LayoutIsNeeded_t needsLayout,
                              DeinitIsNeeded_t needsDeinitTypes);
 
+  // If any local type data is needed for \p type, add it.
+  //
+  // NOTE: To be called from TypeData instances.
   void collectTypeMetadata(SILType type);
 
   void emitCallToOutlinedCopy(Address dest, Address src,

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -80,6 +80,10 @@ public:
                              LayoutIsNeeded_t needsLayout,
                              DeinitIsNeeded_t needsDeinitTypes);
 
+  unsigned size() const {
+    return Subs.has_value() ? Requirements.size() : Values.size();
+  }
+
   // If any local type data is needed for \p type, add it.
   //
   // NOTE: To be called from TypeData instances.

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -20,6 +20,7 @@
 #include "IRGen.h"
 #include "LocalTypeDataKind.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/SIL/SILType.h"
 #include "llvm/ADT/MapVector.h"
 
 namespace llvm {
@@ -33,6 +34,7 @@ class CanType;
 enum IsInitialization_t : bool;
 enum IsTake_t : bool;
 class SILType;
+class NominalTypeDecl;
 
 namespace irgen {
 class Address;
@@ -60,6 +62,7 @@ enum DeinitIsNeeded_t : bool {
 ///   - emit the call to the outlined copy/destroy helper
 class OutliningMetadataCollector {
 public:
+  SILType T;
   IRGenFunction &IGF;
   const unsigned needsLayout : 1;
   const unsigned needsDeinit : 1;
@@ -69,7 +72,8 @@ private:
   friend class IRGenModule;
 
 public:
-  OutliningMetadataCollector(IRGenFunction &IGF, LayoutIsNeeded_t needsLayout,
+  OutliningMetadataCollector(SILType T, IRGenFunction &IGF,
+                             LayoutIsNeeded_t needsLayout,
                              DeinitIsNeeded_t needsDeinitTypes);
 
   void collectTypeMetadata(SILType type);

--- a/lib/IRGen/ResilientTypeInfo.h
+++ b/lib/IRGen/ResilientTypeInfo.h
@@ -158,7 +158,7 @@ public:
 
   void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                    SILType T) const override {
-    collector.collectTypeMetadataForLayout(T);
+    collector.collectTypeMetadata(T);
   }
 };
 

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -570,12 +570,13 @@ public:
   virtual void verify(IRGenTypeVerifierFunction &IGF,
                       llvm::Value *typeMetadata,
                       SILType T) const;
-  /// Perform \p invocation with the appropriate metadata collector if there is
-  /// one.
+  /// Perform \p invocation with the appropriate metadata collector for use in
+  /// emitting an outlined value function of a value operation that can be
+  /// performed with a value witness.
   ///
-  /// Returns whether there was an appropriate metadata collector (and whether
-  /// \p invocation was called.
-  bool withMetadataCollector(
+  /// Returns whether there was an appropriate emitter (and whether \p
+  /// invocation was called).
+  bool withWitnessableMetadataCollector(
       IRGenFunction &IGF, SILType T, LayoutIsNeeded_t needsLayout,
       DeinitIsNeeded_t needsDeinit,
       llvm::function_ref<void(OutliningMetadataCollector &)> invocation) const;

--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -120,6 +120,31 @@ public enum OuterSinglePayloadNC_3<T>: ~Copyable {
   case some(InnerDeinitingDestructableNC<T>)
 }
 
+public enum OuterMultiPayloadNC_1<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingWithLayoutNC<T>)
+  case some2(InnerDeinitingWithLayoutNC<T>)
+}
+
+public enum OuterMultiPayloadNC_2<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingWithoutLayoutNC<T>)
+  case some2(InnerDeinitingWithoutLayoutNC<T>)
+}
+
+// FIXME: Uncomment.
+public enum OuterMultiPayloadNC_3<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingReleasableNC<T>)
+  case some2(InnerDeinitingReleasableNC<T>)
+}
+
+public enum OuterMultiPayloadNC_4<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingDestructableNC<T>)
+  case some2(InnerDeinitingDestructableNC<T>)
+}
+
 // Destroyed value:
 // - has deinit
 // On lifetime end:
@@ -311,3 +336,107 @@ public func takeOuterSinglePayloadNC_2<T>(_ e: consuming OuterSinglePayloadNC_2<
 //           :        ptr noalias swiftself %0)
 // CHECK:       }
 public func takeOuterSinglePayloadNC_3<T>(_ e: consuming OuterSinglePayloadNC_3<T>) {}
+
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions25takeOuterMultiPayloadNC_1yyAA0efgH2_1OyxGnlF"(
+// CHECK-SAME:      ptr noalias %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_1OyxGlWOh"(
+// CHECK-SAME:        ptr %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_1OyxGlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE1:%[^,]+]] = call{{.*}} @"$s24moveonly_value_functions26InnerDeinitingWithLayoutNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA1:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE1]], 0
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions26InnerDeinitingWithLayoutNCVfD"(
+// CHECK-SAME:        ptr [[METADATA1]], 
+// CHECK-SAME:        ptr noalias swiftself %0)
+// CHECK:         [[RESPONSE2:%[^,]+]] = call{{.*}} @"$s24moveonly_value_functions26InnerDeinitingWithLayoutNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA2:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE2]], 0
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions26InnerDeinitingWithLayoutNCVfD"(
+// CHECK-SAME:        ptr [[METADATA2]], 
+// CHECK-SAME:        ptr noalias swiftself %0)
+// CHECK:       }
+public func takeOuterMultiPayloadNC_1<T>(_ e: consuming OuterMultiPayloadNC_1<T>) {}
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions25takeOuterMultiPayloadNC_2yyAA0efgH2_2OyxGnlF"(
+//           :      i64 %0, 
+//           :      i8 %1, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_2OyxGlWOe"(
+//           :        i64 %0, 
+//           :        i8 %1, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_2OyxGlWOe"(
+//           :      i64 %0, 
+//           :      i8 %1, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions29InnerDeinitingWithoutLayoutNCVfD"(
+//           :        i64 %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions29InnerDeinitingWithoutLayoutNCVfD"(
+//           :        i64 %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+public func takeOuterMultiPayloadNC_2<T>(_ e: consuming OuterMultiPayloadNC_2<T>) {}
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions25takeOuterMultiPayloadNC_3yyAA0efgH2_3OyxGnlF"(
+// CHECK-SAME:      ptr noalias nocapture dereferenceable(64) %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_3OyxGlWOs"(
+// CHECK-SAME:        ptr %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_3OyxGlWOs"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_3OyxGlWOe"(
+//           :        i64 %2, 
+//           :        i64 %4, 
+//           :        i64 %6, 
+//           :        i64 %8, 
+//           :        i64 %10, 
+//           :        i64 %12, 
+//           :        i64 %14, 
+//           :        i64 %16, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+public func takeOuterMultiPayloadNC_3<T>(_ e: consuming OuterMultiPayloadNC_3<T>) {}
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions25takeOuterMultiPayloadNC_4yyAA0efgH2_4OyxGnlF"(
+// CHECK-SAME:      ptr noalias %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_4OyxGlWOh"(
+// CHECK-SAME:        ptr %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_4OyxGlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE1:%[^,]+]] = call{{.*}} @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA1:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE1]], 0
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVfD"(
+// CHECK-SAME:        ptr [[METADATA1]], 
+// CHECK-SAME:        ptr noalias swiftself %0)
+// CHECK:         [[RESPONSE2:%[^,]+]] = call{{.*}} @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA2:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE2]], 0
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVfD"(
+// CHECK-SAME:        ptr [[METADATA2]], 
+// CHECK-SAME:        ptr noalias swiftself %0)
+// CHECK:       }
+public func takeOuterMultiPayloadNC_4<T>(_ e: consuming OuterMultiPayloadNC_4<T>) {}

--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -49,6 +49,16 @@ public struct InnerDeinitingDestructableNC<T> : ~Copyable {
   }
 }
 
+public struct InnerDeinitingWithLayoutNC<T> : ~Copyable {
+  public let t: T
+  deinit {}
+}
+
+public struct InnerDeinitingWithoutLayoutNC<T>: ~Copyable {
+  public let ptr: Int
+  deinit {}
+}
+
 public struct OuterDeinitingNC_1<T> : ~Copyable {
   public let i1: Int
   public let c1: C<T>
@@ -93,6 +103,21 @@ extension GenericContext_1 : P where T : P {
     }
     func beinit() {}
   }
+}
+
+public enum OuterSinglePayloadNC_1<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingWithoutLayoutNC<T>)
+}
+
+public enum OuterSinglePayloadNC_2<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingReleasableNC<T>)
+}
+
+public enum OuterSinglePayloadNC_3<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingDestructableNC<T>)
 }
 
 // Destroyed value:
@@ -218,3 +243,71 @@ public func takeOuterNC_2<T>(_ o: consuming OuterNC_2<T>) {
 // CHECK-SAME:        ptr noalias swiftself %0)
 // CHECK:       }
 public func takeGenericContext_1OuterNC_1<T : P>(_ e: consuming GenericContext_1<T>.OuterNC_1) {}
+
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions26takeOuterSinglePayloadNC_1yyAA0efgH2_1OyxGnlF"(
+//           :      i64 %0, 
+//           :      i8 %1, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_1OyxGlWOe"(
+//           :        i64 %0, 
+//           :        i1 %2, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_1OyxGlWOe"(
+//           :      i64 %0, 
+//           :      i1 %1, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions29InnerDeinitingWithoutLayoutNCVfD"(
+//           :        i64 %0,
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+public func takeOuterSinglePayloadNC_1<T>(_ e: consuming OuterSinglePayloadNC_1<T>) {}
+
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions26takeOuterSinglePayloadNC_2yyAA0efgH2_2OyxGnlF"(
+// CHECK-SAME:      ptr noalias nocapture dereferenceable(64) %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_2OyxGlWOs"(
+// CHECK-SAME:        ptr %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_2OyxGlWOs"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_2OyxGlWOe"(
+//            :       i64 %2, 
+//            :       i64 %4, 
+//            :       i64 %6, 
+//            :       i64 %8, 
+//            :       i64 %10, 
+//            :       i64 %12, 
+//            :       i64 %14, 
+//            :       i64 %16, 
+//            :       ptr %T)
+// CHECK:       }
+public func takeOuterSinglePayloadNC_2<T>(_ e: consuming OuterSinglePayloadNC_2<T>) {}
+
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions26takeOuterSinglePayloadNC_3yyAA0efgH2_3OyxGnlF"(
+// CHECK-SAME:      ptr noalias %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME: {
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_3OyxGlWOh"(
+// CHECK-SAME:        ptr %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_3OyxGlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE:%[^,]+]] = call{{.*}} @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE:%[^,]+]], 0
+// CHECK:         call{{.*}} @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVfD"(
+// CHECK-SAME:        ptr [[METADATA:%[^,]+]], 
+//           :        ptr noalias swiftself %0)
+// CHECK:       }
+public func takeOuterSinglePayloadNC_3<T>(_ e: consuming OuterSinglePayloadNC_3<T>) {}

--- a/test/IRGen/moveonly_value_functions_onone.swift
+++ b/test/IRGen/moveonly_value_functions_onone.swift
@@ -99,6 +99,21 @@ extension GenericContext_1 : P where T : P {
   }
 }
 
+public enum OuterSinglePayloadNC_1<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingWithoutLayoutNC<T>)
+}
+
+public enum OuterSinglePayloadNC_2<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingReleasableNC<T>)
+}
+
+public enum OuterSinglePayloadNC_3<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingDestructableNC<T>)
+}
+
 // Destroyed value:
 // - has deinit
 // On lifetime end:
@@ -222,3 +237,68 @@ public func takeOuterNC_2<T>(_ o: consuming OuterNC_2<T>) {
 // CHECK-SAME:        ptr noalias swiftself %0)
 // CHECK:       }
 public func takeGenericContext_1OuterNC_1<T : P>(_ e: consuming GenericContext_1<T>.OuterNC_1) {}
+
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone26takeOuterSinglePayloadNC_1yyAA0fghI2_1OyxGnlF"(
+//           :      i64 %0, 
+//           :      i8 %1, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone22OuterSinglePayloadNC_1OyxGlWOh"(
+//           :        i64 %0, 
+//           :        i1 %2, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone22OuterSinglePayloadNC_1OyxGlWOh"(
+//           :      i64 %0, 
+//           :      i1 %1, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone29InnerDeinitingWithoutLayoutNCVfD"(
+//           :        i64 %0,
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+public func takeOuterSinglePayloadNC_1<T>(_ e: consuming OuterSinglePayloadNC_1<T>) {}
+
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone26takeOuterSinglePayloadNC_2yyAA0fghI2_2OyxGnlF"(
+// CHECK-SAME:      ptr noalias nocapture dereferenceable(64) %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone22OuterSinglePayloadNC_2OyxGlWOh"(
+//           :        ptr %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone22OuterSinglePayloadNC_2OyxGlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE:%[^,]+]] = call swiftcc %swift.metadata_response @"$s30moveonly_value_functions_onone26InnerDeinitingReleasableNCVMa"(
+// CHECK-SAME:        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+// CHECK:         call swiftcc void @"$s30moveonly_value_functions_onone26InnerDeinitingReleasableNCVfD"(
+// CHECK-SAME:        ptr [[METADATA]],
+// CHECK-SAME:        ptr noalias nocapture swiftself dereferenceable(64) %0)
+// CHECK:       }
+public func takeOuterSinglePayloadNC_2<T>(_ e: consuming OuterSinglePayloadNC_2<T>) {}
+
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone26takeOuterSinglePayloadNC_3yyAA0fghI2_3OyxGnlF"(
+// CHECK-SAME:      ptr noalias %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME: {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone22OuterSinglePayloadNC_3OyxGlWOh"(
+//           :        ptr %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone22OuterSinglePayloadNC_3OyxGlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE:%[^,]+]] = call{{.*}} @"$s30moveonly_value_functions_onone28InnerDeinitingDestructableNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE:%[^,]+]], 0
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone28InnerDeinitingDestructableNCVfD"(
+// CHECK-SAME:        ptr [[METADATA:%[^,]+]], 
+//           :        ptr noalias swiftself %0)
+// CHECK:       }
+public func takeOuterSinglePayloadNC_3<T>(_ e: consuming OuterSinglePayloadNC_3<T>) {}

--- a/test/IRGen/moveonly_value_functions_onone.swift
+++ b/test/IRGen/moveonly_value_functions_onone.swift
@@ -48,6 +48,12 @@ public struct InnerDeinitingDestructableNC<T> : ~Copyable {
     external_symbol()
   }
 }
+
+public struct InnerDeinitingWithLayoutNC<T> : ~Copyable {
+  public let t: T
+  deinit {}
+}
+
 public struct InnerDeinitingWithoutLayoutNC<T>: ~Copyable {
   public let ptr: Int
   deinit {}
@@ -112,6 +118,30 @@ public enum OuterSinglePayloadNC_2<T>: ~Copyable {
 public enum OuterSinglePayloadNC_3<T>: ~Copyable {
   case none
   case some(InnerDeinitingDestructableNC<T>)
+}
+
+public enum OuterMultiPayloadNC_1<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingWithLayoutNC<T>)
+  case some2(InnerDeinitingWithLayoutNC<T>)
+}
+
+public enum OuterMultiPayloadNC_2<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingWithoutLayoutNC<T>)
+  case some2(InnerDeinitingWithoutLayoutNC<T>)
+}
+
+public enum OuterMultiPayloadNC_3<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingReleasableNC<T>)
+  case some2(InnerDeinitingReleasableNC<T>)
+}
+
+public enum OuterMultiPayloadNC_4<T>: ~Copyable {
+  case none
+  case some(InnerDeinitingDestructableNC<T>)
+  case some2(InnerDeinitingDestructableNC<T>)
 }
 
 // Destroyed value:
@@ -302,3 +332,107 @@ public func takeOuterSinglePayloadNC_2<T>(_ e: consuming OuterSinglePayloadNC_2<
 //           :        ptr noalias swiftself %0)
 // CHECK:       }
 public func takeOuterSinglePayloadNC_3<T>(_ e: consuming OuterSinglePayloadNC_3<T>) {}
+
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone25takeOuterMultiPayloadNC_1yyAA0fghI2_1OyxGnlF"(
+// CHECK-SAME:      ptr noalias %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_1OyxGlWOh"(
+//           :        ptr %5, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_1OyxGlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE1:%[^,]+]] = call{{.*}} @"$s30moveonly_value_functions_onone26InnerDeinitingWithLayoutNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA1:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE1]], 0
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone26InnerDeinitingWithLayoutNCVfD"(
+// CHECK-SAME:        ptr [[METADATA1]], 
+// CHECK-SAME:        ptr noalias swiftself %0)
+// CHECK:         [[RESPONSE2:%[^,]+]] = call{{.*}} @"$s30moveonly_value_functions_onone26InnerDeinitingWithLayoutNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA2:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE2]], 0
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone26InnerDeinitingWithLayoutNCVfD"(
+// CHECK-SAME:        ptr [[METADATA2]], 
+// CHECK-SAME:        ptr noalias swiftself %0)
+// CHECK:       }
+public func takeOuterMultiPayloadNC_1<T>(_ e: consuming OuterMultiPayloadNC_1<T>) {}
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone25takeOuterMultiPayloadNC_2yyAA0fghI2_2OyxGnlF"(
+//           :      i64 %0, 
+//           :      i8 %1, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_2OyxGlWOe"(
+//           :        i64 %0, 
+//           :        i8 %1, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_2OyxGlWOe"(
+//           :      i64 %0, 
+//           :      i8 %1, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone29InnerDeinitingWithoutLayoutNCVfD"(
+//           :        i64 %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone29InnerDeinitingWithoutLayoutNCVfD"(
+//           :        i64 %0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+public func takeOuterMultiPayloadNC_2<T>(_ e: consuming OuterMultiPayloadNC_2<T>) {}
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone25takeOuterMultiPayloadNC_3yyAA0fghI2_3OyxGnlF"(
+// CHECK-SAME:      ptr noalias nocapture dereferenceable(64) %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_3OyxGlWOh"(
+//           :        ptr %e, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_3OyxGlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_3OyxGlWOe"(
+//           :        i64 %2, 
+//           :        i64 %4, 
+//           :        i64 %6, 
+//           :        i64 %8, 
+//           :        i64 %10, 
+//           :        i64 %12, 
+//           :        i64 %14, 
+//           :        i64 %16, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+public func takeOuterMultiPayloadNC_3<T>(_ e: consuming OuterMultiPayloadNC_3<T>) {}
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone25takeOuterMultiPayloadNC_4yyAA0fghI2_4OyxGnlF"(
+// CHECK-SAME:      ptr noalias %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_4OyxGlWOh"(
+//           :        ptr %5, 
+// CHECK-SAME:        ptr %T)
+// CHECK:       }
+// CHECK-LABEL: define{{.*}} @"$s30moveonly_value_functions_onone21OuterMultiPayloadNC_4OyxGlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %T)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE1:%[^,]+]] = call{{.*}} @"$s30moveonly_value_functions_onone28InnerDeinitingDestructableNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA1:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE1]], 0
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone28InnerDeinitingDestructableNCVfD"(
+// CHECK-SAME:        ptr [[METADATA1]], 
+// CHECK-SAME:        ptr noalias swiftself %0)
+// CHECK:         [[RESPONSE2:%[^,]+]] = call{{.*}} @"$s30moveonly_value_functions_onone28InnerDeinitingDestructableNCVMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %T)
+// CHECK:         [[METADATA2:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE2]], 0
+// CHECK:         call{{.*}} @"$s30moveonly_value_functions_onone28InnerDeinitingDestructableNCVfD"(
+// CHECK-SAME:        ptr [[METADATA2]], 
+// CHECK-SAME:        ptr noalias swiftself %0)
+// CHECK:       }
+public func takeOuterMultiPayloadNC_4<T>(_ e: consuming OuterMultiPayloadNC_4<T>) {}

--- a/validation-test/IRGen/moveonly_partial_consumption_linked_list.swift
+++ b/validation-test/IRGen/moveonly_partial_consumption_linked_list.swift
@@ -1,0 +1,110 @@
+// RUN: %target-swift-emit-ir \
+// RUN:     %s \
+// RUN:     -enable-builtin-module \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-experimental-feature BorrowingSwitch \
+// RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -sil-verify-all \
+// RUN:     -verify
+
+// Check that a simple version of the noncopyable linked list works through the
+// SIL pipeline.
+
+struct List<Element>: ~Copyable {
+  struct Node: ~Copyable {
+    var element: Element
+    var next: Link
+  }
+
+  enum Link: ~Copyable {
+    case empty
+    case more(Box<Node>)
+  }
+
+  var head: Link = .empty
+
+  deinit {
+    dumpList(self)
+    var head = self.head // self is immutable so a local variable must be introduced
+    while case .more(let box) = consume head {
+      head = box.move().next
+    }
+  }
+}
+
+func dumpList<Element>(_ l: borrowing List<Element>) {}
+
+struct Box<Wrapped: ~Copyable>: ~Copyable {
+  private let _pointer: MyLittlePointer<Wrapped>
+  
+  init(_ element: consuming Wrapped) {
+    _pointer = .allocate(capacity: 1)
+    _pointer.initialize(to: element)
+  }
+      
+  deinit {
+    _pointer.deinitialize(count: 1)
+    _pointer.deallocate()
+  }
+  
+  consuming func move() -> Wrapped {
+    let wrapped = _pointer.move()
+    _pointer.deallocate()
+    discard self
+    return wrapped
+  }
+}
+
+// Standalone version of MemoryLayout + UnsafeMutablePointer with noncopyable T.
+
+import Builtin
+
+@frozen
+public enum MyLittleLayout<T : ~Copyable> {
+  @_transparent
+  public static var size: Int {
+    return Int(Builtin.sizeof(T.self))
+  }
+  @_transparent
+  public static var stride: Int {
+    return Int(Builtin.strideof(T.self))
+  }
+}
+
+struct MyLittlePointer<Pointee : ~Copyable> : Copyable {
+  public let _rawValue: Builtin.RawPointer
+
+  @_transparent
+  public init(_ _rawValue: Builtin.RawPointer) {
+    self._rawValue = _rawValue
+  }
+
+  @inlinable
+  public static func allocate(capacity count: Int)
+    -> MyLittlePointer<Pointee> {
+    let size = MyLittleLayout<Pointee>.stride * count
+    let align = (0)._builtinWordValue
+    let rawPtr = Builtin.allocRaw(size._builtinWordValue, align)
+    Builtin.bindMemory(rawPtr, count._builtinWordValue, Pointee.self)
+    return MyLittlePointer(rawPtr)
+  }
+
+  @inlinable
+  public func deallocate() {
+    Builtin.deallocRaw(_rawValue, (-1)._builtinWordValue, (0)._builtinWordValue)
+  }
+
+  @inlinable
+  public func initialize(to value: consuming Pointee) {
+    Builtin.initialize(value, self._rawValue)
+  }
+  @inlinable
+  public func deinitialize(count: Int) {
+    Builtin.destroyArray(Pointee.self, _rawValue, count._builtinWordValue)
+  }
+  @inlinable
+  public func move() -> Pointee {
+    return Builtin.take(_rawValue)
+  }
+}
+

--- a/validation-test/SILOptimizer/moveonly_partial_consumption_linked_list.swift
+++ b/validation-test/SILOptimizer/moveonly_partial_consumption_linked_list.swift
@@ -2,6 +2,7 @@
 // RUN:     %s \
 // RUN:     -enable-builtin-module \
 // RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-experimental-feature BorrowingSwitch \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -sil-verify-all \
 // RUN:     -verify


### PR DESCRIPTION
If any deinits will be called, pass the full generic environment of the type for which an outlined value function is being emitted.  Use the metadata collector to determine whether such deinits exist for single and multi payload enum consumes.
