### PR TITLE
Enable task-to-thread model by default for mixin_stdlib_minimal

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2671,6 +2671,7 @@ build-swift-stdlib-static-print=1
 darwin-crash-reporter-client=0
 swift-stdlib-use-relative-protocol-witness-tables=1
 swift-stdlib-overridable-retain-release=0
+swift-stdlib-task-to-thread-model-concurrency=1
 
 [preset: stdlib_S_standalone_minimal_macho_x86_64,build]
 mixin-preset=

--- a/utils/swift_build_support/swift_build_support/products/minimalstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/minimalstdlib.py
@@ -171,6 +171,8 @@ class MinimalStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_THREADING_PACKAGE:STRING', 'none')
         self.cmake_options.define(
             'SWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE:BOOL', 'FALSE')
+        self.cmake_options.define(
+            'SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY:BOOL', 'TRUE')
 
         # Build!
         self.build_with_cmake(["swift-stdlib-freestanding"], build_variant, [],


### PR DESCRIPTION
Fix the issue around failing CI bot which was testing stdlib_S_standalone_minimal_macho_x86_64 but didn't have the task-to-thread model enabled.

Radar-Id: rdar://problem/121121793