### PR TITLE
Sema: Record a default witness for requirements with satisfied Obj-C siblings

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4828,6 +4828,23 @@ public:
   bool isCached() const { return true; }
 };
 
+class ObjCRequirementMapRequest
+    : public SimpleRequest<ObjCRequirementMapRequest,
+                           ObjCRequirementMap(const ProtocolDecl *proto),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ObjCRequirementMap evaluate(Evaluator &evaluator,
+                              const ProtocolDecl *proto) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -559,3 +559,7 @@ SWIFT_REQUEST(TypeChecker, UniqueUnderlyingTypeSubstitutionsRequest,
 SWIFT_REQUEST(TypeChecker, LocalTypeDeclsRequest,
               ArrayRef<TypeDecl *>(SourceFile *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ObjCRequirementMapRequest,
+              ObjCRequirementMap(const ProtocolDecl *proto),
+              Cached, NoLocationInfo)
+

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6467,6 +6467,15 @@ ProtocolDecl::getInvertibleProtocolKind() const {
   return std::nullopt;
 }
 
+ObjCRequirementMap ProtocolDecl::getObjCRequiremenMap() const {
+  ObjCRequirementMap defaultMap;
+  if (!isObjC())
+    return defaultMap;
+
+  return evaluateOrDefault(getASTContext().evaluator,
+                           ObjCRequirementMapRequest{this}, defaultMap);
+}
+
 ArrayRef<ProtocolDecl *> ProtocolDecl::getInheritedProtocols() const {
   auto *mutThis = const_cast<ProtocolDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -455,7 +455,6 @@ bool ClangImporter::addHeaderDependencies(
     ModuleDependencyID moduleID,
     clang::tooling::dependencies::DependencyScanningTool &clangScanningTool,
     ModuleDependenciesCache &cache) {
-  auto &ctx = Impl.SwiftContext;
   auto optionalTargetModule = cache.findDependency(moduleID);
   assert(optionalTargetModule.has_value());
   auto targetModule = *(optionalTargetModule.value());

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8202,7 +8202,6 @@ bool UnableToInferClosureReturnType::diagnoseAsError() {
 
 bool UnableToInferGenericPackElementType::diagnoseAsError() {
   auto *locator = getLocator();
-  auto path = locator->getPath();
 
   auto packElementElt = locator->getLastElementAs<LocatorPathElt::PackElement>();
   assert(packElementElt && "Expected path to end with a pack element locator");

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -168,6 +168,9 @@ public:
   /// particular requirement and adoptee is required, before the
   /// conformance has been completed checked.
   void resolveSingleWitness(ValueDecl *requirement);
+
+private:
+  bool allowOptionalWitness(ValueDecl *requirement);
 };
 
 /// Match the given witness to the given requirement.

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -168,9 +168,6 @@ public:
   /// particular requirement and adoptee is required, before the
   /// conformance has been completed checked.
   void resolveSingleWitness(ValueDecl *requirement);
-
-private:
-  bool allowOptionalWitness(ValueDecl *requirement);
 };
 
 /// Match the given witness to the given requirement.

--- a/test/ClangImporter/protocol-member-renaming.swift
+++ b/test/ClangImporter/protocol-member-renaming.swift
@@ -9,7 +9,6 @@ class Modern : NSObject, FooDelegate {
 class PreMigration : NSObject, FooDelegate {
   func foo(_ foo: Foo, willConsumeObject object: Any) {}
   // expected-error@-1 {{'foo(_:willConsumeObject:)' has been renamed to 'foo(_:willConsume:)'}} {{24-41=willConsume}}
-  // expected-error@-2 {{method 'foo(_:willConsumeObject:)' has different argument labels from those required by protocol 'FooDelegate' ('foo(_:willConsume:)')}} {{24-41=willConsume}}
 }
 
 class OptionalButUnavailableImpl : OptionalButUnavailable {

--- a/test/Serialization/conformance-objc-async.swift
+++ b/test/Serialization/conformance-objc-async.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-emit-module-interface(%t/Conformance.swiftinterface) -module-name Conformance -I %t %t/Conformance.swift
+// RUN: %target-swift-emit-module-interface(%t/Conformance.swiftinterface) -target %target-swift-abi-5.5-triple -module-name Conformance -I %t %t/Conformance.swift
+// RUN: %target-swift-emit-module-interface(%t/Conformance.swiftinterface) -target %target-swift-abi-5.5-triple -module-name Conformance -experimental-lazy-typecheck -I %t %t/Conformance.swift
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Conformance.swiftinterface -module-name Conformance -o /dev/null -I %t
 // REQUIRES: objc_interop
-
-// REQUIRES: rdar119435253
+// REQUIRES: concurrency
 
 //--- module.modulemap
 module ObjCProto {
@@ -20,11 +20,80 @@ module ObjCProto {
 //--- Conformance.swift
 import ObjCProto
 
-public final class ConformsToDoableWithCompletionHandler: Doable {
+public final class DoableWithCompletionHandler: Doable {
+  // Matches synchronous requirement
   public func doIt(completion: @escaping () -> Void) {}
 }
 
-@available(SwiftStdlib 5.5, *)
-public final class ConformsToDoableWithAsync:Doable {
+public final class DoableWithAsync: Doable {
+  // Matches async requirement
+  public func doIt() async {}
+}
+
+public final class DoableWithCompletionHandlerAndAsyncCandidate: Doable {
+  // Matches synchronous requirement
+  public func doIt(completion: @escaping () -> Void) {}
+
+  // Near-miss for async requirement
+  public func doIt() async -> Int {}
+}
+
+public final class DoableWithCompletionHandlerAndAsyncCandidate2: Doable {
+  // Near-miss for async requirement
+  public func doIt() async -> Int {}
+
+  // Matches synchronous requirement
+  public func doIt(completion: @escaping () -> Void) {}
+}
+
+public final class DoableWithCompletionHandlerAndMultipleAsyncCandidates: Doable {
+  // Matches synchronous requirement
+  public func doIt(completion: @escaping () -> Void) {}
+
+  // Multiple near-misses for async requirement
+  public func doIt() async -> Int {}
+  public func doIt() async -> Double {}
+}
+
+public final class DoableWithCompletionHandlerAndMultipleAsyncCandidates2: Doable {
+  // Multiple near-misses for async requirement
+  public func doIt() async -> Int {}
+  public func doIt() async -> Double {}
+
+  // Matches synchronous requirement
+  public func doIt(completion: @escaping () -> Void) {}
+}
+
+public final class DoableWithAsyncAndCompletionHandlerCandidate: Doable {
+  // Matches async requirement
+  public func doIt() async {}
+
+  // Near-miss for synchronous requirement
+  public func doIt(reply: @escaping () -> Void) {}
+}
+
+public final class DoableWithAsyncAndCompletionHandlerCandidate2: Doable {
+  // Near-miss for synchronous requirement
+  public func doIt(reply: @escaping () -> Void) {}
+
+  // Matches async requirement
+  public func doIt() async {}
+}
+
+public final class DoableWithAsyncAndMultipleCompletionHandlerCandidates: Doable {
+  // Matches async requirement
+  public func doIt() async {}
+
+  // Multiple near-misses for synchronous requirement
+  public func doIt(reply: @escaping () -> Void) {}
+  public func doIt(otherReply: @escaping () -> Void) {}
+}
+
+public final class DoableWithAsyncAndMultipleCompletionHandlerCandidates2: Doable {
+  // Multiple near-misses for synchronous requirement
+  public func doIt(otherReply: @escaping () -> Void) {}
+  public func doIt(reply: @escaping () -> Void) {}
+
+  // Matches async requirement
   public func doIt() async {}
 }


### PR DESCRIPTION
Rather than just skipping requirements with satisfied Obj-C siblings during `resolveValueWitnesses()`, proactively record a default witness for these requirements. This prevents lazy value witness resolution from giving the skipped requirements a default witness after the conformance is already marked complete, which causes an assertion to fail.

Includes some refactoring for clarity and performance, as well as drive-by fixes for some warnings.

Resolves rdar://119435253