### PR TITLE
[cxx-interop] Copy bridging header to same directory as other headers

### DIFF
--- a/lib/ClangImporter/SwiftBridging/CMakeLists.txt
+++ b/lib/ClangImporter/SwiftBridging/CMakeLists.txt
@@ -1,16 +1,14 @@
 # Mark - copy "bridging" (support header) into the local include directory and
 # install it into the compiler toolchain.
-set(SWIFTINC_DIR
-    "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/include/swift")
 
 add_custom_command(
-    OUTPUT "${SWIFTINC_DIR}/bridging"
+    OUTPUT "${SWIFT_INCLUDE_DIR}/swift/bridging"
     DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/swift/bridging"
-    COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${CMAKE_CURRENT_SOURCE_DIR}/swift/bridging" "${SWIFTINC_DIR}")
+    COMMAND "${CMAKE_COMMAND}" "-E" "copy" "${CMAKE_CURRENT_SOURCE_DIR}/swift/bridging" "${SWIFT_INCLUDE_DIR}/swift")
 
 add_custom_target("copy_cxxInterop_support_header"
-    DEPENDS "${SWIFTINC_DIR}/bridging"
-    COMMENT "Copying C++ interop support header to ${SWIFTINC_DIR}")
+    DEPENDS "${SWIFT_INCLUDE_DIR}/swift/bridging"
+    COMMENT "Copying C++ interop support header to ${SWIFT_INCLUDE_DIR}/swift")
 
 swift_install_in_component(FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/swift/bridging"


### PR DESCRIPTION
The `bridging` header for C++ interop was calculating an include directory using `CMAKE_BINARY_DIR` and `CMAKE_CFG_INTDIR` while the rest of the headers consistently use `CMAKE_CURRENT_BINARY_DIR` and no `CMAKE_CFG_INTDIR`.

In some configurations of CMake (for example when using Swift as an external project of LLVM and building an unified toolchain), this means that the `brigding` header will end up in a different directory than the rest of the headers, which complicates testing.

The changes in this commit reuses `SWIFT_INCLUDE_DIR` to keep consistency with the rest of the headers. Any build started by `build-script` should not notice the difference.
