### PR TITLE
[Concurrency] Change TypeBase::isSendable() to return false for unavailable conformances.

### DIFF
--- a/lib/AST/ConformanceLookup.cpp
+++ b/lib/AST/ConformanceLookup.cpp
@@ -852,16 +852,9 @@ bool TypeBase::isSendableType() {
   if (auto *fas = getAs<AnyFunctionType>())
     return fas->isSendable();
 
-  auto conformance = proto->getParentModule()->checkConformance(this, proto);
-  if (conformance.isInvalid())
-    return false;
-
-  // Look for missing Sendable conformances.
-  return !conformance.forEachMissingConformance(
-      [](BuiltinProtocolConformance *missing) {
-        return missing->getProtocol()->isSpecificProtocol(
-            KnownProtocolKind::Sendable);
-      });
+  auto conformance = proto->getParentModule()->checkConformance(
+      this, proto, false /*allow missing*/);
+  return conformance && !conformance.hasUnavailableConformance();
 }
 
 ///

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -96,6 +96,8 @@ public actor MyActor: MyProto {
 
   func g(ns1: NS1) async {
     await nonisolatedAsyncFunc1(ns1) // expected-targeted-and-complete-warning{{passing argument of non-sendable type 'NS1' outside of actor-isolated context may introduce data races}}
+    // expected-tns-warning @-1 {{transferring 'ns1' may cause a race}}
+    // expected-tns-note @-2 {{transferring actor-isolated 'ns1' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
     _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
   }
 }
@@ -352,13 +354,12 @@ func testPointersAreNotSendable() {
 extension SynthesizedConformances.NotSendable: Sendable {}
 
 enum SynthesizedConformances {
-  // expected-note@+1 2 {{consider making struct 'NotSendable' conform to the 'Sendable' protocol}}
   struct NotSendable: Equatable {}
 
-  // expected-warning@+2 2{{non-sendable type 'SynthesizedConformances.NotSendable' in asynchronous access to main actor-isolated property 'x' cannot cross actor boundary}}
-  // expected-note@+1 2 {{in derived conformance to 'Equatable'}}
+  // expected-warning@+2 2{{main actor-isolated property 'x' can not be referenced from a non-isolated context}}
+  // expected-note@+1 2{{in static method '==' for derived conformance to 'Equatable'}}
   @MainActor struct Isolated: Equatable {
-    let x: NotSendable
+    let x: NotSendable // expected-note 2{{property declared here}}
   }
 }
 

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking -verify  %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// This test makes sure that we treat types with an unavailable Sendable
+// conformance as being non-Sendable.
+
+public class NonSendable {
+  func foo() {
+  }
+}
+
+@available(*, unavailable)
+extension NonSendable: Sendable {}
+
+actor Bar {
+  init(_ _: NonSendable) {
+  }
+  func bar() async {
+    let ns = NonSendable() // expected-note {{variable defined here}}
+    _ = Bar(ns) // expected-warning {{transferring 'ns' may cause a race}}
+    // TODO: This needs to be:
+    // disconnected 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
+    // expected-note @-3 {{'ns' is transferred from actor-isolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    ns.foo() // expected-note {{access here could race}}
+  }
+}


### PR DESCRIPTION
rdar://122174496
