### PR TITLE
Fix computation of argument index in the presence of indirect error results

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -959,7 +959,8 @@ void ElementUseCollector::collectUses(SILValue Pointer, unsigned BaseEltNo) {
       unsigned ArgumentNumber = Op->getOperandNumber() - 1;
 
       // If this is an out-parameter, it is like a store.
-      unsigned NumIndirectResults = substConv.getNumIndirectSILResults();
+      unsigned NumIndirectResults = substConv.getNumIndirectSILResults() +
+                                    substConv.getNumIndirectSILErrorResults();
       if (ArgumentNumber < NumIndirectResults) {
         assert(!InStructSubElement && "We're initializing sub-members?");
         addElementUses(BaseEltNo, PointeeType, User, DIUseKind::Initialization);

--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -364,7 +364,8 @@ bool ElementUseCollector::collectUses(SILValue Pointer) {
       unsigned ArgumentNumber = UI->getOperandNumber() - 1;
 
       // If this is an out-parameter, it is like a store.
-      unsigned NumIndirectResults = substConv.getNumIndirectSILResults();
+      unsigned NumIndirectResults = substConv.getNumIndirectSILResults() +
+                                    substConv.getNumIndirectSILErrorResults();
       if (ArgumentNumber < NumIndirectResults) {
         // We do not support initializing sub members. This is an old
         // restriction from when this code was used by Definite

--- a/test/SIL/typed_throws_sil_crash.swift
+++ b/test/SIL/typed_throws_sil_crash.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -module-name=test -emit-sil %s -enable-builtin-module
+
+import Builtin
+
+// Ensure compiler does not crash
+struct Wrapper {
+  var a = [1, 2, 3]
+  init() {
+    _withUnsafeMutablePointer(to: &a) {
+      bar($0)
+    }
+  }
+}
+
+func _withUnsafeMutablePointer<T, E: Error, Result>(
+  to value: inout T,
+  _ body: (UnsafeMutablePointer<T>) throws(E) -> Result
+) throws(E) -> Result {
+  try body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
+}
+
+func bar<T>(_ arg: UnsafeMutablePointer<[T]>) {}
+


### PR DESCRIPTION
Fixes rdar://124108894

With typed throws, we can have indirect error results, this changes how we compute argument index. Update 2 incorrect instances exposed by  rdar://124108894. 

