### PR TITLE
[test][embedded] REQUIRE synchronization in test that uses synchornization

### DIFF
--- a/test/embedded/synchronization.swift
+++ b/test/embedded/synchronization.swift
@@ -7,6 +7,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: synchronization
 
 import Synchronization
 


### PR DESCRIPTION
This tests imports the Synchronization module, so it will not work if Synchonization is not part of the build. Mark it as `REQUIRES: synchronization` to skip it in case synchronization has not been built.

The test was added in #72293.
