### PR TITLE
[Concurrency] Look through caller-side default arguments for `#isolation`  when computing the isolated actor expression for a call.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3378,6 +3378,12 @@ namespace {
 
         // FIXME: CurrentContextIsolationExpr does not have its actor set
         // at this point.
+        if (auto *defaultArg = dyn_cast<DefaultArgumentExpr>(arg)) {
+          // Look through caller-side default arguments for #isolation.
+          if (defaultArg->isCallerSide()) {
+            arg = defaultArg->getCallerSideDefaultExpr();
+          }
+        }
         if (auto *macro = dyn_cast<MacroExpansionExpr>(arg)) {
           auto *expansion = macro->getRewritten();
           if (auto *isolation = dyn_cast<CurrentContextIsolationExpr>(expansion)) {

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3055,7 +3055,7 @@ namespace {
       ctx.Diags.diagnose(loc, diag::shared_mutable_state_access, value)
           .limitBehaviorUntilSwiftVersion(limit, 6)
           // Preconcurrency global variables are warnings even in Swift 6
-          .limitBehaviorIf(isPreconcurrencyImport, DiagnosticBehavior::Warning);
+          .limitBehaviorIf(isPreconcurrencyImport, limit);
       value->diagnose(diag::kind_declared_here, value->getDescriptiveKind());
       if (const auto sourceFile = getDeclContext()->getParentSourceFile();
           sourceFile && isPreconcurrencyImport) {

--- a/test/Concurrency/global_variables.swift
+++ b/test/Concurrency/global_variables.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/GlobalVariables.swiftmodule -module-name GlobalVariables -parse-as-library -strict-concurrency=minimal -swift-version 5 %S/Inputs/GlobalVariables.swift
-// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -swift-version 6 -I %t %s -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -disable-availability-checking -parse-as-library -swift-version 6 -I %t -emit-sil -o /dev/null -verify %s
 
 // REQUIRES: concurrency
 
@@ -71,7 +71,7 @@ func testLocalNonisolatedUnsafe() async {
 
 func testImportedGlobals() { // expected-note{{add '@MainActor' to make global function 'testImportedGlobals()' part of global actor 'MainActor'}}
   let _ = Globals.integerConstant
-  let _ = Globals.integerMutable // expected-warning{{reference to static property 'integerMutable' is not concurrency-safe because it involves shared mutable state}}
+  let _ = Globals.integerMutable
   let _ = Globals.nonisolatedUnsafeIntegerConstant
   let _ = Globals.nonisolatedUnsafeIntegerMutable
   let _ = Globals.actorInteger // expected-error{{main actor-isolated static property 'actorInteger' can not be referenced from a non-isolated context}}

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -482,6 +482,11 @@ public func useDefaultIsolation(
   _ isolation: isolated (any Actor)? = #isolation
 ) {}
 
+public func useDefaultIsolationWithoutIsolatedParam(
+  _ isolation: (any Actor)? = #isolation
+) {}
+
 @MainActor func callUseDefaultIsolation() async {
   useDefaultIsolation()
+  useDefaultIsolationWithoutIsolatedParam()
 }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -477,3 +477,11 @@ nonisolated func fromNonisolated(ns: NotSendable) async -> NotSendable {
 func invalidIsolatedClosureParam<A: AnyActor> (
   _: (isolated A) async throws -> Void // expected-error {{'isolated' parameter type 'A' does not conform to 'Actor' or 'DistributedActor'}}
 ) {}
+
+public func useDefaultIsolation(
+  _ isolation: isolated (any Actor)? = #isolation
+) {}
+
+@MainActor func callUseDefaultIsolation() async {
+  useDefaultIsolation()
+}


### PR DESCRIPTION
Resolves an issue where the actor isolation checker did not compute the correct isolation for a call when the callee used `#isolation` as a default argument, which sometimes as missing `await` errors when `await` was not written on the call, and manifested as a SILGen crash otherwise due to the underlying actor of `CurrentContextIsoaltionExpr` being `nullptr`.

Note that this PR contains the commit from https://github.com/apple/swift/pull/72079

Resolves: rdar://123771114, rdar://123868148, rdar://123793070