### PR TITLE
WASI: Enable `netdb.h` in `wasi-libc.modulemap`

### DIFF
--- a/stdlib/public/Platform/wasi-libc.modulemap
+++ b/stdlib/public/Platform/wasi-libc.modulemap
@@ -41,6 +41,7 @@ module SwiftWASILibc [system] {
   header "langinfo.h"
   header "libgen.h"
   header "monetary.h"
+  header "netdb.h"
   header "netinet/in.h"
   header "netinet/tcp.h"
   header "nl_types.h"


### PR DESCRIPTION
This header is present in WASI-libc, and its absence blocks SwiftNIO from building with WASI.
