### PR TITLE
[5.10] Tests: disable foundation-and-std-module.swift on Mac Catalyst

### DIFF
--- a/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
+++ b/test/Interop/Cxx/stdlib/foundation-and-std-module.swift
@@ -12,6 +12,9 @@
 
 // REQUIRES: OS=macosx || OS=linux-gnu
 
+// rdar://121125636
+// UNSUPPORTED: OS=maccatalyst
+
 #if canImport(Foundation)
 import Foundation
 #endif


### PR DESCRIPTION
Disabling test for rdar://121125636.

I'm not fully sure this syntax will work so it may need revisiting in a few days.