### PR TITLE
[ModuleInterface] Print `-enable-experimental-opaque-type-erasure` in swiftinterface files.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -238,7 +238,7 @@ EXPERIMENTAL_FEATURE(AdditiveArithmeticDerivedConformances, false)
 EXPERIMENTAL_FEATURE(SendableCompletionHandlers, false)
 
 /// Enables opaque type erasure without also enabling implict dynamic
-EXPERIMENTAL_FEATURE(OpaqueTypeErasure, false)
+EXPERIMENTAL_FEATURE(OpaqueTypeErasure, true)
 
 /// Whether to perform round-trip testing of the Swift Swift parser.
 EXPERIMENTAL_FEATURE(ParserRoundTrip, false)

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -306,6 +306,10 @@ let Flags = [FrontendOption, NoDriverOption, HelpHidden, ModuleInterfaceOption] 
     Flag<["-"], "disable-objc-interop">,
     HelpText<"Disable Objective-C interop code generation and config directives">;
 
+  def enable_experimental_opaque_type_erasure :
+    Flag<["-"], "enable-experimental-opaque-type-erasure">,
+    HelpText<"Type-erases opaque types that conform to @_typeEraser protocols">;
+
   def enable_objc_attr_requires_foundation_module :
     Flag<["-"], "enable-objc-attr-requires-foundation-module">,
     HelpText<"Enable requiring uses of @objc to require importing the "
@@ -696,10 +700,6 @@ def enable_implicit_dynamic : Flag<["-"], "enable-implicit-dynamic">,
 def bypass_resilience : Flag<["-"], "bypass-resilience-checks">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
   HelpText<"Ignore all checks for module resilience.">;
-  
-def enable_experimental_opaque_type_erasure : Flag<["-"], "enable-experimental-opaque-type-erasure">,
-  Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,
-  HelpText<"Type-erases opaque types that conform to @_typeEraser protocols">;
 
 def enable_llvm_vfe : Flag<["-"], "enable-llvm-vfe">,
   Flags<[FrontendOption, NoInteractiveOption, HelpHidden]>,

--- a/test/Sema/Inputs/import_with_opaque_type_erasure.swift
+++ b/test/Sema/Inputs/import_with_opaque_type_erasure.swift
@@ -1,0 +1,5 @@
+import erasure
+
+var erased: some P {
+  testTypeErased()
+}

--- a/test/Sema/type_eraser_experimental_flag.swift
+++ b/test/Sema/type_eraser_experimental_flag.swift
@@ -1,17 +1,43 @@
 // RUN: %target-swift-frontend -typecheck -disable-availability-checking -dump-ast -enable-experimental-opaque-type-erasure %s | %FileCheck %s
 
-class AnyP: P {
-  init<T: P>(erasing: T) {}
+public struct AnyP: P {
+  public init<T: P>(erasing: T) {}
 }
 
 @_typeEraser(AnyP)
-protocol P {}
+public protocol P {}
 
-struct ConcreteP: P, Hashable {}
+public struct ConcreteP: P, Hashable {
+  public init() {}
+}
 
 // CHECK-LABEL: testTypeErased
-func testTypeErased() -> some P {
+@inlinable public func testTypeErased() -> some P {
   // CHECK: underlying_to_opaque_expr{{.*}}"some P"
   // CHECK-NEXT: call_expr implicit type="AnyP"
   ConcreteP()
 }
+
+// Check with -enable-experimental-opaque-type-erasure
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/test1/erasure.swiftinterface) %s -module-name erasure -enable-experimental-opaque-type-erasure -enable-library-evolution
+// RUN: %FileCheck %s --check-prefix CHECK-INTERFACE < %t/test1/erasure.swiftinterface
+// CHECK-INTERFACE: swift-module-flags:{{.*}} -enable-experimental-opaque-type-erasure
+
+// RUN: %target-swift-frontend -I %t/test1/ -emit-sil %S/Inputs/import_with_opaque_type_erasure.swift | %FileCheck %s --check-prefix CHECK-UNDERLYING-TYPE
+// CHECK-UNDERLYING-TYPE-LABEL: s31import_with_opaque_type_erasure6erasedQrvg
+// CHECK-UNDERLYING-TYPE: bb0(%0 : $*AnyP):
+// CHECK-UNDERLYING-TYPE: function_ref @$s7erasure14testTypeErasedQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <AnyP>
+
+
+// Check with -enable-experimental-feature OpaqueTypeErasure
+
+// RUN: %target-swift-emit-module-interface(%t/test2/erasure.swiftinterface) %s -module-name erasure -enable-experimental-feature OpaqueTypeErasure -enable-library-evolution
+// RUN: %FileCheck %s --check-prefix CHECK-INTERFACE2 < %t/test2/erasure.swiftinterface
+// CHECK-INTERFACE2: swift-module-flags:{{.*}} -enable-experimental-feature OpaqueTypeErasure
+
+// RUN: %target-swift-frontend -I %t/test2/ -emit-sil %S/Inputs/import_with_opaque_type_erasure.swift | %FileCheck %s --check-prefix CHECK-UNDERLYING-TYPE2
+// CHECK-UNDERLYING-TYPE2-LABEL: s31import_with_opaque_type_erasure6erasedQrvg
+// CHECK-UNDERLYING-TYPE2: bb0(%0 : $*AnyP):
+// CHECK-UNDERLYING-TYPE2: function_ref @$s7erasure14testTypeErasedQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <AnyP>

--- a/test/Sema/type_eraser_experimental_flag.swift
+++ b/test/Sema/type_eraser_experimental_flag.swift
@@ -21,11 +21,11 @@ public struct ConcreteP: P, Hashable {
 // Check with -enable-experimental-opaque-type-erasure
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/test1/erasure.swiftinterface) %s -module-name erasure -enable-experimental-opaque-type-erasure -enable-library-evolution
+// RUN: %target-swift-emit-module-interface(%t/test1/erasure.swiftinterface) %s -module-name erasure -enable-experimental-opaque-type-erasure -enable-library-evolution -disable-availability-checking
 // RUN: %FileCheck %s --check-prefix CHECK-INTERFACE < %t/test1/erasure.swiftinterface
 // CHECK-INTERFACE: swift-module-flags:{{.*}} -enable-experimental-opaque-type-erasure
 
-// RUN: %target-swift-frontend -I %t/test1/ -emit-sil %S/Inputs/import_with_opaque_type_erasure.swift | %FileCheck %s --check-prefix CHECK-UNDERLYING-TYPE
+// RUN: %target-swift-frontend -disable-availability-checking -I %t/test1/ -emit-sil %S/Inputs/import_with_opaque_type_erasure.swift | %FileCheck %s --check-prefix CHECK-UNDERLYING-TYPE
 // CHECK-UNDERLYING-TYPE-LABEL: s31import_with_opaque_type_erasure6erasedQrvg
 // CHECK-UNDERLYING-TYPE: bb0(%0 : $*AnyP):
 // CHECK-UNDERLYING-TYPE: function_ref @$s7erasure14testTypeErasedQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <AnyP>
@@ -33,11 +33,11 @@ public struct ConcreteP: P, Hashable {
 
 // Check with -enable-experimental-feature OpaqueTypeErasure
 
-// RUN: %target-swift-emit-module-interface(%t/test2/erasure.swiftinterface) %s -module-name erasure -enable-experimental-feature OpaqueTypeErasure -enable-library-evolution
+// RUN: %target-swift-emit-module-interface(%t/test2/erasure.swiftinterface) %s -module-name erasure -enable-experimental-feature OpaqueTypeErasure -enable-library-evolution -disable-availability-checking
 // RUN: %FileCheck %s --check-prefix CHECK-INTERFACE2 < %t/test2/erasure.swiftinterface
 // CHECK-INTERFACE2: swift-module-flags:{{.*}} -enable-experimental-feature OpaqueTypeErasure
 
-// RUN: %target-swift-frontend -I %t/test2/ -emit-sil %S/Inputs/import_with_opaque_type_erasure.swift | %FileCheck %s --check-prefix CHECK-UNDERLYING-TYPE2
+// RUN: %target-swift-frontend -disable-availability-checking -I %t/test2/ -emit-sil %S/Inputs/import_with_opaque_type_erasure.swift | %FileCheck %s --check-prefix CHECK-UNDERLYING-TYPE2
 // CHECK-UNDERLYING-TYPE2-LABEL: s31import_with_opaque_type_erasure6erasedQrvg
 // CHECK-UNDERLYING-TYPE2: bb0(%0 : $*AnyP):
 // CHECK-UNDERLYING-TYPE2: function_ref @$s7erasure14testTypeErasedQryF : $@convention(thin) @substituted <τ_0_0> () -> @out τ_0_0 for <AnyP>


### PR DESCRIPTION
`OpaqueTypeErasure` can change the underlying type of opaque return types, including in inlinable code. However, the flag to enable opaque type erasure was not printed in swiftinterface files, meaning there could be disagreements about what the underlying type of inlinable code is when rebuilding a module from its swiftinterface, which can lead to miscompiles when the experimental feature is enabled.

This change prints `-enable-experimental-opaque-type-erasure` into swiftinterface files to fix that, and also makes `OpaqueTypeErasure` enable-able in noasserts builds so that the bespoke `-enable-experimental-opaque-type-erasure` flag can be removed later on in favor of the standard `-enable-experimental-feature` flag.

Resolves: rdar://124028996