### PR TITLE
[IRGen] Defer materializing metadata for outlining

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1861,6 +1861,7 @@ namespace {
                                            DeinitIsNeeded);
       IGF.getTypeInfo(theEnumType)
           .collectMetadataForOutlining(collector, theEnumType);
+      collector.materialize();
       if (!consumeEnumFunction)
         consumeEnumFunction =
             emitConsumeEnumFunction(IGF.IGM, theEnumType, collector);
@@ -4870,6 +4871,7 @@ namespace {
         OutliningMetadataCollector collector(T, IGF, LayoutIsNotNeeded,
                                              DeinitIsNeeded);
         IGF.getTypeInfo(T).collectMetadataForOutlining(collector, T);
+        collector.materialize();
         if (!consumeEnumFunction)
           consumeEnumFunction = emitConsumeEnumFunction(IGM, T, collector);
         Explosion tmp;

--- a/lib/IRGen/Outlining.h
+++ b/lib/IRGen/Outlining.h
@@ -21,6 +21,7 @@
 #include "LocalTypeDataKind.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/TaggedUnion.h"
 #include "swift/IRGen/GenericRequirement.h"
 #include "swift/SIL/SILType.h"
 #include "llvm/ADT/MapVector.h"
@@ -55,13 +56,34 @@ enum DeinitIsNeeded_t : bool {
   DeinitIsNeeded = true
 };
 
-/// A helper class for emitting outlined value operations.
+/// Emit outlined value operations.
 ///
-/// The use-pattern for this class is:
-///   - construct it
-///   - collect all the metadata that will be required in order to perform
-///     the value operations
-///   - emit the call to the outlined copy/destroy helper
+/// The typical use-pattern is:
+/// - construct it
+///   OutliningMetadataCollector::OutliningMetadataCollector
+/// - collect polymorphic values required for outlining
+///   TypeInfo::collectMetadataForOutlining
+/// - materialize the arguments for those values in the caller
+///   OutliningMetadataCollector::materialize
+/// - emit the call to the outlined value function
+///   OutliningMetadataCollector::emitCallToOutlined(Copy|Destroy|Release)
+///
+/// For custom outlined functions (e.g. the outlined consume function for enums)
+/// the use-pattern is:
+/// - construct it
+///   OutliningMetadataCollector::OutliningMetadataCollector
+/// - collect polymorphic values required for outlining
+///   TypeInfo::collectMetadataForOutlining
+/// - materialize the arguments for those values in the caller
+///   OutliningMetadataCollector::materialize
+/// - add the polymorphic arguments to the list of arguments to be passed
+///   OutliningMetadataCollector::addPolymorphicArguments
+/// - when creating the outlined function, add the polymorphic parameters to its
+///   signature
+///   OutliningMetadataCollector::addPolymorphicParameterTypes
+/// - when emitting the outlined function, after binding the custom parameters,
+///   bind the polymorphic parameters
+///   OutliningMetadataCollector::bindPolymorphicParameters
 class OutliningMetadataCollector {
 public:
   SILType T;
@@ -69,20 +91,10 @@ public:
   const unsigned needsLayout : 1;
   const unsigned needsDeinit : 1;
 
-private:
-  llvm::MapVector<LocalTypeDataKey, llvm::Value *> Values;
-  llvm::MapVector<GenericRequirement, llvm::Value *> Requirements;
-  std::optional<SubstitutionMap> Subs;
-  friend class IRGenModule;
-
-public:
   OutliningMetadataCollector(SILType T, IRGenFunction &IGF,
                              LayoutIsNeeded_t needsLayout,
                              DeinitIsNeeded_t needsDeinitTypes);
-
-  unsigned size() const {
-    return Subs.has_value() ? Requirements.size() : Values.size();
-  }
+  unsigned size() const;
 
   // If any local type data is needed for \p type, add it.
   //
@@ -102,13 +114,207 @@ public:
   addPolymorphicParameterTypes(SmallVectorImpl<llvm::Type *> &paramTys) const;
   void bindPolymorphicParameters(IRGenFunction &helperIGF,
                                  Explosion &params) const;
+  void materialize();
 
 private:
-  void collectTypeMetadataForLayout(SILType type);
-  void collectTypeMetadataForDeinit(SILType type);
-  void collectFormalTypeMetadata(CanType type);
-  void collectRepresentationTypeMetadata(SILType ty);
+  void collectTypeMetadataForLayout(SILType ty);
+  void collectTypeMetadataForDeinit(SILType ty);
+
+  /// Emulates the following enum with associated values:
+  ///
+  /// enum State {
+  ///   case empty
+  ///   enum Collecting {
+  ///     enum Element {
+  ///       case metadataForFormal(CanType)
+  ///       case metadataForRepresentation(SILType)
+  ///     }
+  ///     case elements([Element])
+  ///     case environment
+  ///   }
+  ///   case collecting(Collecting)
+  ///   enum Collected {
+  ///     case elements([LocalTypeDataKey : llvm::Value *])
+  ///     case environment(SubstitutionMap [GenericRequirement : llvm::Value *])
+  ///   }
+  ///   case collected(Collected)
+  /// }
+  class State {
+  public:
+    enum class CollectionKind {
+      Elements,
+      Environment,
+    };
+    enum class ElementKind {
+      MetadataForFormal,
+      MetadataForRepresentation,
+    };
+
+  private:
+    struct Empty {};
+    class Collecting {
+      struct Elements {
+        class Element {
+          struct MetadataForFormal {
+            CanType ty;
+          };
+          struct MetadataForRepresentation {
+            SILType ty;
+          };
+          using Payload =
+              TaggedUnion<MetadataForFormal, MetadataForRepresentation>;
+          Payload payload;
+          Element(Payload payload) : payload(payload) {}
+
+        public:
+          using Kind = ElementKind;
+          operator Kind() {
+            if (payload.isa<MetadataForFormal>())
+              return Kind::MetadataForFormal;
+            return Kind::MetadataForRepresentation;
+          }
+          static Element metadataForFormal(CanType ty) {
+            return {MetadataForFormal{ty}};
+          }
+          static Element metadataForRepresentation(SILType ty) {
+            return {MetadataForRepresentation{ty}};
+          }
+          CanType getFormalType() {
+            return payload.get<MetadataForFormal>().ty;
+          }
+          SILType getRepresentationType() {
+            return payload.get<MetadataForRepresentation>().ty;
+          }
+        };
+        llvm::SmallVector<Element, 4> elements;
+      };
+      struct Environment {};
+      using Payload = TaggedUnion<Elements, Environment>;
+      Payload payload;
+
+    public:
+      Collecting() : payload(Elements{}) {}
+      using Kind = CollectionKind;
+      operator Kind() const {
+        if (payload.isa<Elements>()) {
+          return Kind::Elements;
+        }
+        return Kind::Environment;
+      }
+      void addRepresentationTypeMetadata(SILType ty) {
+        if (*this == Kind::Environment)
+          return;
+        payload.get<Elements>().elements.push_back(
+            Elements::Element::metadataForRepresentation(ty));
+      }
+      void addFormalTypeMetadata(CanType ty) {
+        if (*this == Kind::Environment)
+          return;
+        payload.get<Elements>().elements.push_back(
+            Elements::Element::metadataForFormal(ty));
+      }
+      void addValueTypeWithDeinit(SILType ty) {
+        if (*this == Kind::Environment)
+          return;
+        payload = {Environment{}};
+      }
+      Elements &getElements() { return payload.get<Elements>(); };
+    };
+
+  public:
+    class Collected {
+    public:
+      struct Elements {
+        llvm::MapVector<LocalTypeDataKey, llvm::Value *> Values;
+      };
+      struct Environment {
+        llvm::MapVector<GenericRequirement, llvm::Value *> Requirements;
+        SubstitutionMap Subs;
+      };
+
+    private:
+      using Payload = TaggedUnion<Elements, Environment>;
+      Payload payload;
+      Collected(Payload payload) : payload(payload) {}
+
+    public:
+      using Kind = CollectionKind;
+      operator Kind() const {
+        if (payload.isa<Elements>())
+          return Kind::Elements;
+        return Kind::Environment;
+      }
+      static Collected elements() { return {Elements{}}; };
+      static Collected environment(SubstitutionMap subs) {
+        return {Environment{{}, subs}};
+      }
+      Elements &getElements() { return payload.get<Elements>(); }
+      Elements const &getElements() const { return payload.get<Elements>(); }
+      Environment &getEnvironment() { return payload.get<Environment>(); }
+      Environment const &getEnvironment() const {
+        return payload.get<Environment>();
+      }
+      unsigned size() const {
+        switch (*this) {
+        case Kind::Elements:
+          return getElements().Values.size();
+        case Kind::Environment:
+          return getEnvironment().Requirements.size();
+        }
+      }
+    };
+
+  private:
+    using Payload = TaggedUnion<Empty, Collecting, Collected>;
+    Payload payload;
+
+  public:
+    State() : payload(Empty{}) {}
+    enum class Kind {
+      Empty,
+      Collecting,
+      Collected,
+    };
+    operator Kind() const {
+      if (payload.isa<Empty>())
+        return Kind::Empty;
+      if (payload.isa<Collecting>())
+        return Kind::Collecting;
+      return Kind::Collected;
+    }
+    Collecting &getCollecting() {
+      if (payload.isa<Empty>())
+        payload = Collecting{};
+      return payload.get<Collecting>();
+    }
+    Collected const &getCollected() const { return payload.get<Collected>(); }
+    Collected::Elements &setCollectedElements() {
+      assert(*this == Kind::Collecting);
+      payload = Collected::elements();
+      return payload.get<Collected>().getElements();
+    }
+    Collected::Environment &setCollectedEnvironment(SubstitutionMap subs) {
+      assert(*this == Kind::Collecting);
+      payload = Collected::environment(subs);
+      return payload.get<Collected>().getEnvironment();
+    }
+  };
+  State state;
+  bool hasFinished() const {
+    return state == State::Kind::Empty || state == State::Kind::Collected;
+  }
+
+  void materializeFormalTypeMetadata(CanType ty,
+                                     State::Collected::Elements &into);
+  void materializeRepresentationTypeMetadata(SILType ty,
+                                             State::Collected::Elements &into);
+
+  friend class IRGenModule;
 };
+
+inline unsigned OutliningMetadataCollector::size() const {
+  return state.getCollected().size();
+}
 
 std::pair<CanType, CanGenericSignature>
 getTypeAndGenericSignatureForManglingOutlineFunction(SILType type);

--- a/test/IRGen/moveonly_value_functions.swift
+++ b/test/IRGen/moveonly_value_functions.swift
@@ -216,6 +216,8 @@ public func takeOuterNC_1<T>(_ o: consuming OuterNC_1<T>) {
 // CHECK-SAME:      ptr{{.*}} %0,
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
+// CHECK-NOT:     @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"
+// CHECK-NOT:     @"$s24moveonly_value_functions9OuterNC_2VMa"
 // CHECK:         call{{.*}} @"$s24moveonly_value_functions9OuterNC_2VyxGlWOh"(
 // CHECK-SAME:        ptr %0,
 // CHECK-SAME:        ptr %T)
@@ -248,6 +250,8 @@ public func takeOuterNC_2<T>(_ o: consuming OuterNC_2<T>) {
 // CHECK-SAME:      ptr %T, 
 // CHECK-SAME:      ptr %T.P)
 // CHECK-SAME:  {
+// CHECK-NOT:     @"$s24moveonly_value_functions16GenericContext_1VA2A1PRzlE9Inner_NC1VMa"
+// CHECK-NOT:     @"$s24moveonly_value_functions16GenericContext_1VA2A1PRzlE9OuterNC_1VMa"
 // CHECK:         call ptr @"$s24moveonly_value_functions16GenericContext_1VA2A1PRzlE9OuterNC_1Vyx_GAaDRzlWOh"(
 // CHECK-SAME:        ptr %0, 
 // CHECK-SAME:        ptr %T, 
@@ -319,6 +323,8 @@ public func takeOuterSinglePayloadNC_2<T>(_ e: consuming OuterSinglePayloadNC_2<
 // CHECK-SAME:      ptr noalias %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME: {
+// CHECK-NOT:     @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"
+// CHECK-NOT:     @"$s24moveonly_value_functions22OuterSinglePayloadNC_3OMa"
 // CHECK:         call{{.*}} @"$s24moveonly_value_functions22OuterSinglePayloadNC_3OyxGlWOh"(
 // CHECK-SAME:        ptr %0, 
 // CHECK-SAME:        ptr %T)
@@ -341,6 +347,8 @@ public func takeOuterSinglePayloadNC_3<T>(_ e: consuming OuterSinglePayloadNC_3<
 // CHECK-SAME:      ptr noalias %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
+// CHECK-NOT:     @"$s24moveonly_value_functions26InnerDeinitingWithLayoutNCVMa"
+// CHECK-NOT:     @"$s24moveonly_value_functions21OuterMultiPayloadNC_1OMa"
 // CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_1OyxGlWOh"(
 // CHECK-SAME:        ptr %0, 
 // CHECK-SAME:        ptr %T)
@@ -416,6 +424,8 @@ public func takeOuterMultiPayloadNC_3<T>(_ e: consuming OuterMultiPayloadNC_3<T>
 // CHECK-SAME:      ptr noalias %0, 
 // CHECK-SAME:      ptr %T)
 // CHECK-SAME:  {
+// CHECK-NOT:     @"$s24moveonly_value_functions28InnerDeinitingDestructableNCVMa"
+// CHECK-NOT:     @"$s24moveonly_value_functions21OuterMultiPayloadNC_4OMa"
 // CHECK:         call{{.*}} @"$s24moveonly_value_functions21OuterMultiPayloadNC_4OyxGlWOh"(
 // CHECK-SAME:        ptr %0, 
 // CHECK-SAME:        ptr %T)


### PR DESCRIPTION
Rather than materializing the metadata on demand during visitation, only collect the types that may be required.  Finally, materialize everything that's needed at the end.
