### PR TITLE
Emit reflection metadata for noncopyable fields more often

### DIFF
--- a/test/IRGen/noncopyable_field_descriptors.swift
+++ b/test/IRGen/noncopyable_field_descriptors.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-ir -o - %s -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -parse-as-library \
+// RUN:   -enable-library-evolution \
+// RUN:   > %t/test.irgen
+
+// RUN: %FileCheck %s < %t/test.irgen
+
+@frozen
+public enum ConditionallyCopyable<Wrapped: ~Copyable>: ~Copyable {
+  case none
+  case some(Wrapped)
+}
+
+extension ConditionallyCopyable: Copyable where Wrapped: Copyable { }
+
+@frozen
+public enum NeverCopyable<Wrapped: ~Copyable>: ~Copyable {
+  case none
+  case some(Wrapped)
+}
+
+@frozen
+public struct NonCopyable: ~Copyable { }
+
+// CHECK: @"$s4test1CCMF" = 
+// CHECK-SAME: @"symbolic _____yxG 4test21ConditionallyCopyableOAARiczrlE"
+// CHECK-SAME: @"get_type_metadata Riczl4test21ConditionallyCopyableOyAA03NonC0VG.3"
+// CHECK-SAME: @"symbolic _____yxG 4test21ConditionallyCopyableOAARiczrlE"
+// CHECK-SAME: @"get_type_metadata Riczl4test21ConditionallyCopyableOyAA03NonC0VG.3"
+public class C<T: ~Copyable> {
+  var ccT: ConditionallyCopyable<T> = .none
+  var ccNC: ConditionallyCopyable<NonCopyable> = .none
+  var ncT: ConditionallyCopyable<T> = .none
+  var ncNC: ConditionallyCopyable<NonCopyable> = .none
+}


### PR DESCRIPTION
When emitting reflection metadata for fields that have noncopyable type with deployment targets that predate support for noncopyable types, we introduce some indirection to make sure that these fields are only visible to reflection clients (e.g., mirrors) when running on a sufficiently-new Swift runtime. However, this indirection has the downside that out-of-process clients (such as LLDB) can no longer reflect the fields.

Tweak the heuristic to only introduce the indirection if the field is *guaranteed* to have noncopyable type. If it somehow could be copyable, e.g., based on the properties of its generic arguments, then still emit the normal metadata. This eliminates regressions when existing generic types like Optional become conditionally Copyable (based on their Wrapped functions).
