### PR TITLE
On 'canImport' of Clang submodules of modules with an umbrella header, attempt to infer the submodule

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2039,7 +2039,7 @@ bool ClangImporter::canImportModule(ImportPath::Module modulePath,
 
   if (modulePath.hasSubmodule()) {
     for (auto &component : modulePath.getSubmodulePath()) {
-      clangModule = clangModule->findSubmodule(component.Item.str());
+      clangModule = clangModule->findOrInferSubmodule(component.Item.str());
 
       // Special case: a submodule named "Foo.Private" can be moved to a
       // top-level module named "Foo_Private". Clang has special support for

--- a/test/ScanDependencies/Inputs/Frameworks/WithInferredClangModule.framework/Headers/InferredClangModule.h
+++ b/test/ScanDependencies/Inputs/Frameworks/WithInferredClangModule.framework/Headers/InferredClangModule.h
@@ -1,0 +1,1 @@
+void funcInferred(void);

--- a/test/ScanDependencies/Inputs/Frameworks/WithInferredClangModule.framework/Headers/WithInferredClangModule.h
+++ b/test/ScanDependencies/Inputs/Frameworks/WithInferredClangModule.framework/Headers/WithInferredClangModule.h
@@ -1,0 +1,2 @@
+#import <WithInferredClangModule/InferredClangModule.h>
+void funcWith(void);

--- a/test/ScanDependencies/Inputs/Frameworks/WithInferredClangModule.framework/Modules/module.modulemap
+++ b/test/ScanDependencies/Inputs/Frameworks/WithInferredClangModule.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module WithInferredClangModule [system] {
+    header "WithInferredClangModule.h"
+    umbrella "Headers"
+
+    export *
+    explicit module * { export * }
+}

--- a/test/ScanDependencies/can_import_inferred_submodule.swift
+++ b/test/ScanDependencies/can_import_inferred_submodule.swift
@@ -1,0 +1,11 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -F %S/Inputs/Frameworks
+// RUN: %validate-json %t/deps.json | %FileCheck %s
+
+#if canImport(WithInferredClangModule.InferredClangModule)
+import ScannerTestKit
+#endif
+
+// Ensure that the 'WithInferredClangModule.InferredClangModule' can be imported
+// CHECK: "swift": "ScannerTestKit"


### PR DESCRIPTION
Resolves rdar://124163264