### PR TITLE
Fix preinverse generics crossmodule

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -70,7 +70,7 @@ static bool inversesAllowed(const Decl *decl) {
     if (auto *storage = accessor->getStorage())
       decl = storage;
 
-  return !decl->getParsedAttrs().hasAttribute<PreInverseGenericsAttr>();
+  return !decl->getAttrs().hasAttribute<PreInverseGenericsAttr>();
 }
 
 static bool inversesAllowedIn(const DeclContext *ctx) {

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -96,3 +96,6 @@ extension Outer.InnerStruct {
 }
 
 public struct Freestanding<T: ~Copyable> where T: ~Escapable {}
+
+@_preInverseGenerics
+public func old_swap<T: ~Copyable>(_ a: inout T, _ b: inout T) {}


### PR DESCRIPTION
turns out getParsedAttrs doesn't include the attr if it's coming from another module. needed getAttrs() here.