### PR TITLE
Fix enum inspection of a no-payload enum inside another enum

### DIFF
--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -450,9 +450,13 @@ public:
   }
 };
 
-// Old bit hack for setting all the bits lower than
-// the highest set bit.
+// Given a count, return a mask that is just
+// big enough to preserve values less than that count.
+// E.g., given a count of 6, max value is 5 (binary 0101),
+// so we want to return binary 0111.
 static uint32_t maskForCount(uint32_t t) {
+  t -= 1; // Convert count => max value
+  // Set all bits below highest bit...
   t |= t >> 16;
   t |= t >> 8;
   t |= t >> 4;

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -450,6 +450,17 @@ public:
   }
 };
 
+// Old bit hack for setting all the bits lower than
+// the highest set bit.
+static uint32_t maskForCount(uint32_t t) {
+  t |= t >> 16;
+  t |= t >> 8;
+  t |= t >> 4;
+  t |= t >> 2;
+  t |= t >> 1;
+  return t;
+}
+
 // Enum with 2 or more non-payload cases and no payload cases
 class NoPayloadEnumTypeInfo: public EnumTypeInfo {
 public:
@@ -489,6 +500,9 @@ public:
     if (!reader.readInteger(address, getSize(), &tag)) {
       return false;
     }
+    // Strip bits that might be used by a containing MPE:
+    uint32_t mask = maskForCount(getNumCases());
+    tag &= mask;
     if (tag < getNumCases()) {
       *CaseIndex = tag;
       return true;

--- a/validation-test/Reflection/reflect_Enum_values4.swift
+++ b/validation-test/Reflection/reflect_Enum_values4.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -lswiftSwiftReflectionTest %s -o %t/reflect_Enum_values4
+// RUN: %target-codesign %t/reflect_Enum_values4
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_Enum_values4 | tee /dev/stderr | %FileCheck %s --check-prefix=CHECK%target-ptrsize --check-prefix=CHECKALL --dump-input=fail %add_num_extra_inhabitants
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+
+enum NonPayloadEnum {
+  case one
+  case two
+}
+
+enum SmallMultipayloadEnum {
+  case empty
+  case a(NonPayloadEnum)
+  case b(NonPayloadEnum)
+}
+
+reflect(enumValue: SmallMultipayloadEnum.b(.two))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values4.SmallMultipayloadEnum)
+// CHECKALL-NEXT: Value: .b(.two)
+
+reflect(enumValue: SmallMultipayloadEnum.empty)
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values4.SmallMultipayloadEnum)
+// CHECKALL-NEXT: Value: .empty
+
+reflect(enumValue: SmallMultipayloadEnum.a(.one))
+
+// CHECKALL: Reflecting an enum value.
+// CHECKALL-NEXT: Type reference:
+// CHECKALL-NEXT: (enum reflect_Enum_values4.SmallMultipayloadEnum)
+// CHECKALL-NEXT: Value: .a(.one)
+
+
+doneReflecting()
+
+// CHECKALL: Done.
+


### PR DESCRIPTION
When a no-payload enum is stored inside a multi-payload enum, the outer enum may be using some of the extra high-order bits. So when we examine the inner enum, we should just strip those bits.

Resolves rdar://123727657