### PR TITLE
[Caching] Fix stack-use-after-scope in CachedDiagnostics

### DIFF
--- a/test/CAS/cached_diagnostics.swift
+++ b/test/CAS/cached_diagnostics.swift
@@ -4,8 +4,13 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -scan-dependencies -module-name Test -O -import-objc-header %S/Inputs/objc.h \
-// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import \
 // RUN:   %s -o %t/deps.json -cache-compile-job -cas-path %t/cas
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:SwiftShims > %t/shim.cmd
+// RUN: %swift_frontend_plain @%t/shim.cmd
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Swift > %t/swift.cmd
+// RUN: %swift_frontend_plain @%t/swift.cmd
 
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json bridgingHeader | tail -n +2  > %t/header.cmd
 // RUN: %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules %S/Inputs/objc.h -O -o %t/objc.pch 2>&1 | %FileCheck %s -check-prefix CHECK-BRIDGE
@@ -13,15 +18,19 @@
 // RUN:   %target-swift-frontend @%t/header.cmd -disable-implicit-swift-modules %S/Inputs/objc.h -O -o %t/objc.pch > %t/keys.json
 // RUN: %{python} %S/Inputs/ExtractOutputKey.py %t/keys.json %S/Inputs/objc.h > %t/key
 
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
 // RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-string-processing-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-concurrency-module-import\"" >> %t/MyApp.cmd
 // RUN: echo "\"-disable-implicit-swift-modules\"" >> %t/MyApp.cmd
-// RUN: echo "\"-parse-stdlib\"" >> %t/MyApp.cmd
 // RUN: echo "\"-import-objc-header\"" >> %t/MyApp.cmd
 // RUN: echo "\"%t/objc.pch\"" >> %t/MyApp.cmd
 // RUN: echo "\"-bridging-header-pch-key\"" >> %t/MyApp.cmd
 // RUN: echo "\"@%t/key\"" >> %t/MyApp.cmd
+// RUN: echo "\"-explicit-swift-module-map-file\"" >> %t/MyApp.cmd
+// RUN: echo "\"@%t/map.casid\"" >> %t/MyApp.cmd
 
 // RUN: %target-swift-frontend  -cache-compile-job -module-name Test -O -cas-path %t/cas @%t/MyApp.cmd %s \
 // RUN:   -emit-module -o %t/test.swiftmodule 2>&1 | %FileCheck %s
@@ -31,6 +40,15 @@
 // RUN:   -emit-module -o %t/test.swiftmodule 2>&1 | %FileCheck %s
 
 #warning("this is a warning")  // expected-warning {{this is a warning}}
+
+enum MyEnum {
+    case kind
+    case none
+}
+
+let _ : MyEnum? = .none // expected-warning {{assuming you mean 'Optional<MyEnum>.none'; did you mean 'MyEnum.none' instead?}}
+// expected-note@-1 {{explicitly specify 'Optional' to silence this warning}} {{19-19=Optional}}
+// expected-note@-2 {{use 'MyEnum.none' instead}} {{19-19=MyEnum}}
 
 // CHECK-BRIDGE: warning: warning in bridging header
 // CHECK: warning: this is a warning


### PR DESCRIPTION
Fix a stack-use-after-scope in the CachedDiagnostics when the DiagnosticInfo entry that is getting deserialized has ChildDiagnostics.

There are some fields in the DiagnosticInfo are not owned by the DiagnosticsInfo itself. While the callback during the deserialization ensures those fields are still alive for the top level DiagnosticInfo when it gets used, it is not true for any child diagnostics info inside.

rdar://123846525
