### PR TITLE
[CMake] Ensure module tracing is off during configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,11 @@ include(FetchContent)
 # optional until we have a bootstrap story.
 check_language(Swift)
 if(CMAKE_Swift_COMPILER)
+  # we are not interested in logging any Swift module used
+  # when configuring the build system -- those are not useful
+  # since they will not contribute to the build of the compiler itself
+  unset(ENV{SWIFT_LOADED_MODULE_TRACE_FILE})
+
   enable_language(Swift)
   set(DEFAULT_SWIFT_MIN_RUNTIME_VERSION "${CMAKE_Swift_COMPILER_VERSION}")
 else()

--- a/cmake/modules/SwiftImplicitImport.cmake
+++ b/cmake/modules/SwiftImplicitImport.cmake
@@ -3,8 +3,6 @@ function(swift_supports_implicit_module module_name out_var)
   file(WRITE "${CMAKE_BINARY_DIR}/tmp/empty-check-${module_name}.swift" "")
   execute_process(
     COMMAND
-      ${CMAKE_COMMAND}
-      -E env --unset=SWIFT_LOADED_MODULE_TRACE_FILE
       "${CMAKE_Swift_COMPILER}"
       -Xfrontend -disable-implicit-${module_name}-module-import
       -Xfrontend -parse-stdlib


### PR DESCRIPTION
Such module usages are not relevant for the final build, they are used only to detect the capabilities of the compiler.

This generalizes #68453, and would be needed for Apple internal configurations that set `SWIFT_LOADED_MODULE_TRACE_FILE` when building the compiler.

Addresses rdar://124954349