### PR TITLE
Map package optimization flags to features

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -219,6 +219,19 @@ EXPERIMENTAL_FEATURE(LayoutPrespecialization, true)
 
 EXPERIMENTAL_FEATURE(AccessLevelOnImport, true)
 
+/// Enables a module to allow non resilient access from other
+/// modules within a package if built from source.
+EXPERIMENTAL_FEATURE(AllowNonResilientAccessInPackage, false)
+
+/// Enables a client module within a package to bypass resilient
+/// access (at use site) to decls defined in another module within
+/// the same package.
+EXPERIMENTAL_FEATURE(ClientBypassResilientAccessInPackage, false)
+
+/// Enables serialization of package decls and bodies and performs
+/// CMO within a package.
+EXPERIMENTAL_FEATURE(PackageCMO, false)
+
 /// Whether to enable experimental layout string value witnesses
 EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(LayoutStringValueWitnesses, true)
 EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(LayoutStringValueWitnessesInstantiation, true)

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -570,6 +570,13 @@ namespace swift {
     /// Enable implicit lifetime dependence for ~Escapable return types.
     bool EnableExperimentalLifetimeDependenceInference = true;
 
+    /// Skips decls that cannot be referenced externally.
+    bool SkipNonExportableDecls = false;
+
+    /// True if -experimental-allow-non-resilient-access is passed and built
+    /// from source.
+    bool AllowNonResilientAccess = false;
+
     /// Enables dumping type witness systems from associated type inference.
     bool DumpTypeWitnessSystems = false;
 

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -312,13 +312,6 @@ public:
   /// times) when compiling a module interface?
   bool SerializeModuleInterfaceDependencyHashes = false;
 
-  /// Should we skip decls that cannot be referenced externally?
-  bool SkipNonExportableDecls = false;
-
-  /// True if -experimental-allow-non-resilient-access is passed and built
-  /// from source.
-  bool AllowNonResilientAccess = false;
-
   /// Should we warn if an imported module needed to be rebuilt from a
   /// module interface file?
   bool RemarkOnRebuildFromModuleInterface = false;

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -468,6 +468,8 @@ static bool usesFeatureLayoutPrespecialization(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(AccessLevelOnImport)
+UNINTERESTING_FEATURE(AllowNonResilientAccessInPackage)
+UNINTERESTING_FEATURE(ClientBypassResilientAccessInPackage)
 UNINTERESTING_FEATURE(LayoutStringValueWitnesses)
 UNINTERESTING_FEATURE(LayoutStringValueWitnessesInstantiation)
 UNINTERESTING_FEATURE(DifferentiableProgramming)
@@ -475,6 +477,7 @@ UNINTERESTING_FEATURE(ForwardModeDifferentiation)
 UNINTERESTING_FEATURE(AdditiveArithmeticDerivedConformances)
 UNINTERESTING_FEATURE(SendableCompletionHandlers)
 UNINTERESTING_FEATURE(OpaqueTypeErasure)
+UNINTERESTING_FEATURE(PackageCMO)
 UNINTERESTING_FEATURE(ParserRoundTrip)
 UNINTERESTING_FEATURE(ParserValidation)
 UNINTERESTING_FEATURE(ParserDiagnostics)

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -301,48 +301,6 @@ bool ArgsToFrontendOptionsConverter::convert(
         A->getOption().matches(OPT_serialize_debugging_options);
   }
 
-  if (Args.hasArg(OPT_enable_library_evolution)) {
-    Opts.SkipNonExportableDecls |=
-        Args.hasArg(OPT_experimental_skip_non_exportable_decls);
-
-    Opts.SkipNonExportableDecls |=
-        Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
-        Args.hasArg(
-            OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
-  } else {
-    if (Args.hasArg(OPT_experimental_skip_non_exportable_decls))
-      Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
-                     "-experimental-skip-non-exportable-decls",
-                     "-enable-library-evolution");
-  }
-
-  Opts.AllowNonResilientAccess = Args.hasArg(OPT_experimental_allow_non_resilient_access);
-  if (Opts.AllowNonResilientAccess) {
-    // Override the option to skip non-exportable decls.
-    if (Opts.SkipNonExportableDecls) {
-      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
-                     "-experimental-skip-non-exportable-decls",
-                     "-experimental-allow-non-resilient-access");
-      Opts.SkipNonExportableDecls = false;
-    }
-    // If built from interface, non-resilient access should not be allowed.
-    if (Opts.AllowNonResilientAccess &&
-        (Opts.RequestedAction == FrontendOptions::ActionType::CompileModuleFromInterface ||
-         Opts.RequestedAction == FrontendOptions::ActionType::TypecheckModuleFromInterface)) {
-      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
-                     "-experimental-allow-non-resilient-access",
-                     "-compile-module-from-interface or -typecheck-module-from-interface");
-      Opts.AllowNonResilientAccess = false;
-    }
-  }
-
-  // HACK: The driver currently erroneously passes all flags to module interface
-  // verification jobs. -experimental-skip-non-exportable-decls is not
-  // appropriate for verification tasks and should be ignored, though.
-  if (Opts.RequestedAction ==
-      FrontendOptions::ActionType::TypecheckModuleFromInterface)
-    Opts.SkipNonExportableDecls = false;
-
   Opts.DebugPrefixSerializedDebuggingOptions |=
       Args.hasArg(OPT_prefix_serialized_debugging_options);
   Opts.EnableSourceImport |= Args.hasArg(OPT_enable_source_import);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -681,8 +681,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnablePackageInterfaceLoad = Args.hasArg(OPT_experimental_package_interface_load) ||
                                     ::getenv("SWIFT_ENABLE_PACKAGE_INTERFACE_LOAD");
 
-  Opts.EnableBypassResilienceInPackage = Args.hasArg(OPT_experimental_package_bypass_resilience) ||
-                                         Opts.hasFeature(Feature::ClientBypassResilientAccessInPackage);
+  Opts.EnableBypassResilienceInPackage =
+      Args.hasArg(OPT_experimental_package_bypass_resilience) ||
+      Opts.hasFeature(Feature::ClientBypassResilientAccessInPackage);
 
   Opts.DisableAvailabilityChecking |=
       Args.hasArg(OPT_disable_availability_checking);
@@ -1115,11 +1116,12 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   if (Args.hasArg(OPT_enable_library_evolution)) {
     Opts.SkipNonExportableDecls |=
-    Args.hasArg(OPT_experimental_skip_non_exportable_decls);
+        Args.hasArg(OPT_experimental_skip_non_exportable_decls);
 
     Opts.SkipNonExportableDecls |=
-    Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
-    Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
+        Args.hasArg(OPT_experimental_skip_non_inlinable_function_bodies) &&
+        Args.hasArg(
+            OPT_experimental_skip_non_inlinable_function_bodies_is_lazy);
   } else {
     if (Args.hasArg(OPT_experimental_skip_non_exportable_decls))
       Diags.diagnose(SourceLoc(), diag::ignoring_option_requires_option,
@@ -1127,8 +1129,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                      "-enable-library-evolution");
   }
 
-  Opts.AllowNonResilientAccess = Args.hasArg(OPT_experimental_allow_non_resilient_access) ||
-                                 Opts.hasFeature(Feature::AllowNonResilientAccessInPackage);
+  Opts.AllowNonResilientAccess =
+      Args.hasArg(OPT_experimental_allow_non_resilient_access) ||
+      Opts.hasFeature(Feature::AllowNonResilientAccessInPackage);
   if (Opts.AllowNonResilientAccess) {
     // Override the option to skip non-exportable decls.
     if (Opts.SkipNonExportableDecls) {
@@ -1139,11 +1142,14 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
     // If built from interface, non-resilient access should not be allowed.
     if (Opts.AllowNonResilientAccess &&
-        (FrontendOpts.RequestedAction == FrontendOptions::ActionType::CompileModuleFromInterface ||
-         FrontendOpts.RequestedAction == FrontendOptions::ActionType::TypecheckModuleFromInterface)) {
-      Diags.diagnose(SourceLoc(), diag::warn_ignore_option_overriden_by,
-                     "-experimental-allow-non-resilient-access",
-                     "-compile-module-from-interface or -typecheck-module-from-interface");
+        (FrontendOpts.RequestedAction ==
+             FrontendOptions::ActionType::CompileModuleFromInterface ||
+         FrontendOpts.RequestedAction ==
+             FrontendOptions::ActionType::TypecheckModuleFromInterface)) {
+      Diags.diagnose(
+          SourceLoc(), diag::warn_ignore_option_overriden_by,
+          "-experimental-allow-non-resilient-access",
+          "-compile-module-from-interface or -typecheck-module-from-interface");
       Opts.AllowNonResilientAccess = false;
     }
   }
@@ -2140,11 +2146,9 @@ void parseExclusivityEnforcementOptions(const llvm::opt::Arg *A,
 }
 
 static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
-                         IRGenOptions &IRGenOpts,
-                         const FrontendOptions &FEOpts,
+                         IRGenOptions &IRGenOpts, const FrontendOptions &FEOpts,
                          const TypeCheckerOptions &TCOpts,
-                         DiagnosticEngine &Diags,
-                         LangOptions &LangOpts,
+                         DiagnosticEngine &Diags, LangOptions &LangOpts,
                          ClangImporterOptions &ClangOpts) {
   using namespace options;
 
@@ -2484,7 +2488,7 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
   if (const Arg *A = Args.getLastArg(options::OPT_sanitize_EQ)) {
     Opts.Sanitizers = parseSanitizerArgValues(
         Args, A, LangOpts.Target, Diags,
-        /* sanitizerRuntimeLibExists= */[](StringRef libName, bool shared) {
+        /* sanitizerRuntimeLibExists= */ [](StringRef libName, bool shared) {
 
           // The driver has checked the existence of the library
           // already.
@@ -3332,8 +3336,7 @@ bool CompilerInvocation::parseArgs(
   }
 
   if (ParseSILArgs(SILOpts, ParsedArgs, IRGenOpts, FrontendOpts,
-                   TypeCheckerOpts, Diags,
-                   LangOpts, ClangImporterOpts)) {
+                   TypeCheckerOpts, Diags, LangOpts, ClangImporterOpts)) {
     return true;
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1402,7 +1402,7 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     if (Invocation.getLangOptions().EnableCXXInterop &&
         Invocation.getLangOptions().RequireCxxInteropToImportCxxInteropModule)
       MainModule->setHasCxxInteroperability();
-    if (Invocation.getFrontendOptions().AllowNonResilientAccess)
+    if (Invocation.getLangOptions().AllowNonResilientAccess)
       MainModule->setAllowNonResilientAccess();
 
     // Register the main module with the AST context.

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -249,7 +249,8 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
 
   serializationOpts.IsOSSA = getSILOptions().EnableOSSAModules;
 
-  serializationOpts.SkipNonExportableDecls = opts.SkipNonExportableDecls;
+  serializationOpts.SkipNonExportableDecls =
+      getLangOptions().SkipNonExportableDecls;
 
   serializationOpts.ExplicitModuleBuild = FrontendOpts.DisableImplicitModules;
 


### PR DESCRIPTION
Create features mapped to package optimization flags to
allow a more standard way to pass experimental features
from build systems. Also moved other flags relevant to
diagnostics from Frontend options to Lang options.

Ref: rdar://124648653
