### PR TITLE
[Refactoring] Skip failed witness decls in "add codable implementation"

### DIFF
--- a/lib/Refactoring/AddExplicitCodableImplementation.cpp
+++ b/lib/Refactoring/AddExplicitCodableImplementation.cpp
@@ -133,7 +133,7 @@ class AddCodableContext {
           kind == KnownProtocolKind::Decodable) {
         for (auto requirement : protocol->getProtocolRequirements()) {
           auto witness = conformance->getWitnessDecl(requirement);
-          if (witness->isSynthesized()) {
+          if (witness && witness->isSynthesized()) {
             Printer.printNewline();
             witness->print(Printer, Options);
             Printer.printNewline();

--- a/test/refactoring/AddCodableImplementation/Outputs/has_error/invalid_member.swift.expected
+++ b/test/refactoring/AddCodableImplementation/Outputs/has_error/invalid_member.swift.expected
@@ -1,0 +1,9 @@
+
+struct Foo: Codable {
+    var other: Unknown
+
+    private enum CodingKeys: CodingKey {
+      case other
+    }
+}
+

--- a/test/refactoring/AddCodableImplementation/has_error.swift
+++ b/test/refactoring/AddCodableImplementation/has_error.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t.result)
+
+// RUN: %refactor -add-explicit-codable-implementation -source-filename %s -pos=%(line + 2):8 > %t.result/invalid_member.swift
+// RUN: diff -u %S/Outputs/has_error/invalid_member.swift.expected %t.result/invalid_member.swift
+struct Foo: Codable {
+    var other: Unknown
+}
+


### PR DESCRIPTION
When there are problems in the properties in the target type, witness methods may not be synthesized. Don't try to add such methods.

Fixes https://github.com/apple/swift/issues/72387

