### PR TITLE
Simplify `checked_cast_addr_br` to enable a shortcut check  in embedded swift's `Array.append(contentsOf:)`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -12,6 +12,7 @@ swift_compiler_sources(Optimizer
   SimplifyBeginCOWMutation.swift
   SimplifyBranch.swift
   SimplifyBuiltin.swift
+  SimplifyCheckedCast.swift
   SimplifyCondBranch.swift
   SimplifyCondFail.swift
   SimplifyConvertEscapeToNoEscape.swift

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCheckedCast.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyCheckedCast.swift
@@ -1,0 +1,52 @@
+//===--- SimplifyCheckedCast.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+extension CheckedCastAddrBranchInst : OnoneSimplifyable {
+  func simplify(_ context: SimplifyContext) {
+    guard let castWillSucceed = self.dynamicCastResult else {
+      return
+    }
+    if castWillSucceed {
+      replaceSuccess(context)
+    } else {
+      replaceFailure(context)
+    }
+  }
+}
+
+private extension CheckedCastAddrBranchInst {
+  func replaceSuccess(_ context: SimplifyContext) {
+    let builder = Builder(before: self, context)
+    switch consumptionKind {
+    case .TakeAlways, .TakeOnSuccess:
+      builder.createCopyAddr(from: source, to: destination, takeSource: true, initializeDest: true)
+    case .CopyOnSuccess:
+      builder.createCopyAddr(from: source, to: destination, takeSource: false, initializeDest: true)
+    }
+    builder.createBranch(to: successBlock)
+    context.erase(instruction: self)
+  }
+
+  func replaceFailure(_ context: SimplifyContext) {
+    let builder = Builder(before: self, context)
+    switch consumptionKind {
+    case .TakeAlways:
+      builder.createDestroyAddr(address: source)
+    case .CopyOnSuccess, .TakeOnSuccess:
+      break
+    }
+    builder.createBranch(to: failureBlock)
+    context.erase(instruction: self)
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -695,3 +695,23 @@ func getGlobalInitialization(
   }
   return nil
 }
+
+func canDynamicallyCast(from sourceType: Type, to destType: Type, in function: Function, sourceTypeIsExact: Bool) -> Bool? {
+  switch classifyDynamicCastBridged(sourceType.bridged, destType.bridged, function.bridged, sourceTypeIsExact) {
+    case .willSucceed: return true
+    case .maySucceed:  return nil
+    case .willFail:    return false
+    default: fatalError("unknown result from classifyDynamicCastBridged")
+  }
+}
+
+extension CheckedCastAddrBranchInst {
+  var dynamicCastResult: Bool? {
+    switch classifyDynamicCastBridged(bridged) {
+      case .willSucceed: return true
+      case .maySucceed:  return nil
+      case .willFail:    return false
+      default: fatalError("unknown result from classifyDynamicCastBridged")
+    }
+  }
+}

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1481,5 +1481,35 @@ final public class CheckedCastBranchInst : TermInst, UnaryInstruction {
   public var failureBlock: BasicBlock { bridged.CheckedCastBranch_getFailureBlock().block }
 }
 
-final public class CheckedCastAddrBranchInst : TermInst, UnaryInstruction {
+final public class CheckedCastAddrBranchInst : TermInst {
+  public var source: Value { operands[0].value }
+  public var destination: Value { operands[1].value }
+
+  public var successBlock: BasicBlock { bridged.CheckedCastAddrBranch_getSuccessBlock().block }
+  public var failureBlock: BasicBlock { bridged.CheckedCastAddrBranch_getFailureBlock().block }
+
+  public enum CastConsumptionKind {
+    /// The source value is always taken, regardless of whether the cast
+    /// succeeds.  That is, if the cast fails, the source value is
+    /// destroyed.
+    case TakeAlways
+
+    /// The source value is taken only on a successful cast; otherwise,
+    /// it is left in place.
+    case TakeOnSuccess
+
+    /// The source value is always left in place, and the destination
+    /// value is copied into on success.
+    case CopyOnSuccess
+  }
+
+  public var consumptionKind: CastConsumptionKind {
+    switch bridged.CheckedCastAddrBranch_getConsumptionKind() {
+    case .TakeAlways:    return .TakeAlways
+    case .TakeOnSuccess: return .TakeOnSuccess
+    case .CopyOnSuccess: return .CopyOnSuccess
+    default:
+      fatalError("invalid cast consumption kind")
+    }
+  }
 }

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -823,6 +823,12 @@ struct BridgedInstruction {
     SwiftInt numFunctions;
   };
 
+  enum class CastConsumptionKind {
+    TakeAlways,
+    TakeOnSuccess,
+    CopyOnSuccess
+  };
+
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedStringRef CondFailInst_getMessage() const;
   BRIDGED_INLINE SwiftInt LoadInst_getLoadOwnership() const ;
   BRIDGED_INLINE BuiltinValueKind BuiltinInst_getID() const;
@@ -904,6 +910,9 @@ struct BridgedInstruction {
   BRIDGED_INLINE void LoadInst_setOwnership(SwiftInt ownership) const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastBranch_getSuccessBlock() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastBranch_getFailureBlock() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastAddrBranch_getSuccessBlock() const;
+  SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedBasicBlock CheckedCastAddrBranch_getFailureBlock() const;
+  BRIDGED_INLINE CastConsumptionKind CheckedCastAddrBranch_getConsumptionKind() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedSubstitutionMap ApplySite_getSubstitutionMap() const;
   SWIFT_IMPORT_UNSAFE BRIDGED_INLINE BridgedASTType ApplySite_getSubstitutedCalleeType() const;
   BRIDGED_INLINE SwiftInt ApplySite_getNumArguments() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -1244,6 +1244,27 @@ BridgedBasicBlock BridgedInstruction::CheckedCastBranch_getFailureBlock() const 
   return {getAs<swift::CheckedCastBranchInst>()->getFailureBB()};
 }
 
+BridgedBasicBlock BridgedInstruction::CheckedCastAddrBranch_getSuccessBlock() const {
+  return {getAs<swift::CheckedCastAddrBranchInst>()->getSuccessBB()};
+}
+
+BridgedBasicBlock BridgedInstruction::CheckedCastAddrBranch_getFailureBlock() const {
+  return {getAs<swift::CheckedCastAddrBranchInst>()->getFailureBB()};
+}
+
+BridgedInstruction::CastConsumptionKind BridgedInstruction::CheckedCastAddrBranch_getConsumptionKind() const {
+  static_assert((int)BridgedInstruction::CastConsumptionKind::TakeAlways ==
+                (int)swift::CastConsumptionKind::TakeAlways);
+  static_assert((int)BridgedInstruction::CastConsumptionKind::TakeOnSuccess ==
+                (int)swift::CastConsumptionKind::TakeOnSuccess);
+  static_assert((int)BridgedInstruction::CastConsumptionKind::CopyOnSuccess ==
+                (int)swift::CastConsumptionKind::CopyOnSuccess);
+
+  return static_cast<BridgedInstruction::CastConsumptionKind>(
+           getAs<swift::CheckedCastAddrBranchInst>()->getConsumptionKind());
+}
+
+
 BridgedSubstitutionMap BridgedInstruction::ApplySite_getSubstitutionMap() const {
   auto as = swift::ApplySite(unbridged());
   return as.getSubstitutionMap();

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -331,6 +331,18 @@ struct BridgedPassContext {
 
 bool FullApplySite_canInline(BridgedInstruction apply);
 
+enum class BridgedDynamicCastResult {
+  willSucceed,
+  maySucceed,
+  willFail
+};
+
+BridgedDynamicCastResult classifyDynamicCastBridged(BridgedType sourceTy, BridgedType destTy,
+                                                    BridgedFunction function,
+                                                    bool sourceTypeIsExact);
+
+BridgedDynamicCastResult classifyDynamicCastBridged(BridgedInstruction inst);
+
 //===----------------------------------------------------------------------===//
 //                          Pass registration
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1254,7 +1254,6 @@ extension Array: RangeReplaceableCollection {
 
     if _slowPath(writtenUpTo == buf.endIndex) {
 
-#if !$Embedded
       // A shortcut for appending an Array: If newElements is an Array then it's
       // guaranteed that buf.initialize(from: newElements) already appended all
       // elements. It reduces code size, because the following code
@@ -1264,7 +1263,6 @@ extension Array: RangeReplaceableCollection {
         _internalInvariant(remainder.next() == nil)
         return
       }
-#endif
 
       // there may be elements that didn't fit in the existing buffer,
       // append them in slow sequence-only mode

--- a/test/SILOptimizer/simplify_checked_cast_addr_br.sil
+++ b/test/SILOptimizer/simplify_checked_cast_addr_br.sil
@@ -1,0 +1,131 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -onone-simplification -simplify-instruction=checked_cast_addr_br | %FileCheck %s
+
+
+// REQUIRES: swift_in_compiler
+
+import Swift
+import Builtin
+
+class X {}
+class D: X {}
+
+struct S {
+  var x: X
+}
+
+// CHECK-LABEL: sil @same_type_take_always
+// CHECK:         copy_addr [take] %1 to [init] %0 : $*X
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK-NOT:   bb2:
+// CHECK:       } // end sil function 'same_type_take_always'
+sil @same_type_take_always : $@convention(thin) (@in X) -> @out X {
+bb0(%0 : $*X, %1 : $*X):
+  checked_cast_addr_br take_always X in %1 : $*X to X in %0 : $*X, bb1, bb2
+bb1:
+  %r = tuple()
+  return %r : $()
+bb2:
+  unreachable
+}
+
+// CHECK-LABEL: sil @same_type_take_on_success
+// CHECK:         copy_addr [take] %1 to [init] %0 : $*X
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK-NOT:   bb2:
+// CHECK:       } // end sil function 'same_type_take_on_success'
+sil @same_type_take_on_success : $@convention(thin) (@in X) -> @out X {
+bb0(%0 : $*X, %1 : $*X):
+  checked_cast_addr_br take_on_success X in %1 : $*X to X in %0 : $*X, bb1, bb2
+bb1:
+  %r = tuple()
+  return %r : $()
+bb2:
+  unreachable
+}
+
+// CHECK-LABEL: sil @same_type_copy_on_success
+// CHECK:         copy_addr %1 to [init] %0 : $*X
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    tuple
+// CHECK-NEXT:    return
+// CHECK-NOT:   bb2:
+// CHECK:       } // end sil function 'same_type_copy_on_success'
+sil @same_type_copy_on_success : $@convention(thin) (@in X) -> @out X {
+bb0(%0 : $*X, %1 : $*X):
+  checked_cast_addr_br copy_on_success X in %1 : $*X to X in %0 : $*X, bb1, bb2
+bb1:
+  %r = tuple()
+  return %r : $()
+bb2:
+  unreachable
+}
+
+// CHECK-LABEL: sil @fail_with_take_always
+// CHECK:       bb0(%0 : $*S, %1 : $*String):
+// CHECK-NEXT:    destroy_addr %1 : $*String
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    unreachable
+// CHECK:       } // end sil function 'fail_with_take_always'
+sil @fail_with_take_always : $@convention(thin) (@in String) -> @out S {
+bb0(%0 : $*S, %1 : $*String):
+  checked_cast_addr_br take_always String in %1 : $*String to S in %0 : $*S, bb1, bb2
+bb1:
+  %r = tuple()
+  return %r : $()
+bb2:
+  unreachable
+}
+
+// CHECK-LABEL: sil @fail_with_take_on_success
+// CHECK:       bb0(%0 : $*S, %1 : $*String):
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    unreachable
+// CHECK:       } // end sil function 'fail_with_take_on_success'
+sil @fail_with_take_on_success : $@convention(thin) (@in String) -> @out S {
+bb0(%0 : $*S, %1 : $*String):
+  checked_cast_addr_br take_on_success String in %1 : $*String to S in %0 : $*S, bb1, bb2
+bb1:
+  %r = tuple()
+  return %r : $()
+bb2:
+  unreachable
+}
+
+// CHECK-LABEL: sil @fail_with_copy_on_success
+// CHECK:       bb0(%0 : $*S, %1 : $*String):
+// CHECK-NEXT:    br bb1
+// CHECK:       bb1:
+// CHECK-NEXT:    unreachable
+// CHECK:       } // end sil function 'fail_with_copy_on_success'
+sil @fail_with_copy_on_success : $@convention(thin) (@in String) -> @out S {
+bb0(%0 : $*S, %1 : $*String):
+  checked_cast_addr_br copy_on_success String in %1 : $*String to S in %0 : $*S, bb1, bb2
+bb1:
+  %r = tuple()
+  return %r : $()
+bb2:
+  unreachable
+}
+
+// CHECK-LABEL: sil @unknown_result
+// CHECK:         checked_cast_addr_br
+// CHECK:       } // end sil function 'unknown_result'
+sil @unknown_result : $@convention(thin) (@in X) -> @out D {
+bb0(%0 : $*D, %1 : $*X):
+  checked_cast_addr_br copy_on_success X in %1 : $*X to D in %0 : $*D, bb1, bb2
+bb1:
+  %r = tuple()
+  return %r : $()
+bb2:
+  unreachable
+}
+

--- a/test/embedded/arrays.swift
+++ b/test/embedded/arrays.swift
@@ -43,6 +43,18 @@ func print(_ array: [Int]) {
     print("]")
 }
 
+func isArray<S: Sequence>(_ s: S) -> Bool where S.Element == Int {
+  return s is [Int]
+}
+
+public func testIsArray() -> Bool {
+  return isArray(Array<Int>())
+}
+
+public func testIsNotArray() -> Bool {
+  return isArray(Array<Int>().lazy)
+}
+
 func test() {
   var a = [1, 2, 3]
   a.append(8)
@@ -51,6 +63,11 @@ func test() {
   var c = b
   c = c.reversed().filter { $0 % 2 == 0 }
   print(c) // CHECK: [8, 4, 2]
+
+  // CHECK: yes
+  print(testIsArray() ? "yes" : "no")
+  // CHECK: no
+  print(testIsNotArray() ? "yes" : "no")
 }
 
 test()


### PR DESCRIPTION
The shortcut check  in `Array.append(contentsOf:)` reduces code size if appending one array to another.
To enable this check it's needed to constant fold `checked_cast_addr_br`.

To do this, add bridging for dynamic cast utilities and use those utilities in the existing simplification for the metatype comparison builtin.
Also, make a simple improvement in the dynamic cast utilities: a dynamic cast from base to derived class is known to fail if the source type is exact.

rdar://124581515