### PR TITLE
Initial support work for Package CMO

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -126,6 +126,14 @@ public:
   /// Controls whether cross module optimization is enabled.
   CrossModuleOptimizationMode CMOMode = CrossModuleOptimizationMode::Off;
 
+  /// Optimization to perform default CMO within a package boundary.
+  /// Unlike the existing CMO, package CMO can be built with
+  /// -enable-library-evolution since package modules are required
+  /// to be built in the same project. To enable this optimization, the
+  /// module also needs to opt in to allow non-resilient access with
+  /// -experimental-allow-non-resilient-access.
+  bool EnableSerializePackage = true;
+
   /// Enables the emission of stack protectors in functions.
   bool EnableStackProtection = true;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -984,6 +984,10 @@ def Oplayground : Flag<["-"], "Oplayground">, Group<O_Group>,
   Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,
   HelpText<"Compile with optimizations appropriate for a playground">;
 
+def ExperimentalPackageCMO : Flag<["-"], "experimental-package-cmo">,
+  Flags<[FrontendOption]>,
+  HelpText<"Enable optimization to perform defalut CMO within a package boundary">;
+
 def EnbaleDefaultCMO : Flag<["-"], "enable-default-cmo">,
   Flags<[HelpHidden, FrontendOption]>,
   HelpText<"Perform conservative cross-module optimization">;

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -289,6 +289,26 @@ inline bool hasPublicVisibility(SILLinkage linkage) {
   llvm_unreachable("Unhandled SILLinkage in switch.");
 }
 
+inline bool hasPublicOrPackageVisibility(SILLinkage linkage, bool includePackage) {
+    switch (linkage) {
+    case SILLinkage::Public:
+    case SILLinkage::PublicExternal:
+    case SILLinkage::PublicNonABI:
+        return true;
+    case SILLinkage::Package:
+    case SILLinkage::PackageExternal:
+    case SILLinkage::PackageNonABI:
+        return includePackage;
+    case SILLinkage::Hidden:
+    case SILLinkage::Shared:
+    case SILLinkage::Private:
+    case SILLinkage::HiddenExternal:
+        return false;
+    }
+
+    llvm_unreachable("Unhandled SILLinkage in switch.");
+}
+
 inline bool hasSharedVisibility(SILLinkage linkage) {
   switch (linkage) {
   case SILLinkage::Shared:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -300,6 +300,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_suppress_warnings);
   inputArgs.AddLastArg(arguments, options::OPT_suppress_remarks);
   inputArgs.AddLastArg(arguments, options::OPT_experimental_package_bypass_resilience);
+  inputArgs.AddLastArg(arguments, options::OPT_ExperimentalPackageCMO);
   inputArgs.AddLastArg(arguments, options::OPT_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_profile_coverage_mapping);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2335,6 +2335,18 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   } else if (Args.hasArg(OPT_EnbaleCMOEverything)) {
     Opts.CMOMode = CrossModuleOptimizationMode::Everything;
   }
+
+  if (Args.hasArg(OPT_ExperimentalPackageCMO)) {
+    if (!FEOpts.AllowNonResilientAccess) {
+      Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
+                     "-experimental-package-cmo",
+                     "-experimental-allow-non-resilient-access");
+    } else {
+      Opts.EnableSerializePackage = true;
+      Opts.CMOMode = CrossModuleOptimizationMode::Default;
+    }
+  }
+
   Opts.EnableStackProtection =
       Args.hasFlag(OPT_enable_stack_protector, OPT_disable_stack_protector,
                    Opts.EnableStackProtection);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2446,8 +2446,10 @@ void IRGenModule::emitSILFunction(SILFunction *f) {
       f->getLoweredFunctionType()->isPolymorphic())
     return;
 
-  // Do not emit bodies of public_external functions.
-  if (hasPublicVisibility(f->getLinkage()) && f->isAvailableExternally())
+  // Do not emit bodies of public_external or package_external functions.
+  if (hasPublicOrPackageVisibility(f->getLinkage(),
+                                   f->getASTContext().SILOpts.EnableSerializePackage) &&
+      f->isAvailableExternally())
     return;
 
   PrettyStackTraceSILFunction stackTrace("emitting IR", f);

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -898,8 +898,8 @@ bool SILFunction::hasValidLinkageForFragileRef() const {
       isAvailableExternally())
     return false;
 
-  // Otherwise, only public functions can be referenced.
-  return hasPublicVisibility(getLinkage());
+  // Otherwise, only public or package functions can be referenced.
+  return hasPublicOrPackageVisibility(getLinkage(), getModule().getOptions().EnableSerializePackage);
 }
 
 bool

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2417,7 +2417,7 @@ public:
     }
     if (F.isSerialized()) {
       require(RefG->isSerialized()
-                || hasPublicVisibility(RefG->getLinkage()),
+                || hasPublicOrPackageVisibility(RefG->getLinkage(), F.getModule().getOptions().EnableSerializePackage),
               "alloc_global inside fragile function cannot "
               "reference a private or hidden symbol");
     }
@@ -2436,7 +2436,7 @@ public:
     }
     if (F.isSerialized()) {
       require(RefG->isSerialized()
-              || hasPublicVisibility(RefG->getLinkage()),
+              || hasPublicOrPackageVisibility(RefG->getLinkage(), F.getModule().getOptions().EnableSerializePackage),
               "global_addr/value inside fragile function cannot "
               "reference a private or hidden symbol");
     }

--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -161,6 +161,17 @@ public:
   }
 };
 
+static bool isVisible(SILLinkage linkage, SILOptions options) {
+  if (options.EnableSerializePackage)
+    return linkage == SILLinkage::Public || linkage == SILLinkage::Package;
+  return linkage == SILLinkage::Public;
+}
+static bool isVisible(AccessLevel accessLevel, SILOptions options) {
+  if (options.EnableSerializePackage)
+    return accessLevel == AccessLevel::Package || accessLevel == AccessLevel::Public;
+  return accessLevel == AccessLevel::Public;
+}
+
 /// Select functions in the module which should be serialized.
 void CrossModuleOptimization::serializeFunctionsInModule() {
 
@@ -168,7 +179,8 @@ void CrossModuleOptimization::serializeFunctionsInModule() {
 
   // Start with public functions.
   for (SILFunction &F : M) {
-    if (F.getLinkage() == SILLinkage::Public || everything) {
+    if (isVisible(F.getLinkage(), M.getOptions()) ||
+        everything) {
       if (canSerializeFunction(&F, canSerializeFlags, /*maxDepth*/ 64)) {
         serializeFunction(&F, canSerializeFlags);
       }
@@ -185,7 +197,6 @@ bool CrossModuleOptimization::canSerializeFunction(
                                FunctionFlags &canSerializeFlags,
                                int maxDepth) {
   auto iter = canSerializeFlags.find(function);
-  
   // Avoid infinite recursion in case it's a cycle in the call graph.
   if (iter != canSerializeFlags.end())
     return iter->second;
@@ -270,7 +281,7 @@ bool CrossModuleOptimization::canSerializeInstruction(SILInstruction *inst,
     // function is completely inlined afterwards.
     // Also, when emitting TBD files, we cannot introduce a new public symbol.
     if ((conservative || M.getOptions().emitTBD) &&
-        !hasPublicVisibility(callee->getLinkage())) {
+        !hasPublicOrPackageVisibility(callee->getLinkage(), M.getOptions().EnableSerializePackage)) {
       return false;
     }
 
@@ -290,13 +301,12 @@ bool CrossModuleOptimization::canSerializeInstruction(SILInstruction *inst,
     // inline.
     if (!canUseFromInline(callee))
       return false;
-  
     return true;
   }
   if (auto *GAI = dyn_cast<GlobalAddrInst>(inst)) {
     SILGlobalVariable *global = GAI->getReferencedGlobal();
     if ((conservative || M.getOptions().emitTBD) &&
-        !hasPublicVisibility(global->getLinkage())) {
+        !hasPublicOrPackageVisibility(global->getLinkage(), M.getOptions().EnableSerializePackage)) {
       return false;
     }
 
@@ -344,7 +354,7 @@ bool CrossModuleOptimization::canSerializeGlobal(SILGlobalVariable *global) {
       // function is completely inlined afterwards.
       // Also, when emitting TBD files, we cannot introduce a new public symbol.
       if ((conservative || M.getOptions().emitTBD) &&
-          !hasPublicVisibility(referencedFunc->getLinkage())) {
+          !hasPublicOrPackageVisibility(referencedFunc->getLinkage(), M.getOptions().EnableSerializePackage)) {
         return false;
       }
 
@@ -368,7 +378,7 @@ bool CrossModuleOptimization::canSerializeType(SILType type) {
         if (conservative && subNT->getEffectiveAccess() < AccessLevel::Package) {
           return true;
         }
-      
+
         // Exclude types which are defined in an @_implementationOnly imported
         // module. Such modules are not transitively available.
         if (!canUseFromInline(subNT)) {
@@ -542,7 +552,7 @@ void CrossModuleOptimization::serializeInstruction(SILInstruction *inst,
       }
     }
     serializeFunction(callee, canSerializeFlags);
-    assert(callee->isSerialized() || callee->getLinkage() == SILLinkage::Public);
+    assert(callee->isSerialized() || isVisible(callee->getLinkage(), M.getOptions()));
     return;
   }
   if (auto *GAI = dyn_cast<GlobalAddrInst>(inst)) {
@@ -550,7 +560,7 @@ void CrossModuleOptimization::serializeInstruction(SILInstruction *inst,
     if (canSerializeGlobal(global)) {
       serializeGlobal(global);
     }
-    if (!hasPublicVisibility(global->getLinkage())) {
+    if (!hasPublicOrPackageVisibility(global->getLinkage(), M.getOptions().EnableSerializePackage)) {
       global->setLinkage(SILLinkage::Public);
     }
     return;
@@ -606,7 +616,7 @@ void CrossModuleOptimization::makeDeclUsableFromInline(ValueDecl *decl) {
   if (M.getSwiftModule() != decl->getDeclContext()->getParentModule())
     return;
 
-  if (decl->getFormalAccess() < AccessLevel::Public &&
+  if (!isVisible(decl->getFormalAccess(), M.getOptions()) &&
       !decl->isUsableFromInline()) {
     // Mark the nominal type as "usableFromInline".
     // TODO: find a way to do this without modifying the AST. The AST should be

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -77,6 +77,7 @@ static std::optional<SILLinkage> fromStableSILLinkage(unsigned value) {
   case SIL_LINKAGE_SHARED: return SILLinkage::Shared;
   case SIL_LINKAGE_PRIVATE: return SILLinkage::Private;
   case SIL_LINKAGE_PUBLIC_EXTERNAL: return SILLinkage::PublicExternal;
+  case SIL_LINKAGE_PACKAGE_EXTERNAL: return SILLinkage::PackageExternal;
   case SIL_LINKAGE_HIDDEN_EXTERNAL: return SILLinkage::HiddenExternal;
   }
 

--- a/test/SILOptimizer/Inputs/cross-module/default-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-module.swift
@@ -1,4 +1,3 @@
-
 import Submodule
 import PrivateCModule
 
@@ -6,12 +5,25 @@ public func incrementByThree(_ x: Int) -> Int {
   return incrementByOne(x) + 2
 }
 
+package func pkgFunc(_ x: Int) -> Int {
+  return subPkgFunc(x) + 2
+}
+
 public func incrementByThreeWithCall(_ x: Int) -> Int {
   return incrementByOneNoCMO(x) + 2
 }
 
+package func pkgFuncNoCMO(_ x: Int) -> Int {
+  return subPkgFuncNoCMO(x) + 2
+}
+
 public func submoduleKlassMember() -> Int {
   let k = SubmoduleKlass()
+  return k.i
+}
+
+package func pkgSubmoduleKlassMember() -> Int {
+  let k = PkgSubmoduleKlass()
   return k.i
 }
 
@@ -28,9 +40,27 @@ public func moduleKlassMember() -> Int {
   return k.i
 }
 
+package final class PkgModuleKlass {
+  package var i: Int
+
+  package init() {
+    i = 27
+  }
+}
+
+package func pkgModuleKlassMember() -> Int {
+  let k = PkgModuleKlass()
+  return k.i
+}
+
 public struct ModuleStruct {
   public static var publicFunctionPointer: (Int) -> (Int) = incrementByThree
   public static var privateFunctionPointer: (Int) -> (Int) = { $0 }
+}
+
+package struct PkgModuleStruct {
+  package static var funcPointer: (Int) -> (Int) = pkgFunc
+  package static var closurePointer: (Int) -> (Int) = { $0 }
 }
 
 public func callPrivateCFunc() -> Int {

--- a/test/SILOptimizer/Inputs/cross-module/default-submodule.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-submodule.swift
@@ -3,8 +3,17 @@ public func incrementByOne(_ x: Int) -> Int {
   return x + 1
 }
 
+package func subPkgFunc(_ x: Int) -> Int {
+  return x + 1
+}
+
 @_semantics("optimize.no.crossmodule")
 public func incrementByOneNoCMO(_ x: Int) -> Int {
+  return x + 1
+}
+
+@_semantics("optimize.no.crossmodule")
+package func subPkgFuncNoCMO(_ x: Int) -> Int {
   return x + 1
 }
 
@@ -16,3 +25,10 @@ public final class SubmoduleKlass {
   }
 }
 
+package final class PkgSubmoduleKlass {
+  package var i: Int
+
+  package init() {
+    i = 27
+  }
+}

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -1,11 +1,11 @@
 
 // RUN: %empty-directory(%t) 
 
-// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-module -emit-module-path=%t/Submodule.swiftmodule -module-name=Submodule %S/Inputs/cross-module/default-submodule.swift -c -o %t/submodule.o
-// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/module.o
-// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-tbd -emit-tbd-path %t/ModuleTBD.tbd -emit-module -emit-module-path=%t/ModuleTBD.swiftmodule -module-name=ModuleTBD -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/moduletbd.o -Xfrontend -tbd-install_name -Xfrontend module
+// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-module -emit-module-path=%t/Submodule.swiftmodule -module-name=Submodule -package-name Pkg %S/Inputs/cross-module/default-submodule.swift -c -o %t/submodule.o
+// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -package-name Pkg -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/module.o
+// RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-tbd -emit-tbd-path %t/ModuleTBD.tbd -emit-module -emit-module-path=%t/ModuleTBD.swiftmodule -module-name=ModuleTBD -package-name Pkg -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/moduletbd.o -Xfrontend -tbd-install_name -Xfrontend module
 
-// RUN: %target-build-swift -O -wmo -module-name=Main -I%t -I%S/Inputs/cross-module %s -emit-sil | %FileCheck %s
+// RUN: %target-build-swift -O -wmo -module-name=Main -package-name Pkg -I%t -I%S/Inputs/cross-module %s -emit-sil | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 

--- a/test/SILOptimizer/package-cmo.swift
+++ b/test/SILOptimizer/package-cmo.swift
@@ -1,0 +1,200 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -O -wmo -Xfrontend -experimental-package-cmo -Xfrontend -experimental-allow-non-resilient-access -parse-as-library -emit-module -emit-module-path=%t/Submodule.swiftmodule -module-name=Submodule -package-name Pkg %S/Inputs/cross-module/default-submodule.swift -c -o %t/submodule.o
+// RUN: %target-build-swift -O -wmo -Xfrontend -experimental-package-cmo -Xfrontend -experimental-allow-non-resilient-access -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -package-name Pkg -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/module.o
+// RUN: %target-build-swift -O -wmo -Xfrontend -experimental-package-cmo -Xfrontend -experimental-allow-non-resilient-access -parse-as-library -emit-tbd -emit-tbd-path %t/ModuleTBD.tbd -emit-module -emit-module-path=%t/ModuleTBD.swiftmodule -module-name=ModuleTBD -package-name Pkg -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/moduletbd.o -Xfrontend -tbd-install_name -Xfrontend module
+
+// RUN: %target-build-swift -O -wmo -module-name=Main -package-name Pkg -I%t -I%S/Inputs/cross-module %s -emit-sil -o %t/Main.sil
+// RUN: %FileCheck %s < %t/Main.sil
+
+// REQUIRES: swift_in_compiler
+
+import Module
+import ModuleTBD
+
+// CHECK-LABEL: sil_global public_external @$s6Module0A6StructV22privateFunctionPointeryS2icvpZ : $@callee_guaranteed (Int) -> Int{{$}}
+public func callPrivateFunctionPointer(_ x: Int) -> Int {
+  return Module.ModuleStruct.privateFunctionPointer(x)
+}
+
+// CHECK-LABEL: sil_global package_external @$s6Module03PkgA6StructV14closurePointeryS2icvpZ : $@callee_guaranteed (Int) -> Int{{$}}
+package func callStaticPkgClosurePointer(_ x: Int) -> Int {
+  return Module.PkgModuleStruct.closurePointer(x)
+}
+
+// CHECK-LABEL: sil_global public_external [serialized] @$s6Module0A6StructV21publicFunctionPointeryS2icvpZ : $@callee_guaranteed (Int) -> Int = {
+  // function_ref incrementByThree(_:)
+// CHECK:       [[REF:%.*]] = function_ref @$s6Module16incrementByThreeyS2iF : $@convention(thin) (Int) -> Int
+// CHECK-NEXT:  [[INITVAL:%.*]] = thin_to_thick_function [[REF]] : $@convention(thin) (Int) -> Int to $@callee_guaranteed (Int) -> Int
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_global package_external [serialized] @$s6Module03PkgA6StructV11funcPointeryS2icvpZ : $@callee_guaranteed (Int) -> Int = {
+// CHECK:      [[REF:%.*]] = function_ref @$s6Module7pkgFuncyS2iF : $@convention(thin) (Int) -> Int
+// CHECK-NEXT: [[INITVAL:%.*]] = thin_to_thick_function [[REF]] : $@convention(thin) (Int) -> Int to $@callee_guaranteed (Int) -> Int
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil @$s4Main25callPublicFunctionPointeryS2iF : $@convention(thin) (Int) -> Int {
+// CHECK:         global_addr @$s6Module0A6StructV21publicFunctionPointeryS2icvpZ : $*@callee_guaranteed (Int) -> Int
+// CHECK:         load
+// CHECK:         apply
+// CHECK:       } // end sil function '$s4Main25callPublicFunctionPointeryS2iF'
+public func callPublicFunctionPointer(_ x: Int) -> Int {
+  return Module.ModuleStruct.publicFunctionPointer(x)
+}
+
+// CHECK-LABEL: sil package @$s4Main28callStaticPkgFunctionPointeryS2iF : $@convention(thin) (Int) -> Int {
+// CHECK:         global_addr @$s6Module03PkgA6StructV11funcPointeryS2icvpZ : $*@callee_guaranteed (Int) -> Int
+// CHECK:         load
+// CHECK:         apply
+// CHECK:       } // end sil function '$s4Main28callStaticPkgFunctionPointeryS2iF'
+package func callStaticPkgFunctionPointer(_ x: Int) -> Int {
+  return Module.PkgModuleStruct.funcPointer(x)
+}
+
+// CHECK-LABEL: sil @$s4Main24callPrivateCFuncInModuleSiyF : $@convention(thin) () -> Int {
+// CHECK:         function_ref @$s6Module16callPrivateCFuncSiyF
+// CHECK:       } // end sil function '$s4Main24callPrivateCFuncInModuleSiyF'
+public func callPrivateCFuncInModule() -> Int {
+  return Module.callPrivateCFunc()
+}
+
+// CHECK-LABEL: sil @$s4Main22usePrivateCVarInModuleSiyF : $@convention(thin) () -> Int {
+// CHECK:         function_ref @$s6Module14usePrivateCVarSiyF
+// CHECK:       } // end sil function '$s4Main22usePrivateCVarInModuleSiyF'
+public func usePrivateCVarInModule() -> Int {
+  return Module.usePrivateCVar()
+}
+
+// CHECK-LABEL: sil @$s4Main11doIncrementyS2iF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main11doIncrementyS2iF'
+// CHECK-LABEL: sil public_external @$s6Module16incrementByThreeyS2iF : $@convention(thin) (Int) -> Int {
+public func doIncrement(_ x: Int) -> Int {
+  return Module.incrementByThree(x)
+}
+
+// CHECK-LABEL: sil package @$s4Main11callPkgFuncyS2iF : $@convention(thin) (Int) -> Int {
+// CHECK-NOT:     function_ref
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function '$s4Main11callPkgFuncyS2iF'
+// CHECK-LABEL: sil public_external @$s6Module7pkgFuncyS2iF : $@convention(thin) (Int) -> Int {
+package func callPkgFunc(_ x: Int) -> Int {
+  return Module.pkgFunc(x)
+}
+
+// CHECK-LABEL: sil @$s4Main19doIncrementWithCallyS2iF
+// CHECK:         function_ref @$s9Submodule19incrementByOneNoCMOyS2iF
+// CHECK:       } // end sil function '$s4Main19doIncrementWithCallyS2iF'
+public func doIncrementWithCall(_ x: Int) -> Int {
+  return Module.incrementByThreeWithCall(x)
+}
+
+// CHECK-LABEL: sil package @$s4Main16callPkgFuncNoCMOyS2iF : $@convention(thin) (Int) -> Int {
+// CHECK:         function_ref @$s9Submodule15subPkgFuncNoCMOyS2iF
+// CHECK:       } // end sil function '$s4Main16callPkgFuncNoCMOyS2iF'
+package func callPkgFuncNoCMO(_ x: Int) -> Int {
+  return Module.pkgFuncNoCMO(x)
+}
+
+// CHECK-LABEL: sil @$s4Main14doIncrementTBDyS2iF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main14doIncrementTBDyS2iF'
+public func doIncrementTBD(_ x: Int) -> Int {
+  return ModuleTBD.incrementByThree(x)
+}
+
+// CHECK-LABEL: sil package @$s4Main14callPkgFuncTBDyS2iF : $@convention(thin) (Int) -> Int {
+// CHECK-NOT:     function_ref
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function '$s4Main14callPkgFuncTBDyS2iF'
+package func callPkgFuncTBD(_ x: Int) -> Int {
+  return ModuleTBD.pkgFunc(x)
+}
+
+// CHECK-LABEL: sil @$s4Main22doIncrementTBDWithCallyS2iF
+// CHECK:         function_ref @$s9ModuleTBD24incrementByThreeWithCallyS2iF
+// CHECK:       } // end sil function '$s4Main22doIncrementTBDWithCallyS2iF'
+// CHECK-LABEL: sil @$s9ModuleTBD24incrementByThreeWithCallyS2iF : $@convention(thin) (Int) -> Int
+public func doIncrementTBDWithCall(_ x: Int) -> Int {
+  return ModuleTBD.incrementByThreeWithCall(x)
+}
+
+// CHECK-LABEL: sil package @$s4Main19callPkgFuncNoCMOTBDyS2iF : $@convention(thin) (Int) -> Int {
+// CHECK:         function_ref @$s9ModuleTBD12pkgFuncNoCMOyS2iF
+// CHECK:       } // end sil function '$s4Main19callPkgFuncNoCMOTBDyS2iF'
+// FIXME: should package_external be package?
+// CHECK-LABEL: sil package_external @$s9ModuleTBD12pkgFuncNoCMOyS2iF : $@convention(thin) (Int) -> Int
+package func callPkgFuncNoCMOTBD(_ x: Int) -> Int {
+  return ModuleTBD.pkgFuncNoCMO(x)
+}
+
+// CHECK-LABEL: sil @$s4Main23getSubmoduleKlassMemberSiyF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main23getSubmoduleKlassMemberSiyF'
+public func getSubmoduleKlassMember() -> Int {
+  return Module.submoduleKlassMember()
+}
+
+// CHECK-LABEL: sil package @$s4Main26getPkgSubmoduleKlassMemberSiyF : $@convention(thin) () -> Int {
+// CHECK-NOT:     function_ref
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function '$s4Main26getPkgSubmoduleKlassMemberSiyF'
+package func getPkgSubmoduleKlassMember() -> Int {
+  return Module.pkgSubmoduleKlassMember()
+}
+
+// CHECK-LABEL: sil @$s4Main26getSubmoduleKlassMemberTBDSiyF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main26getSubmoduleKlassMemberTBDSiyF'
+public func getSubmoduleKlassMemberTBD() -> Int {
+  return ModuleTBD.submoduleKlassMember()
+}
+
+// CHECK-LABEL: sil package @$s4Main29getPkgSubmoduleKlassMemberTBDSiyF : $@convention(thin) () -> Int {
+// FIXME: should not contain function_ref/apply
+// CHECK:     function_ref
+// CHECK:     apply
+// CHECK:       } // end sil function '$s4Main29getPkgSubmoduleKlassMemberTBDSiyF'
+package func getPkgSubmoduleKlassMemberTBD() -> Int {
+  return ModuleTBD.pkgSubmoduleKlassMember()
+}
+
+// CHECK-LABEL: sil @$s4Main20getModuleKlassMemberSiyF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main20getModuleKlassMemberSiyF'
+public func getModuleKlassMember() -> Int {
+  return Module.moduleKlassMember()
+}
+
+// CHECK-LABEL: sil package @$s4Main23getPkgModuleKlassMemberSiyF : $@convention(thin) () -> Int {
+// CHECK-NOT:     function_ref
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function '$s4Main23getPkgModuleKlassMemberSiyF'
+package func getPkgModuleKlassMember() -> Int {
+  return Module.pkgModuleKlassMember()
+}
+
+// CHECK-LABEL: sil @$s4Main23getModuleKlassMemberTBDSiyF
+// CHECK-NOT:     function_ref 
+// CHECK-NOT:     apply 
+// CHECK:       } // end sil function '$s4Main23getModuleKlassMemberTBDSiyF'
+public func getModuleKlassMemberTBD() -> Int {
+  return ModuleTBD.moduleKlassMember()
+}
+
+// CHECK-LABEL: sil package @$s4Main26getPkgModuleKlassMemberTBDSiyF : $@convention(thin) () -> Int {
+// CHECK-NOT:     function_ref
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function '$s4Main26getPkgModuleKlassMemberTBDSiyF'
+package func getPkgModuleKlassMemberTBD() -> Int {
+  return ModuleTBD.pkgModuleKlassMember()
+}
+
+
+// CHECK-LABEL: sil [_semantics "optimize.no.crossmodule"] @$s9Submodule19incrementByOneNoCMOyS2iF : $@convention(thin) (Int) -> Int
+
+// CHECK-LABEL: sil package_external [_semantics "optimize.no.crossmodule"] @$s9Submodule15subPkgFuncNoCMOyS2iF : $@convention(thin) (Int) -> Int


### PR DESCRIPTION
* Add a new flag -experimental-package-cmo that requires -experimental-allow-non-resilient-access.
* Support serializing package decls for CMO in package if enabled.
* Only applies to default mode CMO.
* Unlike the existing CMO, package CMO can be built with -enable-library-evolution as package
modules are required to be built together in the same project.
* Create hasPublicOrPackageVisibility to opt in for package decls; needed for CMO, SILVerifier,
and other call sites that verify or determine codegen.

Resolves rdar://121976014
