### PR TITLE
[Test] Update test and target to 5.6 aligned.

### DIFF
--- a/test/Interpreter/builtin_bridge_object.swift
+++ b/test/Interpreter/builtin_bridge_object.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-Onone -parse-stdlib -Xfrontend -enable-copy-propagation) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG
-// RUN: %target-run-simple-swift(-O -parse-stdlib -Xfrontend -enable-copy-propagation) | %FileCheck --check-prefixes=CHECK,CHECK-OPT %s
+// RUN: %target-run-simple-swift(-Onone -parse-stdlib -Xfrontend -enable-copy-propagation -target %target-swift-abi-5.6-triple) | %FileCheck %s --check-prefixes=CHECK,CHECK-DBG
+// RUN: %target-run-simple-swift(-O -parse-stdlib -Xfrontend -enable-copy-propagation -target %target-swift-abi-5.6-triple) | %FileCheck --check-prefixes=CHECK,CHECK-OPT %s
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
@@ -160,7 +160,7 @@ if true {
   
   var bo3 = nonNativeBridgeObject(unTaggedString)
   print(Bool(_builtinBooleanLiteral: Builtin.isUnique(&bo3)))
-  // CHECK-NEXT: false
+  // CHECK-NEXT: true
   _fixLifetime(bo3)
 }
 


### PR DESCRIPTION
The test emits a different function based on deployment target.  And that different function results in different behavior.  But some platforms don't have old enough deployment targets to use the function for older platforms.  So just target newer platforms.

rdar://124700033
