### PR TITLE
[stdlib] convert `withUnsafePointer()` to typed throws

### DIFF
--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -166,11 +166,22 @@ func __abi_withUnsafePointer<T, Result>(
 ///     `withUnsafeMutablePointer(to:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
 @inlinable
-public func withUnsafePointer<T, Result>(
+@_alwaysEmitIntoClient
+public func withUnsafePointer<T, E: Error, Result>(
+  to value: inout T,
+  _ body: (UnsafePointer<T>) throws(E) -> Result
+) throws(E) -> Result {
+  try body(UnsafePointer<T>(Builtin.addressof(&value)))
+}
+
+/// ABI: Historical withUnsafePointer(to:_:) rethrows,
+/// expressed as "throws", which is ABI-compatible with "rethrows".
+@_silgen_name("$ss17withUnsafePointer2to_q_xz_q_SPyxGKXEtKr0_lF")
+@usableFromInline
+func __abi_se0413_withUnsafePointer<T, Result>(
   to value: inout T,
   _ body: (UnsafePointer<T>) throws -> Result
-) rethrows -> Result
-{
+) throws -> Result {
   return try body(UnsafePointer<T>(Builtin.addressof(&value)))
 }
 
@@ -179,11 +190,10 @@ public func withUnsafePointer<T, Result>(
 /// This function is similar to `withUnsafePointer`, except that it
 /// doesn't trigger stack protection for the pointer.
 @_alwaysEmitIntoClient
-public func _withUnprotectedUnsafePointer<T, Result>(
+public func _withUnprotectedUnsafePointer<T, E: Error, Result>(
   to value: inout T,
-  _ body: (UnsafePointer<T>) throws -> Result
-) rethrows -> Result
-{
+  _ body: (UnsafePointer<T>) throws(E) -> Result
+) throws(E) -> Result {
 #if $BuiltinUnprotectedAddressOf
   return try body(UnsafePointer<T>(Builtin.unprotectedAddressOf(&value)))
 #else

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -107,6 +107,8 @@ Func Result.get() has been renamed to Func __abi_get()
 Func Result.get() has mangled name changing from 'Swift.Result.get() throws -> A' to 'Swift.Result.__abi_get() throws -> A'
 Func withUnsafePointer(to:_:) has been renamed to Func __abi_withUnsafePointer(to:_:)
 Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
+Func withUnsafePointer(to:_:) has been renamed to Func __abi_se0413_withUnsafePointer(to:_:)
+Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: inout A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafePointer<A, B>(to: inout A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
 Func withUnsafePointer(to:_:) is now without @rethrows
 Func withoutActuallyEscaping(_:do:) has been renamed to Func __abi_withoutActuallyEscaping(_:do:)
 Func withoutActuallyEscaping(_:do:) has mangled name changing from 'Swift.withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B' to 'Swift.__abi_withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B'
@@ -114,6 +116,7 @@ Func withoutActuallyEscaping(_:do:) is now without @rethrows
 Func _openExistential(_:do:) has been renamed to Func __abi_openExistential(_:do:)
 Func _openExistential(_:do:) has mangled name changing from 'Swift._openExistential<A, B, C>(_: A, do: (B) throws -> C) throws -> C' to 'Swift.__abi_openExistential<A, B, C>(_: A, do: (B) throws -> C) throws -> C'
 Func _openExistential(_:do:) is now without @rethrows
+
 
 // These haven't actually been removed; they are simply marked unavailable.
 // This seems to be a false positive in the ABI checker. This is not an ABI


### PR DESCRIPTION
Part of the ongoing conversion of standard library rethrows functions, after [SE-0413](https://github.com/apple/swift-evolution/blob/main/proposals/0413-typed-throws.md).

This converts the top-level, `inout`-taking `withUnsafePointer()` function, and its corresponding no-stack-protection equivalent.