### PR TITLE
[Noncopyable generics] Suppress inverse conformance mangling for more symbols

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -214,6 +214,9 @@ std::string IRGenMangler::mangleProtocolConformanceDescriptor(
 
 std::string IRGenMangler::mangleProtocolConformanceDescriptorRecord(
                                  const RootProtocolConformance *conformance) {
+  llvm::SaveAndRestore X(AllowInverses,
+                         inversesAllowedIn(conformance->getDeclContext()));
+
   beginMangling();
   appendProtocolConformance(conformance);
   appendOperator("Hc");
@@ -222,6 +225,9 @@ std::string IRGenMangler::mangleProtocolConformanceDescriptorRecord(
 
 std::string IRGenMangler::mangleProtocolConformanceInstantiationCache(
                                  const RootProtocolConformance *conformance) {
+  llvm::SaveAndRestore X(AllowInverses,
+                         inversesAllowedIn(conformance->getDeclContext()));
+
   beginMangling();
   if (isa<NormalProtocolConformance>(conformance)) {
     appendProtocolConformance(conformance);
@@ -511,3 +517,17 @@ IRGenMangler::appendExtendedExistentialTypeShape(CanGenericSignature genSig,
   appendOperator(genSig ? "XG" : "Xg");
 }
 
+std::string
+IRGenMangler::mangleConformanceSymbol(Type type,
+                                      const ProtocolConformance *Conformance,
+                                      const char *Op) {
+llvm::SaveAndRestore X(AllowInverses,
+                       inversesAllowedIn(Conformance->getDeclContext()));
+
+  beginMangling();
+  if (type)
+    appendType(type, nullptr);
+  appendProtocolConformance(Conformance);
+  appendOperator(Op);
+  return finalize();
+}

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -46,6 +46,9 @@ public:
   IRGenMangler() { }
 
   std::string mangleDispatchThunk(const FuncDecl *func) {
+    // Dispatch thunks do not mangle inverse conformances.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     appendEntity(func);
     appendOperator("Tj");
@@ -55,6 +58,9 @@ public:
   std::string mangleDerivativeDispatchThunk(
       const AbstractFunctionDecl *func,
       AutoDiffDerivativeFunctionIdentifier *derivativeId) {
+    // Dispatch thunks do not mangle inverse conformances.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
     auto *resultIndices =
@@ -71,6 +77,9 @@ public:
 
   std::string mangleConstructorDispatchThunk(const ConstructorDecl *ctor,
                                              bool isAllocating) {
+    // Dispatch thunks do not mangle inverse conformances.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     appendConstructorEntity(ctor, isAllocating);
     appendOperator("Tj");
@@ -78,6 +87,9 @@ public:
   }
 
   std::string mangleMethodDescriptor(const FuncDecl *func) {
+    // Method descriptors do not mangle inverse conformances.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     appendEntity(func);
     appendOperator("Tq");
@@ -87,6 +99,9 @@ public:
   std::string mangleDerivativeMethodDescriptor(
       const AbstractFunctionDecl *func,
       AutoDiffDerivativeFunctionIdentifier *derivativeId) {
+    // Method descriptors do not mangle inverse conformances.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
     auto *resultIndices =
@@ -103,6 +118,9 @@ public:
 
   std::string mangleConstructorMethodDescriptor(const ConstructorDecl *ctor,
                                                 bool isAllocating) {
+    // Method descriptors do not mangle inverse conformances.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     appendConstructorEntity(ctor, isAllocating);
     appendOperator("Tq");
@@ -327,6 +345,10 @@ public:
     // among the type descriptors of different protocols.
     llvm::SaveAndRestore<bool> optimizeProtocolNames(OptimizeProtocolNames,
                                                      false);
+
+    // No mangling of inverse conformances inside protocols.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     bool isAssocTypeAtDepth = false;
     (void)appendAssocType(
@@ -341,6 +363,9 @@ public:
       const ProtocolDecl *proto,
       CanType subject,
       const ProtocolDecl *requirement) {
+    // No mangling of inverse conformances inside protocols.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     appendAnyGenericType(proto);
     if (isa<GenericTypeParamType>(subject)) {
@@ -357,6 +382,9 @@ public:
   std::string mangleBaseConformanceDescriptor(
       const ProtocolDecl *proto,
       const ProtocolDecl *requirement) {
+    // No mangling of inverse conformances inside protocols.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     appendAnyGenericType(proto);
     appendProtocolName(requirement);
@@ -368,6 +396,9 @@ public:
       const ProtocolDecl *proto,
       CanType subject,
       const ProtocolDecl *requirement) {
+    // No mangling of inverse conformances inside protocols.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     appendAnyGenericType(proto);
     bool isFirstAssociatedTypeIdentifier = true;
@@ -385,6 +416,7 @@ public:
                                     const RootProtocolConformance *conformance);
 
   std::string manglePropertyDescriptor(const AbstractStorageDecl *storage) {
+    llvm::SaveAndRestore X(AllowInverses, inversesAllowed(storage));
     beginMangling();
     appendEntity(storage);
     appendOperator("MV");
@@ -392,6 +424,9 @@ public:
   }
 
   std::string mangleFieldOffset(const ValueDecl *Decl) {
+    // No mangling of inverse conformances.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     appendEntity(Decl);
     appendOperator("Wvd");
@@ -399,6 +434,9 @@ public:
   }
 
   std::string mangleEnumCase(const ValueDecl *Decl) {
+    // No mangling of inverse conformances.
+    llvm::SaveAndRestore X(AllowInverses, false);
+
     beginMangling();
     appendEntity(Decl);
     appendOperator("WC");
@@ -713,14 +751,7 @@ protected:
 
   std::string mangleConformanceSymbol(Type type,
                                       const ProtocolConformance *Conformance,
-                                      const char *Op) {
-    beginMangling();
-    if (type)
-      appendType(type, nullptr);
-    appendProtocolConformance(Conformance);
-    appendOperator(Op);
-    return finalize();
-  }
+                                      const char *Op);
 };
 
 /// Determines if the minimum deployment target's runtime demangler will not

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -12,7 +12,7 @@ public protocol P: ~Copyable { }
 
 public protocol Hello<Person>: ~Copyable {
   // CHECK: @"$s4test5HelloP6PersonAC_AA1PTn"
-  // CHECK: @"$s6Person4test5HelloPTl" = alias
+  // CHECK: @"$s6Person4test5HelloPTl" =
   associatedtype Person: P & ~Copyable
 
   // CHECK: @"$s4test5HelloP14favoritePerson0D0QzvrTq" = alias

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-ir -o - %s -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -parse-as-library \
+// RUN:   -enable-library-evolution \
+// RUN:   > %t/test.irgen
+
+// RUN: %FileCheck %s < %t/test.irgen
+
+public protocol P: ~Copyable { }
+
+public protocol Hello<Person>: ~Copyable {
+  // CHECK: @"$s4test5HelloP6PersonAC_AA1PTn"
+  // CHECK: @"$s6Person4test5HelloPTl" = alias
+  associatedtype Person: P & ~Copyable
+
+  // CHECK: @"$s4test5HelloP14favoritePerson0D0QzvrTq" = alias
+  var favoritePerson: Person { get }
+
+  // CHECK: @"$s4test5HelloP5greetyy6PersonQzFTq"
+  func greet(_ person: borrowing Person)
+}
+
+public struct Wrapper<T: ~Copyable> {
+  var wrapped: T { fatalError("boom") }
+}

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -15,7 +15,7 @@ public protocol Hello<Person>: ~Copyable {
   // CHECK: @"$s6Person4test5HelloPTl" =
   associatedtype Person: P & ~Copyable
 
-  // CHECK: @"$s4test5HelloP14favoritePerson0D0QzvrTq" = alias
+  // CHECK: @"$s4test5HelloP14favoritePerson0D0QzvrTq" =
   var favoritePerson: Person { get }
 
   // CHECK: @"$s4test5HelloP5greetyy6PersonQzFTq"


### PR DESCRIPTION
Don't mangle inverse conformances for symbols related to dispatch thunks, protocol members, and other entities that are inexorably tied to the primary definition of the type and must have stable names.

Extend the conditional suppression of inverse conformance mangling to property descriptors and more conformance-related symbols.
