### PR TITLE
[CS] Rename `SyntacticElementTarget::forEachStmt` -> `forEachPreamble`

### DIFF
--- a/include/swift/Sema/SyntacticElementTarget.h
+++ b/include/swift/Sema/SyntacticElementTarget.h
@@ -71,7 +71,10 @@ public:
     caseLabelItem,
     patternBinding,
     uninitializedVar,
-    forEachStmt,
+
+    /// The preamble of a for-in statement, including everything except the
+    /// body.
+    forEachPreamble,
   } kind;
 
 private:
@@ -245,7 +248,7 @@ public:
   SyntacticElementTarget(ForEachStmt *stmt, DeclContext *dc,
                          bool ignoreWhereClause,
                          GenericEnvironment *packElementEnv)
-      : kind(Kind::forEachStmt) {
+      : kind(Kind::forEachPreamble) {
     forEachStmt.stmt = stmt;
     forEachStmt.dc = dc;
     forEachStmt.ignoreWhereClause = ignoreWhereClause;
@@ -268,11 +271,11 @@ public:
   static SyntacticElementTarget
   forReturn(ReturnStmt *returnStmt, Type contextTy, DeclContext *dc);
 
-  /// Form a target for a for-in loop.
+  /// Form a target for the preamble of a for-in loop, excluding its body.
   static SyntacticElementTarget
-  forForEachStmt(ForEachStmt *stmt, DeclContext *dc,
-                 bool ignoreWhereClause = false,
-                 GenericEnvironment *packElementEnv = nullptr);
+  forForEachPreamble(ForEachStmt *stmt, DeclContext *dc,
+                     bool ignoreWhereClause = false,
+                     GenericEnvironment *packElementEnv = nullptr);
 
   /// Form a target for a property with an attached property wrapper that is
   /// initialized out-of-line.
@@ -311,7 +314,7 @@ public:
       return ref.getAbstractClosureExpr();
     }
 
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return getAsForEachStmt();
 
     case Kind::stmtCondition:
@@ -339,7 +342,7 @@ public:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
     case Kind::uninitializedVar:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return nullptr;
     }
     llvm_unreachable("invalid expression type");
@@ -372,7 +375,7 @@ public:
       return uninitializedVar.binding->getInitContext(uninitializedVar.index);
     }
 
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return forEachStmt.dc;
     }
     llvm_unreachable("invalid decl context type");
@@ -477,8 +480,8 @@ public:
   /// For a pattern initialization target, retrieve the contextual pattern.
   ContextualPattern getContextualPattern() const;
 
-  /// Whether this target is for a for-in statement.
-  bool isForEachStmt() const { return kind == Kind::forEachStmt; }
+  /// Whether this target is for a for-in preamble, excluding the body.
+  bool isForEachPreamble() const { return kind == Kind::forEachPreamble; }
 
   /// Whether this is an initialization for an Optional.Some pattern.
   bool isOptionalSomePatternInit() const {
@@ -502,7 +505,7 @@ public:
   bool shouldBindPatternVarsOneWay() const {
     if (kind == Kind::expression)
       return expression.bindPatternVarsOneWay;
-    if (kind == Kind::forEachStmt)
+    if (kind == Kind::forEachPreamble)
       return !ignoreForEachWhereClause() && forEachStmt.stmt->getWhere();
     return false;
   }
@@ -553,22 +556,22 @@ public:
   }
 
   bool ignoreForEachWhereClause() const {
-    assert(isForEachStmt());
+    assert(isForEachPreamble());
     return forEachStmt.ignoreWhereClause;
   }
 
   GenericEnvironment *getPackElementEnv() const {
-    assert(isForEachStmt());
+    assert(isForEachPreamble());
     return forEachStmt.packElementEnv;
   }
 
   const ForEachStmtInfo &getForEachStmtInfo() const {
-    assert(isForEachStmt());
+    assert(isForEachPreamble());
     return forEachStmt.info;
   }
 
   ForEachStmtInfo &getForEachStmtInfo() {
-    assert(isForEachStmt());
+    assert(isForEachPreamble());
     return forEachStmt.info;
   }
 
@@ -595,7 +598,7 @@ public:
       return;
     }
 
-    if (kind == Kind::forEachStmt) {
+    if (kind == Kind::forEachPreamble) {
       forEachStmt.pattern = pattern;
       return;
     }
@@ -621,7 +624,7 @@ public:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
     case Kind::uninitializedVar:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return std::nullopt;
 
     case Kind::function:
@@ -638,7 +641,7 @@ public:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
     case Kind::uninitializedVar:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return std::nullopt;
 
     case Kind::stmtCondition:
@@ -655,7 +658,7 @@ public:
     case Kind::stmtCondition:
     case Kind::patternBinding:
     case Kind::uninitializedVar:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return std::nullopt;
 
     case Kind::caseLabelItem:
@@ -672,7 +675,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::uninitializedVar:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return nullptr;
 
     case Kind::patternBinding:
@@ -689,7 +692,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return nullptr;
 
     case Kind::uninitializedVar:
@@ -706,7 +709,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return nullptr;
 
     case Kind::uninitializedVar:
@@ -726,7 +729,7 @@ public:
     case Kind::uninitializedVar:
       return nullptr;
 
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return forEachStmt.stmt;
     }
     llvm_unreachable("invalid case label type");
@@ -740,7 +743,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return nullptr;
 
     case Kind::uninitializedVar:
@@ -757,7 +760,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return nullptr;
 
     case Kind::uninitializedVar:
@@ -774,7 +777,7 @@ public:
     case Kind::stmtCondition:
     case Kind::caseLabelItem:
     case Kind::patternBinding:
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return 0;
 
     case Kind::uninitializedVar:
@@ -837,8 +840,8 @@ public:
       return uninitializedVar.declaration.get<Pattern *>()->getSourceRange();
     }
 
-    // For-in statement target doesn't cover the body.
-    case Kind::forEachStmt:
+    // For-in preamble target doesn't cover the body.
+    case Kind::forEachPreamble:
       auto *stmt = forEachStmt.stmt;
       SourceLoc startLoc = stmt->getForLoc();
       SourceLoc endLoc = stmt->getParsedSequence()->getEndLoc();
@@ -881,7 +884,7 @@ public:
       return uninitializedVar.declaration.get<Pattern *>()->getLoc();
     }
 
-    case Kind::forEachStmt:
+    case Kind::forEachPreamble:
       return forEachStmt.stmt->getStartLoc();
     }
     llvm_unreachable("invalid target type");

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4708,8 +4708,8 @@ generateForEachStmtConstraints(ConstraintSystem &cs, DeclContext *dc,
 }
 
 static std::optional<SyntacticElementTarget>
-generateForEachStmtConstraints(ConstraintSystem &cs,
-                               SyntacticElementTarget target) {
+generateForEachPreambleConstraints(ConstraintSystem &cs,
+                                   SyntacticElementTarget target) {
   ForEachStmt *stmt = target.getAsForEachStmt();
   auto *forEachExpr = stmt->getParsedSequence();
   auto *dc = target.getDeclContext();
@@ -4952,7 +4952,7 @@ bool ConstraintSystem::generateConstraints(
     }
   }
 
-  case SyntacticElementTarget::Kind::forEachStmt: {
+  case SyntacticElementTarget::Kind::forEachPreamble: {
 
     // Cache the outer generic environment, if it exists.
     if (target.getPackElementEnv()) {
@@ -4961,7 +4961,7 @@ bool ConstraintSystem::generateConstraints(
 
     // For a for-each statement, generate constraints for the pattern, where
     // clause, and sequence traversal.
-    auto resultTarget = generateForEachStmtConstraints(*this, target);
+    auto resultTarget = generateForEachPreambleConstraints(*this, target);
     if (!resultTarget)
       return true;
 

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -651,7 +651,7 @@ private:
     // records it as a separate conjunction element to allow for a more
     // granular control over what contextual information is brought into
     // the scope during pattern + sequence and `where` clause solving.
-    auto target = SyntacticElementTarget::forForEachStmt(
+    auto target = SyntacticElementTarget::forForEachPreamble(
         forEachStmt, context.getAsDeclContext(),
         /*ignoreWhereClause=*/true);
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7188,7 +7188,7 @@ void ConstraintSystem::diagnoseFailureFor(SyntacticElementTarget target) {
     }
   } else if (auto *var = target.getAsUninitializedVar()) {
     DE.diagnose(target.getLoc(), diag::failed_to_produce_diagnostic);
-  } else if (target.isForEachStmt()) {
+  } else if (target.isForEachPreamble()) {
     DE.diagnose(target.getLoc(), diag::failed_to_produce_diagnostic);
   } else {
     // Emit a poor fallback message.

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2366,7 +2366,7 @@ bool ConstraintSystem::preCheckTarget(SyntacticElementTarget &target,
     target.setExpr(expr);
   }
 
-  if (target.isForEachStmt()) {
+  if (target.isForEachPreamble()) {
     auto *stmt = target.getAsForEachStmt();
 
     auto *sequenceExpr = stmt->getParsedSequence();

--- a/lib/Sema/SyntacticElementTarget.cpp
+++ b/lib/Sema/SyntacticElementTarget.cpp
@@ -193,9 +193,9 @@ SyntacticElementTarget::forReturn(ReturnStmt *returnStmt, Type contextTy,
 }
 
 SyntacticElementTarget
-SyntacticElementTarget::forForEachStmt(ForEachStmt *stmt, DeclContext *dc,
-                                       bool ignoreWhereClause,
-                                       GenericEnvironment *packElementEnv) {
+SyntacticElementTarget::forForEachPreamble(ForEachStmt *stmt, DeclContext *dc,
+                                           bool ignoreWhereClause,
+                                           GenericEnvironment *packElementEnv) {
   SyntacticElementTarget target(stmt, dc, ignoreWhereClause, packElementEnv);
   return target;
 }
@@ -235,7 +235,7 @@ ContextualPattern SyntacticElementTarget::getContextualPattern() const {
                                                     uninitializedVar.index);
   }
 
-  if (isForEachStmt()) {
+  if (isForEachPreamble()) {
     return ContextualPattern::forRawPattern(forEachStmt.pattern,
                                             forEachStmt.dc);
   }
@@ -395,7 +395,7 @@ SyntacticElementTarget::walk(ASTWalker &walker) const {
     }
     break;
   }
-  case Kind::forEachStmt: {
+  case Kind::forEachPreamble: {
     // We need to skip the where clause if requested, and we currently do not
     // type-check a for loop's BraceStmt as part of the SyntacticElementTarget,
     // so we need to skip it here.

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -394,7 +394,7 @@ void constraints::performSyntacticDiagnosticsForTarget(
     return;
   }
 
-  case SyntacticElementTarget::Kind::forEachStmt: {
+  case SyntacticElementTarget::Kind::forEachPreamble: {
     auto *stmt = target.getAsForEachStmt();
 
     // First emit diagnostics for the main expression.
@@ -928,8 +928,8 @@ bool TypeChecker::typeCheckPatternBinding(PatternBindingDecl *PBD,
   return hadError;
 }
 
-bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt,
-                                          GenericEnvironment *packElementEnv) {
+bool TypeChecker::typeCheckForEachPreamble(DeclContext *dc, ForEachStmt *stmt,
+                                           GenericEnvironment *packElementEnv) {
   auto &Context = dc->getASTContext();
   FrontendStatsTracer statsTracer(Context.Stats, "typecheck-for-each", stmt);
   PrettyStackTraceStmt stackTrace(Context, "type-checking-for-each", stmt);
@@ -945,7 +945,7 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt,
     return true;
   };
 
-  auto target = SyntacticElementTarget::forForEachStmt(
+  auto target = SyntacticElementTarget::forForEachPreamble(
       stmt, dc, /*ignoreWhereClause=*/false, packElementEnv);
   if (!typeCheckTarget(target))
     return failed();

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1413,7 +1413,7 @@ public:
     GenericEnvironment *genericSignature =
         genericSigStack.empty() ? nullptr : genericSigStack.back();
 
-    if (TypeChecker::typeCheckForEachBinding(DC, S, genericSignature))
+    if (TypeChecker::typeCheckForEachPreamble(DC, S, genericSignature))
       return nullptr;
 
     // Type-check the body of the loop.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -750,11 +750,12 @@ bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber,
                              Type patternType = Type(),
                              TypeCheckExprOptions options = {});
 
-/// Type-check a for-each loop's pattern binding and sequence together.
+/// Type-check a for-each loop's pattern binding, sequence, and where clause
+/// together.
 ///
 /// \returns true if a failure occurred.
-bool typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt,
-                             GenericEnvironment *packElementEnv);
+bool typeCheckForEachPreamble(DeclContext *dc, ForEachStmt *stmt,
+                              GenericEnvironment *packElementEnv);
 
 /// Compute the set of captures for the given function or closure.
 void computeCaptures(AnyFunctionRef AFR);


### PR DESCRIPTION
This more closely matches what we're actually type-checking, since we do not currently include the body.
