### PR TITLE
[Distributed] Add more tests exercising the distributed protocol calls

### DIFF
--- a/lib/Macros/Sources/SwiftMacros/DistributedProtocolMacro.swift
+++ b/lib/Macros/Sources/SwiftMacros/DistributedProtocolMacro.swift
@@ -19,7 +19,13 @@ import SwiftSyntaxBuilder
 /// - `distributed actor $MyDistributedActor<ActorSystem>: $MyDistributedActor, _DistributedActorStub where ...`
 /// - `extension MyDistributedActor where Self: _DistributedActorStub {}`
 public struct DistributedProtocolMacro: ExtensionMacro, PeerMacro {
+}
 
+
+// ===== -----------------------------------------------------------------------
+// MARK: Default Stub implementations Extension
+
+extension DistributedProtocolMacro {
   /// Introduce the `extension MyDistributedActor` which contains default
   /// implementations of the protocol's requirements.
   public static func expansion(
@@ -58,57 +64,167 @@ public struct DistributedProtocolMacro: ExtensionMacro, PeerMacro {
       """
     return [extensionDecl.cast(ExtensionDeclSyntax.self)]
   }
+}
 
+// ===== -----------------------------------------------------------------------
+// MARK: Distributed Actor Stub type
+
+extension DistributedProtocolMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingPeersOf declaration: some DeclSyntaxProtocol,
     in context: some MacroExpansionContext
   ) throws -> [DeclSyntax] {
     guard let proto = declaration.as(ProtocolDeclSyntax.self) else {
-      return []
+      try throwIllegalTargetDecl(node: node, declaration)
     }
 
+    var isGenericStub = false
+    var specificActorSystemRequirement: TypeSyntax?
     // FIXME must detect this off the protocol
     let serializationRequirementType: String = "Codable"
-    let specificActorSystemRequirement: TypeSyntax?
 
     for req in proto.genericWhereClause?.requirements ?? [] {
       print("req.requirement: \(req.requirement)")
       switch req.requirement {
-      case .conformanceRequirement(let conformanceReq):
+      case .conformanceRequirement(let conformanceReq)
+           where conformanceReq.leftType.isActorSystem:
         print("conf: \(conformanceReq)")
+        specificActorSystemRequirement = conformanceReq.rightType.trimmed
+        isGenericStub = true
 
-      case .sameTypeRequirement(let sameTypeReq):
+      case .sameTypeRequirement(let sameTypeReq)
+           where sameTypeReq.leftType.isActorSystem:
         print("same type: \(sameTypeReq)")
-        if sameTypeReq.leftType.trimmedDescription == "ActorSystem" {
-          let specificActorSystemRequirement = sameTypeReq.rightType.trimmed
+        specificActorSystemRequirement = sameTypeReq.rightType.trimmed
+        isGenericStub = false
 
-          return [
-            """
-            distributed actor $\(proto.name.trimmed): \(proto.name.trimmed), 
-              Distributed._DistributedActorStub
-            { 
-              typealias ActorSystem = \(specificActorSystemRequirement) 
-            }
-            """
-          ]
-        }
-      case .layoutRequirement(let layoutReq):
-        print("layout: \(layoutReq)")
+      default:
+        print("SKIP: \(req)")
+        continue
       }
     }
 
     let stubActorDecl: DeclSyntax =
-      """
-      distributed actor $\(proto.name.trimmed)<ActorSystem>: \(proto.name.trimmed), 
-        Distributed._DistributedActorStub
-        where ActorSystem: DistributedActorSystem<any \(raw: serializationRequirementType)>, 
-          ActorSystem.ActorID: \(raw: serializationRequirementType) 
-      { }
-      """
+      if (isGenericStub) {
+        """
+        distributed actor $\(proto.name.trimmed)<ActorSystem>: \(proto.name.trimmed), 
+          Distributed._DistributedActorStub
+          where ActorSystem: DistributedActorSystem<any \(raw: serializationRequirementType)>, 
+            ActorSystem.ActorID: \(raw: serializationRequirementType) 
+        { }
+        """
+     } else if let specificActorSystemRequirement {
+        """
+        distributed actor $\\(proto.name.trimmed): \\(proto.name.trimmed), 
+          Distributed._DistributedActorStub
+        { 
+          \(typealiasActorSystem(specificActorSystemRequirement)) 
+        }
+        """
+      } else {
+        throw DiagnosticsError(
+          syntax: node,
+          message: "'@DistributedProtocolMacro' cannot be applied to ", id: .invalidApplication)
+      }
 
-    // return [extensionDecl, stubActorDecl]
     return [stubActorDecl]
   }
 
+  private static func typealiasActorSystem(_ type: TypeSyntax) -> DeclSyntax {
+    "typealias ActorSystem = \(type)"
+  }
+}
+
+// ===== -----------------------------------------------------------------------
+// MARK: Convenience Extensions
+
+extension TypeSyntax {
+  fileprivate var isActorSystem: Bool {
+    self.trimmedDescription == "ActorSystem"
+  }
+}
+
+extension DeclSyntaxProtocol {
+  var isClass: Bool {
+    return self.is(ClassDeclSyntax.self)
+  }
+
+  var isActor: Bool {
+    return self.is(ActorDeclSyntax.self)
+  }
+
+  var isEnum: Bool {
+    return self.is(EnumDeclSyntax.self)
+  }
+
+  var isStruct: Bool {
+    return self.is(StructDeclSyntax.self)
+  }
+}
+
+// ===== -----------------------------------------------------------------------
+// MARK: DistributedProtocol macro errors
+
+extension DistributedProtocolMacro {
+  static func throwIllegalTargetDecl(node: AttributeSyntax, _ declaration: some DeclSyntaxProtocol) throws -> Never {
+    let kind =
+      if declaration.isClass {
+        "class"
+      } else if declaration.isActor {
+        "actor"
+      } else if declaration.isStruct {
+        "struct"
+      } else if declaration.isStruct {
+        "enum"
+      } else {
+        "\(declaration.kind)"
+      }
+
+    throw DiagnosticsError(
+      syntax: node,
+      message: "'@DistributedProtocol' can only be applied to 'protocol', but was attached to '\(kind)'", id: .invalidApplication)
+  }
+}
+
+struct DistributedProtocolMacroDiagnostic: DiagnosticMessage {
+  enum ID: String {
+    case invalidApplication = "invalid type"
+    case missingInitializer = "missing initializer"
+  }
+
+  var message: String
+  var diagnosticID: MessageID
+  var severity: DiagnosticSeverity
+
+  init(message: String, diagnosticID: SwiftDiagnostics.MessageID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
+    self.message = message
+    self.diagnosticID = diagnosticID
+    self.severity = severity
+  }
+
+  init(message: String, domain: String, id: ID, severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
+    self.message = message
+    self.diagnosticID = MessageID(domain: domain, id: id.rawValue)
+    self.severity = severity
+  }
+}
+
+extension DiagnosticsError {
+  init<S: SyntaxProtocol>(
+    syntax: S,
+    message: String,
+    domain: String = "Distributed",
+    id: DistributedProtocolMacroDiagnostic.ID,
+    severity: SwiftDiagnostics.DiagnosticSeverity = .error) {
+    self.init(diagnostics: [
+      Diagnostic(
+        node: Syntax(syntax),
+        message: DistributedProtocolMacroDiagnostic(
+          message: message,
+          domain: domain,
+          id: id,
+          severity: severity))
+    ])
+  }
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3332,9 +3332,8 @@ public:
       }
     }
 
-    if (CD->isDistributedActor()) {
-      TypeChecker::checkDistributedActor(SF, CD);
-    }
+    // Check distributed actors
+    TypeChecker::checkDistributedActor(SF, CD);
 
     // Force lowering of stored properties.
     (void) CD->getStoredProperties();
@@ -3945,8 +3944,7 @@ public:
 
     checkExplicitAvailability(ED);
 
-    if (nominal->isDistributedActor())
-      TypeChecker::checkDistributedActor(SF, nominal);
+    TypeChecker::checkDistributedActor(SF, nominal);
 
     diagnoseIncompatibleProtocolsForMoveOnlyType(ED);
     diagnoseExtensionOfMarkerProtocol(ED);

--- a/lib/Sema/TypeCheckDistributed.cpp
+++ b/lib/Sema/TypeCheckDistributed.cpp
@@ -686,7 +686,7 @@ void swift::checkDistributedActorProperties(const NominalTypeDecl *decl) {
 // ==== ------------------------------------------------------------------------
 
 void TypeChecker::checkDistributedActor(SourceFile *SF, NominalTypeDecl *nominal) {
-  if (!nominal)
+  if (!nominal || !nominal->isDistributedActor())
     return;
 
   // ==== Ensure the Distributed module is available,

--- a/stdlib/public/Distributed/DistributedMacros.swift
+++ b/stdlib/public/Distributed/DistributedMacros.swift
@@ -15,8 +15,17 @@
 import Swift
 import _Concurrency
 
-#if $Macros
+// Macros are disabled when Swift is built without swift-syntax.
+#if $Macros && hasAttribute(attached)
 
+/// Enables the attached to protocol to be resolved as remote distributed
+/// actor reference.
+///
+/// ### Requirements
+///
+/// The attached to type must be a protocol that refines the `DistributedActor`
+/// protocol. It must either specify a concrete `ActorSystem` or constrain it
+/// in such way that the system's `SerializationRequirement` is statically known.
 @attached(peer, names: prefixed(`$`)) // provides $Greeter concrete stub type
 @attached(extension, names: arbitrary) // provides extension for Greeter & _DistributedActorStub
 public macro _DistributedProtocol() =

--- a/stdlib/public/runtime/AccessibleFunction.cpp
+++ b/stdlib/public/runtime/AccessibleFunction.cpp
@@ -161,10 +161,6 @@ swift::runtime::swift_findAccessibleFunction(const char *targetNameStart,
                                              size_t targetNameLength) {
   auto &S = Functions.get();
 
-  fprintf(stderr, "[%s:%d](%s) searching for: %s\n", __FILE_NAME__, __LINE__, __FUNCTION__,
-          targetNameStart);
-  _dumpAccessibleFunctionRecords();
-
   llvm::StringRef name{targetNameStart, targetNameLength};
   // Look for an existing entry.
   {

--- a/stdlib/public/runtime/AccessibleFunction.cpp
+++ b/stdlib/public/runtime/AccessibleFunction.cpp
@@ -161,6 +161,10 @@ swift::runtime::swift_findAccessibleFunction(const char *targetNameStart,
                                              size_t targetNameLength) {
   auto &S = Functions.get();
 
+  fprintf(stderr, "[%s:%d](%s) searching for: %s\n", __FILE_NAME__, __LINE__, __FUNCTION__,
+          targetNameStart);
+  _dumpAccessibleFunctionRecords();
+
   llvm::StringRef name{targetNameStart, targetNameLength};
   // Look for an existing entry.
   {

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
@@ -30,3 +30,4 @@ distributed actor Caplin {
 protocol Fail: DistributedActor {
   distributed func method() -> String
 }
+

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
@@ -1,0 +1,27 @@
+// REQUIRES: swift_swift_parser, asserts
+//
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t-scratch)
+
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -plugin-path %swift-plugin-dir -parse-as-library -I %t %S/../Inputs/FakeDistributedActorSystems.swift -dump-macro-expansions %s -dump-macro-expansions 2>&1
+
+import Distributed
+
+@_DistributedProtocol // expected-error{{'@DistributedProtocol' can only be applied to 'protocol', but was attached to 'struct' (from macro '_DistributedProtocol')}}
+struct Struct {}
+
+@_DistributedProtocol // expected-error{{'@DistributedProtocol' can only be applied to 'protocol', but was attached to 'class' (from macro '_DistributedProtocol')}}
+class Clazz {}
+
+@_DistributedProtocol // expected-error{{'@DistributedProtocol' can only be applied to 'protocol', but was attached to 'actor' (from macro '_DistributedProtocol')}}
+actor Act {}
+
+@_DistributedProtocol // expected-error{{'@DistributedProtocol' can only be applied to 'protocol', but was attached to 'actor' (from macro '_DistributedProtocol')}}
+distributed actor Caplin {
+  typealias ActorSystem = FakeActorSystem
+}

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
@@ -8,7 +8,7 @@
 // RUN: %empty-directory(%t-scratch)
 
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -plugin-path %swift-plugin-dir -parse-as-library -I %t %S/../Inputs/FakeDistributedActorSystems.swift -dump-macro-expansions %s -dump-macro-expansions 2>&1
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -plugin-path %swift-plugin-dir -parse-as-library -I %t %S/../Inputs/FakeDistributedActorSystems.swift -dump-macro-expansions %s 2>&1
 
 import Distributed
 

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_errors.swift
@@ -25,3 +25,8 @@ actor Act {}
 distributed actor Caplin {
   typealias ActorSystem = FakeActorSystem
 }
+
+@_DistributedProtocol // expected-error{{Distributed protocol must declare actor system with SerializationRequirement}}
+protocol Fail: DistributedActor {
+  distributed func method() -> String
+}

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
@@ -17,16 +17,8 @@ typealias System = LocalTestingDistributedActorSystem
 protocol EmptyBase {}
 
 // @_DistributedProtocol ->
-//
-// CHECK: distributed actor $EmptyBase<ActorSystem>: EmptyBase,
-// CHECK:   Distributed._DistributedActorStub
-// CHECK:   where ActorSystem: DistributedActorSystem<any Codable>,
-// CHECK:         ActorSystem.ActorID: Codable
-// CHECK:  {
-// CHECK:  }
 
-// CHECK: extension EmptyBase where Self: Distributed._DistributedActorStub {
-// CHECK: }
+// nothing, no-op
 
 // ==== ------------------------------------------------------------------------
 

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
@@ -31,8 +31,7 @@ protocol G3<ActorSystem>: DistributedActor, EmptyBase where ActorSystem: Distrib
 // @_DistributedProtocol ->
 // CHECK: distributed actor $G3<ActorSystem>: G3
 // CHECK:   Distributed._DistributedActorStub
-// CHECK:   where ActorSystem: DistributedActorSystem<any Codable>,
-// CHECK:         ActorSystem.ActorID: Codable
+// CHECK:   where ActorSystem: DistributedActorSystem<any Codable>
 // CHECK: {
 // CHECK: }
 

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
@@ -14,21 +14,33 @@ import Distributed
 typealias System = LocalTestingDistributedActorSystem
 
 @_DistributedProtocol
-protocol EmptyBase {}
+protocol Base: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
+  distributed func base() -> Int
+}
+// CHECK: distributed actor $Base<ActorSystem>: Base
+// CHECK:   Distributed._DistributedActorStub
+// CHECK:   where ActorSystem: DistributedActorSystem<any Codable>
+// CHECK: {
+// CHECK: }
 
-// @_DistributedProtocol ->
-
-// nothing, no-op
+// CHECK: extension Base where Self: Distributed._DistributedActorStub {
+// CHECK:   distributed func base() -> Int {
+// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
 
 // ==== ------------------------------------------------------------------------
 
 @_DistributedProtocol
-protocol G3<ActorSystem>: DistributedActor, EmptyBase where ActorSystem: DistributedActorSystem<any Codable> {
+protocol G3<ActorSystem>: DistributedActor, Base where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func get() -> String
   distributed func greet(name: String) -> String
 }
 
-// @_DistributedProtocol ->
 // CHECK: distributed actor $G3<ActorSystem>: G3
 // CHECK:   Distributed._DistributedActorStub
 // CHECK:   where ActorSystem: DistributedActorSystem<any Codable>

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_sameType.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_sameType.swift
@@ -1,0 +1,36 @@
+// REQUIRES: swift_swift_parser, asserts
+//
+// UNSUPPORTED: back_deploy_concurrency
+// REQUIRES: concurrency
+// REQUIRES: distributed
+//
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t-scratch)
+
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -plugin-path %swift-plugin-dir -parse-as-library -I %t %S/../Inputs/FakeDistributedActorSystems.swift -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s --dump-input=always
+
+import Distributed
+
+@_DistributedProtocol
+protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
+  distributed func greet(name: String) -> String
+}
+
+// @_DistributedProtocol ->
+
+// CHECK:      distributed actor $Greeter: Greeter,
+// CHECK-NEXT:    Distributed._DistributedActorStub
+// CHECK-NEXT: {
+// CHECK-NEXT:   typealias ActorSystem = FakeActorSystem
+// CHECK-NEXT: }
+
+// CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
+// CHECK-NEXT:   distributed func greet(name: String) -> String {
+// CHECK-NEXT:     if #available (SwiftStdlib 6.0, *) {
+// CHECK-NEXT:       Distributed._distributedStubFatalError()
+// CHECK-NEXT:     } else {
+// CHECK-NEXT:       fatalError()
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
@@ -20,8 +20,7 @@ protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any
 
 // CHECK: distributed actor $Greeter<ActorSystem>: Greeter,
 // CHECK-NEXT: Distributed._DistributedActorStub
-// CHECK-NEXT: where ActorSystem: DistributedActorSystem<any Codable>,
-// CHECK-NEXT: ActorSystem.ActorID: Codable
+// CHECK-NEXT: where ActorSystem: DistributedActorSystem<any Codable>
 // CHECK-NEXT: {
 // CHECK-NEXT: }
 

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
@@ -96,3 +96,31 @@ public protocol Greeter4: DistributedActor where ActorSystem == FakeActorSystem 
 // CHECK:     }
 // CHECK:   }
 // CHECK: }
+
+@_DistributedProtocol
+public protocol GreeterMore: DistributedActor where ActorSystem == FakeActorSystem {
+  distributed var name: String { get }
+  distributed func greet(name: String) -> String
+}
+// CHECK: public distributed actor $GreeterMore: GreeterMore,
+// CHECK:    Distributed._DistributedActorStub
+// CHECK: {
+// CHECK:   public typealias ActorSystem = FakeActorSystem
+// CHECK: }
+
+// CHECK: extension GreeterMore where Self: Distributed._DistributedActorStub {
+// CHECK:   public distributed var  name : String {
+// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK:   public distributed func greet(name: String) -> String {
+// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK: }

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
@@ -101,6 +101,7 @@ public protocol Greeter4: DistributedActor where ActorSystem == FakeActorSystem 
 public protocol GreeterMore: DistributedActor where ActorSystem == FakeActorSystem {
   distributed var name: String { get }
   distributed func greet(name: String) -> String
+  distributed func another(string: String, int: Int) async throws -> Double
 }
 // CHECK: public distributed actor $GreeterMore: GreeterMore,
 // CHECK:    Distributed._DistributedActorStub
@@ -117,6 +118,13 @@ public protocol GreeterMore: DistributedActor where ActorSystem == FakeActorSyst
 // CHECK:     }
 // CHECK:   }
 // CHECK:   public distributed func greet(name: String) -> String {
+// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK:   public distributed func another(string: String, int: Int) async throws -> Double {
 // CHECK:     if #available (SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
@@ -102,6 +102,7 @@ public protocol GreeterMore: DistributedActor where ActorSystem == FakeActorSyst
   distributed var name: String { get }
   distributed func greet(name: String) -> String
   distributed func another(string: String, int: Int) async throws -> Double
+  distributed func generic<T: Codable>(value: T, int: Int) async throws -> T
 }
 // CHECK: public distributed actor $GreeterMore: GreeterMore,
 // CHECK:    Distributed._DistributedActorStub
@@ -125,6 +126,13 @@ public protocol GreeterMore: DistributedActor where ActorSystem == FakeActorSyst
 // CHECK:     }
 // CHECK:   }
 // CHECK:   public distributed func another(string: String, int: Int) async throws -> Double {
+// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK:   public distributed func generic<T: Codable>(value: T, int: Int) async throws -> T {
 // CHECK:     if #available (SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
@@ -8,7 +8,7 @@
 // RUN: %empty-directory(%t-scratch)
 
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -plugin-path %swift-plugin-dir -parse-as-library -I %t %S/../Inputs/FakeDistributedActorSystems.swift -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s --dump-input=always
+// RUN: %target-swift-frontend -typecheck -verify -disable-availability-checking -plugin-path %swift-plugin-dir -parse-as-library -I %t %S/../Inputs/FakeDistributedActorSystems.swift -dump-macro-expansions %s -dump-macro-expansions 2>&1 | %FileCheck %s
 
 import Distributed
 
@@ -16,9 +16,6 @@ import Distributed
 protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
   distributed func greet(name: String) -> String
 }
-
-// @_DistributedProtocol ->
-
 // CHECK: distributed actor $Greeter: Greeter,
 // CHECK:    Distributed._DistributedActorStub
 // CHECK: {
@@ -36,19 +33,41 @@ protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
 // CHECK: }
 
 @_DistributedProtocol
-protocol Greeter2: DistributedActor where ActorSystem: FakeRoundtripActorSystem {
+protocol Greeter2: DistributedActor where ActorSystem: DistributedActorSystem<any Codable> {
   distributed func greet(name: String) -> String
 }
-
-// @_DistributedProtocol ->
-
 // CHECK: distributed actor $Greeter2<ActorSystem>: Greeter2,
 // CHECK:   Distributed._DistributedActorStub
-// CHECK:   where ActorSystem: FakeRoundtripActorSystem
+// CHECK:   where ActorSystem: DistributedActorSystem<any Codable>
 // CHECK: {
 // CHECK: }
 
 // CHECK: extension Greeter2 where Self: Distributed._DistributedActorStub {
+// CHECK:   distributed func greet(name: String) -> String {
+// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
+
+extension String: CustomSerializationProtocol {
+  public func toBytes() throws -> [UInt8] { [] }
+  public static func fromBytes(_ bytes: [UInt8]) throws -> Self { "" }
+}
+
+@_DistributedProtocol
+protocol Greeter3: DistributedActor where ActorSystem: DistributedActorSystem<any CustomSerializationProtocol> {
+  distributed func greet(name: String) -> String
+}
+// CHECK: distributed actor $Greeter3<ActorSystem>: Greeter3,
+// CHECK:   Distributed._DistributedActorStub
+// CHECK:   where ActorSystem: DistributedActorSystem<any CustomSerializationProtocol>
+// CHECK: {
+// CHECK: }
+
+// CHECK: extension Greeter3 where Self: Distributed._DistributedActorStub {
 // CHECK:   distributed func greet(name: String) -> String {
 // CHECK:     if #available (SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
@@ -12,28 +12,28 @@
 
 import Distributed
 
-//@_DistributedProtocol
-//protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
-//  distributed func greet(name: String) -> String
-//}
+@_DistributedProtocol
+protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
+  distributed func greet(name: String) -> String
+}
 
 // @_DistributedProtocol ->
 
-// CHECK:      distributed actor $Greeter: Greeter,
-// CHECK-NEXT:    Distributed._DistributedActorStub
-// CHECK-NEXT: {
-// CHECK-NEXT:   typealias ActorSystem = FakeActorSystem
-// CHECK-NEXT: }
+// CHECK: distributed actor $Greeter: Greeter,
+// CHECK:    Distributed._DistributedActorStub
+// CHECK: {
+// CHECK:   typealias ActorSystem = FakeActorSystem
+// CHECK: }
 
-// CHECK:      extension Greeter where Self: Distributed._DistributedActorStub {
-// CHECK-NEXT:   distributed func greet(name: String) -> String {
-// CHECK-NEXT:     if #available (SwiftStdlib 6.0, *) {
-// CHECK-NEXT:       Distributed._distributedStubFatalError()
-// CHECK-NEXT:     } else {
-// CHECK-NEXT:       fatalError()
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
+// CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
+// CHECK:   distributed func greet(name: String) -> String {
+// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK: }
 
 @_DistributedProtocol
 protocol Greeter2: DistributedActor where ActorSystem: FakeRoundtripActorSystem {
@@ -42,18 +42,18 @@ protocol Greeter2: DistributedActor where ActorSystem: FakeRoundtripActorSystem 
 
 // @_DistributedProtocol ->
 
-// CHECK:        distributed actor $Greeter2: Greeter,
-//// CHECK-NEXT:     Distributed._DistributedActorStub
-//// CHECK-NEXT:     where ActorSystem: FakeActorSystem
-//// CHECK-NEXT: {
-//// CHECK-NEXT: }
+// CHECK: distributed actor $Greeter2<ActorSystem>: Greeter2,
+// CHECK:   Distributed._DistributedActorStub
+// CHECK:   where ActorSystem: FakeRoundtripActorSystem
+// CHECK: {
+// CHECK: }
 
-// CHECK:      extension Greeter2 where Self: Distributed._DistributedActorStub {
-// CHECK-NEXT:   distributed func greet(name: String) -> String {
-// CHECK-NEXT:     if #available (SwiftStdlib 6.0, *) {
-// CHECK-NEXT:       Distributed._distributedStubFatalError()
-// CHECK-NEXT:     } else {
-// CHECK-NEXT:       fatalError()
-// CHECK-NEXT:     }
-// CHECK-NEXT:   }
-// CHECK-NEXT: }
+// CHECK: extension Greeter2 where Self: Distributed._DistributedActorStub {
+// CHECK:   distributed func greet(name: String) -> String {
+// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK: }

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
@@ -12,10 +12,10 @@
 
 import Distributed
 
-@_DistributedProtocol
-protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
-  distributed func greet(name: String) -> String
-}
+//@_DistributedProtocol
+//protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
+//  distributed func greet(name: String) -> String
+//}
 
 // @_DistributedProtocol ->
 
@@ -25,7 +25,30 @@ protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
 // CHECK-NEXT:   typealias ActorSystem = FakeActorSystem
 // CHECK-NEXT: }
 
-// CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
+// CHECK:      extension Greeter where Self: Distributed._DistributedActorStub {
+// CHECK-NEXT:   distributed func greet(name: String) -> String {
+// CHECK-NEXT:     if #available (SwiftStdlib 6.0, *) {
+// CHECK-NEXT:       Distributed._distributedStubFatalError()
+// CHECK-NEXT:     } else {
+// CHECK-NEXT:       fatalError()
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+@_DistributedProtocol
+protocol Greeter2: DistributedActor where ActorSystem: FakeRoundtripActorSystem {
+  distributed func greet(name: String) -> String
+}
+
+// @_DistributedProtocol ->
+
+// CHECK:        distributed actor $Greeter2: Greeter,
+//// CHECK-NEXT:     Distributed._DistributedActorStub
+//// CHECK-NEXT:     where ActorSystem: FakeActorSystem
+//// CHECK-NEXT: {
+//// CHECK-NEXT: }
+
+// CHECK:      extension Greeter2 where Self: Distributed._DistributedActorStub {
 // CHECK-NEXT:   distributed func greet(name: String) -> String {
 // CHECK-NEXT:     if #available (SwiftStdlib 6.0, *) {
 // CHECK-NEXT:       Distributed._distributedStubFatalError()

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
@@ -76,3 +76,23 @@ protocol Greeter3: DistributedActor where ActorSystem: DistributedActorSystem<an
 // CHECK:     }
 // CHECK:   }
 // CHECK: }
+
+@_DistributedProtocol
+public protocol Greeter4: DistributedActor where ActorSystem == FakeActorSystem {
+  distributed func greet(name: String) -> String
+}
+// CHECK: public distributed actor $Greeter4: Greeter4,
+// CHECK:    Distributed._DistributedActorStub
+// CHECK: {
+// CHECK:   public typealias ActorSystem = FakeActorSystem
+// CHECK: }
+
+// CHECK: extension Greeter4 where Self: Distributed._DistributedActorStub {
+// CHECK:   public distributed func greet(name: String) -> String {
+// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:       Distributed._distributedStubFatalError()
+// CHECK:     } else {
+// CHECK:       fatalError()
+// CHECK:     }
+// CHECK:   }
+// CHECK: }

--- a/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
+++ b/test/Distributed/Runtime/distributed_actor_localSystem_distributedProtocol.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -module-name main -j2 -parse-as-library -I %t %s -o %t/a.out
+// RUN: %target-build-swift -module-name main -j2 -parse-as-library -I %t %s -plugin-path %swift-plugin-dir -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
@@ -16,8 +16,14 @@
 
 import Distributed
 
+@_DistributedProtocol
 @available(SwiftStdlib 6.0, *)
-distributed actor Worker<ActorSystem> where ActorSystem: DistributedActorSystem<any Codable> {
+protocol WorkerProtocol: DistributedActor where ActorSystem == LocalTestingDistributedActorSystem {
+  distributed func hi(name: String)
+}
+
+@available(SwiftStdlib 6.0, *)
+distributed actor Worker: WorkerProtocol {
   distributed func hi(name: String) {
     print("Hi, \(name)!")
   }


### PR DESCRIPTION
This has an issue today with the distributed property:

`Assertion failed: (!isDirectUse && "direct use of protocol accessor?"), function getBaseAccessorFunctionRef, file SILGenApply.cpp, line 6676.`

when:
```
protocol WorkerProtocol: DistributedActor where ActorSystem == LocalTestingDistributedActorSystem {
  distributed var variable: String { get }
}
distributed actor Worker: WorkerProtocol {
  distributed var variable: String { "implemented!" }
}

let worker: any WorkerProtocol = Worker(actorSystem: ...)
try await worker.variable // problem here when called through protocol; the distributed thunk we call comes 
```