### PR TITLE
Make UnsafeRawBufferPointer.loadUnaligned inlinable to match other pointer load methods

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -431,6 +431,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   /// - Returns: A new instance of type `T`, copied from the buffer pointer's
   ///   memory.
 #if $BitwiseCopyable
+  @inlinable
   @_alwaysEmitIntoClient
   public func loadUnaligned<T : _BitwiseCopyable>(
     fromByteOffset offset: Int = 0,
@@ -442,6 +443,7 @@ extension Unsafe${Mutable}RawBufferPointer {
     return baseAddress!.loadUnaligned(fromByteOffset: offset, as: T.self)
   }
 #endif
+  @inlinable
   @_alwaysEmitIntoClient
   public func loadUnaligned<T>(
     fromByteOffset offset: Int = 0,


### PR DESCRIPTION
Fixes rdar://124038640 (UnsignedRawBufferPointer.loadUnaligned should be inlinable)