### PR TITLE
Updates to initializers with explicit lifetime dependence

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -115,11 +115,6 @@ public:
     if (auto *AFD = TheFunction.dyn_cast<AbstractFunctionDecl *>()) {
       if (auto *FD = dyn_cast<FuncDecl>(AFD))
         return FD->mapTypeIntoContext(FD->getResultInterfaceType());
-      if (auto *CD = dyn_cast<ConstructorDecl>(AFD)) {
-        if (CD->hasLifetimeDependentReturn()) {
-          return CD->mapTypeIntoContext(CD->getResultInterfaceType());
-        }
-      }
       return TupleType::getEmpty(AFD->getASTContext());
     }
     return TheFunction.get<AbstractClosureExpr *>()->getResultType();

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -1076,12 +1076,7 @@ public:
       } else if (auto closure = dyn_cast<AbstractClosureExpr>(func)) {
         resultType = closure->getResultType();
       } else if (auto *CD = dyn_cast<ConstructorDecl>(func)) {
-        if (CD->hasLifetimeDependentReturn()) {
-          resultType = CD->getResultInterfaceType();
-          resultType = CD->mapTypeIntoContext(resultType);
-        } else {
-          resultType = TupleType::getEmpty(Ctx);
-        }
+        resultType = TupleType::getEmpty(Ctx);
       } else {
         resultType = TupleType::getEmpty(Ctx);
       }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9921,8 +9921,19 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
   if (auto *lifetimeTyR =
           dyn_cast_or_null<LifetimeDependentReturnTypeRepr>(FuncRetTy)) {
-    if (!lifetimeTyR->getBase()->isSimpleUnqualifiedIdentifier(
-            Context.Id_Self)) {
+    auto *base = lifetimeTyR->getBase();
+
+    auto isOptionalSimpleUnqualifiedIdentifier = [](TypeRepr *typeRepr,
+                                                    Identifier str) {
+      if (auto *optionalTR = dyn_cast<OptionalTypeRepr>(typeRepr)) {
+        return optionalTR->getBase()->isSimpleUnqualifiedIdentifier(str);
+      }
+      return false;
+    };
+
+    // Diagnose if return type is not Self or Self?
+    if (!base->isSimpleUnqualifiedIdentifier(Context.Id_Self) &&
+        !isOptionalSimpleUnqualifiedIdentifier(base, Context.Id_Self)) {
       diagnose(FuncRetTy->getStartLoc(),
                diag::lifetime_dependence_invalid_init_return);
       return nullptr;

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -683,13 +683,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   // Create a basic block to jump to for the implicit 'self' return.
   // We won't emit this until after we've emitted the body.
   // The epilog takes a void return because the return of 'self' is implicit.
-  // When lifetime dependence specifiers are present, epilog will take the
-  // explicit 'self' return.
-  prepareEpilog(ctor,
-                ctor->hasLifetimeDependentReturn()
-                    ? std::optional<Type>(ctor->getResultInterfaceType())
-                    : std::nullopt,
-                ctor->getEffectiveThrownErrorType(), CleanupLocation(ctor));
+  prepareEpilog(ctor, std::nullopt, ctor->getEffectiveThrownErrorType(),
+                CleanupLocation(ctor));
 
   // If the constructor can fail, set up an alternative epilog for constructor
   // failure.
@@ -772,11 +767,6 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
   emitProfilerIncrement(ctor->getTypecheckedBody());
   // Emit the constructor body.
   emitStmt(ctor->getTypecheckedBody());
-
-  if (ctor->hasLifetimeDependentReturn()) {
-    emitEpilog(ctor, /*UsesCustomEpilog*/ false);
-    return;
-  }
 
   // Build a custom epilog block, since the AST representation of the
   // constructor decl (which has no self in the return type) doesn't match the

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1723,6 +1723,10 @@ Stmt *PreCheckReturnStmtRequest::evaluate(Evaluator &evaluator, ReturnStmt *RS,
         bool isSelf = false;
         if (auto *UDRE = dyn_cast<UnresolvedDeclRefExpr>(E)) {
           isSelf = UDRE->getName().isSimpleName(ctx.Id_self);
+          // Result the result expression so that rest of the compilation
+          // pipeline handles initializers with lifetime dependence specifiers
+          // in the same way as other initializers.
+          RS->setResult(nullptr);
         }
         if (!isSelf) {
           ctx.Diags.diagnose(

--- a/test/Sema/explicit_lifetime_dependence_specifiers1.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers1.swift
@@ -11,16 +11,26 @@ struct BufferView : ~Escapable {
   init(_ ptr: UnsafeRawBufferPointer) {
     self.ptr = ptr
   }
-  init(_ c: borrowing Container) -> _borrow(c) Self { // expected-error{{invalid lifetime dependence on bitwise copyable type}}
-    self.ptr = c.ptr
-    return self
-  }
   init(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<Int>) -> _borrow(arr) Self {
     self.ptr = ptr
     return self
   }
   init(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<Double>) -> _borrow(arr) Self {
     self.ptr = ptr
+  }
+  // TODO: Once Optional is ~Escapable, the error will go away
+  init?(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<Float>) -> _borrow(arr) Self? { // expected-error{{lifetime dependence can only be specified on ~Escapable results}}
+    if (Int.random(in: 1..<100) == 0) {
+      return nil
+    }
+    self.ptr = ptr
+  }
+  init?(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<String>) -> _borrow(arr) Self? { // expected-error{{lifetime dependence can only be specified on ~Escapable results}}
+    if (Int.random(in: 1..<100) == 0) {
+      return nil
+    }
+    self.ptr = ptr
+    return self
   }
 }
 

--- a/test/Sema/explicit_lifetime_dependence_specifiers1.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers1.swift
@@ -1,18 +1,8 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip   -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BitwiseCopyable
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip   -enable-experimental-feature NoncopyableGenerics
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
-// REQUIRES: nonescapable_types
 
 struct Container {
   let ptr: UnsafeRawBufferPointer
-}
-
-struct AnotherBufferView : ~Escapable, _BitwiseCopyable {
-  let ptr: UnsafeRawBufferPointer
-  @_unsafeNonescapableResult
-  init(_ ptr: UnsafeRawBufferPointer) {
-    self.ptr = ptr
-  }
 }
 
 struct BufferView : ~Escapable {
@@ -25,9 +15,12 @@ struct BufferView : ~Escapable {
     self.ptr = c.ptr
     return self
   }
-  init(_ bv: borrowing AnotherBufferView) -> _borrow(bv) Self {
-    self.ptr = bv.ptr
+  init(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<Int>) -> _borrow(arr) Self {
+    self.ptr = ptr
     return self
+  }
+  init(_ ptr: UnsafeRawBufferPointer, _ arr: borrowing Array<Double>) -> _borrow(arr) Self {
+    self.ptr = ptr
   }
 }
 

--- a/test/Sema/explicit_lifetime_dependence_specifiers2.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers2.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip   -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BitwiseCopyable
+// REQUIRES: asserts
+// REQUIRES: noncopyable_generics
+// REQUIRES: nonescapable_types
+
+struct AnotherBufferView : ~Escapable, _BitwiseCopyable {
+  let ptr: UnsafeRawBufferPointer
+  @_unsafeNonescapableResult
+  init(_ ptr: UnsafeRawBufferPointer) {
+    self.ptr = ptr
+  }
+}
+
+struct BufferView : ~Escapable {
+  let ptr: UnsafeRawBufferPointer
+  init(_ bv: borrowing AnotherBufferView) -> _borrow(bv) Self {
+    self.ptr = bv.ptr
+    return self
+  }
+}
+


### PR DESCRIPTION
Allow previously banned implicit return in such initializers
Allow parsing Self? return type in failable initializers with explicit lifetime dependence