### PR TITLE
embedded: allow dead function elimination for de-serialized functions

### DIFF
--- a/lib/SIL/IR/Linker.cpp
+++ b/lib/SIL/IR/Linker.cpp
@@ -448,11 +448,6 @@ void SILLinkerVisitor::process() {
       Fn->setSerialized(IsSerialized_t::IsNotSerialized);
     }
 
-    // TODO: This should probably be done as a separate SIL pass ("internalize")
-    if (Fn->getModule().getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
-      Fn->setLinkage(stripExternalFromLinkage(Fn->getLinkage()));
-    }
-
     LLVM_DEBUG(llvm::dbgs() << "Process imports in function: "
                             << Fn->getName() << "\n");
 

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -940,6 +940,9 @@ bool SILFunction::shouldBePreservedForDebugger() const {
   if (getEffectiveOptimizationMode() != OptimizationMode::NoOptimization)
     return false;
 
+  if (isAvailableExternally())
+    return false;
+
   if (hasSemanticsAttr("no.preserve.debugger"))
     return false;
 

--- a/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
+++ b/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
@@ -87,6 +87,15 @@ class IRGenPrepare : public SILFunctionTransform {
   void run() override {
     SILFunction *F = getFunction();
 
+    if (getOptions().EmbeddedSwift) {
+      // In embedded swift all the code is generated in the top-level module.
+      // Even de-serialized functions must be code-gen'd.
+      SILLinkage linkage = F->getLinkage();
+      if (isAvailableExternally(linkage)) {
+        F->setLinkage(stripExternalFromLinkage(linkage));
+      }
+    }
+
     bool shouldInvalidate = cleanFunction(*F);
 
     if (shouldInvalidate)

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -86,6 +86,13 @@ public:
 
     if (M.linkFunction(Fn, LinkMode))
       invalidateAnalysis(Fn, SILAnalysis::InvalidationKind::Everything);
+
+    // Make sure that dead-function-elimination doesn't remove runtime functions.
+    // TODO: lazily emit runtime functions in IRGen so that we don't have to
+    //       rely on dead-stripping in the linker to remove unused runtime
+    //       functions.
+    if (Fn->isDefinition())
+      Fn->setLinkage(SILLinkage::Public);
   }
 };
 } // end anonymous namespace

--- a/test/embedded/floatingpoint.swift
+++ b/test/embedded/floatingpoint.swift
@@ -1,0 +1,22 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -lto=llvm-full %lto_flags -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+// Check that initializing a Double with an integer literal doesn't result in unresolved symbols
+@inline(never)
+func testLiteral() -> Double {
+  return Double(1)
+} 
+
+@main
+struct Main {
+  static func main() {
+    print(testLiteral() == 1.0)
+    // CHECK: true
+  }
+}

--- a/test/embedded/stdlib-basic.swift
+++ b/test/embedded/stdlib-basic.swift
@@ -43,12 +43,8 @@ public func checks(n: Int) {
 
 // CHECK: define {{.*}}i32 @main(i32 %0, ptr %1)
 // CHECK: define {{.*}}i1 @"$s4main4boolSbyF"()
-// CHECK: define {{.*}}i1 @"$sSb22_builtinBooleanLiteralSbBi1__tcfC"(i1 %0)
 // CHECK: define {{.*}}{{i32|i64}} @"$s4main3intSiyF"()
-// CHECK: define {{.*}}{{i32|i64}} @"$sSi22_builtinIntegerLiteralSiBI_tcfC"(ptr %0, {{i32|i64}} %1)
 // CHECK: define {{.*}}ptr @"$s4main3ptr1p1nS2V_SitF"(ptr %0, {{i32|i64}} %1)
-// CHECK: define {{.*}}ptr @"$sSV8advanced2bySVSi_tF"({{i32|i64}} %0, ptr %1)
 // CHECK: define {{.*}}{ {{i32|i64}}, i8 } @"$s4main8optionalSiSgyF"()
 // CHECK: define {{.*}}{ {{i32|i64}}, {{i32|i64}}, i8 } @"$s4main12staticstrings12StaticStringVyF"()
-// CHECK: define {{.*}}{ {{i32|i64}}, {{i32|i64}}, i8 } @"$ss12StaticStringV08_builtinB7Literal17utf8CodeUnitCount7isASCIIABBp_BwBi1_tcfC"(ptr %0, {{i32|i64}} %1, i1 %2)
 // CHECK: define {{.*}}void @"$s4main6checks1nySi_tF"({{i32|i64}} %0)


### PR DESCRIPTION
In embedded swift all de-serialized get public linkage because all the code is generated in the top-level module. This change moves the point where we make de-serialized functions public to the end of the pipeline. This allows dead function elimination to remove unused de-serialized functions. For some stdlib functions (actually one: the Double initializer for a builtin integer) is essential, because codegen for embedded produces an unresolved symbol.

rdar://123772098
