### PR TITLE
CMake: Pass `-no_warn_duplicate_libraries` to the linker when supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -979,6 +979,18 @@ endif()
 set(SWIFT_USE_LINKER ${SWIFT_USE_LINKER_default} CACHE STRING
     "Build Swift with a non-default linker")
 
+include(CheckLinkerFlag)
+
+# Apple's linker complains about duplicate libraries, which CMake likes to do
+# to support ELF platforms. To silence that warning, we can use
+# -no_warn_duplicate_libraries, but only in versions of the linker that
+# support that flag.
+if(NOT LLVM_USE_LINKER AND ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  check_linker_flag(C "-Wl,-no_warn_duplicate_libraries" SWIFT_LINKER_SUPPORTS_NO_WARN_DUPLICATE_LIBRARIES)
+else()
+  set(SWIFT_LINKER_SUPPORTS_NO_WARN_DUPLICATE_LIBRARIES OFF CACHE INTERNAL "")
+endif()
+
 #
 # Enable additional warnings.
 #

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -441,6 +441,12 @@ function(_add_host_variant_link_flags target)
         "SHELL:-Xlinker -dead_strip")
     endif()
   endif()
+
+  if(SWIFT_LINKER_SUPPORTS_NO_WARN_DUPLICATE_LIBRARIES)
+    target_link_options(${target} PRIVATE
+      "SHELL:-Xlinker -no_warn_duplicate_libraries")
+  endif()
+
 endfunction()
 
 function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)


### PR DESCRIPTION
The output of build-script on macOS is currently full of spammy linker warnings like this:

```
ld: warning: ignoring duplicate libraries: '.../swift-project/build/Ninja-RelWithDebInfoAssert/llvm-macosx-arm64/lib/libLLVMDemangle.a', 'lib/libswiftDemangling.a'
```

Apple's linker complains about duplicate libraries, which CMake likes to do to support ELF platforms. To silence that warning, we can use `-no_warn_duplicate_libraries`, but only in versions of the linker that support that flag.
