### PR TITLE
[6.0] Fix test IRGen/relative_protocol_witness_table.swift on arm64e

### DIFF
--- a/test/IRGen/relative_protocol_witness_table.swift
+++ b/test/IRGen/relative_protocol_witness_table.swift
@@ -344,7 +344,7 @@ public func requireFormallyResilientWitness<T: ResilientProto> (_ t: T) {
 }
 
 // EVO: define{{.*}} swiftcc void @"$s1A27useFormallyResilientWitnessyyF"()
-// EVO: call swiftcc void @"$s1A31requireFormallyResilientWitnessyyx9resilient0C5ProtoRzlF"(ptr noalias %4, ptr %1, ptr @"$s9resilient15ResilientStructVyxGAA0B5ProtoAAWP")
+// EVO: call swiftcc void @"$s1A31requireFormallyResilientWitnessyyx9resilient0C5ProtoRzlF"(ptr noalias %4, ptr %1, ptr @"$s9resilient15ResilientStructVyxGAA0B5ProtoAAWP{{(.ptrauth)?}}")
 public func useFormallyResilientWitness() {
   requireFormallyResilientWitness(ResilientStruct(1))
 }


### PR DESCRIPTION
(cherry picked from commit c96803f8374ee8372d5f0ec4204524eee7ea9b57)