### PR TITLE
[Parser] Remove remaining `-disable-experimental-parser-round-trip` uses in test cases

### DIFF
--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -disable-experimental-parser-round-trip -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify -enable-upcoming-feature RegionBasedIsolation %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -strict-concurrency=complete -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify -enable-upcoming-feature RegionBasedIsolation %s -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/ModuleInterface/lifetime_dependence_test.swift
+++ b/test/ModuleInterface/lifetime_dependence_test.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
-// RUN:     -disable-experimental-parser-round-trip \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o %t/lifetime_dependence.swiftmodule \
@@ -16,13 +15,11 @@
 // See if we can compile a module through just the interface and typecheck using it.
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
-// RUN:    -disable-experimental-parser-round-trip \
 // RUN:    -enable-experimental-feature NoncopyableGenerics \
 // RUN:    -enable-experimental-feature NonescapableTypes \
 // RUN:    %t/lifetime_dependence.swiftinterface -o %t/lifetime_dependence.swiftmodule
 
 // RUN: %target-swift-frontend -typecheck -I %t %s \
-// RUN:    -disable-experimental-parser-round-trip \
 // RUN:    -enable-experimental-feature NoncopyableGenerics \
 // RUN:    -enable-experimental-feature NonescapableTypes
 

--- a/test/Parse/explicit_lifetime_dependence_specifiers.swift
+++ b/test/Parse/explicit_lifetime_dependence_specifiers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip   -enable-experimental-feature NoncopyableGenerics -enable-builtin-module
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics -enable-builtin-module
 // REQUIRES: asserts
 
 import Builtin

--- a/test/Parse/result_depends_on.swift
+++ b/test/Parse/result_depends_on.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip
+// RUN: %target-typecheck-verify-swift  -enable-builtin-module -enable-experimental-feature NonescapableTypes
 // REQUIRES: asserts
 
 import Builtin

--- a/test/Parse/transferring.swift
+++ b/test/Parse/transferring.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-experimental-parser-round-trip -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: asserts
 

--- a/test/SIL/explicit_lifetime_dependence_specifiers.swift
+++ b/test/SIL/explicit_lifetime_dependence_specifiers.swift
@@ -2,7 +2,6 @@
 // RUN: -emit-sil  \
 // RUN: -enable-builtin-module \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -disable-experimental-parser-round-trip \
 // RUN: -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
 
 

--- a/test/SIL/implicit_lifetime_dependence.swift
+++ b/test/SIL/implicit_lifetime_dependence.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s \
 // RUN: -emit-sil  \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -disable-experimental-parser-round-trip \
 // RUN: -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
 // REQUIRES: asserts
 

--- a/test/SIL/lifetime_dependence_buffer_view_test.swift
+++ b/test/SIL/lifetime_dependence_buffer_view_test.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-lifetime-dependence-inference \

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend %s -emit-sil \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
 

--- a/test/SIL/result_depends_on.swift
+++ b/test/SIL/result_depends_on.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend %s -emit-sil  -enable-builtin-module -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip
+// RUN: %target-swift-frontend %s -emit-sil  -enable-builtin-module -enable-experimental-feature NonescapableTypes
 // REQUIRES: asserts
 
 import Builtin

--- a/test/SILOptimizer/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   2>&1 | %FileCheck %s
 

--- a/test/SILOptimizer/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence_generic.swift
@@ -2,7 +2,6 @@
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -parse-stdlib -module-name Swift

--- a/test/SILOptimizer/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence_insertion.swift
@@ -2,7 +2,6 @@
 // RUN:   -Xllvm -sil-print-after=lifetime-dependence-insertion \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -o /dev/null 2>&1 | %FileCheck %s
 

--- a/test/SILOptimizer/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence_mutate.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence_param.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_param_fail.swift
@@ -3,7 +3,6 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
-// RUN:   -disable-experimental-parser-round-trip \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   2>&1 | %FileCheck %s
 

--- a/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope_fixup.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-sil -o /dev/null -verify \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -disable-experimental-parser-round-trip \
 // RUN: -enable-experimental-feature NoncopyableGenerics
 
 // REQUIRES: asserts

--- a/test/Sema/explicit_lifetime_dependence_specifiers1.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers1.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip   -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics
 // REQUIRES: asserts
 
 struct Container {

--- a/test/Sema/explicit_lifetime_dependence_specifiers2.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers2.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -disable-experimental-parser-round-trip   -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BitwiseCopyable
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BitwiseCopyable
 // REQUIRES: asserts
 // REQUIRES: noncopyable_generics
 // REQUIRES: nonescapable_types

--- a/test/Sema/transferring.swift
+++ b/test/Sema/transferring.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -disable-experimental-parser-round-trip -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults
 
 // REQUIRES: asserts
 // REQUIRES: concurrency

--- a/test/Serialization/explicit_lifetime_dependence.swift
+++ b/test/Serialization/explicit_lifetime_dependence.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_explicit_lifetime_dependence.swift \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -disable-experimental-parser-round-trip \
 // RUN: -enable-experimental-feature NoncopyableGenerics \
 // RUN: -disable-lifetime-dependence-diagnostics
 
@@ -9,7 +8,6 @@
 
 // RUN: %target-swift-frontend -module-name lifetime-dependence -emit-sil -I %t %s \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -disable-experimental-parser-round-trip \
 // RUN: -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
 
 import def_explicit_lifetime_dependence

--- a/test/Serialization/implicit_lifetime_dependence.swift
+++ b/test/Serialization/implicit_lifetime_dependence.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t  %S/Inputs/def_implicit_lifetime_dependence.swift \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -disable-experimental-parser-round-trip \
 // RUN: -enable-experimental-feature NoncopyableGenerics \
 // RUN: -disable-lifetime-dependence-diagnostics
 
@@ -9,7 +8,6 @@
 
 // RUN: %target-swift-frontend -module-name lifetime-dependence -emit-sil -I %t %s \
 // RUN: -enable-experimental-feature NonescapableTypes \
-// RUN: -disable-experimental-parser-round-trip \
 // RUN: -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
 
 import def_implicit_lifetime_dependence

--- a/test/Serialization/transferring.swift
+++ b/test/Serialization/transferring.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults -disable-experimental-parser-round-trip -module-name transferring_test -emit-module -o %t/transferring_test.swiftmodule %S/Inputs/transferring.swift
-// RUN: %target-swift-frontend -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults -disable-experimental-parser-round-trip -emit-sil -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults -module-name transferring_test -emit-module -o %t/transferring_test.swiftmodule %S/Inputs/transferring.swift
+// RUN: %target-swift-frontend -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults -emit-sil -I %t %s | %FileCheck %s
 // RUN: %target-sil-opt -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults %t/transferring_test.swiftmodule | %FileCheck -check-prefix=AST %s
 
 // REQUIRES: concurrency


### PR DESCRIPTION
All the features in these test cases are now supported by the new parser, so we don’t need the opt-out anymore.

rdar://124646502
