### PR TITLE
Set default linker to lld for Amazon Linux 2023

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -948,6 +948,10 @@ if(XCODE)
   swift_common_xcode_cxx_config()
 endif()
 
+# Check what linux distribution is being used.
+# This can be used to determine the default linker to use.
+cmake_host_system_information(RESULT DISTRO_NAME  QUERY DISTRIB_PRETTY_NAME)
+
 # Which default linker to use. Prefer LLVM_USE_LINKER if it set, otherwise use
 # our own defaults. This should only be possible in a unified (not stand alone)
 # build environment.
@@ -959,6 +963,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows" AND NOT CMAKE_HOST_SYSTEM_NAME STREQ
   set(SWIFT_USE_LINKER_default "lld")
 elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   set(SWIFT_USE_LINKER_default "")
+elseif(DISTRO_NAME STREQUAL "Amazon Linux 2023")
+  set(SWIFT_USE_LINKER_default "lld")
 else()
   set(SWIFT_USE_LINKER_default "gold")
 endif()

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <fstream>
+
 #include "ToolChains.h"
 
 #include "swift/Basic/LLVM.h"
@@ -108,9 +110,24 @@ ToolChain::InvocationInfo toolchains::GenericUnix::constructInvocation(
 
   return II;
 }
+// Amazon Linux 2023 requires lld as the default linker.
+bool isAmazonLinux2023Host() {
+      std::ifstream file("/etc/os-release");
+      std::string line;
+
+      while (std::getline(file, line)) {
+        if (line.substr(0, 12) == "PRETTY_NAME=") {
+          if (line.substr(12) == "\"Amazon Linux 2023\"") {
+            file.close();
+            return true;
+          }
+        }
+      }
+      return false;
+    }
 
 std::string toolchains::GenericUnix::getDefaultLinker() const {
-  if (getTriple().isAndroid())
+  if (getTriple().isAndroid() || isAmazonLinux2023Host())
     return "lld";
 
   switch (getTriple().getArch()) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
The `gold` linker is no longer available in Amazon Linux 2023 and requires `lld` to be set as the default linker.

This removes the need to build the gold linker from source as proposed here - https://github.com/apple/swift-installer-scripts/pull/278

These changes only effect `amazonlinux 2023` and should not impact on the current builds of `amazonlinux 2` .
