### PR TITLE
[Noncopyable] Mangle enum elements as "always in the primary definition"

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -461,12 +461,24 @@ protected:
     bool innermostTypeDecl;
     bool extension;
     std::optional<unsigned> mangledDepth; // for inverses
+    std::optional<unsigned> suppressedInnermostDepth;
   public:
     bool reachedInnermostTypeDecl() {
       bool answer = innermostTypeDecl;
       innermostTypeDecl = false;
       return answer;
     }
+
+    /// Whether inverses of the innermost declaration's generic parameters
+    /// should be suppressed.
+    ///
+    /// This makes sense only for entities that can only ever be defined
+    /// within the primary type, such as enum cases and the stored properties
+    /// of struct and class types.
+    std::optional<unsigned> getSuppressedInnermostInversesDepth() const {
+      return suppressedInnermostDepth;
+    }
+
     bool reachedExtension() const { return extension; }
     void setReachedExtension() { assert(!extension); extension = true; }
     GenericSignature getSignature() const { return sig; }

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -401,9 +401,6 @@ public:
   }
 
   std::string mangleEnumCase(const ValueDecl *Decl) {
-    // No mangling of inverse conformances.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendEntity(Decl);
     appendOperator("WC");

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -12,8 +12,8 @@ public protocol P: ~Copyable { }
 
 public struct CallMe<U: ~Copyable> {
   public enum Maybe<T: ~Copyable>: ~Copyable {
-    // CHECK-LABEL: @"$s4test6CallMeV5MaybeO4someyAEyx_qd__Gqd__cAGmr__lFWC"
-    // CHECK: @"$s4test6CallMeV5MaybeO4noneyAEyx_qd__GAGmr__lFWC"
+    // CHECK-LABEL: @"$s4test6CallMeV5MaybeOAARiczrlE4someyAEyx_qd__Gqd__cAGmr__lFWC"
+    // CHECK: @"$s4test6CallMeV5MaybeOAARiczrlE4noneyAEyx_qd__GAGmr__lFWC"
     case none
     case some(T)
   }


### PR DESCRIPTION
For entities that must be part of the primary definition of a type, mangle without inverses on the generic parameters of the enclosing type. This ensures that we can adopt noncopyable on the generic parameters without breaking the mangling of the fundamental entities that describe the layout of the type.

Do this for enum elements first, so we don't break the mangling of `Optional`. There will be other cases to consider as well.
