### PR TITLE
[embedded] Use `__has_feature(swiftcc)` to detect Swift calling convention

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -228,8 +228,12 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 
 // SWIFT_CC(swiftasync) is the Swift async calling convention.
 // We assume that it supports mandatory tail call elimination.
-#if __has_feature(swiftasynccc) && __has_attribute(swiftasynccall)
-#define SWIFT_CC_swiftasync __attribute__((swiftasynccall))
+#if __has_attribute(swiftasynccall)
+# if __has_feature(swiftasynccc) || __has_extension(swiftasynccc)
+#  define SWIFT_CC_swiftasync __attribute__((swiftasynccall))
+# else
+#  define SWIFT_CC_swiftasync SWIFT_CC_swift
+# endif
 #else
 #define SWIFT_CC_swiftasync SWIFT_CC_swift
 #endif

--- a/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
+++ b/stdlib/public/SwiftShims/swift/shims/EmbeddedShims.h
@@ -28,8 +28,9 @@
 extern "C" {
 #endif
 
-// FIXME: Replace with __has_feature(swiftcc) once that's added to Clang.
-#if __has_feature(swiftasynccc)
+// TODO: __has_feature(swiftasynccc) is just for older clang. Remove this
+// when we no longer support older clang.
+#if __has_extension(swiftcc) || __has_feature(swiftasynccc)
 #define SWIFT_CC_swift __attribute__((swiftcall))
 #define SWIFT_CONTEXT __attribute__((swift_context))
 #define SWIFT_ERROR_RESULT __attribute__((swift_error_result))

--- a/test/embedded/classes-wasm.swift
+++ b/test/embedded/classes-wasm.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %swift-frontend -c %t/check.swift -parse-as-library -target wasm32-unknown-none-wasm \
+// RUN:   -enable-experimental-feature Embedded -Xcc -fdeclspec -disable-stack-protector \
+// RUN:   -o %t/check.o
+// RUN: %clang -target wasm32-unknown-none-wasm %t/check.o %t/rt.c -nostdlib -o %t/check.wasm
+// RUN: %target-run %t/check.wasm
+// REQUIRES: executable_test
+// REQUIRES: CPU=wasm32
+
+//--- rt.c
+
+#include <stddef.h>
+#include <stdint.h>
+
+void free(void *ptr) {}
+
+int posix_memalign(void **memptr, size_t alignment, size_t size) {
+    uintptr_t mem = __builtin_wasm_memory_grow(0, (size + 0xffff) / 0x10000);
+    if (mem == -1) {
+        return -1;
+    }
+    *memptr = (void *)(mem * 0x10000);
+    *memptr = (void *)(((uintptr_t)*memptr + alignment - 1) & -alignment);
+    return 0;
+}
+
+//--- check.swift
+
+class Foo {}
+
+@_cdecl("_start")
+func main() {
+  _ = Foo()
+}

--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -101,7 +101,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         # Test configuration
         self.cmake_options.define('SWIFT_INCLUDE_TESTS:BOOL', 'TRUE')
         self.cmake_options.define('SWIFT_ENABLE_SOURCEKIT_TESTS:BOOL', 'FALSE')
-        lit_test_paths = ['IRGen', 'stdlib', 'Concurrency/Runtime']
+        lit_test_paths = ['IRGen', 'stdlib', 'Concurrency/Runtime', 'embedded']
         lit_test_paths = [os.path.join(
             self.build_dir, 'test-wasi-wasm32', path) for path in lit_test_paths]
         self.cmake_options.define('SWIFT_LIT_TEST_PATHS:STRING',


### PR DESCRIPTION
This change replaces the use of `__has_feature(swiftasynccc)` with `__has_feature(swiftcc)` to detect the SwiftCC availability. The former condition works fine for most platforms that support both SwiftCC and SwiftAsyncCC or neither, but it fails for WebAssembly, which supports SwiftCC but not SwiftAsyncCC.

This change depends on https://github.com/llvm/llvm-project/pull/85347

Close https://github.com/apple/swift/issues/72343