### PR TITLE
[BitwiseCopyable] Suppress a few conformances.

### DIFF
--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -61,4 +61,7 @@ public enum CommandLine {
     = (0..<Int(argc)).map { String(cString: _unsafeArgv[$0]!) }
 }
 
+@available(*, unavailable)
+extension CommandLine : _BitwiseCopyable {}
+
 #endif // SWIFT_STDLIB_HAS_COMMANDLINE

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -76,6 +76,9 @@ public enum MemoryLayout<T> {
   }
 }
 
+@available(*, unavailable)
+extension MemoryLayout : _BitwiseCopyable {}
+
 extension MemoryLayout {
   /// Returns the contiguous memory footprint of the given instance.
   ///

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -674,3 +674,6 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
 @frozen
 public enum Unicode {}
 
+@available(*, unavailable)
+extension Unicode : _BitwiseCopyable {}
+

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -40,3 +40,11 @@ func passMemoryLayout<T>(_ m: MemoryLayout<T>) { take(m) } // expected-error{{co
 func passCommandLine(_ m: CommandLine) { take(m) } // expected-error{{conformance_availability_unavailable}}
 
 func passUnicode(_ m: Unicode) { take(m) } // expected-error{{conformance_availability_unavailable}}
+
+import Builtin
+
+#if arch(arm)
+func passBuiltinFloat16(_ f: Builtin.FPIEEE16) { take(f) }
+@available(SwiftStdlib 5.3, *)
+func passFloat16(_ f: Float16) { take(f) }
+#endif

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -1,5 +1,4 @@
 // RUN: %target-typecheck-verify-swift                       \
-// RUN:     -disable-availability-checking                   \
 // RUN:     -enable-experimental-feature NonescapableTypes   \
 // RUN:     -enable-experimental-feature BitwiseCopyable     \
 // RUN:     -enable-builtin-module                           \
@@ -35,3 +34,5 @@ func take<T : _BitwiseCopyable>(_ t: T) {}
 
 func passInternalUsableStruct(_ s: InternalUsableStruct) { take(s) } // expected-error{{type_does_not_conform_decl_owner}}
                                                                      // expected-note@-8{{where_requirement_failure_one_subst}}
+
+func passMemoryLayout<T>(_ m: MemoryLayout<T>) { take(m) } // expected-error{{conformance_availability_unavailable}}

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -38,3 +38,5 @@ func passInternalUsableStruct(_ s: InternalUsableStruct) { take(s) } // expected
 func passMemoryLayout<T>(_ m: MemoryLayout<T>) { take(m) } // expected-error{{conformance_availability_unavailable}}
 
 func passCommandLine(_ m: CommandLine) { take(m) } // expected-error{{conformance_availability_unavailable}}
+
+func passUnicode(_ m: Unicode) { take(m) } // expected-error{{conformance_availability_unavailable}}

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -48,3 +48,17 @@ func passBuiltinFloat16(_ f: Builtin.FPIEEE16) { take(f) }
 @available(SwiftStdlib 5.3, *)
 func passFloat16(_ f: Float16) { take(f) }
 #endif
+
+enum E_Raw_Int : Int {
+  case one = 1
+  case sixty_three = 63
+}
+
+func passE_Raw_Int(_ e: E_Raw_Int) { take(e) }
+
+enum E_Raw_String : String {
+  case one = "one"
+  case sixty_three = "sixty three"
+}
+
+func passE_Raw_String(_ e: E_Raw_String) { take(e) }

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -36,3 +36,5 @@ func passInternalUsableStruct(_ s: InternalUsableStruct) { take(s) } // expected
                                                                      // expected-note@-8{{where_requirement_failure_one_subst}}
 
 func passMemoryLayout<T>(_ m: MemoryLayout<T>) { take(m) } // expected-error{{conformance_availability_unavailable}}
+
+func passCommandLine(_ m: CommandLine) { take(m) } // expected-error{{conformance_availability_unavailable}}


### PR DESCRIPTION
Suppress the conformances of Unicode, CommandLine, and MemoryLayout.  Add a couple tests.
