### PR TITLE
Add an option -sil-break-before-pass-count

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -215,6 +215,7 @@ class SILPassManager {
 
   unsigned maxNumPassesToRun = UINT_MAX;
   unsigned maxNumSubpassesToRun = UINT_MAX;
+  unsigned breakBeforePassCount = UINT_MAX;
 
   /// For invoking Swift passes.
   SwiftPassInvocation swiftPassInvocation;
@@ -428,7 +429,8 @@ public:
   void runSwiftModuleVerification();
 
 private:
-  void parsePassCount(StringRef countsStr);
+  void parsePassesToRunCount(StringRef countsStr);
+  void parseBreakBeforePassCount(StringRef countsStr);
 
   bool doPrintBefore(SILTransform *T, SILFunction *F);
 
@@ -460,6 +462,9 @@ private:
   /// A helper function that returns (based on SIL stage and debug
   /// options) whether we should continue running passes.
   bool continueTransforming();
+
+  /// Break before running a pass.
+  bool breakBeforeRunning(StringRef fnName, SILFunctionTransform *SFT);
 
   /// Return true if all analyses are unlocked.
   bool analysesUnlocked();


### PR DESCRIPTION
We often look at the SIL output of -sil-print-function and may want to debug a specific pass after looking at the output.

-sil-break-before-pass-count=<pass_number> will allow to automatically break in the debugger after <pass_count> of passes are run.

Example:
From -sil-print-function dump:
"SIL function after  #6680, stage MidLevel,Function, pass 38: RedundantLoadElimination"

-Xllvm -sil-break-before-pass-count=6680 will break before running this pass in the debugger

