### PR TITLE
build: Install `llvm-ranlib` in OSS toolchains

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -19,7 +19,7 @@ swift-install-components=back-deployment;compiler;clang-builtin-headers;libexec;
 [preset: mixin_buildbot_install_components_with_clang]
 
 swift-install-components=autolink-driver;back-deployment;compiler;clang-resource-dir-symlink;libexec;stdlib;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-xpc-service;swift-remote-mirror;swift-remote-mirror-headers;swift-external-generic-metadata-builder;swift-external-generic-metadata-builder-headers
-llvm-install-components=llvm-ar;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO;clang-features-file
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;dsymutil;LTO;clang-features-file
 
 [preset: mixin_buildbot_trunk_base]
 # Build standard library and SDK overlay for iOS device and simulator.
@@ -804,7 +804,7 @@ no-swift-stdlib-assertions
 [preset: mixin_linux_install_components_with_clang]
 
 swift-install-components=autolink-driver;compiler;clang-resource-dir-symlink;libexec;stdlib;swift-remote-mirror;sdk-overlay;static-mirror-lib;toolchain-tools;license;sourcekit-inproc
-llvm-install-components=llvm-ar;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;lld;LTO;clang-features-file
+llvm-install-components=llvm-ar;llvm-ranlib;llvm-cov;llvm-profdata;IndexStore;clang;clang-resource-headers;compiler-rt;clangd;lld;LTO;clang-features-file
 
 [preset: mixin_linux_installation]
 mixin-preset=


### PR DESCRIPTION
This change adds `llvm-ranlib` to the list of components installed into the OSS toolchains for macOS and Linux. The `llvm-ranlib` tool is required for WebAssembly builds because system `ranlib` usually cannot recognize Wasm object format. `llvm-ranlib` is just a symlink to `llvm-ar`, so extra space is hopefully not a concern.

Without installing the tool, each Swift SDK for WebAssembly needs to build and distribute `llvm-ranlib` as a part of the SDK even though the toolchain has the actual code of `llvm-ranlib` as `llvm-ar`.