### PR TITLE
[PrintAsClang] Don’t print any objcImpl overrides

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2872,7 +2872,7 @@ static bool excludeForObjCImplementation(const ValueDecl *VD) {
     return true;
   // Exclude overrides in an @_objcImplementation extension; the decl they're
   // overriding is declared elsewhere.
-  if (VD->isImplicit() && VD->getOverriddenDecl()) {
+  if (VD->getOverriddenDecl()) {
     auto ED = dyn_cast<ExtensionDecl>(VD->getDeclContext());
     if (ED && ED->isObjCImplementation())
       return true;

--- a/test/PrintAsObjC/Inputs/custom-modules/objc_implementation/objc_implementation.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/objc_implementation/objc_implementation.h
@@ -6,4 +6,8 @@
 
 @end
 
+@interface ObjCClass2 : NSObject
+
+@end
+
 void CImplFunc(void);

--- a/test/PrintAsObjC/objc_implementation.swift
+++ b/test/PrintAsObjC/objc_implementation.swift
@@ -30,10 +30,17 @@ extension ObjCClass {
   // Implicit `override init()` to override superclass
 
   // NEGATIVE-NOT: )swiftMethod{{ }}
-  @objc func swiftMethod() -> Any? { nil }
+  @objc public func swiftMethod() -> Any? { nil }
 
   // NEGATIVE-NOT: )privateMethod{{ }}
   @objc private func privateMethod() -> Any? { nil }
+}
+
+// Has no contents that need to be printed
+// NEGATIVE-NOT: ObjCClass2
+@_objcImplementation extension ObjCClass2 {
+  // NEGATIVE-NOT: )init{{ }}
+  public override init() { }
 }
 
 @_cdecl("CImplFunc") @_objcImplementation func CImplFunc() {}


### PR DESCRIPTION
Previously we only excluded implicitly-created overrides, but it turns out explicit overrides are just as problematic and just as unnecessary.

Fixes rdar://123633538.