### PR TITLE
Remove 'bootstrapping=bootstrapping' from the last two macOS CI jobs settings

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -190,11 +190,6 @@ skip-test-ios-host
 skip-test-tvos-host
 skip-test-watchos-host
 
-# Test the full bootstrapping on at least some jobs
-# (the default is bootstrapping-with-hostlibs)
-bootstrapping=bootstrapping
-enable-experimental-cxx-interop
-
 [preset: buildbot,tools=RA,stdlib=RD,test=non_executable]
 mixin-preset=
      mixin_buildbot_tools_RA_stdlib_RD
@@ -227,11 +222,6 @@ skip-test-osx
 skip-test-ios-simulator
 skip-test-tvos-simulator
 skip-test-watchos-simulator
-
-# Test the full bootstrapping on at least some jobs
-# (the default is bootstrapping-with-hostlibs)
-bootstrapping=bootstrapping
-enable-experimental-cxx-interop
 
 [preset: buildbot,tools=RA,stdlib=RDA]
 mixin-preset=


### PR DESCRIPTION
`bootstrapping=bootstrapping` is not really relevant in Darwin CI jobs, let's remove it and resolve the current build failure this way on this job:

https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RD_test-simulator/3689/

Also let's remove `enable-experimental-cxx-interop` because that's on by default in build-script now.
