### PR TITLE
[stdlib] Sendablize all the things

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -103,6 +103,8 @@ public struct EnumeratedSequence<Base: Sequence> {
   }
 }
 
+extension EnumeratedSequence: Sendable where Base: Sendable {}
+
 extension EnumeratedSequence {
   /// The iterator for `EnumeratedSequence`.
   ///
@@ -133,6 +135,8 @@ extension EnumeratedSequence {
     }
   }
 }
+
+extension EnumeratedSequence.Iterator: Sendable where Base.Iterator: Sendable {}
 
 extension EnumeratedSequence.Iterator: IteratorProtocol, Sequence {
   /// The type of element returned by `next()`.

--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -212,6 +212,9 @@ public struct AnyHashable {
   }
 }
 
+@available(*, unavailable)
+extension AnyHashable: Sendable {}
+
 @_unavailableInEmbedded
 extension AnyHashable: Equatable {
   /// Returns a Boolean value indicating whether two type-erased hashable

--- a/stdlib/public/core/AtomicInt.swift.gyb
+++ b/stdlib/public/core/AtomicInt.swift.gyb
@@ -60,6 +60,9 @@ public final class _stdlib_AtomicInt {
   }
 }
 
+@available(*, unavailable)
+extension _stdlib_AtomicInt: Sendable {}
+
 @usableFromInline // used by SwiftPrivate._stdlib_AtomicInt
 internal func _swift_stdlib_atomicCompareExchangeStrongInt(
   object target: UnsafeMutablePointer<Int>,

--- a/stdlib/public/core/Bitset.swift
+++ b/stdlib/public/core/Bitset.swift
@@ -33,6 +33,9 @@ internal struct _UnsafeBitset {
   }
 }
 
+@available(*, unavailable)
+extension _UnsafeBitset: Sendable {}
+
 extension _UnsafeBitset {
   @inlinable
   @inline(__always)
@@ -178,6 +181,9 @@ extension _UnsafeBitset: Sequence {
     }
   }
 }
+
+@available(*, unavailable)
+extension _UnsafeBitset.Iterator: Sendable {}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -182,6 +182,7 @@ public struct _BridgeableMetatype: _ObjectiveCBridgeable {
   }
 }
 
+extension _BridgeableMetatype: Sendable {}
 
 //===--- Bridging facilities written in Objective-C -----------------------===//
 // Functions that must discover and possibly use an arbitrary type's

--- a/stdlib/public/core/CocoaArray.swift
+++ b/stdlib/public/core/CocoaArray.swift
@@ -160,4 +160,8 @@ internal struct _CocoaArrayWrapper: RandomAccessCollection {
     return (IndexingIterator(_elements: self, _position: c), c)
   }
 }
+
+@available(*, unavailable)
+extension _CocoaArrayWrapper: Sendable {}
+
 #endif

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -933,6 +933,9 @@ public struct KeyedEncodingContainer<K: CodingKey> :
   }
 }
 
+@available(*, unavailable)
+extension KeyedEncodingContainer: Sendable {}
+
 /// A type that provides a view into a decoder's storage and is used to hold
 /// the encoded properties of a decodable type in a keyed manner.
 ///
@@ -2114,6 +2117,9 @@ public struct KeyedDecodingContainer<K: CodingKey> :
     return try _box.superDecoder(forKey: key)
   }
 }
+
+@available(*, unavailable)
+extension KeyedDecodingContainer: Sendable {}
 
 //===----------------------------------------------------------------------===//
 // Unkeyed Encoding Containers

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -63,6 +63,9 @@ internal final class __EmptyArrayStorage
   }
 }
 
+@available(*, unavailable)
+extension __EmptyArrayStorage: Sendable {}
+
 #if $Embedded
 // In embedded Swift, the stdlib is a .swiftmodule only without any .o/.a files,
 // to allow consuming it by clients with different LLVM codegen setting (-mcpu
@@ -116,6 +119,9 @@ internal final class __StaticArrayStorage
     fatalError("__StaticArrayStorage.staticElementType must not be called")
   }
 }
+
+@available(*, unavailable)
+extension __StaticArrayStorage: Sendable {}
 
 /// The empty array prototype.  We use the same object for all empty
 /// `[Native]Array<Element>`s.
@@ -305,6 +311,9 @@ internal final class _ContiguousArrayStorage<
     return UnsafeMutablePointer(Builtin.projectTailElems(self, Element.self))
   }
 }
+
+@available(*, unavailable)
+extension _ContiguousArrayStorage: Sendable {}
 
 @_alwaysEmitIntoClient
 @inline(__always)
@@ -968,6 +977,9 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
   }
 }
 
+@available(*, unavailable)
+extension _ContiguousArrayBuffer: Sendable {}
+
 /// Append the elements of `rhs` to `lhs`.
 @inlinable
 internal func += <Element, C: Collection>(
@@ -1218,3 +1230,6 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
     return ContiguousArray(_buffer: finalResult)
   }
 }
+
+@available(*, unavailable)
+extension _UnsafePartiallyInitializedContiguousArrayBuffer: Sendable {}

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1789,6 +1789,8 @@ extension Dictionary {
   }
 }
 
+extension Dictionary.Index._Variant: @unchecked Sendable {}
+
 extension Dictionary.Index {
 #if _runtime(_ObjC)
   @usableFromInline @_transparent
@@ -1967,6 +1969,9 @@ extension Dictionary {
   }
 }
 
+extension Dictionary.Iterator._Variant: @unchecked Sendable
+  where Key: Sendable, Value: Sendable {}
+
 extension Dictionary.Iterator {
 #if _runtime(_ObjC)
   @usableFromInline @_transparent
@@ -2119,16 +2124,16 @@ public typealias DictionaryIterator<Key: Hashable, Value> =
   Dictionary<Key, Value>.Iterator
 
 extension Dictionary: @unchecked Sendable
-  where Key: Sendable, Value: Sendable { }
+  where Key: Sendable, Value: Sendable {}
 extension Dictionary.Keys: @unchecked Sendable
-  where Key: Sendable, Value: Sendable { }
+  where Key: Sendable, Value: Sendable {}
 extension Dictionary.Values: @unchecked Sendable
-  where Key: Sendable, Value: Sendable { }
+  where Key: Sendable, Value: Sendable {}
 extension Dictionary.Keys.Iterator: @unchecked Sendable
-  where Key: Sendable, Value: Sendable { }
+  where Key: Sendable, Value: Sendable {}
 extension Dictionary.Values.Iterator: @unchecked Sendable
-  where Key: Sendable, Value: Sendable { }
+  where Key: Sendable, Value: Sendable {}
 extension Dictionary.Index: @unchecked Sendable
-  where Key: Sendable, Value: Sendable { }
+  where Key: Sendable, Value: Sendable {}
 extension Dictionary.Iterator: @unchecked Sendable
-  where Key: Sendable, Value: Sendable { }
+  where Key: Sendable, Value: Sendable {}

--- a/stdlib/public/core/DictionaryBridging.swift
+++ b/stdlib/public/core/DictionaryBridging.swift
@@ -421,6 +421,9 @@ final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   }
 }
 
+@available(*, unavailable)
+extension _SwiftDeferredNSDictionary: Sendable {}
+
 // NOTE: older runtimes called this struct _CocoaDictionary. The two
 // must coexist without conflicting ObjC class names from the nested
 // classes, so it was renamed. The old names must not be used in the new
@@ -436,6 +439,9 @@ internal struct __CocoaDictionary {
     self.object = object
   }
 }
+
+@available(*, unavailable)
+extension __CocoaDictionary: Sendable {}
 
 extension __CocoaDictionary {
   @usableFromInline
@@ -732,6 +738,9 @@ extension __CocoaDictionary: Sequence {
     return Iterator(self)
   }
 }
+
+@available(*, unavailable)
+extension __CocoaDictionary.Iterator: Sendable {}
 
 extension __CocoaDictionary.Iterator: IteratorProtocol {
   @usableFromInline

--- a/stdlib/public/core/DictionaryBuilder.swift
+++ b/stdlib/public/core/DictionaryBuilder.swift
@@ -43,6 +43,9 @@ struct _DictionaryBuilder<Key: Hashable, Value> {
   }
 }
 
+@available(*, unavailable)
+extension _DictionaryBuilder: Sendable {}
+
 extension Dictionary {
   /// Creates a new dictionary with the specified capacity, then calls the given
   /// closure to initialize its contents.

--- a/stdlib/public/core/DictionaryStorage.swift
+++ b/stdlib/public/core/DictionaryStorage.swift
@@ -110,6 +110,9 @@ internal class __RawDictionaryStorage: __SwiftNativeNSDictionary {
   }
 }
 
+@available(*, unavailable)
+extension __RawDictionaryStorage: Sendable {}
+
 /// The storage class for the singleton empty set.
 /// The single instance of this class is created by the runtime.
 // NOTE: older runtimes called this class _EmptyDictionarySingleton.
@@ -135,6 +138,9 @@ internal class __EmptyDictionarySingleton: __RawDictionaryStorage {
   }
 #endif
 }
+
+@available(*, unavailable)
+extension __EmptyDictionarySingleton: Sendable {}
 
 #if _runtime(_ObjC)
 extension __EmptyDictionarySingleton: _NSDictionaryCore {
@@ -505,3 +511,6 @@ extension _DictionaryStorage {
     return storage
   }
 }
+
+extension _DictionaryStorage: @unchecked Sendable
+  where Key: Sendable, Value: Sendable {}

--- a/stdlib/public/core/DropWhile.swift
+++ b/stdlib/public/core/DropWhile.swift
@@ -28,8 +28,10 @@ public struct LazyDropWhileSequence<Base: Sequence> {
     self._base = _base
     self._predicate = predicate
   }
-
 }
+
+@available(*, unavailable)
+extension LazyDropWhileSequence: Sendable {}
 
 extension LazyDropWhileSequence {
   /// An iterator over the elements traversed by a base iterator that follow the
@@ -56,6 +58,9 @@ extension LazyDropWhileSequence {
     }
   }
 }
+
+@available(*, unavailable)
+extension LazyDropWhileSequence.Iterator: Sendable {}
 
 extension LazyDropWhileSequence.Iterator: IteratorProtocol {
   @inlinable // lazy-performance

--- a/stdlib/public/core/ExistentialCollection.swift
+++ b/stdlib/public/core/ExistentialCollection.swift
@@ -90,6 +90,9 @@ public struct AnyIterator<Element> {
   }
 }
 
+@available(*, unavailable)
+extension AnyIterator: Sendable {}
+
 extension AnyIterator: IteratorProtocol {
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
@@ -120,6 +123,9 @@ internal struct _ClosureBasedIterator<Element>: IteratorProtocol {
   internal func next() -> Element? { return _body() }
 }
 
+@available(*, unavailable)
+extension _ClosureBasedIterator: Sendable {}
+
 @_fixed_layout
 @usableFromInline
 internal class _AnyIteratorBoxBase<Element>: IteratorProtocol {
@@ -139,6 +145,9 @@ internal class _AnyIteratorBoxBase<Element>: IteratorProtocol {
   internal func next() -> Element? { _abstract() }
 }
 
+@available(*, unavailable)
+extension _AnyIteratorBoxBase: Sendable {}
+
 @_fixed_layout
 @usableFromInline
 internal final class _IteratorBox<Base: IteratorProtocol>
@@ -156,6 +165,9 @@ internal final class _IteratorBox<Base: IteratorProtocol>
   @usableFromInline
   internal var _base: Base
 }
+
+@available(*, unavailable)
+extension _IteratorBox: Sendable {}
 
 //===--- Sequence ---------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
@@ -250,6 +262,9 @@ internal class _AnySequenceBox<Element> {
     _abstract()
   }
 }
+
+@available(*, unavailable)
+extension _AnySequenceBox: Sendable {}
 
 @_fixed_layout
 @usableFromInline
@@ -387,6 +402,9 @@ internal class _AnyCollectionBox<Element>: _AnySequenceBox<Element> {
   ) -> _AnyCollectionBox<Element> { _abstract() }
 }
 
+@available(*, unavailable)
+extension _AnyCollectionBox: Sendable {}
+
 @_fixed_layout
 @usableFromInline
 internal class _AnyBidirectionalCollectionBox<Element>
@@ -450,6 +468,9 @@ internal class _AnyBidirectionalCollectionBox<Element>
   internal func _formIndex(before i: _AnyIndexBox) { _abstract() }
 }
 
+@available(*, unavailable)
+extension _AnyBidirectionalCollectionBox: Sendable {}
+
 @_fixed_layout
 @usableFromInline
 internal class _AnyRandomAccessCollectionBox<Element>
@@ -506,6 +527,9 @@ internal class _AnyRandomAccessCollectionBox<Element>
     end end: _AnyIndexBox
   ) -> _AnyRandomAccessCollectionBox<Element> { _abstract() }
 }
+
+@available(*, unavailable)
+extension _AnyRandomAccessCollectionBox: Sendable {}
 
 @_fixed_layout
 @usableFromInline
@@ -602,6 +626,9 @@ internal final class _SequenceBox<S: Sequence>: _AnySequenceBox<S.Element> {
   @usableFromInline
   internal var _base: S
 }
+
+@available(*, unavailable)
+extension _SequenceBox: Sendable {}
 
 @_fixed_layout
 @usableFromInline
@@ -800,6 +827,9 @@ internal final class _CollectionBox<S: Collection>: _AnyCollectionBox<S.Element>
   @usableFromInline
   internal var _base: S
 }
+
+@available(*, unavailable)
+extension _CollectionBox: Sendable {}
 
 @_fixed_layout
 @usableFromInline
@@ -1018,6 +1048,9 @@ internal final class _BidirectionalCollectionBox<S: BidirectionalCollection>
   internal var _base: S
 }
 
+@available(*, unavailable)
+extension _BidirectionalCollectionBox: Sendable {}
+
 @_fixed_layout
 @usableFromInline
 internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
@@ -1234,6 +1267,9 @@ internal final class _RandomAccessCollectionBox<S: RandomAccessCollection>
   internal var _base: S
 }
 
+@available(*, unavailable)
+extension _RandomAccessCollectionBox: Sendable {}
+
 @usableFromInline
 @frozen
 internal struct _ClosureBasedSequence<Iterator: IteratorProtocol> {
@@ -1245,6 +1281,9 @@ internal struct _ClosureBasedSequence<Iterator: IteratorProtocol> {
     self._makeUnderlyingIterator = makeUnderlyingIterator
   }
 }
+
+@available(*, unavailable)
+extension _ClosureBasedSequence: Sendable {}
 
 extension _ClosureBasedSequence: Sequence {
 
@@ -1282,6 +1321,9 @@ public struct AnySequence<Element> {
     self._box = _box
   }
 }
+
+@available(*, unavailable)
+extension AnySequence: Sendable {}
 
 extension  AnySequence: Sequence {
   public typealias Iterator = AnyIterator<Element>
@@ -1776,6 +1818,9 @@ internal final class _IndexBox<BaseIndex: Comparable>: _AnyIndexBox {
   }
 }
 
+@available(*, unavailable)
+extension _IndexBox: Sendable {}
+
 /// A wrapper over an underlying index that hides the specific underlying type.
 @frozen
 @_unavailableInEmbedded
@@ -1799,6 +1844,9 @@ public struct AnyIndex {
     return _box._typeID
   }
 }
+
+@available(*, unavailable)
+extension AnyIndex: Sendable {}
 
 @_unavailableInEmbedded
 extension AnyIndex: Comparable {
@@ -1858,6 +1906,9 @@ public struct AnyCollection<Element> {
     self._box = _box
   }
 }
+
+@available(*, unavailable)
+extension AnyCollection: Sendable {}
 
 @_unavailableInEmbedded
 extension AnyCollection: Collection {
@@ -2078,6 +2129,9 @@ public struct AnyBidirectionalCollection<Element> {
     self._box = _box
   }
 }
+
+@available(*, unavailable)
+extension AnyBidirectionalCollection: Sendable {}
 
 @_unavailableInEmbedded
 extension AnyBidirectionalCollection: BidirectionalCollection {
@@ -2306,6 +2360,9 @@ public struct AnyRandomAccessCollection<Element> {
     self._box = _box
   }
 }
+
+@available(*, unavailable)
+extension AnyRandomAccessCollection: Sendable {}
 
 @_unavailableInEmbedded
 extension AnyRandomAccessCollection: RandomAccessCollection {

--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -36,6 +36,9 @@ public struct LazyFilterSequence<Base: Sequence> {
   }
 }
 
+@available(*, unavailable)
+extension LazyFilterSequence: Sendable {}
+
 extension LazyFilterSequence {
   /// An iterator over the elements traversed by some base iterator that also
   /// satisfy a given predicate.
@@ -61,6 +64,9 @@ extension LazyFilterSequence {
     }
   }
 }
+
+@available(*, unavailable)
+extension LazyFilterSequence.Iterator: Sendable {}
 
 extension LazyFilterSequence.Iterator: IteratorProtocol, Sequence {
   public typealias Element = Base.Element

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -38,6 +38,8 @@ public struct FlattenSequence<Base: Sequence> where Base.Element: Sequence {
   }
 }
 
+extension FlattenSequence: Sendable where Base: Sendable {}
+
 extension FlattenSequence {
   @frozen // lazy-performance
   public struct Iterator {
@@ -53,6 +55,9 @@ extension FlattenSequence {
     }
   }
 }
+
+extension FlattenSequence.Iterator: Sendable
+  where Base.Iterator: Sendable, Base.Element.Iterator: Sendable {}
 
 extension FlattenSequence.Iterator: IteratorProtocol {
   public typealias Element = Base.Element.Element
@@ -160,6 +165,9 @@ extension FlattenSequence where Base: Collection, Base.Element: Collection {
     }
   }
 }
+
+extension FlattenSequence.Index: Sendable
+  where Base.Index: Sendable, Base.Element.Index: Sendable {}
 
 extension FlattenSequence.Index: Equatable where Base: Collection, Base.Element: Collection {
   @inlinable // lazy-performance

--- a/stdlib/public/core/HashTable.swift
+++ b/stdlib/public/core/HashTable.swift
@@ -65,6 +65,9 @@ internal struct _HashTable {
   }
 }
 
+@available(*, unavailable)
+extension _HashTable: Sendable {}
+
 extension _HashTable {
   /// The inverse of the maximum hash table load factor.
   private static var maxLoadFactor: Double {
@@ -271,6 +274,9 @@ extension _HashTable: Sequence {
     return Iterator(self)
   }
 }
+
+@available(*, unavailable)
+extension _HashTable.Iterator: Sendable {}
 
 extension _HashTable {
   @inlinable

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -34,6 +34,8 @@ public struct JoinedSequence<Base: Sequence> where Base.Element: Sequence {
   }
 }
 
+extension JoinedSequence: Sendable where Base: Sendable, Element: Sendable {}
+
 extension JoinedSequence {
   /// An iterator that presents the elements of the sequences traversed
   /// by a base iterator, concatenated using a given separator.
@@ -71,6 +73,11 @@ extension JoinedSequence {
     }
   }
 }
+
+extension JoinedSequence.Iterator: Sendable
+  where Base.Iterator: Sendable,
+        Base.Element.Iterator: Sendable,
+        Element: Sendable {}
 
 extension JoinedSequence.Iterator: IteratorProtocol {
   public typealias Element = Base.Element.Element

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -262,15 +262,9 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   }
 }
 
-@available(*, unavailable)
-extension AnyKeyPath: Sendable {}
-
 /// A partially type-erased key path, from a concrete root type to any
 /// resulting value type.
 public class PartialKeyPath<Root>: AnyKeyPath { }
-
-@available(*, unavailable)
-extension PartialKeyPath: Sendable {}
 
 // MARK: Concrete implementations
 internal enum KeyPathKind { case readOnly, value, reference }
@@ -377,9 +371,6 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   }
 }
 
-@available(*, unavailable)
-extension KeyPath: Sendable {}
-
 /// A key path that supports reading from and writing to the resulting value.
 public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
   // MARK: Implementation detail
@@ -447,9 +438,6 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
     }
   }
 }
-
-@available(*, unavailable)
-extension WritableKeyPath: Sendable {}
 
 /// A key path that supports reading from and writing to the resulting value
 /// with reference semantics.
@@ -521,9 +509,6 @@ public class ReferenceWritableKeyPath<
     return (address, keepAlive)
   }
 }
-
-@available(*, unavailable)
-extension ReferenceWritableKeyPath: Sendable {}
 
 // MARK: Implementation details
 

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -262,9 +262,15 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   }
 }
 
+@available(*, unavailable)
+extension AnyKeyPath: Sendable {}
+
 /// A partially type-erased key path, from a concrete root type to any
 /// resulting value type.
 public class PartialKeyPath<Root>: AnyKeyPath { }
+
+@available(*, unavailable)
+extension PartialKeyPath: Sendable {}
 
 // MARK: Concrete implementations
 internal enum KeyPathKind { case readOnly, value, reference }
@@ -371,6 +377,9 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   }
 }
 
+@available(*, unavailable)
+extension KeyPath: Sendable {}
+
 /// A key path that supports reading from and writing to the resulting value.
 public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
   // MARK: Implementation detail
@@ -438,6 +447,9 @@ public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> {
     }
   }
 }
+
+@available(*, unavailable)
+extension WritableKeyPath: Sendable {}
 
 /// A key path that supports reading from and writing to the resulting value
 /// with reference semantics.
@@ -509,6 +521,9 @@ public class ReferenceWritableKeyPath<
     return (address, keepAlive)
   }
 }
+
+@available(*, unavailable)
+extension ReferenceWritableKeyPath: Sendable {}
 
 // MARK: Implementation details
 

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -188,6 +188,8 @@ public struct LazySequence<Base: Sequence> {
   }
 }
 
+extension LazySequence: Sendable where Base: Sendable {}
+
 extension LazySequence: Sequence {
   public typealias Element = Base.Element
   public typealias Iterator = Base.Iterator

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -64,6 +64,9 @@ open class ManagedBuffer<Header, Element> {
   deinit {}
 }
 
+@available(*, unavailable)
+extension ManagedBuffer: Sendable {}
+
 extension ManagedBuffer {
   /// Create a new instance of the most-derived class, calling
   /// `factory` on the partially-constructed object to generate

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -33,6 +33,9 @@ public struct LazyMapSequence<Base: Sequence, Element> {
   }
 }
 
+@available(*, unavailable)
+extension LazyMapSequence: Sendable {}
+
 extension LazyMapSequence {
   @frozen
   public struct Iterator {
@@ -54,6 +57,9 @@ extension LazyMapSequence {
     }
   }
 }
+
+@available(*, unavailable)
+extension LazyMapSequence.Iterator: Sendable {}
 
 extension LazyMapSequence.Iterator: IteratorProtocol, Sequence {
   /// Advances to the next element and returns it, or `nil` if no next element

--- a/stdlib/public/core/MigrationSupport.swift
+++ b/stdlib/public/core/MigrationSupport.swift
@@ -623,6 +623,9 @@ public enum _PlaygroundQuickLook {
   case _raw([UInt8], String)
 }
 
+@available(*, unavailable)
+extension _PlaygroundQuickLook: Sendable {}
+
 #if SWIFT_ENABLE_REFLECTION
 extension _PlaygroundQuickLook {
   /// Creates a new Quick Look for the given instance.

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -216,6 +216,9 @@ public struct Mirror {
   }
 }
 
+@available(*, unavailable)
+extension Mirror: Sendable {}
+
 extension Mirror {
   /// Representation of descendant classes that don't override
   /// `customMirror`.
@@ -347,6 +350,9 @@ extension Mirror {
     return Mirror._noSuperclassMirror
   }
 }
+
+@available(*, unavailable)
+extension Mirror.AncestorRepresentation: Sendable {}
 
 /// A type that explicitly supplies its own mirror.
 ///

--- a/stdlib/public/core/NativeDictionary.swift
+++ b/stdlib/public/core/NativeDictionary.swift
@@ -68,6 +68,9 @@ internal struct _NativeDictionary<Key: Hashable, Value> {
 #endif
 }
 
+@available(*, unavailable)
+extension _NativeDictionary: Sendable {}
+
 extension _NativeDictionary { // Primitive fields
   @usableFromInline
   internal typealias Bucket = _HashTable.Bucket
@@ -852,6 +855,9 @@ extension _NativeDictionary: Sequence {
   }
 }
 
+@available(*, unavailable)
+extension _NativeDictionary.Iterator: Sendable {}
+
 extension _NativeDictionary.Iterator: IteratorProtocol {
   @usableFromInline
   internal typealias Element = (key: Key, value: Value)
@@ -879,4 +885,3 @@ extension _NativeDictionary.Iterator: IteratorProtocol {
     return (key, value)
   }
 }
-

--- a/stdlib/public/core/NativeSet.swift
+++ b/stdlib/public/core/NativeSet.swift
@@ -65,6 +65,9 @@ internal struct _NativeSet<Element: Hashable> {
 #endif
 }
 
+@available(*, unavailable)
+extension _NativeSet: Sendable {}
+
 extension _NativeSet { // Primitive fields
   @usableFromInline
   internal typealias Bucket = _HashTable.Bucket
@@ -590,6 +593,9 @@ extension _NativeSet: Sequence {
     return Iterator(self)
   }
 }
+
+@available(*, unavailable)
+extension _NativeSet.Iterator: Sendable {}
 
 extension _NativeSet.Iterator: IteratorProtocol {
   @inlinable

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -36,6 +36,8 @@ public struct LazyPrefixWhileSequence<Base: Sequence> {
   }
 }
 
+@available(*, unavailable)
+extension LazyPrefixWhileSequence: Sendable {}
 
 extension LazyPrefixWhileSequence {
   /// An iterator over the initial elements traversed by a base iterator that
@@ -62,6 +64,9 @@ extension LazyPrefixWhileSequence {
     }
   }
 }
+
+@available(*, unavailable)
+extension LazyPrefixWhileSequence.Iterator: Sendable {}
 
 extension LazyPrefixWhileSequence.Iterator: IteratorProtocol, Sequence {
   @inlinable // lazy-performance
@@ -148,6 +153,12 @@ extension LazyPrefixWhileCollection {
     }
   }
 }
+
+extension LazyPrefixWhileSequence._IndexRepresentation: Sendable
+  where Base.Index: Sendable {}
+
+extension LazyPrefixWhileSequence.Index: Sendable
+  where Base.Index: Sendable {}
 
 // FIXME: should work on the typealias
 extension LazyPrefixWhileSequence.Index: Comparable where Base: Collection {

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -213,6 +213,9 @@ public struct _EachFieldOptions: OptionSet {
   public static var ignoreUnknown = _EachFieldOptions(rawValue: 1 << 1)
 }
 
+@available(SwiftStdlib 5.2, *)
+extension _EachFieldOptions: Sendable {}
+
 /// The metadata "kind" for a type.
 @available(SwiftStdlib 5.2, *)
 @_spi(Reflection)
@@ -248,6 +251,9 @@ public enum _MetadataKind: UInt {
     }
   }
 }
+
+@available(SwiftStdlib 5.2, *)
+extension _MetadataKind: Sendable {}
 
 /// Calls the given closure on every field of the specified type.
 ///

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -63,6 +63,8 @@ public struct ReversedCollection<Base: BidirectionalCollection> {
   }
 }
 
+extension ReversedCollection: Sendable where Base: Sendable {}
+
 extension ReversedCollection {
   // An iterator that can be much faster than the iterator of a reversed slice.
   @frozen
@@ -82,6 +84,9 @@ extension ReversedCollection {
     }
   }
 }
+
+extension ReversedCollection.Iterator: Sendable
+  where Base: Sendable, Base.Index: Sendable {}
 
 extension ReversedCollection.Iterator: IteratorProtocol, Sequence {
   public typealias Element = Base.Element
@@ -169,6 +174,8 @@ extension ReversedCollection {
     }
   }
 }
+
+extension ReversedCollection.Index: Sendable where Base.Index: Sendable {}
 
 extension ReversedCollection.Index: Comparable {
   @inlinable

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -562,6 +562,9 @@ internal class __SwiftNativeNSArray {
   deinit {}
 }
 
+@available(*, unavailable)
+extension __SwiftNativeNSArray: Sendable {}
+
 @_fixed_layout
 @usableFromInline
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSMutableArrayBase)
@@ -574,6 +577,9 @@ internal class _SwiftNativeNSMutableArray {
   deinit {}
 }
 
+@available(*, unavailable)
+extension _SwiftNativeNSMutableArray: Sendable {}
+
 @_fixed_layout
 @usableFromInline
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSDictionaryBase)
@@ -584,6 +590,9 @@ internal class __SwiftNativeNSDictionary {
   deinit {}
 }
 
+@available(*, unavailable)
+extension __SwiftNativeNSDictionary: Sendable {}
+
 @_fixed_layout
 @usableFromInline
 @objc @_swift_native_objc_runtime_base(__SwiftNativeNSSetBase)
@@ -593,6 +602,9 @@ internal class __SwiftNativeNSSet {
   @objc public init(coder: AnyObject) {}
   deinit {}
 }
+
+@available(*, unavailable)
+extension __SwiftNativeNSSet: Sendable {}
 
 @objc
 @_swift_native_objc_runtime_base(__SwiftNativeNSEnumeratorBase)

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -722,6 +722,8 @@ public struct SIMDMask<Storage>: SIMD
   }
 }
 
+extension SIMDMask: Sendable where Storage: Sendable {}
+
 extension SIMDMask {
   /// Returns a vector mask with `true` or `false` randomly assigned in each
   /// lane, using the given generator as a source for randomness.

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -487,6 +487,8 @@ public struct DropFirstSequence<Base: Sequence> {
   }
 }
 
+extension DropFirstSequence: Sendable where Base: Sendable {}
+
 extension DropFirstSequence: Sequence {
   public typealias Element = Base.Element
   public typealias Iterator = Base.Iterator
@@ -530,6 +532,8 @@ public struct PrefixSequence<Base: Sequence> {
   }
 }
 
+extension PrefixSequence: Sendable where Base: Sendable {}
+
 extension PrefixSequence {
   @frozen
   public struct Iterator {
@@ -545,6 +549,8 @@ extension PrefixSequence {
     }
   }  
 }
+
+extension PrefixSequence.Iterator: Sendable where Base.Iterator: Sendable {}
 
 extension PrefixSequence.Iterator: IteratorProtocol {
   public typealias Element = Base.Element
@@ -603,6 +609,9 @@ public struct DropWhileSequence<Base: Sequence> {
   }
 }
 
+extension DropWhileSequence: Sendable
+  where Base.Iterator: Sendable, Element: Sendable {}
+
 extension DropWhileSequence {
   @frozen
   public struct Iterator {
@@ -618,6 +627,9 @@ extension DropWhileSequence {
     }
   }
 }
+
+extension DropWhileSequence.Iterator: Sendable
+  where Base.Iterator: Sendable, Element: Sendable {}
 
 extension DropWhileSequence.Iterator: IteratorProtocol {
   public typealias Element = Base.Element

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1506,6 +1506,9 @@ extension Set {
   }
 }
 
+@available(*, unavailable)
+extension Set.Iterator._Variant: Sendable {}
+
 extension Set.Iterator {
 #if _runtime(_ObjC)
   @usableFromInline @_transparent

--- a/stdlib/public/core/SetBridging.swift
+++ b/stdlib/public/core/SetBridging.swift
@@ -302,6 +302,9 @@ internal struct __CocoaSet {
   }
 }
 
+@available(*, unavailable)
+extension __CocoaSet: Sendable {}
+
 extension __CocoaSet {
   @usableFromInline
   @_effects(releasenone)
@@ -558,6 +561,9 @@ extension __CocoaSet: Sequence {
     return Iterator(self)
   }
 }
+
+@available(*, unavailable)
+extension __CocoaSet.Iterator: Sendable {}
 
 extension __CocoaSet.Iterator: IteratorProtocol {
   @usableFromInline

--- a/stdlib/public/core/SetBuilder.swift
+++ b/stdlib/public/core/SetBuilder.swift
@@ -43,3 +43,6 @@ struct _SetBuilder<Element: Hashable> {
     return Set(_native: _target)
   }
 }
+
+@available(*, unavailable)
+extension _SetBuilder: Sendable {}

--- a/stdlib/public/core/SetStorage.swift
+++ b/stdlib/public/core/SetStorage.swift
@@ -105,6 +105,9 @@ internal class __RawSetStorage: __SwiftNativeNSSet {
   }
 }
 
+@available(*, unavailable)
+extension __RawSetStorage: Sendable {}
+
 /// The storage class for the singleton empty set.
 /// The single instance of this class is created by the runtime.
 // NOTE: older runtimes called this class _EmptySetSingleton. The two
@@ -126,6 +129,9 @@ internal class __EmptySetSingleton: __RawSetStorage {
   }
 #endif
 }
+
+@available(*, unavailable)
+extension __EmptySetSingleton: Sendable {}
 
 #if $Embedded
 // In embedded Swift, the stdlib is a .swiftmodule only without any .o/.a files,
@@ -309,6 +315,9 @@ final internal class _SetStorage<Element: Hashable>
   }
 #endif
 }
+
+@available(*, unavailable)
+extension _SetStorage: Sendable {}
 
 extension _SetStorage {
   @usableFromInline

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -465,6 +465,9 @@ internal struct _SliceBuffer<Element>
   }
 }
 
+@available(*, unavailable)
+extension _SliceBuffer: Sendable {}
+
 extension _SliceBuffer {
   @inlinable
   internal __consuming func _copyToContiguousArray() -> ContiguousArray<Element> {

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -746,6 +746,9 @@ internal func _SwiftCreateBridgedString_DoNotCall(
   deinit {}
 }
 
+@available(*, unavailable)
+extension __SwiftNativeNSString: Sendable {}
+
 // Called by the SwiftObject implementation to get the description of a value
 // as an NSString.
 @_silgen_name("swift_stdlib_getDescription")

--- a/stdlib/public/core/StringTesting.swift
+++ b/stdlib/public/core/StringTesting.swift
@@ -36,6 +36,12 @@ struct _StringRepresentation {
   }
 }
 
+@available(*, unavailable)
+extension _StringRepresentation: Sendable {}
+
+@available(*, unavailable)
+extension _StringRepresentation._Form: Sendable {}
+
 extension String {
   public // @testable
   func _classify() -> _StringRepresentation { return _guts._classify() }

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -61,6 +61,9 @@ internal class __SwiftNativeNSArrayWithContiguousStorage
   }
 }
 
+@available(*, unavailable)
+extension __SwiftNativeNSArrayWithContiguousStorage: Sendable {}
+
 private let NSNotFound: Int = .max
 
 // Implement the APIs required by NSArray 
@@ -322,6 +325,9 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
   }
 }
 
+@available(*, unavailable)
+extension _SwiftNSMutableArray: Sendable {}
+
 /// An `NSArray` whose contiguous storage is created and filled, upon
 /// first access, by bridging the elements of a Swift `Array`.
 ///
@@ -429,6 +435,9 @@ extension __SwiftNativeNSArrayWithContiguousStorage {
   }
 }
 
+@available(*, unavailable)
+extension __SwiftDeferredNSArray: Sendable {}
+
 /// A `__SwiftDeferredNSArray` which is used for static read-only Swift Arrays.
 ///
 /// In contrast to its base class, `__SwiftDeferredStaticNSArray` is generic
@@ -500,6 +509,10 @@ internal class __SwiftNativeNSArrayWithContiguousStorage {
   @inlinable
   deinit {}
 }
+
+@available(*, unavailable)
+extension __SwiftNativeNSArrayWithContiguousStorage: Sendable {}
+
 #endif
 
 /// Base class of the heap buffer backing arrays.  
@@ -580,3 +593,6 @@ internal class __ContiguousArrayStorageBase
       self !== _emptyArrayStorage, "Deallocating empty array storage?!")
   }
 }
+
+@available(*, unavailable)
+extension __ContiguousArrayStorageBase: Sendable {}

--- a/stdlib/public/core/UIntBuffer.swift
+++ b/stdlib/public/core/UIntBuffer.swift
@@ -35,6 +35,8 @@ public struct _UIntBuffer<Element: UnsignedInteger & FixedWidthInteger> {
   }
 }
 
+extension _UIntBuffer: Sendable where Element: Sendable {}
+
 extension _UIntBuffer: Sequence {
   public typealias SubSequence = Slice<_UIntBuffer>
 
@@ -64,6 +66,8 @@ extension _UIntBuffer: Sequence {
     return Iterator(self)
   }
 }
+
+extension _UIntBuffer.Iterator: Sendable where Element: Sendable {}
 
 extension _UIntBuffer: Collection {
   @frozen
@@ -230,5 +234,3 @@ extension _UIntBuffer: RangeReplaceableCollection {
       truncatingIfNeeded: Int(_bitCount) &+ growth &* w)
   }
 }
-
-extension _UIntBuffer: Sendable where Element: Sendable { }

--- a/stdlib/public/core/UnfoldSequence.swift
+++ b/stdlib/public/core/UnfoldSequence.swift
@@ -126,3 +126,6 @@ public struct UnfoldSequence<Element, State>: Sequence, IteratorProtocol {
     self._next = _next
   }
 }
+
+extension UnfoldSequence: @unchecked Sendable
+  where Element: Sendable, State: Sendable {}

--- a/stdlib/public/core/UnicodeSPI.swift
+++ b/stdlib/public/core/UnicodeSPI.swift
@@ -25,6 +25,9 @@ extension Unicode {
 }
 
 @available(SwiftStdlib 5.7, *)
+extension Unicode._NFD: Sendable {}
+
+@available(SwiftStdlib 5.7, *)
 extension Unicode._NFD {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
@@ -32,6 +35,9 @@ extension Unicode._NFD {
     var base: Unicode._InternalNFD<Substring>.Iterator
   }
 }
+
+@available(SwiftStdlib 5.7, *)
+extension Unicode._NFD.Iterator: Sendable {}
 
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFD.Iterator: IteratorProtocol {
@@ -80,6 +86,9 @@ extension Unicode {
 }
 
 @available(SwiftStdlib 5.7, *)
+extension Unicode._NFC: Sendable {}
+
+@available(SwiftStdlib 5.7, *)
 extension Unicode._NFC {
   @_spi(_Unicode)
   @available(SwiftStdlib 5.7, *)
@@ -87,6 +96,9 @@ extension Unicode._NFC {
     var base: Unicode._InternalNFC<Substring>.Iterator
   }
 }
+
+@available(SwiftStdlib 5.7, *)
+extension Unicode._NFC.Iterator: Sendable {}
 
 @available(SwiftStdlib 5.7, *)
 extension Unicode._NFC.Iterator: IteratorProtocol {

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -712,3 +712,6 @@ final internal class __VaListBuilder {
 }
 
 #endif
+
+@available(*, unavailable)
+extension __VaListBuilder: Sendable {}


### PR DESCRIPTION
This PR adds sendable information to all public/UFI types to produce 0 warnings with `-require-explicit-sendable`. This patch doesn't turn that flag on yet because we'll have to audit other standard library modules to conform.