### PR TITLE
[test] Add swift-scan-test to test dependencies

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,7 +58,8 @@ function(get_test_dependencies SDK result_var_name)
       swift-ide-test
       swift-refactor
       swift-reflection-dump
-      swift-remoteast-test)
+      swift-remoteast-test
+      swift-scan-test)
 
     if(SWIFT_BUILD_SOURCEKIT)
       list(APPEND deps_binaries sourcekitd-test complete-test)


### PR DESCRIPTION
The swift-scan-test is exclusively used from the tests, but it was not added to the `*-test-depends` targets, so trying to prepare the test dependencies will not had build it, and test failures will happen.
