### PR TITLE
[NoncopyablePartialConsumption] Sharpen diagnosis.

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -422,14 +422,13 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
     void checkConsumeExpr(ConsumeExpr *consumeExpr) {
       auto partialConsumptionEnabled =
           Ctx.LangOpts.hasFeature(Feature::MoveOnlyPartialConsumption);
+      auto *subExpr = consumeExpr->getSubExpr();
+      bool noncopyable =
+          subExpr->getType()->getCanonicalType()->isNoncopyable();
 
-      bool noncopyable = false;
       bool partial = false;
-      Expr *current = consumeExpr->getSubExpr();
+      Expr *current = subExpr;
       while (current) {
-        if (current->getType()->getCanonicalType()->isNoncopyable()) {
-          noncopyable = true;
-        }
         if (auto *dre = dyn_cast<DeclRefExpr>(current)) {
           if (partial & !noncopyable) {
             Ctx.Diags.diagnose(consumeExpr->getLoc(),

--- a/test/Sema/move_expr_moveonly_partial_consumption.swift
+++ b/test/Sema/move_expr_moveonly_partial_consumption.swift
@@ -18,10 +18,10 @@ extension Quad_NC {
   consuming func explicitEveryLeaf() {
     _ = consume p1.u1
     _ = consume p1.u2
-    _ = consume p1.c
+    _ = consume p1.c // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
     _ = consume p2.u1
     _ = consume p2.u2
-    _ = consume p2.c
+    _ = consume p2.c // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
   }
 
   consuming func explicitSomeNonStorage() {
@@ -112,18 +112,18 @@ func decompose(_ c: consuming Container_NC) {
 // ====================== NONCOPYABLE GENERIC (BEGIN) ========================{{
 // =============================================================================
 
-extension Quad_NCG {
+extension Quad_NCG where T : ~Copyable {
   consuming func explicitEveryLeaf() {
     _ = consume p1.u1
     _ = consume p1.u1.t
     _ = consume p1.u2
     _ = consume p1.u2.t
-    _ = consume p1.c
+    _ = consume p1.c // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
     _ = consume p2.u1
     _ = consume p2.u1.t
     _ = consume p2.u2
     _ = consume p2.u2.t
-    _ = consume p2.c
+    _ = consume p2.c // expected-error{{'consume' can only be used to partially consume storage of a noncopyable type}}
   }
 
   consuming func explicitSomeNonStorage() {


### PR DESCRIPTION
Noncopyable fields of noncopyable aggregates may be partially consumed with the `consume` keyword.
