### PR TITLE
AST: Don't drop inferred available attributes containing just `unavailable`

### DIFF
--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -111,7 +111,8 @@ static AvailableAttr *createAvailableAttr(PlatformKind Platform,
                                           ASTContext &Context) {
   // If there is no information that would go into the availability attribute,
   // don't create one.
-  if (!Inferred.Introduced && !Inferred.Deprecated && !Inferred.Obsoleted &&
+  if (Inferred.PlatformAgnostic == PlatformAgnosticAvailabilityKind::None &&
+      !Inferred.Introduced && !Inferred.Deprecated && !Inferred.Obsoleted &&
       Message.empty() && Rename.empty() && !RenameDecl)
     return nullptr;
 

--- a/test/ModuleInterface/property_wrapper_availability.swift
+++ b/test/ModuleInterface/property_wrapper_availability.swift
@@ -13,6 +13,19 @@ public struct ConditionallyAvailableWrapper<T> {
   }
 }
 
+@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+@propertyWrapper
+public struct UnavailableWrapper<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
 // CHECK: public struct HasWrappers {
 public struct HasWrappers {
   // CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
@@ -25,4 +38,30 @@ public struct HasWrappers {
   // CHECK-NEXT: }
   @available(SwiftStdlib 5.2, *)
   @ConditionallyAvailableWrapper public var x: Int
+}
+
+// CHECK:       @available(macOS, unavailable)
+// CHECK-NEXT:  @available(iOS, unavailable)
+// CHECK-NEXT:  @available(watchOS, unavailable)
+// CHECK-NEXT:  @available(tvOS, unavailable)
+// CHECK-NEXT:  public struct UnavailableHasWrappers {
+@available(macOS, unavailable)
+@available(iOS, unavailable)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public struct UnavailableHasWrappers {
+  // CHECK-LABEL:   @Library.UnavailableWrapper public var x: Swift.Int {
+  // CHECK-NEXT:      get
+  // CHECK-NEXT:      @available(iOS, unavailable)
+  // CHECK-NEXT:      @available(tvOS, unavailable)
+  // CHECK-NEXT:      @available(watchOS, unavailable)
+  // CHECK-NEXT:      @available(macOS, unavailable)
+  // CHECK-NEXT:      set
+  // CHECK-NEXT:      @available(iOS, unavailable)
+  // CHECK-NEXT:      @available(tvOS, unavailable)
+  // CHECK-NEXT:      @available(watchOS, unavailable)
+  // CHECK-NEXT:      @available(macOS, unavailable)
+  // CHECK-NEXT:      _modify
+  // CHECK-NEXT:    }
+  @UnavailableWrapper public var x: Int
 }


### PR DESCRIPTION
Fixes a regression from https://github.com/apple/swift/pull/71922.

Resolves rdar://124073829
