### PR TITLE
[5.10] Tests: fix typo in unsupported statement in IRGen/lto_autolink.swift

### DIFF
--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -63,6 +63,6 @@ import AutolinkModuleMapLink
 #endif
 
 // UNSUPPORTED: OS=macosx && CPU=arm64
-// UNSUPPORTED: OS=iphoneos && CPU=arm64e
+// UNSUPPORTED: OS=ios && CPU=arm64e
 // UNSUPPORTED: OS=watchos && CPU=arm64_32
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64


### PR DESCRIPTION
Cherry-pick of #72166.

rdar://122672371