### PR TITLE
Concurrency: Guard use of `withoutActuallyEscaping()` in inlinable code

### DIFF
--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -363,12 +363,16 @@ extension Actor {
       fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
     }
 
+    #if $TypedThrows
     // To do the unsafe cast, we have to pretend it's @escaping.
     return try withoutActuallyEscaping(operation) {
       (_ fn: @escaping YesActor) throws -> T in
       let rawFn = unsafeBitCast(fn, to: NoActor.self)
       return try rawFn(self)
     }
+    #else
+    fatalError("unsupported compiler")
+    #endif
   }
 }
 

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -155,12 +155,16 @@ extension MainActor {
       fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
     }
 
+    #if $TypedThrows
     // To do the unsafe cast, we have to pretend it's @escaping.
     return try withoutActuallyEscaping(operation) {
       (_ fn: @escaping YesActor) throws -> T in
       let rawFn = unsafeBitCast(fn, to: NoActor.self)
       return try rawFn()
     }
+    #else
+    fatalError("unsupported compiler")
+    #endif
   }
 }
 #endif

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -174,12 +174,16 @@ extension DistributedActor {
       fatalError("Incorrect actor executor assumption; Expected same executor as \(self).", file: file, line: line)
     }
 
+    #if $TypedThrows
     // To do the unsafe cast, we have to pretend it's @escaping.
     return try withoutActuallyEscaping(operation) {
       (_ fn: @escaping YesActor) throws -> T in
       let rawFn = unsafeBitCast(fn, to: NoActor.self)
       return try rawFn(self)
     }
+    #else
+    fatalError("unsupported compiler")
+    #endif
   }
 }
 


### PR DESCRIPTION
Since `withoutActuallyEscaping()` has adopted typed throws, it's no longer visible to older compilers that do not support typed throws. We need to guard use of the function in inlinable code to make sure the textual interface of `_Concurrency` remains buildable with older compilers.

Resolves rdar://124352900