### PR TITLE
[region-isolation] Eliminate most of the rest of the "task or actor" isolated error

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -968,34 +968,21 @@ NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
       "transferring %0 may cause a race",
       (Identifier))
-ERROR(regionbasedisolation_stronglytransfer_assignment_yields_race_name, none,
-      "assigning %0 to transferring parameter %1 may cause a race",
-      (Identifier, Identifier))
-NOTE(regionbasedisolation_named_transfer_into_transferring_param, none,
-      "%0 %1 is passed as a transferring parameter; Uses in callee may race with later %0 uses",
-      (StringRef, Identifier))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
      "%0 is transferred from %1 caller to %2 callee. Later uses in caller could race with potential uses in callee",
      (Identifier, ActorIsolation, ActorIsolation))
-NOTE(regionbasedisolation_transfer_non_transferrable_named_note, none,
+NOTE(regionbasedisolation_named_transfer_non_transferrable, none,
       "transferring %1 %0 to %2 callee could cause races between %2 and %1 uses",
       (Identifier, ActorIsolation, ActorIsolation))
-NOTE(regionbasedisolation_named_info_isolated_capture, none,
-     "%1 value %0 is captured by %2 closure. Later local uses could race",
-     (Identifier, ActorIsolation, ActorIsolation))
-NOTE(regionbasedisolation_named_arg_info, none,
-     "Transferring task-isolated function argument %0 could yield races with caller uses",
-     (Identifier))
-NOTE(regionbasedisolation_named_stronglytransferred_binding, none,
-     "Cannot access a transferring parameter after the parameter has been transferred", ())
-NOTE(regionbasedisolation_note_arg_passed_to_strongly_transferred_param, none,
-     "%0 value of type %1 passed as a strongly transferred parameter; later accesses could race",
-     (StringRef, Identifier, Type))
-ERROR(regionbasedisolation_named_arg_passed_to_strongly_transferred_param, none,
-      "%0 %1 passed as a strongly transferred parameter; Uses in callee could race with later %0 uses",
-      (StringRef, Identifier))
+NOTE(regionbasedisolation_named_transfer_into_transferring_param, none,
+     "%0 %1 is passed as a transferring parameter; Uses in callee may race with later %0 uses",
+     (StringRef, Identifier))
+NOTE(regionbasedisolation_named_notransfer_transfer_into_result, none,
+     "%0 %1 cannot be a transferring result. %0 uses may race with caller uses",
+     (StringRef, Identifier))
 
+// Misc Error.
 ERROR(regionbasedisolation_task_or_actor_isolated_transferred, none,
       "task or actor isolated value cannot be transferred", ())
 

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -276,6 +276,12 @@ VariableNameInferrer::findDebugInfoProvidingValueHelper(SILValue searchValue) {
       continue;
     }
 
+    if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(searchValue)) {
+      variableNamePath.push_back(uedi);
+      searchValue = uedi->getOperand();
+      continue;
+    }
+
     if (auto *tei = dyn_cast<TupleExtractInst>(searchValue)) {
       variableNamePath.push_back(tei);
       searchValue = tei->getOperand();
@@ -291,6 +297,12 @@ VariableNameInferrer::findDebugInfoProvidingValueHelper(SILValue searchValue) {
     if (auto *tei = dyn_cast<TupleElementAddrInst>(searchValue)) {
       variableNamePath.push_back(tei);
       searchValue = tei->getOperand();
+      continue;
+    }
+
+    if (auto *e = dyn_cast<UncheckedTakeEnumDataAddrInst>(searchValue)) {
+      variableNamePath.push_back(e);
+      searchValue = e->getOperand();
       continue;
     }
 
@@ -473,6 +485,11 @@ void VariableNameInferrer::popSingleVariableName() {
       return;
     }
 
+    if (auto *uedi = dyn_cast<UncheckedEnumDataInst>(inst)) {
+      resultingString += getNameFromDecl(uedi->getElement());
+      return;
+    }
+
     if (auto *sei = dyn_cast<StructElementAddrInst>(inst)) {
       resultingString += getNameFromDecl(sei->getField());
       return;
@@ -481,6 +498,11 @@ void VariableNameInferrer::popSingleVariableName() {
     if (auto *tei = dyn_cast<TupleElementAddrInst>(inst)) {
       llvm::raw_svector_ostream stream(resultingString);
       stream << tei->getFieldIndex();
+      return;
+    }
+
+    if (auto *uedi = dyn_cast<UncheckedTakeEnumDataAddrInst>(inst)) {
+      resultingString += getNameFromDecl(uedi->getElement());
       return;
     }
 

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -277,7 +277,8 @@ bb2(%1 : @guaranteed $NonSendableKlass):
   br bb3(%3 : $FakeOptional<NonSendableKlass>)
 
 bb3(%4 : @owned $FakeOptional<NonSendableKlass>):
-  return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{task or actor isolated value cannot be transferred}}
+  return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{transferring 'myname.some' may cause a race}}
+  // expected-note @-1 {{main actor-isolated 'myname.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
 sil [ossa] @warningIfCallingGetter : $@convention(method) @async (@sil_isolated @guaranteed MyActor) -> () {

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -222,7 +222,8 @@ bb0(%0 : @guaranteed $NonSendableStruct):
   debug_value %0 : $NonSendableStruct, var, name "myname"
   %2 = struct_extract %0 : $NonSendableStruct, #NonSendableStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{task or actor isolated value cannot be transferred}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a race}}
+  // expected-note @-1 {{task-isolated 'myname.ns' cannot be a transferring result. task-isolated uses may race with caller uses}}
 }
 
 sil [ossa] @synchronous_returns_transferring_globalactor_struct_structextract : $@convention(method) (@guaranteed MainActorIsolatedStruct) -> @sil_transferring @owned NonSendableKlass {
@@ -230,7 +231,8 @@ bb0(%0 : @guaranteed $MainActorIsolatedStruct):
   debug_value %0 : $MainActorIsolatedStruct, var, name "myname"
   %2 = struct_extract %0 : $MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{task or actor isolated value cannot be transferred}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a race}}
+  // expected-note @-1 {{main actor-isolated 'myname.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
 sil [ossa] @synchronous_returns_transferring_globalactor_struct_structelementaddr : $@convention(method) (@in_guaranteed MainActorIsolatedStruct) -> @sil_transferring @owned NonSendableKlass {
@@ -238,7 +240,8 @@ bb0(%0 : $*MainActorIsolatedStruct):
   debug_value %0 : $*MainActorIsolatedStruct, var, name "myname"
   %2 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   %3 = load [copy] %2 : $*NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{task or actor isolated value cannot be transferred}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a race}}
+  // expected-note @-1 {{main actor-isolated 'myname.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
 sil [ossa] @synchronous_returns_transferring_globalactor_enum_uncheckedenumdata : $@convention(method) (@guaranteed MainActorIsolatedEnum) -> @sil_transferring @owned NonSendableKlass {

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -249,7 +249,8 @@ bb0(%0 : @guaranteed $MainActorIsolatedEnum):
   debug_value %0 : $MainActorIsolatedEnum, var, name "myname"
   %2 = unchecked_enum_data %0 : $MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{task or actor isolated value cannot be transferred}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.second' may cause a race}}
+  // expected-note @-1 {{main actor-isolated 'myname.second' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
 sil [ossa] @synchronous_returns_transferring_globalactor_enum_uncheckedtakeenumdataaddr : $@convention(method) (@in MainActorIsolatedEnum) -> @sil_transferring @owned NonSendableKlass {
@@ -257,7 +258,8 @@ bb0(%0 : $*MainActorIsolatedEnum):
   debug_value %0 : $*MainActorIsolatedEnum, var, name "myname"
   %2 = unchecked_take_enum_data_addr %0 : $*MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
   %3 = load [take] %2 : $*NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{task or actor isolated value cannot be transferred}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.second' may cause a race}}
+  // expected-note @-1 {{main actor-isolated 'myname.second' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
 sil [ossa] @synchronous_returns_transferring_globalactor_enum_switchenum : $@convention(method) (@guaranteed MainActorIsolatedEnum) -> @sil_transferring @owned FakeOptional<NonSendableKlass> {

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -153,8 +153,8 @@ extension MainActorIsolatedEnum {
     case .second(let ns):
       return ns
     }
-    // TODO: This should be on return ns.
-  } // expected-warning {{task or actor isolated value cannot be transferred}}
+  } // expected-warning {{transferring 'ns.some' may cause a race}}
+  // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func testSwitchReturnNoTransfer() -> NonSendableKlass? {
     switch self {
@@ -170,7 +170,8 @@ extension MainActorIsolatedEnum {
       return ns // TODO: The error below should be here.
     }
     return nil
-  } // expected-warning {{task or actor isolated value cannot be transferred}} 
+  } // expected-warning {{transferring 'ns.some' may cause a race}}
+  // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}} 
 
   func testIfLetReturnNoTransfer() -> NonSendableKlass? {
     if case .second(let ns) = self {

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -110,7 +110,14 @@ func transferInAndOut(_ x: transferring NonSendableKlass) -> transferring NonSen
 
 
 func transferReturnArg(_ x: NonSendableKlass) -> transferring NonSendableKlass {
-  return x // expected-warning {{task or actor isolated value cannot be transferred}}
+  return x // expected-warning {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{task-isolated 'x' cannot be a transferring result. task-isolated uses may race with caller uses}}
+}
+
+// TODO: This will be fixed once I represent @MainActor on func types.
+@MainActor func transferReturnArgMainActor(_ x: NonSendableKlass) -> transferring NonSendableKlass {
+  return x // expected-warning {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{task-isolated 'x' cannot be a transferring result. task-isolated uses may race with caller uses}}
 }
 
 // This is safe since we are returning the whole tuple fresh. In contrast,
@@ -130,7 +137,8 @@ func useTransferredResult() async {
 
 extension MainActorIsolatedStruct {
   func testNonSendableErrorReturnWithTransfer() -> transferring NonSendableKlass {
-    return ns // expected-warning {{task or actor isolated value cannot be transferred}}
+    return ns // expected-warning {{transferring 'self.ns' may cause a race}}
+    // expected-note @-1 {{main actor-isolated 'self.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
   }
   func testNonSendableErrorReturnNoTransfer() -> NonSendableKlass {
     return ns

--- a/test/SILOptimizer/moveonly_borrowing_switch.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch.swift
@@ -214,7 +214,7 @@ func testOuterAO(consuming bas: consuming AOBas) { // expected-error{{'bas' used
       where condition(x):
         nibble(payload: x)
         eat(payload: x)
-    case .payload(let x) // expected-error {{'unknown' is borrowed and cannot be consumed}}
+    case .payload(let x) // expected-error {{'bas.payload' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note {{consumed here}}
         nibble(payload: x)
         eat(payload: x)
@@ -222,7 +222,7 @@ func testOuterAO(consuming bas: consuming AOBas) { // expected-error{{'bas' used
       where condition(x):
         nibble(payload: x)
         eat(payload: x)
-    case .payload(.loadablePayload(.payload(let x))) // expected-error{{'unknown' is borrowed and cannot be consumed}}
+    case .payload(.loadablePayload(.payload(let x))) // expected-error{{'bas.payload.loadablePayload' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note{{consumed here}}
         nibble(payload: x)
         eat(payload: x)

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -31,6 +31,11 @@ sil @getContainsKlass : $@convention(thin) () -> @owned ContainsKlass
 sil @useIndirect : $@convention(thin) <T> (@in_guaranteed T) -> ()
 sil @sideEffect : $@convention(thin) () -> ()
 
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
 //===----------------------------------------------------------------------===//
 //                                MARK: Tests
 //===----------------------------------------------------------------------===//
@@ -391,12 +396,12 @@ bb0(%0 : @owned $Klass, %1 : @guaranteed $KlassWithKlassPair):
   return %37 : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_from_result: variable-name-inference with: @trace[0]
+// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_structextract: variable-name-inference with: @trace[0]
 // CHECK: Input Value:   %3 = copy_value %2 : $Klass
 // CHECK: Name: 'self.lhs'
 // CHECK: Root: %0 = argument of bb0 : $KlassPair
-// CHECK: end running test 1 of 1 on function_argument_inference_from_result: variable-name-inference with: @trace[0]
-sil [ossa] @function_argument_inference_from_result : $@convention(thin) (@guaranteed KlassPair) -> @owned Klass {
+// CHECK: end running test 1 of 1 on function_argument_inference_through_structextract: variable-name-inference with: @trace[0]
+sil [ossa] @function_argument_inference_through_structextract : $@convention(thin) (@guaranteed KlassPair) -> @owned Klass {
 bb0(%0 : @guaranteed $KlassPair):
   specify_test "variable-name-inference @trace[0]"
   debug_value %0 : $KlassPair, let, name "self", argno 1, implicit
@@ -405,3 +410,49 @@ bb0(%0 : @guaranteed $KlassPair):
   debug_value [trace] %3 : $Klass
   return %3 : $Klass
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_uncheckedenumdata: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %3 = copy_value %2 : $Klass
+// CHECK: Name: 'self.some'
+// CHECK: Root: %0 = argument of bb0 : $FakeOptional<Klass>
+// CHECK: end running test 1 of 1 on function_argument_inference_through_uncheckedenumdata: variable-name-inference with: @trace[0]
+sil [ossa] @function_argument_inference_through_uncheckedenumdata : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> @owned Klass {
+bb0(%0 : @guaranteed $FakeOptional<Klass>):
+  specify_test "variable-name-inference @trace[0]"
+  debug_value %0 : $FakeOptional<Klass>, let, name "self", argno 1, implicit
+  %2 = unchecked_enum_data %0 : $FakeOptional<Klass>, #FakeOptional.some!enumelt
+  %3 = copy_value %2 : $Klass
+  debug_value [trace] %3 : $Klass
+  return %3 : $Klass
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %3 = load [take] %2 : $*Klass
+// CHECK: Name: 'self.some'
+// CHECK: Root: %0 = argument of bb0 : $*FakeOptional<Klass>
+// CHECK: end running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr: variable-name-inference with: @trace[0]
+sil [ossa] @function_argument_inference_through_uncheckedtakeenumdataaddr : $@convention(thin) (@in FakeOptional<Klass>) -> @owned Klass {
+bb0(%0 : $*FakeOptional<Klass>):
+  specify_test "variable-name-inference @trace[0]"
+  debug_value %0 : $*FakeOptional<Klass>, let, name "self", argno 1, implicit
+  %2 = unchecked_take_enum_data_addr %0 : $*FakeOptional<Klass>, #FakeOptional.some!enumelt
+  %3 = load [take] %2 : $*Klass
+  debug_value [trace] %3 : $Klass
+  return %3 : $Klass
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr_2: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %2 = unchecked_take_enum_data_addr %0
+// CHECK: Name: 'self.some'
+// CHECK: Root: %0 = argument of bb0 : $*FakeOptional<Klass>
+// CHECK: end running test 1 of 1 on function_argument_inference_through_uncheckedtakeenumdataaddr_2: variable-name-inference with: @trace[0]
+sil [ossa] @function_argument_inference_through_uncheckedtakeenumdataaddr_2 : $@convention(thin) (@in FakeOptional<Klass>) -> @owned Klass {
+bb0(%0 : $*FakeOptional<Klass>):
+  specify_test "variable-name-inference @trace[0]"
+  debug_value %0 : $*FakeOptional<Klass>, let, name "self", argno 1, implicit
+  %2 = unchecked_take_enum_data_addr %0 : $*FakeOptional<Klass>, #FakeOptional.some!enumelt
+  debug_value [trace] %2 : $*Klass
+  %3 = load [take] %2 : $*Klass
+  return %3 : $Klass
+}
+

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -36,6 +36,17 @@ case none
 case some(T)
 }
 
+enum FirstSecondEnum<T> {
+case first
+case second(T)
+}
+
+enum FirstSecondThirdEnum<T> {
+case first
+case second(T)
+case third(FakeOptional<T>)
+}
+
 //===----------------------------------------------------------------------===//
 //                                MARK: Tests
 //===----------------------------------------------------------------------===//
@@ -456,3 +467,133 @@ bb0(%0 : $*FakeOptional<Klass>):
   return %3 : $Klass
 }
 
+// For diamonds, we just recursively visit the uses of the phi and take the
+// first one that gives a value. This is generally used for diagnostics, so we
+// are ok with just giving one.
+//
+// TODO: If we need to do better, we can perhaps emit all of them.
+
+// CHECK-LABEL: begin running test 1 of 1 on handle_diamond: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %9 = argument of bb3
+// CHECK: Name: 'myname.some'
+// CHECK: Root: %0 = argument of bb0
+// CHECK: end running test 1 of 1 on handle_diamond: variable-name-inference with: @trace[0]
+sil [ossa] @handle_diamond : $@convention(method) (@guaranteed FirstSecondEnum<Klass>) -> @sil_transferring @owned FakeOptional<Klass> {
+bb0(%0 : @guaranteed $FirstSecondEnum<Klass>):
+  specify_test "variable-name-inference @trace[0]"
+  debug_value %0 : $FirstSecondEnum<Klass>, var, name "myname"
+  switch_enum %0 : $FirstSecondEnum<Klass>, case #FirstSecondEnum.first!enumelt: bb1, case #FirstSecondEnum.second!enumelt: bb2
+
+bb1:
+  %nil = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
+  br bb3(%nil : $FakeOptional<Klass>)
+
+bb2(%1 : @guaranteed $Klass):
+  %2 = copy_value %1 : $Klass
+  %3 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %2 : $Klass
+  br bb3(%3 : $FakeOptional<Klass>)
+
+bb3(%4 : @owned $FakeOptional<Klass>):
+  debug_value [trace] %4 : $FakeOptional<Klass>
+  return %4 : $FakeOptional<Klass>
+}
+
+// For diamonds, we just recursively visit the uses of the phi and take the
+// first one that gives a value. This is generally used for diagnostics, so we
+// are ok with just giving one.
+//
+// TODO: If we need to do better, we can perhaps emit all of them.
+
+// CHECK-LABEL: begin running test 1 of 1 on handle_loop: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %16 = argument of bb5
+// CHECK: Name: 'myname.some.third'
+// CHECK: Root: %0 = argument of bb0
+// CHECK: end running test 1 of 1 on handle_loop: variable-name-inference with: @trace[0]
+sil [ossa] @handle_loop : $@convention(method) (@guaranteed FirstSecondThirdEnum<Klass>) -> @sil_transferring @owned FirstSecondThirdEnum<Klass> {
+bb0(%0 : @guaranteed $FirstSecondThirdEnum<Klass>):
+  specify_test "variable-name-inference @trace[0]"
+  debug_value %0 : $FirstSecondThirdEnum<Klass>, var, name "myname"
+  %0a = copy_value %0 : $FirstSecondThirdEnum<Klass>
+  br bb1(%0a : $FirstSecondThirdEnum<Klass>)
+
+bb1(%1a : @owned $FirstSecondThirdEnum<Klass>):
+  br bb2(%1a : $FirstSecondThirdEnum<Klass>)
+
+bb2(%1b : @owned $FirstSecondThirdEnum<Klass>):
+  switch_enum %1b : $FirstSecondThirdEnum<Klass>, case #FirstSecondThirdEnum.first!enumelt: bb3, case #FirstSecondThirdEnum.second!enumelt: bb4, case #FirstSecondThirdEnum.third!enumeult: bb4a
+
+bb3:
+  %nil = enum $FirstSecondThirdEnum<Klass>, #FirstSecondThirdEnum.first!enumelt
+  br bb5(%nil : $FirstSecondThirdEnum<Klass>)
+
+bb4(%1 : @owned $Klass):
+  %2 = copy_value %1 : $Klass
+  %3 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %2 : $Klass
+  %3a = enum $FirstSecondThirdEnum<Klass>, #FirstSecondThirdEnum.third!enumelt, %3 : $FakeOptional<Klass>
+  destroy_value %1 : $Klass
+  br bb5(%3a : $FirstSecondThirdEnum<Klass>)
+
+bb5(%4 : @owned $FirstSecondThirdEnum<Klass>):
+  br bb6
+
+bb6:
+  cond_br undef, bb7, bb8
+
+bb7:
+  br bb1(%4 : $FirstSecondThirdEnum<Klass>)
+
+bb4a(%unused : @owned $FakeOptional<Klass>):
+  unreachable
+
+bb8:
+  debug_value [trace] %4 : $FirstSecondThirdEnum<Klass>
+  return %4 : $FirstSecondThirdEnum<Klass>
+}
+
+// Make sure that we properly scope by switching edge order.
+//
+// CHECK-LABEL: begin running test 1 of 1 on handle_loop_other_order: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %16 = argument of bb5
+// CHECK: Name: 'myname.some.third'
+// CHECK: Root: %0 = argument of bb0
+// CHECK: end running test 1 of 1 on handle_loop_other_order: variable-name-inference with: @trace[0]
+sil [ossa] @handle_loop_other_order : $@convention(method) (@guaranteed FirstSecondThirdEnum<Klass>) -> @sil_transferring @owned FirstSecondThirdEnum<Klass> {
+bb0(%0 : @guaranteed $FirstSecondThirdEnum<Klass>):
+  specify_test "variable-name-inference @trace[0]"
+  debug_value %0 : $FirstSecondThirdEnum<Klass>, var, name "myname"
+  %0a = copy_value %0 : $FirstSecondThirdEnum<Klass>
+  br bb1(%0a : $FirstSecondThirdEnum<Klass>)
+
+bb1(%1a : @owned $FirstSecondThirdEnum<Klass>):
+  br bb2(%1a : $FirstSecondThirdEnum<Klass>)
+
+bb2(%1b : @owned $FirstSecondThirdEnum<Klass>):
+  switch_enum %1b : $FirstSecondThirdEnum<Klass>, case #FirstSecondThirdEnum.first!enumelt: bb4, case #FirstSecondThirdEnum.second!enumelt: bb3, case #FirstSecondThirdEnum.third!enumeult: bb4a
+
+bb3(%1 : @owned $Klass):
+  %2 = copy_value %1 : $Klass
+  %3 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, %2 : $Klass
+  %3a = enum $FirstSecondThirdEnum<Klass>, #FirstSecondThirdEnum.third!enumelt, %3 : $FakeOptional<Klass>
+  destroy_value %1 : $Klass
+  br bb5(%3a : $FirstSecondThirdEnum<Klass>)
+
+bb4:
+  %nil = enum $FirstSecondThirdEnum<Klass>, #FirstSecondThirdEnum.first!enumelt
+  br bb5(%nil : $FirstSecondThirdEnum<Klass>)
+
+bb5(%4 : @owned $FirstSecondThirdEnum<Klass>):
+  br bb6
+
+bb6:
+  cond_br undef, bb7, bb8
+
+bb7:
+  br bb1(%4 : $FirstSecondThirdEnum<Klass>)
+
+bb4a(%unused : @owned $FakeOptional<Klass>):
+  unreachable
+
+bb8:
+  debug_value [trace] %4 : $FirstSecondThirdEnum<Klass>
+  return %4 : $FirstSecondThirdEnum<Klass>
+}


### PR DESCRIPTION
In this PR, I eliminate all of the rest of the "misc error" error. The only ones left are things that the async let PR that I am going to land in a bit.

Specifically:

1. I changed the transfer non-transferrable thing to transferring parameter error to be a named error. So we now say:
```swift
func transferReturnArg(_ x: NonSendableKlass) -> transferring NonSendableKlass {
   return x // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{task-isolated 'x' cannot be a transferring result. task-isolated uses may race with caller uses}}
 }
```
2. I taught the variable name inferrer how to handle unchecked_enum_data and unchecked_take_enum_data_addr.
3. I taught the variable name inferrer how to handle phi nodes so that we can emit errors around enums:
```swift
  func testIfLetReturn() -> transferring NonSendableKlass? {
    if case .second(let ns) = self {
       return ns // TODO: The error below should be here.
     }
     return nil
   } // expected-warning {{transferring 'ns.some' may cause a race}}
   // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}} 
```