### PR TITLE
Demangle inverse requirements when building AST types 

### DIFF
--- a/include/swift/AST/ASTDemangler.h
+++ b/include/swift/AST/ASTDemangler.h
@@ -83,6 +83,7 @@ public:
   using BuiltProtocolDecl = swift::ProtocolDecl *;
   using BuiltGenericSignature = swift::GenericSignature;
   using BuiltRequirement = swift::Requirement;
+  using BuiltInverseRequirement = swift::InverseRequirement;
   using BuiltSubstitutionMap = swift::SubstitutionMap;
 
   static constexpr bool needsToPrecomputeParentGenericContextShapes = false;
@@ -161,8 +162,10 @@ public:
 
   Type createProtocolTypeFromDecl(ProtocolDecl *protocol);
 
-  Type createConstrainedExistentialType(Type base,
-                                        ArrayRef<BuiltRequirement> constraints);
+  Type createConstrainedExistentialType(
+      Type base,
+      ArrayRef<BuiltRequirement> constraints,
+      ArrayRef<BuiltInverseRequirement> inverseRequirements);
 
   Type createSymbolicExtendedExistentialType(NodePointer shapeNode,
                                              ArrayRef<Type> genArgs);
@@ -193,9 +196,11 @@ public:
   using BuiltSILBoxField = llvm::PointerIntPair<Type, 1>;
   using BuiltSubstitution = std::pair<Type, Type>;
   using BuiltLayoutConstraint = swift::LayoutConstraint;
-  Type createSILBoxTypeWithLayout(ArrayRef<BuiltSILBoxField> Fields,
-                                  ArrayRef<BuiltSubstitution> Substitutions,
-                                  ArrayRef<BuiltRequirement> Requirements);
+  Type createSILBoxTypeWithLayout(
+      ArrayRef<BuiltSILBoxField> Fields,
+      ArrayRef<BuiltSubstitution> Substitutions,
+      ArrayRef<BuiltRequirement> Requirements,
+      ArrayRef<BuiltInverseRequirement> inverseRequirements);
 
   bool isExistential(Type type) {
     return type->isExistentialType();
@@ -237,6 +242,9 @@ public:
   LayoutConstraint getLayoutConstraintWithSizeAlign(LayoutConstraintKind kind,
                                                     unsigned size,
                                                     unsigned alignment);
+
+  InverseRequirement createInverseRequirement(
+      Type subject, InvertibleProtocolKind kind);
 
 private:
   bool validateParentType(TypeDecl *decl, Type parent);

--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -461,12 +461,24 @@ protected:
     bool innermostTypeDecl;
     bool extension;
     std::optional<unsigned> mangledDepth; // for inverses
+    std::optional<unsigned> suppressedInnermostDepth;
   public:
     bool reachedInnermostTypeDecl() {
       bool answer = innermostTypeDecl;
       innermostTypeDecl = false;
       return answer;
     }
+
+    /// Whether inverses of the innermost declaration's generic parameters
+    /// should be suppressed.
+    ///
+    /// This makes sense only for entities that can only ever be defined
+    /// within the primary type, such as enum cases and the stored properties
+    /// of struct and class types.
+    std::optional<unsigned> getSuppressedInnermostInversesDepth() const {
+      return suppressedInnermostDepth;
+    }
+
     bool reachedExtension() const { return extension; }
     void setReachedExtension() { assert(!extension); extension = true; }
     GenericSignature getSignature() const { return sig; }

--- a/include/swift/AST/InvertibleProtocolKind.h
+++ b/include/swift/AST/InvertibleProtocolKind.h
@@ -1,0 +1,33 @@
+//===--- InvertibleProtocolKind.h - -----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This header declares the InvertibleProtocolKind enum and some
+// related operations.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_INVERTIBLEPROTOCOLKIND_H
+#define SWIFT_AST_INVERTIBLEPROTOCOLKIND_H
+
+#include <stdint.h>
+
+namespace swift {
+
+enum class InvertibleProtocolKind : uint8_t {
+#define INVERTIBLE_PROTOCOL_WITH_NAME(Id, Name) Id,
+#include "swift/AST/KnownProtocols.def"
+};
+
+
+} // end namespace swift
+
+#endif // SWIFT_AST_INVERTIBLEPROTOCOLKIND_H

--- a/include/swift/AST/KnownProtocols.h
+++ b/include/swift/AST/KnownProtocols.h
@@ -15,6 +15,7 @@
 
 #include "swift/Basic/InlineBitfield.h"
 #include "swift/Basic/FixedBitSet.h"
+#include "swift/AST/InvertibleProtocolKind.h"
 #include "swift/Config.h"
 
 namespace llvm {
@@ -54,11 +55,6 @@ enum : uint8_t {
 #define INVERTIBLE_PROTOCOL_WITH_NAME(Id, Name) +1
   /// The number of invertible protocols.
   NumInvertibleProtocols =
-#include "swift/AST/KnownProtocols.def"
-};
-
-enum class InvertibleProtocolKind : uint8_t {
-#define INVERTIBLE_PROTOCOL_WITH_NAME(Id, Name) Id,
 #include "swift/AST/KnownProtocols.def"
 };
 

--- a/include/swift/RemoteInspection/TypeRef.h
+++ b/include/swift/RemoteInspection/TypeRef.h
@@ -192,6 +192,25 @@ public:
   }
 };
 
+class TypeRefInverseRequirement {
+  llvm::PointerIntPair<const TypeRef *, 3, InvertibleProtocolKind> Storage;
+
+public:
+  TypeRefInverseRequirement(const TypeRef *first, InvertibleProtocolKind proto)
+      : Storage(first, proto) {
+    assert(first);
+  }
+
+  /// Retrieve the first type.
+  const TypeRef *getFirstType() const {
+    return Storage.getPointer();
+  }
+
+  /// Determine the kind of requirement.
+  InvertibleProtocolKind getKind() const { return Storage.getInt(); }
+};
+
+
 // On 32-bit systems this needs more than just pointer alignment to fit the
 // extra bits needed by TypeRefRequirement.
 class alignas(8) TypeRef {

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -389,6 +389,7 @@ public:
       std::optional<std::pair<std::string, bool /*isObjC*/>>;
   using BuiltSubstitution = std::pair<const TypeRef *, const TypeRef *>;
   using BuiltRequirement = TypeRefRequirement;
+  using BuiltInverseRequirement = TypeRefInverseRequirement;
   using BuiltLayoutConstraint = TypeRefLayoutConstraint;
   using BuiltGenericTypeParam = const GenericTypeParameterTypeRef *;
   using BuiltGenericSignature = const GenericSignatureRef *;
@@ -1221,7 +1222,9 @@ public:
   }
 
   const ConstrainedExistentialTypeRef *createConstrainedExistentialType(
-      const TypeRef *base, llvm::ArrayRef<BuiltRequirement> constraints) {
+      const TypeRef *base, llvm::ArrayRef<BuiltRequirement> constraints,
+      llvm::ArrayRef<BuiltInverseRequirement> InverseRequirements) {
+    // FIXME: Handle inverse requirements.
     auto *baseProto = llvm::dyn_cast<ProtocolCompositionTypeRef>(base);
     if (!baseProto)
       return nullptr;
@@ -1295,10 +1298,17 @@ public:
     return {};
   }
 
+  BuiltInverseRequirement createInverseRequirement(
+      const TypeRef *subject, InvertibleProtocolKind proto) {
+    return TypeRefInverseRequirement(subject, proto);
+  }
+
   const SILBoxTypeWithLayoutTypeRef *createSILBoxTypeWithLayout(
       const llvm::SmallVectorImpl<BuiltSILBoxField> &Fields,
       const llvm::SmallVectorImpl<BuiltSubstitution> &Substitutions,
-      const llvm::SmallVectorImpl<BuiltRequirement> &Requirements) {
+      const llvm::SmallVectorImpl<BuiltRequirement> &Requirements,
+      llvm::ArrayRef<BuiltInverseRequirement> InverseRequirements) {
+    // FIXME: Handle inverse requirements.
     return SILBoxTypeWithLayoutTypeRef::create(*this, Fields, Substitutions,
                                                Requirements);
   }

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -730,7 +730,8 @@ Type ASTBuilder::createExistentialMetatypeType(
 }
 
 Type ASTBuilder::createConstrainedExistentialType(
-    Type base, ArrayRef<BuiltRequirement> constraints) {
+    Type base, ArrayRef<BuiltRequirement> constraints,
+    ArrayRef<BuiltInverseRequirement> inverseRequirements) {
   // FIXME: Generalize to other kinds of bases.
   if (!base->getAs<ProtocolType>())
     return Type();
@@ -759,8 +760,19 @@ Type ASTBuilder::createConstrainedExistentialType(
     }
     args.push_back(argTy->getSecond());
   }
-  auto constrainedBase =
+  Type constrainedBase =
       ParameterizedProtocolType::get(base->getASTContext(), baseTy, args);
+
+  // Handle inverse requirements.
+  if (!inverseRequirements.empty()) {
+    InvertibleProtocolSet inverseSet;
+    for (const auto &inverseReq : inverseRequirements) {
+      inverseSet.insert(inverseReq.getKind());
+    }
+    constrainedBase = ProtocolCompositionType::get(
+        Ctx, { constrainedBase }, inverseSet, /*hasExplicitAnyObject=*/false);
+  }
+
   return ExistentialType::get(constrainedBase);
 }
 
@@ -847,10 +859,31 @@ Type ASTBuilder::createSILBoxType(Type base) {
   return SILBoxType::get(base->getCanonicalType());
 }
 
+/// Utility function to produce a Requirement from an InverseRequirement.
+static Requirement inverseAsRequirement(const InverseRequirement &inverseReq) {
+  ASTContext &ctx = inverseReq.subject->getASTContext();
+  InvertibleProtocolSet inverses;
+  inverses.insert(inverseReq.getKind());
+  Type constraintType = ProtocolCompositionType::get(
+      ctx, { }, inverses, /*hasExplicitAnyObject=*/false);
+  return Requirement(
+      RequirementKind::Conformance, inverseReq.subject, constraintType);
+}
+
+/// Utility function to append Requirements produced from the given set of
+/// InverseRequirements to the `requirements` vector.
+static void appendInversesAsRequirements(
+    ArrayRef<InverseRequirement> inverseRequirements,
+    SmallVectorImpl<Requirement> &requirements) {
+  for (const auto &inverseReq : inverseRequirements)
+    requirements.push_back(inverseAsRequirement(inverseReq));
+}
+
 Type ASTBuilder::createSILBoxTypeWithLayout(
     ArrayRef<BuiltSILBoxField> fields,
     ArrayRef<BuiltSubstitution> Substitutions,
-    ArrayRef<BuiltRequirement> Requirements) {
+    ArrayRef<BuiltRequirement> Requirements,
+    ArrayRef<BuiltInverseRequirement> InverseRequirements) {
   SmallVector<Type, 4> replacements;
   SmallVector<GenericTypeParamType *, 2> genericTypeParams;
   for (const auto &s : Substitutions) {
@@ -862,6 +895,7 @@ Type ASTBuilder::createSILBoxTypeWithLayout(
   GenericSignature signature;
   if (!genericTypeParams.empty()) {
     SmallVector<BuiltRequirement, 2> RequirementsVec(Requirements);
+    appendInversesAsRequirements(InverseRequirements, RequirementsVec);
     signature = swift::buildGenericSignature(Ctx,
                                              signature,
                                              genericTypeParams,
@@ -1101,6 +1135,13 @@ LayoutConstraint ASTBuilder::getLayoutConstraintWithSizeAlign(
                                                getASTContext());
 }
 
+InverseRequirement ASTBuilder::createInverseRequirement(
+    Type subject, InvertibleProtocolKind kind) {
+  auto knownProtoKind = getKnownProtocolKind(kind);
+  auto proto = subject->getASTContext().getProtocol(knownProtoKind);
+  return InverseRequirement(subject, proto, SourceLoc());
+}
+
 CanGenericSignature ASTBuilder::demangleGenericSignature(
     NominalTypeDecl *nominalDecl,
     NodePointer node) {
@@ -1119,8 +1160,11 @@ CanGenericSignature ASTBuilder::demangleGenericSignature(
   // Constrained extensions mangle the subset of requirements not satisfied
   // by the nominal's generic signature.
   SmallVector<Requirement, 2> requirements;
-  decodeRequirement<BuiltType, BuiltRequirement, BuiltLayoutConstraint,
-                    ASTBuilder>(node, requirements, *this);
+  SmallVector<InverseRequirement, 2> inverseRequirements;
+  decodeRequirement<BuiltType, BuiltRequirement, BuiltInverseRequirement,
+                    BuiltLayoutConstraint, ASTBuilder>(
+      node, requirements, inverseRequirements, *this);
+  appendInversesAsRequirements(inverseRequirements, requirements);
 
   return buildGenericSignature(Ctx, baseGenericSig, {}, std::move(requirements),
                                /*allowInverses=*/true)
@@ -1232,7 +1276,8 @@ ASTBuilder::findDeclContext(NodePointer node) {
         continue;
 
       if (!ext->isConstrainedExtension()) {
-        if (!genericSig)
+        if (!genericSig ||
+            genericSig->isEqual(nominalDecl->getGenericSignature()))
           return ext;
         continue;
       }

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -401,9 +401,6 @@ public:
   }
 
   std::string mangleEnumCase(const ValueDecl *Decl) {
-    // No mangling of inverse conformances.
-    llvm::SaveAndRestore X(AllowInverses, false);
-
     beginMangling();
     appendEntity(Decl);
     appendOperator("WC");

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1627,6 +1627,11 @@ public:
     }
   };
 
+  struct BuiltInverseRequirement {
+    BuiltType SubjectType;
+    InvertibleProtocolKind Kind;
+  };
+
   DecodedMetadataBuilder(Demangler &demangler,
                          SubstGenericParameterFn substGenericParameter,
                          SubstDependentWitnessTableFn substWitnessTable)
@@ -1912,8 +1917,10 @@ public:
   }
 
   TypeLookupErrorOr<BuiltType>
-  createConstrainedExistentialType(BuiltType base,
-                                   llvm::ArrayRef<BuiltRequirement> rs) const {
+  createConstrainedExistentialType(
+      BuiltType base,
+      llvm::ArrayRef<BuiltRequirement> rs,
+      llvm::ArrayRef<BuiltInverseRequirement> InverseRequirements) const {
     // FIXME: Runtime plumbing.
     return BuiltType();
   }
@@ -2198,10 +2205,16 @@ public:
     return {};
   }
 
+  BuiltInverseRequirement createInverseRequirement(
+      BuiltType subjectType, InvertibleProtocolKind kind) {
+    return BuiltInverseRequirement{subjectType, kind};
+  }
+
   TypeLookupErrorOr<BuiltType> createSILBoxTypeWithLayout(
       llvm::ArrayRef<BuiltSILBoxField> Fields,
       llvm::ArrayRef<BuiltSubstitution> Substitutions,
-      llvm::ArrayRef<BuiltRequirement> Requirements) const {
+      llvm::ArrayRef<BuiltRequirement> Requirements,
+      llvm::ArrayRef<BuiltInverseRequirement> InverseRequirements) const {
     // FIXME: Implement.
     return BuiltType();
   }

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -4,6 +4,7 @@
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -parse-as-library \
 // RUN:   -enable-library-evolution \
+// RUN:   -g \
 // RUN:   > %t/test.irgen
 
 // RUN: %FileCheck %s < %t/test.irgen
@@ -44,4 +45,16 @@ public protocol Hello<Person>: ~Copyable {
 
   // CHECK: @"$s4test5HelloP10overloadedyyqd__Ricd__lFTj"
   func overloaded<T: ~Copyable>(_: borrowing T)
+}
+
+// CHECK: $s4test2XQVAARiczrlE1AVMi
+protocol Q: ~Copyable {
+  associatedtype A: ~Copyable
+}
+
+struct XQ<T: ~Copyable>: ~Copyable {
+}
+
+extension XQ: Q where T: ~Copyable {
+  struct A { }
 }

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -12,8 +12,8 @@ public protocol P: ~Copyable { }
 
 public struct CallMe<U: ~Copyable> {
   public enum Maybe<T: ~Copyable>: ~Copyable {
-    // CHECK-LABEL: @"$s4test6CallMeV5MaybeO4someyAEyx_qd__Gqd__cAGmr__lFWC"
-    // CHECK: @"$s4test6CallMeV5MaybeO4noneyAEyx_qd__GAGmr__lFWC"
+    // CHECK-LABEL: @"$s4test6CallMeV5MaybeOAARiczrlE4someyAEyx_qd__Gqd__cAGmr__lFWC"
+    // CHECK: @"$s4test6CallMeV5MaybeOAARiczrlE4noneyAEyx_qd__GAGmr__lFWC"
     case none
     case some(T)
   }


### PR DESCRIPTION
Extend TypeDecoder with support for inverse requirements, passing them
along to the type builder. Then implement support for inverse
requirements within the AST demangler, which addresses the round-trip
demangling failures we've been seeing.

The runtime and remote inspection facilities still need metadata to
deal with inverse requirements.

Fixes rdar://124564447.