### PR TITLE
SIL: fix runtime effect of copy_addr of trivial types

### DIFF
--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -746,6 +746,8 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
 
   case SILInstructionKind::CopyAddrInst: {
     auto *ca = cast<CopyAddrInst>(inst);
+    if (ca->getSrc()->getType().isTrivial(ca->getFunction()))
+      return RuntimeEffect::NoEffect;
     impactType = ca->getSrc()->getType();
     if (!ca->isInitializationOfDest())
       return RuntimeEffect::MetaData | RuntimeEffect::Releasing;

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -492,3 +492,16 @@ func matchCEnum(_ variant: c_closed_enum_t) -> Int {
   }
 }
 
+public struct GenericStruct<T> {
+    private var x = 0
+    private var y: T?
+    @inline(never)
+    init() {}
+}
+
+@_noLocks
+func testLargeTuple() {
+    typealias SixInt8s = (Int8, Int8, Int8, Int8, Int8, Int8)
+    _ = GenericStruct<SixInt8s>()
+}
+


### PR DESCRIPTION
Fixes a false performance error
Reported in https://forums.swift.org/t/generic-type-nolocks-trouble/70667
