### PR TITLE
[IRGen] Collect metadata for empty fields.

### DIFF
--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -274,6 +274,33 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
       rootWTable = emitOpaqueTypeWitnessTableRef(IGF, opaqueRoot,
                                                  rootProtocol);
     }
+#ifndef NDEBUG
+    if (!rootWTable) {
+      llvm::errs()
+          << "Root witness table not bound in function.\n"
+          << "  The witness table could be missing entirely because it needs "
+             "to be passed to the function.\n"
+          << "  Or the witness table is present and not bound in which case "
+             "setScopedLocalTypeData or similar must be called.\n";
+      llvm::errs() << "Root archetype for conformance: " << rootArchetype
+                   << "\n";
+      rootArchetype->dump(llvm::errs());
+      llvm::errs() << "Root protocol without wtable: " << rootProtocol << "\n";
+      rootProtocol->dump(llvm::errs());
+      llvm::errs() << "Archetype for conformance: " << archetype << "\n";
+      archetype->dump(llvm::errs());
+      llvm::errs() << "Protocol for conformance: " << protocol << "\n";
+      protocol->dump(llvm::errs());
+      llvm::errs() << "Function:\n";
+      IGF.CurFn->print(llvm::errs());
+      if (auto localTypeData = IGF.getLocalTypeData()) {
+        llvm::errs() << "LocalTypeData:\n";
+        localTypeData->dump();
+      } else {
+        llvm::errs() << "No LocalTypeDataCache for this function!\n";
+      }
+    }
+#endif
     assert(rootWTable && "root witness table not bound in local context!");
   }
 

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -487,8 +487,6 @@ public:
   void collectMetadataForOutlining(OutliningMetadataCollector &collector,
                                    SILType T) const override {
     for (auto &field : getFields()) {
-      if (field.isEmpty())
-        continue;
       auto fType = field.getType(collector.IGF.IGM, T);
       field.getTypeInfo().collectMetadataForOutlining(collector, fType);
     }

--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -440,3 +440,26 @@ public func takeOuterMultiPayloadNC_3<T>(_ e: consuming OuterMultiPayloadNC_3<T>
 // CHECK-SAME:        ptr noalias swiftself %0)
 // CHECK:       }
 public func takeOuterMultiPayloadNC_4<T>(_ e: consuming OuterMultiPayloadNC_4<T>) {}
+
+public struct EmptyDeinitingNC_1<Wrapped: ~Copyable>: ~Copyable {
+  deinit {}
+}
+
+public enum SinglePayloadNC_1<Element: Equatable>: ~Copyable {
+  case empty
+  case node(EmptyDeinitingNC_1<Self>, Element)
+}
+// CHECK-LABEL: define{{.*}} @"$s24moveonly_value_functions18EmptyDeinitingNC_1VyAA013SinglePayloadF2_1OyxGG_xtSQRzlWOh"(
+// CHECK-SAME:      ptr %0, 
+// CHECK-SAME:      ptr %Element,
+// CHECK-SAME:      ptr %Element.Equatable)
+// CHECK-SAME:  {
+// CHECK:         [[RESPONSE:%[^,]+]] = call swiftcc %swift.metadata_response @"$s24moveonly_value_functions17SinglePayloadNC_1OMa"(
+//           :        i64 0, 
+// CHECK-SAME:        ptr %Element,
+// CHECK-SAME:        ptr %Element.Equatable)
+// CHECK:         [[METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+// CHECK:         call swiftcc void @"$s24moveonly_value_functions18EmptyDeinitingNC_1VAARiczrlEfD"(
+// CHECK-SAME:        ptr [[METADATA]])
+// CHECK:       }
+


### PR DESCRIPTION
Previously, when the metadata collector only collected for layout, it was wasteful to visit the empty fields of records.  Now that the field may require a deinit call, it's necessary to visit it.

rdar://123577998
