### PR TITLE
Frontend: Allow use of `@_spiOnly` by default in Swift 6

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -44,6 +44,11 @@ ERROR(error_unknown_library_level, none,
       "unknown library level '%0', "
       "expected one of 'api', 'spi', 'ipi', or 'other'", (StringRef))
 
+ERROR(error_old_spi_only_import_unsupported, none,
+      "'-experimental-spi-imports' is unsupported in Swift 6, "
+      "use '@_spiOnly' instead",
+      ())
+
 ERROR(error_unknown_require_explicit_availability, none,
       "unknown argument '%0', passed to -require-explicit-availability, "
       "expected 'error', 'warn' or 'ignore'",

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -3337,6 +3337,17 @@ bool CompilerInvocation::parseArgs(
     }
   }
 
+  // With Swift 6, enable @_spiOnly by default and forbid the old version.
+  // This also enables proper error reporting of ioi references from spi decls.
+  if (LangOpts.EffectiveLanguageVersion.isVersionAtLeast(6)) {
+    LangOpts.EnableSPIOnlyImports = true;
+
+    if (ParsedArgs.hasArg(OPT_experimental_spi_imports)) {
+      Diags.diagnose(SourceLoc(), diag::error_old_spi_only_import_unsupported);
+      return true;
+    }
+  }
+
   return false;
 }
 

--- a/test/ModuleInterface/access-level-import-swiftinterfaces.swift
+++ b/test/ModuleInterface/access-level-import-swiftinterfaces.swift
@@ -108,7 +108,7 @@
 /// Build a client with multiple files.
 // RUN: %target-swift-frontend -typecheck %t/MultiFiles?.swift -I %t \
 // RUN:   -package-name TestPackage -module-name MultiFiles_Swift6 \
-// RUN:   -experimental-spi-only-imports -experimental-spi-imports \
+// RUN:   -experimental-spi-only-imports \
 // RUN:   -enable-library-evolution -swift-version 6 \
 // RUN:   -emit-module-interface-path %t/MultiFiles_Swift6.swiftinterface \
 // RUN:   -emit-private-module-interface-path %t/MultiFiles_Swift6.private.swiftinterface \

--- a/test/SPI/experimental_spi_imports_swiftinterface.swift
+++ b/test/SPI/experimental_spi_imports_swiftinterface.swift
@@ -16,6 +16,11 @@
 // RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/main.swiftinterface
 // RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/main.private.swiftinterface
 
+/// The flag is rejected in Swift 6.
+// RUN: not %target-swift-frontend -typecheck % -swift-version 6 \
+// RUN:   -experimental-spi-imports 2>&1 | %FileCheck %s -check-prefix=CHECK-6
+// CHECK-6: error: '-experimental-spi-imports' is unsupported in Swift 6, use '@_spiOnly' instead
+
 @_spi(dummy) @_implementationOnly import ExperimentalImported
 // CHECK-PUBLIC-NOT: import ExperimentalImported
 // CHECK-PRIVATE: @_implementationOnly @_spi{{.*}} import ExperimentalImported

--- a/test/SPI/spi_only_import_flag_check.swift
+++ b/test/SPI/spi_only_import_flag_check.swift
@@ -16,6 +16,11 @@
 // RUN:   -module-name Client -emit-module-path %t/Client.swiftmodule \
 // RUN:   -experimental-spi-only-imports
 
+/// Attribute is accepted without the flag in Swift 6.
+// RUN: %target-swift-frontend -emit-module %t/Client.swift -I %t \
+// RUN:   -module-name Client -emit-module-path %t/Client.swiftmodule \
+// RUN:   -swift-version 6
+
 /// Attribute is accepted without the flag when in a swiftinterface.
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) \
 // RUN:   -I %t -module-name Client


### PR DESCRIPTION
Enabling `@_spiOnly` also enables stronger type-checking of SPI decls. As this could be source breaking, it has always been opt-in. Turn it on by default in Swift 6 mode where the stronger type-checking will also become expected.

At the same time, disable the old alternative to `@_spiOnly` which was designed to be compatible with old compilers. Any user of that feature should move to `@_spiOnly` or `package import` instead.