### PR TITLE
Tests: un-xfail tests on the freestanding bot

### DIFF
--- a/test/Concurrency/Runtime/actor_counters_freestanding.swift
+++ b/test/Concurrency/Runtime/actor_counters_freestanding.swift
@@ -8,9 +8,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// rdar://124277662
-// XFAIL: freestanding
-
 @_spi(_TaskToThreadModel) import _Concurrency
 import StdlibUnittest
 import Darwin

--- a/test/Concurrency/Runtime/async_let_throw_completion_order.swift
+++ b/test/Concurrency/Runtime/async_let_throw_completion_order.swift
@@ -7,9 +7,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// rdar://124277662
-// XFAIL: freestanding
-
 struct Bad: Error {}
 
 class Foo { init() async throws {}; deinit { print("Foo down") } }

--- a/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_asynciterator_semantics.swift
@@ -5,9 +5,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// rdar://124277662
-// XFAIL: freestanding
-
 struct Boom: Error {}
 
 func boom() async throws -> Int {

--- a/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_is_asyncsequence.swift
@@ -7,9 +7,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// rdar://124277662
-// XFAIL: freestanding
-
 @available(SwiftStdlib 5.1, *)
 func test_taskGroup_is_asyncSequence() async {
   print(#function)

--- a/test/Concurrency/blocking_continuations.swift
+++ b/test/Concurrency/blocking_continuations.swift
@@ -5,9 +5,6 @@
 // REQUIRES: freestanding
 // UNSUPPORTED: threading_none
 
-// rdar://124277662
-// XFAIL: freestanding
-
 @_spi(_TaskToThreadModel) import _Concurrency
 import StdlibUnittest
 import Darwin

--- a/test/Concurrency/execute_child_on_await.swift
+++ b/test/Concurrency/execute_child_on_await.swift
@@ -5,9 +5,6 @@
 // REQUIRES: freestanding
 // REQUIRES: concurrency_runtime
 
-// rdar://124277662
-// XFAIL: freestanding
-
 @_spi(_TaskToThreadModel) import _Concurrency
 import StdlibUnittest
 import Darwin

--- a/test/stdlib/run_inline.swift
+++ b/test/stdlib/run_inline.swift
@@ -5,9 +5,6 @@
 // REQUIRES: freestanding
 // REQUIRES: concurrency_runtime
 
-// rdar://124277662
-// XFAIL: freestanding
-
 @_spi(_TaskToThreadModel) import _Concurrency
 
 // =============================================================================


### PR DESCRIPTION
Un-xfailing tests fixed by #72283.

Three tests are still failing:
```
stdlib/freestanding-check-symbols.test-sh
Concurrency/optional_isolated_parameters.swift
Concurrency/ShrinkWrap.swift
```