### PR TITLE
[cmake] Unify usage of create_symlink/copy across the build files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,9 +360,11 @@ How swift-C++ bridging code is compiled:
 ]=] DEFAULT)
 
 option(SWIFT_USE_SYMLINKS "Use symlinks instead of copying binaries" ${CMAKE_HOST_UNIX})
-set(SWIFT_COPY_OR_SYMLINK "copy")
+set(SWIFT_COPY_OR_SYMLINK "copy_if_different")
+set(SWIFT_COPY_OR_SYMLINK_DIR "copy_directory")
 if(SWIFT_USE_SYMLINKS)
   set(SWIFT_COPY_OR_SYMLINK "create_symlink")
+  set(SWIFT_COPY_OR_SYMLINK_DIR "create_symlink")
 endif()
 
 # The following only works with the Ninja generator in CMake >= 3.0.

--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -171,14 +171,10 @@ function(swift_create_post_build_symlink target)
     ""
     ${ARGN})
 
-  if("${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-    if(CS_IS_DIRECTORY)
-      set(cmake_symlink_option "copy_directory")
-    else()
-      set(cmake_symlink_option "copy_if_different")
-    endif()
+  if(CS_IS_DIRECTORY)
+    set(cmake_symlink_option "${SWIFT_COPY_OR_SYMLINK_DIR}")
   else()
-      set(cmake_symlink_option "create_symlink")
+    set(cmake_symlink_option "${SWIFT_COPY_OR_SYMLINK}")
   endif()
 
   add_custom_command(TARGET "${target}" POST_BUILD

--- a/lib/Migrator/CMakeLists.txt
+++ b/lib/Migrator/CMakeLists.txt
@@ -23,18 +23,13 @@ set(outputs)
 foreach(input ${datafiles})
   set(source "${CMAKE_CURRENT_SOURCE_DIR}/${input}")
   set(dest "${output_dir}/${input}")
-  if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    set(CMAKE_SYMLINK_COMMAND copy)
-  else()
-    set(CMAKE_SYMLINK_COMMAND create_symlink)
-  endif()
 
   add_custom_command(OUTPUT
                        "${output_dir}/${input}"
                      DEPENDS
                        "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
                      COMMAND
-                       "${CMAKE_COMMAND}" "-E" "${CMAKE_SYMLINK_COMMAND}" "${source}" "${dest}")
+                       "${CMAKE_COMMAND}" "-E" "${SWIFT_COPY_OR_SYMLINK}" "${source}" "${dest}")
   list(APPEND outputs "${output_dir}/${input}")
 endforeach()
 list(APPEND outputs "${output_dir}")

--- a/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
+++ b/stdlib/public/SwiftShims/swift/shims/CMakeLists.txt
@@ -129,17 +129,11 @@ else()
   set(clang_headers_location "${LLVM_LIBRARY_OUTPUT_INTDIR}/clang/${CLANG_VERSION_MAJOR}")
 endif()
 
-if("${CMAKE_HOST_SYSTEM_NAME}" STREQUAL "Windows")
-  set(cmake_symlink_option "copy_directory")
-else()
-  set(cmake_symlink_option "create_symlink")
-endif()
-
 add_custom_command_target(unused_var
     COMMAND
       "${CMAKE_COMMAND}" "-E" "make_directory" "${SWIFTLIB_DIR}"
     COMMAND
-      "${CMAKE_COMMAND}" "-E" "${cmake_symlink_option}"
+      "${CMAKE_COMMAND}" "-E" "${SWIFT_COPY_OR_SYMLINK_DIR}"
       "${clang_headers_location}"
       "${SWIFTLIB_DIR}/clang"
 
@@ -154,7 +148,7 @@ if(SWIFT_BUILD_STATIC_STDLIB)
       COMMAND
         "${CMAKE_COMMAND}" "-E" "make_directory" "${SWIFTSTATICLIB_DIR}"
       COMMAND
-        "${CMAKE_COMMAND}" "-E" "${cmake_symlink_option}"
+        "${CMAKE_COMMAND}" "-E" "${SWIFT_COPY_OR_SYMLINK_DIR}"
         "${clang_headers_location}"
         "${SWIFTSTATICLIB_DIR}/clang"
 
@@ -193,10 +187,10 @@ if(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
         COMMAND
           "${CMAKE_COMMAND}" "-E" "make_directory" "${outdir}"
         COMMAND
-          "${CMAKE_COMMAND}" "-E" ${cmake_symlink_option}
+          "${CMAKE_COMMAND}" "-E" ${SWIFT_COPY_OR_SYMLINK_DIR}
           ${output_dir} "${outdir}/shims"
         COMMAND
-          "${CMAKE_COMMAND}" "-E" "${cmake_symlink_option}"
+          "${CMAKE_COMMAND}" "-E" "${SWIFT_COPY_OR_SYMLINK_DIR}"
           "${clang_headers_location}"
           "${outdir}/clang"
 
@@ -212,7 +206,7 @@ if(BOOTSTRAPPING_MODE MATCHES "BOOTSTRAPPING.*")
           COMMAND
             "${CMAKE_COMMAND}" "-E" "make_directory" "${outdir}"
           COMMAND
-            "${CMAKE_COMMAND}" "-E" ${cmake_symlink_option}
+            "${CMAKE_COMMAND}" "-E" ${SWIFT_COPY_OR_SYMLINK_DIR}
             "${output_dir}/../module.modulemap" "${outdir}/module.modulemap"
 
           CUSTOM_TARGET_NAME ${modulemap_target_name}

--- a/utils/api_checker/CMakeLists.txt
+++ b/utils/api_checker/CMakeLists.txt
@@ -16,14 +16,9 @@ set(SWIFTLIB_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/swift")
 set(dest "${SWIFTLIB_DIR}/${framework}")
 set(source "${CMAKE_CURRENT_SOURCE_DIR}/${framework}")
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
-    set(CMAKE_SYMLINK_COMMAND copy)
-else()
-    set(CMAKE_SYMLINK_COMMAND create_symlink)
-endif()
 add_custom_command(OUTPUT "${dest}"
                    DEPENDS "${source}"
-                   COMMAND "${CMAKE_COMMAND}" "-E" "${CMAKE_SYMLINK_COMMAND}" "${source}" "${dest}"
+                   COMMAND "${CMAKE_COMMAND}" "-E" "${SWIFT_COPY_OR_SYMLINK}" "${source}" "${dest}"
                    COMMENT "Symlinking ABI checker baseline data to ${dest}")
 add_custom_target("symlink_abi_checker_data" ALL
                   DEPENDS "${dest}"


### PR DESCRIPTION
In several places, there was the same or similar code to either do a symlink or use copy/copy_if_different/copy_directory in Windows systems. The checks were also slightly different in some cases.

There is a `SWIFT_COPY_OR_SYMLINK` that can be controlled as a CMake option, and uses `CMAKE_HOST_UNIX` as default. Change all cases that I can find to use that value. Also create a parallel value `SWIFT_COPY_OR_SYMLINK_DIR` to apply to directories.

There is still a couple of cases that are specific to macOS SourceKit framework which I have left as-is, since symlinks is probably the only right thing to do there.

There's a case for Windows specifically that uses symlinks (in https://github.com/apple/swift/blob/523f80769487b0fea30880ca98c42470f740ff02/cmake/modules/SwiftConfigureSDK.cmake#L502) which I have not modified as well.
