### PR TITLE
Root the virtual <compiler-generated> file in the root directory. 

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -580,6 +580,8 @@ private:
       // Leave <compiler-generated> & friends as is, without directory.
       if (!(File.startswith("<") && File.endswith(">")))
         Dir = CurDir;
+      else
+        Dir = llvm::sys::path::root_directory(CurDir);
     }
     llvm::DIFile *F =
         DBuilder.createFile(DebugPrefixMap.remapPath(File),

--- a/test/Backtracing/CrashWithThunk.swift
+++ b/test/Backtracing/CrashWithThunk.swift
@@ -35,7 +35,7 @@ struct CrashWithThunk {
 // CHECK: Thread 0 {{(".*" )?}}crashed:
 
 // CHECK: 0                    0x{{[0-9a-f]+}} crash() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:21:15
-// CHECK-NEXT: 1 [ra] [thunk]  0x{{[0-9a-f]+}} thunk for @escaping @callee_guaranteed () -> () + {{[0-9]+}} in CrashWithThunk at {{.*}}/Backtracing/<compiler-generated>
+// CHECK-NEXT: 1 [ra] [thunk]  0x{{[0-9a-f]+}} thunk for @escaping @callee_guaranteed () -> () + {{[0-9]+}} in CrashWithThunk at {{.*}}/<compiler-generated>
 // CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} static CrashWithThunk.main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:29:9
 // CHECK-NEXT: 3 [ra] [system] 0x{{[0-9a-f]+}} static CrashWithThunk.$main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/<compiler-generated>
 // CHECK-NEXT: 4 [ra] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift

--- a/test/DebugInfo/thunks.swift
+++ b/test/DebugInfo/thunks.swift
@@ -16,7 +16,7 @@ let i = foo.foo(-, x: y)
 // CHECK: define {{.*}}@"$ss5Int64VABIyByd_A2BIegyd_TR"
 // CHECK-NOT: ret
 // CHECK: call {{.*}}, !dbg ![[LOC:.*]]
-// CHECK: ![[FILE:[0-9]+]] = !DIFile(filename: "<compiler-generated>", directory: "")
+// CHECK: ![[FILE:[0-9]+]] = !DIFile(filename: "<compiler-generated>", directory: "/")
 // CHECK: ![[THUNK:.*]] = distinct !DISubprogram(linkageName: "$ss5Int64VABIyByd_A2BIegyd_TR"
 // CHECK-SAME:                          file: ![[FILE]]
 // CHECK-NOT:                           line:


### PR DESCRIPTION
Using CWD gives a false sense of accuracy.

rdar://124233848
