### PR TITLE
[InterfaceFile] Improve flag extraction from interface file

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -22,6 +22,8 @@
 #define SWIFT_COMPILER_VERSION_KEY "swift-compiler-version"
 #define SWIFT_MODULE_FLAGS_KEY "swift-module-flags"
 #define SWIFT_MODULE_FLAGS_IGNORABLE_KEY "swift-module-flags-ignorable"
+#define SWIFT_MODULE_FLAGS_IGNORABLE_PRIVATE_KEY                               \
+  "swift-module-flags-ignorable-private"
 
 namespace swift {
 

--- a/test/ModuleInterface/SmokeTest.swiftinterface
+++ b/test/ModuleInterface/SmokeTest.swiftinterface
@@ -1,7 +1,6 @@
 // The "flags" line in this test deliberately has no flags and no space after
 // the colon, just to make sure that works (even though it'll never be printed
 // that way).
-
 // swift-module-flags:
 // swift-interface-format-version: 1.0
 

--- a/test/ModuleInterface/noncopyable_generics_interface_extensions.swift
+++ b/test/ModuleInterface/noncopyable_generics_interface_extensions.swift
@@ -3,7 +3,6 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/bug.swiftinterface) -I %t
 
 //--- bug.swiftinterface
-
 // swift-interface-format-version: 1.0
 // swift-compiler-version: Apple Swift version 6.0 effective-5.10 (swiftlang-6.0.0.4.52 clang-1600.0.21.1.3)
 // swift-module-flags: -enable-objc-interop -enable-library-evolution -module-name bug

--- a/test/SPI/spi_only_import_flag_check.swift
+++ b/test/SPI/spi_only_import_flag_check.swift
@@ -31,7 +31,6 @@
 @_spiOnly import Empty // expected-error {{'@_spiOnly' requires setting the frontend flag '-experimental-spi-only-imports'}}
 
 //--- Client.private.swiftinterface
-
 // swift-interface-format-version: 1.0
 // swift-compiler-version: Swift version 5.8-dev effective-4.1.50
 // swift-module-flags: -swift-version 4 -module-name Client


### PR DESCRIPTION
Improve the version/flags extract from interface file by moving away from using Regex and limiting the search to the beginning of the file.

Switch away from Regex will give 5-10% improvement in time and instruction counts, and limiting the search lines can save a lot of time if the swiftinterface is large. For example, the extract time for Swift stdlib is 10x faster after the patch.
