### PR TITLE
[Concurrency] Never skip global actor attributes in the ASTPrinter.

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -953,8 +953,12 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
   AttributeVector modifiers;
 
   for (auto DA : llvm::reverse(FlattenedAttrs)) {
-    // Always print result builder attribute.
-    if (!Options.PrintImplicitAttrs && DA->isImplicit())
+    // Don't skip implicit custom attributes. Custom attributes like global
+    // actor isolation have critical semantic meaning and should never be
+    // suppressed. Other custom attrs that can be suppressed, like macros,
+    // are handled below.
+    if (DA->getKind() != DeclAttrKind::Custom &&
+        !Options.PrintImplicitAttrs && DA->isImplicit())
       continue;
     if (!Options.PrintUserInaccessibleAttrs &&
         DeclAttribute::isUserInaccessible(DA->getKind()))

--- a/test/SourceKit/CursorInfo/concurrency.swift
+++ b/test/SourceKit/CursorInfo/concurrency.swift
@@ -1,0 +1,18 @@
+@MainActor
+protocol P {}
+
+class InferMainActor: P {
+  func test() {}
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=4:7 %s -- %s -module-name ConcurrencyTest | %FileCheck %s --check-prefix=CHECK-CLASS
+// CHECK-CLASS: source.lang.swift.decl.class
+// CHECK-CLASS-NEXT: InferMainActor
+// CHECK-CLASS: <Declaration>@<Type usr="s:ScM">MainActor</Type> class InferMainActor : <Type usr="s:15ConcurrencyTest1PP">P</Type></Declaration>
+// CHECK-CLASS: <decl.class><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@<ref.class usr="s:ScM">MainActor</ref.class></syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>InferMainActor</decl.name> : <ref.protocol usr="s:15ConcurrencyTest1PP">P</ref.protocol></decl.class>
+
+// RUN: %sourcekitd-test -req=cursor -pos=5:8 %s -- %s -module-name ConcurrencyTest | %FileCheck %s --check-prefix=CHECK-FUNC
+// CHECK-FUNC: source.lang.swift.decl.function.method.instance
+// CHECK-FUNC-NEXT: test()
+// CHECK-FUNC: <Declaration>@<Type usr="s:ScM">MainActor</Type> func test()</Declaration>
+// CHECK-FUNC: <decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@<ref.class usr="s:ScM">MainActor</ref.class></syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>test</decl.name>()</decl.function.method.instance>


### PR DESCRIPTION
Custom attributes like global actors carry crucial semantic information and should never be suppressed in the ASTPrinter. In particular, `printQuickHelpDeclaration()` sets `PrintImplicitAttrs` to false, but it's important for quick help / cursor info to include global actors.

Resolves rdar://119909301