### PR TITLE
[stdlib] convert `_withUnprotectedUnsafeMutablePointer()` to typed throws

### DIFF
--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -87,10 +87,10 @@ public func withUnsafeMutablePointer<T, Result>(
 /// This function is similar to `withUnsafeMutablePointer`, except that it
 /// doesn't trigger stack protection for the pointer.
 @_alwaysEmitIntoClient
-public func _withUnprotectedUnsafeMutablePointer<T, Result>(
+public func _withUnprotectedUnsafeMutablePointer<T, E: Error, Result>(
   to value: inout T,
-  _ body: (UnsafeMutablePointer<T>) throws -> Result
-) rethrows -> Result
+  _ body: (UnsafeMutablePointer<T>) throws(E) -> Result
+) throws(E) -> Result
 {
 #if $BuiltinUnprotectedAddressOf
   return try body(UnsafeMutablePointer<T>(Builtin.unprotectedAddressOf(&value)))


### PR DESCRIPTION
Part of the ongoing conversion of standard library rethrows functions, after [SE-0413](https://github.com/apple/swift-evolution/blob/main/proposals/0413-typed-throws.md).

This converts the top-level, no-stack-protection function `_withUnprotectedUnsafeMutablePointer()`.