### PR TITLE
Fix SILType::isEscapable for box types.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/AllocVectorLowering.swift
@@ -414,7 +414,7 @@ private struct ComputeNonEscapingLiferange : EscapeVisitorWithResult {
       if dominates {
         liferange.insert(user)
       }
-      if !apply.type.isEscapable {
+      if !apply.isEscapable {
         return .abort
       }
       return .ignore

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -35,7 +35,9 @@ let lifetimeDependenceDiagnosticsPass = FunctionPass(
   log(" --- Diagnosing lifetime dependence in \(function.name)")
   log("\(function)")
 
-  for argument in function.arguments where !argument.type.isEscapable {
+  for argument in function.arguments
+      where !argument.type.isEscapable(in: function)
+  {
     // Indirect results are not checked here. Type checking ensures
     // that they have a lifetime dependence.
     if let lifetimeDep = LifetimeDependence(argument, context) {

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -63,8 +63,12 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
 
   public var isMoveOnly: Bool { bridged.isMoveOnly() }
 
-  public var isEscapable: Bool { bridged.isEscapable() }
-  public var mayEscape: Bool { !isNoEscapeFunction && isEscapable }
+  public func isEscapable(in function: Function) -> Bool {
+    bridged.isEscapable(function.bridged)
+  }
+  public func mayEscape(in function: Function) -> Bool {
+    !isNoEscapeFunction && isEscapable(in: function)
+  }
 
   /// Can only be used if the type is in fact a nominal type (`isNominal` is true).
   public var nominal: NominalTypeDecl {
@@ -143,6 +147,16 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
 
   public var description: String {
     String(taking: bridged.getDebugDescription())
+  }
+}
+
+extension Value {
+  public var isEscapable: Bool {
+    type.objectType.isEscapable(in: parentFunction)
+  }
+
+  public var mayEscape: Bool {
+    type.objectType.mayEscape(in: parentFunction)
   }
 }
 

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -350,7 +350,7 @@ struct BridgedType {
   BRIDGED_INLINE bool isEmpty(BridgedFunction f) const;
   BRIDGED_INLINE TraitResult canBeClass() const;
   BRIDGED_INLINE bool isMoveOnly() const;
-  BRIDGED_INLINE bool isEscapable() const;
+  BRIDGED_INLINE bool isEscapable(BridgedFunction f) const;
   BRIDGED_INLINE bool isOrContainsObjectiveCClass() const;
   BRIDGED_INLINE bool isBuiltinInteger() const;
   BRIDGED_INLINE bool isBuiltinFloat() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -274,8 +274,8 @@ bool BridgedType::isMoveOnly() const {
   return unbridged().isMoveOnly();
 }
 
-bool BridgedType::isEscapable() const {
-  return unbridged().isEscapable();
+bool BridgedType::isEscapable(BridgedFunction f) const {
+  return unbridged().isEscapable(*f.getFunction());
 }
 
 bool BridgedType::isOrContainsObjectiveCClass() const {

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -897,13 +897,15 @@ public:
 
   /// False if SILValues of this type cannot be used outside the scope of their
   /// lifetime dependence.
-  bool isEscapable() const;
+  bool isEscapable(const SILFunction &function) const;
 
   /// True for (isEscapable && !isNoEscapeFunction)
   ///
   /// Equivalent to getASTType()->mayEscape(), but handles SIL-specific types,
   /// namely SILFunctionType.
-  bool mayEscape() const { return !isNoEscapeFunction() && isEscapable(); }
+  bool mayEscape(const SILFunction &function) const {
+    return !isNoEscapeFunction() && isEscapable(function);
+  }
 
   //
   // Accessors for types used in SIL instructions:

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -1051,7 +1051,7 @@ SILType::getSingletonAggregateFieldType(SILModule &M,
   return SILType();
 }
 
-bool SILType::isEscapable() const {
+bool SILType::isEscapable(const SILFunction &function) const {
   CanType ty = getASTType();
 
   // For storage with reference ownership, check the referent.
@@ -1065,7 +1065,8 @@ bool SILType::isEscapable() const {
   if (auto boxTy = getAs<SILBoxType>()) {
     auto fields = boxTy->getLayout()->getFields();
     assert(fields.size() == 1);
-    ty = fields[0].getLoweredType();
+    ty = ::getSILBoxFieldLoweredType(function.getTypeExpansionContext(), boxTy,
+                                     function.getModule().Types, 0);
   }
 
   // TODO: Support ~Escapable in parameter packs.

--- a/test/SILOptimizer/lifetime_dependence_diagnostics_generic.sil
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics_generic.sil
@@ -1,0 +1,18 @@
+// RUN: %target-sil-opt %s \
+// RUN:   -o /dev/null \
+// RUN:   -sil-verify-all \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -lifetime-dependence-diagnostics
+
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+
+sil_stage raw
+
+// Test that SILType.isEscpable does not crash on a generic box when NoncopyableGenerics is enabled.
+sil shared [serialized] [ossa] @testLocalFunc : $@convention(thin) <T, U> (@guaranteed <τ_0_0> { var τ_0_0 } <U>) -> () {
+bb0(%1 : @closureCapture @guaranteed $<τ_0_0> { var τ_0_0 } <U>):
+  %33 = tuple ()
+  return %33 : $()
+}


### PR DESCRIPTION
SILBoxTypes have their own generic signature and substitution
map. This means that every time we query isEscapable or mayEscape, we
need to extract the type of the box's field and perform type
substitution so that the AST query only sees types from the function's
generic environment.

Fixes rdar://124179106 (Assertion failed in SIL:
(!type->hasTypeParameter() && "caller forgot to mapTypeIntoContext!"))