### PR TITLE
Enable `@_preInverseGenerics` to suppress mangled names in more places

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -521,8 +521,8 @@ std::string
 IRGenMangler::mangleConformanceSymbol(Type type,
                                       const ProtocolConformance *Conformance,
                                       const char *Op) {
-llvm::SaveAndRestore X(AllowInverses,
-                       inversesAllowedIn(Conformance->getDeclContext()));
+  llvm::SaveAndRestore X(AllowInverses,
+                         inversesAllowedIn(Conformance->getDeclContext()));
 
   beginMangling();
   if (type)

--- a/lib/IRGen/IRGenMangler.h
+++ b/lib/IRGen/IRGenMangler.h
@@ -46,6 +46,7 @@ public:
   IRGenMangler() { }
 
   std::string mangleDispatchThunk(const FuncDecl *func) {
+    llvm::SaveAndRestore X(AllowInverses, inversesAllowed(func));
     beginMangling();
     appendEntity(func);
     appendOperator("Tj");
@@ -55,6 +56,7 @@ public:
   std::string mangleDerivativeDispatchThunk(
       const AbstractFunctionDecl *func,
       AutoDiffDerivativeFunctionIdentifier *derivativeId) {
+    llvm::SaveAndRestore X(AllowInverses, inversesAllowed(func));
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
     auto *resultIndices =
@@ -71,6 +73,7 @@ public:
 
   std::string mangleConstructorDispatchThunk(const ConstructorDecl *ctor,
                                              bool isAllocating) {
+    llvm::SaveAndRestore X(AllowInverses, inversesAllowed(ctor));
     beginMangling();
     appendConstructorEntity(ctor, isAllocating);
     appendOperator("Tj");
@@ -78,6 +81,7 @@ public:
   }
 
   std::string mangleMethodDescriptor(const FuncDecl *func) {
+    llvm::SaveAndRestore X(AllowInverses, inversesAllowed(func));
     beginMangling();
     appendEntity(func);
     appendOperator("Tq");
@@ -87,6 +91,7 @@ public:
   std::string mangleDerivativeMethodDescriptor(
       const AbstractFunctionDecl *func,
       AutoDiffDerivativeFunctionIdentifier *derivativeId) {
+    llvm::SaveAndRestore X(AllowInverses, inversesAllowed(func));
     beginManglingWithAutoDiffOriginalFunction(func);
     auto kind = Demangle::getAutoDiffFunctionKind(derivativeId->getKind());
     auto *resultIndices =
@@ -103,6 +108,7 @@ public:
 
   std::string mangleConstructorMethodDescriptor(const ConstructorDecl *ctor,
                                                 bool isAllocating) {
+    llvm::SaveAndRestore X(AllowInverses, inversesAllowed(ctor));
     beginMangling();
     appendConstructorEntity(ctor, isAllocating);
     appendOperator("Tq");
@@ -394,6 +400,7 @@ public:
   }
 
   std::string mangleFieldOffset(const ValueDecl *Decl) {
+    llvm::SaveAndRestore X(AllowInverses, inversesAllowed(Decl));
     beginMangling();
     appendEntity(Decl);
     appendOperator("Wvd");

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -29,6 +29,9 @@ extension CallMe {
   }
 }
 
+// CHECK: @"$s4test13ManagedBufferC12_doNotCallMeACyxq_Gyt_tcfCTq"
+
+
 public protocol Hello<Person>: ~Copyable {
   // CHECK: @"$s4test5HelloP6PersonAC_AA1PTn"
   // CHECK: @"$s6Person4test5HelloPTl" =
@@ -57,4 +60,19 @@ struct XQ<T: ~Copyable>: ~Copyable {
 
 extension XQ: Q where T: ~Copyable {
   struct A { }
+}
+
+// Class metadata
+
+@_fixed_layout
+open class ManagedBuffer<Header, Element: ~Copyable> {
+   @_preInverseGenerics
+  public final var header: Header
+
+  // CHECK: @"$s4test13ManagedBufferC12_doNotCallMeACyxq_Gyt_tcfCTj"
+  @_preInverseGenerics
+  @usableFromInline
+  internal init(_doNotCallMe: ()) {
+    fatalError("boom")
+  }
 }


### PR DESCRIPTION
Fixes rdar://124644596.
