### PR TITLE
[region-isolation] Make async let closures non-Sendable and require actor isolation crossing function into an async let use a transferring result.

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -884,7 +884,7 @@ BUILTIN_MISC_OPERATION_WITH_SILGEN(GetCurrentAsyncTask, "getCurrentAsyncTask", "
 BUILTIN_MISC_OPERATION_WITH_SILGEN(CancelAsyncTask, "cancelAsyncTask", "", Special)
 
 /// startAsyncLet()<T>: (
-///     __owned @Sendable @escaping () async throws -> T
+///     __owned @escaping () async throws -> transferring T
 /// ) -> Builtin.RawPointer
 ///
 /// DEPRECATED. startAsyncLetWithLocalBuffer is used instead.
@@ -894,7 +894,7 @@ BUILTIN_MISC_OPERATION_WITH_SILGEN(CancelAsyncTask, "cancelAsyncTask", "", Speci
 BUILTIN_MISC_OPERATION(StartAsyncLet, "startAsyncLet", "", Special)
 
 /// startAsyncLetWithLocalBuffer()<T>: (
-///     __owned @Sendable @escaping () async throws -> T,
+///     __owned @escaping () async throws -> transferring T,
 ///     _ resultBuf: Builtin.RawPointer
 /// ) -> Builtin.RawPointer
 ///

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -811,13 +811,18 @@ public:
     }
   }
 
-  /// Return the applied argument without indirect results.
-  unsigned getAppliedArgIndexWithoutIndirectResult(const Operand &oper) const {
+  /// Return the applied argument index for the given operand ignoring indirect
+  /// results.
+  ///
+  /// So for instance:
+  ///
+  /// apply %f(%result, %0, %1, %2, ...).
+  unsigned getAppliedArgIndexWithoutIndirectResults(const Operand &oper) const {
     assert(oper.getUser() == **this);
     assert(isArgumentOperand(oper));
 
-    return oper.getOperandNumber() - getOperandIndexOfFirstArgument() -
-           getNumIndirectSILResults() - getNumIndirectSILErrorResults();
+    return getAppliedArgIndex(oper) - getNumIndirectSILResults() -
+           getNumIndirectSILErrorResults();
   }
 
   static FullApplySite getFromOpaqueValue(void *p) { return FullApplySite(p); }

--- a/include/swift/SIL/SILDeclRef.h
+++ b/include/swift/SIL/SILDeclRef.h
@@ -197,6 +197,8 @@ struct SILDeclRef {
   BackDeploymentKind backDeploymentKind : 2;
   /// The default argument index for a default argument getter.
   unsigned defaultArgIndex : 10;
+  /// Set if this is for an async let closure.
+  unsigned isAsyncLetClosure : 1;
 
   PointerUnion<AutoDiffDerivativeFunctionIdentifier *,
                const GenericSignatureImpl *, CustomAttr *>
@@ -229,9 +231,10 @@ struct SILDeclRef {
 
   /// Produces a null SILDeclRef.
   SILDeclRef()
-      : loc(), kind(Kind::Func), isForeign(0), 
-        isDistributed(0), isKnownToBeLocal(0), isRuntimeAccessible(0),
-        backDeploymentKind(BackDeploymentKind::None), defaultArgIndex(0) {}
+      : loc(), kind(Kind::Func), isForeign(0), isDistributed(0),
+        isKnownToBeLocal(0), isRuntimeAccessible(0),
+        backDeploymentKind(BackDeploymentKind::None), defaultArgIndex(0),
+        isAsyncLetClosure(0) {}
 
   /// Produces a SILDeclRef of the given kind for the given decl.
   explicit SILDeclRef(
@@ -397,10 +400,9 @@ struct SILDeclRef {
 
   /// Return the hash code for the SIL declaration.
   friend llvm::hash_code hash_value(const SILDeclRef &ref) {
-    return llvm::hash_combine(ref.loc.getOpaqueValue(),
-                              static_cast<int>(ref.kind),
-                              ref.isForeign, ref.isDistributed,
-                              ref.defaultArgIndex);
+    return llvm::hash_combine(
+        ref.loc.getOpaqueValue(), static_cast<int>(ref.kind), ref.isForeign,
+        ref.isDistributed, ref.defaultArgIndex, ref.isAsyncLetClosure);
   }
 
   bool operator==(SILDeclRef rhs) const {
@@ -408,8 +410,8 @@ struct SILDeclRef {
            kind == rhs.kind && isForeign == rhs.isForeign &&
            isDistributed == rhs.isDistributed &&
            backDeploymentKind == rhs.backDeploymentKind &&
-           defaultArgIndex == rhs.defaultArgIndex &&
-           pointer == rhs.pointer;
+           defaultArgIndex == rhs.defaultArgIndex && pointer == rhs.pointer &&
+           isAsyncLetClosure == rhs.isAsyncLetClosure;
   }
   bool operator!=(SILDeclRef rhs) const {
     return !(*this == rhs);
@@ -427,9 +429,8 @@ struct SILDeclRef {
                       /*foreign=*/foreign,
                       /*distributed=*/false,
                       /*knownToBeLocal=*/false,
-                      /*runtimeAccessible=*/false,
-                      backDeploymentKind,
-                      defaultArgIndex,
+                      /*runtimeAccessible=*/false, backDeploymentKind,
+                      defaultArgIndex, isAsyncLetClosure,
                       pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
   }
   /// Returns the distributed entry point corresponding to the same decl.
@@ -437,10 +438,8 @@ struct SILDeclRef {
     return SILDeclRef(loc.getOpaqueValue(), kind,
                       /*foreign=*/false,
                       /*distributed=*/distributed,
-                      /*knownToBeLocal=*/false,
-                      isRuntimeAccessible,
-                      backDeploymentKind,
-                      defaultArgIndex,
+                      /*knownToBeLocal=*/false, isRuntimeAccessible,
+                      backDeploymentKind, defaultArgIndex, isAsyncLetClosure,
                       pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
   }
 
@@ -451,9 +450,8 @@ struct SILDeclRef {
                       /*foreign=*/false,
                       /*distributed=*/false,
                       /*distributedKnownToBeLocal=*/isLocal,
-                      isRuntimeAccessible,
-                      backDeploymentKind,
-                      defaultArgIndex,
+                      isRuntimeAccessible, backDeploymentKind, defaultArgIndex,
+                      isAsyncLetClosure,
                       pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
   }
 
@@ -466,13 +464,9 @@ struct SILDeclRef {
 
   /// Returns a copy of the decl with the given back deployment kind.
   SILDeclRef asBackDeploymentKind(BackDeploymentKind backDeploymentKind) const {
-    return SILDeclRef(loc.getOpaqueValue(), kind,
-                      isForeign,
-                      isDistributed,
-                      isKnownToBeLocal,
-                      isRuntimeAccessible,
-                      backDeploymentKind,
-                      defaultArgIndex,
+    return SILDeclRef(loc.getOpaqueValue(), kind, isForeign, isDistributed,
+                      isKnownToBeLocal, isRuntimeAccessible, backDeploymentKind,
+                      defaultArgIndex, isAsyncLetClosure,
                       pointer.get<AutoDiffDerivativeFunctionIdentifier *>());
   }
 
@@ -606,21 +600,18 @@ struct SILDeclRef {
 private:
   friend struct llvm::DenseMapInfo<swift::SILDeclRef>;
   /// Produces a SILDeclRef from an opaque value.
-  explicit SILDeclRef(void *opaqueLoc, Kind kind,
-                      bool isForeign,
-                      bool isDistributed,
-                      bool isKnownToBeLocal,
+  explicit SILDeclRef(void *opaqueLoc, Kind kind, bool isForeign,
+                      bool isDistributed, bool isKnownToBeLocal,
                       bool isRuntimeAccessible,
                       BackDeploymentKind backDeploymentKind,
-                      unsigned defaultArgIndex,
+                      unsigned defaultArgIndex, bool isAsyncLetClosure,
                       AutoDiffDerivativeFunctionIdentifier *derivativeId)
       : loc(Loc::getFromOpaqueValue(opaqueLoc)), kind(kind),
-        isForeign(isForeign),
-        isDistributed(isDistributed),
+        isForeign(isForeign), isDistributed(isDistributed),
         isKnownToBeLocal(isKnownToBeLocal),
         isRuntimeAccessible(isRuntimeAccessible),
         backDeploymentKind(backDeploymentKind),
-        defaultArgIndex(defaultArgIndex),
+        defaultArgIndex(defaultArgIndex), isAsyncLetClosure(isAsyncLetClosure),
         pointer(derivativeId) {}
 };
 
@@ -644,11 +635,13 @@ template<> struct DenseMapInfo<swift::SILDeclRef> {
 
   static SILDeclRef getEmptyKey() {
     return SILDeclRef(PointerInfo::getEmptyKey(), Kind::Func, false, false,
-                      false, false, BackDeploymentKind::None, 0, nullptr);
+                      false, false, BackDeploymentKind::None, 0, false,
+                      nullptr);
   }
   static SILDeclRef getTombstoneKey() {
     return SILDeclRef(PointerInfo::getTombstoneKey(), Kind::Func, false, false,
-                      false, false, BackDeploymentKind::None, 0, nullptr);
+                      false, false, BackDeploymentKind::None, 0, false,
+                      nullptr);
   }
   static unsigned getHashValue(swift::SILDeclRef Val) {
     unsigned h1 = PointerInfo::getHashValue(Val.loc.getOpaqueValue());

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1998,6 +1998,8 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
         convention = ParameterConvention::Direct_Guaranteed;
       }
       SILParameterInfo param(loweredTy.getASTType(), convention, options);
+      if (function.isAsyncLetClosure)
+        param = param.addingOption(SILParameterInfo::Transferring);
       inputs.push_back(param);
       break;
     }
@@ -2013,6 +2015,8 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
           /*mutable*/ true);
       auto convention = ParameterConvention::Direct_Guaranteed;
       auto param = SILParameterInfo(boxTy, convention, options);
+      if (function.isAsyncLetClosure)
+        param = param.addingOption(SILParameterInfo::Transferring);
       inputs.push_back(param);
       break;
     }
@@ -2028,6 +2032,8 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
           /*mutable*/ false);
       auto convention = ParameterConvention::Direct_Guaranteed;
       auto param = SILParameterInfo(boxTy, convention, options);
+      if (function.isAsyncLetClosure)
+        param = param.addingOption(SILParameterInfo::Transferring);
       inputs.push_back(param);
       break;
     }
@@ -2037,6 +2043,8 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       auto param = SILParameterInfo(
           ty.getASTType(), ParameterConvention::Indirect_InoutAliasable,
           options);
+      if (function.isAsyncLetClosure)
+        param = param.addingOption(SILParameterInfo::Transferring);
       inputs.push_back(param);
       break;
     }
@@ -2047,6 +2055,8 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       auto param = SILParameterInfo(ty.getASTType(),
                                     ParameterConvention::Indirect_In_Guaranteed,
                                     options);
+      if (function.isAsyncLetClosure)
+        param = param.addingOption(SILParameterInfo::Transferring);
       inputs.push_back(param);
       break;
     }

--- a/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
+++ b/lib/SILOptimizer/Mandatory/CapturePromotion.cpp
@@ -405,7 +405,8 @@ computeNewArgInterfaceTypes(SILFunction *f, IndicesSet &promotableIndices,
       convention = param.isGuaranteed() ? ParameterConvention::Direct_Guaranteed
                                         : ParameterConvention::Direct_Owned;
     }
-    outTys.push_back(SILParameterInfo(paramBoxedTy.getASTType(), convention));
+    outTys.push_back(SILParameterInfo(paramBoxedTy.getASTType(), convention,
+                                      param.getOptions()));
   }
 }
 

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -72,7 +72,7 @@ static Expr *inferArgumentExprFromApplyExpr(ApplyExpr *sourceApply,
     unsigned argNum = [&]() -> unsigned {
       if (fai.isCalleeOperand(*op))
         return op->getOperandNumber();
-      return fai.getAppliedArgIndexWithoutIndirectResult(*op);
+      return fai.getAppliedArgIndexWithoutIndirectResults(*op);
     }();
 
     // Something happened that we do not understand.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8936,6 +8936,24 @@ bool ConstraintSystem::applySolutionFixes(const Solution &solution) {
   return diagnosedAnyErrors;
 }
 
+/// Pattern match if an initializer has as its value a callee that returns
+/// transferring.
+static bool isTransferringInitializer(Expr *initializer) {
+  auto *await = dyn_cast<AwaitExpr>(initializer);
+  if (!await)
+    return false;
+
+  auto *call = dyn_cast<CallExpr>(await->getSubExpr());
+  if (!call)
+    return false;
+
+  auto *fType = call->getFn()->getType()->getAs<AnyFunctionType>();
+  if (!fType)
+    return false;
+
+  return fType->hasTransferringResult();
+}
+
 /// For the initializer of an `async let`, wrap it in an autoclosure and then
 /// a call to that autoclosure, so that the code for the child task is captured
 /// entirely within the autoclosure. This captures the semantics of the
@@ -8947,11 +8965,15 @@ static Expr *wrapAsyncLetInitializer(
   Type initializerType = initializer->getType();
   bool throws = TypeChecker::canThrow(cs.getASTContext(), initializer)
                   .has_value();
+  bool hasTransferringResult = isTransferringInitializer(initializer);
+  bool isSendable = !cs.getASTContext().LangOpts.hasFeature(
+      Feature::TransferringArgsAndResults);
   auto extInfo = ASTExtInfoBuilder()
-    .withAsync()
-    .withSendable()
-    .withThrows(throws, /*FIXME:*/Type())
-    .build();
+                     .withAsync()
+                     .withThrows(throws, /*FIXME:*/ Type())
+                     .withSendable(isSendable)
+                     .withTransferringResult(hasTransferringResult)
+                     .build();
 
   // Form the autoclosure expression. The actual closure here encapsulates the
   // child task.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3539,15 +3539,36 @@ namespace {
       // Check for sendability of the result type if we do not have a
       // transferring result.
       if ((!ctx.LangOpts.hasFeature(Feature::TransferringArgsAndResults) ||
-           !fnType->hasTransferringResult()) &&
-          diagnoseNonSendableTypes(
-             fnType->getResult(), getDeclContext(),
-             /*inDerivedConformance*/Type(),
-             apply->getLoc(),
-             diag::non_sendable_call_result_type,
-             apply->isImplicitlyAsync().has_value(),
-             *unsatisfiedIsolation))
-        return true;
+           !fnType->hasTransferringResult())) {
+        // See if we are a autoclosure that has a direct callee that has the
+        // same non-transferred type value returned. If so, do not emit an
+        // error... we are going to emit an error on the call expr and do not
+        // want to emit the error twice.
+        auto willDoubleError = [&]() -> bool {
+          auto *autoclosure = dyn_cast<AutoClosureExpr>(apply->getFn());
+          if (!autoclosure)
+            return false;
+          auto *await =
+              dyn_cast<AwaitExpr>(autoclosure->getSingleExpressionBody());
+          if (!await)
+            return false;
+          auto *subCallExpr = dyn_cast<CallExpr>(await->getSubExpr());
+          if (!subCallExpr)
+            return false;
+          return subCallExpr->getType().getPointer() ==
+                 fnType->getResult().getPointer();
+        };
+
+        if (!willDoubleError() &&
+            diagnoseNonSendableTypes(fnType->getResult(), getDeclContext(),
+                                     /*inDerivedConformance*/ Type(),
+                                     apply->getLoc(),
+                                     diag::non_sendable_call_result_type,
+                                     apply->isImplicitlyAsync().has_value(),
+                                     *unsatisfiedIsolation)) {
+          return true;
+        }
+      }
 
       return false;
     }

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -2498,8 +2498,10 @@ namespace {
           auto *patternBindingDecl = getTopPatternBindingDecl();
           if (patternBindingDecl && patternBindingDecl->isAsyncLet()) {
             // Defer diagnosing checking of non-Sendable types that are passed
-            // into async let to SIL level region based isolation.
-            if (!ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation)) {
+            // into async let to SIL level region based isolation if we have
+            // transferring and region based isolation enabled.
+            if (!ctx.LangOpts.hasFeature(Feature::RegionBasedIsolation) ||
+                !ctx.LangOpts.hasFeature(Feature::TransferringArgsAndResults)) {
               diagnoseNonSendableTypes(
                   type, getDeclContext(),
                   /*inDerivedConformance*/Type(), capture.getLoc(),

--- a/test/Concurrency/issue-57376.swift
+++ b/test/Concurrency/issue-57376.swift
@@ -1,6 +1,13 @@
 // RUN: %target-swift-frontend -disable-availability-checking -strict-concurrency=targeted %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-and-complete-
 // RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix targeted-and-complete-
-// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -verify-additional-prefix tns-
+
+// NOTE: We test separately with region isolation and region isolation +
+// transferring args and results since the semantics when transferring args and
+// results are enabled is different since async let in such a case takes a
+// non-Sendable closure whose captures are transferred in while without it, we
+// leave the async let closure as sendable and use sema level checking.
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -verify-additional-prefix tns- -verify-additional-prefix no-transferring-tns-
+// RUN: %target-swift-frontend -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults -verify-additional-prefix tns- -verify-additional-prefix transferring-tns-
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -8,54 +15,66 @@
 // https://github.com/apple/swift/issues/57376
 
 func testAsyncSequenceTypedPatternSendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let result: Int = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{immutable value 'result' was never used; consider replacing with '_' or removing it}}
+  async let result: Int = seq.reduce(0) { $0 + $1 } // OK
+  let _ = try! await result
 }
 
 func testAsyncSequenceTypedPattern1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let _: Int = seq.reduce(0) { $0 + $1 } // OK
+  async let _: Int = seq.reduce(0) { $0 + $1 } // OK
 }
 
 func testAsyncSequenceSendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let result = seq.reduce(0) { $0 + $1 } // OK
-   // expected-warning@-1{{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
+  async let result = seq.reduce(0) { $0 + $1 } // OK
+  let _ = try! await result
 }
 
 func testAsyncSequence1Sendable<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int, Seq: Sendable {
-   async let _ = seq.reduce(0) { $0 + $1 } // OK
+  async let _ = seq.reduce(0) { $0 + $1 } // OK
 }
 
 func testAsyncSequenceTypedPattern<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
-   async let result: Int = seq.reduce(0) { $0 + $1 } // expected-tns-warning {{task or actor isolated value cannot be transferred}}
-   // expected-warning @-1 {{immutable value 'result' was never used; consider replacing with '_' or removing it}}
-   // expected-targeted-and-complete-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{54-54=, Sendable}}
+  async let result: Int = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  let _ = try! await result
 }
 
 func testAsyncSequenceTypedPattern1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
-   async let _: Int = seq.reduce(0) { $0 + $1 } // expected-tns-warning {{task or actor isolated value cannot be transferred}}
-   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{55-55=, Sendable}}
+  async let _: Int = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequence<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
-   async let result = seq.reduce(0) { $0 + $1 } // // expected-tns-warning {{task or actor isolated value cannot be transferred}}
-   // expected-warning @-1 {{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
-   // expected-targeted-and-complete-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{42-42=, Sendable}}
+  async let result = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  let _ = try! await result
 }
 
 func testAsyncSequence1<Seq: AsyncSequence>(_ seq: Seq) async throws where Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}
-   async let _ = seq.reduce(0) { $0 + $1 } // // expected-tns-warning {{task or actor isolated value cannot be transferred}}
-   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{43-43=, Sendable}}
+  async let _ = seq.reduce(0) { $0 + $1 } // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func testAsyncSequence3<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
-  async let result = seq // // expected-tns-warning {{task or actor isolated value cannot be transferred}}
+  // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
+  async let result = seq // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
-   //expected-warning @-2 {{initialization of immutable value 'result' was never used; consider replacing with assignment to '_' or removing it}}
+  // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  let _ = await result
 }
 
 func testAsyncSequence4<Seq>(_ seq: Seq) async throws where Seq: AsyncSequence, Seq.Element == Int { // expected-targeted-and-complete-note {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
-  async let _ = seq // // expected-tns-warning {{task or actor isolated value cannot be transferred}}
-   // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-note @-1 {{consider making generic parameter 'Seq' conform to the 'Sendable' protocol}} {{28-28=: Sendable}}
+  async let _ = seq // expected-transferring-tns-warning {{task or actor isolated value cannot be transferred}}
+  // expected-targeted-and-complete-warning @-1 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
+  // expected-no-transferring-tns-warning @-2 {{capture of 'seq' with non-sendable type 'Seq' in 'async let' binding}}
 }
 
 func search(query: String, entities: [String]) async throws -> [String] {
@@ -64,28 +83,28 @@ func search(query: String, entities: [String]) async throws -> [String] {
 }
 
 @rethrows protocol TestRethrowProtocol {
-    func fn() async throws
+  func fn() async throws
 }
 extension TestRethrowProtocol {
-    func testRethrow() async rethrows {
-        try await self.fn()
-    }
+  func testRethrow() async rethrows {
+    try await self.fn()
+  }
 }
 
 struct TestRethrowStruct: TestRethrowProtocol {
-    func fn() async throws {}
+  func fn() async throws {}
 }
 
 func testStructRethrows() async throws {
-   let s = TestRethrowStruct()
-   async let rt: () = s.testRethrow()
-   try await rt // OK
+  let s = TestRethrowStruct()
+  async let rt: () = s.testRethrow()
+  try await rt // OK
 }
 
 // https://github.com/apple/swift/issues/60351
 func foo() async {
-    let stream = AsyncStream<Int>{ _ in }
-    async let bar = stream.first { _ in true}
+  let stream = AsyncStream<Int>{ _ in }
+  async let bar = stream.first { _ in true}
 
-    _ = await bar // OK
+  _ = await bar // OK
 }

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -317,3 +317,39 @@ bb0(%0 : @guaranteed $MyActor):
   %19 = tuple ()
   return %19 : $()
 }
+
+sil @sendableAsyncLetClosure : $@convention(thin) @Sendable @async @substituted <τ_0_0> (@guaranteed NonSendableKlass) -> (@out τ_0_0, @error any Error) for <Int>
+
+sil [ossa] @sendableAsyncLetClosureTest : $@convention(thin) @async () -> () {
+bb0:
+  %3 = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+  %4 = apply %3() : $@convention(thin) () -> @owned NonSendableKlass
+  %5 = move_value [lexical] [var_decl] %4 : $NonSendableKlass
+  debug_value %5 : $NonSendableKlass, let, name "x"
+  %7 = alloc_stack $Int
+  %8 = address_to_pointer %7 : $*Int to $Builtin.RawPointer
+  %9 = enum $Optional<Builtin.RawPointer>, #Optional.none!enumelt
+  %10 = function_ref @sendableAsyncLetClosure : $@convention(thin) @Sendable @async @substituted <τ_0_0> (@guaranteed NonSendableKlass) -> (@out τ_0_0, @error any Error) for <Int>
+  %11 = copy_value %5 : $NonSendableKlass
+  %12 = partial_apply [callee_guaranteed] %10(%11) : $@convention(thin) @Sendable @async @substituted <τ_0_0> (@guaranteed NonSendableKlass) -> (@out τ_0_0, @error any Error) for <Int>
+  %13 = convert_function %12 : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int> to $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>
+  %14 = convert_escape_to_noescape [not_guaranteed] %13 : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int> to $@noescape @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>
+  %15 = builtin "startAsyncLetWithLocalBuffer"<Int>(%9 : $Optional<Builtin.RawPointer>, %14 : $@noescape @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>, %8 : $Builtin.RawPointer) : $Builtin.RawPointer
+
+  %useValue = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+  apply %useValue(%5) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
+
+  %26 = function_ref @swift_asyncLet_get : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
+  %27 = apply %26(%15, %8) : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
+  %29 = load [trivial] %7 : $*Int
+  %30 = function_ref @swift_asyncLet_finish : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
+  %31 = apply %30(%15, %8) : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
+  %33 = builtin "endAsyncLetLifetime"(%15 : $Builtin.RawPointer) : $()
+  destroy_value %14 : $@noescape @async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>
+  destroy_value %13 : $@async @callee_guaranteed @substituted <τ_0_0> () -> (@out τ_0_0, @error any Error) for <Int>
+  dealloc_stack %7 : $*Int
+  destroy_value %5 : $NonSendableKlass
+  %38 = tuple ()
+  return %38 : $()
+}
+

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts


### PR DESCRIPTION
This PR contains four different commits:

1. The first commit fixes an issue where in the AST we were emitting a Sendable diagnostic twice both on an auto closure and on the function being called inside the auto closure. We just pattern match that we are going to emit the same error and suppress the auto closure one.
2. The second commit makes it so that:
a. If transferring is enabled, async let begin at the SIL level now expects a transferring non-Sendable closure not a Sendable closure. Of course a Sendable closure will just be thunked to the non-Sendable variant, so we are ok.
b. If transferring is enabled, autoclosure_expr gains a transferring result if it has as its initialized value a call expr with a transferring result.
c. I added support to region isolation checking for properly handling thunked async lets.
d. I discovered a bug where we were including indirect out results when attempting to come up with a correspondence in between partial_apply arguments and AST level arguments. Including the indirect results messes with this, so I added a new API that solves this and updated the code to use it.
3. I added some code that ensures that in region isolation, we do not process Sendable async let closures since we know that Sema would have emitted an error earlier since non-Sendable types cannot be captured by Sendable closures. Before the change, we would try to process it like a normal async let.
4. I added some more specific async let diagnostics. This is in preparation for beginning some refactoring of the diagnostics where I am going to simplify the code, make it so that we know the exact actor actor derived things are from, and add a mechanism to get the region history... but those things are for a later PR.