### PR TITLE
[embedded] Specialize superclasses in VTableSpecializer as part of MandatoryPerformanceOptimizations

### DIFF
--- a/test/embedded/generic-classes2.swift
+++ b/test/embedded/generic-classes2.swift
@@ -1,0 +1,31 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+// RUN: %target-run-simple-swift(-Osize -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+class B<T> {
+}
+
+class D<T>: B<T> {
+}
+
+func callee<T>(_ t: T.Type) {
+  _ = D<T>()
+}
+
+public func test() {
+  callee(Int.self)
+}
+
+@main
+struct Main {
+  static func main() {
+    test()
+    print("OK!")
+  }
+}
+
+// CHECK: OK!


### PR DESCRIPTION
We have some cases left where we fail to specialize a vtable, e.g. when it's a base class of a specialized class that's otherwise unused. When MandatoryPerformanceOptimizations specializes a vtable, let's immediate trigger specialization of all superclasses, too. This resolves a crash that the attached testcases triggers:
```
Assertion failed: (vtable), function emitEmbeddedVTable, file GenMeta.cpp, line 5113.
```

rdar://124581262
