### PR TITLE
[NoncopyablePartialConsumption] Allow consume.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7741,6 +7741,16 @@ ERROR(moveOnly_not_allowed_here,none,
       "'@_moveOnly' attribute is only valid on structs or enums", ())
 ERROR(consume_expression_not_passed_lvalue,none,
       "'consume' can only be applied to a local binding ('let', 'var', or parameter)", ())
+ERROR(consume_expression_partial_copyable,none,
+      "'consume' can only be used to partially consume storage of a noncopyable type", ())
+ERROR(consume_expression_non_storage,none,
+      "'consume' can only be used to partially consume storage", ())
+NOTE(note_consume_expression_non_storage_call,none,
+      "non-storage produced by this call", ())
+NOTE(note_consume_expression_non_storage_subscript,none,
+      "non-storage produced by this subscript", ())
+NOTE(note_consume_expression_non_storage_property,none,
+      "non-storage produced by this computed property", ())
 ERROR(borrow_expression_not_passed_lvalue,none,
       "'borrow' can only be applied to a local binding ('let', 'var', or parameter)", ())
 ERROR(copy_expression_not_passed_lvalue,none,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
@@ -94,7 +94,8 @@ class MoveOnlyAddressCheckerTesterPass : public SILFunctionTransform {
     llvm::SmallSetVector<MarkUnresolvedNonCopyableValueInst *, 32>
         moveIntroducersToProcess;
     searchForCandidateAddressMarkUnresolvedNonCopyableValueInsts(
-        fn, moveIntroducersToProcess, diagnosticEmitter);
+        fn, getAnalysis<PostOrderAnalysis>(), moveIntroducersToProcess,
+        diagnosticEmitter);
 
     LLVM_DEBUG(llvm::dbgs()
                << "Emitting diagnostic when checking for mark must check inst: "

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
@@ -17,6 +17,8 @@
 
 namespace swift {
 
+class PostOrderAnalysis;
+
 namespace siloptimizer {
 
 class DiagnosticEmitter;
@@ -26,7 +28,7 @@ class DiagnosticEmitter;
 /// NOTE: To see if we emitted a diagnostic, use \p
 /// diagnosticEmitter.getDiagnosticCount().
 void searchForCandidateAddressMarkUnresolvedNonCopyableValueInsts(
-    SILFunction *fn,
+    SILFunction *fn, PostOrderAnalysis *poa,
     llvm::SmallSetVector<MarkUnresolvedNonCopyableValueInst *, 32>
         &moveIntroducersToProcess,
     DiagnosticEmitter &diagnosticEmitter);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -186,7 +186,7 @@ void MoveOnlyChecker::checkAddresses() {
   llvm::SmallSetVector<MarkUnresolvedNonCopyableValueInst *, 32>
       moveIntroducersToProcess;
   searchForCandidateAddressMarkUnresolvedNonCopyableValueInsts(
-      fn, moveIntroducersToProcess, diagnosticEmitter);
+      fn, poa, moveIntroducersToProcess, diagnosticEmitter);
 
   LLVM_DEBUG(
       llvm::dbgs()

--- a/lib/SILOptimizer/Mandatory/MoveOnlyTempAllocationFromLetTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyTempAllocationFromLetTester.cpp
@@ -51,7 +51,8 @@ struct MoveOnlyTempAllocationFromLetTester : SILFunctionTransform {
 
     unsigned diagCount = diagnosticEmitter.getDiagnosticCount();
     searchForCandidateAddressMarkUnresolvedNonCopyableValueInsts(
-        getFunction(), moveIntroducersToProcess, diagnosticEmitter);
+        getFunction(), getAnalysis<PostOrderAnalysis>(),
+        moveIntroducersToProcess, diagnosticEmitter);
 
     // Return early if we emitted a diagnostic.
     if (diagCount != diagnosticEmitter.getDiagnosticCount())

--- a/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
+++ b/test/Interop/Cxx/operators/move-only/move-only-synthesized-property-typecheck.swift
@@ -30,8 +30,8 @@ func testNonCopyableHolderConstDerefPointee() {
     holder.pointee.mutMethod(1) // expected-error {{cannot use mutating member on immutable value: 'pointee' is a get-only property}}
     holder.pointee.x = 2 // expected-error {{cannot assign to property: 'pointee' is a get-only property}}
 #else
-    consumingNC(holder.pointee) // CHECK: [[@LINE]]:{{.*}}: error:
-    let consumeVal = holder.pointee // CHECK: [[@LINE]]:{{.*}}: error:
+    consumingNC(holder.pointee) // CHECK-DAG: [[@LINE]]:{{.*}}: error:
+    let consumeVal = holder.pointee // CHECK-DAG: [[@LINE]]:{{.*}}: error:
 #endif
 }
 

--- a/test/Interpreter/move_expr_moveonly_partial_consumption.swift
+++ b/test/Interpreter/move_expr_moveonly_partial_consumption.swift
@@ -1,0 +1,115 @@
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-parse-as-library -O -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+@main struct App { static func main() {
+  test1((1,2,3,4))
+}}
+
+func barrier() { print("barrier") }
+
+struct Ur<T> : ~Copyable {
+  var t: T
+  var name: String
+  init(_ t: T, named name: String) {
+    self.t = t
+    self.name = name
+    print("hi", name)
+  }
+  deinit {
+    print("bye", name)
+  }
+}
+func take<T>(_ u: consuming Ur<T>) {}
+
+struct Pair<T> : ~Copyable {
+  var u1: Ur<T>
+  var u2: Ur<T>
+  init(_ t1: T, _ t2: T, named name: String) {
+    u1 = .init(t1, named: "\(name).u1")
+    u2 = .init(t2, named: "\(name).u2")
+  }
+}
+func take<T>(_ u: consuming Pair<T>) {}
+
+struct Quad<T> : ~Copyable {
+  var p1: Pair<T>
+  var p2: Pair<T>
+  init(_ t1: T, _ t2: T, _ t3: T, _ t4: T, named name: String) {
+    p1 = .init(t1, t2, named: "\(name).p1")
+    p2 = .init(t3, t4, named: "\(name).p2")
+  }
+}
+func take<T>(_ u: consuming Quad<T>) {}
+
+func test1<T>(_ ts: (T, T, T, T)) {
+do {
+  let q1 = Quad<T>(ts.0, ts.1, ts.2, ts.3, named: "\(#function).q1")
+  barrier()
+  // CHECK: barrier
+  // CHECK: bye test1(_:).q1.p1.u1
+  // CHECK: bye test1(_:).q1.p1.u2
+  // CHECK: bye test1(_:).q1.p2.u1
+  // CHECK: bye test1(_:).q1.p2.u2
+}
+
+  let q2 = Quad<T>(ts.0, ts.1, ts.2, ts.3, named: "\(#function).q2")
+  take(q2.p2.u2)
+  take(q2.p2.u1)
+  barrier()
+  take(q2.p1.u2)
+  take(q2.p1.u1)
+  // CHECK: bye test1(_:).q2.p2.u2
+  // CHECK: bye test1(_:).q2.p2.u1
+  // CHECK: barrier
+  // CHECK: bye test1(_:).q2.p1.u2
+  // CHECK: bye test1(_:).q2.p1.u1
+
+  let q3 = Quad<T>(ts.0, ts.1, ts.2, ts.3, named: "\(#function).q3")
+  _ = consume q3.p2.u2
+  _ = consume q3.p2.u1
+  _ = consume q3.p1.u2
+  barrier()
+  _ = consume q3.p1.u1
+  // CHECK: bye test1(_:).q3.p2.u2
+  // CHECK: bye test1(_:).q3.p2.u1
+  // CHECK: bye test1(_:).q3.p1.u2
+  // CHECK: barrier
+  // CHECK: bye test1(_:).q3.p1.u1
+
+  let q4 = Quad<T>(ts.0, ts.1, ts.2, ts.3, named: "\(#function).q4")
+  _ = consume q4.p1.u1
+  barrier()
+  _ = consume q4.p2.u1
+  _ = consume q4.p1.u2
+  _ = consume q4.p2.u2
+  // CHECK: bye test1(_:).q4.p1.u1
+  // CHECK: barrier
+  // CHECK: bye test1(_:).q4.p2.u1
+  // CHECK: bye test1(_:).q4.p1.u2
+  // CHECK: bye test1(_:).q4.p2.u2
+
+do {
+  let q5 = Quad<T>(ts.0, ts.1, ts.2, ts.3, named: "\(#function).q5")
+  take(q5.p1.u1)
+  _ = consume q5.p2.u1
+  _ = consume q5.p1.u2
+  take(q5.p2.u2)
+  // CHECK: bye test1(_:).q5.p1.u1
+  // CHECK: bye test1(_:).q5.p2.u1
+  // CHECK: bye test1(_:).q5.p1.u2
+  // CHECK: bye test1(_:).q5.p2.u2
+}
+do {
+  let q6 = Quad<T>(ts.0, ts.1, ts.2, ts.3, named: "\(#function).q6")
+  if Bool.random() {
+    take(q6.p1.u1)
+    _ = consume q6.p2.u1
+  } else {
+    _ = consume q6.p1.u2
+    take(q6.p2.u2)
+  }
+}
+}
+

--- a/test/Sema/move_expr_moveonly_partial_consumption.swift
+++ b/test/Sema/move_expr_moveonly_partial_consumption.swift
@@ -1,0 +1,391 @@
+// RUN: %target-typecheck-verify-swift                              \
+// RUN:     -disable-availability-checking                          \
+// RUN:     -enable-experimental-feature NoImplicitCopy             \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption \
+// RUN:     -enable-experimental-feature NoncopyableGenerics        \
+// RUN:     -debug-diagnostic-names
+
+@_silgen_name("get")
+func get<T : ~Copyable>(_ t: T.Type = T.self) -> T
+
+class C {}
+
+// =============================================================================
+// ====================== NONCOPYABLE NON-GENERIC (BEGIN) ===================={{
+// =============================================================================
+
+extension Quad_NC {
+  consuming func explicitEveryLeaf() {
+    _ = consume p1.u1
+    _ = consume p1.u2
+    _ = consume p1.c
+    _ = consume p2.u1
+    _ = consume p2.u2
+    _ = consume p2.c
+  }
+
+  consuming func explicitSomeNonStorage() {
+    _ = consume p1.u3 // expected-error{{'consume' can only be used to partially consume storage}}
+                      // expected-note@-1{{non-storage produced by this computed property}}
+    _ = consume p1.getUr_NC() // expected-error{{'consume' can only be used to partially consume storage}}
+                           // expected-note@-1{{non-storage produced by this call}}
+    _ = consume p1[] // expected-error{{'consume' can only be used to partially consume storage}}
+                     // expected-note@-1{{non-storage produced by this subscript}}
+    _ = consume forward(self) // expected-error{{'consume' can only be used to partially consume storage}}
+                              // expected-note@-1{{non-storage produced by this call}}
+    _ = consume forward_self() // expected-error{{'consume' can only be used to partially consume storage}}
+                               // expected-note@-1{{non-storage produced by this call}}
+    _ = consume forward(p1) // expected-error{{'consume' can only be used to partially consume storage}}
+                            // expected-note@-1{{non-storage produced by this call}}
+    _ = consume p1.forward_self() // expected-error{{'consume' can only be used to partially consume storage}}
+                                  // expected-note@-1{{non-storage produced by this call}}
+    _ = consume forward(p1.u1) // expected-error{{'consume' can only be used to partially consume storage}}
+                               // expected-note@-1{{non-storage produced by this call}}
+    _ = consume p1.u1.forward_self() // expected-error{{'consume' can only be used to partially consume storage}}
+                                     // expected-note@-1{{non-storage produced by this call}}
+  }
+}
+
+struct Ur_NC : ~Copyable {
+  consuming func forward_self() -> Self { self }
+  deinit {}
+}
+func hold(_ u: borrowing Ur_NC) {}
+func take(_ u: consuming Ur_NC) {}
+func forward(_ u: consuming Ur_NC) -> Ur_NC { u }
+
+struct Pair_NC : ~Copyable {
+  // Storage
+  var u1: Ur_NC
+  var u2: Ur_NC
+  var c: C
+
+  // Not storage
+  var u3: Ur_NC {
+    Ur_NC()
+  }
+  func getUr_NC() -> Ur_NC { Ur_NC() }
+  subscript() -> Ur_NC { Ur_NC() }
+  consuming func forward_self() -> Self { self }
+}
+func forward(_ u: consuming Pair_NC) -> Pair_NC { u }
+
+struct Quad_NC : ~Copyable {
+  var p1: Pair_NC
+  var p2: Pair_NC
+  consuming func forward_self() -> Self { self }
+  deinit {
+    _ = consume p1
+    _ = consume p2
+    _ = consume p1.u1
+    _ = consume p1.u2
+    _ = consume p2.u1
+    _ = consume p2.u2
+  }
+}
+func forward(_ u: consuming Quad_NC) -> Quad_NC { u }
+
+class Container_NC {
+  var q: Quad_NC
+  init() { fatalError() }
+  deinit {
+    _ = consume q
+    _ = consume q.p1
+    _ = consume q.p2
+    _ = consume q.p1.u1
+    _ = consume q.p1.u2
+    _ = consume q.p2.u1
+    _ = consume q.p2.u2
+  }
+}
+
+func decompose(_ c: consuming Container_NC) {
+  _ = consume c.q.p1 // expected-error{{'consume' can only be used to partially consume storage}}
+                     // expected-note@-1{{non-storage produced by this computed property}}
+}
+
+// =============================================================================
+// ======================= NONCOPYABLE NON-GENERIC (END) =====================}}
+// =============================================================================
+
+// =============================================================================
+// ====================== NONCOPYABLE GENERIC (BEGIN) ========================{{
+// =============================================================================
+
+extension Quad_NCG {
+  consuming func explicitEveryLeaf() {
+    _ = consume p1.u1
+    _ = consume p1.u1.t
+    _ = consume p1.u2
+    _ = consume p1.u2.t
+    _ = consume p1.c
+    _ = consume p2.u1
+    _ = consume p2.u1.t
+    _ = consume p2.u2
+    _ = consume p2.u2.t
+    _ = consume p2.c
+  }
+
+  consuming func explicitSomeNonStorage() {
+    _ = consume p1.u3 // expected-error{{'consume' can only be used to partially consume storage}}
+                      // expected-note@-1{{non-storage produced by this computed property}}
+    _ = consume p1.getUr_NCG() // expected-error{{'consume' can only be used to partially consume storage}}
+                           // expected-note@-1{{non-storage produced by this call}}
+    _ = consume p1[] // expected-error{{'consume' can only be used to partially consume storage}}
+                     // expected-note@-1{{non-storage produced by this subscript}}
+    _ = consume p1[].t // expected-error{{'consume' can only be used to partially consume storage}}
+                       // expected-note@-1{{non-storage produced by this subscript}}
+    _ = consume forward(self) // expected-error{{'consume' can only be used to partially consume storage}}
+                              // expected-note@-1{{non-storage produced by this call}}
+    _ = consume forward_self() // expected-error{{'consume' can only be used to partially consume storage}}
+                               // expected-note@-1{{non-storage produced by this call}}
+    _ = consume forward(p1) // expected-error{{'consume' can only be used to partially consume storage}}
+                            // expected-note@-1{{non-storage produced by this call}}
+    _ = consume p1.forward_self() // expected-error{{'consume' can only be used to partially consume storage}}
+                                  // expected-note@-1{{non-storage produced by this call}}
+    _ = consume forward(p1.u1) // expected-error{{'consume' can only be used to partially consume storage}}
+                               // expected-note@-1{{non-storage produced by this call}}
+    _ = consume p1.u1.forward_self() // expected-error{{'consume' can only be used to partially consume storage}}
+                                     // expected-note@-1{{non-storage produced by this call}}
+    _ = consume p1.u1.forward_self().t // expected-error{{'consume' can only be used to partially consume storage}}
+                                       // expected-note@-1{{non-storage produced by this call}}
+  }
+}
+
+struct Ur_NCG<T : ~Copyable> : ~Copyable {
+  var t: T
+  consuming func forward_self() -> Self { self }
+  deinit {}
+}
+func hold<T : ~Copyable>(_ u: borrowing Ur_NCG<T>) {}
+func take<T : ~Copyable>(_ u: consuming Ur_NCG<T>) {}
+func forward<T : ~Copyable>(_ u: consuming Ur_NCG<T>) -> Ur_NCG<T> { u }
+
+struct Pair_NCG<T : ~Copyable> : ~Copyable {
+  // Storage
+  var u1: Ur_NCG<T>
+  var u2: Ur_NCG<T>
+  var c: C
+
+  // Not storage
+  var u3: Ur_NCG<T> {
+    Ur_NCG(t: get(T.self))
+  }
+  func getUr_NCG() -> Ur_NCG<T> { Ur_NCG(t: get(T.self)) }
+  subscript() -> Ur_NCG<T> { Ur_NCG(t: get(T.self)) }
+  consuming func forward_self() -> Self { self }
+}
+func forward<T : ~Copyable>(_ u: consuming Pair_NCG<T>) -> Pair_NCG<T> { u }
+
+struct Quad_NCG<T : ~Copyable> : ~Copyable {
+  var p1: Pair_NCG<T>
+  var p2: Pair_NCG<T>
+  consuming func forward_self() -> Self { self }
+  deinit {
+    _ = consume p1
+    _ = consume p2
+    _ = consume p1.u1
+    _ = consume p1.u1.t
+    _ = consume p1.u2
+    _ = consume p1.u2.t
+    _ = consume p2.u1
+    _ = consume p2.u1.t
+    _ = consume p2.u2
+    _ = consume p2.u2.t
+  }
+}
+func forward<T : ~Copyable>(_ u: consuming Quad_NCG<T>) -> Quad_NCG<T> { u }
+
+class Container_NCG<T : ~Copyable> {
+  var q: Quad_NCG<T>
+  init() { fatalError() }
+  deinit {
+    _ = consume q.p1
+    _ = consume q.p2
+    _ = consume q.p1.u1
+    _ = consume q.p1.u1.t
+    _ = consume q.p1.u2
+    _ = consume q.p1.u2.t
+    _ = consume q.p2.u1
+    _ = consume q.p2.u1.t
+    _ = consume q.p2.u2
+    _ = consume q.p2.u2.t
+  }
+}
+
+func decompose<T : ~Copyable>(_ c: consuming Container_NCG<T>) {
+  _ = consume c.q.p1 // expected-error{{'consume' can only be used to partially consume storage}}
+                     // expected-note@-1{{non-storage produced by this computed property}}
+}
+
+// =============================================================================
+// ====================== NONCOPYABLE GENERIC (BEGIN) ========================}}
+// =============================================================================
+
+// =============================================================================
+// ======================== COPYABLE NON-GENERIC (BEGIN) ====================={{
+// =============================================================================
+
+extension Quad_C {
+  consuming func explicitEveryLeaf() {
+    _ = consume p1.u1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.u2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.c // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p2.u1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p2.u2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p2.c // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+  }
+
+  consuming func explicitSomeNonStorage() {
+    _ = consume p1.u3 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.getUr_C() // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1[] // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume forward(self) // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume forward_self() // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume forward(p1) // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.forward_self() // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume forward(p1.u1) // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.u1.forward_self() // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+  }
+}
+
+struct Ur_C {
+  consuming func forward_self() -> Self { self }
+}
+func hold(_ u: borrowing Ur_C) {}
+func take(_ u: consuming Ur_C) {}
+func forward(_ u: consuming Ur_C) -> Ur_C { u }
+
+struct Pair_C {
+  // Storage
+  var u1: Ur_C
+  var u2: Ur_C
+  var c: C
+
+  // Not storage
+  var u3: Ur_C {
+    Ur_C()
+  }
+  func getUr_C() -> Ur_C { Ur_C() }
+  subscript() -> Ur_C { Ur_C() }
+  consuming func forward_self() -> Self { self }
+}
+func forward(_ u: consuming Pair_C) -> Pair_C { u }
+
+struct Quad_C {
+  var p1: Pair_C
+  var p2: Pair_C
+  consuming func forward_self() -> Self { self }
+}
+func forward(_ u: consuming Quad_C) -> Quad_C { u }
+
+class Container_C {
+  var q: Quad_C
+  init() { fatalError() }
+  deinit {
+    _ = consume q // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p1.u1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p1.u2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p2.u1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p2.u2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+  }
+}
+
+func decompose(_ c: consuming Container_C) {
+  _ = consume c.q.p1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+}
+
+// =============================================================================
+// ========================= COPYABLE NON-GENERIC (END) ======================}}
+// =============================================================================
+
+// =============================================================================
+// ======================== COPYABLE GENERIC (BEGIN) ========================={{
+// =============================================================================
+
+extension Quad_CG {
+  consuming func explicitEveryLeaf() {
+    _ = consume p1.u1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.u1.t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.u2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.u2.t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.c // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p2.u1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p2.u1.t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p2.u2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p2.u2.t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p2.c // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+  }
+
+  consuming func explicitSomeNonStorage() {
+    _ = consume p1.u3 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.getUr_CG() // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1[] // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1[].t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume forward(self) // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume forward_self() // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume forward(p1) // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.forward_self() // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume forward(p1.u1) // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.u1.forward_self() // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume p1.u1.forward_self().t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+  }
+}
+
+struct Ur_CG<T> {
+  var t: T
+  consuming func forward_self() -> Self { self }
+}
+func hold<T>(_ u: borrowing Ur_CG<T>) {}
+func take<T>(_ u: consuming Ur_CG<T>) {}
+func forward<T>(_ u: consuming Ur_CG<T>) -> Ur_CG<T> { u }
+
+struct Pair_CG<T> {
+  // Storage
+  var u1: Ur_CG<T>
+  var u2: Ur_CG<T>
+  var c: C
+
+  // Not storage
+  var u3: Ur_CG<T> {
+    Ur_CG(t: get(T.self))
+  }
+  func getUr_CG() -> Ur_CG<T> { Ur_CG(t: get(T.self)) }
+  subscript() -> Ur_CG<T> { Ur_CG(t: get(T.self)) }
+  consuming func forward_self() -> Self { self }
+}
+func forward<T>(_ u: consuming Pair_CG<T>) -> Pair_CG<T> { u }
+
+struct Quad_CG<T> {
+  var p1: Pair_CG<T>
+  var p2: Pair_CG<T>
+  consuming func forward_self() -> Self { self }
+}
+func forward<T>(_ u: consuming Quad_CG<T>) -> Quad_CG<T> { u }
+
+class Container_CG<T> {
+  var q: Quad_CG<T>
+  init() { fatalError() }
+  deinit {
+    _ = consume q.p1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p1.u1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p1.u1.t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p1.u2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p1.u2.t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p2.u1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p2.u1.t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p2.u2 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+    _ = consume q.p2.u2.t // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+  }
+}
+
+func decompose<T>(_ c: consuming Container_CG<T>) {
+  _ = consume c.q.p1 // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
+}
+
+// =============================================================================
+// ======================== COPYABLE GENERIC (BEGIN) =========================}}
+// =============================================================================


### PR DESCRIPTION
Allow a noncopyable value to be partially consumed via the `consume` keyword.

