### PR TITLE
Embedded: enable `*-unknown-windows-coff` triples in `Platform.cpp`

### DIFF
--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -225,7 +225,7 @@ StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
     case llvm::Triple::Itanium:
       return "windows";
     default:
-      llvm_unreachable("unsupported Windows environment");
+      return "none";
     }
   case llvm::Triple::PS4:
     return "ps4";


### PR DESCRIPTION
This allows the frontend to proceed when building with `-target i686-unknown-windows-coff -enable-experimental-feature Embedded` arguments.
