### PR TITLE
[region-isolation] When inferring AST arg nums from SIL operand numbers, ignoring indirect operands.

### DIFF
--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -811,6 +811,15 @@ public:
     }
   }
 
+  /// Return the applied argument without indirect results.
+  unsigned getAppliedArgIndexWithoutIndirectResult(const Operand &oper) const {
+    assert(oper.getUser() == **this);
+    assert(isArgumentOperand(oper));
+
+    return oper.getOperandNumber() - getOperandIndexOfFirstArgument() -
+           getNumIndirectSILResults() - getNumIndirectSILErrorResults();
+  }
+
   static FullApplySite getFromOpaqueValue(void *p) { return FullApplySite(p); }
 
   static bool classof(const SILInstruction *inst) {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -957,10 +957,18 @@ void InferredCallerArgumentTypeInfo::initForApply(const Operand *op,
     unsigned argNum = [&]() -> unsigned {
       if (fai.isCalleeOperand(*op))
         return op->getOperandNumber();
-      return fai.getAppliedArgIndex(*op);
+      return fai.getAppliedArgIndexWithoutIndirectResult(*op);
     }();
-    assert(argNum < sourceApply->getArgs()->size());
-    foundExpr = getFoundExprForParam(sourceApply, argNum);
+
+    // If something funny happened and we get an arg num that is larger than our
+    // num args... just return nullptr so we emit an error using our initial
+    // foundExpr.
+    //
+    // TODO: We should emit a "I don't understand error" so this gets reported
+    // to us.
+    if (argNum < sourceApply->getArgs()->size()) {
+      foundExpr = getFoundExprForParam(sourceApply, argNum);
+    }
   }
 
   auto inferredArgType =

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -72,9 +72,13 @@ static Expr *inferArgumentExprFromApplyExpr(ApplyExpr *sourceApply,
     unsigned argNum = [&]() -> unsigned {
       if (fai.isCalleeOperand(*op))
         return op->getOperandNumber();
-      return fai.getAppliedArgIndex(*op);
+      return fai.getAppliedArgIndexWithoutIndirectResult(*op);
     }();
-    assert(argNum < sourceApply->getArgs()->size());
+
+    // Something happened that we do not understand.
+    if (argNum >= sourceApply->getArgs()->size()) {
+      return nullptr;
+    }
 
     foundExpr = sourceApply->getArgs()->getExpr(argNum);
 


### PR DESCRIPTION
Otherwise, we get off by one errors.

NOTE: I removed the assert that this originally hit since it is possible for us to perhaps hit other issues and it would be better to just emit a suboptimal error than crashing. With time, I will probably make it so if we miss we emit a "compiler couldn't understand error".

rdar://124478890
