### PR TITLE
[Index] Scope the setting of `IgnoreAdjacentModules`

### DIFF
--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -757,10 +757,10 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
       module->getResilienceStrategy() == ResilienceStrategy::Resilient &&
       !module->isBuiltFromInterface() &&
       !module->isStdlibModule()) {
-    module->getASTContext().setIgnoreAdjacentModules(true);
+    auto &ctx = module->getASTContext();
+    llvm::SaveAndRestore<bool> S(ctx.IgnoreAdjacentModules, true);
 
     ImportPath::Module::Builder builder(module->getName());
-    ASTContext &ctx = module->getASTContext();
     auto reloadedModule = ctx.getModule(builder.get(),
                                         /*AllowMemoryCached=*/false);
 


### PR DESCRIPTION
I don't _think_ this currently causes any issues, but make sure we unset `IgnoreAdjacentModules` when done loading the module.