### PR TITLE
[PrintAsObjC] Use NSUInteger if protocol requires

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -963,11 +963,26 @@ private:
 
   template <typename T>
   static const T *findClangBase(const T *member) {
-    while (member) {
-      if (member->getClangDecl())
-        return member;
-      member = member->getOverriddenDecl();
+    // Search overridden members.
+    const T *ancestorMember = member;
+    while (ancestorMember) {
+      if (ancestorMember->getClangDecl())
+        return ancestorMember;
+      ancestorMember = ancestorMember->getOverriddenDecl();
     }
+
+    // Search witnessed requirements.
+    // FIXME: Semi-arbitrary behavior if `member` witnesses several requirements
+    // (The conformance which sorts first will be used; the others will be
+    // ignored.)
+    for (const ValueDecl *requirementVD :
+            member->getSatisfiedProtocolRequirements(/*Sorted=*/true)) {
+      const T *requirement = dyn_cast<T>(requirementVD);
+      if (requirement && requirement->getClangDecl())
+        return requirement;
+    }
+
+    // No related clang members found.
     return nullptr;
   }
 

--- a/test/PrintAsObjC/Inputs/custom-modules/override.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/override.h
@@ -16,3 +16,11 @@
 - (BOOL)doAnotherThingWithError:(NSError **)error;
 
 @end
+
+@protocol Proto <NSObject>
+
+- (NSUInteger)proto;
+- (NSUInteger)proto:(NSUInteger)ignored;
+- (NSUInteger)proto:(NSUInteger)x y:(NSUInteger)y;
+
+@end

--- a/test/PrintAsObjC/override.swift
+++ b/test/PrintAsObjC/override.swift
@@ -45,6 +45,18 @@ class A_Child : Base {
   // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 } // CHECK-NEXT: @end
 
+// CHECK-LABEL: @interface A_Child ({{.*}}) <Proto>
+extension A_Child : Proto {
+  // CHECK-NEXT: - (NSUInteger)proto SWIFT_WARN_UNUSED_RESULT;
+  func proto() -> Int { return 0 }
+
+  // CHECK-NEXT: - (NSUInteger)proto:(NSUInteger)_ SWIFT_WARN_UNUSED_RESULT;
+  func proto(_: Int) -> Int { return 0 }
+
+  // CHECK-NEXT: - (NSUInteger)proto:(NSUInteger)_ y:(NSUInteger)y SWIFT_WARN_UNUSED_RESULT;
+  func proto(_: Int, y: Int) -> Int { return 0 }
+} // CHECK-NEXT: @end
+
 // CHECK-LABEL: @interface A_Grandchild : A_Child
 class A_Grandchild : A_Child {
   // CHECK-NEXT: @property (nonatomic, readonly, getter=getProp) NSUInteger prop;


### PR DESCRIPTION
When printing an ObjC member into a header with an `Int` parameter or result, PrintAsClang would look up any imported Objective-C member it overrode to see if ClangImporter imported `NSUInteger` as `Int`, and if so, would print `NSUInteger` instead of `NSInteger`. However, it did not do the same for protocol requirements the member witnessed. Correct this oversight.

Fixes rdar://124300674.