### PR TITLE
[5.10] Tests: mark armv7k as unsupported for lto_autolink.swift

### DIFF
--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -64,5 +64,5 @@ import AutolinkModuleMapLink
 
 // UNSUPPORTED: OS=macosx && CPU=arm64
 // UNSUPPORTED: OS=ios && CPU=arm64e
-// UNSUPPORTED: OS=watchos && CPU=arm64_32
+// UNSUPPORTED: OS=watchos && (CPU=arm64_32 || CPU=armv7k)
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64


### PR DESCRIPTION
This test also fails on armv7k. Addressing the failure on 5.10 first as the corresponding bot on main fails earlier.

Followup to #72167
rdar://122672371