### PR TITLE
Erase existential thrown error types

### DIFF
--- a/test/Concurrency/async_sequence_existential.swift
+++ b/test/Concurrency/async_sequence_existential.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
+
+// RUN: %target-swift-frontend  -disable-availability-checking %s -dump-ast 2>&1 | %FileCheck %s
+
+// REQUIRES: concurrency
+
+extension Error {
+  func printMe() { }
+}
+
+func test(seq: any AsyncSequence) async {
+  // CHECK: "error" interface type="any Error"
+  do {
+    for try await _ in seq { }
+  } catch {
+    error.printMe()
+  }
+}


### PR DESCRIPTION
When performing a throwing operation on an opened existential, the thrown error type could be dependent on the opened existential type, e.g., if the thrown error type is an associated type of one of the corresponding protocols. In such cases, type-erase the thrown error type at the point where it is thrown so that the opened archetype cannot "escape" the enclosing opened-existential operation via throwing.

There is an alternative approach we could take that has `OpenExistentialExpr` handle the type erasure of the thrown error type. This would make `OpenExistentialExpr` a catch node, which would type-erase and then rethrow. This is arguably better, because it could mean fewer places where we do the type erasure and is more in line with the design of opened archetypes. However, it would also be much more invasive, and we should be able to do this later.

Fixes rdar://124273722.
