### PR TITLE
[region-isolation] Take into account that Swift's RPO order doesn't include blocks that are dead.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -61,6 +61,12 @@ class BlockPartitionState {
   /// Set if this block in the next iteration needs to be visited.
   bool needsUpdate = false;
 
+  /// Set if this block is live.
+  ///
+  /// If the block is not live, then we shouldnt try to emit diagnostics for it
+  /// since we will not have performed dataflow upon it.
+  bool isLive = false;
+
   /// The partition of elements into regions at the top of the block.
   Partition entryPartition;
 
@@ -81,6 +87,8 @@ class BlockPartitionState {
                       TransferringOperandSetFactory &ptrSetFactory);
 
 public:
+  bool getLiveness() const { return isLive; }
+
   ArrayRef<PartitionOp> getPartitionOps() const { return blockPartitionOps; }
 
   const Partition &getEntryPartition() const { return entryPartition; }

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3057,6 +3057,7 @@ void RegionAnalysisFunctionInfo::runDataflow() {
 
     for (auto *block : pofi->getReversePostOrder()) {
       auto &blockState = (*blockStates)[block];
+      blockState.isLive = true;
 
       LLVM_DEBUG(llvm::dbgs() << "Block: bb" << block->getDebugID() << "\n");
       if (!blockState.needsUpdate) {

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1324,6 +1324,12 @@ void TransferNonSendableImpl::runDiagnosticEvaluator() {
   LLVM_DEBUG(llvm::dbgs() << "Walking blocks for diagnostics.\n");
   for (auto [block, blockState] : regionInfo->getRange()) {
     LLVM_DEBUG(llvm::dbgs() << "|--> Block bb" << block.getDebugID() << "\n");
+
+    if (!blockState.getLiveness()) {
+      LLVM_DEBUG(llvm::dbgs() << "Dead block... skipping!\n");
+      continue;
+    }
+
     LLVM_DEBUG(llvm::dbgs() << "Entry Partition: ";
                blockState.getEntryPartition().print(llvm::dbgs()));
 

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -175,3 +175,27 @@ bb0:
   %19 = tuple ()
   return %19 : $()
 }
+
+// Dead block crasher
+//
+// We used to crash here since we attempted to process /all/ blocks for
+// diagnostic even for non-dead blocks. This is a problem since the dataflow
+// uses a reverse post order traversal to get quick convergence and that skips
+// dead blocks.
+sil [ossa] @dead_block_crasher : $@convention(thin) @async () -> () {
+bb0:
+  %0 = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+  %1 = apply %0() : $@convention(thin) () -> @owned NonSendableKlass
+  br bb1
+
+bbDeadBlock:
+  %transfer = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  br bb1
+
+bb1:
+  destroy_value %1 : $NonSendableKlass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+


### PR DESCRIPTION
When we run RegionAnalysis, since it uses RPO order, we do not visit dead blocks. This can create a problem when we emit diagnostics since we may merge in a value into the region that was never actually defined. In this patch, if we actually visit the block while performing dataflow, I mark a bit in its state saying that it was live. Then when we emit diagnostics, I do not visit blocks that were not marked live.

rdar://124042351
