### PR TITLE
[BitwiseCopyable] Imported type improvements.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7650,6 +7650,8 @@ ERROR(non_bitwise_copyable_type_nonescapable,none,
       "nonescapable type cannot conform to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_type_cxx_nontrivial,none,
       "non-trivial C++ type cannot conform to 'BitwiseCopyable'", ())
+ERROR(non_bitwise_copyable_c_type_nontrivial,none,
+      "type with unrepresentable fields cannot derive conformance to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_type_member,none,
       "%select{stored property %2|associated value %2}1 of "
       "'BitwiseCopyable'-conforming %kind3 has non-bitwise-copyable type %0",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7652,6 +7652,8 @@ ERROR(non_bitwise_copyable_type_cxx_nontrivial,none,
       "non-trivial C++ type cannot conform to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_c_type_nontrivial,none,
       "type with unrepresentable fields cannot derive conformance to 'BitwiseCopyable'", ())
+NOTE(note_non_bitwise_copyable_c_type_add_attr,none,
+     "annotate the type __attribute__((__swift_attr__(\"_BitwiseCopyable\")))",())
 ERROR(non_bitwise_copyable_type_member,none,
       "%select{stored property %2|associated value %2}1 of "
       "'BitwiseCopyable'-conforming %kind3 has non-bitwise-copyable type %0",

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -272,6 +272,7 @@ static bool checkBitwiseCopyableInstanceStorage(NominalTypeDecl *nominal,
   if (sd && sd->hasUnreferenceableStorage()) {
     if (!isImplicit(check)) {
       sd->diagnose(diag::non_bitwise_copyable_c_type_nontrivial);
+      sd->diagnose(diag::note_non_bitwise_copyable_c_type_add_attr);
     }
     return true;
   }

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -269,6 +269,13 @@ static bool checkBitwiseCopyableInstanceStorage(NominalTypeDecl *nominal,
     return true;
   }
 
+  if (sd && sd->hasUnreferenceableStorage()) {
+    if (!isImplicit(check)) {
+      sd->diagnose(diag::non_bitwise_copyable_c_type_nontrivial);
+    }
+    return true;
+  }
+
   BitwiseCopyableStorageVisitor visitor(nominal, dc, check);
 
   return visitor.visit(nominal, dc) || visitor.invalid;

--- a/test/Sema/bitwse_copyable_import.swift
+++ b/test/Sema/bitwse_copyable_import.swift
@@ -54,6 +54,12 @@ struct IntsTrailing2 {
   int is[];
 };
 
+struct IntsTrailing3 {
+  double d;
+  float f;
+  int is[];
+} __attribute__((__swift_attr__("_BitwiseCopyable")));
+
 //--- Downstream.swift
 
 func take<T : _BitwiseCopyable>(_ t: T) {}
@@ -74,5 +80,8 @@ func passIntsTrailing(_ t: IntsTrailing) {
 }
 extension IntsTrailing2 : _BitwiseCopyable {} //expected-error{{bitwise_copyable_outside_module}}
 func passIntsTrailing2(_ t: IntsTrailing2) {
+  take(t)
+}
+func passIntsTrailing3(_ t: IntsTrailing3) {
   take(t)
 }

--- a/test/Sema/bitwse_copyable_import.swift
+++ b/test/Sema/bitwse_copyable_import.swift
@@ -1,0 +1,58 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend                               \
+// RUN:     %t/Downstream.swift                              \
+// RUN:     -typecheck -verify                               \
+// RUN:     -enable-experimental-feature NonescapableTypes   \
+// RUN:     -enable-experimental-feature BitwiseCopyable     \
+// RUN:     -enable-builtin-module                           \
+// RUN:     -debug-diagnostic-names                          \
+// RUN:     -import-objc-header %t/Library.h
+
+//--- Library.h
+
+struct Tenple {
+  int i0;
+  int i1;
+  int i2;
+  int i3;
+  int i4;
+  int i5;
+  int i6;
+  int i7;
+  int i8;
+  int i9;
+};
+
+struct Ints128 {
+  int is[128];
+};
+
+struct VoidPointers {
+  void *p1;
+  void *p2;
+  void *p3;
+  void *p4;
+  void *p5;
+  void *p6;
+  void *p7;
+  void *p8;
+  void *p9;
+  void *p10;
+};
+
+//--- Downstream.swift
+
+func take<T : _BitwiseCopyable>(_ t: T) {}
+
+func passTenple(_ t: Tenple) { take(t) }
+func passInts128(_ t: Ints128) {
+  take(t)
+  take(t.is.0)
+  take(t.is.17)
+}
+func passVoidPointers(_ t: VoidPointers) { 
+  take(t) 
+  take(t.p10)
+}

--- a/test/Sema/bitwse_copyable_import.swift
+++ b/test/Sema/bitwse_copyable_import.swift
@@ -42,6 +42,18 @@ struct VoidPointers {
   void *p10;
 };
 
+struct IntsTrailing {
+  double d;
+  float f;
+  int is[];
+};
+
+struct IntsTrailing2 {
+  double d;
+  float f;
+  int is[];
+};
+
 //--- Downstream.swift
 
 func take<T : _BitwiseCopyable>(_ t: T) {}
@@ -55,4 +67,12 @@ func passInts128(_ t: Ints128) {
 func passVoidPointers(_ t: VoidPointers) { 
   take(t) 
   take(t.p10)
+}
+func passIntsTrailing(_ t: IntsTrailing) {
+  take(t) // expected-error{{type_does_not_conform_decl_owner}}
+          // expected-note@-14{{where_requirement_failure_one_subst}}
+}
+extension IntsTrailing2 : _BitwiseCopyable {} //expected-error{{bitwise_copyable_outside_module}}
+func passIntsTrailing2(_ t: IntsTrailing2) {
+  take(t)
 }


### PR DESCRIPTION
Tested inference for imported types.  Don't infer when an imported type has storage that isn't imported into Swift.  Allow a type to explicitly state conformance via `__swift_attr__`.
