### PR TITLE
[SILGen] Move non-trivial none-ownership values.

### DIFF
--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -788,20 +788,20 @@ public:
                 ConsumableAndAssignable);
       }
 
-      // Otherwise, if we don't have a no implicit copy trivial type, just
-      // return value.
-      if (!vd->isNoImplicitCopy() || !value->getType().isTrivial(SGF.F))
-        return value;
+      // If we have a no implicit copy trivial type, wrap it in the move only
+      // wrapper and mark it as needing checking by the move checker.
+      if (vd->isNoImplicitCopy() && value->getType().isTrivial(SGF.F)) {
+        value =
+            SGF.B.createOwnedCopyableToMoveOnlyWrapperValue(PrologueLoc, value);
+        value = SGF.B.createMoveValue(PrologueLoc, value, IsLexical);
+        return SGF.B.createMarkUnresolvedNonCopyableValueInst(
+            PrologueLoc, value,
+            MarkUnresolvedNonCopyableValueInst::CheckKind::
+                ConsumableAndAssignable);
+      }
 
-      // Otherwise, we have a no implicit copy trivial type, so wrap it in the
-      // move only wrapper and mark it as needing checking by the move cherk.
-      value =
-          SGF.B.createOwnedCopyableToMoveOnlyWrapperValue(PrologueLoc, value);
-      value = SGF.B.createMoveValue(PrologueLoc, value, IsLexical);
-      return SGF.B.createMarkUnresolvedNonCopyableValueInst(
-          PrologueLoc, value,
-          MarkUnresolvedNonCopyableValueInst::CheckKind::
-              ConsumableAndAssignable);
+
+      return value;
     }
 
     // Otherwise, we need to perform some additional processing. First, if we

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -800,6 +800,12 @@ public:
                 ConsumableAndAssignable);
       }
 
+      if (!value->getType().isTrivial(SGF.F)) {
+        // A value without ownership of non-trivial type, e.g. Optional<K>.none.
+        // Mark that it is from a VarDecl.
+        return SGF.B.createMoveValue(PrologueLoc, value, IsNotLexical,
+                                     DoesNotHavePointerEscape, IsFromVarDecl);
+      }
 
       return value;
     }

--- a/test/Concurrency/flow_isolation.swift
+++ b/test/Concurrency/flow_isolation.swift
@@ -706,9 +706,7 @@ actor OhBrother {
     let blah = { (x: OhBrother) -> Int in 0 }
     giver = blah
 
-    // TODO: would be nice if we didn't say "after this closure" since it's not a capture, but a call.
-
-    _ = blah(self) // expected-note {{after this closure involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
+    _ = blah(self) // expected-note {{after a call involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
 
     whatever = 2 // expected-warning {{cannot access property 'whatever' here in non-isolated initializer; this is an error in the Swift 6 language mode}}
   }
@@ -788,7 +786,7 @@ func testActorWithInitAccessorInit() {
       let escapingSelf: (EscapeBeforeFullInit) -> Void = { _ in }
 
       escapingSelf(self) // expected-error {{'self' used before all stored properties are initialized}}
-      // expected-note@-1 {{after this closure involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
+      // expected-note@-1 {{after a call involving 'self', only non-isolated properties of 'self' can be accessed from this init}}
 
       self.a = v
       // expected-warning@-1 {{cannot access property '_a' here in non-isolated initializer; this is an error in the Swift 6 language mode}}

--- a/test/SILGen/async_conversion.swift
+++ b/test/SILGen/async_conversion.swift
@@ -47,8 +47,11 @@ actor A: P2 {
   // CHECK: hop_to_executor {{.*}} : $MainActor
   // CHECK: [[F:%.*]] = function_ref @$s4test11mainActorFnyyF : $@convention(thin) () -> ()
   // CHECK: [[THICK_F:%.*]] = thin_to_thick_function [[F]] : $@convention(thin) () -> () to $@callee_guaranteed () -> ()
+  // CHECK: [[THICK_F_VAR:%.*]] = move_value [var_decl] [[THICK_F]]
+  // CHECK: [[THICK_F_BORROW:%.*]] = begin_borrow [[THICK_F_VAR]]
+  // CHECK: [[THICK_F_COPY:%.*]] = copy_value [[THICK_F_BORROW]]
   // CHECK: [[THUNK:%.*]] = function_ref @$sIeg_IegH_TR : $@convention(thin) @async (@guaranteed @callee_guaranteed () -> ()) -> ()
-  // CHECK:  = partial_apply [callee_guaranteed] [[THUNK]]([[THICK_F]]) : $@convention(thin) @async (@guaranteed @callee_guaranteed () -> ()) -> ()
+  // CHECK:  = partial_apply [callee_guaranteed] [[THUNK]]([[THICK_F_COPY]]) : $@convention(thin) @async (@guaranteed @callee_guaranteed () -> ()) -> ()
   // ... after applying ...
   // CHECK: hop_to_executor {{.*}} : $MainActor
   let f: () -> () = mainActorFn

--- a/test/SILGen/cf_members.swift
+++ b/test/SILGen/cf_members.swift
@@ -39,7 +39,10 @@ public func foo(_ x: Double) {
 
   // CHECK: [[FN:%.*]] = function_ref @$s10cf_members3fooyySdFSo10IAMStruct1VSdcfu_ : $@convention(thin) (Double) -> Struct1
   // CHECK: [[A:%.*]] = thin_to_thick_function [[FN]]
-  // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[A]]
+  // CHECK: [[MOVED_A:%.*]] = move_value [var_decl] [[A]]
+  // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[MOVED_A]]
+  // CHECK: [[COPIED_A:%.*]] = copy_value [[BORROWED_A]]
+  // CHECK: [[BORROWED_A:%.*]] = begin_borrow [[COPIED_A]]
   let a: (Double) -> Struct1 = Struct1.init(value:)
   // CHECK: [[NEW_Z_VALUE:%.*]] = apply [[BORROWED_A]]([[X]])
   // CHECK: end_borrow [[BORROWED_A]]
@@ -78,10 +81,13 @@ public func foo(_ x: Double) {
   z = c(x)
   // CHECK: [[THUNK:%.*]] = function_ref @$s10cf_members3fooyySdFSo10IAMStruct1VSdcADcfu2_ : $@convention(thin) (Struct1) -> @owned @callee_guaranteed (Double) -> Struct1
   // CHECK: [[THICK:%.*]] = thin_to_thick_function [[THUNK]]
+  // CHECK: [[MOVED_THICK:%.*]] = move_value [var_decl] [[THICK]]
+  // CHECK: [[BORROWED_THICK:%.*]] = begin_borrow [[MOVED_THICK]]
+  // CHECK: [[COPIED_THICK:%.*]] = copy_value [[BORROWED_THICK]]
   let d: (Struct1) -> (Double) -> Struct1 = Struct1.translate(radians:)
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[Z]] : $*Struct1
   // CHECK: [[ZVAL:%.*]] = load [trivial] [[READ]]
-  // CHECK: [[THICK_BORROW:%.*]] = begin_borrow [[THICK]]
+  // CHECK: [[THICK_BORROW:%.*]] = begin_borrow [[COPIED_THICK]]
   // CHECK: apply [[THICK_BORROW]]([[ZVAL]])
   // CHECK: end_borrow [[THICK_BORROW]]
   z = d(z)(x)
@@ -156,8 +162,11 @@ public func foo(_ x: Double) {
   var y = Struct1.staticMethod()
   // CHECK: [[THUNK:%.*]] = function_ref @$s10cf_members3fooyySdFs5Int32Vycfu8_ : $@convention(thin) () -> Int32 
   // CHECK: [[I2:%.*]] = thin_to_thick_function [[THUNK]]
+  // CHECK: [[MOVED_I2:%.*]] = move_value [var_decl] [[I2]]
+  // CHECK: [[BORROWED_I2:%.*]] = begin_borrow [[MOVED_I2]]
+  // CHECK: [[COPIED_I2:%.*]] = copy_value [[BORROWED_I2]]
   let i = Struct1.staticMethod
-  // CHECK: [[BORROWED_I2:%.*]] = begin_borrow [[I2]]
+  // CHECK: [[BORROWED_I2:%.*]] = begin_borrow [[COPIED_I2]]
   // CHECK: apply [[BORROWED_I2]]()
   y = i()
 

--- a/test/SILGen/implicitly_unwrapped_optional.swift
+++ b/test/SILGen/implicitly_unwrapped_optional.swift
@@ -73,7 +73,10 @@ func f_46343() {
   // Verify that there are no additional reabstractions introduced.
   // CHECK: [[CLOSURE:%.+]] = function_ref @$s29implicitly_unwrapped_optional7f_46343yyFyypSgcfU_ : $@convention(thin) (@in_guaranteed Optional<Any>) -> ()
   // CHECK: [[F:%.+]] = thin_to_thick_function [[CLOSURE]] : $@convention(thin) (@in_guaranteed Optional<Any>) -> () to $@callee_guaranteed (@in_guaranteed Optional<Any>) -> ()
-  // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[F]]
+  // CHECK: [[MOVED_F:%.*]] = move_value [var_decl] [[F]]
+  // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[MOVED_F]]
+  // CHECK: [[COPIED_F:%.*]] = copy_value [[BORROWED_F]]
+  // CHECK: [[BORROWED_F:%.*]] = begin_borrow [[COPIED_F]]
   // CHECK: = apply [[BORROWED_F]]({{%.+}}) : $@callee_guaranteed (@in_guaranteed Optional<Any>) -> ()
   // CHECK: end_borrow [[BORROWED_F]]
   let f: ((Any?) -> Void) = { (arg: Any!) in }

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.swift
@@ -362,6 +362,15 @@ public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x
     }
 }
 
+func f(x:[Int]?)
+{
+}
+func g()
+{
+    let x:[Int]? = nil
+    f(x: consume x)
+}
+
 /////////////////////////
 // Partial Apply Tests //
 /////////////////////////


### PR DESCRIPTION
All non-trivial values which correspond to `VarDecl`s must be marked appropriately so that they can be found by the relevant checker.  Here, values with none ownership are marked.
