### PR TITLE
#56350 - Give Identifier a hasUnderscoredNaming() helper

### DIFF
--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -177,6 +177,10 @@ public:
     return str().startswith("$") && !(getLength() == 1);
   }
   
+  bool hasUnderscoredNaming() const {
+    return str().startswith("_");
+  }
+  
   const void *getAsOpaquePointer() const {
       return static_cast<const void *>(Pointer);
   }

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -304,7 +304,7 @@ public:
   void includeInstanceMembers() { IncludeInstanceMembers = true; }
 
   bool isHiddenModuleName(Identifier Name) {
-    return (Name.str().startswith("_") || Name == Ctx.SwiftShimsModuleName ||
+    return (Name.hasUnderscoredNaming() || Name == Ctx.SwiftShimsModuleName ||
             Name.str() == SWIFT_ONONE_SUPPORT);
   }
 

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1335,8 +1335,7 @@ class UseWrappedValue final : public ConstraintFix {
         PropertyWrapper(propertyWrapper), Base(base), Wrapper(wrapper) {}
 
   bool usingProjection() const {
-    auto nameStr = PropertyWrapper->getName().str();
-    return !nameStr.startswith("_");
+    return !PropertyWrapper->getName().hasUnderscoredNaming();
   }
 
 public:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1083,7 +1083,7 @@ bool Decl::hasUnderscoredNaming() const {
   }
 
   if (!VD->getBaseName().isSpecial() &&
-      VD->getBaseIdentifier().str().startswith("_")) {
+      VD->getBaseIdentifier().hasUnderscoredNaming()) {
     return true;
   }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2296,7 +2296,7 @@ void ModuleDecl::findDeclaredCrossImportOverlaysTransitive(
         for (Identifier overlay: overlays) {
           // We don't present non-underscored overlays as part of the underlying
           // module, so ignore them.
-          if (!overlay.str().startswith("_"))
+          if (!overlay.hasUnderscoredNaming())
             continue;
           ModuleDecl *overlayMod =
               getASTContext().getModuleByName(overlay.str());

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2422,7 +2422,7 @@ static void installPropertyWrapperMembersIfNeeded(NominalTypeDecl *target,
     return;
 
   if ((!baseName.getIdentifier().str().startswith("$") &&
-       !baseName.getIdentifier().str().startswith("_")) ||
+       !baseName.getIdentifier().hasUnderscoredNaming()) ||
       baseName.getIdentifier().str().size() <= 1) {
     return;
   }

--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -834,7 +834,7 @@ public:
             [&](const ValueDecl *vd) {
               return !printer.isVisible(vd) || vd->isObjC() ||
                      (vd->isStdlibDecl() && !vd->getName().isSpecial() &&
-                      vd->getBaseIdentifier().str().startswith("_")) ||
+                      vd->getBaseIdentifier().hasUnderscoredNaming()) ||
                      (vd->isStdlibDecl() && isa<StructDecl>(vd)) ||
                      (vd->isStdlibDecl() &&
                       vd->getASTContext().getErrorDecl() == vd);


### PR DESCRIPTION
#56350 
I gave Identifier a hasUnderscoredNaming() helper. Which is just:
```swift
bool hasUnderscoredNaming() const {
   return str().startswith("_");
}
```
I put it right under `hasDollarPrefix` figuring that made the most sense. I also replaced parts of the code using `str().startsWith("_")` to use the new helper. I think the helper makes intention more clear and it is definitely more convenient (especially with code completion). 

I then reran swift/test:
<img width="1451" alt="Screenshot 2024-03-02 at 5 30 41 PM" src="https://github.com/apple/swift/assets/147935617/21ccfeb8-dbf5-428d-9f5b-8fa4a8270d76">

There are 6 failures but these same tests always fail for me. I haven't looked too much into the failures (one is a module not being found, another is I am missing some python stuff) but I don't think they are related to the changes. 