### PR TITLE
Opt in for package linkage in hasPublicOrPackageVisibility

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -132,7 +132,7 @@ public:
   /// to be built in the same project. To enable this optimization, the
   /// module also needs to opt in to allow non-resilient access with
   /// -experimental-allow-non-resilient-access.
-  bool EnableSerializePackage = true;
+  bool EnableSerializePackage = false;
 
   /// Enables the emission of stack protectors in functions.
   bool EnableStackProtection = true;

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -289,6 +289,9 @@ inline bool hasPublicVisibility(SILLinkage linkage) {
   llvm_unreachable("Unhandled SILLinkage in switch.");
 }
 
+/// Opt in package linkage for visibility in case Package CMO is enabled.
+/// Used in SIL verification and other checks that determine inlinability to
+/// accomodate for the optimization.
 inline bool hasPublicOrPackageVisibility(SILLinkage linkage, bool includePackage) {
     switch (linkage) {
     case SILLinkage::Public:

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -899,7 +899,9 @@ bool SILFunction::hasValidLinkageForFragileRef() const {
     return false;
 
   // Otherwise, only public or package functions can be referenced.
-  return hasPublicOrPackageVisibility(getLinkage(), getModule().getOptions().EnableSerializePackage);
+  // If it has a package linkage at this point, package CMO must
+  // have been enabled, so opt in for visibility.
+  return hasPublicOrPackageVisibility(getLinkage(), /*includePackage*/ true);
 }
 
 bool

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2418,8 +2418,10 @@ public:
               "cannot access storage of resilient global");
     }
     if (F.isSerialized()) {
+      // If it has a package linkage at this point, package CMO must
+      // have been enabled, so opt in for visibility.
       require(RefG->isSerialized()
-                || hasPublicOrPackageVisibility(RefG->getLinkage(), F.getModule().getOptions().EnableSerializePackage),
+              || hasPublicOrPackageVisibility(RefG->getLinkage(), /*includePackage*/ true),
               "alloc_global inside fragile function cannot "
               "reference a private or hidden symbol");
     }
@@ -2437,8 +2439,10 @@ public:
               "cannot access storage of resilient global");
     }
     if (F.isSerialized()) {
+      // If it has a package linkage at this point, package CMO must
+      // have been enabled, so opt in for visibility.
       require(RefG->isSerialized()
-              || hasPublicOrPackageVisibility(RefG->getLinkage(), F.getModule().getOptions().EnableSerializePackage),
+              || hasPublicOrPackageVisibility(RefG->getLinkage(), /*includePackage*/ true),
               "global_addr/value inside fragile function cannot "
               "reference a private or hidden symbol");
     }


### PR DESCRIPTION
If package-cmo is enabled, package linkage should be treated visible. 
rdar://124651962
