### PR TITLE
[CanonicalizeInstruction] Process instruction "at" load after rewriting.

### DIFF
--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -141,6 +141,8 @@ static void replaceUsesOfExtract(SingleValueInstruction *extract,
 // (load (struct_element_addr %base, #field)
 static SILBasicBlock::iterator
 splitAggregateLoad(LoadOperation loadInst, CanonicalizeInstruction &pass) {
+  auto *block = loadInst->getParentBlock();
+  auto *instBeforeLoad = loadInst->getPreviousInstruction();
   // Keep track of the next iterator after any newly added or to-be-deleted
   // instructions. This must be valid regardless of whether the pass immediately
   // deletes the instructions or simply records them for later deletion.
@@ -336,7 +338,22 @@ splitAggregateLoad(LoadOperation loadInst, CanonicalizeInstruction &pass) {
     ++nextII;
   }
   deleteAllDebugUses(*loadInst, pass.getCallbacks());
-  return killInstAndIncidentalUses(*loadInst, nextII, pass);
+  nextII = killInstAndIncidentalUses(*loadInst, nextII, pass);
+  /// A change has been made; and the load instruction is deleted.  The caller
+  /// should now process the instruction where the load was before.
+  ///
+  /// BEFORE TRANSFORM   |   AFTER TRANSFORM
+  ///    prequel_2       |      prequel_2
+  ///    prequel_1       |      prequel_1
+  ///    load            |  +-> ???
+  ///    sequel_1        |  |   ???
+  ///    sequel_2        |  |   ???
+  ///                       |
+  ///                       The instruction the caller should process next.
+  if (instBeforeLoad)
+    return instBeforeLoad->getNextInstruction()->getIterator();
+  else
+    return block->begin();
 }
 
 // Given a store within a single property struct, recursively form the parent

--- a/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeInstruction.cpp
@@ -139,8 +139,6 @@ static void replaceUsesOfExtract(SingleValueInstruction *extract,
 // (struct_extract (load %base))
 //   ->
 // (load (struct_element_addr %base, #field)
-//
-// TODO: Consider handling LoadBorrowInst.
 static SILBasicBlock::iterator
 splitAggregateLoad(LoadOperation loadInst, CanonicalizeInstruction &pass) {
   // Keep track of the next iterator after any newly added or to-be-deleted

--- a/test/Interpreter/moveonly_partial_consume_value.swift
+++ b/test/Interpreter/moveonly_partial_consume_value.swift
@@ -1,0 +1,59 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature MoveOnlyPartialConsumption) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+func destructure() {
+  let q = getQuad(name: "q")
+
+  // CHECK: hi q.p1.u1
+  // CHECK: hi q.p1.u2
+  // CHECK: hi q.p2.u1
+  // CHECK: hi q.p2.u2
+
+  take(q.p1.u1)
+  // CHECK: bye q.p1.u1
+  take(q.p1.u2)
+  // CHECK: bye q.p1.u2
+  take(q.p2.u1)
+  // CHECK: bye q.p2.u1
+  take(q.p2.u2)
+  // CHECK: bye q.p2.u2
+}
+
+struct Unique : ~Copyable {
+  let name: String
+  init(name: String) {
+    self.name = name
+    print("hi", name)
+  }
+  deinit {
+    print("bye", name)
+  }
+}
+
+func take(_ u: consuming Unique) {}
+
+struct Pair : ~Copyable {
+  var u1: Unique
+  var u2: Unique
+  init(name: String) {
+    self.u1 = .init(name: "\(name).u1")
+    self.u2 = .init(name: "\(name).u2")
+  }
+}
+
+struct Quad : ~Copyable {
+  var p1: Pair
+  var p2: Pair
+  init(name: String) {
+    self.p1 = .init(name: "\(name).p1")
+    self.p2 = .init(name: "\(name).p2")
+  }
+}
+
+func getQuad(name: String) -> Quad {
+  return Quad(name: name)
+}
+
+destructure()

--- a/test/SILOptimizer/silgen_cleanup.sil
+++ b/test/SILOptimizer/silgen_cleanup.sil
@@ -362,3 +362,45 @@ bb9(%0 : @owned $Klass):
   destroy_value %0 : $Klass
   return %v : $Builtin.Int64
 }
+
+struct Outer {
+  var middle: Middle
+}
+
+struct Middle {
+  var inner: Inner
+}
+
+struct Inner {
+  var guts: Builtin.AnyObject
+}
+
+sil @getOuter : $@convention(thin) () -> @owned Outer
+sil @takeInner : $@convention(thin) (@owned Inner) -> ()
+
+// CHECK-LABEL: sil [ossa] @narrowLoadThroughProjectionSequence : {{.*}} {
+// CHECK:         [[OUTER_ADDR:%[^,]+]] = project_box
+// CHECK:         [[MIDDLE_ADDR:%[^,]+]] = struct_element_addr [[OUTER_ADDR]]
+// CHECK:         [[INNER_ADDR:%[^,]+]] = struct_element_addr [[MIDDLE_ADDR]]
+// CHECK:         [[INNER_BORROW:%[^,]+]] = load_borrow [[INNER_ADDR]]
+// CHECK:         copy_value [[INNER_BORROW]]
+// CHECK-LABEL: } // end sil function 'narrowLoadThroughProjectionSequence'
+sil [ossa] @narrowLoadThroughProjectionSequence : $@convention(thin) () -> () {
+  %box = alloc_box ${ let Outer }
+  %box_borrow = begin_borrow [lexical] [var_decl] %box : ${ let Outer }
+  %outer_addr = project_box %box_borrow : ${ let Outer }, 0
+  %getOuter = function_ref @getOuter : $@convention(thin) () -> @owned Outer
+  %outer = apply %getOuter() : $@convention(thin) () -> @owned Outer
+  store %outer to [init] %outer_addr : $*Outer
+  %outer_borrow = load_borrow %outer_addr : $*Outer
+  %middle = struct_extract %outer_borrow : $Outer, #Outer.middle
+  %inner = struct_extract %middle : $Middle, #Middle.inner
+  %inner_copy = copy_value %inner : $Inner
+  %takeInner = function_ref @takeInner : $@convention(thin) (@owned Inner) -> ()
+  apply %takeInner(%inner_copy) : $@convention(thin) (@owned Inner) -> ()
+  end_borrow %outer_borrow : $Outer
+  end_borrow %box_borrow : ${ let Outer }
+  dealloc_box %box : ${ let Outer }
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
When a `load`/`load_borrow` is canonicalized, canonicalization should continue from where the load was before rather than the first instruction that was after it.  Enables narrowing the load through a sequence of projections.
