### PR TITLE
[BitwiseCopyable] Loosen validation assertion.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3196,7 +3196,9 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
     if (hasNoNonconformingNode) {
       llvm::errs() << "Trivial type without a BitwiseCopyable conformance!?:\n"
                    << substType << "\n"
-                   << "of " << origType << "\n";
+                   << "of " << origType << "\n"
+                   << "Disable this validation with -Xllvm "
+                      "-type-lowering-disable-verification.\n";
       assert(false);
     }
   }
@@ -3260,7 +3262,9 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
       llvm::errs() << "Non-trivial type with _BitwiseCopyable conformance!?:\n"
                    << substType << "\n";
       conformance.print(llvm::errs());
-      llvm::errs() << "\n";
+      llvm::errs() << "\n"
+                   << "Disable this validation with -Xllvm "
+                      "-type-lowering-disable-verification.\n";
       assert(false);
     }
   }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3202,9 +3202,10 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
   }
 
   if (!lowering.isTrivial() && conformance) {
-    // A non-trivial type can have a conformance in one case:
+    // A non-trivial type can have a conformance in a few cases:
     // (1) contains a conforming archetype
     // (2) is resilient with minimal expansion
+    // (3) containing or being ~Escapable
     bool hasNoConformingArchetypeNode = visitAggregateLeaves(
         origType, substType, forExpansion,
         /*isLeaf=*/
@@ -3215,6 +3216,12 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
           if (nominal && nominal->isResilient() &&
               forExpansion.getResilienceExpansion() ==
                   ResilienceExpansion::Minimal) {
+            return true;
+          }
+          // A type that may not be escapable is non-trivial but can conform
+          // (case (3)).
+          if (nominal &&
+              nominal->canBeEscapable() != TypeDecl::CanBeInvertible::Always) {
             return true;
           }
           // Walk into every aggregate.
@@ -3233,6 +3240,13 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
           if (nominal && nominal->isResilient() &&
               forExpansion.getResilienceExpansion() ==
                   ResilienceExpansion::Minimal) {
+            return false;
+          }
+
+          // A type that may not be escapable is non-trivial but can conform
+          // (case (3)).
+          if (nominal &&
+              nominal->canBeEscapable() != TypeDecl::CanBeInvertible::Always) {
             return false;
           }
 

--- a/test/SILGen/bitwise_copyable_stdlib.swift
+++ b/test/SILGen/bitwise_copyable_stdlib.swift
@@ -1,0 +1,30 @@
+// R N: %target-swift-frontend -enable-experimental-feature NonescapableTypes -enable-experimental-feature BuiltinModule -enable-experimental-feature NoncopyableGenerics -parse-stdlib -module-name Swift -DEMPTY -emit-sil -verify %s
+
+// RUN: %target-swift-frontend                               \
+// RUN:     -emit-sil                                        \
+// RUN:     %s                                               \
+// RUN:     -parse-stdlib                                    \
+// RUN:     -module-name Swift                               \
+// RUN:     -disable-availability-checking                   \
+// RUN:     -enable-experimental-feature BuiltinModule       \
+// RUN:     -enable-experimental-feature BitwiseCopyable     \
+// RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature NonescapableTypes   \
+// RUN:     -enable-builtin-module
+
+// REQUIRES: asserts
+
+// Force verification of TypeLowering's isTrivial.
+
+import Builtin
+
+@_marker public protocol Copyable: ~Escapable {}
+@_marker public protocol Escapable: ~Copyable {}
+@_marker public protocol _BitwiseCopyable : ~Escapable {}
+
+struct Storage : ~Escapable, _BitwiseCopyable {}
+
+
+func take<T : _BitwiseCopyable & ~Escapable>(_ t: T) {}
+
+func passStorage(_ s: Storage) { take(s) }


### PR DESCRIPTION
Now that it's possible to be `BitwiseCopyable` and `~Escapable`, because the latter implies non-trivial, verification must permit a type to be non-trivial but conform to `BitwiseCopyable` when it contains a `~Escapable` field.

rdar://124552608
