### PR TITLE
Tests: disable many tests failing on armv7k

### DIFF
--- a/test/DebugInfo/BuiltinStdlibTypes.swift
+++ b/test/DebugInfo/BuiltinStdlibTypes.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend %s -Onone -emit-ir -gdwarf-types -o - | %FileCheck %s
 
+// rdar://124465351
+// UNSUPPORTED: CPU=armv7k
+
 // File is empty as this test check for the builtin stdlib types that should 
 // always be emitted.
 

--- a/test/DebugInfo/classes.swift
+++ b/test/DebugInfo/classes.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend -primary-file %s -emit-ir -gdwarf-types -o - | %FileCheck %s
 
+// rdar://124465351
+// UNSUPPORTED: CPU=armv7k
+
 class SomeClass {
   let first = 4
   let second = "Hello"

--- a/test/IRGen/lto_autolink.swift
+++ b/test/IRGen/lto_autolink.swift
@@ -45,6 +45,6 @@ import AutolinkModuleMapLink
 
 // UNSUPPORTED: OS=macosx && CPU=arm64
 // UNSUPPORTED: OS=ios && CPU=arm64e
-// UNSUPPORTED: OS=watchos && CPU=arm64_32
+// UNSUPPORTED: OS=watchos && (CPU=arm64_32 || CPU=armv7k)
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 // UNSUPPORTED: CPU=wasm32

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
@@ -4,6 +4,9 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
 
+// rdar://124466216
+// UNSUPPORTED: CPU=armv7k
+
 public class C {
     public var x: Int
     public init(x: Int) { self.x = x }

--- a/test/SIL/moveonly_ownership.sil
+++ b/test/SIL/moveonly_ownership.sil
@@ -1,5 +1,8 @@
 // RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
 
+// rdar://124466060
+// UNSUPPORTED: CPU=armv7k
+
 sil_stage raw
 
 import Builtin


### PR DESCRIPTION
The bot testing armv7k was blocked by earlier tests for a few weeks now and didn't reach armv7k. The recent run revealed failures that may have been hidden for some time. Let's disable all of them to make sure they don't hide even more failures.