### PR TITLE
[Sema] A few minor fixes for `InferSendableFromCaptures` feature

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10208,6 +10208,9 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
   // where the base type has a conditional Sendable conformance
   if (Context.LangOpts.hasFeature(Feature::InferSendableFromCaptures)) {
     auto shouldCheckSendabilityOfBase = [&]() {
+      if (!Context.getProtocol(KnownProtocolKind::Sendable))
+        return false;
+
       // Static members are always sendable because they only capture
       // metatypes which are Sendable.
       if (baseObjTy->is<AnyMetatypeType>())

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -5449,6 +5449,11 @@ static void maybeDiagnoseCallToKeyValueObserveMethod(const Expr *E,
       auto isKeyPathLiteral = [&](Expr *argExpr) -> KeyPathExpr * {
         if (auto *DTBE = getAsExpr<DerivedToBaseExpr>(argExpr))
           argExpr = DTBE->getSubExpr();
+        // Sendable key path literals are represented as an existential
+        // protocol composition with `Sendable` protocol which has to be
+        // opened in certain scenarios i.e. to pass it to non-Sendable version.
+        if (auto *OEE = getAsExpr<OpenExistentialExpr>(argExpr))
+          argExpr = OEE->getExistentialValue();
         return getAsExpr<KeyPathExpr>(argExpr);
       };
 

--- a/test/Concurrency/sendable_keypath-observe-objc.swift
+++ b/test/Concurrency/sendable_keypath-observe-objc.swift
@@ -1,0 +1,60 @@
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature InferSendableFromCaptures
+
+// REQUIRES: objc_interop
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// This is a copy of test/expr/primary/keypath/keypath-observe-objc.swift with additional requirements to test sendable key paths
+
+import Foundation
+
+class Foo: NSObject {
+  var number1 = 1
+  dynamic var number2 = 2
+  @objc var number3 = 3
+  @objc dynamic var number4 = 4
+  @objc var number5: Int {
+    get { return 5 }
+    set {}
+  }
+}
+
+class Bar: NSObject {
+  @objc dynamic let foo: Foo
+
+  init(foo: Foo) {
+    self.foo = foo
+    super.init()
+
+    _ = observe(\.foo.number1, options: [.new]) { _, change in
+      // expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number1' to KVO method 'observe(_:options:changeHandler:)' may lead to unexpected behavior or runtime trap}}
+      print("observer1")
+    }
+
+    _ = observe(\.foo.number2, options: [.new]) { _, change in
+      // expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number2' to KVO method 'observe(_:options:changeHandler:)' may lead to unexpected behavior or runtime trap}}
+      print("observer2")
+    }
+
+    _ = observe(\.foo.number3, options: [.new]) { _, change in
+      // expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number3' to KVO method 'observe(_:options:changeHandler:)' may lead to unexpected behavior or runtime trap}}
+      print("observer3")
+    }
+
+    _ = observe(\.foo.number4, options: [.new]) { _, change in // Okay
+      print("observer4")
+    }
+
+    _ = observe(\.foo.number5, options: [.new]) { _, change in // Okay
+      print("observer4")
+    }
+  }
+}
+
+@_semantics("keypath.mustBeValidForKVO")
+func quux<T, V, U>(_ object: T, at keyPath: KeyPath<T, V>, _ keyPath2: KeyPath<T, U>) { }
+
+// The presence of a valid keypath should not prevent detection of invalid ones
+// later in the argument list, so start with a valid one here.
+quux(Foo(), at: \.number4, \.number1)
+// expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number1' to KVO method 'quux(_:at:_:)' may lead to unexpected behavior or runtime trap}}


### PR DESCRIPTION
-  [MiscDiagnostics] KeyPath KVO diagnostics should handle existential opening
- [CSSimplify] InferSendableFromCaptures: Don't expect Sendable to be always present

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
