### PR TITLE
[embedded] Diagnose usage of weak and unowned variables in embedded Swift

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2032,6 +2032,9 @@ ERROR(attr_only_at_non_generic_scope, none,
 ERROR(attr_only_on_static_properties, none,
       "properties with attribute '_section' must be static", (StringRef))
 
+ERROR(weak_unowned_in_embedded_swift, none,
+      "attribute %0 cannot be used in embedded Swift", (ReferenceOwnership))
+
 ERROR(access_control_in_protocol,none,
       "%0 modifier cannot be used in protocols", (DeclAttribute))
 NOTE(access_control_in_protocol_detail,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3055,6 +3055,14 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       AttrRange = SourceRange(Loc);
     }
 
+    // Embedded Swift prohibits weak/unowned but allows unowned(unsafe).
+    if (Context.LangOpts.hasFeature(Feature::Embedded)) {
+      if (Kind == ReferenceOwnership::Weak ||
+          Kind == ReferenceOwnership::Unowned) {
+        diagnose(Loc, diag::weak_unowned_in_embedded_swift, Kind);
+      }
+    }
+
     if (!DiscardAttribute)
       Attributes.add(
           new (Context) ReferenceOwnershipAttr(AttrRange, Kind));

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3055,14 +3055,6 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
       AttrRange = SourceRange(Loc);
     }
 
-    // Embedded Swift prohibits weak/unowned but allows unowned(unsafe).
-    if (Context.LangOpts.hasFeature(Feature::Embedded)) {
-      if (Kind == ReferenceOwnership::Weak ||
-          Kind == ReferenceOwnership::Unowned) {
-        diagnose(Loc, diag::weak_unowned_in_embedded_swift, Kind);
-      }
-    }
-
     if (!DiscardAttribute)
       Attributes.add(
           new (Context) ReferenceOwnershipAttr(AttrRange, Kind));

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4682,6 +4682,16 @@ Type TypeChecker::checkReferenceOwnershipAttr(VarDecl *var, Type type,
     attr->setInvalid();
   }
 
+  // Embedded Swift prohibits weak/unowned but allows unowned(unsafe).
+  if (var->getASTContext().LangOpts.hasFeature(Feature::Embedded)) {
+    if (ownershipKind == ReferenceOwnership::Weak ||
+        ownershipKind == ReferenceOwnership::Unowned) {
+      Diags.diagnose(attr->getLocation(), diag::weak_unowned_in_embedded_swift,
+               ownershipKind);
+      attr->setInvalid();
+    }
+  }
+
   if (attr->isInvalid())
     return type;
 

--- a/test/embedded/weak-unowned.swift
+++ b/test/embedded/weak-unowned.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-emit-ir %s -wmo
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded -verify
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+public class MyClass { }
+
+public struct MyStruct {
+  var normalVar: MyClass
+  weak var weakVar: MyClass? // expected-error {{attribute 'weak' cannot be used in embedded Swift}}
+  unowned var unownedVar: MyClass // expected-error {{attribute 'unowned' cannot be used in embedded Swift}}
+  unowned(unsafe) var unownedUnsafe: MyClass
+}


### PR DESCRIPTION
As much as it would be nice to actually support weak and unowned variables in embedded Swift, they produce linker errors today (missing runtime support). Let's at least improve the diagnostics.