### PR TITLE
[build presets] Run sourcekit-lsp tests on macOS sourcekit-lsp CI job

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1934,6 +1934,7 @@ mixin-preset=mixin_swiftpm_package_macos_platform
 release
 assertions
 sourcekit-lsp
+test-sourcekit-lsp
 swiftformat
 install-swiftformat
 sourcekit-lsp-lint


### PR DESCRIPTION
Turns out we weren’t actually running sourcekit-lsp tests on the macOS sourcekit-lsp PR job.
