### PR TITLE
[region-isolation] Make fields of global actor guarded types that are non-Sendable be considered as actor isolated.

### DIFF
--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -935,8 +935,7 @@ class SILExtInfoBuilder {
     DifferentiabilityMask = 0x7 << DifferentiabilityMaskOffset,
     UnimplementableMask = 1 << 12,
     ErasedIsolationMask = 1 << 13,
-    TransferringResultMask = 1 << 14,
-    NumMaskBits = 15
+    NumMaskBits = 14
   };
 
   unsigned bits; // Naturally sized for speed.
@@ -957,17 +956,15 @@ class SILExtInfoBuilder {
                                      bool isNoEscape, bool isSendable,
                                      bool isAsync, bool isUnimplementable,
                                      SILFunctionTypeIsolation isolation,
-                                     bool hasTransferringResult,
                                      DifferentiabilityKind diffKind) {
     return ((unsigned)rep) | (isPseudogeneric ? PseudogenericMask : 0) |
            (isNoEscape ? NoEscapeMask : 0) | (isSendable ? SendableMask : 0) |
            (isAsync ? AsyncMask : 0) |
            (isUnimplementable ? UnimplementableMask : 0) |
-           (isolation == SILFunctionTypeIsolation::Erased
-              ? ErasedIsolationMask : 0) |
+           (isolation == SILFunctionTypeIsolation::Erased ? ErasedIsolationMask
+                                                          : 0) |
            (((unsigned)diffKind << DifferentiabilityMaskOffset) &
-            DifferentiabilityMask) |
-           (hasTransferringResult ? TransferringResultMask : 0);
+            DifferentiabilityMask);
   }
 
 public:
@@ -976,7 +973,7 @@ public:
   SILExtInfoBuilder()
       : SILExtInfoBuilder(makeBits(SILFunctionTypeRepresentation::Thick, false,
                                    false, false, false, false,
-                                   SILFunctionTypeIsolation::Unknown, false,
+                                   SILFunctionTypeIsolation::Unknown,
                                    DifferentiabilityKind::NonDifferentiable),
                           ClangTypeInfo(nullptr), LifetimeDependenceInfo()) {}
 
@@ -984,11 +981,10 @@ public:
                     bool isSendable, bool isAsync, bool isUnimplementable,
                     SILFunctionTypeIsolation isolation,
                     DifferentiabilityKind diffKind, const clang::Type *type,
-                    LifetimeDependenceInfo lifetimeDependenceInfo,
-                    bool hasTransferringResult)
+                    LifetimeDependenceInfo lifetimeDependenceInfo)
       : SILExtInfoBuilder(makeBits(rep, isPseudogeneric, isNoEscape, isSendable,
                                    isAsync, isUnimplementable, isolation,
-                                   hasTransferringResult, diffKind),
+                                   diffKind),
                           ClangTypeInfo(type), lifetimeDependenceInfo) {}
 
   // Constructor for polymorphic type.
@@ -999,7 +995,6 @@ public:
                                    info.getIsolation().isErased()
                                        ? SILFunctionTypeIsolation::Erased
                                        : SILFunctionTypeIsolation::Unknown,
-                                   /*has transferring result*/ false,
                                    info.getDifferentiabilityKind()),
                           info.getClangTypeInfo(),
                           info.getLifetimeDependenceInfo()) {}
@@ -1028,10 +1023,6 @@ public:
   constexpr bool isSendable() const { return bits & SendableMask; }
 
   constexpr bool isAsync() const { return bits & AsyncMask; }
-
-  constexpr bool hasTransferringResult() const {
-    return bits & TransferringResultMask;
-  }
 
   constexpr DifferentiabilityKind getDifferentiabilityKind() const {
     return DifferentiabilityKind((bits & DifferentiabilityMask) >>
@@ -1166,14 +1157,6 @@ public:
                              clangTypeInfo, lifetimeDependenceInfo);
   }
 
-  [[nodiscard]] SILExtInfoBuilder
-  withTransferringResult(bool hasTransferringResult = true) const {
-    return SILExtInfoBuilder(hasTransferringResult
-                                 ? (bits | TransferringResultMask)
-                                 : (bits & ~TransferringResultMask),
-                             clangTypeInfo, lifetimeDependenceInfo);
-  }
-
   [[nodiscard]]
   SILExtInfoBuilder
   withDifferentiabilityKind(DifferentiabilityKind differentiability) const {
@@ -1239,11 +1222,11 @@ public:
 
   /// A default ExtInfo but with a Thin convention.
   static SILExtInfo getThin() {
-    return SILExtInfoBuilder(
-               SILExtInfoBuilder::Representation::Thin, false, false, false,
-               false, false, SILFunctionTypeIsolation::Unknown,
-               DifferentiabilityKind::NonDifferentiable, nullptr,
-               LifetimeDependenceInfo(), false /*transferring result*/)
+    return SILExtInfoBuilder(SILExtInfoBuilder::Representation::Thin, false,
+                             false, false, false, false,
+                             SILFunctionTypeIsolation::Unknown,
+                             DifferentiabilityKind::NonDifferentiable, nullptr,
+                             LifetimeDependenceInfo())
         .build();
   }
 
@@ -1279,10 +1262,6 @@ public:
   }
   constexpr SILFunctionTypeIsolation getIsolation() const {
     return builder.getIsolation();
-  }
-
-  constexpr bool hasTransferringResult() const {
-    return builder.hasTransferringResult();
   }
 
   constexpr DifferentiabilityKind getDifferentiabilityKind() const {
@@ -1329,10 +1308,6 @@ public:
 
   SILExtInfo withUnimplementable(bool isUnimplementable = true) const {
     return builder.withUnimplementable(isUnimplementable).build();
-  }
-
-  SILExtInfo withTransferringResult(bool hasTransferringResult = true) const {
-    return builder.withTransferringResult(hasTransferringResult).build();
   }
 
   SILExtInfo withLifetimeDependenceInfo(LifetimeDependenceInfo info) const {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -383,7 +383,7 @@ class alignas(1 << TypeAlignInBits) TypeBase
 
 protected:
   enum { NumAFTExtInfoBits = 15 };
-  enum { NumSILExtInfoBits = 15 };
+  enum { NumSILExtInfoBits = 14 };
 
   // clang-format off
   union { uint64_t OpaqueBits;
@@ -4462,6 +4462,11 @@ public:
     /// - The function type is `@differentiable`, the function is
     ///   differentiable with respect to this result.
     NotDifferentiable = 0x1,
+
+    /// Set if a return type is transferring. This means that the returned value
+    /// must be disconnected and not in any strongly structured regions like an
+    /// actor or a task isolated variable.
+    IsTransferring = 0x2,
   };
 
   using Options = OptionSet<Flag>;
@@ -4906,8 +4911,13 @@ public:
   SILFunctionTypeIsolation getIsolation() const {
     return getExtInfo().getIsolation();
   }
+
+  /// Return true if all
   bool hasTransferringResult() const {
-    return getExtInfo().hasTransferringResult();
+    // For now all functions either have all transferring results or no
+    // transferring results. This is validated with a SILVerifier check.
+    return getNumResults() &&
+           getResults().front().hasOption(SILResultInfo::IsTransferring);
   }
 
   /// Return the array of all the yields.

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -116,6 +116,7 @@ using ImplParameterInfoOptions = OptionSet<ImplParameterInfoFlags>;
 
 enum class ImplResultInfoFlags : uint8_t {
   NotDifferentiable = 0x1,
+  IsTransferring = 0x2,
 };
 
 using ImplResultInfoOptions = OptionSet<ImplResultInfoFlags>;

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -558,6 +558,11 @@ getResultOptions(ImplResultInfoOptions implOptions) {
     result |= SILResultInfo::NotDifferentiable;
   }
 
+  if (implOptions.contains(ImplResultInfoFlags::IsTransferring)) {
+    implOptions -= ImplResultInfoFlags::IsTransferring;
+    result |= SILResultInfo::IsTransferring;
+  }
+
   // If we did not remove all of the options from implOptions, someone forgot to
   // update this code for a new type of flag. Return none to signal error!
   if (bool(implOptions))
@@ -664,8 +669,7 @@ Type ASTBuilder::createImplFunctionType(
   auto einfo = SILFunctionType::ExtInfoBuilder(
                    representation, flags.isPseudogeneric(), !flags.isEscaping(),
                    flags.isSendable(), flags.isAsync(), unimplementable,
-                   isolation, diffKind, clangFnType, LifetimeDependenceInfo(),
-                   flags.hasTransferringResult())
+                   isolation, diffKind, clangFnType, LifetimeDependenceInfo())
                    .build();
 
   return SILFunctionType::get(genericSig, einfo, funcCoroutineKind,

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6740,10 +6740,6 @@ public:
       }
       sub->Printer << ") -> ";
 
-      if (T->hasTransferringResult()) {
-        sub->Printer << "transferring ";
-      }
-
       auto lifetimeDependenceInfo = T->getLifetimeDependenceInfo();
       if (!lifetimeDependenceInfo.empty()) {
         sub->Printer << lifetimeDependenceInfo.getString() << " ";
@@ -7530,6 +7526,11 @@ void SILResultInfo::print(ASTPrinter &Printer, const PrintOptions &Opts) const {
   if (options.contains(SILResultInfo::NotDifferentiable)) {
     options -= SILResultInfo::NotDifferentiable;
     Printer << "@noDerivative ";
+  }
+
+  if (options.contains(SILResultInfo::IsTransferring)) {
+    options -= SILResultInfo::IsTransferring;
+    Printer << "@sil_transferring ";
   }
 
   assert(!bool(options) && "ResultInfo has option that was not handled?!");

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6518,6 +6518,17 @@ public:
     require(!FTy->hasErasedIsolation() ||
              FTy->getRepresentation() == SILFunctionType::Representation::Thick,
             "only thick function types can have erased isolation");
+
+    // If our function hasTransferringResult, then /all/ results must be
+    // transferring.
+    require(FTy->hasTransferringResult() ==
+                (FTy->getResults().size() &&
+                 llvm::all_of(FTy->getResults(),
+                              [](SILResultInfo result) {
+                                return result.hasOption(
+                                    SILResultInfo::IsTransferring);
+                              })),
+            "transferring result means all results are transferring");
   }
 
   struct VerifyFlowSensitiveRulesDetails {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4293,14 +4293,10 @@ NeverNullType TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,
     }
   }
 
-  bool hasTransferringResult =
-      isa_and_nonnull<TransferringTypeRepr>(repr->getResultTypeRepr());
-
   // TODO: Handle LifetimeDependenceInfo here.
   auto extInfoBuilder = SILFunctionType::ExtInfoBuilder(
       representation, pseudogeneric, noescape, sendable, async, unimplementable,
-      isolation, diffKind, clangFnType, LifetimeDependenceInfo(),
-      hasTransferringResult);
+      isolation, diffKind, clangFnType, LifetimeDependenceInfo());
 
   // Resolve parameter and result types using the function's generic
   // environment.
@@ -4631,6 +4627,10 @@ bool TypeResolver::resolveSingleSILResult(
     // Recognize `@noDerivative`.
     if (claim<NoDerivativeTypeAttr>(attrs)) {
       resultInfoOptions |= SILResultInfo::NotDifferentiable;
+    }
+
+    if (claim<SILTransferringTypeAttr>(attrs)) {
+      resultInfoOptions |= SILResultInfo::IsTransferring;
     }
 
     type = resolveAttributedType(repr, options, attrs);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6560,6 +6560,11 @@ getActualSILResultOptions(uint8_t raw) {
     result |= SILResultInfo::NotDifferentiable;
   }
 
+  if (options.contains(serialization::SILResultInfoFlags::IsTransferring)) {
+    options -= serialization::SILResultInfoFlags::IsTransferring;
+    result |= SILResultInfo::IsTransferring;
+  }
+
   // Check if we have any remaining options and return none if we do. We found
   // some option that we did not understand.
   if (bool(options)) {
@@ -7356,7 +7361,6 @@ Expected<Type> DESERIALIZE_TYPE(SIL_FUNCTION_TYPE)(
   bool noescape;
   bool erasedIsolation;
   bool hasErrorResult;
-  bool hasTransferringResult;
   unsigned numParams;
   unsigned numYields;
   unsigned numResults;
@@ -7369,7 +7373,7 @@ Expected<Type> DESERIALIZE_TYPE(SIL_FUNCTION_TYPE)(
   decls_block::SILFunctionTypeLayout::readRecord(
       scratch, concurrent, async, rawCoroutineKind, rawCalleeConvention,
       rawRepresentation, pseudogeneric, noescape, unimplementable,
-      erasedIsolation, rawDiffKind, hasErrorResult, hasTransferringResult,
+      erasedIsolation, rawDiffKind, hasErrorResult,
       numParams, numYields, numResults, rawInvocationGenericSig,
       rawInvocationSubs, rawPatternSubs, clangFunctionTypeID, variableData);
 
@@ -7399,7 +7403,7 @@ Expected<Type> DESERIALIZE_TYPE(SIL_FUNCTION_TYPE)(
       SILFunctionType::ExtInfoBuilder(
           *representation, pseudogeneric, noescape, concurrent, async,
           unimplementable, isolation, *diffKind, clangFunctionType,
-          LifetimeDependenceInfo(), hasTransferringResult)
+          LifetimeDependenceInfo())
           .build();
 
   // Process the coroutine kind.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,8 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR =
-    862; // add lifetime dependence info in type serialization as well.
+const uint16_t SWIFTMODULE_VERSION_MINOR = 863; // @sil_transferring
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -424,6 +423,7 @@ using ResultConventionField = BCFixed<3>;
 /// module version.
 enum class SILResultInfoFlags : uint8_t {
   NotDifferentiable = 0x1,
+  IsTransferring = 0x2,
 };
 
 using SILResultInfoOptions = OptionSet<SILResultInfoFlags>;
@@ -1364,7 +1364,6 @@ namespace decls_block {
     BCFixed<1>,                         // erased isolation?
     DifferentiabilityKindField,         // differentiability kind
     BCFixed<1>,                         // error result?
-    BCFixed<1>,                         // transferring result
     BCVBR<6>,                           // number of parameters
     BCVBR<5>,                           // number of yields
     BCVBR<5>,                           // number of results

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -5219,6 +5219,11 @@ getRawSILResultInfoOptions(swift::SILResultInfo::Options options) {
     result |= SILResultInfoFlags::NotDifferentiable;
   }
 
+  if (options.contains(SILResultInfo::IsTransferring)) {
+    options -= SILResultInfo::IsTransferring;
+    result |= SILResultInfoFlags::IsTransferring;
+  }
+
   // If we still have any options set, then this code is out of sync. Signal an
   // error by returning none!
   if (bool(options))
@@ -5706,7 +5711,7 @@ public:
         fnTy->isAsync(), stableCoroutineKind, stableCalleeConvention,
         stableRepresentation, fnTy->isPseudogeneric(), fnTy->isNoEscape(),
         fnTy->isUnimplementable(), fnTy->hasErasedIsolation(),
-        stableDiffKind, fnTy->hasErrorResult(), fnTy->hasTransferringResult(),
+        stableDiffKind, fnTy->hasErrorResult(),
         fnTy->getParameters().size(),
         fnTy->getNumYields(), fnTy->getNumResults(),
         invocationSigID, invocationSubstMapID, patternSubstMapID,

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -transfer-non-sendable -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete %s -o /dev/null -verify
+// RUN: %target-sil-opt -transfer-non-sendable -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults -strict-concurrency=complete %s -o /dev/null -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts
@@ -199,3 +199,10 @@ bb1:
   return %9999 : $()
 }
 
+sil [ossa] @synchronous_returns_transferring_error : $@convention(method) (@guaranteed NonSendableStruct) -> @sil_transferring @owned NonSendableKlass {
+bb0(%0 : @guaranteed $NonSendableStruct):
+  debug_value %0 : $NonSendableStruct, var, name "myname"
+  %2 = struct_extract %0 : $NonSendableStruct, #NonSendableStruct.ns
+  %3 = copy_value %2 : $NonSendableKlass
+  return %3 : $NonSendableKlass // expected-warning {{call site passes `self`}}
+}

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -13,6 +13,7 @@ sil_stage raw
 
 import Swift
 import Builtin
+import _Concurrency
 
 ////////////////////////
 // MARK: Declarations //
@@ -76,6 +77,17 @@ case some(T)
 
 sil @swift_asyncLet_get : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
 sil @swift_asyncLet_finish : $@convention(thin) @async (Builtin.RawPointer, Builtin.RawPointer) -> ()
+
+@MainActor
+struct MainActorIsolatedStruct {
+  let ns: NonSendableKlass
+}
+
+@MainActor
+enum MainActorIsolatedEnum {
+  case first
+  case second(NonSendableKlass)
+}
 
 /////////////////
 // MARK: Tests //
@@ -199,10 +211,60 @@ bb1:
   return %9999 : $()
 }
 
-sil [ossa] @synchronous_returns_transferring_error : $@convention(method) (@guaranteed NonSendableStruct) -> @sil_transferring @owned NonSendableKlass {
+sil [ossa] @synchronous_returns_transferring : $@convention(method) (@guaranteed NonSendableStruct) -> @sil_transferring @owned NonSendableKlass {
 bb0(%0 : @guaranteed $NonSendableStruct):
   debug_value %0 : $NonSendableStruct, var, name "myname"
   %2 = struct_extract %0 : $NonSendableStruct, #NonSendableStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
   return %3 : $NonSendableKlass // expected-warning {{call site passes `self`}}
+}
+
+sil [ossa] @synchronous_returns_transferring_globalactor_struct_structextract : $@convention(method) (@guaranteed MainActorIsolatedStruct) -> @sil_transferring @owned NonSendableKlass {
+bb0(%0 : @guaranteed $MainActorIsolatedStruct):
+  debug_value %0 : $MainActorIsolatedStruct, var, name "myname"
+  %2 = struct_extract %0 : $MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
+  %3 = copy_value %2 : $NonSendableKlass
+  return %3 : $NonSendableKlass // expected-warning {{call site passes `self`}}
+}
+
+sil [ossa] @synchronous_returns_transferring_globalactor_struct_structelementaddr : $@convention(method) (@in_guaranteed MainActorIsolatedStruct) -> @sil_transferring @owned NonSendableKlass {
+bb0(%0 : $*MainActorIsolatedStruct):
+  debug_value %0 : $*MainActorIsolatedStruct, var, name "myname"
+  %2 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
+  %3 = load [copy] %2 : $*NonSendableKlass
+  return %3 : $NonSendableKlass // expected-warning {{call site passes `self`}}
+}
+
+sil [ossa] @synchronous_returns_transferring_globalactor_enum_uncheckedenumdata : $@convention(method) (@guaranteed MainActorIsolatedEnum) -> @sil_transferring @owned NonSendableKlass {
+bb0(%0 : @guaranteed $MainActorIsolatedEnum):
+  debug_value %0 : $MainActorIsolatedEnum, var, name "myname"
+  %2 = unchecked_enum_data %0 : $MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
+  %3 = copy_value %2 : $NonSendableKlass
+  return %3 : $NonSendableKlass // expected-warning {{call site passes `self`}}
+}
+
+sil [ossa] @synchronous_returns_transferring_globalactor_enum_uncheckedtakeenumdataaddr : $@convention(method) (@in MainActorIsolatedEnum) -> @sil_transferring @owned NonSendableKlass {
+bb0(%0 : $*MainActorIsolatedEnum):
+  debug_value %0 : $*MainActorIsolatedEnum, var, name "myname"
+  %2 = unchecked_take_enum_data_addr %0 : $*MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
+  %3 = load [take] %2 : $*NonSendableKlass
+  return %3 : $NonSendableKlass // expected-warning {{call site passes `self`}}
+}
+
+sil [ossa] @synchronous_returns_transferring_globalactor_enum_switchenum : $@convention(method) (@guaranteed MainActorIsolatedEnum) -> @sil_transferring @owned FakeOptional<NonSendableKlass> {
+bb0(%0 : @guaranteed $MainActorIsolatedEnum):
+  debug_value %0 : $MainActorIsolatedEnum, var, name "myname"
+  switch_enum %0 : $MainActorIsolatedEnum, case #MainActorIsolatedEnum.first!enumelt: bb1, case #MainActorIsolatedEnum.second!enumelt: bb2
+
+bb1:
+  %nil = enum $FakeOptional<NonSendableKlass>, #FakeOptional.none!enumelt
+  br bb3(%nil : $FakeOptional<NonSendableKlass>)
+
+bb2(%1 : @guaranteed $NonSendableKlass):
+  %2 = copy_value %1 : $NonSendableKlass
+  %3 = enum $FakeOptional<NonSendableKlass>, #FakeOptional.some!enumelt, %2 : $NonSendableKlass
+  br bb3(%3 : $FakeOptional<NonSendableKlass>)
+
+bb3(%4 : @owned $FakeOptional<NonSendableKlass>):
+  return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{call site passes `self`}}
 }

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -53,6 +53,11 @@ func transferAsyncResultWithTransferringArg2Throwing(_ x: transferring NonSendab
 
 @MainActor var globalNonSendableKlass = NonSendableKlass()
 
+@MainActor
+struct MainActorIsolatedStruct {
+  let ns = NonSendableKlass()
+}
+
 /////////////////
 // MARK: Tests //
 /////////////////
@@ -115,4 +120,13 @@ func useTransferredResultMainActor() async {
 
 func useTransferredResult() async {
   let _ = await transferAsyncResult()
+}
+
+extension MainActorIsolatedStruct {
+  func testNonSendableErrorReturnWithTransfer() -> transferring NonSendableKlass {
+    return ns
+  }
+  func testNonSendableErrorReturnNoTransfer() -> NonSendableKlass {
+    return ns
+  }
 }

--- a/test/SILGen/transferring.swift
+++ b/test/SILGen/transferring.swift
@@ -2,97 +2,97 @@
 
 class NonSendable {}
 
-// CHECK-LABEL: sil hidden [ossa] @$s12transferring15returnsSendableSSyYTF : $@convention(thin) () -> transferring @owned String {
+// CHECK-LABEL: sil hidden [ossa] @$s12transferring15returnsSendableSSyYTF : $@convention(thin) () -> @sil_transferring @owned String {
 func returnsSendable() -> transferring String { fatalError() }
-// CHECK-LABEL: sil hidden [ossa] @$s12transferring18returnsNonSendableAA0cD0CyYTF : $@convention(thin) () -> transferring @owned NonSendable {
+// CHECK-LABEL: sil hidden [ossa] @$s12transferring18returnsNonSendableAA0cD0CyYTF : $@convention(thin) () -> @sil_transferring @owned NonSendable {
 func returnsNonSendable() -> transferring NonSendable { fatalError() }
-// CHECK-LABEL: sil hidden [ossa] @$s12transferring25genericReturnsNonSendablexyYTlF : $@convention(thin) <T> () -> transferring @out T {
+// CHECK-LABEL: sil hidden [ossa] @$s12transferring25genericReturnsNonSendablexyYTlF : $@convention(thin) <T> () -> @sil_transferring @out T {
 func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 
 actor MyActor {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC15returnsSendableSSyYTF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC15returnsSendableSSyYTF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_transferring @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC18returnsNonSendableAA0eF0CyYTF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC18returnsNonSendableAA0eF0CyYTF : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @sil_transferring @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@sil_isolated @guaranteed MyActor) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring7MyActorC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@sil_isolated @guaranteed MyActor) -> @sil_transferring @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 struct Struct {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV15returnsSendableSSyYTF : $@convention(method) (Struct) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV15returnsSendableSSyYTF : $@convention(method) (Struct) -> @sil_transferring @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV18returnsNonSendableAA0dE0CyYTF : $@convention(method) (Struct) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV18returnsNonSendableAA0dE0CyYTF : $@convention(method) (Struct) -> @sil_transferring @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (Struct) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (Struct) -> @sil_transferring @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 @MainActor
 struct MainActorStruct {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV15returnsSendableSSyYTF : $@convention(method) (MainActorStruct) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV15returnsSendableSSyYTF : $@convention(method) (MainActorStruct) -> @sil_transferring @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV18returnsNonSendableAA0fG0CyYTF : $@convention(method) (MainActorStruct) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV18returnsNonSendableAA0fG0CyYTF : $@convention(method) (MainActorStruct) -> @sil_transferring @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (MainActorStruct) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring15MainActorStructV25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (MainActorStruct) -> @sil_transferring @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 class Class {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed Class) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed Class) -> @sil_transferring @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC18returnsNonSendableAA0dE0CyYTF : $@convention(method) (@guaranteed Class) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC18returnsNonSendableAA0dE0CyYTF : $@convention(method) (@guaranteed Class) -> @sil_transferring @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed Class) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring5ClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed Class) -> @sil_transferring @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 final class FinalClass {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed FinalClass) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed FinalClass) -> @sil_transferring @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC18returnsNonSendableAA0eF0CyYTF : $@convention(method) (@guaranteed FinalClass) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC18returnsNonSendableAA0eF0CyYTF : $@convention(method) (@guaranteed FinalClass) -> @sil_transferring @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed FinalClass) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring10FinalClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed FinalClass) -> @sil_transferring @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 @MainActor
 class MainActorClass {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed MainActorClass) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed MainActorClass) -> @sil_transferring @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC18returnsNonSendableAA0fG0CyYTF : $@convention(method) (@guaranteed MainActorClass) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC18returnsNonSendableAA0fG0CyYTF : $@convention(method) (@guaranteed MainActorClass) -> @sil_transferring @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed MainActorClass) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring14MainActorClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed MainActorClass) -> @sil_transferring @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 @MainActor
 final class FinalMainActorClass {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed FinalMainActorClass) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC15returnsSendableSSyYTF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_transferring @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC18returnsNonSendableAA0gH0CyYTF : $@convention(method) (@guaranteed FinalMainActorClass) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC18returnsNonSendableAA0gH0CyYTF : $@convention(method) (@guaranteed FinalMainActorClass) -> @sil_transferring @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed FinalMainActorClass) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring19FinalMainActorClassC25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (@guaranteed FinalMainActorClass) -> @sil_transferring @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 enum Enum {
   case myCase
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO15returnsSendableSSyYTF : $@convention(method) (Enum) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO15returnsSendableSSyYTF : $@convention(method) (Enum) -> @sil_transferring @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO18returnsNonSendableAA0dE0CyYTF : $@convention(method) (Enum) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO18returnsNonSendableAA0dE0CyYTF : $@convention(method) (Enum) -> @sil_transferring @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (Enum) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring4EnumO25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (Enum) -> @sil_transferring @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 @MainActor
 enum MainActorEnum {
   case myCase
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO15returnsSendableSSyYTF : $@convention(method) (MainActorEnum) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO15returnsSendableSSyYTF : $@convention(method) (MainActorEnum) -> @sil_transferring @owned String {
   func returnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO18returnsNonSendableAA0fG0CyYTF : $@convention(method) (MainActorEnum) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO18returnsNonSendableAA0fG0CyYTF : $@convention(method) (MainActorEnum) -> @sil_transferring @owned NonSendable {
   func returnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (MainActorEnum) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring13MainActorEnumO25genericReturnsNonSendablexyYTlF : $@convention(method) <T> (MainActorEnum) -> @sil_transferring @out T {
   func genericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
@@ -103,19 +103,19 @@ protocol P {
 }
 
 extension P {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE19protReturnsSendableSSyYTF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE19protReturnsSendableSSyYTF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_transferring @owned String {
   func protReturnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE22protReturnsNonSendableAA0dE0CyYTF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE22protReturnsNonSendableAA0dE0CyYTF : $@convention(method) <Self where Self : P> (@in_guaranteed Self) -> @sil_transferring @owned NonSendable {
   func protReturnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE29protGenericReturnsNonSendableqd__yYTlF : $@convention(method) <Self where Self : P><T> (@in_guaranteed Self) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring1PPAAE29protGenericReturnsNonSendableqd__yYTlF : $@convention(method) <Self where Self : P><T> (@in_guaranteed Self) -> @sil_transferring @out T {
   func protGenericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }
 
 extension Struct : P {
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV19protReturnsSendableSSyYTF : $@convention(method) (Struct) -> transferring @owned String {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV19protReturnsSendableSSyYTF : $@convention(method) (Struct) -> @sil_transferring @owned String {
   func protReturnsSendable() -> transferring String { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV22protReturnsNonSendableAA0eF0CyYTF : $@convention(method) (Struct) -> transferring @owned NonSendable {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV22protReturnsNonSendableAA0eF0CyYTF : $@convention(method) (Struct) -> @sil_transferring @owned NonSendable {
   func protReturnsNonSendable() -> transferring NonSendable { fatalError() }
-  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV29protGenericReturnsNonSendablexyYTlF : $@convention(method) <T> (Struct) -> transferring @out T {
+  // CHECK-LABEL: sil hidden [ossa] @$s12transferring6StructV29protGenericReturnsNonSendablexyYTlF : $@convention(method) <T> (Struct) -> @sil_transferring @out T {
   func protGenericReturnsNonSendable<T>() -> transferring T { fatalError() }
 }

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -390,3 +390,18 @@ bb0(%0 : @owned $Klass, %1 : @guaranteed $KlassWithKlassPair):
   %37 = tuple ()
   return %37 : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_from_result: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %3 = copy_value %2 : $Klass
+// CHECK: Name: 'self.lhs'
+// CHECK: Root: %0 = argument of bb0 : $KlassPair
+// CHECK: end running test 1 of 1 on function_argument_inference_from_result: variable-name-inference with: @trace[0]
+sil [ossa] @function_argument_inference_from_result : $@convention(thin) (@guaranteed KlassPair) -> @owned Klass {
+bb0(%0 : @guaranteed $KlassPair):
+  specify_test "variable-name-inference @trace[0]"
+  debug_value %0 : $KlassPair, let, name "self", argno 1, implicit
+  %2 = struct_extract %0 : $KlassPair, #KlassPair.lhs
+  %3 = copy_value %2 : $Klass
+  debug_value [trace] %3 : $Klass
+  return %3 : $Klass
+}

--- a/test/Serialization/transferring.swift
+++ b/test/Serialization/transferring.swift
@@ -18,6 +18,6 @@ func main() {
   let y = test(x)
 }
 
-// CHECK-LABEL: sil @$s17transferring_test0B0yS2SnYuYTF : $@convention(thin) (@sil_transferring @owned String) -> transferring @owned String
+// CHECK-LABEL: sil @$s17transferring_test0B0yS2SnYuYTF : $@convention(thin) (@sil_transferring @owned String) -> @sil_transferring @owned String
 
 // AST-LABEL: func test(_ x: transferring String) -> transferring String


### PR DESCRIPTION
This PR has a few commits in it that ensure that we treat global actor isolated types (which are considered non-Sendable) as actor isolated when performing region isolation checking.

Specifically:

1. The first commit changes how we represent transferring results at the SIL level. Instead of using a bit in the SILFunctionType (like we are doing in AnyFunctionType since AnyFunctionType), we instead just propagate the bit in TypeLowering to all SILResultInfo. I put in a verification check that if any SILResultInfo are transferring, then all must be transferring. In the fullness of time this will ensure that at the SIL level we will be a bee to easily handle results with different transferring semantics. It also made it so that I could actually write SIL level tests with sil_transferring (the previous implementation relied upon the AST level printer by mistake which caused @owned/@guaranteed to be parsed, but ignored).
2. The second commit simplifies how we emit diagnostics in TransferNonTransferrable to match what UseAfterTransfer does. Specifically, previously we would have a machine that would produce UseDiagnosticInfo via inference and then a second machine that would consume those and emit a diagnostic. This made it heavy to add new diagnostics (too much code to touch) and hard to track down why a diagnostic was emitted. Instead we now use an emitter helper that in the inference code just immediately emits the error making it easy to diagnose why the error happened using swift-diagnostics-assert-on-error.
3. This is the meat commit where I ensure that we handle structs/enums that are main actor isolated correctly.

rdar://123488540