### PR TITLE
SILGen: Fixes for consuming noncopyable optional chaining.

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -1081,28 +1081,6 @@ SILGenBuilder::createOpaqueConsumeBeginAccess(SILLocation loc,
 }
 
 ManagedValue
-SILGenBuilder::createFormalAccessOpaqueBorrowBeginAccess(SILLocation loc,
-                                                         ManagedValue address) {
-  auto access = createBeginAccess(loc, address.getValue(),
-                                  SILAccessKind::Read,
-                                  SILAccessEnforcement::Static,
-                                  /*no nested conflict*/ true, false);
-  SGF.Cleanups.pushCleanup<EndAccessCleanup>(access);
-  return ManagedValue::forBorrowedAddressRValue(access);
-}
-
-ManagedValue
-SILGenBuilder::createFormalAccessOpaqueConsumeBeginAccess(SILLocation loc,
-                                                          ManagedValue address) {
-  auto access = createBeginAccess(loc, address.forward(SGF),
-                                  SILAccessKind::Deinit,
-                                  SILAccessEnforcement::Static,
-                                  /*no nested conflict*/ true, false);
-  SGF.Cleanups.pushCleanup<EndAccessCleanup>(access);
-  return SGF.emitFormalAccessManagedRValueWithCleanup(loc, access);
-}
-
-ManagedValue
 SILGenBuilder::createBeginBorrow(SILLocation loc, ManagedValue value,
                                  IsLexical_t isLexical,
                                  BeginBorrowInst::IsFixed_t isFixed) {

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -470,13 +470,8 @@ public:
 
   ManagedValue createOpaqueBorrowBeginAccess(SILLocation loc,
                                              ManagedValue address);
-  ManagedValue createFormalAccessOpaqueBorrowBeginAccess(SILLocation loc,
-                                                         ManagedValue address);
-
   ManagedValue createOpaqueConsumeBeginAccess(SILLocation loc,
                                               ManagedValue address);
-  ManagedValue createFormalAccessOpaqueConsumeBeginAccess(SILLocation loc,
-                                                          ManagedValue address);
 
   using SILBuilder::createBeginBorrow;
   ManagedValue createBeginBorrow(

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5422,7 +5422,7 @@ ManagedValue SILGenFunction::emitBindOptional(SILLocation loc,
 
   // For move checking purposes, binding always consumes the value whole.
   if (optValue.getType().isMoveOnly() && optValue.getType().isAddress()) {
-    optValue = B.createFormalAccessOpaqueConsumeBeginAccess(loc, optValue);
+    optValue = B.createOpaqueConsumeBeginAccess(loc, optValue);
   }
 
   SILType optValueTy = optValue.getType();

--- a/test/SILGen/moveonly_optional_operations_2.swift
+++ b/test/SILGen/moveonly_optional_operations_2.swift
@@ -1,0 +1,97 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -parse-stdlib -module-name Swift %s | %FileCheck %s
+
+@_marker protocol Copyable {}
+@_marker protocol Escapable {}
+
+enum Optional<Wrapped: ~Copyable>: ~Copyable {
+    case none
+    case some(Wrapped)
+}
+
+extension Optional: Copyable where Wrapped: Copyable { }
+
+func _diagnoseUnexpectedNilOptional(_filenameStart: Builtin.RawPointer,
+                                    _filenameLength: Builtin.Word,
+                                    _filenameIsASCII: Builtin.Int1,
+                                    _line: Builtin.Word,
+                                    _isImplicitUnwrap: Builtin.Int1) {
+}
+
+precedencegroup AssignmentPrecedence {}
+
+struct NC: ~Copyable {
+    borrowing func b() {}
+    mutating func m() {}
+    consuming func c() {}
+
+    consuming func c2() -> NC { c2() } // expected-warning{{}}
+    consuming func c3() -> NCAO { c3() } // expected-warning{{}}
+}
+
+struct NCAO: ~Copyable {
+    var x: Any
+
+    borrowing func b() {}
+    mutating func m() {}
+    consuming func c() {}
+
+    consuming func c2() -> NC { c2() } // expected-warning{{}}
+    consuming func c3() -> NCAO { c3() } // expected-warning{{}}
+}
+
+struct NCPair: ~Copyable {
+    var first: NC? = .none
+    var second: NCAO? = .none
+}
+
+func consumingSwitchSubject(nc: consuming NC?,
+                            ncao: consuming NCAO?) {
+    switch nc?.c2() {
+    default:
+      break
+    }
+    switch ncao?.c2() {
+    default:
+      break
+    }
+}
+
+func consumingSwitchSubject2(nc: consuming NC?,
+                             ncao: consuming NCAO?) {
+    switch nc?.c3() {
+    default:
+      break
+    }
+    switch ncao?.c3() {
+    default:
+      break
+    }
+}
+
+// CHECK-LABEL: sil {{.*}}@${{.*}}23consumingSwitchSubject3
+func consumingSwitchSubject3(ncp: consuming NCPair) {
+    // CHECK:   [[PAIR_ACCESS:%.*]] = begin_access [deinit] [unknown] {{.*}} : $*NCPair
+    // CHECK:   [[PAIR_MARK:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[PAIR_ACCESS]]
+    // CHECK:   [[FIELD:%.*]] = struct_element_addr [[PAIR_MARK]]
+    // CHECK:   [[FIELD_ACCESS:%.*]] = begin_access [deinit] [static] [no_nested_conflict] [[FIELD]]
+    // CHECK:   cond_br {{.*}}, [[SOME_BB:bb[0-9]+]],
+    // CHECK: [[SOME_BB]]:
+    // CHECK:   [[PAYLOAD_ADDR:%.*]] = unchecked_take_enum_data_addr [[FIELD_ACCESS]]
+    // CHECK:   [[PAYLOAD:%.*]] = load [take] [[PAYLOAD_ADDR]]
+    // CHECK:   apply {{.*}}({{.*}}, [[PAYLOAD]]) : ${{.*}} (@owned NC)
+    // CHECK-NOT: destroy_addr
+    // CHECK-NOT: destroy_value
+    // CHECK:   end_access [[FIELD_ACCESS]]
+    // CHECK-NEXT: end_access [[PAIR_ACCESS]]
+    // CHECK-NEXT: inject_enum_addr 
+    // CHECK-NEXT: br 
+
+    switch ncp.first?.c3() {
+    default:
+      break
+    }
+    switch ncp.second?.c3() {
+    default:
+      break
+    }
+}


### PR DESCRIPTION
Use the lvalue mechanism to build opaque formal accesses so that they nest properly with writebacks. Don't put a cleanup on the lvalue because that creates a double destroy. Fixes rdar://124362085.