### PR TITLE
[Noncopyable] Mangle protocol members without the inverse requirements of the protocol itself

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -4669,6 +4669,11 @@ ASTMangler::BaseEntitySignature::BaseEntitySignature(const Decl *decl)
     case DeclKind::Struct:
     case DeclKind::Class:
       sig = decl->getInnermostDeclContext()->getGenericSignatureOfContext();
+
+      // Protocol members never mangle inverse constraints on `Self`.
+      if (isa<ProtocolDecl>(decl->getDeclContext()))
+        setDepth(0);
+
       break;
 
     case DeclKind::TypeAlias: // FIXME: is this right? typealiases have a generic signature!

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -505,7 +505,7 @@ IRGenMangler::appendExtendedExistentialTypeShape(CanGenericSignature genSig,
                                                  CanType shapeType) {
   // Append the generalization signature.
   if (genSig) {
-    // Generalization signature never reference inverses.
+    // Generalization signature never mangles inverses.
     llvm::SaveAndRestore X(AllowInverses, false);
     appendGenericSignature(genSig);
   }

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -46,9 +46,6 @@ public:
   IRGenMangler() { }
 
   std::string mangleDispatchThunk(const FuncDecl *func) {
-    // Dispatch thunks do not mangle inverse conformances.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendEntity(func);
     appendOperator("Tj");
@@ -58,9 +55,6 @@ public:
   std::string mangleDerivativeDispatchThunk(
       const AbstractFunctionDecl *func,
       AutoDiffDerivativeFunctionIdentifier *derivativeId) {
-    // Dispatch thunks do not mangle inverse conformances.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
     auto *resultIndices =
@@ -77,9 +71,6 @@ public:
 
   std::string mangleConstructorDispatchThunk(const ConstructorDecl *ctor,
                                              bool isAllocating) {
-    // Dispatch thunks do not mangle inverse conformances.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendConstructorEntity(ctor, isAllocating);
     appendOperator("Tj");
@@ -87,9 +78,6 @@ public:
   }
 
   std::string mangleMethodDescriptor(const FuncDecl *func) {
-    // Method descriptors do not mangle inverse conformances.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendEntity(func);
     appendOperator("Tq");
@@ -99,9 +87,6 @@ public:
   std::string mangleDerivativeMethodDescriptor(
       const AbstractFunctionDecl *func,
       AutoDiffDerivativeFunctionIdentifier *derivativeId) {
-    // Method descriptors do not mangle inverse conformances.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
     auto *resultIndices =
@@ -118,9 +103,6 @@ public:
 
   std::string mangleConstructorMethodDescriptor(const ConstructorDecl *ctor,
                                                 bool isAllocating) {
-    // Method descriptors do not mangle inverse conformances.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendConstructorEntity(ctor, isAllocating);
     appendOperator("Tq");
@@ -346,9 +328,6 @@ public:
     llvm::SaveAndRestore<bool> optimizeProtocolNames(OptimizeProtocolNames,
                                                      false);
 
-    // No mangling of inverse conformances inside protocols.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     bool isAssocTypeAtDepth = false;
     (void)appendAssocType(
@@ -363,9 +342,6 @@ public:
       const ProtocolDecl *proto,
       CanType subject,
       const ProtocolDecl *requirement) {
-    // No mangling of inverse conformances inside protocols.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendAnyGenericType(proto);
     if (isa<GenericTypeParamType>(subject)) {
@@ -382,9 +358,6 @@ public:
   std::string mangleBaseConformanceDescriptor(
       const ProtocolDecl *proto,
       const ProtocolDecl *requirement) {
-    // No mangling of inverse conformances inside protocols.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendAnyGenericType(proto);
     appendProtocolName(requirement);
@@ -396,9 +369,6 @@ public:
       const ProtocolDecl *proto,
       CanType subject,
       const ProtocolDecl *requirement) {
-    // No mangling of inverse conformances inside protocols.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendAnyGenericType(proto);
     bool isFirstAssociatedTypeIdentifier = true;
@@ -424,9 +394,6 @@ public:
   }
 
   std::string mangleFieldOffset(const ValueDecl *Decl) {
-    // No mangling of inverse conformances.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendEntity(Decl);
     appendOperator("Wvd");

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -10,6 +10,24 @@
 
 public protocol P: ~Copyable { }
 
+public struct CallMe<U: ~Copyable> {
+  public enum Maybe<T: ~Copyable>: ~Copyable {
+    // CHECK-LABEL: @"$s4test6CallMeV5MaybeO4someyAEyx_qd__Gqd__cAGmr__lFWC"
+    // CHECK: @"$s4test6CallMeV5MaybeO4noneyAEyx_qd__GAGmr__lFWC"
+    case none
+    case some(T)
+  }
+}
+
+extension CallMe {
+  public enum Box<T: ~Copyable>: ~Copyable {
+    // CHECK-LABEL: @"$s4test6CallMeV3BoxO4someyAEyx_qd__Gqd__cAGmr__lFWC"
+    // CHECK: @"$s4test6CallMeV3BoxO4noneyAEyx_qd__GAGmr__lFWC"
+    case none
+    case some(T)
+  }
+}
+
 public protocol Hello<Person>: ~Copyable {
   // CHECK: @"$s4test5HelloP6PersonAC_AA1PTn"
   // CHECK: @"$s6Person4test5HelloPTl" =
@@ -20,8 +38,10 @@ public protocol Hello<Person>: ~Copyable {
 
   // CHECK: @"$s4test5HelloP5greetyy6PersonQzFTq"
   func greet(_ person: borrowing Person)
-}
 
-public struct Wrapper<T: ~Copyable> {
-  var wrapped: T { fatalError("boom") }
+  // CHECK: @"$s4test5HelloP10overloadedyyqd__lFTj"
+  func overloaded<T>(_: borrowing T)
+
+  // CHECK: @"$s4test5HelloP10overloadedyyqd__Ricd__lFTj"
+  func overloaded<T: ~Copyable>(_: borrowing T)
 }


### PR DESCRIPTION
This eliminates the ABI impact of making `Self` or associated types in a protocol `~Copyable`.
