### PR TITLE
Observation: Stop using deprecated SwiftSyntax APIs

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/Extensions.swift
+++ b/lib/Macros/Sources/ObservationMacros/Extensions.swift
@@ -40,10 +40,7 @@ extension VariableDeclSyntax {
   }
 
   func accessorsMatching(_ predicate: (TokenKind) -> Bool) -> [AccessorDeclSyntax] {
-    let patternBindings = bindings.compactMap { binding in
-      binding.as(PatternBindingSyntax.self)
-    }
-    let accessors: [AccessorDeclListSyntax.Element] = patternBindings.compactMap { patternBinding in
+    let accessors: [AccessorDeclListSyntax.Element] = bindings.compactMap { patternBinding in
       switch patternBinding.accessorBlock?.accessors {
       case .accessors(let accessors):
         return accessors
@@ -52,11 +49,8 @@ extension VariableDeclSyntax {
       }
     }.flatMap { $0 }
     return accessors.compactMap { accessor in
-      guard let decl = accessor.as(AccessorDeclSyntax.self) else {
-        return nil
-      }
-      if predicate(decl.accessorSpecifier.tokenKind) {
-        return decl
+      if predicate(accessor.accessorSpecifier.tokenKind) {
+        return accessor
       } else {
         return nil
       }
@@ -211,7 +205,7 @@ extension DeclGroupSyntax {
   var memberFunctionStandins: [FunctionDeclSyntax.SignatureStandin] {
     var standins = [FunctionDeclSyntax.SignatureStandin]()
     for member in memberBlock.members {
-      if let function = member.as(MemberBlockItemSyntax.self)?.decl.as(FunctionDeclSyntax.self) {
+      if let function = member.decl.as(FunctionDeclSyntax.self) {
         standins.append(function.signatureStandin)
       }
     }
@@ -220,7 +214,7 @@ extension DeclGroupSyntax {
   
   func hasMemberFunction(equvalentTo other: FunctionDeclSyntax) -> Bool {
     for member in memberBlock.members {
-      if let function = member.as(MemberBlockItemSyntax.self)?.decl.as(FunctionDeclSyntax.self) {
+      if let function = member.decl.as(FunctionDeclSyntax.self) {
         if function.isEquivalent(to: other) {
           return true
         }
@@ -231,7 +225,7 @@ extension DeclGroupSyntax {
   
   func hasMemberProperty(equivalentTo other: VariableDeclSyntax) -> Bool {
     for member in memberBlock.members {
-      if let variable = member.as(MemberBlockItemSyntax.self)?.decl.as(VariableDeclSyntax.self) {
+      if let variable = member.decl.as(VariableDeclSyntax.self) {
         if variable.isEquivalent(to: other) {
           return true
         }
@@ -242,7 +236,7 @@ extension DeclGroupSyntax {
   
   var definedVariables: [VariableDeclSyntax] {
     memberBlock.members.compactMap { member in
-      if let variableDecl = member.as(MemberBlockItemSyntax.self)?.decl.as(VariableDeclSyntax.self) {
+      if let variableDecl = member.decl.as(VariableDeclSyntax.self) {
         return variableDecl
       }
       return nil


### PR DESCRIPTION
Addresses a few warnings about use of `as()`:

```
warning: 'as' is deprecated: This cast will always succeed
```
