### PR TITLE
[DebugInfo] Move type size information to CompletedDebugTypeInfo

### DIFF
--- a/include/swift/SIL/SILDebugInfoExpression.h
+++ b/include/swift/SIL/SILDebugInfoExpression.h
@@ -296,16 +296,6 @@ public:
     return Elements.size() &&
            Elements[0].getAsOperator() == SILDIExprOperator::Dereference;
   }
-
-  /// Return true if this DIExpression has a fragment (at the end)
-  bool hasFragment() const {
-    return (Elements.size() >= 2 &&
-           Elements[Elements.size() - 2].getAsOperator() ==
-            SILDIExprOperator::Fragment) ||
-            (Elements.size() >= 3 &&
-             Elements[Elements.size() - 3].getAsOperator() ==
-             SILDIExprOperator::TupleFragment);
-  }
 };
 
 /// Returns the hashcode for the di expr element.

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -57,7 +57,8 @@ DebugTypeInfo DebugTypeInfo::getFromTypeInfo(swift::Type Ty, const TypeInfo &TI,
   assert(TI.getStorageType() && "StorageType is a nullptr");
   return DebugTypeInfo(Ty.getPointer(), StorageType,
                        TI.getBestKnownAlignment(), ::hasDefaultAlignment(Ty),
-                       false, false, NumExtraInhabitants);
+                       /* IsMetadataType = */ false,
+                       /* IsFixedBuffer = */ false, NumExtraInhabitants);
 }
 
 DebugTypeInfo DebugTypeInfo::getLocalVariable(VarDecl *Decl, swift::Type Ty,
@@ -82,7 +83,9 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(VarDecl *Decl, swift::Type Ty,
 DebugTypeInfo DebugTypeInfo::getGlobalMetadata(swift::Type Ty,
                                                llvm::Type *StorageTy, Size size,
                                                Alignment align) {
-  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, align, true, false);
+  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, align,
+                      /* HasDefaultAlignment = */ true,
+                      /* IsMetadataType = */ false);
   assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type metadata cannot contain an archetype");
@@ -92,7 +95,9 @@ DebugTypeInfo DebugTypeInfo::getGlobalMetadata(swift::Type Ty,
 DebugTypeInfo DebugTypeInfo::getTypeMetadata(swift::Type Ty,
                                              llvm::Type *StorageTy, Size size,
                                              Alignment align) {
-  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, align, true, true);
+  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, align,
+                      /* HasDefaultAlignment = */ true,
+                      /* IsMetadataType = */ true);
   assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type metadata cannot contain an archetype");
@@ -138,7 +143,8 @@ DebugTypeInfo::getGlobalFixedBuffer(SILGlobalVariable *GV,
       Type = DeclType.getPointer();
   }
   DebugTypeInfo DbgTy(Type, FragmentStorageType,
-                      Align, ::hasDefaultAlignment(Type), false, true);
+                      Align, ::hasDefaultAlignment(Type),
+                      /* IsMetadataType = */ false, /* IsFixedBuffer = */ true);
   assert(FragmentStorageType && "FragmentStorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type of global variable cannot be an archetype");
@@ -149,7 +155,9 @@ DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass,
                                           llvm::Type *FragmentStorageType,
                                           Size SizeInBytes, Alignment align) {
   DebugTypeInfo DbgTy(theClass->getInterfaceType().getPointer(),
-                      FragmentStorageType, align, true, false);
+                      FragmentStorageType, align,
+                      /* HasDefaultAlignment = */ true,
+                      /* IsMetadataType = */ false);
   assert(FragmentStorageType && "FragmentStorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type of objc class cannot be an archetype");

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -152,7 +152,7 @@ template <> struct DenseMapInfo<swift::irgen::DebugTypeInfo> {
   static swift::irgen::DebugTypeInfo getTombstoneKey() {
     return swift::irgen::DebugTypeInfo(
         llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(), nullptr,
-        swift::irgen::Alignment(), false, false);
+        swift::irgen::Alignment(), /* HasDefaultAlignment = */ false);
   }
   static unsigned getHashValue(swift::irgen::DebugTypeInfo Val) {
     return DenseMapInfo<swift::CanType>::getHashValue(Val.getType());

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -110,9 +110,6 @@ public:
       assert(FragmentStorageType && "only defined types may have a size");
     return FragmentStorageType;
   }
-  std::optional<Size::int_type> getTypeSizeInBits() const {
-    return SizeIsFragmentSize ? std::nullopt : SizeInBits;
-  }
   std::optional<Size::int_type> getRawSizeInBits() const { return SizeInBits; }
   Alignment getAlignment() const { return Align; }
   bool isNull() const { return Type == nullptr; }

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -48,7 +48,6 @@ protected:
   Alignment Align;
   bool DefaultAlignment = true;
   bool IsMetadataType = false;
-  bool SizeIsFragmentSize = false;
   bool IsFixedBuffer = false;
 
 public:
@@ -56,13 +55,12 @@ public:
   DebugTypeInfo(swift::Type Ty, llvm::Type *StorageTy = nullptr,
                 Alignment AlignInBytes = Alignment(1),
                 bool HasDefaultAlignment = true, bool IsMetadataType = false,
-                bool IsFragmentTypeInfo = false, bool IsFixedBuffer = false,
+                bool IsFixedBuffer = false,
                 std::optional<uint32_t> NumExtraInhabitants = {});
 
   /// Create type for a local variable.
   static DebugTypeInfo getLocalVariable(VarDecl *Decl, swift::Type Ty,
-                                        const TypeInfo &Info, IRGenModule &IGM,
-                                        bool IsFragmentTypeInfo);
+                                        const TypeInfo &Info, IRGenModule &IGM);
   /// Create type for global type metadata.
   static DebugTypeInfo getGlobalMetadata(swift::Type Ty, llvm::Type *StorageTy,
                                          Size size, Alignment align);
@@ -75,8 +73,7 @@ public:
 
   /// Create a standalone type from a TypeInfo object.
   static DebugTypeInfo getFromTypeInfo(swift::Type Ty, const TypeInfo &Info,
-                                       IRGenModule &IGM,
-                                       bool IsFragmentTypeInfo);
+                                       IRGenModule &IGM);
   /// Global variables.
   static DebugTypeInfo getGlobal(SILGlobalVariable *GV,
                                  llvm::Type *StorageType, IRGenModule &IGM);
@@ -109,7 +106,6 @@ public:
   bool isForwardDecl() const { return FragmentStorageType == nullptr; }
   bool isMetadataType() const { return IsMetadataType; }
   bool hasDefaultAlignment() const { return DefaultAlignment; }
-  bool isSizeFragmentSize() const { return SizeIsFragmentSize; }
   bool isFixedBuffer() const { return IsFixedBuffer; }
   std::optional<uint32_t> getNumExtraInhabitants() const {
     return NumExtraInhabitants;
@@ -156,7 +152,7 @@ template <> struct DenseMapInfo<swift::irgen::DebugTypeInfo> {
   static swift::irgen::DebugTypeInfo getTombstoneKey() {
     return swift::irgen::DebugTypeInfo(
         llvm::DenseMapInfo<swift::TypeBase *>::getTombstoneKey(), nullptr,
-        swift::irgen::Alignment(), false, false, false);
+        swift::irgen::Alignment(), false, false);
   }
   static unsigned getHashValue(swift::irgen::DebugTypeInfo Val) {
     return DenseMapInfo<swift::CanType>::getHashValue(Val.getType());

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1688,9 +1688,8 @@ private:
     // to emit the (target!) size of the underlying basic type.
     uint64_t SizeOfByte = CI.getTargetInfo().getCharWidth();
     // FIXME: SizeInBits is redundant with DbgTy, remove it.
-    uint64_t SizeInBits = 0;
-    if (DbgTy.getTypeSizeInBits())
-      SizeInBits = *DbgTy.getTypeSizeInBits();
+    auto *llvmty = IGM.getStorageTypeForUnlowered(DbgTy.getType());
+    uint64_t SizeInBits = llvmty->isSized() ? IGM.DataLayout.getTypeSizeInBits(llvmty) : 0;
     unsigned AlignInBits = DbgTy.hasDefaultAlignment()
                                ? 0
                                : DbgTy.getAlignment().getValue() * SizeOfByte;

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2090,8 +2090,9 @@ private:
       // in the decl of the alias type.
       DebugTypeInfo AliasedDbgTy(
           AliasedTy, DbgTy.getFragmentStorageType(),
-          DbgTy.getAlignment(), DbgTy.hasDefaultAlignment(), false,
-          DbgTy.isFixedBuffer(), DbgTy.getNumExtraInhabitants());
+          DbgTy.getAlignment(), DbgTy.hasDefaultAlignment(),
+          /* IsMetadataType = */ false, DbgTy.isFixedBuffer(),
+          DbgTy.getNumExtraInhabitants());
       return DBuilder.createTypedef(getOrCreateType(AliasedDbgTy), MangledName,
                                     L.File, 0, Scope);
     }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1141,7 +1141,7 @@ private:
           memberTy,
           IGM.getTypeInfoForUnlowered(
               IGM.getSILTypes().getAbstractionPattern(VD), memberTy),
-          IGM, false);
+          IGM);
       unsigned OffsetInBits = 0;
       llvm::DIType *DITy = createMemberType(DbgTy, VD->getName().str(),
                                             OffsetInBits, Scope, File, Flags);
@@ -1176,8 +1176,7 @@ private:
     UnsubstitutedTy = Decl->mapTypeIntoContext(UnsubstitutedTy);
 
     auto DbgTy = DebugTypeInfo::getFromTypeInfo(
-        UnsubstitutedTy, IGM.getTypeInfoForUnlowered(UnsubstitutedTy), IGM,
-        false);
+        UnsubstitutedTy, IGM.getTypeInfoForUnlowered(UnsubstitutedTy), IGM);
     Mangle::ASTMangler Mangler;
     std::string DeclTypeMangledName = Mangler.mangleTypeForDebugger(
         UnsubstitutedTy->mapTypeOutOfContext(), {});
@@ -1195,8 +1194,7 @@ private:
       auto SuperClassTy = ClassTy->getSuperclass();
       if (SuperClassTy) {
         auto SuperClassDbgTy = DebugTypeInfo::getFromTypeInfo(
-            SuperClassTy, IGM.getTypeInfoForUnlowered(SuperClassTy), IGM,
-            false);
+            SuperClassTy, IGM.getTypeInfoForUnlowered(SuperClassTy), IGM);
 
         llvm::DIType *SuperClassDITy = getOrCreateType(SuperClassDbgTy);
         assert(SuperClassDITy && "getOrCreateType should never return null!");
@@ -1376,7 +1374,7 @@ private:
         // A variant case which carries a payload.
         ArgTy = ElemDecl->getParentEnum()->mapTypeIntoContext(ArgTy);
         ElemDbgTy = DebugTypeInfo::getFromTypeInfo(
-            ArgTy, IGM.getTypeInfoForUnlowered(ArgTy), IGM, false);
+            ArgTy, IGM.getTypeInfoForUnlowered(ArgTy), IGM);
         unsigned Offset = 0;
         auto MTy =
             createMemberType(*ElemDbgTy, ElemDecl->getBaseIdentifier().str(),
@@ -1419,8 +1417,7 @@ private:
   llvm::DIType *getOrCreateDesugaredType(Type Ty, DebugTypeInfo DbgTy) {
     DebugTypeInfo BlandDbgTy(Ty, DbgTy.getFragmentStorageType(),
                              DbgTy.getAlignment(), DbgTy.hasDefaultAlignment(),
-                             DbgTy.isMetadataType(), DbgTy.isSizeFragmentSize(),
-                             DbgTy.isFixedBuffer());
+                             DbgTy.isMetadataType(), DbgTy.isFixedBuffer());
     return getOrCreateType(BlandDbgTy);
   }
 
@@ -1450,7 +1447,7 @@ private:
         // For full debug info don't generate just a forward declaration  for
         // the generic type parameters.
         ParamDebugType = DebugTypeInfo::getFromTypeInfo(
-            Param, IGM.getTypeInfoForUnlowered(Param), IGM, false);
+            Param, IGM.getTypeInfoForUnlowered(Param), IGM);
       else
         ParamDebugType = DebugTypeInfo::getForwardDecl(Param);
 
@@ -1621,7 +1618,7 @@ private:
       auto &elemTI = IGM.getTypeInfoForUnlowered(
           AbstractionPattern(genericSig, ElemTy->getCanonicalType()), ElemTy);
       auto DbgTy =
-            DebugTypeInfo::getFromTypeInfo(ElemTy, elemTI, IGM, false);
+            DebugTypeInfo::getFromTypeInfo(ElemTy, elemTI, IGM);
         Elements.push_back(
             createMemberType(DbgTy, "", OffsetInBits, Scope, MainFile, Flags));
     }
@@ -1823,8 +1820,7 @@ private:
         auto SuperClassTy = ClassTy->getSuperclass();
         if (SuperClassTy) {
           auto SuperClassDbgTy = DebugTypeInfo::getFromTypeInfo(
-              SuperClassTy, IGM.getTypeInfoForUnlowered(SuperClassTy), IGM,
-              false);
+              SuperClassTy, IGM.getTypeInfoForUnlowered(SuperClassTy), IGM);
 
           llvm::DIType *SuperClassDITy = getOrCreateType(SuperClassDbgTy);
           assert(SuperClassDITy && "getOrCreateType should never return null!");
@@ -1969,7 +1965,7 @@ private:
             IGM.getLoweredType(ProtocolDecl->getInterfaceType()).getASTType();
         auto PDbgTy = DebugTypeInfo::getFromTypeInfo(
             ProtocolDecl->getInterfaceType(), IGM.getTypeInfoForLowered(PTy),
-            IGM, false);
+            IGM);
         auto PDITy = getOrCreateType(PDbgTy);
         Protocols.push_back(
             DBuilder.createInheritance(FwdDecl.get(), PDITy, 0, 0, Flags));
@@ -2033,8 +2029,7 @@ private:
         UnsubstitutedTy = Decl->mapTypeIntoContext(UnsubstitutedTy);
 
         auto DbgTy = DebugTypeInfo::getFromTypeInfo(
-            UnsubstitutedTy, IGM.getTypeInfoForUnlowered(UnsubstitutedTy), IGM,
-            false);
+            UnsubstitutedTy, IGM.getTypeInfoForUnlowered(UnsubstitutedTy), IGM);
         Mangle::ASTMangler Mangler;
         std::string DeclTypeMangledName = Mangler.mangleTypeForDebugger(
             UnsubstitutedTy->mapTypeOutOfContext(), {});
@@ -2061,7 +2056,7 @@ private:
       auto *BuiltinVectorTy = BaseTy->castTo<BuiltinVectorType>();
       auto ElemTy = BuiltinVectorTy->getElementType();
       auto ElemDbgTy = DebugTypeInfo::getFromTypeInfo(
-          ElemTy, IGM.getTypeInfoForUnlowered(ElemTy), IGM, false);
+          ElemTy, IGM.getTypeInfoForUnlowered(ElemTy), IGM);
       unsigned Count = BuiltinVectorTy->getNumElements();
       auto Subscript = DBuilder.getOrCreateSubrange(0, Count ? Count : -1);
       return DBuilder.createVectorType(SizeInBits, AlignInBits,
@@ -2096,8 +2091,7 @@ private:
       DebugTypeInfo AliasedDbgTy(
           AliasedTy, DbgTy.getFragmentStorageType(),
           DbgTy.getAlignment(), DbgTy.hasDefaultAlignment(), false,
-          DbgTy.isSizeFragmentSize(), DbgTy.isFixedBuffer(),
-          DbgTy.getNumExtraInhabitants());
+          DbgTy.isFixedBuffer(), DbgTy.getNumExtraInhabitants());
       return DBuilder.createTypedef(getOrCreateType(AliasedDbgTy), MangledName,
                                     L.File, 0, Scope);
     }
@@ -2216,7 +2210,7 @@ private:
       return;
     for (auto BuiltinType: IGM.getOrCreateSpecialStlibBuiltinTypes()) {
       auto DbgTy = DebugTypeInfo::getFromTypeInfo(
-          BuiltinType, IGM.getTypeInfoForUnlowered(BuiltinType), IGM, false);
+          BuiltinType, IGM.getTypeInfoForUnlowered(BuiltinType), IGM);
       DBuilder.retainType(getOrCreateType(DbgTy));
     }
   }
@@ -2861,7 +2855,7 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
 
       auto DTI = DebugTypeInfo::getFromTypeInfo(
           errorResultTy,
-          IGM.getTypeInfo(SILTy), IGM, false);
+          IGM.getTypeInfo(SILTy), IGM);
       Error = DBuilder.getOrCreateArray({getOrCreateType(DTI)}).get();
     }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -5441,14 +5441,11 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   VarInfo->Name = getVarName(i, IsAnonymous);
   DebugTypeInfo DbgTy;
   SILType SILTy;
-  bool IsFragmentType = false;
   if (auto MaybeSILTy = VarInfo->Type) {
     // If there is auxiliary type info, use it
     SILTy = *MaybeSILTy;
   } else {
     SILTy = SILVal->getType();
-    if (VarInfo->DIExpr)
-      IsFragmentType = VarInfo->DIExpr.hasFragment();
   }
 
   auto RealTy = SILTy.getASTType();
@@ -5473,11 +5470,10 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   // Figure out the debug variable type
   if (VD) {
     DbgTy = DebugTypeInfo::getLocalVariable(VD, RealTy, getTypeInfo(SILTy),
-                                            IGM, IsFragmentType);
+                                            IGM);
   } else if (!SILTy.hasArchetype() && !VarInfo->Name.empty()) {
     // Handle the cases that read from a SIL file
-    DbgTy = DebugTypeInfo::getFromTypeInfo(RealTy, getTypeInfo(SILTy), IGM,
-                                           IsFragmentType);
+    DbgTy = DebugTypeInfo::getFromTypeInfo(RealTy, getTypeInfo(SILTy), IGM);
   } else
     return;
 
@@ -5865,24 +5861,19 @@ void IRGenSILFunction::emitDebugInfoForAllocStack(AllocStackInst *i,
   }
 
   SILType SILTy;
-  bool IsFragmentType = false;
   if (auto MaybeSILTy = VarInfo->Type) {
     // If there is auxiliary type info, use it
     SILTy = *MaybeSILTy;
   } else {
     SILTy = i->getType();
-    if (VarInfo->DIExpr)
-      IsFragmentType = VarInfo->DIExpr.hasFragment();
   }
   auto RealType = SILTy.getASTType();
   DebugTypeInfo DbgTy;
   if (Decl) {
-    DbgTy = DebugTypeInfo::getLocalVariable(Decl, RealType, type, IGM,
-                                            IsFragmentType);
+    DbgTy = DebugTypeInfo::getLocalVariable(Decl, RealType, type, IGM);
   } else if (i->getFunction()->isBare() && !SILTy.hasArchetype() &&
              !VarInfo->Name.empty()) {
-    DbgTy = DebugTypeInfo::getFromTypeInfo(RealType, getTypeInfo(SILTy), IGM,
-                                           IsFragmentType);
+    DbgTy = DebugTypeInfo::getFromTypeInfo(RealType, getTypeInfo(SILTy), IGM);
   } else
     return;
 
@@ -6139,7 +6130,7 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
       i->getBoxType(), IGM.getSILModule().Types, 0);
   auto RealType = SILTy.getASTType();
   auto DbgTy =
-      DebugTypeInfo::getLocalVariable(Decl, RealType, type, IGM, false);
+      DebugTypeInfo::getLocalVariable(Decl, RealType, type, IGM);
 
   auto VarInfo = i->getVarInfo();
   if (!VarInfo)


### PR DESCRIPTION
Remove the estimated type size from the `DebugTypeInfo` class, and move it to `CompletedDebugTypeInfo`. The type size is now computed by `CompletedDebugTypeInfo::getFromTypeInfo`, and is never the size of a fragment.

