### PR TITLE
[DebugInfo] Fix crash on empty tuple fragments

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2954,8 +2954,8 @@ bool IRGenDebugInfoImpl::handleFragmentDIExpr(
   if (!FieldTypeInfo)
     return false;
   llvm::Type *FieldTy = FieldTypeInfo->getStorageType();
-  // Doesn't support non-fixed type right now
-  if (!Offset || !FieldTy)
+  // Doesn't support non-fixed or empty types right now.
+  if (!Offset || !FieldTy || !FieldTy->isSized())
     return false;
 
   uint64_t SizeOfByte = CI.getTargetInfo().getCharWidth();
@@ -2989,8 +2989,8 @@ bool IRGenDebugInfoImpl::handleTupleFragmentDIExpr(
   auto Offset = getFixedTupleElementOffset(IGM, ParentSILType, *Idx);
   auto ElementType = TT->getElement(*Idx).getType()->getCanonicalType();
   llvm::Type *FieldTy = IGM.getStorageTypeForLowered(ElementType);
-  // Doesn't support non-fixed type right now
-  if (!Offset || !FieldTy)
+  // Doesn't support non-fixed or empty types right now.
+  if (!Offset || !FieldTy || !FieldTy->isSized())
     return false;
 
   uint64_t SizeInBits = IGM.DataLayout.getTypeSizeInBits(FieldTy);

--- a/test/DebugInfo/irgen_void_tuple.sil
+++ b/test/DebugInfo/irgen_void_tuple.sil
@@ -1,0 +1,36 @@
+// RUN: %target-swiftc_driver -Xfrontend -disable-debugger-shadow-copies -g -emit-ir %s | %FileCheck %s
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: define {{.*}} @couple_of_voids
+sil hidden @couple_of_voids : $@convention(thin) () -> () {
+bb0:
+  %3 = tuple ()
+  // CHECK-NOT: call void @llvm.dbg.value
+  debug_value %3 : $(), let, (name "success", loc "void.swift":3:1), type $*((), ()), expr op_tuple_fragment:$((), ()):0
+  return %3 : $()
+} // end sil function 'couple_of_voids'
+
+// CHECK-LABEL: define {{.*}} @one_existing
+sil hidden @one_existing : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %1 = integer_literal $Builtin.Int64, 0
+  // CHECK: call void @llvm.dbg.value
+  // CHECK-SAME: metadata ![[RESULT_VAR:[0-9]+]]
+  debug_value %1 : $Builtin.Int64, let, (name "result", loc "void.swift":3:1), type $*(Builtin.Int64, ()), expr op_tuple_fragment:$(Builtin.Int64, ()):0
+  return %1 : $Builtin.Int64
+} // end sil function 'one_existing'
+
+// CHECK-LABEL: define {{.*}} @one_empty
+sil hidden @one_empty : $@convention(thin) () -> () {
+bb0:
+  %3 = tuple ()
+  // CHECK-NOT: call void @llvm.dbg.value
+  debug_value %3 : $(), let, (name "failure", loc "void.swift":3:1), type $*(Builtin.Int64, ()), expr op_tuple_fragment:$(Builtin.Int64, ()):1
+  return %3 : $()
+} // end sil function 'one_empty'
+
+// CHECK: ![[RESULT_VAR]] = !DILocalVariable
+// CHECK-SAME: name: "result"


### PR DESCRIPTION
Fixes a crash when we had a fragment of a tuple with no size (such as Void)

rdar://124408249
