### PR TITLE
[region-isolation] Enable region isolation by default with strict-concurrency

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1057,6 +1057,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Opts.StrictConcurrencyLevel == StrictConcurrency::Complete) {
     Opts.enableFeature(Feature::IsolatedDefaultValues);
     Opts.enableFeature(Feature::GlobalConcurrency);
+    Opts.enableFeature(Feature::RegionBasedIsolation);
   }
 
   Opts.WarnImplicitOverrides =


### PR DESCRIPTION
I added a disable flag -disable-region-based-isolation-with-strict-concurrency so that we do not need to update the current tests.

----

NOTE: I am just starting the source combat testing. I am going to add actual usage of disable-region-based-isolation-with-strict-concurrency in a bit.