### PR TITLE
[6.0][CSSimplify] Mark all type variables in member type as holes if base is a hole

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10733,8 +10733,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
   // reason to perform a lookup because it wouldn't return any results.
   if (shouldAttemptFixes()) {
     auto markMemberTypeAsPotentialHole = [&](Type memberTy) {
-      if (auto *typeVar = memberTy->getAs<TypeVariableType>())
-        recordPotentialHole(typeVar);
+      recordAnyTypeVarAsPotentialHole(simplifyType(memberTy));
     };
 
     // If this is an unresolved member ref e.g. `.foo` and its contextual base

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -816,3 +816,13 @@ func test_mismatch_between_param_and_optional_chain() {
     }
   }
 }
+
+// rdar://124549952 - incorrect "type of expression is ambiguous without a type annotation"
+do {
+  func fn() -> (any BinaryInteger)? {}
+
+  func test() {
+    let _ = fn()?.op().value
+    // expected-error@-1 {{value of type 'any BinaryInteger' has no member 'op'}}
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/72353
---

- Explanation: 

Even if the member type variable is partially resolved, we still need to mark inner type variables
(if any) as holes because they might not be connected to anything that could provide contextual type(s).

- Scope: Member chains with invalid member references.

- Main Branch PR: https://github.com/apple/swift/pull/72353

- Resolves: rdar://124549952

- Risk: Very Low

- Reviewed By: @hborla 

- Testing: Added test-cases to the test suite.

Resolves: rdar://124549952
(cherry picked from commit b6ba3fead8404ac6666d1aa3b4134113d86ea32c)


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
