### PR TITLE
[ExplicitModuleBuild] Support `-vfsoverlay` swift option

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -477,6 +477,10 @@ void SwiftDependencyTracker::addCommonSearchPathDeps(
       FS->status(LayoutFile);
     }
   }
+
+  // Add VFSOverlay file.
+  for (auto &Overlay: Opts.VFSOverlayFiles)
+    FS->status(Overlay);
 }
 
 void SwiftDependencyTracker::startTracking() {

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -199,8 +199,8 @@ ModuleDependencyVector ClangImporter::bridgeClangModuleDependencies(
     // Swift frontend option for input file path (Foo.modulemap).
     swiftArgs.push_back(remapPath(clangModuleDep.ClangModuleMapFile));
 
-    // Handle VFSOverlay.
-    if (!ctx.SearchPathOpts.VFSOverlayFiles.empty()) {
+    // Handle VFSOverlay. If include tree is used, there is no need for overlay.
+    if (!ctx.ClangImporterOpts.UseClangIncludeTree) {
       for (auto &overlay : ctx.SearchPathOpts.VFSOverlayFiles) {
         swiftArgs.push_back("-vfsoverlay");
         swiftArgs.push_back(remapPath(overlay));

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1879,6 +1879,13 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   genericSubInvocation.getSearchPathOptions().ExplicitSwiftModuleMap =
     explicitSwiftModuleMap.str();
 
+  // Pass down VFSOverlay flags (do not need to inherit the options because
+  // FileSystem is shared).
+  for (auto &Overlay : searchPathOpts.VFSOverlayFiles) {
+    GenericArgs.push_back("-vfsoverlay");
+    GenericArgs.push_back(Overlay);
+  }
+
   // Load plugin libraries for macro expression as default arguments
   genericSubInvocation.getSearchPathOptions().PluginSearchOpts =
       searchPathOpts.PluginSearchOpts;

--- a/test/CAS/vfsoverlay.swift
+++ b/test/CAS/vfsoverlay.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: sed -e "s@VFS_DIR@%{/t:regex_replacement}/vfs@g" -e "s@EXTERNAL_DIR@%{/t:regex_replacement}/hidden@g" %t/base.yaml > %t/overlay.yaml
+
+// RUN: %target-swift-frontend -emit-module -module-name B -o %t/B.swiftmodule -swift-version 5 \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -emit-module-interface-path %t/hidden/B.swiftinterface -enable-library-evolution %t/hidden/B.swift
+
+// RUN: %target-swift-frontend -scan-dependencies -module-name Test -module-cache-path %t/clang-module-cache -O \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   %t/vfs/test.swift -o %t/deps.json -swift-version 5 -cache-compile-job -cas-path %t/cas \
+// RUN:   -vfsoverlay %t/overlay.yaml -Xcc -ivfsoverlay -Xcc %t/overlay.yaml -I %t/vfs
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json clang:A > %t/A.cmd
+// RUN: %swift_frontend_plain @%t/A.cmd
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json B > %t/B.cmd
+// RUN: %swift_frontend_plain @%t/B.cmd
+
+// RUN: %{python} %S/Inputs/GenerateExplicitModuleMap.py %t/deps.json > %t/map.json
+// RUN: llvm-cas --cas %t/cas --make-blob --data %t/map.json > %t/map.casid
+
+// RUN: %{python} %S/Inputs/BuildCommandExtractor.py %t/deps.json Test > %t/MyApp.cmd
+// RUN: %target-swift-frontend \
+// RUN:   -typecheck -cache-compile-job -cas-path %t/cas -vfsoverlay %t/overlay.yaml \
+// RUN:   -swift-version 5 -disable-implicit-swift-modules \
+// RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -module-name Test -explicit-swift-module-map-file @%t/map.casid \
+// RUN:   %t/vfs/test.swift @%t/MyApp.cmd
+
+//--- hidden/test.swift
+import A
+import B
+
+//--- hidden/module.modulemap
+module A {
+  header "A.h"
+  export *
+}
+
+//--- hidden/A.h
+void a(void);
+
+//--- hidden/B.swift
+public func b() {}
+
+//--- base.yaml
+{
+  version: 0,
+  roots: [
+    {
+      type: "directory-remap",
+      name: "VFS_DIR",
+      external-contents: "EXTERNAL_DIR"
+    }
+  ]
+}


### PR DESCRIPTION
Support `-vfsoverlay` swift option for explicit module build (including caching build). Previously, if the interface file is discovered from a location that is remapped by overlay, module cannot be built correctly. Make sure the overlay options are passed down to all interface compilaiton command.

For caching build, need to make sure the overlay itself is part of the CAS file system so the downstream compilation can discover that.

rdar://123655183

