### PR TITLE
MemoryLifetimeVerifier: Treat only destructive enum_data_addr insns as writes.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -7031,18 +7031,25 @@ unchecked_take_enum_data_addr
   // #U.DataCase must be a case of enum $U with data
   // %1 will be of address type $*T for the data type of case U.DataCase
 
-Invalidates an enum value, and takes the address of the payload for the given
-enum ``case`` in-place in memory. The referenced enum value is no longer valid,
-but the payload value referenced by the result address is valid and must be
-destroyed. It is undefined behavior if the referenced enum does not contain a
-value of the given ``case``. The result shares memory with the original enum
-value; the enum memory cannot be reinitialized as an enum until the payload has
-also been invalidated.
+Takes the address of the payload for the given enum ``case`` in-place in
+memory. It is undefined behavior if the referenced enum does not contain a
+value of the given ``case``. 
 
-(1.0 only)
+The result shares memory with the original enum value.  If an enum declaration
+is unconditionally loadable (meaning it's loadable regardless of any generic
+parameters), and it has more than one case with an associated value, then it
+may embed the enum tag within the payload area. If this is the case, then
+`unchecked_take_enum_data_addr` will clear the tag from the payload,
+invalidating the referenced enum value, but leaving the
+payload value referenced by the result address valid. In these cases,
+the enum memory cannot be reinitialized as an enum until the payload has also
+been invalidated.
 
-For the first payloaded case of an enum, ``unchecked_take_enum_data_addr``
-is guaranteed to have no side effects; the enum value will not be invalidated.
+If an enum has no more than one payload case, or if the declaration is ever
+address-only, then `unchecked_take_enum_data_addr` is guaranteed to be
+nondestructive, and the payload address can be accessed without invalidating
+the enum in these cases. The payload can be invalidated to invalidate the
+enum (assuming the enum does not have a `deinit` at the type level).
 
 select_enum
 ```````````

--- a/test/Interpreter/moveonly_linkedlist_2_simple.swift
+++ b/test/Interpreter/moveonly_linkedlist_2_simple.swift
@@ -8,6 +8,7 @@
 // RUN: %FileCheck %s --check-prefix=CHECK-IR
 // RUN: %target-run-simple-swift(-parse-as-library -enable-builtin-module -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -Xfrontend -sil-verify-all) | %FileCheck %s
 // RUN: %target-run-simple-swift(-O -parse-as-library -enable-builtin-module -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -Xfrontend -sil-verify-all) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -parse-as-library -enable-builtin-module -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BorrowingSwitch -Xfrontend -sil-verify-all -Xfrontend -enable-ossa-modules) | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -362,7 +362,6 @@ bb0(%0 :  @guaranteed $Optional<T>):
   return %res : $()
 }
 
-// CHECK: SIL memory lifetime failure in @test_store_borrow_take_enum: store-borrow location cannot be written
 sil [ossa] @test_store_borrow_take_enum : $@convention(thin) (@guaranteed Optional<T>) -> () {
 bb0(%0 :  @guaranteed $Optional<T>):
   %s = alloc_stack $Optional<T>


### PR DESCRIPTION
It is ok to project the data from an enum in cases where we know spare bit packing can never happen. Fixes rdar://124240723.