### PR TITLE
[api-digester] re-disable test on non-x86

### DIFF
--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -46,7 +46,7 @@
 // https://github.com/apple/swift/issues/55803
 // We currently only have a baseline for Intel CPUs on macOS.
 // REQUIRES: OS=macosx
-// XXX: CPU=x86_64
+// REQUIRES: CPU=x86_64
 
 // The digester can incorrectly register a generic signature change when
 // declarations are shuffled. rdar://problem/46618883


### PR DESCRIPTION
While fixing this test for another PR, I disabled the `REQUIRES: CPU=x86` line so it'd run on my machine. But I left that change in accidentally. This test needs to stay requiring x86 for now since that's the actual baseline it is testing.