### PR TITLE
Restore (TaskOptionRecordKind)0 to setting the initial serial executor

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2614,8 +2614,10 @@ enum class TaskStatusRecordKind : uint8_t {
 
 /// Kinds of option records that can be passed to creating asynchronous tasks.
 enum class TaskOptionRecordKind : uint8_t {
-  /// Request a task to be kicked off, or resumed, on a specific executor.
-  InitialTaskExecutor = 0,
+  /// Request a task to start running on a specific serial executor.
+  /// This was renamed in 6.0 to disambiguate with task executors, but the
+  /// support was in the runtime from the first release.
+  InitialSerialExecutor = 0,
   /// Request a child task to be part of a specific task group.
   TaskGroup = 1,
   /// DEPRECATED. AsyncLetWithBuffer is used instead.
@@ -2625,6 +2627,8 @@ enum class TaskOptionRecordKind : uint8_t {
   AsyncLetWithBuffer = 3,
   /// Information about the result type of the task, used in embedded Swift.
   ResultTypeInfo = 4,
+  /// Set the initial task executor preference of the task.
+  InitialTaskExecutor = 5,
   /// Request a child task for swift_task_run_inline.
   RunInline = UINT8_MAX,
 };

--- a/include/swift/ABI/TaskOptions.h
+++ b/include/swift/ABI/TaskOptions.h
@@ -97,6 +97,21 @@ public:
   }
 };
 
+/// Task option to specify the initial serial executor for the task.
+class InitialSerialExecutorTaskOptionRecord : public TaskOptionRecord {
+  const SerialExecutorRef Executor;
+public:
+  InitialSerialExecutorTaskOptionRecord(SerialExecutorRef executor)
+      : TaskOptionRecord(TaskOptionRecordKind::InitialSerialExecutor),
+        Executor(executor) {}
+
+  SerialExecutorRef getExecutorRef() const { return Executor; }
+
+  static bool classof(const TaskOptionRecord *record) {
+    return record->getKind() == TaskOptionRecordKind::InitialSerialExecutor;
+  }
+};
+
 /// DEPRECATED. AsyncLetWithBufferTaskOptionRecord is used instead.
 /// Task option to specify that the created task is for an 'async let'.
 class AsyncLetTaskOptionRecord : public TaskOptionRecord {

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -653,6 +653,11 @@ swift_task_create_commonImpl(size_t rawTaskCreateFlags,
   RunInlineTaskOptionRecord *runInlineOption = nullptr;
   for (auto option = options; option; option = option->getParent()) {
     switch (option->getKind()) {
+    case TaskOptionRecordKind::InitialSerialExecutor:
+      serialExecutor = cast<InitialSerialExecutorTaskOptionRecord>(option)
+                          ->getExecutorRef();
+      break;
+
     case TaskOptionRecordKind::InitialTaskExecutor:
       taskExecutor = cast<InitialTaskExecutorPreferenceTaskOptionRecord>(option)
                          ->getExecutorRef();

--- a/test/IRGen/async/builtins.sil
+++ b/test/IRGen/async/builtins.sil
@@ -112,8 +112,32 @@ sil hidden @launch_discarding_future_in_group_with_executor : $@convention(thin)
 bb0(%taskGroup : $Builtin.RawPointer, %taskExecutor : $Builtin.Executor, %taskFunction : $@Sendable @async @callee_guaranteed () -> @error Error, %flags: $Int):
   %optTaskGroup = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt, %taskGroup : $Builtin.RawPointer
   %optTaskExecutor = enum $Optional<Builtin.Executor>, #Optional.some!enumelt, %taskExecutor : $Builtin.Executor
+  // CHECK: [[GROUP_RECORD:%.*]] = alloca %swift.task_group_task_option
+  // CHECK: [[EXECUTOR_RECORD:%.*]] = alloca %swift.task_executor_task_option
   // CHECK-NOT: br i1
-  // CHECK: call swift{{(tail)?}}cc %swift.async_task_and_context @swift_task_create(
+
+  // CHECK: [[BASE_GEP:%.*]] = getelementptr inbounds %swift.task_group_task_option, ptr [[GROUP_RECORD]], i32 0, i32 0
+  // CHECK: [[FLAGS_GEP:%.*]] = getelementptr inbounds %swift.task_option, ptr [[BASE_GEP]], i32 0, i32 0
+  // CHECK: store [[INT]] 1, ptr [[FLAGS_GEP]], align
+  // CHECK: [[PARENT_GEP:%.*]] = getelementptr inbounds %swift.task_option, ptr [[BASE_GEP]], i32 0, i32 1
+  // CHECK: store [[INT]] 0, ptr [[PARENT_GEP]], align
+  // CHECK: [[GROUP_GEP:%.*]] = getelementptr inbounds %swift.task_group_task_option, ptr [[GROUP_RECORD]], i32 0, i32 1
+  // CHECK: store ptr %0, ptr [[GROUP_GEP]], align
+  // CHECK: [[OPTIONS_PTR:%.*]] = ptrtoint ptr [[GROUP_RECORD]] to [[INT]]
+
+  // CHECK: [[BASE_GEP:%.*]] = getelementptr inbounds %swift.task_executor_task_option, ptr [[EXECUTOR_RECORD]], i32 0, i32 0
+  // CHECK: [[FLAGS_GEP:%.*]] = getelementptr inbounds %swift.task_option, ptr [[BASE_GEP]], i32 0, i32 0
+  // CHECK: store [[INT]] 5, ptr [[FLAGS_GEP]], align
+  // CHECK: [[PARENT_GEP:%.*]] = getelementptr inbounds %swift.task_option, ptr [[BASE_GEP]], i32 0, i32 1
+  // CHECK: store [[INT]] [[OPTIONS_PTR]], ptr [[PARENT_GEP]], align
+  // CHECK: [[EXECUTOR_GEP:%.*]] = getelementptr inbounds %swift.task_executor_task_option, ptr [[EXECUTOR_RECORD]], i32 0, i32 1
+  // CHECK: [[EXECUTOR_IDENT_GEP:%.*]] = getelementptr inbounds %swift.executor, ptr [[EXECUTOR_GEP]], i32 0, i32 0
+  // CHECK: store [[INT]] %1, ptr [[EXECUTOR_IDENT_GEP]], align
+  // CHECK: [[EXECUTOR_IMPL_GEP:%.*]] = getelementptr inbounds %swift.executor, ptr [[EXECUTOR_GEP]], i32 0, i32 1
+  // CHECK: store [[INT]] %2, ptr [[EXECUTOR_IMPL_GEP]], align
+  // CHECK: [[OPTIONS_PTR:%.*]] = ptrtoint ptr [[EXECUTOR_RECORD]] to [[INT]]
+
+  // CHECK: call swift{{(tail)?}}cc %swift.async_task_and_context @swift_task_create([[INT]] %5, [[INT]] [[OPTIONS_PTR]]
   %9 = builtin "createAsyncTask"(%flags : $Int, %optTaskGroup : $Optional<Builtin.RawPointer>, %optTaskExecutor: $Optional<Builtin.Executor>, %taskFunction : $@Sendable @async @callee_guaranteed () -> @error Error) : $(Builtin.NativeObject, Builtin.RawPointer)
   %10 = tuple_extract %9 : $(Builtin.NativeObject, Builtin.RawPointer), 0
   strong_release %10 : $Builtin.NativeObject


### PR DESCRIPTION
This has been the behavior of the runtime since the initial release. Initially, it was thought that task executors would provide similar functionality, so they naturally took over the enumerator.  After that changed, we forgot to change it back.  Fortunately, we haven't released any versions of Swift with the task executors feature yet, so it's not too late to fix this.