### PR TITLE
MandatoryInlining and ConstExpr: look through sendable function conversions

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1119,7 +1119,7 @@ public:
   }
 
   constexpr TargetFunctionTypeFlags<int_type>
-  withConcurrent(bool isSendable) const {
+  withSendable(bool isSendable) const {
     return TargetFunctionTypeFlags<int_type>(
         (Data & ~SendableMask) |
         (isSendable ? SendableMask : 0));

--- a/include/swift/AST/ASTSynthesis.h
+++ b/include/swift/AST/ASTSynthesis.h
@@ -490,7 +490,7 @@ ASTExtInfo synthesizeExtInfo(SynthesisContext &SC,
 template <class S>
 ASTExtInfo synthesizeExtInfo(SynthesisContext &SC,
                              const SendableModSynthesizer<S> &s) {
-  return synthesizeExtInfo(SC, s.sub).withConcurrent();
+  return synthesizeExtInfo(SC, s.sub).withSendable();
 }
 
 /// Synthesize a function type.

--- a/include/swift/AST/ExtInfo.h
+++ b/include/swift/AST/ExtInfo.h
@@ -620,7 +620,7 @@ public:
         clangTypeInfo, globalActor, thrownError, lifetimeDependenceInfo);
   }
   [[nodiscard]]
-  ASTExtInfoBuilder withConcurrent(bool concurrent = true) const {
+  ASTExtInfoBuilder withSendable(bool concurrent = true) const {
     return ASTExtInfoBuilder(
         concurrent ? (bits | SendableMask) : (bits & ~SendableMask),
         clangTypeInfo, globalActor, thrownError, lifetimeDependenceInfo);
@@ -808,10 +808,10 @@ public:
 
   /// Helper method for changing only the concurrent field.
   ///
-  /// Prefer using \c ASTExtInfoBuilder::withConcurrent for chaining.
+  /// Prefer using \c ASTExtInfoBuilder::withSendable for chaining.
   [[nodiscard]]
-  ASTExtInfo withConcurrent(bool concurrent = true) const {
-    return builder.withConcurrent(concurrent).build();
+  ASTExtInfo withSendable(bool isSendable = true) const {
+    return builder.withSendable(isSendable).build();
   }
 
   /// Helper method for changing only the throws field.
@@ -1122,7 +1122,7 @@ public:
                              clangTypeInfo, lifetimeDependenceInfo);
   }
   [[nodiscard]]
-  SILExtInfoBuilder withConcurrent(bool isSendable = true) const {
+  SILExtInfoBuilder withSendable(bool isSendable = true) const {
     return SILExtInfoBuilder(isSendable ? (bits | SendableMask)
                                         : (bits & ~SendableMask),
                              clangTypeInfo, lifetimeDependenceInfo);
@@ -1294,8 +1294,8 @@ public:
     return builder.withNoEscape(noEscape).build();
   }
   
-  SILExtInfo withConcurrent(bool isSendable = true) const {
-    return builder.withConcurrent(isSendable).build();
+  SILExtInfo withSendable(bool isSendable = true) const {
+    return builder.withSendable(isSendable).build();
   }
 
   SILExtInfo withAsync(bool isAsync = true) const {

--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -311,7 +311,7 @@ public:
   }
 
   ImplFunctionTypeFlags
-  withConcurrent() const {
+  withSendable() const {
     return ImplFunctionTypeFlags(
         ImplFunctionRepresentation(Rep), Pseudogeneric, Escaping, true, Async,
         ErasedIsolation,
@@ -967,7 +967,7 @@ protected:
         ++firstChildIdx;
       }
 
-      flags = flags.withConcurrent(isSendable)
+      flags = flags.withSendable(isSendable)
           .withAsync(isAsync).withThrows(isThrow)
           .withDifferentiable(diffKind.isDifferentiable());
 
@@ -1046,7 +1046,7 @@ protected:
           if (!child->hasText())
             return MAKE_NODE_TYPE_ERROR0(child, "expected text");
           if (child->getText() == "@Sendable") {
-            flags = flags.withConcurrent();
+            flags = flags.withSendable();
           } else if (child->getText() == "@async") {
             flags = flags.withAsync();
           }

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -1162,7 +1162,7 @@ public:
       break;
     }
 
-    funcFlags = funcFlags.withConcurrent(flags.isSendable());
+    funcFlags = funcFlags.withSendable(flags.isSendable());
     funcFlags = funcFlags.withAsync(flags.isAsync());
     funcFlags = funcFlags.withDifferentiable(flags.isDifferentiable());
     extFuncFlags =

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -5740,6 +5740,9 @@ public:
   /// argument and return types, as well as all other attributes, after substitution,
   /// such as converting `$<A, B> in (A) -> B for <Int, String>` to `(Int) -> String`.
   bool onlyConvertsSubstitutions() const;
+
+  /// Returns true if the source and destination types only differ by `@Sendable`.
+  bool onlyConvertsSendable() const;
 };
 
 /// ConvertEscapeToNoEscapeInst - Change the type of a escaping function value

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -475,7 +475,7 @@ Type ASTBuilder::createFunctionType(
                    resultDiffKind, clangFunctionType, isolation,
                    LifetimeDependenceInfo(), extFlags.hasTransferringResult())
                    .withAsync(flags.isAsync())
-                   .withConcurrent(flags.isSendable())
+                   .withSendable(flags.isSendable())
                    .build();
 
   return FunctionType::get(funcParams, output, einfo);

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1565,7 +1565,7 @@ static ValueDecl *getCreateAsyncTask(ASTContext &ctx, Identifier id,
     builder.addParameter(makeConcrete(ctx.TheExecutorType)); // executor
   }
   auto extInfo = ASTExtInfoBuilder().withAsync().withThrows()
-                                    .withConcurrent(true).build();
+                                    .withSendable(true).build();
   Type operationResultType;
   if (isDiscarding) {
     operationResultType = TupleType::getEmpty(ctx); // ()

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3377,7 +3377,7 @@ mapSignatureExtInfo(AnyFunctionType::ExtInfo info,
     return AnyFunctionType::ExtInfo();
   return AnyFunctionType::ExtInfoBuilder()
       .withRepresentation(info.getRepresentation())
-      .withConcurrent(info.isSendable())
+      .withSendable(info.isSendable())
       .withAsync(info.isAsync())
       .withThrows(info.isThrowing(), info.getThrownError())
       .withClangFunctionType(info.getClangTypeInfo().getType())

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -920,7 +920,7 @@ Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {
     // Strip off Sendable and (possibly) the global actor.
     ASTExtInfo extInfo =
         fnType->hasExtInfo() ? fnType->getExtInfo() : ASTExtInfo();
-    extInfo = extInfo.withConcurrent(false);
+    extInfo = extInfo.withSendable(false);
     if (dropGlobalActor)
       extInfo = extInfo.withoutIsolation();
 
@@ -3156,12 +3156,12 @@ static bool matchesFunctionType(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
     // Removing '@Sendable' is ABI-compatible because there's nothing wrong with
     // a function being sendable when it doesn't need to be.
     if (!ext2.isSendable())
-      ext1 = ext1.withConcurrent(false);
+      ext1 = ext1.withSendable(false);
   }
 
   if (matchMode.contains(TypeMatchFlags::IgnoreFunctionSendability)) {
-    ext1 = ext1.withConcurrent(false);
-    ext2 = ext2.withConcurrent(false);
+    ext1 = ext1.withSendable(false);
+    ext2 = ext2.withSendable(false);
   }
 
   // If specified, allow an escaping function parameter to override a

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2005,7 +2005,7 @@ private:
 
   Result visitAnyFunctionType(AnyFunctionType *ty) {
     auto newFn = applyToFunctionType(ty, [](ASTExtInfo extInfo) {
-      return extInfo.withConcurrent();
+      return extInfo.withSendable();
     });
     return { newFn, true };
   }

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1428,7 +1428,7 @@ getFunctionTypeFlags(CanFunctionType type) {
   auto flags = FunctionTypeFlags()
       .withConvention(metadataConvention)
       .withAsync(type->isAsync())
-      .withConcurrent(type->isSendable())
+      .withSendable(type->isSendable())
       .withThrows(type->isThrowing())
       .withParameterFlags(hasParameterFlags)
       .withEscaping(isEscaping)

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -2407,7 +2407,7 @@ static CanSILFunctionType getSILFunctionType(
   }
   auto silExtInfo = extInfoBuilder.withClangFunctionType(clangType)
                         .withIsPseudogeneric(pseudogeneric)
-                        .withConcurrent(isSendable)
+                        .withSendable(isSendable)
                         .withAsync(isAsync)
                         .withUnimplementable(unimplementable)
                         .withLifetimeDependenceInfo(
@@ -2493,7 +2493,7 @@ static CanSILFunctionType getSILFunctionTypeForInitAccessor(
   auto silExtInfo =
       SILExtInfoBuilder()
           .withRepresentation(SILFunctionTypeRepresentation::Thin)
-          .withConcurrent(substAccessorType->getExtInfo().isSendable())
+          .withSendable(substAccessorType->getExtInfo().isSendable())
           .build();
 
   return SILFunctionType::get(

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2744,6 +2744,16 @@ bool ConvertFunctionInst::onlyConvertsSubstitutions() const {
   return fromType->getUnsubstitutedType(M) == toType->getUnsubstitutedType(M);
 }
 
+static SILFunctionType *getNonSendableFuncType(SILType ty) {
+  auto fnTy = ty.castTo<SILFunctionType>();
+  return fnTy->getWithExtInfo(fnTy->getExtInfo().withConcurrent(false));
+}
+
+bool ConvertFunctionInst::onlyConvertsSendable() const {
+  return getNonSendableFuncType(getOperand()->getType()) ==
+         getNonSendableFuncType(getType());
+}
+
 ConvertEscapeToNoEscapeInst *ConvertEscapeToNoEscapeInst::create(
     SILDebugLocation DebugLoc, SILValue Operand, SILType Ty, SILFunction &F,
     bool isLifetimeGuaranteed) {

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2746,7 +2746,7 @@ bool ConvertFunctionInst::onlyConvertsSubstitutions() const {
 
 static SILFunctionType *getNonSendableFuncType(SILType ty) {
   auto fnTy = ty.castTo<SILFunctionType>();
-  return fnTy->getWithExtInfo(fnTy->getExtInfo().withConcurrent(false));
+  return fnTy->getWithExtInfo(fnTy->getExtInfo().withSendable(false));
 }
 
 bool ConvertFunctionInst::onlyConvertsSendable() const {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3783,7 +3783,7 @@ getFunctionInterfaceTypeWithCaptures(TypeConverter &TC,
       AnyFunctionType::ExtInfoBuilder(FunctionType::Representation::Thin,
                                       funcType->isThrowing(),
                                       funcType->getThrownError())
-          .withConcurrent(funcType->isSendable())
+          .withSendable(funcType->isSendable())
           .withAsync(funcType->isAsync())
           .withIsolation(funcType->getIsolation())
           .withLifetimeDependenceInfo(funcType->getLifetimeDependenceInfo())

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2305,7 +2305,7 @@ public:
       auto fnType = requireObjectType(SILFunctionType, arguments[4],
                                       "result of createAsyncTask");
       auto expectedExtInfo =
-        SILExtInfoBuilder().withAsync(true).withConcurrent(true).build();
+        SILExtInfoBuilder().withAsync(true).withSendable(true).build();
       require(fnType->getExtInfo().isEqualTo(expectedExtInfo, /*clang types*/true),
               "function argument to createAsyncTask has incorrect ext info");
       // FIXME: it'd be better if we took a consuming closure here

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1511,7 +1511,7 @@ SILFunction *SILGenFunction::emitNativeAsyncToForeignThunk(SILDeclRef thunk) {
   auto closureExtInfo = objcFnTy->getExtInfo().intoBuilder()
     .withRepresentation(SILFunctionTypeRepresentation::Thin)
     .withAsync()
-    .withConcurrent()
+    .withSendable()
     .build();
   auto closureTy = objcFnTy->getWithExtInfo(closureExtInfo);
   

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1620,7 +1620,7 @@ static ManagedValue emitCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
         ASTExtInfoBuilder()
             .withAsync()
             .withThrows()
-            .withConcurrent(true)
+            .withSendable(true)
             .withRepresentation(GenericFunctionType::Representation::Swift)
             .build();
 
@@ -1733,7 +1733,7 @@ SILGenFunction::emitCreateAsyncMainTask(SILLocation loc, SubstitutionMap subs,
   CanType flagsType = ctx.getIntType()->getCanonicalType();
   CanType functionType =
     FunctionType::get({}, ctx.TheEmptyTupleType,
-                      ASTExtInfo().withAsync().withThrows().withConcurrent(true))
+                      ASTExtInfo().withAsync().withThrows().withSendable(true))
       ->getCanonicalType();
 
   using Param = FunctionType::Param;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2904,12 +2904,12 @@ static bool canEmitClosureFunctionUnderConversion(
   // interferes with the implementation of `reasync`.
   auto literalWithoutEffects = literalFnType->getExtInfo().intoBuilder()
     .withNoEscape(false)
-    .withConcurrent(false)
+    .withSendable(false)
     .withThrows(false, Type());
 
   auto convertedWithoutEffects = convertedFnType->getExtInfo().intoBuilder()
     .withNoEscape(false)
-    .withConcurrent(false)
+    .withSendable(false)
     .withThrows(false, Type());
 
   // If the converted type has erased isolation, remove the isolation from

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -520,7 +520,7 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
   // TODO: Certain covariant or otherwise ABI-compatible conversions should
   // be handled as well.
   if (auto cf = dyn_cast<ConvertFunctionInst>(value)) {
-    if (cf->onlyConvertsSubstitutions()) {
+    if (cf->onlyConvertsSubstitutions() || cf->onlyConvertsSendable()) {
       return getConstantValue(cf->getOperand());
     }
   }

--- a/lib/Sema/AssociatedTypeInference.cpp
+++ b/lib/Sema/AssociatedTypeInference.cpp
@@ -2122,7 +2122,7 @@ Type swift::adjustInferredAssociatedType(TypeAdjustment adjustment, Type type,
     if (adjustment == TypeAdjustment::NoescapeToEscaping)
       return info.withNoEscape(false);
     else
-      return info.withConcurrent(true);
+      return info.withSendable(true);
   };
 
   // If we have a noescape function type, make it escaping.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7349,7 +7349,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     // to the closure without invalidating prior analysis.
     auto fromEI = fromFunc->getExtInfo();
     if (toEI.isSendable() && !fromEI.isSendable()) {
-      auto newFromFuncType = fromFunc->withExtInfo(fromEI.withConcurrent());
+      auto newFromFuncType = fromFunc->withExtInfo(fromEI.withSendable());
       if (applyTypeToClosureExpr(cs, expr, newFromFuncType)) {
         fromFunc = newFromFuncType->castTo<FunctionType>();
 
@@ -8949,7 +8949,7 @@ static Expr *wrapAsyncLetInitializer(
                   .has_value();
   auto extInfo = ASTExtInfoBuilder()
     .withAsync()
-    .withConcurrent()
+    .withSendable()
     .withThrows(throws, /*FIXME:*/Type())
     .build();
 

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -671,7 +671,7 @@ bool BindingSet::finalize(
           bool isKeyPathSendable = capability && capability->second;
           if (!isKeyPathSendable && extInfo.isSendable()) {
             fnType = FunctionType::get(fnType->getParams(), fnType->getResult(),
-                                       extInfo.withConcurrent(false));
+                                       extInfo.withSendable(false));
           }
 
           updatedBindings.insert(binding.withType(fnType));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11879,7 +11879,7 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   auto closureExtInfo = inferredClosureType->getExtInfo();
   if (auto contextualFnType = contextualType->getAs<FunctionType>()) {
     if (contextualFnType->isSendable())
-      closureExtInfo = closureExtInfo.withConcurrent();
+      closureExtInfo = closureExtInfo.withSendable();
   }
 
   // Isolated parameters override any other kind of isolation we might infer.

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6009,7 +6009,7 @@ static Type applyUnsafeConcurrencyToParameterType(
                   type->getASTContext().getMainActorType());
 
   return fnType->withExtInfo(fnType->getExtInfo()
-                               .withConcurrent(sendable)
+                               .withSendable(sendable)
                                .withIsolation(isolation));
 }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2553,7 +2553,7 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
       maybeAddParameterIsolation(infoBuilder, argTy);
       infoBuilder = infoBuilder.withAsync(AFD->hasAsync());
-      infoBuilder = infoBuilder.withConcurrent(AFD->isSendable());
+      infoBuilder = infoBuilder.withSendable(AFD->isSendable());
       // 'throws' only applies to the innermost function.
       infoBuilder = infoBuilder.withThrows(AFD->hasThrows(), thrownTy);
       // Defer bodies must not escape.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4094,7 +4094,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
         getASTContext().getClangFunctionType(params, outputTy, representation);
 
   auto extInfo = extInfoBuilder.withRepresentation(representation)
-                     .withConcurrent(sendable)
+                     .withSendable(sendable)
                      .withAsync(repr->isAsync())
                      .withClangFunctionType(clangFnType)
                      .build();

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6795,7 +6795,7 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
                                            StringRef blobData, bool isGeneric) {
   TypeID resultID;
   uint8_t rawRepresentation, rawDiffKind;
-  bool noescape = false, concurrent, async, throws, hasTransferringResult;
+  bool noescape = false, sendable, async, throws, hasTransferringResult;
   TypeID thrownErrorID;
   GenericSignature genericSig;
   TypeID clangTypeID;
@@ -6803,13 +6803,13 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
 
   if (!isGeneric) {
     decls_block::FunctionTypeLayout::readRecord(
-        scratch, resultID, rawRepresentation, clangTypeID, noescape, concurrent,
+        scratch, resultID, rawRepresentation, clangTypeID, noescape, sendable,
         async, throws, thrownErrorID, rawDiffKind, rawIsolation,
         hasTransferringResult);
   } else {
     GenericSignatureID rawGenericSig;
     decls_block::GenericFunctionTypeLayout::readRecord(
-        scratch, resultID, rawRepresentation, concurrent, async, throws,
+        scratch, resultID, rawRepresentation, sendable, async, throws,
         thrownErrorID, rawDiffKind, rawIsolation, hasTransferringResult,
         rawGenericSig);
     genericSig = MF.getGenericSignature(rawGenericSig);
@@ -6862,7 +6862,7 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
                   *representation, noescape, throws, thrownError, *diffKind,
                   clangFunctionType, isolation, LifetimeDependenceInfo(),
                   hasTransferringResult)
-                  .withConcurrent(concurrent)
+                  .withSendable(sendable)
                   .withAsync(async)
                   .build();
 
@@ -7357,7 +7357,7 @@ Expected<Type> DESERIALIZE_TYPE(SIL_FUNCTION_TYPE)(
   uint8_t rawDiffKind;
   bool pseudogeneric = false;
   bool unimplementable;
-  bool concurrent;
+  bool sendable;
   bool noescape;
   bool erasedIsolation;
   bool hasErrorResult;
@@ -7371,7 +7371,7 @@ Expected<Type> DESERIALIZE_TYPE(SIL_FUNCTION_TYPE)(
   ClangTypeID clangFunctionTypeID;
 
   decls_block::SILFunctionTypeLayout::readRecord(
-      scratch, concurrent, async, rawCoroutineKind, rawCalleeConvention,
+      scratch, sendable, async, rawCoroutineKind, rawCalleeConvention,
       rawRepresentation, pseudogeneric, noescape, unimplementable,
       erasedIsolation, rawDiffKind, hasErrorResult,
       numParams, numYields, numResults, rawInvocationGenericSig,
@@ -7401,7 +7401,7 @@ Expected<Type> DESERIALIZE_TYPE(SIL_FUNCTION_TYPE)(
 
   auto extInfo =
       SILFunctionType::ExtInfoBuilder(
-          *representation, pseudogeneric, noescape, concurrent, async,
+          *representation, pseudogeneric, noescape, sendable, async,
           unimplementable, isolation, *diffKind, clangFunctionType,
           LifetimeDependenceInfo())
           .build();

--- a/test/SILOptimizer/constant_evaluable_profiler_test.swift
+++ b/test/SILOptimizer/constant_evaluable_profiler_test.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -profile-generate -emit-silgen -primary-file %S/Inputs/constant_evaluable.swift -o %t/constant_evaluable_profiler_test_silgen.sil
+// RUN: %target-swift-frontend -profile-generate -enable-upcoming-feature InferSendableFromCaptures -emit-silgen -primary-file %S/Inputs/constant_evaluable.swift -o %t/constant_evaluable_profiler_test_silgen.sil
 //
 // Run the (mandatory) passes on which constant evaluator depends, and test the
 // constant evaluator on the SIL produced after the dependent passes are run.

--- a/test/SILOptimizer/constant_evaluable_subset_test.swift
+++ b/test/SILOptimizer/constant_evaluable_subset_test.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-silgen -primary-file %S/Inputs/constant_evaluable.swift -o %t/constant_evaluable_subset_test_silgen.sil
+// RUN: %target-swift-frontend -enable-upcoming-feature InferSendableFromCaptures -emit-silgen -primary-file %S/Inputs/constant_evaluable.swift -o %t/constant_evaluable_subset_test_silgen.sil
 //
 // Run the (mandatory) passes on which constant evaluator depends, and test the
 // constant evaluator on the SIL produced after the dependent passes are run.

--- a/test/SILOptimizer/diagnostic_constant_propagation.swift
+++ b/test/SILOptimizer/diagnostic_constant_propagation.swift
@@ -347,6 +347,12 @@ func add<T : SignedInteger>(_ left: T, _ right: T) -> T {
   return left + right
 }
 
+@Sendable
+@_transparent
+func sendableAdd<T : SignedInteger>(_ left: T, _ right: T) -> T {
+  return left + right
+}
+
 @_transparent
 func applyBinary<T : SignedInteger>(_ fn: (T, T) -> (T), _ left: T, _ right: T) -> T {
   return fn(left, right)
@@ -354,6 +360,10 @@ func applyBinary<T : SignedInteger>(_ fn: (T, T) -> (T), _ left: T, _ right: T) 
 
 func testTransparentApply() -> Int8 {
   return applyBinary(add, Int8.max, Int8.max) // expected-error {{arithmetic operation '127 + 127' (on signed 8-bit integer type) results in an overflow}}
+}
+
+func testTransparentApplySendable() -> Int8 {
+  return applyBinary(sendableAdd, Int8.max, Int8.max) // expected-error {{arithmetic operation '127 + 127' (on signed 8-bit integer type) results in an overflow}}
 }
 
 func testBuiltinGlobalStringTablePointerNoError() -> UnsafePointer<CChar> {

--- a/unittests/Reflection/TypeRef.cpp
+++ b/unittests/Reflection/TypeRef.cpp
@@ -256,15 +256,15 @@ TEST(TypeRefTest, UniqueFunctionTypeRef) {
 
   // Test sendable.
   auto F14 = Builder.createFunctionType(
-      Parameters1, Result, FunctionTypeFlags().withConcurrent(true),
+      Parameters1, Result, FunctionTypeFlags().withSendable(true),
       ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F15 = Builder.createFunctionType(
-      Parameters1, Result, FunctionTypeFlags().withConcurrent(true),
+      Parameters1, Result, FunctionTypeFlags().withSendable(true),
       ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   auto F16 = Builder.createFunctionType(
-      Parameters1, Result, FunctionTypeFlags().withConcurrent(false),
+      Parameters1, Result, FunctionTypeFlags().withSendable(false),
       ExtendedFunctionTypeFlags(),
       FunctionMetadataDifferentiabilityKind::NonDifferentiable, nullptr, nullptr);
   EXPECT_EQ(F14, F15);


### PR DESCRIPTION
Allows inlining of sendable transparent functions

rdar://124401627

Also, rename `withConcurrent` to `withSendable`. That was missed when "concurrent" was renamed to "sendable"
