### PR TITLE
Never print the inferred Failure associated type witness in a .swiftinterface

### DIFF
--- a/test/ModuleInterface/async_sequence_conformance.swift
+++ b/test/ModuleInterface/async_sequence_conformance.swift
@@ -22,8 +22,8 @@ public struct SequenceAdapter<Base: AsyncSequence>: AsyncSequence {
   // CHECK-LABEL: public func makeAsyncIterator
   public func makeAsyncIterator() -> AsyncIterator { AsyncIterator() }
 
-  // CHECK: @available(
-  // CHECK-NEXT: public typealias Failure = Base.Failure
+  // CHECK-NOT: public typealias Failure =
+  // CHECK: }
 }
 
 // CHECK: @available(


### PR DESCRIPTION
Extend the heuristic used previously for suppressing the inferred type witness for AsyncSequence.Failure to always suppress printing, because this typealias gets in the way of processing the resulting .swiftinterface files.

Fixes rdar://124342348.
