### PR TITLE
[6.0🍒][api-digester] re-disable test on non-x86

### DIFF
--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -46,7 +46,7 @@
 // https://github.com/apple/swift/issues/55803
 // We currently only have a baseline for Intel CPUs on macOS.
 // REQUIRES: OS=macosx
-// XXX: CPU=x86_64
+// REQUIRES: CPU=x86_64
 
 // The digester can incorrectly register a generic signature change when
 // declarations are shuffled. rdar://problem/46618883


### PR DESCRIPTION
cherry-pick of https://github.com/apple/swift/pull/72400 to fix CI