### PR TITLE
stdlib: Guard `@inlinable` use of `withMemoryRebound()` with `#if $TypedThrows`

### DIFF
--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1133,6 +1133,7 @@ extension Unsafe${Mutable}RawBufferPointer {
   public func withContiguousMutableStorageIfAvailable<R>(
     _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
+    #if $TypedThrows
     try withMemoryRebound(to: Element.self) { b in
       var buffer = b
       defer {
@@ -1143,6 +1144,9 @@ extension Unsafe${Mutable}RawBufferPointer {
       }
       return try body(&buffer)
     }
+    #else
+    fatalError("unsupported compiler")
+    #endif
   }
 
 %  end
@@ -1151,9 +1155,13 @@ extension Unsafe${Mutable}RawBufferPointer {
   public func withContiguousStorageIfAvailable<R>(
     _ body: (UnsafeBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
+    #if $TypedThrows
     try withMemoryRebound(to: Element.self) {
       try body(${ 'UnsafeBufferPointer<Element>($0)' if Mutable else '$0' })
     }
+    #else
+    fatalError("unsupported compiler")
+    #endif
   }
 }
 


### PR DESCRIPTION
Older compilers can no longer see the definition of `withMemoryRebound()` now that it has adopted typed throws (https://github.com/apple/swift/pull/72036).

Resolves rdar://124540428
