### PR TITLE
[stdlib] convert `withUnsafeMutablePointer()` to typed throws

### DIFF
--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -74,11 +74,20 @@ public func _fixLifetime<T>(_ x: T) {
 ///     execution.
 /// - Returns: The return value, if any, of the `body` closure.
 @inlinable
-public func withUnsafeMutablePointer<T, Result>(
+@_alwaysEmitIntoClient
+public func withUnsafeMutablePointer<T, E: Error, Result>(
+  to value: inout T,
+  _ body: (UnsafeMutablePointer<T>) throws(E) -> Result
+) throws(E) -> Result {
+  try body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
+}
+
+@_silgen_name("$ss24withUnsafeMutablePointer2to_q_xz_q_SpyxGKXEtKr0_lF")
+@usableFromInline
+func __abi_se0413_withUnsafeMutablePointer<T, Result>(
   to value: inout T,
   _ body: (UnsafeMutablePointer<T>) throws -> Result
-) rethrows -> Result
-{
+) throws -> Result {
   return try body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
 }
 

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -41,6 +41,8 @@ Func Collection.map(_:) is now without @rethrows
 Func Sequence.map(_:) has generic signature change from <Self, T where Self : Swift.Sequence> to <Self, T, E where Self : Swift.Sequence, E : Swift.Error>
 Func Sequence.map(_:) is now without @rethrows
 Constructor Result.init(catching:) has generic signature change from <Success, Failure where Failure == any Swift.Error> to <Success, Failure where Failure : Swift.Error>
+Func withUnsafeMutablePointer(to:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error>
+Func withUnsafeMutablePointer(to:_:) is now without @rethrows
 Func withUnsafePointer(to:_:) has generic signature change from <T, Result> to <T, E, Result where E : Swift.Error>
 Func withUnsafePointer(to:_:) is now without @rethrows
 Func withoutActuallyEscaping(_:do:) has generic signature change from <ClosureType, ResultType> to <ClosureType, ResultType, Failure where Failure : Swift.Error>

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -106,7 +106,7 @@ Constructor Result.init(catching:) has been removed
 Func Result.get() has been renamed to Func __abi_get()
 Func Result.get() has mangled name changing from 'Swift.Result.get() throws -> A' to 'Swift.Result.__abi_get() throws -> A'
 Func withUnsafeMutablePointer(to:_:) has been renamed to Func __abi_se0413_withUnsafeMutablePointer(to:_:)
-Func withUnsafeMutablePointer(to:_:) has mangled name changing from 'Swift.withUnsafeMutablePointer<A, B>(to: A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutablePointer<A, B>(to: A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B'
+Func withUnsafeMutablePointer(to:_:) has mangled name changing from 'Swift.withUnsafeMutablePointer<A, B>(to: inout A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutablePointer<A, B>(to: inout A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B'
 Func withUnsafeMutablePointer(to:_:) is now without @rethrows
 Func withUnsafePointer(to:_:) has been renamed to Func __abi_withUnsafePointer(to:_:)
 Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -105,6 +105,9 @@ Constructor Result.init(__abi_catching:) is a new API without @available attribu
 Constructor Result.init(catching:) has been removed
 Func Result.get() has been renamed to Func __abi_get()
 Func Result.get() has mangled name changing from 'Swift.Result.get() throws -> A' to 'Swift.Result.__abi_get() throws -> A'
+Func withUnsafeMutablePointer(to:_:) has been renamed to Func __abi_se0413_withUnsafeMutablePointer(to:_:)
+Func withUnsafeMutablePointer(to:_:) has mangled name changing from 'Swift.withUnsafeMutablePointer<A, B>(to: A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutablePointer<A, B>(to: A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B'
+Func withUnsafeMutablePointer(to:_:) is now without @rethrows
 Func withUnsafePointer(to:_:) has been renamed to Func __abi_withUnsafePointer(to:_:)
 Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
 Func withUnsafePointer(to:_:) is now without @rethrows


### PR DESCRIPTION
Part of the ongoing conversion of standard library rethrows functions, after [SE-0413](https://github.com/apple/swift-evolution/blob/main/proposals/0413-typed-throws.md).

This converts the top-level `withUnsafeMutablePointer(to:_:)` function.
Its corresponding no-stack-protection equivalent is omitted here, due to a compiler issue (rdar://121289127).