### PR TITLE
InitializeStaticGlobals: don't merge stores for structs with unreferencable storage

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/InitializeStaticGlobals.swift
@@ -113,10 +113,14 @@ private func getSequenceOfElementStores(firstStore: StoreInst) -> ([StoreInst], 
     return nil
   }
   let structAddr = elementAddr.struct
-  if structAddr.type.isMoveOnly {
+  let structType = structAddr.type
+  if structType.isMoveOnly {
     return nil
   }
-  guard let fields = structAddr.type.getNominalFields(in: firstStore.parentFunction) else {
+  if structType.nominal.isStructWithUnreferenceableStorage {
+    return nil
+  }
+  guard let fields = structType.getNominalFields(in: firstStore.parentFunction) else {
     return nil
   }
   let numElements = fields.count

--- a/test/SILOptimizer/Inputs/bitfield.h
+++ b/test/SILOptimizer/Inputs/bitfield.h
@@ -1,0 +1,5 @@
+
+struct S {
+    int a;
+    int b : 8;
+};

--- a/test/SILOptimizer/global_init_opt.swift
+++ b/test/SILOptimizer/global_init_opt.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-as-library -O -module-name=test %s -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -parse-as-library -O -import-objc-header %S/Inputs/bitfield.h -module-name=test %s -emit-sil | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 
@@ -6,6 +6,9 @@ var gg: Int = {
   print("gg init")
   return 27
 }()
+
+// Test that the compiler doesn't crash with a global C bitfield.
+var bitfield = S(a: 0, b: 0)
 
 // CHECK-LABEL: sil @$s4test3cseSiyF
 // CHECK:   builtin "once"


### PR DESCRIPTION
like C bitfields.

Fixes a compiler crash
rdar://122360051
