### PR TITLE
Don't set enable-library evolution under SWIFT_STDLIB_USE_FRAGILE_RESILIENT_PROTOCOL_WITNESS_TABLES

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -628,7 +628,6 @@ function(_compile_swift_files
 
   if (SWIFT_STDLIB_USE_FRAGILE_RESILIENT_PROTOCOL_WITNESS_TABLES)
     list(APPEND swift_flags "-Xfrontend" "-enable-fragile-relative-protocol-tables")
-    list(APPEND swift_flags "-enable-library-evolution")
   endif()
 
   if(SWIFT_STDLIB_DISABLE_INSTANTIATION_CACHES)

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2772,6 +2772,7 @@ swift-stdlib-lto=
 swift-enable-runtime-function-counters=0
 swift-stdlib-use-relative-protocol-witness-tables=1
 swift-stdlib-use-fragile-resilient-protocol-witness-tables=1
+swift-stdlib-stable-abi=1
 
 test
 validation-test


### PR DESCRIPTION
Rather, for the purpose of testing set this under an individual build preset configuration.
