### PR TITLE
SILGen: Forward move-only ownership through optional chains.

### DIFF
--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -468,6 +468,16 @@ public:
                                     ManagedValue base,
                                     MarkDependenceKind dependencekind);
 
+  ManagedValue createOpaqueBorrowBeginAccess(SILLocation loc,
+                                             ManagedValue address);
+  ManagedValue createFormalAccessOpaqueBorrowBeginAccess(SILLocation loc,
+                                                         ManagedValue address);
+
+  ManagedValue createOpaqueConsumeBeginAccess(SILLocation loc,
+                                              ManagedValue address);
+  ManagedValue createFormalAccessOpaqueConsumeBeginAccess(SILLocation loc,
+                                                          ManagedValue address);
+
   using SILBuilder::createBeginBorrow;
   ManagedValue createBeginBorrow(SILLocation loc, ManagedValue value,
                                  bool isLexical = false,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -162,6 +162,22 @@ enum class SGFAccessKind : uint8_t {
   OwnedObjectConsume,
 };
 
+static inline bool isBorrowAccess(SGFAccessKind kind) {
+  switch (kind) {
+  case SGFAccessKind::IgnoredRead:
+  case SGFAccessKind::BorrowedAddressRead:
+  case SGFAccessKind::BorrowedObjectRead:
+    return true;
+  case SGFAccessKind::OwnedAddressRead:
+  case SGFAccessKind::OwnedObjectRead:
+  case SGFAccessKind::Write:
+  case SGFAccessKind::ReadWrite:
+  case SGFAccessKind::OwnedAddressConsume:
+  case SGFAccessKind::OwnedObjectConsume:
+    return false;
+  }
+}
+
 static inline bool isReadAccess(SGFAccessKind kind) {
   return uint8_t(kind) <= uint8_t(SGFAccessKind::OwnedObjectRead);
 }
@@ -2234,14 +2250,6 @@ public:
   ManagedValue emitBindOptional(SILLocation loc,
                                 ManagedValue optionalAddrOrValue,
                                 unsigned depth);
-
-  /// Emit the control flow for an optional 'bind' operation, branching to the
-  /// active failure destination if the optional value addressed by optionalAddr
-  /// is nil, and leaving the insertion point on the success branch.
-  ///
-  /// NOTE: This operation does not consume the managed address.
-  void emitBindOptionalAddress(SILLocation loc, ManagedValue optionalAddr,
-                               unsigned depth);
 
   void emitOptionalEvaluation(SILLocation loc, Type optionalType,
                               SmallVectorImpl<ManagedValue> &results,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyTypeUtils.cpp
@@ -101,6 +101,10 @@ TypeOffsetSizePair::walkOneLevelTowardsChild(
   }
 
   if (auto *enumDecl = ancestorType.getEnumOrBoundGenericEnum()) {
+    if (enumDecl == fn->getASTContext().getOptionalDecl()) {
+      // The only possible child of Optional is the wrapped type.
+      return {{ancestorOffsetSize, ancestorType.getOptionalObjectType()}};
+    }
     llvm_unreachable("Cannot find child type of enum!\n");
   }
 
@@ -196,6 +200,14 @@ TypeOffsetSizePair::walkOneLevelTowardsChild(
   }
 
   if (auto *enumDecl = ancestorType.getEnumOrBoundGenericEnum()) {
+    if (enumDecl == fn->getASTContext().getOptionalDecl()) {
+      // The only possible child of Optional is the wrapped type.
+      auto newValue
+        = builder.createUncheckedEnumData(loc, ancestorValue,
+                                    fn->getASTContext().getOptionalSomeDecl());
+      return {{ancestorOffsetSize, newValue}};
+    }
+
     llvm_unreachable("Cannot find child type of enum!\n");
   }
 
@@ -305,6 +317,10 @@ void TypeOffsetSizePair::constructPathString(
     }
 
     if (auto *enumDecl = iterType.getEnumOrBoundGenericEnum()) {
+      if (enumDecl == fn->getASTContext().getOptionalDecl()) {
+        os << '!';
+        continue;
+      }
       llvm_unreachable("Cannot find child type of enum!\n");
     }
 

--- a/test/SILGen/moveonly_optional_operations.swift
+++ b/test/SILGen/moveonly_optional_operations.swift
@@ -1,0 +1,142 @@
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -verify %s
+
+@_marker protocol Copyable {}
+@_marker protocol Escapable {}
+
+enum Optional<Wrapped: ~Copyable>: ~Copyable {
+    case none
+    case some(Wrapped)
+}
+
+extension Optional: Copyable where Wrapped: Copyable { }
+
+func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
+                                    _filenameLength: Builtin.Word,
+                                    _filenameIsASCII: Builtin.Int1,
+                                    _line: Builtin.Word,
+                                    _isImplicitUnwrap: Builtin.Int1) {
+}
+
+precedencegroup AssignmentPrecedence {}
+
+struct NC: ~Copyable {
+    borrowing func b() {}
+    mutating func m() {}
+    consuming func c() {}
+}
+
+struct NCAO: ~Copyable {
+    var x: Any
+
+    borrowing func b() {}
+    mutating func m() {}
+    consuming func c() {}
+}
+
+func borrowingChains(nc: borrowing NC?, // expected-error{{'nc' is borrowed and cannot be consumed}}
+                     ncao: borrowing NCAO?) { // expected-error{{'ncao' is borrowed and cannot be consumed}}
+    nc?.b()
+    nc?.c() // expected-note{{consumed here}}
+
+    ncao?.b()
+    ncao?.c() // expected-note{{consumed here}}
+}
+
+func borrowingChains2(nc: borrowing NC?,
+                      ncao: borrowing NCAO?) {
+    nc?.b()
+
+    ncao?.b()
+}
+
+func mutatingChains(nc: inout NC?, // expected-error{{'nc' used after consume}}
+                    ncao: inout NCAO?) { // expected-error{{'ncao' used after consume}}
+    nc?.b()
+    nc?.m()
+    nc?.c() // expected-note{{consumed here}}
+    nc?.b() // expected-note{{used here}}
+    nc?.m()
+    nc = .none
+    nc?.b()
+    nc?.m()
+
+    ncao?.b()
+    ncao?.m()
+    ncao?.c() // expected-note{{consumed here}}
+    ncao?.b() // expected-note{{used here}}
+    ncao?.m()
+    ncao = .none
+    ncao?.b()
+    ncao?.m()
+}
+
+func mutatingChains2(nc: inout NC?, // expected-error{{'nc' used after consume}}
+                    ncao: inout NCAO?) { // expected-error{{'ncao' used after consume}}
+    nc?.b()
+    nc?.m()
+    nc?.c() // expected-note{{consumed here}}
+    nc?.m() // expected-note{{used here}}
+    nc = .none
+    nc?.m()
+
+    ncao?.b()
+    ncao?.m()
+    ncao?.c() // expected-note{{consumed here}}
+    ncao?.m() // expected-note{{used here}}
+    ncao = .none
+    ncao?.m()
+}
+
+func mutatingChains3(nc: inout NC?,
+                    ncao: inout NCAO?) {
+    nc?.b()
+    nc?.m()
+    nc?.c()
+    nc = .none
+    nc?.b()
+    nc?.m()
+
+    ncao?.b()
+    ncao?.m()
+    ncao?.c()
+    ncao = .none
+    ncao?.b()
+    ncao?.m()
+}
+
+func mutatingChains4(nc: inout NC?, // expected-error{{missing reinitialization of inout parameter 'nc' after consume}}
+                    ncao: inout NCAO?) { // expected-error{{missing reinitialization of inout parameter 'ncao' after consume}}
+    nc?.b()
+    nc?.m()
+    nc?.c() // expected-note{{consumed here}}
+
+    ncao?.b()
+    ncao?.m()
+    ncao?.c() // expected-note{{consumed here}}
+}
+
+func consumingChains(nc: consuming NC?, // expected-error{{'nc' used after consume}}
+                     ncao: consuming NCAO?) { // expected-error{{'ncao' used after consume}}
+    nc?.b()
+    nc?.m()
+    nc?.c() // expected-note{{consumed here}}
+    nc?.b() // expected-note{{used here}}
+    nc?.m()
+
+    ncao?.b()
+    ncao?.m()
+    ncao?.c() // expected-note{{consumed here}}
+    ncao?.b() // expected-note{{used here}}
+    ncao?.m()
+}
+
+func consumingChains2(nc: consuming NC?,
+                      ncao: consuming NCAO?) {
+    nc?.b()
+    nc?.m()
+    nc?.c()
+
+    ncao?.b()
+    ncao?.m()
+    ncao?.c()
+}


### PR DESCRIPTION
Allow noncopyable values to be consumed, borrowed, or mutated transitively through optional chains.