### PR TITLE
[region-isolation] Propagate region information from the analysis into the diagnostic emitter and fix a bunch of issues on the way

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -274,6 +274,9 @@ public:
     llvm_unreachable("Covered switch isn't covered?!");
   }
 
+  void printForDiagnostics(llvm::raw_ostream &os,
+                           StringRef openingQuotationMark = "'") const;
+
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 };
 

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -954,8 +954,8 @@ ERROR(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, non
       "binding of non-Sendable type %0 accessed after being transferred; later accesses could race",
       (Type))
 ERROR(regionbasedisolation_arg_transferred, none,
-      "task-isolated value of type %0 transferred to %1 context; later accesses to value could race",
-      (Type, ActorIsolation))
+      "%0 value of type %1 transferred to %2 context; later accesses to value could race",
+      (StringRef, Type, ActorIsolation))
 ERROR(regionbasedisolation_arg_passed_to_strongly_transferred_param, none,
       "task-isolated value of type %0 passed as a strongly transferred parameter; later accesses could race",
       (Type))

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -954,10 +954,10 @@ ERROR(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, non
       "binding of non-Sendable type %0 accessed after being transferred; later accesses could race",
       (Type))
 ERROR(regionbasedisolation_arg_transferred, none,
-      "task isolated value of type %0 transferred to %1 context; later accesses to value could race",
+      "task-isolated value of type %0 transferred to %1 context; later accesses to value could race",
       (Type, ActorIsolation))
 ERROR(regionbasedisolation_arg_passed_to_strongly_transferred_param, none,
-      "task isolated value of type %0 passed as a strongly transferred parameter; later accesses could race",
+      "task-isolated value of type %0 passed as a strongly transferred parameter; later accesses could race",
       (Type))
 NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
      "value is %0 since it is in the same region as %1",
@@ -974,7 +974,7 @@ ERROR(regionbasedisolation_stronglytransfer_assignment_yields_race_name, none,
       "assigning %0 to transferring parameter %1 may cause a race",
       (Identifier, Identifier))
 NOTE(regionbasedisolation_stronglytransfer_taskisolated_assign_note, none,
-      "%0 is a task isolated value that is assigned into transferring parameter %1. Transferred uses of %1 may race with caller uses of %0",
+      "%0 is a task-isolated value that is assigned into transferring parameter %1. Transferred uses of %1 may race with caller uses of %0",
       (Identifier, Identifier))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
@@ -987,7 +987,7 @@ NOTE(regionbasedisolation_named_info_isolated_capture, none,
      "%1 value %0 is captured by %2 closure. Later local uses could race",
      (Identifier, ActorIsolation, ActorIsolation))
 NOTE(regionbasedisolation_named_arg_info, none,
-     "Transferring task isolated function argument %0 could yield races with caller uses",
+     "Transferring task-isolated function argument %0 could yield races with caller uses",
      (Identifier))
 NOTE(regionbasedisolation_named_stronglytransferred_binding, none,
      "Cannot access a transferring parameter after the parameter has been transferred", ())

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -19,6 +19,7 @@
 #include "swift/SILOptimizer/Utils/PartitionUtils.h"
 
 #include <optional>
+#include <variant>
 
 namespace swift {
 

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -935,40 +935,12 @@ static void formatDiagnosticArgument(StringRef Modifier,
     Out << FormatOpts.OpeningQuotationMark << Arg.getAsLayoutConstraint()
         << FormatOpts.ClosingQuotationMark;
     break;
-  case DiagnosticArgumentKind::ActorIsolation:
+  case DiagnosticArgumentKind::ActorIsolation: {
     assert(Modifier.empty() && "Improper modifier for ActorIsolation argument");
-    switch (auto isolation = Arg.getAsActorIsolation()) {
-    case ActorIsolation::ActorInstance:
-      Out << "actor-isolated";
-      break;
-
-    case ActorIsolation::GlobalActor: {
-      if (isolation.isMainActor()) {
-        Out << "main actor-isolated";
-      } else {
-        Type globalActor = isolation.getGlobalActor();
-        Out << "global actor " << FormatOpts.OpeningQuotationMark
-          << globalActor.getString()
-          << FormatOpts.ClosingQuotationMark << "-isolated";
-      }
-      break;
-    }
-
-    case ActorIsolation::Erased:
-      Out << "@isolated(any)";
-      break;
-
-    case ActorIsolation::Nonisolated:
-    case ActorIsolation::NonisolatedUnsafe:
-    case ActorIsolation::Unspecified:
-      Out << "nonisolated";
-      if (isolation == ActorIsolation::NonisolatedUnsafe) {
-        Out << "(unsafe)";
-      }
-      break;
-    }
+    auto isolation = Arg.getAsActorIsolation();
+    isolation.printForDiagnostics(Out, FormatOpts.OpeningQuotationMark);
     break;
-
+  }
   case DiagnosticArgumentKind::Diagnostic: {
     assert(Modifier.empty() && "Improper modifier for Diagnostic argument");
     auto diagArg = Arg.getAsDiagnostic();

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1684,6 +1684,38 @@ ActorIsolation ActorIsolation::subst(SubstitutionMap subs) const {
   llvm_unreachable("unhandled actor isolation kind!");
 }
 
+void ActorIsolation::printForDiagnostics(llvm::raw_ostream &os,
+                                         StringRef openingQuotationMark) const {
+  switch (*this) {
+  case ActorIsolation::ActorInstance:
+    os << "actor-isolated";
+    break;
+
+  case ActorIsolation::GlobalActor: {
+    if (isMainActor()) {
+      os << "main actor-isolated";
+    } else {
+      Type globalActor = getGlobalActor();
+      os << "global actor " << openingQuotationMark << globalActor.getString()
+         << openingQuotationMark << "-isolated";
+    }
+    break;
+  }
+  case ActorIsolation::Erased:
+    os << "@isolated(any)";
+    break;
+
+  case ActorIsolation::Nonisolated:
+  case ActorIsolation::NonisolatedUnsafe:
+  case ActorIsolation::Unspecified:
+    os << "nonisolated";
+    if (*this == ActorIsolation::NonisolatedUnsafe) {
+      os << "(unsafe)";
+    }
+    break;
+  }
+}
+
 void swift::simple_display(
     llvm::raw_ostream &out, const ActorIsolation &state) {
   if (state.preconcurrency())

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1729,33 +1729,9 @@ public:
       }
     }
 
-    ValueIsolationRegionInfo actorIsolation;
-    for (auto &op : pai->getAllOperands()) {
-      if (auto value = tryToTrackValue(op.get())) {
-        if (auto isolation = value->getValueState().getIsolationRegionInfo()) {
-          actorIsolation = actorIsolation.merge(isolation);
-        }
-      } else {
-        // We only treat Sendable values as propagating actor self if the
-        // partial apply has operand as an sil_isolated parameter.
-        ApplySite applySite(pai);
-        if (applySite.isArgumentOperand(op) &&
-            ApplySite(pai).getArgumentParameterInfo(op).hasOption(
-                SILParameterInfo::Isolated)) {
-          if (auto isolation =
-                  value->getValueState().getIsolationRegionInfo()) {
-            actorIsolation = actorIsolation.merge(isolation);
-          }
-        }
-      }
-    }
-
-    if (actorIsolation.isDisconnected())
-      actorIsolation = ValueIsolationRegionInfo();
     SmallVector<SILValue, 8> applyResults;
     getApplyResults(pai, applyResults);
-    translateSILMultiAssign(applyResults, pai->getOperandValues(),
-                            actorIsolation);
+    translateSILMultiAssign(applyResults, pai->getOperandValues());
   }
 
   void translateSILBuiltin(BuiltinInst *bi) {

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -909,7 +909,7 @@ public:
         diagnoseNote(
             fArg->getDecl()->getLoc(),
             diag::regionbasedisolation_isolated_since_in_same_region_basename,
-            "task isolated", fArg->getDecl()->getBaseName());
+            "task-isolated", fArg->getDecl()->getBaseName());
       }
     }
   }
@@ -930,7 +930,7 @@ public:
     diagnoseNote(
         fArg->getDecl()->getLoc(),
         diag::regionbasedisolation_isolated_since_in_same_region_basename,
-        "task isolated", fArg->getDecl()->getBaseName());
+        "task-isolated", fArg->getDecl()->getBaseName());
   }
 
   void emitFunctionArgumentApplyStronglyTransferred(SILLocation loc,

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1205,7 +1205,7 @@ struct DiagnosticEvaluator final
   }
 
   bool isActorDerived(Element element) const {
-    return info->getValueMap().isActorDerived(element);
+    return info->getValueMap().getIsolationRegion(element).isActorIsolated();
   }
 
   bool isClosureCaptured(Element element, Operand *op) const {

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -878,6 +878,16 @@ public:
 
   Operand *getOperand() const { return info.transferredOperand; }
 
+  SILValue getNonTransferrableValue() const {
+    return info.nonTransferrableValue;
+  }
+
+  /// Return the isolation region info for \p getNonTransferrableValue().
+  ValueIsolationRegionInfo getIsolationRegionInfo() const {
+    return regionInfo->getValueMap().getIsolationRegion(
+        info.nonTransferrableValue);
+  }
+
   void emitUnknownPatternError() {
     diagnoseError(getOperand()->getUser(),
                   diag::regionbasedisolation_unknown_pattern);
@@ -888,23 +898,19 @@ public:
   }
 
   void emitFunctionArgumentApply(SILLocation loc, Type type,
+                                 ValueIsolationRegionInfo regionInfo,
                                  ApplyIsolationCrossing crossing) {
     diagnoseError(loc, diag::regionbasedisolation_arg_transferred, type,
                   crossing.getCalleeIsolation())
         .highlight(getOperand()->getUser()->getLoc().getSourceRange());
-    // Only emit the note if our value is different from the function
-    // argument.
-    auto rep = regionInfo->getValueMap()
-                   .getTrackableValue(getOperand()->get())
-                   .getRepresentative();
-    if (rep.maybeGetValue() == info.nonTransferrableValue)
-      return;
-    auto *fArg = cast<SILFunctionArgument>(info.nonTransferrableValue);
-    if (fArg->getDecl()) {
-      diagnoseNote(
-          fArg->getDecl()->getLoc(),
-          diag::regionbasedisolation_isolated_since_in_same_region_basename,
-          "task isolated", fArg->getDecl()->getBaseName());
+    if (regionInfo.isTaskIsolated()) {
+      auto *fArg = cast<SILFunctionArgument>(info.nonTransferrableValue);
+      if (fArg->getDecl()) {
+        diagnoseNote(
+            fArg->getDecl()->getLoc(),
+            diag::regionbasedisolation_isolated_since_in_same_region_basename,
+            "task isolated", fArg->getDecl()->getBaseName());
+      }
     }
   }
 
@@ -1085,7 +1091,9 @@ bool TransferNonTransferrableDiagnosticInferrer::run() {
       }
     }
 
-    diagnosticEmitter.emitFunctionArgumentApply(loc, type, *isolation);
+    auto isolationRegionInfo = diagnosticEmitter.getIsolationRegionInfo();
+    diagnosticEmitter.emitFunctionArgumentApply(loc, type, isolationRegionInfo,
+                                                *isolation);
     return true;
   }
 
@@ -1100,8 +1108,10 @@ bool TransferNonTransferrableDiagnosticInferrer::run() {
   // See if we are in SIL and have an apply site specified isolation.
   if (auto fas = FullApplySite::isa(op->getUser())) {
     if (auto isolation = fas.getIsolationCrossing()) {
+      auto isolationRegionInfo = diagnosticEmitter.getIsolationRegionInfo();
       diagnosticEmitter.emitFunctionArgumentApply(
-          loc, op->get()->getType().getASTType(), *isolation);
+          loc, op->get()->getType().getASTType(), isolationRegionInfo,
+          *isolation);
       return true;
     }
   }
@@ -1186,10 +1196,6 @@ struct DiagnosticEvaluator final
                                            partitionOp.getSourceInst());
   }
 
-  ArrayRef<Element> getNonTransferrableElements() const {
-    return info->getValueMap().getNonTransferrableElements();
-  }
-
   void handleTransferNonTransferrable(const PartitionOp &partitionOp,
                                       TrackableValueID transferredVal) const {
     LLVM_DEBUG(llvm::dbgs()
@@ -1204,8 +1210,43 @@ struct DiagnosticEvaluator final
                                                    nonTransferrableValue);
   }
 
+  void handleTransferNonTransferrable(
+      const PartitionOp &partitionOp, TrackableValueID transferredVal,
+      TrackableValueID actualNonTransferrableValue) const {
+    LLVM_DEBUG(llvm::dbgs()
+               << "    Emitting TransferNonTransferrable Error!\n"
+               << "        ID:  %%" << transferredVal << "\n"
+               << "        Rep: "
+               << *info->getValueMap().getRepresentative(transferredVal));
+    auto *self = const_cast<DiagnosticEvaluator *>(this);
+    // If we have a non-actor introducing fake representative value, just use
+    // the value that actually introduced the actor isolation.
+    if (auto nonTransferrableValue = info->getValueMap().maybeGetRepresentative(
+            actualNonTransferrableValue)) {
+      self->transferredNonTransferrable.emplace_back(partitionOp.getSourceOp(),
+                                                     nonTransferrableValue);
+    } else {
+      // Otherwise, just use the actual value.
+      //
+      // TODO: We are eventually going to want to be able to say that it is b/c
+      // of the actor isolated parameter. Maybe we should put in the actual
+      // region isolation info here.
+      self->transferredNonTransferrable.emplace_back(
+          partitionOp.getSourceOp(),
+          info->getValueMap().getRepresentative(transferredVal));
+    }
+  }
+
   bool isActorDerived(Element element) const {
     return info->getValueMap().getIsolationRegion(element).isActorIsolated();
+  }
+
+  bool isTaskIsolatedDerived(Element element) const {
+    return info->getValueMap().getIsolationRegion(element).isTaskIsolated();
+  }
+
+  ValueIsolationRegionInfo::Kind hasSpecialDerivation(Element element) const {
+    return info->getValueMap().getIsolationRegion(element).getKind();
   }
 
   bool isClosureCaptured(Element element, Operand *op) const {

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -108,7 +108,7 @@ bb0(%0 : $*{ var NonSendableKlass }):
 
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
   destroy_value %1 : ${ var NonSendableKlass }
 
   %9999 = tuple ()
@@ -282,7 +282,7 @@ bb0(%0 : @guaranteed $MyActor):
   %3 = class_method %0 : $MyActor, #MyActor.klass!getter : (isolated MyActor) -> () -> NonSendableKlass, $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
   %4 = apply %3(%0) : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
   %5 = class_method %4 : $NonSendableKlass, #NonSendableKlass.asyncCall : (NonSendableKlass) -> () async -> (), $@convention(method) @async (@guaranteed NonSendableKlass) -> ()
-  %6 = apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %5(%4) : $@convention(method) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{task isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+  %6 = apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %5(%4) : $@convention(method) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{task-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
   destroy_value %4 : $NonSendableKlass
   hop_to_executor %0 : $MyActor
   %9 = tuple ()

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -92,7 +92,7 @@ enum MainActorIsolatedEnum {
 }
 
 actor MyActor {
-  var klass: NonSendableKlass { get }
+  var klass: NonSendableKlass { get set }
 }
 
 /////////////////
@@ -282,9 +282,32 @@ bb0(%0 : @guaranteed $MyActor):
   %3 = class_method %0 : $MyActor, #MyActor.klass!getter : (isolated MyActor) -> () -> NonSendableKlass, $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
   %4 = apply %3(%0) : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
   %5 = class_method %4 : $NonSendableKlass, #NonSendableKlass.asyncCall : (NonSendableKlass) -> () async -> (), $@convention(method) @async (@guaranteed NonSendableKlass) -> ()
-  %6 = apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %5(%4) : $@convention(method) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{task-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+  %6 = apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %5(%4) : $@convention(method) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{actor-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
   destroy_value %4 : $NonSendableKlass
   hop_to_executor %0 : $MyActor
   %9 = tuple ()
   return %9 : $()
+}
+
+sil [ossa] @assignIntoSetter : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  debug_value %0 : $MyActor, let, name "self", argno 1, implicit
+  hop_to_executor %0 : $MyActor
+  %4 = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+  %5 = apply %4() : $@convention(thin) () -> @owned NonSendableKlass
+  %6 = move_value [lexical] [var_decl] %5 : $NonSendableKlass
+  debug_value %6 : $NonSendableKlass, let, name "x"
+  %8 = copy_value %6 : $NonSendableKlass
+  %9 = class_method %0 : $MyActor, #MyActor.klass!setter : (isolated MyActor) -> (NonSendableKlass) -> (), $@convention(method) (@owned NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %10 = apply %9(%8, %0) : $@convention(method) (@owned NonSendableKlass, @sil_isolated @guaranteed MyActor) -> ()
+  %11 = alloc_stack $NonSendableKlass
+  %12 = store_borrow %6 to %11 : $*NonSendableKlass
+  %13 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %14 = apply [caller_isolation=actor_instance] [callee_isolation=global_actor] %13<NonSendableKlass>(%12) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{actor-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  end_borrow %12 : $*NonSendableKlass
+  dealloc_stack %11 : $*NonSendableKlass
+  hop_to_executor %0 : $MyActor
+  destroy_value %6 : $NonSendableKlass
+  %19 = tuple ()
+  return %19 : $()
 }

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -19,7 +19,9 @@ import _Concurrency
 // MARK: Declarations //
 ////////////////////////
 
-class NonSendableKlass {}
+class NonSendableKlass {
+  func asyncCall() async
+}
 
 sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
 sil @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
@@ -87,6 +89,10 @@ struct MainActorIsolatedStruct {
 enum MainActorIsolatedEnum {
   case first
   case second(NonSendableKlass)
+}
+
+actor MyActor {
+  var klass: NonSendableKlass { get }
 }
 
 /////////////////
@@ -267,4 +273,18 @@ bb2(%1 : @guaranteed $NonSendableKlass):
 
 bb3(%4 : @owned $FakeOptional<NonSendableKlass>):
   return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{call site passes `self`}}
+}
+
+sil [ossa] @warningIfCallingGetter : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> () {
+bb0(%0 : @guaranteed $MyActor):
+  debug_value %0 : $MyActor, let, name "self", argno 1, implicit
+  hop_to_executor %0 : $MyActor
+  %3 = class_method %0 : $MyActor, #MyActor.klass!getter : (isolated MyActor) -> () -> NonSendableKlass, $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  %4 = apply %3(%0) : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
+  %5 = class_method %4 : $NonSendableKlass, #NonSendableKlass.asyncCall : (NonSendableKlass) -> () async -> (), $@convention(method) @async (@guaranteed NonSendableKlass) -> ()
+  %6 = apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %5(%4) : $@convention(method) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{task isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+  destroy_value %4 : $NonSendableKlass
+  hop_to_executor %0 : $MyActor
+  %9 = tuple ()
+  return %9 : $()
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -213,7 +213,7 @@ extension Actor {
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
-  // TODO: Why is this task isolated?
+  // TODO: Why is this task-isolated?
   func simpleClosureCaptureSelfAndTransferThroughTuple() async {
     let closure: () -> () = {
       print(self.klass)
@@ -221,17 +221,17 @@ extension Actor {
     let x = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type '(Int, () -> ())' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{task isolated value of type '(Int, () -> ())' transferred to main actor-isolated context}}
+    // expected-tns-warning @-2 {{task-isolated value of type '(Int, () -> ())' transferred to main actor-isolated context}}
   }
 
-  // TODO: Why is this task isolated?
+  // TODO: Why is this task-isolated?
   func simpleClosureCaptureSelfAndTransferThroughTupleBackwards() async {
     let closure: () -> () = {
       print(self.klass)
     }
 
     let x = (closure, 1)
-    await transferToMain(x) // expected-tns-warning {{task isolated value of type '(() -> (), Int)' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{task-isolated value of type '(() -> (), Int)' transferred to main actor-isolated context}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '(() -> (), Int)' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -1366,26 +1366,26 @@ actor ActorWithSetter {
   var recursive: ActorWithSetter? = nil
   var classBox = TwoFieldKlassClassBox()
 
-  // TODO: Why is this task isolated? This should be actor isolated?
+  // TODO: Why is this task-isolated? This should be actor isolated?
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}    
-    // expected-tns-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1405,7 +1405,7 @@ actor ActorWithSetter {
     let x = NonSendableKlass()
     self.classBox.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 }
 
@@ -1420,21 +1420,21 @@ final actor FinalActorWithSetter {
     let x = NonSendableKlass()
     self.field = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1454,12 +1454,12 @@ final actor FinalActorWithSetter {
     let x = NonSendableKlass()
     self.classBox.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 }
 
 func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let _ = { @MainActor in
-    let _ = x // expected-tns-warning {{task isolated value of type '() -> ()' transferred to main actor-isolated context}}
+    let _ = x // expected-tns-warning {{task-isolated value of type '() -> ()' transferred to main actor-isolated context}}
   }
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -221,7 +221,7 @@ extension Actor {
     let x = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type '(Int, () -> ())' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{task-isolated value of type '(Int, () -> ())' transferred to main actor-isolated context}}
+    // expected-tns-warning @-2 {{actor-isolated value of type '(Int, () -> ())' transferred to main actor-isolated context}}
   }
 
   // TODO: Why is this task-isolated?
@@ -231,7 +231,7 @@ extension Actor {
     }
 
     let x = (closure, 1)
-    await transferToMain(x) // expected-tns-warning {{task-isolated value of type '(() -> (), Int)' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{actor-isolated value of type '(() -> (), Int)' transferred to main actor-isolated context}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '(() -> (), Int)' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -1366,26 +1366,25 @@ actor ActorWithSetter {
   var recursive: ActorWithSetter? = nil
   var classBox = TwoFieldKlassClassBox()
 
-  // TODO: Why is this task-isolated? This should be actor isolated?
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}    
-    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1405,7 +1404,7 @@ actor ActorWithSetter {
     let x = NonSendableKlass()
     self.classBox.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 }
 
@@ -1420,21 +1419,21 @@ final actor FinalActorWithSetter {
     let x = NonSendableKlass()
     self.field = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1454,7 +1453,7 @@ final actor FinalActorWithSetter {
     let x = NonSendableKlass()
     self.classBox.k1 = x
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
   }
 }
 

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -49,12 +49,12 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
   let x = firstList
 
   // TODO: This should say global actor isolated isolated.
-  await transferToMainActor(x) // expected-tns-warning {{task isolated value of type 'NonSendableLinkedList<Int>' transferred to main actor-isolated context}}
+  await transferToMainActor(x) // expected-tns-warning {{task-isolated value of type 'NonSendableLinkedList<Int>' transferred to main actor-isolated context}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
 
   let y = secondList.listHead!.next!
 
-  await transferToMainActor(y) // expected-tns-warning {{task isolated value of type 'NonSendableLinkedListNode<Int>' transferred to main actor-isolated context}}
+  await transferToMainActor(y) // expected-tns-warning {{task-isolated value of type 'NonSendableLinkedListNode<Int>' transferred to main actor-isolated context}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
@@ -140,8 +140,8 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 
   x.1 = firstList
 
-  // TODO: This should be a global actor isolated error, not a task isolated error.
-  await transferToNonIsolated(x) // expected-tns-warning {{task isolated value of type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' transferred to nonisolated context}}
+  // TODO: This should be a global actor isolated error, not a task-isolated error.
+  await transferToNonIsolated(x) // expected-tns-warning {{task-isolated value of type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' transferred to nonisolated context}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -49,12 +49,12 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
   let x = firstList
 
   // TODO: This should say global actor isolated isolated.
-  await transferToMainActor(x) // expected-tns-warning {{task-isolated value of type 'NonSendableLinkedList<Int>' transferred to main actor-isolated context}}
+  await transferToMainActor(x) // expected-tns-warning {{global actor 'GlobalActor'-isolated value of type 'NonSendableLinkedList<Int>' transferred to main actor-isolated context}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
 
   let y = secondList.listHead!.next!
 
-  await transferToMainActor(y) // expected-tns-warning {{task-isolated value of type 'NonSendableLinkedListNode<Int>' transferred to main actor-isolated context}}
+  await transferToMainActor(y) // expected-tns-warning {{global actor 'GlobalActor'-isolated value of type 'NonSendableLinkedListNode<Int>' transferred to main actor-isolated context}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
@@ -141,7 +141,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   x.1 = firstList
 
   // TODO: This should be a global actor isolated error, not a task-isolated error.
-  await transferToNonIsolated(x) // expected-tns-warning {{task-isolated value of type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' transferred to nonisolated context}}
+  await transferToNonIsolated(x) // expected-tns-warning {{global actor 'GlobalActor'-isolated value of type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' transferred to nonisolated context}}
   // expected-complete-warning @-1 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_globalactors.swift
+++ b/test/Concurrency/transfernonsendable_globalactors.swift
@@ -40,16 +40,15 @@ struct CustomActor {
 
 @MainActor func testTransferGlobalActorGuardedValue() async {
   // TODO: Global actor error needed.
-  await transferToCustom(globalKlass) // expected-warning {{task-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
+  await transferToCustom(globalKlass) // expected-warning {{main actor-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
 }
 
 @MainActor func testTransferGlobalActorGuardedValueWithlet() async {
   let x = globalKlass
-  await transferToCustom(x) // expected-warning {{task-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
+  await transferToCustom(x) // expected-warning {{main actor-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
 }
 
 @MainActor func testTransferGlobalActorGuardedValueWithlet(_ k: Klass) async {
-  // expected-note @-1 {{value is task-isolated since it is in the same region as 'k'}}
   globalKlass = k
-  await transferToCustom(k) // expected-warning {{task-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context; later accesses to value could race}}
+  await transferToCustom(k) // expected-warning {{main actor-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context; later accesses to value could race}}
 }

--- a/test/Concurrency/transfernonsendable_globalactors.swift
+++ b/test/Concurrency/transfernonsendable_globalactors.swift
@@ -40,16 +40,16 @@ struct CustomActor {
 
 @MainActor func testTransferGlobalActorGuardedValue() async {
   // TODO: Global actor error needed.
-  await transferToCustom(globalKlass) // expected-warning {{task isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
+  await transferToCustom(globalKlass) // expected-warning {{task-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
 }
 
 @MainActor func testTransferGlobalActorGuardedValueWithlet() async {
   let x = globalKlass
-  await transferToCustom(x) // expected-warning {{task isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
+  await transferToCustom(x) // expected-warning {{task-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
 }
 
 @MainActor func testTransferGlobalActorGuardedValueWithlet(_ k: Klass) async {
-  // expected-note @-1 {{value is task isolated since it is in the same region as 'k'}}
+  // expected-note @-1 {{value is task-isolated since it is in the same region as 'k'}}
   globalKlass = k
-  await transferToCustom(k) // expected-warning {{task isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context; later accesses to value could race}}
+  await transferToCustom(k) // expected-warning {{task-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context; later accesses to value could race}}
 }

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -310,7 +310,7 @@ bb0(%0 : @owned $NonSendableStruct):
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableStruct>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task isolated value of type 'NonSendableStruct' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{task-isolated value of type 'NonSendableStruct' transferred to global actor '<null>'-isolated context}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableStruct>(%2) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -328,7 +328,7 @@ bb0(%0 : $*NonSendableStruct):
   %2 = moveonlywrapper_to_copyable_addr %1 : $*@moveOnly NonSendableStruct
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableStruct>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task isolated value of type 'NonSendableStruct' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{task-isolated value of type 'NonSendableStruct' transferred to global actor '<null>'-isolated context}}
   %9999 = tuple ()
   return %9999 : $()
 }
@@ -340,7 +340,7 @@ bb0(%0 : @owned $@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for 
   store %0 to [init] %blockAddr : $*@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<() -> ()>(%blockAddr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task isolated value of type '@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{task-isolated value of type '@callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <()>' transferred to global actor '<null>'-isolated context}}
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<() -> ()>(%blockAddr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -393,7 +393,7 @@ bb0(%0 : $*NonSendableKlass):
   mark_unresolved_move_addr %0 to %1 : $*NonSendableKlass
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%1) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
   destroy_addr %0 : $*NonSendableKlass
   destroy_addr %1 : $*NonSendableKlass
   dealloc_stack %1 : $*NonSendableKlass
@@ -529,9 +529,9 @@ bb0(%0 : $Builtin.RawPointer):
   // Should error on both since the raw pointer is from an argument.
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%4) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%6) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
-  // expected-warning @-1 {{task isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{task-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
 
   destroy_value %4 : $NonSendableKlass
   destroy_value %6 : $NonSendableKlass
@@ -563,9 +563,9 @@ bb0(%0 : $Builtin.RawPointer):
   // But if we transfer the raw pointers and use them later we get separate errors.
   %transferRawPointer = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%0) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{task isolated value of type 'Builtin.RawPointer' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{task-isolated value of type 'Builtin.RawPointer' transferred to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%2) : $@convention(thin) @async (Builtin.RawPointer) -> ()
-  // expected-warning @-1 {{task isolated value of type 'Builtin.RawPointer' transferred to global actor '<null>'-isolated context}}
+  // expected-warning @-1 {{task-isolated value of type 'Builtin.RawPointer' transferred to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%3a) : $@convention(thin) @async (Builtin.RawPointer) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%5a) : $@convention(thin) @async (Builtin.RawPointer) -> ()

--- a/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
@@ -81,7 +81,7 @@ bb0(%owned_value : @owned $T):
   %unowned_value = unowned_copy_value %owned_value : $T
 
   %4 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<@sil_unowned T>(%unowned_value) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{task isolated value of type 'T' transferred to global actor '<null>'-isolated context}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<@sil_unowned T>(%unowned_value) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{task-isolated value of type 'T' transferred to global actor '<null>'-isolated context}}
 
   destroy_value %unowned_value : $@sil_unowned T
   //destroy_value %value : $T

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -38,17 +38,17 @@ actor ProtectsNonSendable {
 
   nonisolated func testParameter(_ ns: NonSendableKlass) async {
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = ns // expected-warning {{task isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+      isolatedSelf.ns = ns // expected-warning {{task-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
     }
   }
 
   // This should get the note since l is different from 'ns'.
   nonisolated func testParameterMergedIntoLocal(_ ns: NonSendableKlass) async {
-    // expected-note @-1 {{value is task isolated since it is in the same region as 'ns'}}
+    // expected-note @-1 {{value is task-isolated since it is in the same region as 'ns'}}
     let l = NonSendableKlass()
     doSomething(l, ns)
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{task isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+      isolatedSelf.ns = l // expected-warning {{task-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
     }
   }
 

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -424,8 +424,7 @@ actor A_Sendable {
         // actor and is non-Sendable. For now, we ban this since we do not
         // support the ability to dynamically invoke the synchronous closure on
         // the specific actor.
-        // TODO: Should use special closure error.
-        await a.foo(captures_self) // expected-tns-warning {{task-isolated value of type '() -> ()' transferred to actor-isolated context}}
+        await a.foo(captures_self) // expected-tns-warning {{actor-isolated value of type '() -> ()' transferred to actor-isolated context}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
         // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -66,7 +66,7 @@ func test_isolation_crossing_sensitivity(a : A) async {
 }
 
 func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
-    // expected-tns-note @-1:36 {{value is task isolated since it is in the same region as 'ns_arg'}}
+    // expected-tns-note @-1:36 {{value is task-isolated since it is in the same region as 'ns_arg'}}
     let ns_let = NonSendable();
 
     // Safe to consume an rvalue.
@@ -76,7 +76,7 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
     await a.foo(ns_let); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     // Not safe to consume an arg.
-    await a.foo(ns_arg); // expected-tns-warning {{task isolated value of type 'NonSendable' transferred to actor-isolated context; later accesses to value could race}}
+    await a.foo(ns_arg); // expected-tns-warning {{task-isolated value of type 'NonSendable' transferred to actor-isolated context; later accesses to value could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     // Check for no duplicate warnings once self is "consumed"
@@ -381,14 +381,14 @@ class C_NonSendable {
     func bar() {}
 
     func bar(a : A) async {
-        // expected-tns-note @-1:10 {{value is task isolated since it is in the same region as 'self'}}
+        // expected-tns-note @-1:10 {{value is task-isolated since it is in the same region as 'self'}}
         let captures_self = { self.bar() }
 
         // this is not a cross-isolation call, so it should be permitted
         foo_noniso(captures_self)
 
         // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
-        await a.foo(captures_self) // expected-tns-warning {{task isolated value of type '() -> ()' transferred to actor-isolated context; later accesses to value could race}}
+        await a.foo(captures_self) // expected-tns-warning {{task-isolated value of type '() -> ()' transferred to actor-isolated context; later accesses to value could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
         // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }
@@ -425,7 +425,7 @@ actor A_Sendable {
         // support the ability to dynamically invoke the synchronous closure on
         // the specific actor.
         // TODO: Should use special closure error.
-        await a.foo(captures_self) // expected-tns-warning {{task isolated value of type '() -> ()' transferred to actor-isolated context}}
+        await a.foo(captures_self) // expected-tns-warning {{task-isolated value of type '() -> ()' transferred to actor-isolated context}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
         // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     }

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -129,9 +129,8 @@ actor MyActor {
   var field = Klass()
 
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
-    // expected-note @-1:72 {{value is task-isolated since it is in the same region as 'y'}}
     await transferToMain(x)
-    await transferToMain(y) // expected-warning {{task-isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
+    await transferToMain(y) // expected-warning {{actor-isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
@@ -169,12 +168,13 @@ actor MyActor {
 
 @MainActor func canAssignTransferringIntoGlobalActor2(_ x: transferring Klass) async {
   globalKlass = x
+  // TODO: This is incorrect! transferring should be independent of @MainActor.
   await transferToCustom(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
 @MainActor func canAssignTransferringIntoGlobalActor3(_ x: transferring Klass) async {
-  await transferToCustom(globalKlass) // expected-warning {{task-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
+  await transferToCustom(globalKlass) // expected-warning {{main actor-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
 }
 
 func canTransferAssigningIntoLocal(_ x: transferring Klass) async {

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -106,9 +106,9 @@ func testNonStrongTransferDoesntMerge() async {
 //////////////////////////////////
 
 func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) async {
-  // expected-note @-1:71 {{value is task isolated since it is in the same region as 'y'}}
+  // expected-note @-1:71 {{value is task-isolated since it is in the same region as 'y'}}
   await transferToMain(x)
-  await transferToMain(y) // expected-warning {{task isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
+  await transferToMain(y) // expected-warning {{task-isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
@@ -129,9 +129,9 @@ actor MyActor {
   var field = Klass()
 
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
-    // expected-note @-1:72 {{value is task isolated since it is in the same region as 'y'}}
+    // expected-note @-1:72 {{value is task-isolated since it is in the same region as 'y'}}
     await transferToMain(x)
-    await transferToMain(y) // expected-warning {{task isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
+    await transferToMain(y) // expected-warning {{task-isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
@@ -174,7 +174,7 @@ actor MyActor {
 }
 
 @MainActor func canAssignTransferringIntoGlobalActor3(_ x: transferring Klass) async {
-  await transferToCustom(globalKlass) // expected-warning {{task isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
+  await transferToCustom(globalKlass) // expected-warning {{task-isolated value of type 'Klass' transferred to global actor 'CustomActor'-isolated context}}
 }
 
 func canTransferAssigningIntoLocal(_ x: transferring Klass) async {
@@ -336,15 +336,15 @@ func testTransferOtherParamTuple(_ x: transferring Klass, y: (Klass, Klass)) asy
 func useSugaredTypeNameWhenEmittingTaskIsolationError(_ x: @escaping @MainActor () async -> ()) {
   func fakeInit(operation: transferring @escaping () async -> ()) {}
 
-  fakeInit(operation: x) // expected-warning {{task isolated value of type '@MainActor () async -> ()' passed as a strongly transferred parameter}}
+  fakeInit(operation: x) // expected-warning {{task-isolated value of type '@MainActor () async -> ()' passed as a strongly transferred parameter}}
 }
 
 // Make sure we error here on only the second since x by being assigned a part
-// of y becomes task isolated
+// of y becomes task-isolated
 func testMergeWithTaskIsolated(_ x: transferring Klass, y: Klass) async {
   await transferToMain(x)
   x = y
-  // TODO: We need to say that this is task isolated.
+  // TODO: We need to say that this is task-isolated.
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring nonisolated 'x' to main actor-isolated callee could cause races between main actor-isolated and nonisolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -24,12 +24,12 @@ func testIsolationError() async {
   useValue(x) // expected-note {{access here could race}}
 }
 
-func testTransferArgumentError(_ x: NonSendableType) async { // expected-note {{value is task isolated since it is in the same region as 'x'}}
-  await transferToMain(x) // expected-error {{task isolated value of type 'NonSendableType' transferred to main actor-isolated context; later accesses to value could race}}
+func testTransferArgumentError(_ x: NonSendableType) async { // expected-note {{value is task-isolated since it is in the same region as 'x'}}
+  await transferToMain(x) // expected-error {{task-isolated value of type 'NonSendableType' transferred to main actor-isolated context; later accesses to value could race}}
 }
 
 func testPassArgumentAsTransferringParameter(_ x: NonSendableType) async {
-  transferValue(x) // expected-error {{task isolated value of type 'NonSendableType' passed as a strongly transferred parameter; later accesses could race}}
+  transferValue(x) // expected-error {{task-isolated value of type 'NonSendableType' passed as a strongly transferred parameter; later accesses could race}}
 }
 
 func testAssignmentIntoTransferringParameter(_ x: transferring NonSendableType) async {
@@ -53,7 +53,7 @@ func testIsolationCrossingDueToCapture() async {
 
 func testIsolationCrossingDueToCaptureParameter(_ x: NonSendableType) async {
   let _ = { @MainActor in
-    print(x) // expected-error {{task isolated value of type 'NonSendableType' transferred to main actor-isolated context; later accesses to value could race}}
+    print(x) // expected-error {{task-isolated value of type 'NonSendableType' transferred to main actor-isolated context; later accesses to value could race}}
   }
   useValue(x)
 }


### PR DESCRIPTION
This PR does a few things all working towards accomplishing one goal: changing the way the analysis/diagnostic emitter think about actor isolation and task isolation from pattern matching against the AST to a new construct in the analysis that tracks the ValueRegionInfo for all "root" values that we track. I also fixed/standardized some issues on the way that also improved our diagnostics and eliminated a bug in the diagnostics.

With that in mind:

1. In the first commit, I performed an NFC transformation that changed the code that propagated around "actorIsolation" to instead traffic in a new enum type I defined call IsolationRegionInfo which is a struct that contains a union so we can represent other "isolation region information" along side actor information. Importantly, in this commit, I just represented disconnected and actor isolation so I could use the current set of tests to validate NFC. The way to think about it, is the value defines a lattice from disconnected -> task -> actor and a region's value region info is the merge of its elements. Importantly this will let us for a given value be able to discover the other.value that introduced the actor isolation information giving us an important piece of information to tell the user and with time also allow us to discover using a "history" why two values are in the same region.
2. In this commit, I just quickly standardized "task isolated" -> "task-isolated" so that different diagnostics are consistent.
3. Using this new infrastructure, I refactored the code so that instead of tracking non transferrable values in a separate array, we now track it like actor isolation... we create a field in our ValueRegionInfo enum for it and mark the value it afflicts with the info. Then like with actor information, when one wants to determine if a region is task isolated, one walks the entire region and looks for a value with the task isolated bit. NOTE: Of course actor takes precedence if one is around.
4. I eliminated some dead code in this commit. It is dead since I fixed closures that capture self to have sil_isolated.
5. Finally, using the new infrastructure I was able to fix a bunch of cases where we were saying that actor isolated parameters were task isolated. Same semantic causes, but it is misleading.