### PR TITLE
[Distributed] Remove _distributedThunkTarget; it is not necessary

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2609,28 +2609,6 @@ public:
   }
 };
 
-/// The @_distributedThunkTarget(for:) attribute.
-class DistributedThunkTargetAttr final
-    : public DeclAttribute {
-
-  AbstractFunctionDecl *TargetFunction;
-
-public:
-  DistributedThunkTargetAttr(AbstractFunctionDecl *target)
-      : DeclAttribute(DeclAttrKind::DistributedThunkTarget, SourceLoc(),
-                      SourceRange(),
-                      /*Implicit=*/false),
-        TargetFunction(target) {}
-
-  AbstractFunctionDecl *getTargetFunction() const {
-    return TargetFunction;
-  }
-
-  static bool classof(const DeclAttribute *DA) {
-    return DA->getKind() == DeclAttrKind::DistributedThunkTarget;
-  }
-};
-
 /// Predicate used to filter MatchingAttributeRange.
 template <typename ATTR, bool AllowInvalid> struct ToAttributeKind {
   ToAttributeKind() {}

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -485,9 +485,7 @@ SIMPLE_DECL_ATTR(_noExistentials, NoExistentials,
 SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
   OnAbstractFunction | OnSubscript | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIStableToAdd | APIStableToRemove,
   155)
-DECL_ATTR(_distributedThunkTarget, DistributedThunkTarget,
-  OnAbstractFunction | UserInaccessible | ABIStableToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
-  156)
+// Unused '156': Used to be `_distributedThunkTarget` but completed implementation in Swift 6.0 does not need it after all
 DECL_ATTR(_allowFeatureSuppression, AllowFeatureSuppression,
   OnAnyDecl | UserInaccessible | NotSerialized | ABIStableToAdd | APIStableToAdd | ABIStableToRemove | APIStableToRemove,
   157)

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1918,8 +1918,6 @@ StringRef DeclAttribute::getAttrName() const {
     return "_section";
   case DeclAttrKind::Documentation:
     return "_documentation";
-  case DeclAttrKind::DistributedThunkTarget:
-    return "_distributedThunkTarget";
   case DeclAttrKind::Nonisolated:
     if (cast<NonisolatedAttr>(this)->isUnsafe()) {
         return "nonisolated(unsafe)";

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -256,8 +256,7 @@ extension ASTGenVisitor {
         .usableFromInline,
         .used,
         .warnUnqualifiedAccess,
-        .weakLinked,
-        .distributedThunkTarget:
+        .weakLinked:
 
         return self.generateSimpleDeclAttr(attribute: node, kind: attrKind)
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3704,11 +3704,6 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
 
-  case DeclAttrKind::DistributedThunkTarget: {
-    assert(false && "Not implemented");
-    break;
-  }
-
   case DeclAttrKind::TypeEraser: {
     // Parse leading '('
     if (Tok.isNot(tok::l_paren)) {

--- a/lib/Sema/CodeSynthesisDistributedActor.cpp
+++ b/lib/Sema/CodeSynthesisDistributedActor.cpp
@@ -751,10 +751,6 @@ static FuncDecl *createDistributedThunkFunction(FuncDecl *func) {
   if (func->hasBody())
     thunk->setBodySynthesizer(deriveBodyDistributed_thunk, func);
 
-  /// Record which function this is a thunk for, we'll need this to link back
-  /// calls in case this is a distributed requirement witness.
-  thunk->getAttrs().add(new (C) DistributedThunkTargetAttr(func));
-
   return thunk;
 }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -163,7 +163,6 @@ public:
   IGNORED_ATTR(BackDeployed)
   IGNORED_ATTR(Documentation)
   IGNORED_ATTR(LexicalLifetimes)
-  IGNORED_ATTR(DistributedThunkTarget)
   IGNORED_ATTR(AllowFeatureSuppression)
   IGNORED_ATTR(PreInverseGenerics)
 #undef IGNORED_ATTR

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1636,7 +1636,6 @@ namespace  {
     UNINTERESTING_ATTR(NonEscapable)
     UNINTERESTING_ATTR(UnsafeNonEscapableResult)
     UNINTERESTING_ATTR(StaticExclusiveOnly)
-    UNINTERESTING_ATTR(DistributedThunkTarget)
     UNINTERESTING_ATTR(PreInverseGenerics)
 #undef UNINTERESTING_ATTR
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2387,14 +2387,6 @@ namespace decls_block {
     BCArray<IdentifierIDField>
   >;
 
-  using DistributedThunkTargetDeclAttrLayout = BCRecordLayout<
-      DistributedThunkTarget_DECL_ATTR,
-      BCFixed<1>, // implicit flag
-      DeclIDField // target function
-          // FIXME: not entirely right?
-  >;
-
-
   using TypeEraserDeclAttrLayout = BCRecordLayout<
     TypeEraser_DECL_ATTR,
     BCFixed<1>, // implicit flag

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3065,9 +3065,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
           S.addDeclRef(afd), pieces.size(), pieces);
       return;
     }
-    case DeclAttrKind::DistributedThunkTarget: {
-      assert(false && "not implemented");
-    }
 
     case DeclAttrKind::TypeEraser: {
       auto abbrCode = S.DeclTypeAbbrCodes[TypeEraserDeclAttrLayout::Code];


### PR DESCRIPTION
This attribute is not necessary anymore in how we ended up implementing protocol calls.

rdar://124406407