### PR TITLE
[SILGen] Correctly determine the thrown error type for closures

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1537,6 +1537,11 @@ public:
   std::optional<std::pair<AbstractionPattern, CanType>>
   getFunctionThrownErrorType(CanAnyFunctionType substFnInterfaceType) const;
 
+  /// For the abstraction pattern produced by `getFunctionThrownErrorType()`,
+  /// produce the effective thrown error type to be used when we don't have
+  /// a substituted error type.
+  CanType getEffectiveThrownErrorType() const;
+
   /// Given that the value being abstracted is a function type, return
   /// the abstraction pattern for one of its parameter types.
   AbstractionPattern getFunctionParamType(unsigned index) const;

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1340,7 +1340,6 @@ AbstractionPattern::getFunctionThrownErrorType(
   if (!optOrigErrorType)
     return std::nullopt;
 
-  auto &ctx = substFnInterfaceType->getASTContext();
   auto substErrorType = substFnInterfaceType->getEffectiveThrownErrorType();
 
   if (isTypeParameterOrOpaqueArchetype()) {
@@ -1352,14 +1351,19 @@ AbstractionPattern::getFunctionThrownErrorType(
   }
 
   if (!substErrorType) {
-    if (optOrigErrorType->getType()->hasTypeParameter())
-      substErrorType = ctx.getNeverType();
-    else
-      substErrorType = optOrigErrorType->getType();
+    substErrorType = optOrigErrorType->getEffectiveThrownErrorType();
   }
 
   return std::make_pair(*optOrigErrorType,
                         (*substErrorType)->getCanonicalType());
+}
+
+CanType AbstractionPattern::getEffectiveThrownErrorType() const {
+  CanType type = getType();
+  if (type->hasTypeParameter())
+    return type->getASTContext().getNeverType()->getCanonicalType();
+
+  return type;
 }
 
 AbstractionPattern

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1470,14 +1470,9 @@ uint16_t SILGenFunction::emitBasicProlog(
 
   std::optional<AbstractionPattern> origErrorType;
   if (origClosureType && !origClosureType->isTypeParameterOrOpaqueArchetype()) {
-    CanType substClosureType = origClosureType->getType()
-        .subst(origClosureType->getGenericSubstitutions())->getCanonicalType();
-    CanAnyFunctionType substClosureFnType =
-        cast<AnyFunctionType>(substClosureType);
-    if (auto optPair = origClosureType->getFunctionThrownErrorType(substClosureFnType)) {
-      origErrorType = optPair->first;
-      errorType = optPair->second;
-    }
+    origErrorType = origClosureType->getFunctionThrownErrorType();
+    if (origErrorType && !errorType)
+      errorType = origErrorType->getEffectiveThrownErrorType();
   } else if (errorType) {
     origErrorType = AbstractionPattern(genericSig.getCanonicalSignature(),
                                        (*errorType)->getCanonicalType());

--- a/test/SILGen/typed_throws_generic.swift
+++ b/test/SILGen/typed_throws_generic.swift
@@ -332,6 +332,22 @@ extension P2 {
   func f() throws(Failure) { }
 }
 
+public func withUnsafeRawBuffer<T, E>(
+    _ body: (UnsafeMutableRawBufferPointer) throws(E) -> Void
+) throws(E) -> T {
+  fatalError("boom")
+}
+
+// CHECK-LABEL: sil private [ossa] @$s20typed_throws_generic16withUnsafeBufferyxySryxGq_YKXEq_YKs5ErrorR_r0_lFySwq_YKXEfU_ : $@convention(thin) <T, E where E : Error> (UnsafeMutableRawBufferPointer, @guaranteed @noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (UnsafeMutableBufferPointer<τ_0_0>) -> @error_indirect τ_0_1 for <T, E>) -> @error_indirect E {
+// CHECK: try_apply{{.*}}@error_indirect τ_0_1 for <T, E>
+public func withUnsafeBuffer<T, E>(
+    _ body: (UnsafeMutableBufferPointer<T>) throws(E) -> Void
+) throws(E) -> T {
+    try withUnsafeRawBuffer { (buf_ptr: UnsafeMutableRawBufferPointer) throws(E) in
+        try body(buf_ptr.bindMemory(to: T.self))
+    }
+}
+
 // CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s20typed_throws_generic1SVAA2P2A2aDP1fyy7FailureQzYKFTW : $@convention(witness_method: P2) (@in_guaranteed S) -> @error_indirect Never
 // CHECK: bb0(%0 : $*Never, %1 : $*S)
 struct S: P2 {


### PR DESCRIPTION
When a closure throws a generic error type, we were retrieving the substituted error type (involving archetypes) when we needed to be working with the interface type.

Fixes rdar://124484012.
