### PR TITLE
[Concurrency] Fix an issue where `nonisolated(unsafe)` did not suppress concurrency warnings.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2468,6 +2468,15 @@ namespace {
         // If the closure won't execute concurrently with the context in
         // which the declaration occurred, it's okay.
         auto decl = capture.getDecl();
+        auto isolation = getActorIsolation(decl);
+
+        // 'nonisolated' local variables are always okay to capture in
+        // 'Sendable' closures because they can be accessed from anywhere.
+        // Note that only 'nonisolated(unsafe)' can be applied to local
+        // variables.
+        if (isolation.isNonisolated())
+          continue;
+
         auto *context = localFunc.getAsDeclContext();
         auto fnType = localFunc.getType()->getAs<AnyFunctionType>();
         if (!mayExecuteConcurrentlyWith(context, decl->getDeclContext()))

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -367,4 +367,12 @@ final class UseNonisolatedUnsafe: Sendable {
   nonisolated(unsafe) var x1: NonSendable = .init()
   nonisolated(unsafe) let x2: NonSendable = .init()
   nonisolated(unsafe) var x3: Int = 0
+
+  func captureInTask() {
+    nonisolated(unsafe) var x = NonSendable()
+    Task {
+      print(x)
+      x = NonSendable()
+    }
+  }
 }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -361,3 +361,10 @@ enum SynthesizedConformances {
     let x: NotSendable
   }
 }
+
+@available(SwiftStdlib 5.1, *)
+final class UseNonisolatedUnsafe: Sendable {
+  nonisolated(unsafe) var x1: NonSendable = .init()
+  nonisolated(unsafe) let x2: NonSendable = .init()
+  nonisolated(unsafe) var x3: Int = 0
+}


### PR DESCRIPTION
Allow `nonisolated(unsafe)` stored properties in `Sendable` types when the property is mutable or non-`Sendable`:

```swift
final class C: Sendable {
  nonisolated(unsafe) var x = 0 // okay
}
```

Also allow capturing non-`Sendable` local variables marked as `nonisolated(unsafe)` in `@Sendable` closures:

```swift
func test() {
  nonisolated(unsafe) var x = NonSendable()
  Task {
    print(x)
    x = NonSendable()
  }
}
```

Resolves: rdar://124023115