### PR TITLE
[stdlib] convert `withUnsafeBytes()` to typed throws

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1288,10 +1288,23 @@ public func _withUnprotectedUnsafeBytes<T, Result>(
 ///     `withUnsafeMutableBytes(of:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
 @inlinable
-public func withUnsafeBytes<T, Result>(
+@_alwaysEmitIntoClient
+public func withUnsafeBytes<T, E: Error, Result>(
+  of value: T,
+  _ body: (UnsafeRawBufferPointer) throws(E) -> Result
+) throws(E) -> Result {
+  let addr = UnsafeRawPointer(Builtin.addressOfBorrow(value))
+  return try body(.init(start: addr, count: MemoryLayout<T>.size))
+}
+
+/// ABI: Historical withUnsafeBytes(of:_:) rethrows,
+/// expressed as "throws", which is ABI-compatible with "rethrows".
+@_silgen_name("$ss15withUnsafeBytes2of_q_x_q_SWKXEtKr0_lF")
+@usableFromInline
+func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
-) rethrows -> Result {
+) throws -> Result {
   let addr = UnsafeRawPointer(Builtin.addressOfBorrow(value))
   let buffer = UnsafeRawBufferPointer(start: addr, count: MemoryLayout<T>.size)
   return try body(buffer)
@@ -1303,10 +1316,10 @@ public func withUnsafeBytes<T, Result>(
 /// This function is similar to `withUnsafeBytes`, except that it
 /// doesn't trigger stack protection for the pointer.
 @_alwaysEmitIntoClient
-public func _withUnprotectedUnsafeBytes<T, Result>(
+public func _withUnprotectedUnsafeBytes<T, E: Error, Result>(
   of value: T,
-  _ body: (UnsafeRawBufferPointer) throws -> Result
-) rethrows -> Result {
+  _ body: (UnsafeRawBufferPointer) throws(E) -> Result
+) throws(E) -> Result {
 #if $BuiltinUnprotectedAddressOf
   let addr = UnsafeRawPointer(Builtin.unprotectedAddressOfBorrow(value))
 #else

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1242,11 +1242,23 @@ public func withUnsafeMutableBytes<T, Result>(
 ///     `withUnsafeMutableBytes(of:_:)` instead.
 /// - Returns: The return value, if any, of the `body` closure.
 @inlinable
-public func withUnsafeBytes<T, Result>(
+@_alwaysEmitIntoClient
+public func withUnsafeBytes<T, E: Error, Result>(
+  of value: inout T,
+  _ body: (UnsafeRawBufferPointer) throws(E) -> Result
+) throws(E) -> Result {
+  let address = UnsafeRawPointer(Builtin.addressof(&value))
+  return try body(.init(start: address, count: MemoryLayout<T>.size))
+}
+
+/// ABI: Historical withUnsafeBytes(of:_:) rethrows,
+/// expressed as "throws", which is ABI-compatible with "rethrows".
+@_silgen_name("$ss15withUnsafeBytes2of_q_xz_q_SWKXEtKr0_lF")
+@usableFromInline
+func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
-) rethrows -> Result
-{
+) throws -> Result {
   return try withUnsafePointer(to: &value) {
     try body(UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
   }
@@ -1258,14 +1270,16 @@ public func withUnsafeBytes<T, Result>(
 /// This function is similar to `withUnsafeBytes`, except that it
 /// doesn't trigger stack protection for the pointer.
 @_alwaysEmitIntoClient
-public func _withUnprotectedUnsafeBytes<T, Result>(
+public func _withUnprotectedUnsafeBytes<T, E: Error, Result>(
   of value: inout T,
-  _ body: (UnsafeRawBufferPointer) throws -> Result
-) rethrows -> Result
-{
-  return try _withUnprotectedUnsafePointer(to: &value) {
-    try body(UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
-  }
+  _ body: (UnsafeRawBufferPointer) throws(E) -> Result
+) throws(E) -> Result {
+#if $BuiltinUnprotectedAddressOf
+  let p = UnsafeRawPointer(Builtin.unprotectedAddressOf(&value))
+#else
+  let p = UnsafeRawPointer(Builtin.addressof(&value))
+#endif
+  return try body(.init(start: p, count: MemoryLayout<T>.size))
 }
 
 /// Invokes the given closure with a buffer pointer covering the raw bytes of

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1233,6 +1233,24 @@ func __abi_se0413_withUnsafeMutableBytes<T, Result>(
 /// Invokes the given closure with a buffer pointer covering the raw bytes of
 /// the given argument.
 ///
+/// This function is similar to `withUnsafeMutableBytes`, except that it
+/// doesn't trigger stack protection for the pointer.
+@_alwaysEmitIntoClient
+public func _withUnprotectedUnsafeMutableBytes<T, E: Error, Result>(
+  of value: inout T,
+  _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
+) throws(E) -> Result {
+#if $BuiltinUnprotectedAddressOf
+  let pointer = UnsafeMutableRawPointer(Builtin.unprotectedAddressOf(&value))
+#else
+  let pointer = UnsafeMutableRawPointer(Builtin.addressof(&value))
+#endif
+  return try body(.init(start: pointer, count: MemoryLayout<T>.size))
+}
+
+/// Invokes the given closure with a buffer pointer covering the raw bytes of
+/// the given argument.
+///
 /// The buffer pointer argument to the `body` closure provides a collection
 /// interface to the raw bytes of `value`. The buffer is the size of the
 /// instance passed as `value` and does not include any remote storage.

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1207,11 +1207,23 @@ extension ${Self} {
 ///     of the closure's execution.
 /// - Returns: The return value, if any, of the `body` closure.
 @inlinable
-public func withUnsafeMutableBytes<T, Result>(
+@_alwaysEmitIntoClient
+public func withUnsafeMutableBytes<T, E: Error, Result>(
+  of value: inout T,
+  _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Result
+) throws(E) -> Result {
+  let pointer = UnsafeMutableRawPointer(Builtin.addressof(&value))
+  return try body(.init(start: pointer, count: MemoryLayout<T>.size))
+}
+
+/// ABI: Historical withUnsafeMutableBytes(of:_:) rethrows,
+/// expressed as "throws", which is ABI-compatible with "rethrows".
+@_silgen_name("$ss22withUnsafeMutableBytes2of_q_xz_q_SwKXEtKr0_lF")
+@usableFromInline
+func __abi_se0413_withUnsafeMutableBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws -> Result
-) rethrows -> Result
-{
+) throws -> Result {
   return try withUnsafeMutablePointer(to: &value) {
     return try body(UnsafeMutableRawBufferPointer(
         start: $0, count: MemoryLayout<T>.size))

--- a/test/SILOptimizer/stack_protection.swift
+++ b/test/SILOptimizer/stack_protection.swift
@@ -64,6 +64,16 @@ public func unprotectedUnsafeBytes() {
   }
 }
 
+// CHECK-LABEL: sil @$s4test29unprotectedUnsafeMutableBytesyyF
+// CHECK-NOT:     copy_addr
+// CHECK:       } // end sil function '$s4test29unprotectedUnsafeMutableBytesyyF'
+public func unprotectedUnsafeMutableBytes() {
+  var x = 0
+  _withUnprotectedUnsafeMutableBytes(of: &x) {
+    potentiallyBadCFunction($0.bindMemory(to: Int.self).baseAddress!)
+  }
+}
+
 // CHECK-LABEL: sil [stack_protection] @$s4test20overflowInCFunction2yyF
 // CHECK-NOT:     copy_addr
 // CHECK:       } // end sil function '$s4test20overflowInCFunction2yyF'

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -43,6 +43,10 @@ Func Sequence.map(_:) is now without @rethrows
 Constructor Result.init(catching:) has generic signature change from <Success, Failure where Failure == any Swift.Error> to <Success, Failure where Failure : Swift.Error>
 Func withUnsafePointer(to:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error>
 Func withUnsafePointer(to:_:) is now without @rethrows
+Func withUnsafeBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error>
+Func withUnsafeBytes(of:_:) is now without @rethrows
+Func withUnsafeMutableBytes(of:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error>
+Func withUnsafeMutableBytes(of:_:) is now without @rethrows
 Func withoutActuallyEscaping(_:do:) has generic signature change from <ClosureType, ResultType> to <ClosureType, ResultType, Failure where Failure : Swift.Error>
 Func withoutActuallyEscaping(_:do:) is now without @rethrows
 

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -108,6 +108,13 @@ Func Result.get() has mangled name changing from 'Swift.Result.get() throws -> A
 Func withUnsafePointer(to:_:) has been renamed to Func __abi_withUnsafePointer(to:_:)
 Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
 Func withUnsafePointer(to:_:) is now without @rethrows
+Func withUnsafeBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeBytes(of:_:)
+Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeBytes(of:_:) is now without @rethrows
+Func withUnsafeMutableBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeMutableBytes(of:_:)
+Func withUnsafeMutableBytes(of:_:) has mangled name changing from 'Swift.withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeMutableBytes(of:_:) is now without @rethrows
 Func withoutActuallyEscaping(_:do:) has been renamed to Func __abi_withoutActuallyEscaping(_:do:)
 Func withoutActuallyEscaping(_:do:) has mangled name changing from 'Swift.withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B' to 'Swift.__abi_withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B'
 Func withoutActuallyEscaping(_:do:) is now without @rethrows

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -113,7 +113,7 @@ Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeByte
 Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
 Func withUnsafeBytes(of:_:) is now without @rethrows
 Func withUnsafeMutableBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeMutableBytes(of:_:)
-Func withUnsafeMutableBytes(of:_:) has mangled name changing from 'Swift.withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeMutableBytes(of:_:) has mangled name changing from 'Swift.withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeMutableRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeMutableRawBufferPointer) throws -> B) throws -> B'
 Func withUnsafeMutableBytes(of:_:) is now without @rethrows
 Func withoutActuallyEscaping(_:do:) has been renamed to Func __abi_withoutActuallyEscaping(_:do:)
 Func withoutActuallyEscaping(_:do:) has mangled name changing from 'Swift.withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B' to 'Swift.__abi_withoutActuallyEscaping<A, B>(_: A, do: (A) throws -> B) throws -> B'


### PR DESCRIPTION
Part of the ongoing conversion of standard library rethrows functions, after [SE-0413](https://github.com/apple/swift-evolution/blob/main/proposals/0413-typed-throws.md).

This converts the top-level `withUnsafe[Mutable]Bytes(of:_:)` functions, and their corresponding no-stack-protection equivalents. There was no `_withUnprotectedUnsafeMutableBytes()` previously &mdash; added here.