### PR TITLE
Relax overzealous distance(from:to:) directionality

### DIFF
--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -199,10 +199,6 @@ extension LazyFilterCollection: Collection {
 
   @inlinable // lazy-performance
   public func distance(from start: Index, to end: Index) -> Int {
-    // The following line makes sure that distance(from:to:) is invoked on the
-    // _base at least once, to trigger a _precondition in forward only
-    // collections.
-    _ = _base.distance(from: start, to: end)
     var _start: Index
     let _end: Index
     let step: Int


### PR DESCRIPTION
#### Introduction

I noticed that some collection wrappers implement `distance(from:to:)` with preconditions checking whether their bases are "forward only" when the distance would be negative. While this kind of check is, perhaps, appropriate for `index(_:offsetBy:)`—I don't think it makes any sense for `distance(from:to:)` because you can always compute the index distance in a "forward only" manner. You may, for example, sort the indices and negate the positive distance if needed. 

Additionally, computing and discarding some arbitrary distance on the base collection is not always trivial. If the base implementation is sequential, has side effects, or is not inlinable—the operation might be expensive.

#### Proposal

Remove "forward only" preconditions from `distance(from:to:)` in:

- [ ] `FlattenSequence`
- [x] `LazyFilterSequence`