### PR TITLE
SIL: Optimizer fixes for noncopyable optional chains.

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1404,6 +1404,9 @@ public:
     assert(!operand->getType().isTrivial(getFunction()) &&
            "Should not be passing trivial values to this api. Use instead "
            "emitCopyValueOperation");
+    assert((getModule().getStage() == SILStage::Raw
+            || !operand->getType().isMoveOnly())
+           && "should not be copying move-only values in canonical SIL");
     return insert(new (getModule())
                       CopyValueInst(getSILDebugLocation(Loc), operand));
   }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1468,9 +1468,15 @@ SILInstruction *SILCombiner::visitCondBranchInst(CondBranchInst *CBI) {
     if (!CBI->getTrueArgs().empty() || !CBI->getFalseArgs().empty())
       return nullptr;
     auto EnumOperandTy = SEI->getEnumOperand()->getType();
-    // Type should be loadable
-    if (!EnumOperandTy.isLoadable(*SEI->getFunction()))
+    // Type should be loadable and copyable.
+    // TODO: Generalize to work without copying address-only or noncopyable
+    // values.
+    if (!EnumOperandTy.isLoadable(*SEI->getFunction())) {
       return nullptr;
+    }
+    if (EnumOperandTy.isMoveOnly()) {
+      return nullptr;
+    }
 
     // Result of the select_enum should be a boolean.
     if (SEI->getType() != CBI->getCondition()->getType())

--- a/test/SILGen/moveonly_optional_operations_2.swift
+++ b/test/SILGen/moveonly_optional_operations_2.swift
@@ -74,7 +74,7 @@ func consumingSwitchSubject3(ncp: consuming NCPair) {
     // CHECK:   [[PAIR_MARK:%.*]] = mark_unresolved_non_copyable_value [assignable_but_not_consumable] [[PAIR_ACCESS]]
     // CHECK:   [[FIELD:%.*]] = struct_element_addr [[PAIR_MARK]]
     // CHECK:   [[FIELD_ACCESS:%.*]] = begin_access [deinit] [static] [no_nested_conflict] [[FIELD]]
-    // CHECK:   cond_br {{.*}}, [[SOME_BB:bb[0-9]+]],
+    // CHECK:   cond_br {{.*}}, [[SOME_BB:bb[0-9]+]], [[NONE_BB:bb[0-9]+]]
     // CHECK: [[SOME_BB]]:
     // CHECK:   [[PAYLOAD_ADDR:%.*]] = unchecked_take_enum_data_addr [[FIELD_ACCESS]]
     // CHECK:   [[PAYLOAD:%.*]] = load [take] [[PAYLOAD_ADDR]]
@@ -85,6 +85,9 @@ func consumingSwitchSubject3(ncp: consuming NCPair) {
     // CHECK-NEXT: end_access [[PAIR_ACCESS]]
     // CHECK-NEXT: inject_enum_addr 
     // CHECK-NEXT: br 
+    // CHECK: [[NONE_BB]]:
+    // CHECK:   destroy_addr [[FIELD_ACCESS]]
+    // CHECK-NEXT: end_access [[FIELD_ACCESS]]
 
     switch ncp.first?.c3() {
     default:


### PR DESCRIPTION
Don't attempt a SILCombine transform on `select_enum` that inserts a copy when an enum is noncopyable. Adjust the cleanup handling for a consuming optional chain to ensure a `destroy_value` still gets emitted on the `none` path; this shouldn't actually matter since `none` is a trivial case, but the memory verifier isn't that fancy during OSSA, and we can optimize it later. Fixes rdar://124426918.