### PR TITLE
Detect methods by their scope rather than their representation.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2868,9 +2868,7 @@ IRGenDebugInfoImpl::emitFunction(const SILDebugScope *DS, llvm::Function *Fn,
   // Because there's no good way to cross the CU boundary to insert a nested
   // DISubprogram definition in one CU into a type defined in another CU when
   // doing LTO builds.
-  if (Rep == SILFunctionTypeRepresentation::Method ||
-      Rep == SILFunctionTypeRepresentation::ObjCMethod ||
-      Rep == SILFunctionTypeRepresentation::WitnessMethod) {
+  if (llvm::isa<llvm::DICompositeType>(Scope)) {
     llvm::DISubprogram::DISPFlags SPFlags = llvm::DISubprogram::toSPFlags(
         /*IsLocalToUnit=*/Fn ? Fn->hasInternalLinkage() : true,
         /*IsDefinition=*/false, /*IsOptimized=*/Opts.shouldOptimize());

--- a/test/DebugInfo/scope-method.swift
+++ b/test/DebugInfo/scope-method.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -emit-ir -parse-as-library -module-name a -g %s -o - | %FileCheck %s
+public struct S {
+  public func f() {}
+}
+
+// CHECK-DAG: distinct !DISubprogram(name: "f", linkageName: "$s1a1SV1fyyF", scope: ![[STRUCT:[0-9]+]], {{.*}}declaration: ![[SDECL:[0-9]+]]
+// CHECK-DAG: ![[SDECL]] = !DISubprogram(name: "f", linkageName: "$s1a1SV1fyyF", scope: ![[STRUCT]]
+// CHECK-DAG: ![[STRUCT]] = !DICompositeType(tag: DW_TAG_structure_type, name: "S"
+
+public class C {
+  public func f() {}
+}
+
+// CHECK-DAG: distinct !DISubprogram(name: "f", linkageName: "$s1a1CC1fyyF", scope: ![[CLASS:[0-9]+]], {{.*}}declaration: ![[CDECL:[0-9]+]]
+// CHECK-DAG: ![[CDECL]] = !DISubprogram(name: "f", linkageName: "$s1a1CC1fyyF", scope: ![[CLASS]]
+// CHECK-DAG: ![[CLASS]] = !DICompositeType(tag: DW_TAG_structure_type, name: "C"


### PR DESCRIPTION
In the end this condition exists to avoid a BitCode Verifyer check that operates off the scope, so looking for that directly is more future-proof.

rdar://123334375
