### PR TITLE
Enable lifetime dependence diagnostics for Nonescapable types.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
@@ -414,7 +414,7 @@ private struct ComputeNonEscapingLiferange : EscapeVisitorWithResult {
       if dominates {
         liferange.insert(user)
       }
-      if !apply.type.isEscapable {
+      if !apply.isEscapable {
         return .abort
       }
       return .ignore

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -35,7 +35,9 @@ let lifetimeDependenceDiagnosticsPass = FunctionPass(
   log(" --- Diagnosing lifetime dependence in \(function.name)")
   log("\(function)")
 
-  for argument in function.arguments where !argument.type.isEscapable {
+  for argument in function.arguments
+      where !argument.type.isEscapable(in: function)
+  {
     // Indirect results are not checked here. Type checking ensures
     // that they have a lifetime dependence.
     if let lifetimeDep = LifetimeDependence(argument, context) {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -31,6 +31,9 @@ private func log(_ message: @autoclosure () -> String) {
 let lifetimeDependenceScopeFixupPass = FunctionPass(
   name: "lifetime-dependence-scope-fixup")
 { (function: Function, context: FunctionPassContext) in
+  if !context.options.hasFeature(.NonescapableTypes) {
+    return
+  }
   log(" --- Scope fixup for lifetime dependence in \(function.name)")
 
   let localReachabilityCache = LocalVariableReachabilityCache()

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -63,8 +63,12 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
 
   public var isMoveOnly: Bool { bridged.isMoveOnly() }
 
-  public var isEscapable: Bool { bridged.isEscapable() }
-  public var mayEscape: Bool { !isNoEscapeFunction && isEscapable }
+  public func isEscapable(in function: Function) -> Bool {
+    bridged.isEscapable(function.bridged)
+  }
+  public func mayEscape(in function: Function) -> Bool {
+    !isNoEscapeFunction && isEscapable(in: function)
+  }
 
   /// Can only be used if the type is in fact a nominal type (`isNominal` is true).
   public var nominal: NominalTypeDecl {
@@ -143,6 +147,16 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
 
   public var description: String {
     String(taking: bridged.getDebugDescription())
+  }
+}
+
+extension Value {
+  public var isEscapable: Bool {
+    type.objectType.isEscapable(in: parentFunction)
+  }
+
+  public var mayEscape: Bool {
+    type.objectType.mayEscape(in: parentFunction)
   }
 }
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -137,6 +137,9 @@ public:
   /// function pointers.
   bool EnableImportPtrauthFieldFunctionPointers = false;
 
+  /// Enables SIL-level diagnostics for NonescapableTypes.
+  bool EnableLifetimeDependenceDiagnostics = true;
+
   /// Controls whether or not paranoid verification checks are run.
   bool VerifyAll = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1240,6 +1240,13 @@ def disable_import_ptrauth_field_function_pointers :
   Flag<["-"], "disable-import-ptrauth-field-function-pointers">,
   HelpText<"Disable import of custom ptrauth qualified field function pointers">;
 
+def enable_lifetime_dependence_diagnostics :
+  Flag<["-"], "enable-lifetime-dependence-diagnostics">,
+  HelpText<"Enable lifetime dependence diagnostics for Nonescapable types.">;
+def disable_lifetime_dependence_diagnostics :
+  Flag<["-"], "disable-lifetime-dependence-diagnostics">,
+  HelpText<"Disable lifetime dependence diagnostics for Nonescapable types.">;
+
 def enable_collocate_metadata_functions :
   Flag<["-"], "enable-collocate-metadata-functions">,
   HelpText<"Enable collocate metadata functions">;

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -350,7 +350,7 @@ struct BridgedType {
   BRIDGED_INLINE bool isEmpty(BridgedFunction f) const;
   BRIDGED_INLINE TraitResult canBeClass() const;
   BRIDGED_INLINE bool isMoveOnly() const;
-  BRIDGED_INLINE bool isEscapable() const;
+  BRIDGED_INLINE bool isEscapable(BridgedFunction f) const;
   BRIDGED_INLINE bool isOrContainsObjectiveCClass() const;
   BRIDGED_INLINE bool isBuiltinInteger() const;
   BRIDGED_INLINE bool isBuiltinFloat() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -274,8 +274,8 @@ bool BridgedType::isMoveOnly() const {
   return unbridged().isMoveOnly();
 }
 
-bool BridgedType::isEscapable() const {
-  return unbridged().isEscapable();
+bool BridgedType::isEscapable(BridgedFunction f) const {
+  return unbridged().isEscapable(*f.getFunction());
 }
 
 bool BridgedType::isOrContainsObjectiveCClass() const {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -897,13 +897,15 @@ public:
 
   /// False if SILValues of this type cannot be used outside the scope of their
   /// lifetime dependence.
-  bool isEscapable() const;
+  bool isEscapable(const SILFunction &function) const;
 
   /// True for (isEscapable && !isNoEscapeFunction)
   ///
   /// Equivalent to getASTType()->mayEscape(), but handles SIL-specific types,
   /// namely SILFunctionType.
-  bool mayEscape() const { return !isNoEscapeFunction() && isEscapable(); }
+  bool mayEscape(const SILFunction &function) const {
+    return !isNoEscapeFunction() && isEscapable(function);
+  }
 
   //
   // Accessors for types used in SIL instructions:

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2352,6 +2352,11 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
       Args.hasArg(OPT_enable_import_ptrauth_field_function_pointers,
                   OPT_disable_import_ptrauth_field_function_pointers,
                   Opts.EnableImportPtrauthFieldFunctionPointers);
+  Opts.EnableLifetimeDependenceDiagnostics =
+      Args.hasFlag(OPT_enable_lifetime_dependence_diagnostics,
+                   OPT_disable_lifetime_dependence_diagnostics,
+                   Opts.EnableLifetimeDependenceDiagnostics);
+
   Opts.VerifyAll |= Args.hasArg(OPT_sil_verify_all);
   Opts.VerifyNone |= Args.hasArg(OPT_sil_verify_none);
   Opts.DebugSerialization |= Args.hasArg(OPT_sil_debug_serialization);

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1051,7 +1051,7 @@ SILType::getSingletonAggregateFieldType(SILModule &M,
   return SILType();
 }
 
-bool SILType::isEscapable() const {
+bool SILType::isEscapable(const SILFunction &function) const {
   CanType ty = getASTType();
 
   // For storage with reference ownership, check the referent.
@@ -1065,7 +1065,8 @@ bool SILType::isEscapable() const {
   if (auto boxTy = getAs<SILBoxType>()) {
     auto fields = boxTy->getLayout()->getFields();
     assert(fields.size() == 1);
-    ty = fields[0].getLoweredType();
+    ty = ::getSILBoxFieldLoweredType(function.getTypeExpansionContext(), boxTy,
+                                     function.getModule().Types, 0);
   }
 
   // TODO: Support ~Escapable in parameter packs.

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -65,18 +65,6 @@ static llvm::cl::opt<bool>
     EnableDeinitDevirtualizer("enable-deinit-devirtualizer", llvm::cl::init(false),
                           llvm::cl::desc("Enable the DestroyHoisting pass."));
 
-// Temporary flag until the stdlib builds with ~Escapable
-static llvm::cl::opt<bool>
-EnableLifetimeDependenceInsertion(
-  "enable-lifetime-dependence-insertion", llvm::cl::init(false),
-  llvm::cl::desc("Enable lifetime dependence insertion."));
-
-// Temporary flag until the stdlib builds with ~Escapable
-static llvm::cl::opt<bool>
-EnableLifetimeDependenceDiagnostics(
-  "enable-lifetime-dependence-diagnostics", llvm::cl::init(false),
-  llvm::cl::desc("Enable lifetime dependence diagnostics."));
-
 //===----------------------------------------------------------------------===//
 //                          Diagnostic Pass Pipeline
 //===----------------------------------------------------------------------===//
@@ -184,7 +172,7 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addMoveOnlyChecker();
 
   // Check ~Escapable.
-  if (EnableLifetimeDependenceDiagnostics) {
+  if (P.getOptions().EnableLifetimeDependenceDiagnostics) {
     P.addLifetimeDependenceDiagnostics();
   }
   if (EnableDeinitDevirtualizer)
@@ -296,10 +284,8 @@ SILPassPipelinePlan::getSILGenPassPipeline(const SILOptions &Options) {
   P.startPipeline("SILGen Passes");
 
   P.addSILGenCleanup();
-  if (EnableLifetimeDependenceDiagnostics || EnableLifetimeDependenceInsertion) {
+  if (P.getOptions().EnableLifetimeDependenceDiagnostics) {
     P.addLifetimeDependenceInsertion();
-  }
-  if (EnableLifetimeDependenceDiagnostics) {
     P.addLifetimeDependenceScopeFixup();
   }
   if (SILViewSILGenCFG) {

--- a/test/SILOptimizer/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow.swift
@@ -4,8 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
@@ -4,8 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics.swift
@@ -3,7 +3,6 @@
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_diagnostics_generic.sil
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics_generic.sil
@@ -1,0 +1,18 @@
+// RUN: %target-sil-opt %s \
+// RUN:   -o /dev/null \
+// RUN:   -sil-verify-all \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -lifetime-dependence-diagnostics
+
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+
+sil_stage raw
+
+// Test that SILType.isEscpable does not crash on a generic box when NoncopyableGenerics is enabled.
+sil shared [serialized] [ossa] @testLocalFunc : $@convention(thin) <T, U> (@guaranteed <τ_0_0> { var τ_0_0 } <U>) -> () {
+bb0(%1 : @closureCapture @guaranteed $<τ_0_0> { var τ_0_0 } <U>):
+  %33 = tuple ()
+  return %33 : $()
+}

--- a/test/SILOptimizer/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence_generic.swift
@@ -5,7 +5,6 @@
 // RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature NoncopyableGenerics \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics \
 // RUN:   -parse-stdlib -module-name Swift
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit.swift
@@ -4,8 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
@@ -4,8 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence_insertion.swift
@@ -1,10 +1,10 @@
 // RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -Xllvm -sil-print-after=lifetime-dependence-insertion \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-insertion \
-// RUN:   2>&1 | %FileCheck %s
+// RUN:   -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
@@ -34,13 +34,15 @@ struct NC : ~Copyable {
 @_silgen_name("use")
 func use(_ o : borrowing BV)
 
-// CHECK-LABEL: sil hidden @$s4test13bv_borrow_var1p1iySV_SitF : $@convention(thin) (UnsafeRawPointer, Int) -> () {
-// CHECK: [[A:%.*]] = begin_access [read] [static] %{{.*}} : $*NC
-// CHECK: [[L:%.*]] = load [[A]] : $*NC
+// CHECK-LABEL: sil hidden [ossa] @$s4test13bv_borrow_var1p1iySV_SitF : $@convention(thin) (UnsafeRawPointer, Int) -> () {
+// CHECK: [[A:%.*]] = begin_access [read] [unknown] %{{.*}} : $*NC
+// CHECK: [[U:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[A]] : $*NC 
+// CHECK: [[L:%.*]] = load [copy] [[U]] : $*NC
 // CHECK:   [[R:%.*]] = apply %{{.*}}([[L]]) : $@convention(method) (@guaranteed NC) -> _scope(0) @owned BV
 // CHECK:   [[M:%.*]] = mark_dependence [unresolved] [[R]] : $BV on [[A]] : $*NC
 // CHECK:   end_access [[A]] : $*NC
-// CHECK:   %{{.*}} = apply %{{.*}}([[M]]) : $@convention(thin) (@guaranteed BV) -> ()
+// CHECK:   [[MV:%.*]] = move_value [var_decl] [[M]] : $BV
+// CHECK:   %{{.*}} = apply %{{.*}}([[MV]]) : $@convention(thin) (@guaranteed BV) -> ()
 // CHECK-LABEL: } // end sil function '$s4test13bv_borrow_var1p1iySV_SitF'
 func bv_borrow_var(p: UnsafeRawPointer, i: Int) {
   var nc = NC(p: p, i: i)

--- a/test/SILOptimizer/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence_mutate.swift
@@ -4,8 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence_param.swift
@@ -4,8 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_param_fail.swift
@@ -4,8 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/SILOptimizer/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope.swift
@@ -3,7 +3,6 @@
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
@@ -1,8 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify \
 // RUN: -enable-experimental-feature NonescapableTypes \
 // RUN: -disable-experimental-parser-round-trip \
-// RUN: -enable-experimental-feature NoncopyableGenerics \
-// RUN:  -Xllvm -enable-lifetime-dependence-diagnostics=true
+// RUN: -enable-experimental-feature NoncopyableGenerics
 
 // REQUIRES: asserts
 

--- a/test/SILOptimizer/lifetime_dependence_todo.swift
+++ b/test/SILOptimizer/lifetime_dependence_todo.swift
@@ -2,8 +2,7 @@
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
-// RUN:   -enable-experimental-feature NonescapableTypes \
-// RUN:   -Xllvm -enable-lifetime-dependence-diagnostics
+// RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -2,7 +2,8 @@
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_explicit_lifetime_dependence.swift \
 // RUN: -enable-experimental-feature NonescapableTypes \
 // RUN: -disable-experimental-parser-round-trip \
-// RUN: -enable-experimental-feature NoncopyableGenerics
+// RUN: -enable-experimental-feature NoncopyableGenerics \
+// RUN: -disable-lifetime-dependence-diagnostics
 
 // RUN: llvm-bcanalyzer %t/def_explicit_lifetime_dependence.swiftmodule 
 

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -2,7 +2,8 @@
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_implicit_lifetime_dependence.swift \
 // RUN: -enable-experimental-feature NonescapableTypes \
 // RUN: -disable-experimental-parser-round-trip \
-// RUN: -enable-experimental-feature NoncopyableGenerics
+// RUN: -enable-experimental-feature NoncopyableGenerics \
+// RUN: -disable-lifetime-dependence-diagnostics
 
 // RUN: llvm-bcanalyzer %t/def_implicit_lifetime_dependence.swiftmodule 
 


### PR DESCRIPTION
Adds -Xfrontend -disable-lifetime-dependence-diagnostics.

Removes -Xllvm -enable-lifetime-dependence-insertion

Removes -Xllvm -enable-lifetime-dependence-diagnostics