### PR TITLE
#71870 Respect `@discardableResult` when calling with `try?`

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -87,7 +87,7 @@ namespace {
 
         TypeChecker::computeCaptures(CE);
         return Action::SkipNode(E);
-      } 
+      }
 
       if (auto CapE = dyn_cast<CaptureListExpr>(E)) {
         // Capture lists need to be reparented to enclosing autoclosures
@@ -1920,22 +1920,36 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
       .highlight(E->getSourceRange());
     return;
   }
-    
-  // Always complain about 'try?'.
-  if (auto *OTE = dyn_cast<OptionalTryExpr>(valueE)) {
-    DE.diagnose(OTE->getTryLoc(), diag::expression_unused_optional_try)
-      .highlight(E->getSourceRange());
-    return;
-  }
 
   if (auto *LE = dyn_cast<LiteralExpr>(valueE)) {
     diagnoseIgnoredLiteral(Context, LE);
     return;
   }
+  
+  ApplyExpr *call = nullptr;
+  
+  // Unwrap optional try to get inner function calls.
+  {
+    auto nextExpr = valueE;
+    while(true) {
+      if (nextExpr == nullptr) {
+        break;
+      } else if (auto applyExpr = dyn_cast<ApplyExpr>(nextExpr)) {
+        call = applyExpr;
+        break;
+      } else if (auto optionalTry = dyn_cast<OptionalTryExpr>(nextExpr)) {
+        nextExpr = optionalTry->getSubExpr();
+      } else if (auto implicitConversion = dyn_cast<InjectIntoOptionalExpr>(nextExpr)) {
+        nextExpr = implicitConversion->getSubExpr();
+      } else {
+        break;
+      }
+    }
+  }
 
   // Check if we have a call to a function not marked with
   // '@discardableResult'.
-  if (auto call = dyn_cast<ApplyExpr>(valueE)) {
+  if (call != nullptr) {
     // Dig through all levels of calls.
     Expr *fn = call->getFn();
     while (true) {
@@ -1971,6 +1985,13 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
       return;
 
     // Otherwise, complain.  Start with more specific diagnostics.
+    
+    // Always complain about 'try?'.
+    if (auto *OTE = dyn_cast<OptionalTryExpr>(valueE)) {
+      DE.diagnose(OTE->getTryLoc(), diag::expression_unused_optional_try)
+        .highlight(E->getSourceRange());
+      return;
+    }
 
     // Diagnose unused constructor calls.
     if (isa_and_nonnull<ConstructorDecl>(callee) && !call->isImplicit()) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1986,7 +1986,7 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
 
     // Otherwise, complain.  Start with more specific diagnostics.
     
-    // Always complain about 'try?'.
+    // Complain about 'try?'.
     if (auto *OTE = dyn_cast<OptionalTryExpr>(valueE)) {
       DE.diagnose(OTE->getTryLoc(), diag::expression_unused_optional_try)
         .highlight(E->getSourceRange());

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1931,10 +1931,8 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
   // Unwrap optional try to get inner function calls.
   {
     auto nextExpr = valueE;
-    while(true) {
-      if (nextExpr == nullptr) {
-        break;
-      } else if (auto applyExpr = dyn_cast<ApplyExpr>(nextExpr)) {
+    while(nextExpr != nullptr) {
+      if (auto applyExpr = dyn_cast<ApplyExpr>(nextExpr)) {
         call = applyExpr;
         break;
       } else if (auto optionalTry = dyn_cast<OptionalTryExpr>(nextExpr)) {

--- a/test/Parse/omit_return.swift
+++ b/test/Parse/omit_return.swift
@@ -689,7 +689,7 @@ var fv_optionalTryUnusedExplicit: () {
 }
 
 var fv_optionalTryUnusedImplicit: () {
-    try? failableLogAndReturn("oh") //expected-warning {{result of 'try?' is unused}}
+    try? failableLogAndReturn("oh")
 }
 
 var fv_optionalTryExplicit: String? {
@@ -1694,7 +1694,7 @@ class D_optionalTryUnusedExplicit {
 
 class D_optionalTryUnusedImplicit {
     deinit {
-        try? failableLogAndReturn("oh") // expected-warning {{result of 'try?' is unused}}
+        try? failableLogAndReturn("oh")
     }
 }
 

--- a/test/Parse/omit_return_ifdecl.swift
+++ b/test/Parse/omit_return_ifdecl.swift
@@ -997,7 +997,7 @@ var fv_optionalTryUnusedExplicit: () {
 
 var fv_optionalTryUnusedImplicit: () {
     #if true
-    try? failableLogAndReturn("oh") //expected-warning {{result of 'try?' is unused}}
+    try? failableLogAndReturn("oh")
     #endif
 }
 
@@ -2414,7 +2414,7 @@ class D_optionalTryUnusedExplicit {
 class D_optionalTryUnusedImplicit {
     deinit {
         #if true
-        try? failableLogAndReturn("oh") // expected-warning {{result of 'try?' is unused}}
+        try? failableLogAndReturn("oh")
         #endif
     }
 }


### PR DESCRIPTION
When functions are called with optional try (`try?`) raise warnings even if the function annotates `@discardableResult`.

```swift
@discardableResult
func foo() throws -> Int { 1 }

func test() {
  try? foo() // warning: result of 'try?' is unused [expression_unused_optional_try]
}
```

`@discardableResult` should be respected in such a case.

This PR changes the logic to raise the warning after checking `discardableResult` was applied.

`warning` is suppressed with this change.

Resolves #71870
[`@discardableResult` works with `try` and `try!`, but not `try?` · Issue #71870 · apple/swift](https://github.com/apple/swift/issues/71870)