### PR TITLE
Revert "Don't mangle inverse protocols within reabstraction thunks"

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -450,9 +450,6 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
   assert(ThunkType->getPatternSubstitutions().empty() && "not implemented");
   GenericSignature GenSig = ThunkType->getInvocationGenericSignature();
 
-  // Reabstraction thunks never reference inverse conformances.
-  llvm::SaveAndRestore X(AllowInverses, false);
-
   beginMangling();
   appendType(FromType, GenSig);
   appendType(ToType, GenSig);

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -496,9 +496,8 @@ IRGenMangler::appendExtendedExistentialTypeShape(CanGenericSignature genSig,
                                                  CanType shapeType) {
   // Append the generalization signature.
   if (genSig) {
-    // Generalization signature never references inverses.
+    // Generalization signature never reference inverses.
     llvm::SaveAndRestore X(AllowInverses, false);
-
     appendGenericSignature(genSig);
   }
 

--- a/test/SILGen/existential_member_accesses_self_assoctype.swift
+++ b/test/SILGen/existential_member_accesses_self_assoctype.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
 
+// XFAIL: noncopyable_generics
+
 protocol P {
   associatedtype A
 

--- a/test/SILGen/tuple_attribute_reabstraction.swift
+++ b/test/SILGen/tuple_attribute_reabstraction.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-emit-silgen %s | %FileCheck %s
 
+// XFAIL: noncopyable_generics
+
 public struct G<T> {
   var t: T
 

--- a/test/SILGen/variadic-generic-reabstract-tuple-result.swift
+++ b/test/SILGen/variadic-generic-reabstract-tuple-result.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
 
+// XFAIL: noncopyable_generics
+
 // rdar://110391963
 
 struct Use<each T> {}


### PR DESCRIPTION
Reverts apple/swift#72130. We might need to keep the reabstraction thunks separate if they differ only in Copyable requirements.