### PR TITLE
[cxx-interop] Install `swift/bridging` header in a different location

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -47,22 +47,22 @@ set_swift_llvm_is_available(swiftClangImporter)
 if(SWIFT_ENABLE_CXX_INTEROP_SWIFT_BRIDGING_HEADER)
   # Mark - copy "bridging" (support header) into the local include directory and
   # install it into the compiler toolchain.
-  set(SWIFTINC_DIR
-      "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/include/swift")
+  set(SWIFT_BRIDGING_DIR
+      "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/include/SwiftBridging")
 
   add_custom_command(
-      OUTPUT "${SWIFTINC_DIR}/bridging"
+      OUTPUT "${SWIFT_BRIDGING_DIR}/bridging"
       DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/bridging"
-      COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${CMAKE_CURRENT_SOURCE_DIR}/bridging" "${SWIFTINC_DIR}")
+      COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${CMAKE_CURRENT_SOURCE_DIR}/bridging" "${SWIFT_BRIDGING_DIR}")
 
   add_custom_target("copy_cxxInterop_support_header"
-      DEPENDS "${SWIFTINC_DIR}/bridging"
-      COMMENT "Copying C++ interop support header to ${SWIFTINC_DIR}")
+      DEPENDS "${SWIFT_BRIDGING_DIR}/bridging"
+      COMMENT "Copying C++ interop support header to ${SWIFT_BRIDGING_DIR}")
 
   swift_install_in_component(FILES
                              "${CMAKE_CURRENT_SOURCE_DIR}/bridging"
                              "${CMAKE_CURRENT_SOURCE_DIR}/module.modulemap"
-                             DESTINATION "include/swift"
+                             DESTINATION "include/SwiftBridging"
                              COMPONENT compiler)
 
   add_dependencies(swiftClangImporter


### PR DESCRIPTION
The recent Clang compiler change makes `-fno-modulemap-allow-subdirectory-search` the default behavior. This means that projects that use C++ interop and `#include <swift/bridging>` no longer compile, since Clang won't search for the SwiftBridging module under `usr/include/swift` anymore.

This change moves the header to `usr/include/SwiftBridging`. The directory name matches the Clang module name, which will help Clang find this header along with the modulemap.

rdar://123334601