### PR TITLE
[Clang printing] Loosen assertion on noncopyable & nonescaping requirements

### DIFF
--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -18,9 +18,12 @@
 #include "swift/AST/Identifier.h"
 
 namespace swift {
-  class ValueDecl;
-  class EnumDecl;
-  class EnumElementDecl;
+
+class EnumDecl;
+class EnumElementDecl;
+struct InverseRequirement;
+class GenericSignature;
+class ValueDecl;
 
 namespace objc_translation {
   enum CustomNamesOnly_t : bool {
@@ -106,6 +109,9 @@ inline bool isExposableToCxx(const ValueDecl *VD) {
 /// own accord (i.e. without considering its context)
 bool isVisibleToCxx(const ValueDecl *VD, AccessLevel minRequiredAccess,
                     bool checkParent = true);
+
+/// Determine whether the given generic signature can be exposed to C++.
+bool isExposableToCxx(GenericSignature genericSig);
 
 } // end namespace cxx_translation
 

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -281,22 +281,8 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
   }
 
   // Generic requirements are not yet supported in C++.
-  if (genericSignature) {
-
-    // FIXME: This should use getRequirements() and actually
-    // support arbitrary requirements. We don't really want
-    // to use getRequirementsWithInverses() here.
-    //
-    // For now, we use the inverse transform as a quick way to
-    // check for the "default" generic signature where each
-    // generic parameter is Copyable and Escapable, but not
-    // subject to any other requirements; that's exactly the
-    // generic signature that C++ interop supports today.
-    SmallVector<Requirement, 2> reqs;
-    SmallVector<InverseRequirement, 2> inverseReqs;
-    genericSignature->getRequirementsWithInverses(reqs, inverseReqs);
-    if (!reqs.empty() || !inverseReqs.empty())
-      return {Unsupported, UnrepresentableGenericRequirements};
+  if (!isExposableToCxx(genericSignature)) {
+    return {Unsupported, UnrepresentableGenericRequirements};
   }
 
   return {Representable, std::nullopt};
@@ -319,6 +305,51 @@ bool swift::cxx_translation::isVisibleToCxx(const ValueDecl *VD,
     }
   }
   return false;
+}
+
+bool swift::cxx_translation::isExposableToCxx(GenericSignature genericSig) {
+  // If there's no generic signature, it's fine.
+  if (!genericSig)
+    return true;
+
+  // FIXME: This should use getRequirements() and actually
+  // support arbitrary requirements. We don't really want
+  // to use getRequirementsWithInverses() here.
+  //
+  // For now, we use the inverse transform as a quick way to
+  // check for the "default" generic signature where each
+  // generic parameter is Copyable and Escapable, but not
+  // subject to any other requirements; that's exactly the
+  // generic signature that C++ interop supports today.
+  SmallVector<Requirement, 2> reqs;
+  SmallVector<InverseRequirement, 2> inverseReqs;
+  genericSig->getRequirementsWithInverses(reqs, inverseReqs);
+  if (!reqs.empty()) {
+    // Conformance requirements to marker protocols are okay.
+    for (const auto &req: reqs) {
+      if (req.getKind() != RequirementKind::Conformance)
+        return false;
+
+      auto proto = req.getProtocolDecl();
+      if (!proto->isMarkerProtocol())
+        return false;
+    }
+  }
+
+  // Allow Copyable and Escapable.
+  for (const auto &req: inverseReqs) {
+    switch (req.getKind()) {
+    case InvertibleProtocolKind::Copyable:
+      continue;
+
+    case InvertibleProtocolKind::Escapable:
+      continue;
+    }
+
+    return false;
+  }
+
+  return true;
 }
 
 Diagnostic

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -383,22 +383,9 @@ private:
           printMembers(SD->getMembers());
           for (const auto *ed :
                owningPrinter.interopContext.getExtensionsForNominalType(SD)) {
-            SmallVector<Requirement, 2> reqs;
-            SmallVector<InverseRequirement, 2> inverseReqs;
-            if (auto sig = ed->getGenericSignature()) {
-              // FIXME: This should use getRequirements() and actually
-              // support arbitrary requirements. We don't really want
-              // to use getRequirementsWithInverses() here.
-              //
-              // For now, we use the inverse transform as a quick way to
-              // check for the "default" generic signature where each
-              // generic parameter is Copyable and Escapable, but not
-              // subject to any other requirements; that's exactly the
-              // generic signature that C++ interop supports today.
-              sig->getRequirementsWithInverses(reqs, inverseReqs);
-              if (!reqs.empty() || !inverseReqs.empty())
-                continue;
-            }
+            if (!cxx_translation::isExposableToCxx(ed->getGenericSignature()))
+              continue;
+
             printMembers(ed->getMembers());
           }
         },

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -700,21 +700,9 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
   }
   if (FD->isGeneric()) {
     auto Signature = FD->getGenericSignature().getCanonicalSignature();
-
-    // FIXME: This should use getRequirements() and actually
-    // support arbitrary requirements. We don't really want
-    // to use getRequirementsWithInverses() here.
-    //
-    // For now, we use the inverse transform as a quick way to
-    // check for the "default" generic signature where each
-    // generic parameter is Copyable and Escapable, but not
-    // subject to any other requirements; that's exactly the
-    // generic signature that C++ interop supports today.
-    SmallVector<Requirement, 2> reqs;
-    SmallVector<InverseRequirement, 2> inverseReqs;
-    Signature->getRequirementsWithInverses(reqs, inverseReqs);
-    if (!reqs.empty() || !inverseReqs.empty())
+    if (!cxx_translation::isExposableToCxx(Signature))
       return ClangRepresentation::unsupported;
+
     // Print the template and requires clauses for this function.
     if (kind == FunctionSignatureKind::CxxInlineThunk)
       ClangSyntaxPrinter(os).printGenericSignature(Signature);

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/SwiftNameTranslation.h"
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeVisitor.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -193,21 +194,7 @@ void ClangValueTypePrinter::printValueTypeDecl(
   };
   if (typeDecl->isGeneric()) {
     genericSignature = typeDecl->getGenericSignature();
-
-    // FIXME: This should use getRequirements() and actually
-    // support arbitrary requirements. We don't really want
-    // to use getRequirementsWithInverses() here.
-    //
-    // For now, we use the inverse transform as a quick way to
-    // check for the "default" generic signature where each
-    // generic parameter is Copyable and Escapable, but not
-    // subject to any other requirements; that's exactly the
-    // generic signature that C++ interop supports today.
-    SmallVector<Requirement, 2> reqs;
-    SmallVector<InverseRequirement, 2> inverseReqs;
-    genericSignature->getRequirementsWithInverses(reqs, inverseReqs);
-    assert(inverseReqs.empty() && "Non-copyable generics not supported here!");
-    assert(reqs.empty());
+    assert(cxx_translation::isExposableToCxx(genericSignature));
 
     // FIXME: Can we make some better layout than opaque layout for generic
     // types.


### PR DESCRIPTION
Noncopyable and nonescaping APIs in Swift can be expressed in C++ with some downsides. Teach the AST printer to be more lenient, allowing Swift APIs involving noncopyable and nonescapable types to be printed.
