### PR TITLE
[cmake][stdlib] Split the standard library build

### DIFF
--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -99,8 +99,17 @@ function(handle_swift_sources
   endforeach()
 
   set(swift_compile_flags ${SWIFTSOURCES_COMPILE_FLAGS})
+
+  set(module_link_name "${name}")
+
+  # The stdlib swift sources are compiled in the swiftStdlib target, but the
+  # dylib you link against is the swiftCore target.
+  if(SWIFTSOURCES_IS_STDLIB_CORE)
+    set(module_link_name "swiftCore")
+  endif()
+
   if (NOT SWIFTSOURCES_IS_MAIN AND NOT SWIFTSOURCES_NO_LINK_NAME)
-    list(APPEND swift_compile_flags "-module-link-name" "${name}")
+    list(APPEND swift_compile_flags "-module-link-name" "${module_link_name}")
   endif()
 
   if(swift_sources)

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -75,16 +75,6 @@ endif()
 
 add_subdirectory(SwiftShims/swift/shims)
 add_subdirectory(CommandLineSupport)
-if(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP)
-  add_subdirectory(Cxx)
-else()
-  # SwiftCompilerSources rely on C++ interop, specifically on being able to
-  # import the C++ standard library into Swift. On Linux, this is only possible
-  # when using the modulemap that Swift provides for libstdc++. Make sure we
-  # include the libstdc++ modulemap into the build even when not building
-  # C++ interop modules.
-  add_subdirectory(Cxx/libstdcxx)
-endif()
 add_subdirectory(Threading)
 
 # This static library is shared across swiftCore and swiftRemoteInspection
@@ -237,9 +227,10 @@ endif()
 if(SWIFT_BUILD_STDLIB)
   # These must be kept in dependency order so that any referenced targets
   # exist at the time we look for them in add_swift_*.
+  add_subdirectory(core)
   add_subdirectory(runtime)
   add_subdirectory(stubs)
-  add_subdirectory(core)
+  add_subdirectory(stdlib)
   add_subdirectory(SwiftOnoneSupport)
 endif()
 
@@ -280,6 +271,17 @@ if(SWIFT_BUILD_STDLIB AND NOT SWIFT_STDLIB_BUILD_ONLY_CORE_MODULES)
   if(SWIFT_ENABLE_SYNCHRONIZATION)
     add_subdirectory(Synchronization)
   endif()
+endif()
+
+if(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP)
+  add_subdirectory(Cxx)
+else()
+  # SwiftCompilerSources rely on C++ interop, specifically on being able to
+  # import the C++ standard library into Swift. On Linux, this is only possible
+  # when using the modulemap that Swift provides for libstdc++. Make sure we
+  # include the libstdc++ modulemap into the build even when not building
+  # C++ interop modules.
+  add_subdirectory(Cxx/libstdcxx)
 endif()
 
 if(SWIFT_BUILD_REMOTE_MIRROR)

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-#===--- CMakeLists.txt - Build the core standard library -----------------===#
+#===--- CMakeLists.txt - Build the standard library ---------------------===#
 #
 # This source file is part of the Swift.org open source project
 #
@@ -272,25 +272,7 @@ list(APPEND SWIFTLIB_EMBEDDED_SOURCES
   )
 
 set(GROUP_INFO_JSON_FILE ${CMAKE_CURRENT_SOURCE_DIR}/GroupInfo.json)
-set(swift_core_link_flags "${SWIFT_RUNTIME_SWIFT_LINK_FLAGS}")
-set(swift_core_framework_depends)
-set(swift_core_private_link_libraries)
 set(swift_stdlib_compile_flags "${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS}")
-
-if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "CYGWIN")
-  # TODO(compnerd) cache this variable to permit re-configuration
-  execute_process(COMMAND "cygpath" "-u" "$ENV{SYSTEMROOT}" OUTPUT_VARIABLE ENV_SYSTEMROOT)
-  list(APPEND swift_core_private_link_libraries "${ENV_SYSTEMROOT}/system32/psapi.dll")
-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "FREEBSD")
-  find_library(EXECINFO_LIBRARY execinfo)
-  list(APPEND swift_core_private_link_libraries ${EXECINFO_LIBRARY})
-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "LINUX")
-  if(SWIFT_BUILD_STATIC_STDLIB)
-    list(APPEND swift_core_private_link_libraries)
-  endif()
-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WINDOWS")
-  list(APPEND swift_core_private_link_libraries shell32;DbgHelp;Synchronization)
-endif()
 
 if(NOT "${CMAKE_BUILD_TYPE}" STREQUAL "MinSizeRel")
   list(APPEND swift_stdlib_compile_flags "-Xllvm" "-sil-inline-generics")
@@ -327,32 +309,6 @@ list(APPEND swift_stdlib_compile_flags "-external-plugin-path"
   "${swift_lib_dir}/swift/host/plugins#${swift_bin_dir}/swift-plugin-server")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "SymbolLinkageMarkers")
 
-set(swift_core_incorporate_object_libraries)
-list(APPEND swift_core_incorporate_object_libraries swiftRuntime)
-list(APPEND swift_core_incorporate_object_libraries swiftLLVMSupport)
-list(APPEND swift_core_incorporate_object_libraries swiftDemangling)
-list(APPEND swift_core_incorporate_object_libraries swiftStdlibStubs)
-list(APPEND swift_core_incorporate_object_libraries swiftThreading)
-if(SWIFT_STDLIB_HAS_COMMANDLINE)
-  list(APPEND swift_core_incorporate_object_libraries swiftCommandLineSupport)
-endif()
-
-set(swiftCore_common_options
-                  IS_STDLIB IS_STDLIB_CORE
-                    ${SWIFTLIB_SOURCES}
-                  GYB_SOURCES
-                    ${SWIFTLIB_GYB_SOURCES}
-                  LINK_FLAGS
-                    ${swift_core_link_flags}
-                  PRIVATE_LINK_LIBRARIES
-                    ${swift_core_private_link_libraries}
-                  INCORPORATE_OBJECT_LIBRARIES
-                    ${swift_core_incorporate_object_libraries}
-                  FRAMEWORK_DEPENDS
-                    ${swift_core_framework_depends}
-                  SWIFT_COMPILE_FLAGS
-                    ${swift_stdlib_compile_flags} -Xcc -DswiftCore_EXPORTS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS})
-
 # The copy_shim_headers target dependency is required to let the
 # build system know that there's a rule to produce the shims
 # directory, but is not sufficient to cause the object file to be rebuilt
@@ -361,51 +317,18 @@ set(swiftCore_common_options
 set(swiftCore_common_dependencies
     copy_shim_headers "${SWIFTLIB_DIR}/shims" ${GROUP_INFO_JSON_FILE})
 
-if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
-
-  set(b0_deps symlink-headers-bootstrapping0)
-  set(b1_deps symlink-headers-bootstrapping1)
-
-  list(FIND SWIFT_STDLIB_LIBRARY_BUILD_TYPES "SHARED" index_of_shared)
-  if(index_of_shared EQUAL -1)
-    message(FATAL_ERROR "bootstrapping requires SHARED stdlib build type")
-  endif()
-
-  set(swiftCore_common_bootstrapping_options
-                    SHARED
-                    ${swiftCore_common_options}
-                    SDK ${SWIFT_HOST_VARIANT_SDK}
-                    ARCHITECTURE ${SWIFT_HOST_VARIANT_ARCH}
-                    INSTALL_IN_COMPONENT
-                      "never_install")
-
-  # Bootstrapping - stage 0
-
-  add_swift_target_library_single(swiftCore-bootstrapping0 swiftCore
-                    ${swiftCore_common_bootstrapping_options}
-                    FILE_DEPENDS
-                      ${b0_deps} ${swiftCore_common_dependencies}
-                    BOOTSTRAPPING 0)
-
-  # Bootstrapping - stage 1
-
-  add_swift_target_library_single(swiftCore-bootstrapping1 swiftCore
-                    ${swiftCore_common_bootstrapping_options}
-                    FILE_DEPENDS
-                      ${b1_deps} ${swiftCore_common_dependencies}
-                    BOOTSTRAPPING 1)
-endif()
-
-add_swift_target_library(swiftCore
-                  ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
+add_swift_target_library(swiftStdlib IS_STDLIB IS_STDLIB_CORE OBJECT_LIBRARY
+                  ${SWIFTLIB_SOURCES}
+                  GYB_SOURCES
+                    ${SWIFTLIB_GYB_SOURCES}
+                  SWIFT_COMPILE_FLAGS
+                    ${swift_stdlib_compile_flags} -Xcc -DswiftCore_EXPORTS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
                   ${swiftCore_common_options}
                   ${compile_flags_for_final_build}
                   FILE_DEPENDS
                     ${swiftCore_common_dependencies}
                   INSTALL_IN_COMPONENT
                     stdlib
-                  MACCATALYST_BUILD_FLAVOR
-                    zippered
                  )
 
 # Embedded standard library - embedded libraries are built as .swiftmodule only,

--- a/stdlib/public/stdlib/CMakeLists.txt
+++ b/stdlib/public/stdlib/CMakeLists.txt
@@ -1,0 +1,90 @@
+#===--- CMakeLists.txt - Build the core standard library -----------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2024 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+
+set(swift_core_private_link_libraries)
+
+if(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "CYGWIN")
+  # TODO(compnerd) cache this variable to permit re-configuration
+  execute_process(COMMAND "cygpath" "-u" "$ENV{SYSTEMROOT}" OUTPUT_VARIABLE ENV_SYSTEMROOT)
+  list(APPEND swift_core_private_link_libraries "${ENV_SYSTEMROOT}/system32/psapi.dll")
+elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "FREEBSD")
+  find_library(EXECINFO_LIBRARY execinfo)
+  list(APPEND swift_core_private_link_libraries ${EXECINFO_LIBRARY})
+elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "LINUX")
+  if(SWIFT_BUILD_STATIC_STDLIB)
+    list(APPEND swift_core_private_link_libraries)
+  endif()
+elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL "WINDOWS")
+  list(APPEND swift_core_private_link_libraries shell32;DbgHelp;Synchronization)
+endif()
+
+set(swift_core_incorporate_object_libraries)
+list(APPEND swift_core_incorporate_object_libraries swiftStdlib)
+list(APPEND swift_core_incorporate_object_libraries swiftRuntime)
+list(APPEND swift_core_incorporate_object_libraries swiftLLVMSupport)
+list(APPEND swift_core_incorporate_object_libraries swiftDemangling)
+list(APPEND swift_core_incorporate_object_libraries swiftStdlibStubs)
+list(APPEND swift_core_incorporate_object_libraries swiftThreading)
+if(SWIFT_STDLIB_HAS_COMMANDLINE)
+  list(APPEND swift_core_incorporate_object_libraries swiftCommandLineSupport)
+endif()
+
+set(swiftCore_common_options
+                  LINK_FLAGS
+                    ${swift_core_link_flags}
+                  PRIVATE_LINK_LIBRARIES
+                    ${swift_core_private_link_libraries}
+                  INCORPORATE_OBJECT_LIBRARIES
+                    ${swift_core_incorporate_object_libraries})
+
+if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
+
+  set(b0_deps symlink-headers-bootstrapping0)
+  set(b1_deps symlink-headers-bootstrapping1)
+
+  list(FIND SWIFT_STDLIB_LIBRARY_BUILD_TYPES "SHARED" index_of_shared)
+  if(index_of_shared EQUAL -1)
+    message(FATAL_ERROR "bootstrapping requires SHARED stdlib build type")
+  endif()
+
+  set(swiftCore_common_bootstrapping_options
+                    SHARED
+                    ${swiftCore_common_options}
+                    SDK ${SWIFT_HOST_VARIANT_SDK}
+                    ARCHITECTURE ${SWIFT_HOST_VARIANT_ARCH}
+                    INSTALL_IN_COMPONENT
+                      "never_install")
+
+  # Bootstrapping - stage 0
+
+  add_swift_target_library_single(swiftCore-bootstrapping0 swiftCore
+                    ${swiftCore_common_bootstrapping_options}
+                    FILE_DEPENDS
+                      ${b0_deps} ${swiftCore_common_dependencies}
+                    BOOTSTRAPPING 0)
+
+  # Bootstrapping - stage 1
+
+  add_swift_target_library_single(swiftCore-bootstrapping1 swiftCore
+                    ${swiftCore_common_bootstrapping_options}
+                    FILE_DEPENDS
+                      ${b1_deps} ${swiftCore_common_dependencies}
+                    BOOTSTRAPPING 1)
+endif()
+
+add_swift_target_library(swiftCore IS_STDLIB IS_STDLIB_CORE
+                  ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
+                  ${swiftCore_common_options}
+                  INSTALL_IN_COMPONENT
+                    stdlib
+                  MACCATALYST_BUILD_FLAVOR
+                    zippered)


### PR DESCRIPTION
This patch splits the standard library up into 3 phases:

1. Build the stdlib sources in `core` into the `.swiftmodule`, `.swiftinterface` as well as the `Swift.o`. Here we make the stdlib's build an `OBJECT_LIBRARY` while also specifying that we want to generate a module and interface for it.
2. Build the runtime and stubs sources as normal.
3. Create the `libswiftCore.dylib` by linking all the target objects from the runtime, stubs, and pull in the `Swift.o` (as normal, just done later)

Why am I doing this? This effort is in support of allowing the runtime sources to be in Swift themselves and ideally we'd like those Swift sources to be built against the just built stdlib.