### PR TITLE
[Generated header] Emit members of enum extensions into C++ class

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -750,7 +750,7 @@ public:
       for (const Decl *D : declsToWrite) {
         if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
           const auto *type = ED->getExtendedNominal();
-          if (isa<StructDecl>(type))
+          if (isa<StructDecl>(type) || isa<EnumDecl>(type))
             printer.getInteropContext().recordExtensions(type, ED);
         }
       }

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
@@ -14,6 +14,18 @@ public enum E {
     case i(Int)
 }
 
+extension E {
+  public func matchesIntValue(_ value: Int) -> Bool {
+    switch self {
+    case .c:
+      return false
+
+    case .i(let mine):
+      return mine == value
+    }
+  }
+}
+
 // CHECK:      SWIFT_INLINE_THUNK E E::_impl_c::operator()(const C& val) const {
 // CHECK-NEXT:   auto result = E::_make();
 // CHECK-NEXT:   auto op = swift::_impl::_impl_RefCountedClass::copyOpaquePointer(val);
@@ -29,3 +41,6 @@ public enum E {
 // CHECK-NEXT:   char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
 // CHECK-NEXT:   return swift::_impl::implClassFor<C>::type::makeRetained(*reinterpret_cast<void **>(payloadFromDestruction));
 // CHECK-NEXT: }
+
+// CHECK: SWIFT_INLINE_THUNK bool E::matchesIntValue(swift::Int value) const {
+// CHECK-NEXT: return _impl::$s5Enums1EO15matchesIntValueySbSiF(value, _impl::swift_interop_passDirect_Enums_uint64_t_0_8_uint8_t_8_9(_getOpaquePointer()));

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -66,7 +66,8 @@
 // CHECK-NEXT: };
 // CHECK: SWIFT_INLINE_THUNK bool isSome() const;
 // CHECK: SWIFT_INLINE_THUNK bool isNone() const;
-// CHECK: SWIFT_INLINE_THUNK T_0_0 getUnsafelyUnwrapped() const SWIFT_SYMBOL({{.*}});
+// CHECK-DAG: SWIFT_INLINE_THUNK T_0_0 getUnsafelyUnwrapped() const SWIFT_SYMBOL({{.*}});
+// CHECK-DAG: SWIFT_INLINE_THUNK String getDebugDescription() const SWIFT_SYMBOL("s:Sq16debugDescriptionSSvp");
 
 // CHECK: class SWIFT_SYMBOL({{.*}}) String final {
 // CHECK-NEXT: public:


### PR DESCRIPTION
As we do with Swift structs, emit the members of extensions of Swift enums into the corresponding C++ class. This includes exposing more of the Optional API from the standard library into Swift.
