### PR TITLE
[TBDGen][Test] Check implied Obj-C symbol generation based on a stable swift version

### DIFF
--- a/test/TBD/multimodule-implied-objc.swift
+++ b/test/TBD/multimodule-implied-objc.swift
@@ -1,5 +1,4 @@
 // REQUIRES: VENDOR=apple
-// XFAIL: OS=ios && (CPU=arm64e || CPU=arm64)
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/cache)
 // RUN: split-file %s %t
@@ -7,11 +6,13 @@
 /// Create Swift modules to import.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
 // RUN:   -module-name IndirectMixedDependency -I %t \
-// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-library-evolution \
+// RUN:   -target %target-swift-abi-5.8-triple \
 // RUN:   -emit-module %t/IndirectMixedDependency.swift \
 // RUN:   -emit-module-path %t/IndirectMixedDependency.swiftmodule
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
-// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-library-evolution \
+// RUN:   -target %target-swift-abi-5.8-triple \
 // RUN:   -emit-module %t/SwiftDependency.swift \
 // RUN:   -module-name SwiftDependency -I %t\
 // RUN:   -emit-module-path %t/SwiftDependency.swiftmodule
@@ -19,14 +20,15 @@
 // Generate TBD file.
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/cache \
 // RUN:   %t/Client.swift -emit-ir -o/dev/null -parse-as-library \
+// RUN:   -target %target-swift-abi-5.8-triple \
 // RUN:   -module-name client -validate-tbd-against-ir=missing \
 // RUN:   -tbd-install_name client -emit-tbd -emit-tbd-path %t/client.tbd 
 
 // RUN: %validate-json %t/client.tbd | %FileCheck %s
 
-// CHECK: "_OBJC_METACLASS_$__TtCO6client11extendedAPI6Square"
-// CHECK-NOT: "objc_class"
-// CHECK-NOT: _OBJC_C
+// CHECK-NOT: "CLASS_$__TtCO6client11extendedAPI6Square"
+// CHECK: "objc_class"
+// CHECK: "_TtCO6client11extendedAPI6Square"
 
 //--- module.modulemap
 module IndirectMixedDependency {


### PR DESCRIPTION
I previously thought the coupled `OBJC_CLASS | OBJC_METACLASS` was specific to iOS, but it actually seems tied to compiling for deployment versions lower than when swift was shipped with darwin OSes. The test has been updated to use a recent-ish target triple across all CI configurations, where both symbols get emitted. 