### PR TITLE
IRGen: Don't let the offset of an empty field be undef.

### DIFF
--- a/test/IRGen/optimized_offset_of_empty.swift
+++ b/test/IRGen/optimized_offset_of_empty.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -module-name=test %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// RUN: %target-build-swift -module-name=test -O %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+// REQUIRES: executable_test
+
+
+enum E {
+  case A
+}
+
+struct X {}
+
+struct S {
+  let i: Int
+  let e: E
+  let x: X
+}
+
+var gg: Int? = 27
+
+@inline(never)
+func getOffsetE() {
+  gg = MemoryLayout<S>.offset(of: \.e)
+}
+
+@inline(never)
+func getOffsetX() {
+  gg = MemoryLayout<S>.offset(of: \.x)
+}
+
+getOffsetE()
+
+// CHECK: Optional(0)
+print(gg as Any)
+
+gg = 27
+
+getOffsetX()
+
+// CHECK: Optional(0)
+print(gg as Any)

--- a/test/IRGen/struct_layout.sil
+++ b/test/IRGen/struct_layout.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -module-name main -emit-ir -o - | %FileCheck -check-prefix=%target-ptrsize %s
+// RUN: %target-swift-frontend %s -module-name main -emit-ir -o - | %FileCheck -check-prefix=%target-ptrsize  --check-prefix=CHECK %s
 
 import Builtin
 import Swift
@@ -31,4 +31,24 @@ struct Rdar15410780_B {
 
 struct Rdar15410780_C {
   var d: String?
+}
+
+enum EmptyEnum {
+  case A
+}
+
+struct S {
+  @_hasStorage let x: Int
+  @_hasStorage let e: EmptyEnum
+}
+
+// CHECK-LABEL: define {{.*}} @testOffsetOfEmptyType
+// CHECK:         ret ptr null
+// CHECK:       }
+sil @testOffsetOfEmptyType : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = base_addr_for_offset $*S
+  %1 = struct_element_addr %0 : $*S, #S.e
+  %2 = address_to_pointer %1 : $*EmptyEnum to $Builtin.RawPointer
+  return %2 : $Builtin.RawPointer
 }


### PR DESCRIPTION
If the field address comes from a struct_element_addr which is a result of an optimized `MemoryLayout<S>.offset(of: \.field)` we cannot return undef. We have to be consistent with `offset(of:)`, which returns 0. Therefore we need to return the base address of the struct.

rdar://117265274
