### PR TITLE
[Noncopyable] Teach existential generalization about invertible protocols

### DIFF
--- a/lib/AST/Requirement.cpp
+++ b/lib/AST/Requirement.cpp
@@ -349,8 +349,7 @@ void InverseRequirement::expandDefaults(
     ASTContext &ctx,
     ArrayRef<Type> gps,
     SmallVectorImpl<StructuralRequirement> &result) {
-  if (!SWIFT_ENABLE_EXPERIMENTAL_NONCOPYABLE_GENERICS &&
-      !ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics))
+  if (!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics))
     return;
 
   for (auto gp : gps) {

--- a/test/IRGen/existential_shape_metadata.swift
+++ b/test/IRGen/existential_shape_metadata.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -disable-availability-checking | %IRGenFileCheck %s
 
-// XFAIL: noncopyable_generics
-
 // CHECK-LABEL: @"$sl26existential_shape_metadata2Q0_px1TRts_XPXGMq" = linkonce_odr hidden constant
 // CHECK-SAME:  { i32 {{.*}}sub ([[INT]] ptrtoint (ptr @{{[0-9]+}} to [[INT]])
 // CHECK-SAME:    i32 6400,

--- a/test/IRGen/existential_shape_metadata_noncopyable.swift
+++ b/test/IRGen/existential_shape_metadata_noncopyable.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -disable-availability-checking -enable-experimental-feature NoncopyableGenerics -module-name existential_shape_metadata | %IRGenFileCheck %s
+
+// NOTE: Once noncopyable generics are enabled by default, merge this back into existential_shape_metadata.swift
+
+// CHECK: @"$sRiczl26existential_shape_metadata3QNC_px1ARts_XPXGMq" = linkonce_odr
+
+public protocol QNC<A>: ~Copyable {
+  associatedtype A: ~Copyable
+}
+
+public struct NCStruct: ~Copyable { }
+
+
+public func testNoncopyableConcrete() -> (Any & ~Copyable).Type {
+  return (any QNC<NCStruct>).self
+}


### PR DESCRIPTION
The generic signature formed by existential generalization didn't
account for invertible protocols, which caused an unintended change in
name mangling. Capture the appropriate inverted requirements as part
of generalization to restore the prior mangling, as well as correctly
accounting for invertible protocols in the generalized signature.