### PR TITLE
test: Repair CF bridging call test for non x64 targets

### DIFF
--- a/test/IRGen/cf_objc_retainAutoreleasedReturnValue.swift
+++ b/test/IRGen/cf_objc_retainAutoreleasedReturnValue.swift
@@ -17,4 +17,4 @@ public func foo() {
 // CHECK-LABEL: define {{.*}}swiftcc void @"$s37cf_objc_retainAutoreleasedReturnValue3fooyyF"()
 // CHECK: entry:
 // CHECK:   %0 = call {{.*}}@returnsACFBridgedType()
-// CHECK:   %1 = notail call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr %0)
+// CHECK:   %1 = {{.*}}call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr %0)


### PR DESCRIPTION
The test was failing on aarch64 targets because the `notail` is specified only for x86_64 targets.

- https://ci.swift.org/job/oss-swift-package-amazon-linux-2-aarch64/2868/
- https://ci.swift.org/job/oss-swift-package-ubi-9-aarch64/1319/
- https://ci.swift.org/job/oss-swift-package-ubuntu-20_04-aarch64/2792/

```
Command Output (stderr):
--
/home/build-user/swift/test/IRGen/cf_objc_retainAutoreleasedReturnValue.swift:20:11: error: CHECK: expected string not found in input
// CHECK: %1 = notail call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr %0)
          ^
<stdin>:19:40: note: scanning from here
 %0 = call ptr @returnsACFBridgedType()
                                       ^
<stdin>:21:2: note: possible intended match here
 %1 = call ptr @llvm.objc.retainAutoreleasedReturnValue(ptr %0)
 ^

Input file: <stdin>
Check file: /home/build-user/swift/test/IRGen/cf_objc_retainAutoreleasedReturnValue.swift
```

https://github.com/apple/swift/pull/72011