### PR TITLE
[5.10] Tests: fully disable attr_originally_definedin_backward_compatibility on iOS

### DIFF
--- a/test/attr/attr_originally_definedin_backward_compatibility.swift
+++ b/test/attr/attr_originally_definedin_backward_compatibility.swift
@@ -2,7 +2,7 @@
 // REQUIRES: OS=macosx || OS=ios
 // UNSUPPORTED: DARWIN_SIMULATOR=ios
 // rdar://problem/65399527
-// XFAIL: OS=ios && CPU=armv7s
+// UNSUPPORTED: OS=ios
 //
 // RUN: %empty-directory(%t)
 //


### PR DESCRIPTION
This was already disabled on main in https://github.com/apple/swift/pull/70927.