### PR TITLE
[ConsumeAddrChecker] Check inout_aliasable arguments.

### DIFF
--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -2466,7 +2466,8 @@ class ConsumeOperatorCopyableAddressesCheckerPass
       if (arg->getType().isAddress() &&
           (arg->hasConvention(SILArgumentConvention::Indirect_In) ||
            arg->hasConvention(SILArgumentConvention::Indirect_In_Guaranteed) ||
-           arg->hasConvention(SILArgumentConvention::Indirect_Inout)))
+           arg->hasConvention(SILArgumentConvention::Indirect_Inout) ||
+           arg->hasConvention(SILArgumentConvention::Indirect_InoutAliasable)))
         addressesToCheck.insert(arg);
     }
 

--- a/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars.swift
@@ -254,13 +254,12 @@ extension DeferTestProtocol {
         print("123")
     }
 
-    // We do not support moving within a defer right now.
     mutating func deferTestFail1() {
         let selfType = type(of: self)
         let _ = (consume self)
         defer {
             self = selfType.getP()
-            let _ = (consume self) // expected-error {{'consume' applied to value that the compiler does not support}}
+            let _ = (consume self)
         }
         print("123")
     }
@@ -713,4 +712,12 @@ func inoutAndUseTest<T>(_ x: T) {
                                   // expected-note @-1 {{consumed here}}
     useValueAndInOut(&y, consume y) // expected-note {{used here}}
                                   // expected-note @-1 {{consumed here}}
+}
+
+@_silgen_name("consumeInoutAliasable")
+func consumeInoutAliasable<T>(_ x: inout T, other: T) {
+  {
+    _ = consume x
+    x = other
+  }()
 }

--- a/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_loadable_vars.swift
@@ -314,12 +314,11 @@ extension KlassWrapper {
         print("123")
     }
 
-    // We do not support moving within a defer right now.
     mutating func deferTestFail1() {
         let _ = (consume self)
         defer {
             self = KlassWrapper(k: Klass())
-            let _ = (consume self) // expected-error {{'consume' applied to value that the compiler does not support}}
+            let _ = (consume self)
         }
         print("123")
     }


### PR DESCRIPTION
Such values can be referenced in a `ConsumeExpr`, so the checker must check them.  Furthermore it may be legal to consume such values.
