### PR TITLE
SILGen/Sema: Avoid diagnosing @unknown default switch cases as unreachable

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1136,7 +1136,7 @@ void PatternMatchEmission::emitDispatch(ClauseMatrix &clauses, ArgArray args,
                   return item.getPattern()->getKind() == PatternKind::Expr;
                 });
             isParentDoCatch = CS->getParentKind() == CaseParentKind::DoCatch;
-            isDefault = CS->isDefault();
+            isDefault = CS->isDefault() && !CS->hasUnknownAttr();
           }
         } else {
           Loc = clauses[firstRow].getCasePattern()->getStartLoc();

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1058,16 +1058,18 @@ namespace {
                              unknownCase);
         return;
       }
-      
+
       auto uncovered = diff.value();
-      if (unknownCase && uncovered.isEmpty()) {
-        DE.diagnose(unknownCase->getLoc(), diag::redundant_particular_case)
-          .highlight(unknownCase->getSourceRange());
-      }
 
       // Account for unknown cases. If the developer wrote `unknown`, they're
       // all handled; otherwise, we ignore the ones that were added for enums
       // that are implicitly frozen.
+      //
+      // Note that we do not diagnose an unknown case as redundant, even if the
+      // uncovered space is empty because we trust that if the developer went to
+      // the trouble of writing @unknown that it was for a good reason, like
+      // addressing diagnostics in another build configuration where there are
+      // potentially unknown cases.
       uncovered = *uncovered.minus(Space::forUnknown(unknownCase == nullptr),
                                    DC, /*&minusCount*/ nullptr);
 

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -872,7 +872,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch value {
   case _: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   // Test being part of other spaces.
@@ -973,25 +973,25 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   switch interval {
   case .seconds, .milliseconds, .microseconds, .nanoseconds: break
   case .never: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   switch flag {
   case true: break
   case false: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   switch flag as Optional {
   case _?: break
   case nil: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   switch (flag, value) {
   case (true, _): break
   case (false, _): break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 }
 
@@ -1028,7 +1028,7 @@ public func testNonExhaustiveWithinModule(_ value: NonExhaustive, _ payload: Non
 
   switch value {
   case _: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   // Test being part of other spaces.

--- a/test/SILOptimizer/diagnose_unreachable_enum_resilience.swift
+++ b/test/SILOptimizer/diagnose_unreachable_enum_resilience.swift
@@ -1,0 +1,152 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 5 -enable-library-evolution -primary-file %s -o /dev/null -verify
+
+// Re-run with optimizations to check if -O does not make any difference
+// RUN: %target-swift-frontend -O -emit-sil -swift-version 5 -enable-library-evolution -primary-file %s -o /dev/null -verify
+
+public enum NonExhaustive {
+  case a
+}
+
+@frozen public enum Exhaustive {
+  case a
+}
+
+public var optional: Void? = nil
+
+public func testNonExhaustive(_ e: NonExhaustive) {
+  switch e {
+  case .a: break
+  }
+
+  switch e {
+  case .a: break
+  default: break
+  // expected-warning@-1 {{default will never be executed}}
+  }
+
+  switch e {
+  case .a: break
+  @unknown default: break
+  // Ok, @unknown suppresses "default will never be executed"
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  default: break
+  // expected-warning@-1 {{default will never be executed}}
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  @unknown default: break
+  // Ok, @unknown suppresses "default will never be executed"
+  }
+}
+
+@inlinable
+public func testNonExhaustiveInlinable(_ e: NonExhaustive) {
+  switch e {
+  // expected-warning@-1 {{switch covers known cases, but 'NonExhaustive' may have additional unknown values}}
+  // expected-note@-2 {{handle unknown values using "@unknown default"}}
+  case .a: break
+  }
+
+  switch e {
+  case .a: break
+  default: break
+  }
+
+  switch e {
+  case .a: break
+  @unknown default: break
+  }
+
+  switch (e, optional) {
+  // expected-warning@-1 {{switch covers known cases, but '(NonExhaustive, Void?)' may have additional unknown values}}
+  // expected-note@-2 {{add missing case: '(_, _)'}}
+  case (.a, _): break
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  default: break
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  @unknown default: break
+  }
+}
+
+public func testExhaustive(_ e: Exhaustive) {
+  switch e {
+  case .a: break
+  }
+
+  switch e {
+  case .a: break
+  default: break
+  // expected-warning@-1 {{default will never be executed}}
+  }
+
+  switch e {
+  case .a: break
+  @unknown default: break
+  // Ok, @unknown suppresses "default will never be executed"
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  default: break
+  // expected-warning@-1 {{default will never be executed}}
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  @unknown default: break
+  // Ok, @unknown suppresses "default will never be executed"
+  }
+}
+
+@inlinable
+public func testExhaustiveInlinable(_ e: Exhaustive) {
+  switch e {
+  case .a: break
+  }
+
+  switch e {
+  case .a: break
+  default: break
+  // expected-warning@-1 {{default will never be executed}}
+  }
+
+  switch e {
+  case .a: break
+  @unknown default: break
+  // Ok, @unknown suppresses "default will never be executed"
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  default: break
+  // expected-warning@-1 {{default will never be executed}}
+  }
+
+  switch (e, optional) {
+  case (.a, _): break
+  @unknown default: break
+  // Ok, @unknown suppresses "default will never be executed"
+  }
+}

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -838,7 +838,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch value {
   case _: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   // Test being part of other spaces.
@@ -939,25 +939,25 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   switch interval {
   case .seconds, .milliseconds, .microseconds, .nanoseconds: break
   case .never: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   switch flag {
   case true: break
   case false: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   switch flag as Optional {
   case _?: break
   case nil: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   switch (flag, value) {
   case (true, _): break
   case (false, _): break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 }
 
@@ -994,7 +994,7 @@ public func testNonExhaustiveWithinModule(_ value: NonExhaustive, _ payload: Non
 
   switch value {
   case _: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   // Test being part of other spaces.

--- a/test/Sema/exhaustive_switch_debugger.swift
+++ b/test/Sema/exhaustive_switch_debugger.swift
@@ -45,7 +45,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
   switch value {
   case _: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   // Test being part of other spaces.
@@ -144,7 +144,7 @@ public func testNonExhaustiveWithinModule(_ value: NonExhaustive, _ payload: Non
 
   switch value {
   case _: break
-  @unknown case _: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
+  @unknown case _: break
   }
 
   // Test being part of other spaces.


### PR DESCRIPTION
Suppose you have an exhaustive switch statement which matches all the cases of a Swift enum defined in a different module named `External`:

```
import External

var e: External.SomeEnum = //...

switch e {
case .a: break
}
```

If `External` is compiled with library evolution and `SomeEnum` is not frozen, then the compiler will warn:

```
warning: switch covers known cases, but 'SomeEnum' may have additional unknown values
```

You add an `@unknown default` to the switch to resolve this warning. Now suppose in another build configuration, `External` is built _without_ library evolution. The compiler will complain about the unreachability of the default case:

```
warning: Default will never be executed
```

These contradictory compiler diagnostics encourage the developer to change the code in a way that will cause a diagnostic in the other configuration. Developers should have the tools to address all warning diagnostics in a reasonable fashion and this is a case where the compiler makes that especially difficult. Given that writing `@unknown default` instead of `default` is a very intentional action that would be the result of addressing the library evolution configuration, it seems reasonable to suppress the `Default will never be executed` diagnostic.
