### PR TITLE
[DebugInfo] Generate debug info for specialized types

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5887,8 +5887,10 @@ namespace {
     std::optional<SpareBitsMaskInfo> calculateSpareBitsMask() const override {
       SpareBitVector spareBits;
       for (auto enumCase : getElementsWithPayload()) {
-        cast<FixedTypeInfo>(enumCase.ti)
-            ->applyFixedSpareBitsMask(IGM, spareBits);
+        if (auto fixedTI = llvm::dyn_cast<FixedTypeInfo>(enumCase.ti))
+          fixedTI->applyFixedSpareBitsMask(IGM, spareBits);
+        else
+          return {};
       }
       // Trim leading/trailing zero bytes, then pad to a multiple of 32 bits
       llvm::APInt bits = spareBits.asAPInt();

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1155,23 +1155,12 @@ private:
     return DITy;;
   }
 
-  llvm::DIType *createFullDebugInfoGenericForStructOrClassType(
-      BoundGenericType *Type, NominalTypeDecl *Decl, llvm::DIScope *Scope,
-      llvm::DIFile *File, unsigned Line, unsigned SizeInBits,
-      unsigned AlignInBits, llvm::DINode::DIFlags Flags,
-      StringRef MangledName, bool IsClass = false) {
-    // To emit full debug info for generic types, the strategy is to emit
-    // full debug info for the type with archetypes, and still emit opaque
-    // debug information for the specialized type. For example, given:
-    // struct Pair<T, U> {
-    //   let t : T
-    //   let u: U
-    // }
-    // When emitting debug information for a type such as Pair<Int, Double>,
-    // emit full debug info for Pair<T, U>, and emit the regular debug
-    // information for Pair<Int, Double>.
-
-    // Go from Pair<Int, Double> to Pair<T, U>.
+  llvm::DIType *
+  createSpecializedEnumType(NominalOrBoundGenericNominalType *EnumTy,
+                            EnumDecl *Decl, StringRef MangledName,
+                            unsigned SizeInBits, unsigned AlignInBits,
+                            llvm::DIScope *Scope, llvm::DIFile *File,
+                            unsigned Line, llvm::DINode::DIFlags Flags) {
     auto UnsubstitutedTy = Decl->getDeclaredInterfaceType();
     UnsubstitutedTy = Decl->mapTypeIntoContext(UnsubstitutedTy);
 
@@ -1181,38 +1170,98 @@ private:
     std::string DeclTypeMangledName = Mangler.mangleTypeForDebugger(
         UnsubstitutedTy->mapTypeOutOfContext(), {});
     if (DeclTypeMangledName == MangledName) {
-      return createUnsubstitutedGenericStructOrClassType(
-          DbgTy, Decl, UnsubstitutedTy, Scope, File, Line, SizeInBits,
-          AlignInBits, Flags, nullptr, llvm::dwarf::DW_LANG_Swift,
-          DeclTypeMangledName);
+      return createUnsubstitutedVariantType(DbgTy, Decl, MangledName,
+                                            SizeInBits, AlignInBits, Scope,
+                                            File, 0, Flags);
     }
+    auto FwdDecl = llvm::TempDIType(DBuilder.createReplaceableCompositeType(
+        llvm::dwarf::DW_TAG_structure_type, "", Scope, File, 0,
+        llvm::dwarf::DW_LANG_Swift, 0, 0, llvm::DINode::FlagZero, MangledName));
+
+    auto TH = llvm::TrackingMDNodeRef(FwdDecl.get());
+    DITypeCache[EnumTy] = TH;
     // Force the creation of the unsubstituted type, don't create it
     // directly so it goes through all the caching/verification logic.
-    auto UnsubstitutedType = getOrCreateType(DbgTy);
+    auto unsubstitutedDbgTy = getOrCreateType(DbgTy);
+    auto DIType = createOpaqueStruct(
+        Scope, "", File, 0, SizeInBits, AlignInBits, Flags, MangledName,
+        collectGenericParams(EnumTy), unsubstitutedDbgTy);
+    DBuilder.replaceTemporary(std::move(FwdDecl), DIType);
+    return DIType;
+  }
 
-    if (auto *ClassTy = llvm::dyn_cast<BoundGenericClassType>(Type)) {
-      auto SuperClassTy = ClassTy->getSuperclass();
-      if (SuperClassTy) {
-        auto SuperClassDbgTy = DebugTypeInfo::getFromTypeInfo(
-            SuperClassTy, IGM.getTypeInfoForUnlowered(SuperClassTy), IGM);
+/// Create a DICompositeType from a specialized struct. A specialized type
+/// is a generic type, or a child type whose parent is generic.
+llvm::DIType *
+createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
+                                   NominalTypeDecl *Decl, llvm::DIScope *Scope,
+                                   llvm::DIFile *File, unsigned Line,
+                                   unsigned SizeInBits, unsigned AlignInBits,
+                                   llvm::DINode::DIFlags Flags,
+                                   StringRef MangledName,
+                                   bool IsClass = false) {
+  // To emit debug info of the DwarfTypes level for generic types, the strategy
+  // is to emit a description of all the fields for the type with archetypes,
+  // and still the same debug info as the ASTTypes level for the specialized
+  // type. For example, given:
+  // struct Pair<T, U> {
+  //   let t: T
+  //   let u: U
+  // }
+  // When emitting debug information for a type such as Pair<Int, Double>,
+  // emit a description of all the fields for Pair<T, U>, and emit the regular
+  // debug information for Pair<Int, Double>.
 
-        llvm::DIType *SuperClassDITy = getOrCreateType(SuperClassDbgTy);
-        assert(SuperClassDITy && "getOrCreateType should never return null!");
-        DBuilder.createInheritance(UnsubstitutedType, SuperClassDITy, 0, 0,
-                                   llvm::DINode::FlagZero);
-      }
+  auto FwdDecl = llvm::TempDIType(DBuilder.createReplaceableCompositeType(
+      llvm::dwarf::DW_TAG_structure_type, "", Scope, File, Line,
+      llvm::dwarf::DW_LANG_Swift, SizeInBits, 0, Flags, MangledName));
 
-      auto *OpaqueType = createPointerSizedStruct(
-          Scope, Decl ? Decl->getNameStr() : MangledName, File, 0, Flags,
-          MangledName, UnsubstitutedType);
-      return OpaqueType;
+  auto TH = llvm::TrackingMDNodeRef(FwdDecl.get());
+  DITypeCache[Type] = TH;
+
+  // Go from Pair<Int, Double> to Pair<T, U>.
+  auto UnsubstitutedTy = Decl->getDeclaredInterfaceType();
+  UnsubstitutedTy = Decl->mapTypeIntoContext(UnsubstitutedTy);
+
+  auto DbgTy = DebugTypeInfo::getFromTypeInfo(
+      UnsubstitutedTy, IGM.getTypeInfoForUnlowered(UnsubstitutedTy), IGM);
+  Mangle::ASTMangler Mangler;
+  std::string DeclTypeMangledName =
+      Mangler.mangleTypeForDebugger(UnsubstitutedTy->mapTypeOutOfContext(), {});
+  if (DeclTypeMangledName == MangledName) {
+    return createUnsubstitutedGenericStructOrClassType(
+        DbgTy, Decl, UnsubstitutedTy, Scope, File, Line, SizeInBits,
+        AlignInBits, Flags, nullptr, llvm::dwarf::DW_LANG_Swift,
+        DeclTypeMangledName);
+  }
+  // Force the creation of the unsubstituted type, don't create it
+  // directly so it goes through all the caching/verification logic.
+  auto UnsubstitutedType = getOrCreateType(DbgTy);
+
+  if (auto *ClassTy = llvm::dyn_cast<BoundGenericClassType>(Type)) {
+    auto SuperClassTy = ClassTy->getSuperclass();
+    if (SuperClassTy) {
+      auto SuperClassDbgTy = DebugTypeInfo::getFromTypeInfo(
+          SuperClassTy, IGM.getTypeInfoForUnlowered(SuperClassTy), IGM);
+
+      llvm::DIType *SuperClassDITy = getOrCreateType(SuperClassDbgTy);
+      assert(SuperClassDITy && "getOrCreateType should never return null!");
+      DBuilder.createInheritance(UnsubstitutedType, SuperClassDITy, 0, 0,
+                                 llvm::DINode::FlagZero);
     }
 
-    auto *OpaqueType = createOpaqueStruct(
-        Scope, "", File, Line, SizeInBits, AlignInBits, Flags, MangledName,
-        collectGenericParams(Type), UnsubstitutedType);
+    auto *OpaqueType = createPointerSizedStruct(
+        Scope, Decl ? Decl->getNameStr() : MangledName, File, 0, Flags,
+        MangledName, UnsubstitutedType);
     return OpaqueType;
   }
+
+  auto *OpaqueType = createOpaqueStruct(
+      Scope, "", File, Line, SizeInBits, AlignInBits, Flags, MangledName,
+      collectGenericParams(Type), UnsubstitutedType);
+  DBuilder.replaceTemporary(std::move(FwdDecl), OpaqueType);
+  return OpaqueType;
+}
 
   /// Create debug information for an enum with a raw type (enum E : Int {}).
   llvm::DICompositeType *createRawEnumType(CompletedDebugTypeInfo DbgTy,
@@ -1439,17 +1488,29 @@ private:
   /// Collect the type parameters of a bound generic type. This is needed to
   /// anchor any typedefs that may appear in parameters so they can be
   /// resolved in the debugger without needing to query the Swift module.
-  llvm::DINodeArray collectGenericParams(BoundGenericType *BGT) {
+  llvm::DINodeArray
+  collectGenericParams(NominalOrBoundGenericNominalType *BGT) {
+
+    // Collect the generic args from the type and its parent.
+    std::vector<Type> GenericArgs;
+    Type CurrentType = BGT;
+    while (CurrentType && CurrentType->getAnyNominal()) {
+      if (auto *BGT = llvm::dyn_cast<BoundGenericType>(CurrentType))
+        GenericArgs.insert(GenericArgs.end(), BGT->getGenericArgs().begin(),
+                           BGT->getGenericArgs().end());
+      CurrentType = CurrentType->getNominalParent();
+    }
+
     SmallVector<llvm::Metadata *, 16> TemplateParams;
-    for (auto Param : BGT->getGenericArgs()) {
+    for (auto Arg : GenericArgs) {
       DebugTypeInfo ParamDebugType;
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes)
-        // For full debug info don't generate just a forward declaration  for
-        // the generic type parameters.
+        // For the DwarfTypes level don't generate just a forward declaration
+        // for the generic type parameters.
         ParamDebugType = DebugTypeInfo::getFromTypeInfo(
-            Param, IGM.getTypeInfoForUnlowered(Param), IGM);
+            Arg, IGM.getTypeInfoForUnlowered(Arg), IGM);
       else
-        ParamDebugType = DebugTypeInfo::getForwardDecl(Param);
+        ParamDebugType = DebugTypeInfo::getForwardDecl(Arg);
 
       TemplateParams.push_back(DBuilder.createTemplateTypeParameter(
           TheCU, "", getOrCreateType(ParamDebugType), false));
@@ -1623,7 +1684,6 @@ private:
             createMemberType(DbgTy, "", OffsetInBits, Scope, MainFile, Flags));
     }
     // FIXME: assert that SizeInBits == OffsetInBits.
-    SizeInBits = OffsetInBits;
 
     auto FwdDecl = llvm::TempDINode(DBuilder.createReplaceableCompositeType(
         llvm::dwarf::DW_TAG_structure_type, MangledName, Scope, MainFile, 0,
@@ -1784,10 +1844,15 @@ private:
       // don't want a whitespace change to an secondary file trigger a
       // recompilation of the debug info of a primary source file.
       unsigned FwdDeclLine = 0;
-      if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes)
+      if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) {
+        if (StructTy->isSpecialized())
+          return createSpecializedStructOrClassType(
+              StructTy, Decl, Scope, L.File, L.Line, SizeInBits, AlignInBits,
+              Flags, MangledName);
         return createStructType(DbgTy, Decl, StructTy, Scope, L.File, L.Line,
                                 SizeInBits, AlignInBits, Flags, nullptr,
                                 llvm::dwarf::DW_LANG_Swift, MangledName);
+      }
       StringRef Name = Decl->getName().str();
       if (!SizeInBitsOrNull)
         return DBuilder.createForwardDecl(
@@ -1812,6 +1877,11 @@ private:
       assert(SizeInBits ==
              CI.getTargetInfo().getPointerWidth(clang::LangAS::Default));
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) {
+        if (ClassTy->isSpecialized()) 
+          return createSpecializedStructOrClassType(
+              ClassTy, Decl, Scope, L.File, L.Line, SizeInBits, AlignInBits,
+              Flags, MangledName);
+
         auto *DIType = createStructType(
             DbgTy, Decl, ClassTy, Scope, File, L.Line, SizeInBits, AlignInBits,
             Flags, nullptr, llvm::dwarf::DW_LANG_Swift, MangledName);
@@ -1873,7 +1943,7 @@ private:
       auto L = getFileAndLocation(Decl);
       unsigned FwdDeclLine = 0;
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes)
-        return createFullDebugInfoGenericForStructOrClassType(
+        return createSpecializedStructOrClassType(
             StructTy, Decl, Scope, L.File, L.Line, SizeInBits, AlignInBits,
             Flags, MangledName);
       
@@ -1890,7 +1960,7 @@ private:
       unsigned FwdDeclLine = 0;
 
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) 
-        return createFullDebugInfoGenericForStructOrClassType(
+        return createSpecializedStructOrClassType(
             ClassTy, Decl, Scope, L.File, L.Line, SizeInBits, AlignInBits,
             Flags, MangledName);
 
@@ -2009,10 +2079,16 @@ private:
       auto *Decl = EnumTy->getDecl();
       auto L = getFileAndLocation(Decl);
       unsigned FwdDeclLine = 0;
-      if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes)
+      if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) {
+        if (EnumTy->isSpecialized())
+          return createSpecializedEnumType(EnumTy, Decl, MangledName,
+                                           SizeInBits, AlignInBits, Scope, File,
+                                           FwdDeclLine, Flags);
+
         if (CompletedDbgTy)
           return createEnumType(*CompletedDbgTy, Decl, MangledName, AlignInBits,
                                 Scope, L.File, L.Line, Flags);
+      }
       return createOpaqueStruct(Scope, Decl->getName().str(), L.File,
                                 FwdDeclLine, SizeInBits, AlignInBits, Flags,
                                 MangledName);
@@ -2025,25 +2101,13 @@ private:
       unsigned FwdDeclLine = 0;
 
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) {
-        auto UnsubstitutedTy = Decl->getDeclaredInterfaceType();
-        UnsubstitutedTy = Decl->mapTypeIntoContext(UnsubstitutedTy);
-
-        auto DbgTy = DebugTypeInfo::getFromTypeInfo(
-            UnsubstitutedTy, IGM.getTypeInfoForUnlowered(UnsubstitutedTy), IGM);
-        Mangle::ASTMangler Mangler;
-        std::string DeclTypeMangledName = Mangler.mangleTypeForDebugger(
-            UnsubstitutedTy->mapTypeOutOfContext(), {});
-        if (DeclTypeMangledName == MangledName) {
-          return createUnsubstitutedVariantType(DbgTy, Decl, MangledName,
-                                   SizeInBits, AlignInBits, Scope, File,
-                                   FwdDeclLine, Flags);
-        }
-        // Force the creation of the unsubstituted type, don't create it
-        // directly so it goes through all the caching/verification logic.
-        auto unsubstitutedDbgTy = getOrCreateType(DbgTy);
-        return createOpaqueStruct(
-            Scope, "", L.File, FwdDeclLine, SizeInBits, AlignInBits, Flags,
-            MangledName, collectGenericParams(EnumTy), unsubstitutedDbgTy);
+        if (EnumTy->isSpecialized())
+          return createSpecializedEnumType(EnumTy, Decl, MangledName,
+                                           SizeInBits, AlignInBits, Scope, File,
+                                           FwdDeclLine, Flags);
+        if (CompletedDbgTy)
+          return createEnumType(*CompletedDbgTy, Decl, MangledName, AlignInBits,
+                                Scope, L.File, L.Line, Flags);
       }
       return createOpaqueStructWithSizedContainer(
           Scope, Decl->getName().str(), L.File, FwdDeclLine, SizeInBits,
@@ -2182,6 +2246,10 @@ private:
 #ifndef NDEBUG
   /// Verify that the size of this type matches the one of the cached type.
   bool sanityCheckCachedType(DebugTypeInfo DbgTy, llvm::DIType *CachedType) {
+    // If this is a temporary, we're in the middle of creating a recursive type,
+    // so skip the sanity check.
+    if (CachedType->isTemporary())
+      return true;
     if (DbgTy.isForwardDecl())
       return true;
     auto CompletedDbgTy = CompletedDebugTypeInfo::getFromTypeInfo(

--- a/test/DebugInfo/BoundGenericStruct.swift
+++ b/test/DebugInfo/BoundGenericStruct.swift
@@ -25,6 +25,35 @@ public let s = S<Int>(t: 0)
 // DWARF: !DICompositeType(tag: DW_TAG_structure_type, name: "S", 
 // DWARF-SAME:             identifier: "$s18BoundGenericStruct1SVyxGD")
 // DWARF: !DIDerivedType(tag: DW_TAG_member, name: "t"
-// DWARF: !DICompositeType(tag: DW_TAG_structure_type, name: "$sxD"
+// DWARF: ![[GENERIC_PARAM_TYPE:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxD"
 
 
+public struct S2<T> {
+  public struct Inner {
+    let t: T
+  }
+}
+public let inner = S2<Double>.Inner(t:4.2)
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "Inner", 
+// CHECK-SAME: size: 64, {{.*}}identifier: "$s18BoundGenericStruct2S2V5InnerVySd_GD")
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$s18BoundGenericStruct2S2VyxGD", 
+// CHECK-SAME: flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift)
+
+// DWARF: !DICompositeType(tag: DW_TAG_structure_type, scope: ![[SCOPE1:[0-9]+]],
+// DWARF-SAME: size: 64, {{.*}}, templateParams: ![[PARAMS2:[0-9]+]], identifier: "$s18BoundGenericStruct2S2V5InnerVySd_GD"
+// DWARF-SAME: specification_of: ![[SPECIFICATION:[0-9]+]]
+
+// DWARF: ![[SCOPE1]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s18BoundGenericStruct2S2VyxGD", 
+
+// DWARF: ![[PARAMS2]] = !{![[PARAMS3:[0-9]+]]}
+// DWARF: ![[PARAMS3]] = !DITemplateTypeParameter(type: ![[PARAMS4:[0-9]+]])
+// DWARF: ![[PARAMS4]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Double",
+// DWARF-SAME: size: 64, {{.*}}runtimeLang: DW_LANG_Swift, identifier: "$sSdD")
+
+// DWARF: [[SPECIFICATION]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Inner", 
+// DWARF-SAME: elements: ![[ELEMENTS1:[0-9]+]], runtimeLang: DW_LANG_Swift, identifier: "$s18BoundGenericStruct2S2V5InnerVyx_GD")
+
+// DWARF: ![[ELEMENTS1]] = !{![[ELEMENTS2:[0-9]+]]}
+
+// DWARF: ![[ELEMENTS2]] = !DIDerivedType(tag: DW_TAG_member, name: "t", scope: !27, file: !3, baseType: ![[GENERIC_PARAM_TYPE]])


### PR DESCRIPTION
Specialized types are generic types, or types whose parent is specialized.

IRGenDebugInfo was previously mistankenly emitting debug info for nominal specialized types as if they regular nominal types, which caused problems as that code path does not handle references to generic parameters.
