### PR TITLE
SILGen: Avoid crashing for invalid conformances

### DIFF
--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -747,6 +747,9 @@ public:
   /// Override the witness for a given requirement.
   void overrideWitness(ValueDecl *requirement, Witness newWitness);
 
+  /// Triggers a request that resolves all of the conformance's value witnesses.
+  void resolveValueWitnesses() const;
+
   /// Determine whether the witness for the given type requirement
   /// is the default definition.
   bool usesDefaultDefinition(AssociatedTypeDecl *requirement) const {

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -706,6 +706,13 @@ void NormalProtocolConformance::overrideWitness(ValueDecl *requirement,
   Mapping[requirement] = witness;
 }
 
+void NormalProtocolConformance::resolveValueWitnesses() const {
+  auto mutableThis = const_cast<NormalProtocolConformance *>(this);
+  evaluateOrDefault(getProtocol()->getASTContext().evaluator,
+                    ResolveValueWitnessesRequest{mutableThis},
+                    evaluator::SideEffect());
+}
+
 SpecializedProtocolConformance::SpecializedProtocolConformance(
     Type conformingType,
     NormalProtocolConformance *genericConformance,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -2106,7 +2106,7 @@ public:
         SGM.pendingForcedFunctions.pop_front();
       }
       while (!SGM.pendingConformances.empty()) {
-        SGM.getWitnessTable(SGM.pendingConformances.front());
+        (void)SGM.getWitnessTable(SGM.pendingConformances.front());
         SGM.pendingConformances.pop_front();
       }
     }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -23,9 +23,9 @@
 #include "Scope.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/GenericEnvironment.h"
-#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/PropertyWrappers.h"
+#include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/TypeMemberVisitor.h"
@@ -528,6 +528,11 @@ public:
 
     PrettyStackTraceConformance trace("generating SIL witness table",
                                       Conformance);
+
+    // Check whether the conformance is valid first.
+    Conformance->resolveValueWitnesses();
+    if (Conformance->isInvalid())
+      return nullptr;
 
     auto *proto = Conformance->getProtocol();
     visitProtocolDecl(proto);
@@ -1150,7 +1155,7 @@ public:
     for (auto *conformance : theType->getLocalConformances(
                                ConformanceLookupKind::NonInherited)) {
       if (auto *normal = dyn_cast<NormalProtocolConformance>(conformance))
-        SGM.getWitnessTable(normal);
+        (void)SGM.getWitnessTable(normal);
     }
   }
 
@@ -1309,7 +1314,7 @@ public:
       for (auto *conformance : e->getLocalConformances(
                                  ConformanceLookupKind::All)) {
         if (auto *normal =dyn_cast<NormalProtocolConformance>(conformance))
-          SGM.getWitnessTable(normal);
+          (void)SGM.getWitnessTable(normal);
       }
     }
   }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -260,6 +260,8 @@ public:
   }
 
   void emitVTable() {
+    PrettyStackTraceDecl("silgen emitVTable", theClass);
+
     // Imported types don't have vtables right now.
     if (theClass->hasClangNode())
       return;
@@ -1118,6 +1120,8 @@ public:
 
   /// Emit SIL functions for all the members of the type.
   void emitType() {
+    PrettyStackTraceDecl("silgen emitType", theType);
+
     SGM.emitLazyConformancesForType(theType);
 
     for (Decl *member : theType->getABIMembers()) {
@@ -1292,6 +1296,8 @@ public:
 
   /// Emit SIL functions for all the members of the extension.
   void emitExtension(ExtensionDecl *e) {
+    PrettyStackTraceDecl("silgen emitExtension", e);
+
     // Arguably, we should divert to SILGenType::emitType() here if it's an
     // @_objcImplementation extension, but we don't actually need to do any of
     // the stuff that it currently does.

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3473,9 +3473,7 @@ bool ContextualFailure::tryProtocolConformanceFixIt(
       evaluateOrDefault(getASTContext().evaluator,
                         ResolveTypeWitnessesRequest{conformance},
                         evaluator::SideEffect());
-      evaluateOrDefault(getASTContext().evaluator,
-                        ResolveValueWitnessesRequest{conformance},
-                        evaluator::SideEffect());
+      conformance->resolveValueWitnesses();
 
       fakeConformances.push_back(conformance);
     }

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1401,9 +1401,7 @@ ResolveImplicitMemberRequest::evaluate(Evaluator &evaluator,
       // FIXME: This should be more fine-grained to avoid having to check
       // for a cycle here.
       if (!evaluator.hasActiveRequest(ResolveValueWitnessesRequest{conformance})) {
-        evaluateOrDefault(evaluator,
-                          ResolveValueWitnessesRequest{conformance},
-                          evaluator::SideEffect());
+        conformance->resolveValueWitnesses();
       }
     }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2870,9 +2870,7 @@ static ArrayRef<Decl *> evaluateMembersRequest(
     }
 
     if (isDerivable) {
-      evaluateOrDefault(ctx.evaluator,
-                        ResolveValueWitnessesRequest{normal},
-                        evaluator::SideEffect());
+      normal->resolveValueWitnesses();
     }
   }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2472,9 +2472,7 @@ checkIndividualConformance(NormalProtocolConformance *conformance) {
   ensureRequirementsAreSatisfied(Context, conformance);
 
   // Check non-type requirements.
-  evaluateOrDefault(Context.evaluator,
-                    ResolveValueWitnessesRequest{conformance},
-                    evaluator::SideEffect());
+  conformance->resolveValueWitnesses();
 }
 
 /// Add the next associated type deduction to the string representation

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -169,9 +169,7 @@ static void computeLoweredProperties(NominalTypeDecl *decl,
             evaluateOrDefault(ctx.evaluator,
                               ResolveTypeWitnessesRequest{normal},
                               evaluator::SideEffect());
-            evaluateOrDefault(ctx.evaluator,
-                              ResolveValueWitnessesRequest{normal},
-                              evaluator::SideEffect());
+            normal->resolveValueWitnesses();
           }
         }
       };

--- a/test/SILGen/lazy_typecheck_errors.swift
+++ b/test/SILGen/lazy_typecheck_errors.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -module-name Test -enable-library-evolution -experimental-lazy-typecheck -verify
+
+public protocol Proto {
+  func req()
+}
+
+public struct ConformsToProtoMissingRequirement: Proto {
+  // expected-error@-1 {{type 'ConformsToProtoMissingRequirement' does not conform to protocol 'Proto'}}
+}
+
+public struct ConformsToProtoNearMiss: Proto {
+  // expected-error@-1 {{type 'ConformsToProtoNearMiss' does not conform to protocol 'Proto'}}
+
+  public func req(x: Int) {}
+}
+
+public protocol ProtoWithAssociatedType {
+  associatedtype A
+}
+
+public struct ConformsToProtoProtoWithAssociatedType: ProtoWithAssociatedType {
+  // expected-error@-1 {{type 'ConformsToProtoProtoWithAssociatedType' does not conform to protocol 'ProtoWithAssociatedType'}}
+}

--- a/test/SILGen/lazy_typecheck_errors.swift
+++ b/test/SILGen/lazy_typecheck_errors.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -module-name Test -enable-library-evolution -experimental-lazy-typecheck -verify
+// RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -enable-library-evolution -module-name Test -experimental-lazy-typecheck -verify
+// RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -enable-library-evolution -module-name Test -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies -verify
+// RUN: %target-swift-frontend -emit-silgen %s -parse-as-library -enable-library-evolution -module-name Test -experimental-lazy-typecheck -experimental-skip-non-inlinable-function-bodies -experimental-skip-non-exportable-decls -verify
+
 
 public protocol Proto {
   func req()
@@ -20,4 +23,33 @@ public protocol ProtoWithAssociatedType {
 
 public struct ConformsToProtoProtoWithAssociatedType: ProtoWithAssociatedType {
   // expected-error@-1 {{type 'ConformsToProtoProtoWithAssociatedType' does not conform to protocol 'ProtoWithAssociatedType'}}
+}
+
+public struct GenericStruct<T> {
+  public var t: T
+}
+
+public struct GenericStructWithInvalidParameterConstraint<T: NonExistent> {
+  // expected-error@-1 {{cannot find type 'NonExistent' in scope}}
+}
+
+extension GenericStruct where T == NonExistent {
+  // expected-error@-1 {{cannot find type 'NonExistent' in scope}}
+  public func methodInExtensionWithInvalidWhereClause() {}
+}
+
+public class ValidClass {
+  public func methodReturningNonExistentType() -> NonExistent {}
+  // expected-error@-1 {{cannot find type 'NonExistent' in scope}}
+}
+
+public class DerivedFromValidClass: ValidClass {
+  override public func methodReturningNonExistentType() -> NonExistent {}
+  // expected-error@-1 {{cannot find type 'NonExistent' in scope}}
+}
+
+public class DerivedFromNonExistent: NonExistent {
+  // expected-error@-1 {{cannot find type 'NonExistent' in scope}}
+
+  public func method() {}
 }


### PR DESCRIPTION
Force resolution of value witnesses and check the conformance for validity before proceeding to witness table emission in SILGen to avoid crashing because of unexpected errors in the AST.
    
Resolves rdar://123027739