### PR TITLE
Sema: Skip missing async requirements of Obj-C protocols consistently

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4391,11 +4391,12 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
     return ResolveWitnessResult::ExplicitFailed;
   }
 
+  if (!shouldRecordMissingWitness(Proto, Conformance, requirement))
+    return ResolveWitnessResult::Missing;
 
   if (!numViable) {
     // Save the missing requirement for later diagnosis.
-    if (shouldRecordMissingWitness(Proto, Conformance, requirement))
-      getASTContext().addDelayedMissingWitness(Conformance, {requirement, matches});
+    getASTContext().addDelayedMissingWitness(Conformance, {requirement, matches});
     return ResolveWitnessResult::Missing;
   }
 


### PR DESCRIPTION
Requirements of Obj-C protocols that take a completion handler get imported with an `async` sibling requirement which can be fulfilled instead. Exactly one of these two requirements should be fulfilled. When resolving value witnesses ad-hoc, the compiler would only skip diagnosing a missing witness of an async requirement if the sibling requirement were fulfilled and there were zero viable matches. It shouldn't matter how many viable matches there are, though, since the alternative requirement is already witnessed.

There is no test case yet because when this problem reproduces, an assertion about resolving a witness after conformance checking is "complete" fails. A more significant overhaul of this logic should come later, but short-term we must fix source compatibility.

Resolves rdar://124145619
