### PR TITLE
[ConsumeChecker] Check guaranteed arguments.

### DIFF
--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -400,7 +400,9 @@ bool ConsumeOperatorCopyableValuesChecker::check() {
   llvm::SmallSetVector<SILValue, 32> valuesToCheck;
 
   for (auto *arg : fn->getEntryBlock()->getSILFunctionArguments()) {
-    if (arg->getOwnershipKind() == OwnershipKind::Owned &&
+    auto ownership = arg->getOwnershipKind();
+    if ((ownership == OwnershipKind::Owned ||
+         ownership == OwnershipKind::Guaranteed) &&
         !arg->getType().isMoveOnly()) {
       LLVM_DEBUG(llvm::dbgs() << "Found owned arg to check: " << *arg);
       valuesToCheck.insert(arg);

--- a/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
@@ -723,6 +723,12 @@ func consumeInitdArray() {
   _ = consume x
 }
 
+func isNegative(_ c: consuming Int) -> Bool { return c < 0 }
+func consumeInt() {
+    var g = 0 // expected-warning{{variable 'g' was never mutated; consider changing to 'let' constant}}
+    isNegative(consume g) // expected-warning{{result of call to 'isNegative' is unused}}
+}
+
 //////////////////////
 // Reinit in pieces //
 //////////////////////

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.swift
@@ -371,6 +371,11 @@ func g()
     f(x: consume x)
 }
 
+func consumeArrayAny() {
+  let a: [Any] = []
+  _ = consume a
+}
+
 /////////////////////////
 // Partial Apply Tests //
 /////////////////////////

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.swift
@@ -376,6 +376,26 @@ func consumeArrayAny() {
   _ = consume a
 }
 
+func consumeConsuming(_ k: consuming Klass) {
+  _ = consume k
+}
+
+func consumeBorrowing(_ k: borrowing Klass) { // expected-error{{'k' is borrowed and cannot be consumed}}
+  _ = consume k // expected-note{{consumed here}}
+}
+
+func consumeOwned(_ k: __owned Klass) {
+  _ = consume k
+}
+
+func consumeShared(_ k: __shared Klass) {
+  _ = consume k
+}
+
+func consumeBare(_ k: Klass) {
+  _ = consume k
+}
+
 /////////////////////////
 // Partial Apply Tests //
 /////////////////////////

--- a/validation-test/SILOptimizer/gh70234.swift
+++ b/validation-test/SILOptimizer/gh70234.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+func mutateText(_ rawText: NSString?) -> String {
+  guard let text = consume rawText else {
+    return "text unavailable"
+  }
+  return String(text)
+}


### PR DESCRIPTION
Such values could be referenced in a `ConsumeExpr`, so the checker must check them.  Furthermore, it's legal to consume such values so long as they aren't annotated `borrowing`.
