### PR TITLE
[cxx-interop] Faster `std::string` initialization from String

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -21,7 +21,9 @@ extension std.string {
   ///   Swift string.
   public init(_ string: String) {
     self.init()
-    for char in string.utf8 {
+    let utf8 = string.utf8
+    self.reserve(utf8.count)
+    for char in utf8 {
       self.push_back(value_type(bitPattern: char))
     }
   }


### PR DESCRIPTION
Instead of appending characters one-by-one, which resizes the resulting string multiple times, let's reserve the required number of bytes beforehand.

rdar://127423949