### PR TITLE
CSE: fix checking convention of tuple apply results

### DIFF
--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -1136,8 +1136,8 @@ bool CSE::canHandle(SILInstruction *Inst) {
     if (!AI->getFunction()->hasOwnership()) {
       // In non-OSSA we don't balance CSE'd apply results which return an
       // owned value.
-      if (auto ri = AI->getSingleResult()) {
-        if (ri.value().getConvention() != ResultConvention::Unowned)
+      for (const SILResultInfo &ri : AI->getSubstCalleeType()->getResults()) {
+        if (ri.getConvention() != ResultConvention::Unowned)
           return false;
       }
     }

--- a/test/SILOptimizer/cse_apply.sil
+++ b/test/SILOptimizer/cse_apply.sil
@@ -126,7 +126,7 @@ bb0(%0 : $Int64):
   return %14 : $Int64
 }
 
-//CHECK-LABEL: sil @dont_cse_retain_only_apply
+//CHECK-LABEL: sil @dont_cse_retain_only_apply :
 //CHECK: %{{[0-9]+}} = apply
 //CHECK: %{{[0-9]+}} = apply
 //CHECK: return
@@ -139,5 +139,47 @@ bb0:
   strong_release %a2 : $XX
   %r = tuple()
   return %r : $()
+}
+
+sil @get_tuple : $@convention(thin) () -> (@owned XX, Int) {
+[global: ]
+}
+
+//CHECK-LABEL: sil @dont_cse_retain_only_apply2 :
+//CHECK:         %{{[0-9]+}} = apply %0
+//CHECK:         %{{[0-9]+}} = apply %0
+//CHECK:       } // end sil function 'dont_cse_retain_only_apply2'
+sil @dont_cse_retain_only_apply2 : $@convention(thin) () -> () {
+bb0:
+  %0 = function_ref @get_tuple : $@convention(thin) () -> (@owned XX, Int)
+  %1 = apply %0() : $@convention(thin) () -> (@owned XX, Int)
+  %2 = tuple_extract %1 : $(XX, Int), 0
+  release_value %2 : $XX
+  %4 = apply %0() : $@convention(thin) () -> (@owned XX, Int)
+  %5 = tuple_extract %4 : $(XX, Int), 0
+  release_value %5 : $XX
+  %6 = tuple ()
+  return %6 : $()
+}
+
+sil @get_trivial_tuple : $@convention(thin) () -> (Int, Int) {
+[global: ]
+}
+
+//CHECK-LABEL: sil @cse_apply_with_trivial_result :
+//CHECK:         [[R:%.*]] = apply %0
+//CHECK-NEXT:    [[I:%.*]] = tuple_extract [[R]] : $(Int, Int), 0
+//CHECK-NEXT:    [[T:%.*]] = tuple ([[I]] : $Int, [[I]] : $Int)
+//CHECK-NEXT:    return [[T]]
+//CHECK:       } // end sil function 'cse_apply_with_trivial_result'
+sil @cse_apply_with_trivial_result : $@convention(thin) () -> (Int, Int) {
+bb0:
+  %0 = function_ref @get_trivial_tuple : $@convention(thin) () -> (Int, Int)
+  %1 = apply %0() : $@convention(thin) () -> (Int, Int)
+  %2 = tuple_extract %1 : $(Int, Int), 0
+  %4 = apply %0() : $@convention(thin) () -> (Int, Int)
+  %5 = tuple_extract %4 : $(Int, Int), 0
+  %6 = tuple (%2 : $Int, %5 : $Int)
+  return %6 : $(Int, Int)
 }
 


### PR DESCRIPTION
We didn't catch the case where a function returns a tuple where at least one of the tuple elements is returned as `owned`. In such a case the apply must not be cse'd.

Fixes a miscompile which results in an over-release.
rdar://121597250
