### PR TITLE
Revert "[wrangler] Disable IDE/complete_from_clang_framework.swift"

### DIFF
--- a/test/IDE/complete_from_clang_framework.swift
+++ b/test/IDE/complete_from_clang_framework.swift
@@ -46,8 +46,8 @@ struct SwiftStruct {
 // Test that we don't include Clang completions in unexpected places.
 func testSwiftCompletions(foo: SwiftStruct) {
   foo.#^SWIFT_COMPLETIONS^#
-// SWIFT_COMPLETIONS-NEXT: Keyword[self]/CurrNominal: self[#SwiftStruct#]; name=self
-// SWIFT_COMPLETIONS-NEXT: Decl[InstanceVar]/CurrNominal: instanceVar[#Int#]{{; name=.+$}}
+// SWIFT_COMPLETIONS-DAG: Keyword[self]/CurrNominal: self[#SwiftStruct#]; name=self
+// SWIFT_COMPLETIONS-DAG: Decl[InstanceVar]/CurrNominal: instanceVar[#Int#]{{; name=.+$}}
 }
 
 // CLANG_FOO-DAG: Decl[Struct]/OtherModule[Foo]:       FooEnum1[#FooEnum1#]{{; name=.+$}}
@@ -214,99 +214,100 @@ func testCompleteModuleQualifiedBar1() {
 
 func testCompleteFunctionCall1() {
   fooFunc1#^FUNCTION_CALL_1^#
-// FUNCTION_CALL_1-NEXT: Decl[FreeFunction]/OtherModule[Foo]/Flair[ArgLabels]: ({#(a): Int32#})[#Int32#]{{; name=.+$}}
-// FUNCTION_CALL_1-NEXT: Keyword[self]/CurrNominal: .self[#(Int32) -> Int32#]; name=self
+// FUNCTION_CALL_1-DAG: Decl[FreeFunction]/OtherModule[Foo]/Flair[ArgLabels]: ({#(a): Int32#})[#Int32#]{{; name=.+$}}
+// FUNCTION_CALL_1-DAG: Keyword[self]/CurrNominal: .self[#(Int32) -> Int32#]; name=self
 }
 
 func testCompleteFunctionCall2() {
   fooFunc1AnonymousParam#^FUNCTION_CALL_2^#
-// FUNCTION_CALL_2-NEXT: Decl[FreeFunction]/OtherModule[Foo]/Flair[ArgLabels]: ({#Int32#})[#Int32#]{{; name=.+$}}
-// FUNCTION_CALL_2-NEXT: Keyword[self]/CurrNominal: .self[#(Int32) -> Int32#]; name=self
+// FUNCTION_CALL_2-DAG: Decl[FreeFunction]/OtherModule[Foo]/Flair[ArgLabels]: ({#Int32#})[#Int32#]{{; name=.+$}}
+// FUNCTION_CALL_2-DAG: Keyword[self]/CurrNominal: .self[#(Int32) -> Int32#]; name=self
 }
 
 func testCompleteStructMembers1() {
   FooStruct1#^CLANG_STRUCT_MEMBERS_1^#
-// CLANG_STRUCT_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#FooStruct1#]{{; name=.+$}}
-// CLANG_STRUCT_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#x: Int32#}, {#y: Double#})[#FooStruct1#]{{; name=.+$}}
-// CLANG_STRUCT_MEMBERS_1-NEXT: Keyword[self]/CurrNominal: .self[#FooStruct1.Type#]; name=self
-// CLANG_STRUCT_MEMBERS_1-NEXT: Keyword/CurrNominal: .Type[#FooStruct1.Type#]; name=Type
+// CLANG_STRUCT_MEMBERS_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ()[#FooStruct1#]{{; name=.+$}}
+// CLANG_STRUCT_MEMBERS_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ({#x: Int32#}, {#y: Double#})[#FooStruct1#]{{; name=.+$}}
+// CLANG_STRUCT_MEMBERS_1-DAG: Keyword[self]/CurrNominal: .self[#FooStruct1.Type#]; name=self
+// CLANG_STRUCT_MEMBERS_1-DAG: Keyword/CurrNominal: .Type[#FooStruct1.Type#]; name=Type
 }
 
 func testCompleteClassMembers1() {
   FooClassBase#^CLANG_CLASS_MEMBERS_1^#
 // FIXME: do we want to show curried instance functions for Objective-C classes?
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     .fooBaseInstanceFunc0()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFunc0({#(self): FooClassBase#})[#() -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     .fooBaseInstanceFunc1({#(anObject): Any!#})[#FooClassBase!#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFunc1({#(self): FooClassBase#})[#(Any?) -> FooClassBase?#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#FooClassBase!#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#float: Float#})[#FooClassBase!#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     .fooBaseInstanceFuncOverridden()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFuncOverridden({#(self): FooClassBase#})[#() -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     .fooBaseClassFunc0()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#(x): Int32#})[#FooClassBase!#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     ._internalMeth3()[#Any!#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   ._internalMeth3({#(self): FooClassBase#})[#() -> Any?#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     ._internalMeth2()[#Any!#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   ._internalMeth2({#(self): FooClassBase#})[#() -> Any?#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     .nonInternalMeth()[#Any!#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .nonInternalMeth({#(self): FooClassBase#})[#() -> Any?#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[StaticMethod]/CurrNominal:     ._internalMeth1()[#Any!#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   ._internalMeth1({#(self): FooClassBase#})[#() -> Any?#]
-// CLANG_CLASS_MEMBERS_1-NEXT: Keyword[self]/CurrNominal: .self[#FooClassBase.Type#]; name=self
-// CLANG_CLASS_MEMBERS_1-NEXT: Keyword/CurrNominal: .Type[#FooClassBase.Type#]; name=Type
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[StaticMethod]/CurrNominal:     .fooBaseInstanceFunc0()[#Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFunc0({#(self): FooClassBase#})[#() -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[StaticMethod]/CurrNominal:     .fooBaseInstanceFunc1({#(anObject): Any!#})[#FooClassBase!#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFunc1({#(self): FooClassBase#})[#(Any?) -> FooClassBase?#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#FooClassBase!#]
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#float: Float#})[#FooClassBase!#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[StaticMethod]/CurrNominal:     .fooBaseInstanceFuncOverridden()[#Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFuncOverridden({#(self): FooClassBase#})[#() -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[StaticMethod]/CurrNominal:     .fooBaseClassFunc0()[#Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#(x): Int32#})[#FooClassBase!#]
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[StaticMethod]/CurrNominal:     ._internalMeth3()[#Any!#]
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   ._internalMeth3({#(self): FooClassBase#})[#() -> Any?#]
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[StaticMethod]/CurrNominal:     ._internalMeth2()[#Any!#]
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   ._internalMeth2({#(self): FooClassBase#})[#() -> Any?#]
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[StaticMethod]/CurrNominal:     .nonInternalMeth()[#Any!#]
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .nonInternalMeth({#(self): FooClassBase#})[#() -> Any?#]
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[StaticMethod]/CurrNominal:     ._internalMeth1()[#Any!#]
+// CLANG_CLASS_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   ._internalMeth1({#(self): FooClassBase#})[#() -> Any?#]
+// CLANG_CLASS_MEMBERS_1-DAG: Keyword[self]/CurrNominal: .self[#FooClassBase.Type#]; name=self
+// CLANG_CLASS_MEMBERS_1-DAG: Keyword/CurrNominal: .Type[#FooClassBase.Type#]; name=Type
 }
 
 func testCompleteClassMembers2() {
   FooClassDerived#^CLANG_CLASS_MEMBERS_2^#
 
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc0({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc1({#(self): FooClassDerived#})[#(Int32) -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc2({#(self): FooClassDerived#})[#(Int32, withB: Int32) -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFuncOverridden({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/CurrNominal:     .fooClassFunc0()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#FooClassDerived!#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#float: Float#})[#FooClassDerived!#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooProtoFunc({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation1({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation2({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/CurrNominal:     .fooProtoClassFunc()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/Super:           .fooBaseInstanceFunc0()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/Super:         .fooBaseInstanceFunc0({#(self): FooClassBase#})[#() -> Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/Super:           .fooBaseInstanceFunc1({#(anObject): Any!#})[#FooClassBase!#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/Super:         .fooBaseInstanceFunc1({#(self): FooClassBase#})[#(Any?) -> FooClassBase?#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/Super:           .fooBaseInstanceFuncOverridden()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/Super:           .fooBaseClassFunc0()[#Void#]{{; name=.+$}}
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/Super:           ._internalMeth3()[#Any!#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/Super:         ._internalMeth3({#(self): FooClassBase#})[#() -> Any?#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/Super:           ._internalMeth2()[#Any!#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/Super:         ._internalMeth2({#(self): FooClassBase#})[#() -> Any?#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/Super:           .nonInternalMeth()[#Any!#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/Super:         .nonInternalMeth({#(self): FooClassBase#})[#() -> Any?#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[StaticMethod]/Super:           ._internalMeth1()[#Any!#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Decl[InstanceMethod]/Super:         ._internalMeth1({#(self): FooClassBase#})[#() -> Any?#]
-// CLANG_CLASS_MEMBERS_2-NEXT: Keyword[self]/CurrNominal: .self[#FooClassDerived.Type#]; name=self
-// CLANG_CLASS_MEMBERS_2-NEXT: Keyword/CurrNominal: .Type[#FooClassDerived.Type#]; name=Type
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc0({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc1({#(self): FooClassDerived#})[#(Int32) -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc2({#(self): FooClassDerived#})[#(Int32, withB: Int32) -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFuncOverridden({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/CurrNominal:     .fooClassFunc0()[#Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ()[#FooClassDerived!#]
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]:      ({#float: Float#})[#FooClassDerived!#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/CurrNominal:   .fooProtoFunc({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation1({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation2({#(self): FooClassDerived#})[#() -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/CurrNominal:     .fooProtoClassFunc()[#Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           .fooBaseInstanceFunc0()[#Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/Super:         .fooBaseInstanceFunc0({#(self): FooClassBase#})[#() -> Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           .fooBaseInstanceFunc1({#(anObject): Any!#})[#FooClassBase!#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/Super:         .fooBaseInstanceFunc1({#(self): FooClassBase#})[#(Any?) -> FooClassBase?#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           .fooBaseInstanceFuncOverridden()[#Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           .fooBaseClassFunc0()[#Void#]{{; name=.+$}}
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           ._internalMeth3()[#Any!#]
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/Super:         ._internalMeth3({#(self): FooClassBase#})[#() -> Any?#]
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           ._internalMeth2()[#Any!#]
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/Super:         ._internalMeth2({#(self): FooClassBase#})[#() -> Any?#]
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           .nonInternalMeth()[#Any!#]
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/Super:         .nonInternalMeth({#(self): FooClassBase#})[#() -> Any?#]
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           ._internalMeth1()[#Any!#]
+// CLANG_CLASS_MEMBERS_2-DAG: Decl[InstanceMethod]/Super:         ._internalMeth1({#(self): FooClassBase#})[#() -> Any?#]
+// CLANG_CLASS_MEMBERS_2-DAG: Keyword[self]/CurrNominal: .self[#FooClassDerived.Type#]; name=self
+// CLANG_CLASS_MEMBERS_2-DAG: Keyword/CurrNominal: .Type[#FooClassDerived.Type#]; name=Type
 }
 
 func testCompleteInstanceMembers1(fooObject: FooClassDerived) {
   fooObject#^CLANG_INSTANCE_MEMBERS_1^#
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceVar]/CurrNominal:      .fooProperty1[#Int32#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceVar]/CurrNominal:      .fooProperty2[#Int32#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceVar]/CurrNominal:      .fooProperty3[#Int32#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc0()[#Void#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc1({#(a): Int32#})[#Void#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc2({#(a): Int32#}, {#withB: Int32#})[#Void#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFuncOverridden()[#Void#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooProtoFunc()[#Void#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation1()[#Void#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation2()[#Void#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/Super:         .fooBaseInstanceFunc0()[#Void#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/Super:         .fooBaseInstanceFunc1({#(anObject): Any!#})[#FooClassBase!#]{{; name=.+$}}
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/Super:         ._internalMeth3()[#Any!#]
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/Super:         ._internalMeth2()[#Any!#]
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/Super:         .nonInternalMeth()[#Any!#]
-// CLANG_INSTANCE_MEMBERS_1-NEXT: Decl[InstanceMethod]/Super:         ._internalMeth1()[#Any!#]
+// CLANG_INSTANCE_MEMBERS_1-NOT: Instance
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceVar]/CurrNominal:      .fooProperty1[#Int32#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceVar]/CurrNominal:      .fooProperty2[#Int32#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceVar]/CurrNominal:      .fooProperty3[#Int32#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc0()[#Void#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc1({#(a): Int32#})[#Void#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooInstanceFunc2({#(a): Int32#}, {#withB: Int32#})[#Void#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooBaseInstanceFuncOverridden()[#Void#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooProtoFunc()[#Void#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation1()[#Void#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   .fooProtoFuncWithExtraIndentation2()[#Void#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/Super:         .fooBaseInstanceFunc0()[#Void#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/Super:         .fooBaseInstanceFunc1({#(anObject): Any!#})[#FooClassBase!#]{{; name=.+$}}
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/Super:         ._internalMeth3()[#Any!#]
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/Super:         ._internalMeth2()[#Any!#]
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/Super:         .nonInternalMeth()[#Any!#]
+// CLANG_INSTANCE_MEMBERS_1-DAG: Decl[InstanceMethod]/Super:         ._internalMeth1()[#Any!#]
 // CLANG_INSTANCE_MEMBERS_1-NOT: Instance
 }
 

--- a/test/IDE/complete_from_clang_framework.swift
+++ b/test/IDE/complete_from_clang_framework.swift
@@ -31,9 +31,6 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=TYPE_MODULE_QUALIFIER | %FileCheck %s -check-prefix=MODULE_QUALIFIER
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=EXPR_MODULE_QUALIFIER | %FileCheck %s -check-prefix=MODULE_QUALIFIER
 
-// Disabled due to CI failures on macosx-arm64 & watchsimulator-i386 (https://ci.swift.org/job/swift-PR-macos/29960/console)
-// REQUIRES: rdar85471345
-
 import Foo
 // Don't import FooHelper directly in this test!
 // import FooHelper

--- a/test/IDE/complete_from_clang_framework.swift
+++ b/test/IDE/complete_from_clang_framework.swift
@@ -1,35 +1,4 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=SWIFT_COMPLETIONS | %FileCheck %s -check-prefix=SWIFT_COMPLETIONS
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=FW_UNQUAL_1 > %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_FOO < %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_FOO_SUB < %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_FOO_HELPER < %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_FOO_HELPER_SUB < %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_BAR < %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_BOTH_FOO_BAR < %t.compl.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=CLANG_QUAL_FOO_1 > %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_FOO < %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_FOO_SUB < %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_QUAL_FOO_NEGATIVE < %t.compl.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=CLANG_QUAL_BAR_1 > %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_QUAL_BAR_1 < %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_BAR < %t.compl.txt
-// RUN: %FileCheck %s -check-prefix=CLANG_QUAL_BAR_NEGATIVE < %t.compl.txt
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=CLANG_QUAL_FOO_2 | %FileCheck %s -check-prefix=CLANG_QUAL_FOO_2
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=FUNCTION_CALL_1 | %FileCheck %s -check-prefix=FUNCTION_CALL_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=FUNCTION_CALL_2 | %FileCheck %s -check-prefix=FUNCTION_CALL_2
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=CLANG_STRUCT_MEMBERS_1 | %FileCheck %s -check-prefix=CLANG_STRUCT_MEMBERS_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=CLANG_CLASS_MEMBERS_1 | %FileCheck %s -check-prefix=CLANG_CLASS_MEMBERS_1
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=CLANG_CLASS_MEMBERS_2 | %FileCheck %s -check-prefix=CLANG_CLASS_MEMBERS_2
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=CLANG_INSTANCE_MEMBERS_1 | %FileCheck %s -check-prefix=CLANG_INSTANCE_MEMBERS_1
-
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=TYPE_MODULE_QUALIFIER | %FileCheck %s -check-prefix=MODULE_QUALIFIER
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -F %S/Inputs/mock-sdk -enable-objc-interop -code-completion-token=EXPR_MODULE_QUALIFIER | %FileCheck %s -check-prefix=MODULE_QUALIFIER
+// RUN: %batch-code-completion -F %S/Inputs/mock-sdk -enable-objc-interop
 
 import Foo
 // Don't import FooHelper directly in this test!
@@ -123,11 +92,11 @@ func testSwiftCompletions(foo: SwiftStruct) {
 // CLANG_QUAL_BAR_NEGATIVE-NOT: FOO
 
 func testClangModule() {
-  #^FW_UNQUAL_1^#
+  #^FW_UNQUAL_1?check=CLANG_FOO;check=CLANG_FOO_SUB;check=CLANG_FOO_HELPER;check=CLANG_FOO_HELPER_SUB;check=CLANG_BAR;check=CLANG_BOTH_FOO_BAR^#
 }
 
 func testCompleteModuleQualifiedFoo1() {
-  Foo.#^CLANG_QUAL_FOO_1^#
+  Foo.#^CLANG_QUAL_FOO_1?check=CLANG_FOO;check=CLANG_FOO_SUB;check=CLANG_QUAL_FOO_NEGATIVE^#
 }
 
 func testCompleteModuleQualifiedFoo2() {
@@ -206,7 +175,7 @@ func testCompleteModuleQualifiedFoo2() {
 }
 
 func testCompleteModuleQualifiedBar1() {
-  Bar.#^CLANG_QUAL_BAR_1^#
+  Bar.#^CLANG_QUAL_BAR_1?check=CLANG_QUAL_BAR_1;check=CLANG_BAR;check=CLANG_QUAL_BAR_NEGATIVE^#
 // If the number of results below changes, this is an indication that you need
 // to add a result to the appropriate list.  Do not just bump the number!
 // CLANG_QUAL_BAR_1: Begin completions, 8 items
@@ -312,8 +281,8 @@ func testCompleteInstanceMembers1(fooObject: FooClassDerived) {
 }
 
 // Check the FooHelper module is suggested even though it's not imported directly
-func testExportedModuleCompletion() -> #^TYPE_MODULE_QUALIFIER^# {
-  let x = #^EXPR_MODULE_QUALIFIER^#
+func testExportedModuleCompletion() -> #^TYPE_MODULE_QUALIFIER?check=MODULE_QUALIFIER^# {
+  let x = #^EXPR_MODULE_QUALIFIER?check=MODULE_QUALIFIER^#
 // MODULE_QUALIFIER-DAG: Decl[Module]/None: swift_ide_test[#Module#]; name=swift_ide_test
 // MODULE_QUALIFIER-DAG: Decl[Module]/None/IsSystem: Swift[#Module#]; name=Swift
 // MODULE_QUALIFIER-DAG: Decl[Module]/None: Foo[#Module#]; name=Foo


### PR DESCRIPTION
This reverts commit 423f0c3dfeb47050f361458920f63d1df7b25d4b.

The failure was
```
/Users/buildnode/jenkins/workspace/oss-swift-incremental-RA-macos-apple-silicon/swift/test/IDE/complete_from_clang_framework.swift:127:19: error: CLANG_BAR-DAG: expected string not found in input
// CLANG_BAR-DAG: Decl[TypeAlias]/OtherModule[__ObjC]: __builtin_va_list[#(__va_list_tag)#]; name=__builtin_va_list
                  ^
```
But the offending line was removed in c5a715d4ed734257937f4d8539e3284cff8495fc . Let's re-enable the test case.

rdar://85471345