### PR TITLE
[Concurrency] Don't attempt to hop to executor inside default argument generators and stored property initializers.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3045,34 +3045,46 @@ static void emitDelayedArguments(SILGenFunction &SGF,
 done:
 
   if (defaultArgIsolation) {
-    assert(SGF.F.isAsync());
     assert(!isolatedArgs.empty());
 
-    auto &firstArg = *std::get<0>(isolatedArgs[0]);
-    auto loc = firstArg.getDefaultArgLoc();
+    // Only hop to the default arg isolation if the callee is async.
+    // If we're in a synchronous function, the isolation has to match,
+    // so no hop is required. This is enforced by the actor isolation
+    // checker.
+    //
+    // FIXME: Note that we don't end up in this situation for user-written
+    // synchronous functions, because the default argument is only considered
+    // isolated to the callee if the call crosses an isolation boundary. We
+    // do end up here for default argument generators and stored property
+    // initializers. An alternative (and better) approach is to formally model
+    // those generator functions as isolated.
+    if (SGF.F.isAsync()) {
+      auto &firstArg = *std::get<0>(isolatedArgs[0]);
+      auto loc = firstArg.getDefaultArgLoc();
 
-    SILValue executor;
-    switch (*defaultArgIsolation) {
-    case ActorIsolation::GlobalActor:
-      executor = SGF.emitLoadGlobalActorExecutor(
-          defaultArgIsolation->getGlobalActor());
-      break;
+      SILValue executor;
+      switch (*defaultArgIsolation) {
+      case ActorIsolation::GlobalActor:
+        executor = SGF.emitLoadGlobalActorExecutor(
+            defaultArgIsolation->getGlobalActor());
+        break;
 
-    case ActorIsolation::ActorInstance:
-      llvm_unreachable("default arg cannot be actor instance isolated");
+      case ActorIsolation::ActorInstance:
+        llvm_unreachable("default arg cannot be actor instance isolated");
 
-    case ActorIsolation::Erased:
-      llvm_unreachable("default arg cannot have erased isolation");
+      case ActorIsolation::Erased:
+        llvm_unreachable("default arg cannot have erased isolation");
 
-    case ActorIsolation::Unspecified:
-    case ActorIsolation::Nonisolated:
-    case ActorIsolation::NonisolatedUnsafe:
-      llvm_unreachable("Not isolated");
+      case ActorIsolation::Unspecified:
+      case ActorIsolation::Nonisolated:
+      case ActorIsolation::NonisolatedUnsafe:
+        llvm_unreachable("Not isolated");
+      }
+
+      // Hop to the target isolation domain once to evaluate all
+      // default arguments.
+      SGF.emitHopToTargetExecutor(loc, executor);
     }
-
-    // Hop to the target isolation domain once to evaluate all
-    // default arguments.
-    SGF.emitHopToTargetExecutor(loc, executor);
 
     size_t argsEmitted = 0;
     for (auto &isolatedArg : isolatedArgs) {


### PR DESCRIPTION
Otherwise, the compiler will fail an assertion or crash in IRGen because there's a suspension point in a synchronous function. For example:

```swift
@MainActor func onMain() -> Int { 0 }

@MainActor func useDefault(_ x: Int = onMain()) -> Int { x }

@MainActor func anotherDefault(_ x: Int = useDefault()) -> Int { x }
```

The actor isolation checker ensures that the isolation of default arguments matches the isolation of the callee, so this code is valid. However, default argument generators and stored property initializers don't formally model their isolation in these cases, so the compiler attempts to emit a hop in the middle of a synchronous function when the default argument itself makes a call that uses an isolated default argument value. For now, don't emit the hop if the function is synchronous. A better approach would be to formally model the isolation for these function declarations that are generated in SIL.

Resolves: rdar://124502334