### PR TITLE
[stdlib] make swiftinterfaces compatible with older toolchains

### DIFF
--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -169,6 +169,7 @@ extension ${Self}: LosslessStringConvertible {
       self.init(Substring(text))
     } else {
       self = 0.0
+#if hasFeature(TypedThrows)
       let success = _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
         text.withCString { chars -> Bool in
           switch chars[0] {
@@ -184,6 +185,23 @@ extension ${Self}: LosslessStringConvertible {
           return endPtr != nil && endPtr![0] == 0
         }
       }
+#else
+      let success = __abi_se0413_withUnsafeMutablePointer(to: &self) { p -> Bool in
+        text.withCString { chars -> Bool in
+          switch chars[0] {
+          case 9, 10, 11, 12, 13, 32:
+            return false // Reject leading whitespace
+          case 0:
+            return false // Reject empty string
+          default:
+            break
+          }
+          let endPtr = _swift_stdlib_strto${cFuncSuffix2[bits]}_clocale(chars, p)
+          // Succeed only if endPtr points to end of C string
+          return endPtr != nil && endPtr![0] == 0
+        }
+      }
+#endif
       if !success {
         return nil
       }
@@ -198,6 +216,7 @@ extension ${Self}: LosslessStringConvertible {
   @available(SwiftStdlib 5.3, *)
   public init?(_ text: Substring) {
     self = 0.0
+#if hasFeature(TypedThrows)
     let success = _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
       text.withCString { chars -> Bool in
         switch chars[0] {
@@ -213,6 +232,23 @@ extension ${Self}: LosslessStringConvertible {
         return endPtr != nil && endPtr![0] == 0
       }
     }
+#else
+    let success = __abi_se0413_withUnsafeMutablePointer(to: &self) { p -> Bool in
+      text.withCString { chars -> Bool in
+        switch chars[0] {
+        case 9, 10, 11, 12, 13, 32:
+          return false // Reject leading whitespace
+        case 0:
+          return false // Reject empty string
+        default:
+          break
+        }
+        let endPtr = _swift_stdlib_strto${cFuncSuffix2[bits]}_clocale(chars, p)
+        // Succeed only if endPtr points to end of C string
+        return endPtr != nil && endPtr![0] == 0
+      }
+    }
+#endif
     if !success {
       return nil
     }

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -158,9 +158,15 @@ public struct SystemRandomNumberGenerator: RandomNumberGenerator, Sendable {
   @inlinable
   public mutating func next() -> UInt64 {
     var random: UInt64 = 0
+#if hasFeature(TypedThrows)
     _withUnprotectedUnsafeMutablePointer(to: &random) {
       swift_stdlib_random($0, MemoryLayout<UInt64>.size)
     }
+#else
+    __abi_se0413_withUnsafeMutablePointer(to: &random) {
+      swift_stdlib_random($0, MemoryLayout<UInt64>.size)
+    }
+#endif
     return random
   }
 }

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -139,11 +139,19 @@ func _stdlib_atomicInitializeARCRef(
   let desiredPtr = unmanaged.toOpaque()
   let rawTarget = UnsafeMutableRawPointer(target).assumingMemoryBound(
     to: Optional<UnsafeRawPointer>.self)
+#if hasFeature(TypedThrows)
   let wonRace = withUnsafeMutablePointer(to: &expected) {
     _stdlib_atomicCompareExchangeStrongPtr(
       object: rawTarget, expected: $0, desired: desiredPtr
     )
   }
+#else
+  let wonRace = __abi_se0413_withUnsafeMutablePointer(to: &expected) {
+    _stdlib_atomicCompareExchangeStrongPtr(
+      object: rawTarget, expected: $0, desired: desiredPtr
+    )
+  }
+#endif
   if !wonRace {
     // Some other thread initialized the value.  Balance the retain that we
     // performed on 'desired'.

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -535,11 +535,19 @@ extension Unicode.Scalar {
 
     // The first code unit is in the least significant byte of codeUnits.
     codeUnits = codeUnits.littleEndian
+#if hasFeature(TypedThrows)
     return try Swift._withUnprotectedUnsafePointer(to: &codeUnits) {
       return try $0.withMemoryRebound(to: UInt8.self, capacity: 4) {
         return try body(UnsafeBufferPointer(start: $0, count: utf8Count))
       }
     }
+#else
+    return try Swift.__abi_se0413_withUnsafePointer(to: &codeUnits) {
+      return try $0.withMemoryRebound(to: UInt8.self, capacity: 4) {
+        return try body(UnsafeBufferPointer(start: $0, count: utf8Count))
+      }
+    }
+#endif
   }
 }
 

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1378,6 +1378,7 @@ public struct UnsafeMutableRawPointer: _Pointer {
       "storeBytes to misaligned raw pointer")
 
     var temp = value
+#if hasFeature(TypedThrows)
     withUnsafeMutablePointer(to: &temp) { source in
       let rawSrc = UnsafeMutableRawPointer(source)._rawValue
       // FIXME: to be replaced by _memcpy when conversions are implemented.
@@ -1385,6 +1386,15 @@ public struct UnsafeMutableRawPointer: _Pointer {
         (self + offset)._rawValue, rawSrc, UInt64(MemoryLayout<T>.size)._value,
         /*volatile:*/ false._value)
     }
+#else
+    __abi_se0413_withUnsafeMutablePointer(to: &temp) { source in
+      let rawSrc = UnsafeMutableRawPointer(source)._rawValue
+      // FIXME: to be replaced by _memcpy when conversions are implemented.
+      Builtin.int_memcpy_RawPointer_RawPointer_Int64(
+        (self + offset)._rawValue, rawSrc, UInt64(MemoryLayout<T>.size)._value,
+        /*volatile:*/ false._value)
+    }
+#endif
   }
 
   /// Copies the specified number of bytes from the given raw pointer's memory

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -215,11 +215,19 @@ public func _encodeBitsAsWords<T>(_ x: T) -> [Int] {
   _internalInvariant(!result.isEmpty)
   var tmp = x
   // FIXME: use UnsafeMutablePointer.assign(from:) instead of memcpy.
+#if hasFeature(TypedThrows)
   _withUnprotectedUnsafeMutablePointer(to: &tmp) {
     _memcpy(dest: UnsafeMutablePointer(result._baseAddressIfContiguous!),
             src: $0,
             size: UInt(MemoryLayout<T>.size))
   }
+#else
+  __abi_se0413_withUnsafeMutablePointer(to: &tmp) {
+    _memcpy(dest: UnsafeMutablePointer(result._baseAddressIfContiguous!),
+            src: $0,
+            size: UInt(MemoryLayout<T>.size))
+  }
+#endif
   return result
 }
 


### PR DESCRIPTION
Avoid failures when toolchains without typed throws are used