### PR TITLE
[Runtime] Don't enable tracing in logd, diagnosticd, notifyd.

### DIFF
--- a/stdlib/public/Concurrency/TracingSignpost.cpp
+++ b/stdlib/public/Concurrency/TracingSignpost.cpp
@@ -17,6 +17,7 @@
 #if SWIFT_STDLIB_CONCURRENCY_TRACING
 
 #include "TracingSignpost.h"
+#include "swift/Runtime/TracingCommon.h"
 #include <stdio.h>
 
 #define SWIFT_LOG_CONCURRENCY_SUBSYSTEM "com.apple.swift.concurrency"
@@ -30,8 +31,15 @@ namespace trace {
 os_log_t ActorLog;
 os_log_t TaskLog;
 swift::once_t LogsToken;
+bool TracingEnabled;
 
 void setupLogs(void *unused) {
+  if (!swift::runtime::trace::shouldEnableTracing()) {
+    TracingEnabled = false;
+    return;
+  }
+
+  TracingEnabled = true;
   ActorLog = os_log_create(SWIFT_LOG_CONCURRENCY_SUBSYSTEM,
                            SWIFT_LOG_ACTOR_CATEGORY);
   TaskLog = os_log_create(SWIFT_LOG_CONCURRENCY_SUBSYSTEM,

--- a/stdlib/public/Concurrency/TracingSignpost.h
+++ b/stdlib/public/Concurrency/TracingSignpost.h
@@ -70,6 +70,7 @@ namespace trace {
 extern os_log_t ActorLog;
 extern os_log_t TaskLog;
 extern swift::once_t LogsToken;
+extern bool TracingEnabled;
 
 void setupLogs(void *unused);
 
@@ -78,9 +79,9 @@ void setupLogs(void *unused);
 // optimized out.
 #define ENSURE_LOGS(...)                                                       \
   do {                                                                         \
-    if (!SWIFT_RUNTIME_WEAK_CHECK(os_signpost_enabled))                        \
-      return __VA_ARGS__;                                                      \
     swift::once(LogsToken, setupLogs, nullptr);                                \
+    if (!TracingEnabled)                                                       \
+      return __VA_ARGS__;                                                      \
   } while (0)
 
 // Every function does ENSURE_LOGS() before making any os_signpost calls, so

--- a/stdlib/public/runtime/Tracing.h
+++ b/stdlib/public/runtime/Tracing.h
@@ -34,6 +34,7 @@ namespace trace {
 
 extern os_log_t ScanLog;
 extern swift::once_t LogsToken;
+extern bool TracingEnabled;
 
 void setupLogs(void *unused);
 
@@ -48,9 +49,9 @@ void setupLogs(void *unused);
 // optimized out.
 #define ENSURE_LOG(log)                                                        \
   do {                                                                         \
-    if (!SWIFT_RUNTIME_WEAK_CHECK(os_signpost_enabled))                        \
-      return {};                                                               \
     swift::once(LogsToken, setupLogs, nullptr);                                \
+    if (!TracingEnabled)                                                       \
+      return {};                                                               \
   } while (0)
 
 /// A struct that captures the state of a scan tracing signpost. When the scan


### PR DESCRIPTION
We can't use os_log functionality in logd, diagnosticd, or notifyd. Check for them and disable tracing in those processes.

Add a new TracingCommon.h for common code shared between swiftCore and swift_Concurrency tracing. Add a single function that checks if tracing should be enabled, which now checks if os_signpost_enabled is available, and if the process is one of these. Modify the tracing code to check this before creating os_log objects.

rdar://124226334