### PR TITLE
[build-presets] Remove `test-sourcekit-lsp`

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1878,7 +1878,6 @@ swiftsyntax-lint
 swiftformat
 skstresstester
 sourcekit-lsp
-test-sourcekit-lsp
 install-swiftformat
 skip-test-swift=false
 
@@ -1935,7 +1934,6 @@ mixin-preset=mixin_swiftpm_package_macos_platform
 release
 assertions
 sourcekit-lsp
-test-sourcekit-lsp
 swiftformat
 install-swiftformat
 sourcekit-lsp-lint


### PR DESCRIPTION
I added the test-sourcekit-lsp command because I thought that we weren’t running sourcekit-lsp tests on the swift-syntax PR testing job (https://github.com/apple/swift/pull/72030). Then the job started failing with a TSAN failure and I thought that we would now not run sourcekit-lsp tests on the sourcekit-lsp PR testing job, so I added it there as well.

Turns out that my first assumption that we weren’t running sourcekit-lsp tests on swift-syntax PRs was wrong and the downstream failure of that was just due to racing PRs. Furthermore, the `test-sourcekit-lsp` flag doesn’t even exist. Instead, it got typo-corrected (?) to `test-sourcekit-lsp-sanitize-all`, which enabled the TSAN sanitizer on the swift-syntax and sourcekit-lsp PR testing jobs. And that caused test failures.

So, remove the `test-sourcekit-lsp` arguments again. After I made sourcekit-lsp build with strict concurrency / Swift 6 mode, I’ll re-enable TSAN on the sourcekit-lsp PR tests and fix any remaining TSAN issues.
