### PR TITLE
[DeadObjectElimination] Zero init is not a barrier

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -310,6 +310,14 @@ static bool canZapInstruction(SILInstruction *Inst, bool acceptRefCountInsts,
   if (isa<BeginAccessInst>(Inst) || isa<EndAccessInst>(Inst))
     return true;
 
+  // The value form of zero init is not a user of any operand. The address
+  // form however is easily zappable because it's always a trivial store.
+  if (auto bi = dyn_cast<BuiltinInst>(Inst)) {
+    if (bi->getBuiltinKind() == BuiltinValueKind::ZeroInitializer) {
+      return true;
+    }
+  }
+
   // If Inst does not read or write to memory, have side effects, and is not a
   // terminator, we can zap it.
   if (!Inst->mayHaveSideEffects() && !Inst->mayReadFromMemory() &&

--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -719,5 +719,5 @@ bb0:
   %empty = builtin "zeroInitializer"(%0 : $*Kl) : $()
   dealloc_stack %0 : $*Kl
   %1 = tuple ()
-  return %1
+  return %1 : $()
 }

--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -716,8 +716,8 @@ bb0(%0 : $_ContiguousArrayStorage<Element>):
 sil @dead_zero_init : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_stack $Kl
-  builtin "zeroInitializer"(%0 : $*Kl)
-  dealloc_stack %0
+  %empty = builtin "zeroInitializer"(%0 : $*Kl) : $()
+  dealloc_stack %0 : $*Kl
   %1 = tuple ()
   return %1
 }

--- a/test/SILOptimizer/dead_alloc_elim.sil
+++ b/test/SILOptimizer/dead_alloc_elim.sil
@@ -710,3 +710,14 @@ bb0(%0 : $_ContiguousArrayStorage<Element>):
   return %15 : $()
 }
 
+// CHECK-LABEL: @dead_zero_init
+// CHECK-NOT: alloc_stack
+// // CHECK: } // end sil function 'dead_zero_init'
+sil @dead_zero_init : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Kl
+  builtin "zeroInitializer"(%0 : $*Kl)
+  dealloc_stack %0
+  %1 = tuple ()
+  return %1
+}

--- a/test/SILOptimizer/stdlib/Atomics.swift
+++ b/test/SILOptimizer/stdlib/Atomics.swift
@@ -63,3 +63,17 @@ func localCompareExchange() -> (exchanged: Bool, original: Int) {
     ordering: .sequentiallyConsistent
   )
 }
+
+//===----------------------------------------------------------------------===//
+// Dead Object Elimination
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: sil {{.*}} @deadAtomic {{.*}} {
+// CHECK:         %0 = tuple ()
+// CHECK-NEXT:    return %0 : $()
+// CHECK-LABEL: } // end sil function 'deadAtomic'
+@_silgen_name("deadAtomic")
+func deadAtomic() {
+  let _ = Atomic(0)
+  let _ = Atomic<UnsafeRawPointer?>(nil)
+}


### PR DESCRIPTION
The zero init builtin has an address form which can create a use site for potentially dead allocs. Teach DOE that it can always zap this instruction.