### PR TITLE
Serialization: update for new diagnostics format

### DIFF
--- a/test/Serialization/Recovery/module-recovery-remarks.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks.swift
@@ -17,22 +17,22 @@
 // CHECK-MOVED: LibWithXRef.swiftmodule:1:1: remark: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'A_related'
 
 /// Contextual notes about the modules involved.
-// CHECK-MOVED: <unknown>:0: note: the type was expected to be found in module 'A' at '
+// CHECK-MOVED: note: the type was expected to be found in module 'A' at '
 // CHECK-MOVED-SAME: A.swiftmodule'
-// CHECK-MOVED: <unknown>:0: note: or expected to be found in the underlying module 'A' defined at '
+// CHECK-MOVED: note: or expected to be found in the underlying module 'A' defined at '
 // CHECK-MOVED-SAME: module.modulemap'
-// CHECK-MOVED: <unknown>:0: note: the type was actually found in module 'A_related' at '
+// CHECK-MOVED: note: the type was actually found in module 'A_related' at '
 // CHECK-MOVED-SAME: A_related.swiftmodule'
 
 /// More notes depending on the context
-// CHECK-MOVED: <unknown>:0: note: the module 'LibWithXRef' was built with a Swift language version set to 5
+// CHECK-MOVED: note: the module 'LibWithXRef' was built with a Swift language version set to 5
 // CHECK-MOVED-SAME: while the current invocation uses 4
 
-// CHECK-MOVED: <unknown>:0: note: the module 'LibWithXRef' has enabled library-evolution; the following file may need to be deleted if the SDK was modified: '
+// CHECK-MOVED: note: the module 'LibWithXRef' has enabled library-evolution; the following file may need to be deleted if the SDK was modified: '
 // CHECK-MOVED-SAME: LibWithXRef.swiftmodule'
-// CHECK-MOVED: <unknown>:0: note: declarations in the underlying clang module 'A' may be hidden by clang preprocessor macros
-// CHECK-MOVED: <unknown>:0: note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by header maps or search paths
-// CHECK-MOVED: <unknown>:0: note: the type 'MyType' moved between related modules; clang preprocessor macros may affect headers shared between these modules
+// CHECK-MOVED: note: declarations in the underlying clang module 'A' may be hidden by clang preprocessor macros
+// CHECK-MOVED: note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by header maps or search paths
+// CHECK-MOVED: note: the type 'MyType' moved between related modules; clang preprocessor macros may affect headers shared between these modules
 // CHECK-MOVED: note: could not deserialize type for 'foo()'
 // CHECK-MOVED: error: cannot find 'foo' in scope
 
@@ -40,7 +40,7 @@
 // RUN: mv %t/A.swiftmodule %t/sdk/A.swiftmodule
 // RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK-LAYERING-FOUND %s
-// CHECK-LAYERING-FOUND: <unknown>:0: note: the reference may break layering; the candidate was found in the local module 'A_related' for a reference from the distributed module 'LibWithXRef'
+// CHECK-LAYERING-FOUND: note: the reference may break layering; the candidate was found in the local module 'A_related' for a reference from the distributed module 'LibWithXRef'
 // CHECK-LAYERING-FOUND: error: cannot find 'foo' in scope
 
 /// Delete A, keep only the underlying clangmodule for notes about clang modules.
@@ -48,7 +48,7 @@
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A_related.swiftmodule -module-name A_related
 // RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK-CLANG %s
-// CHECK-CLANG: <unknown>:0: note: declarations in the clang module 'A' may be hidden by clang preprocessor macros
+// CHECK-CLANG: note: declarations in the clang module 'A' may be hidden by clang preprocessor macros
 // CHECK-CLANG: error: cannot find 'foo' in scope
 
 

--- a/test/Serialization/modularization-error.swift
+++ b/test/Serialization/modularization-error.swift
@@ -21,11 +21,11 @@
 // CHECK-WORKAROUND: LibWithXRef.swiftmodule:1:1: warning: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
 // CHECK-WORKAROUND-NEXT: A.MyType
 // CHECK-WORKAROUND-NEXT: ^
-// CHECK-WORKAROUND: <unknown>:0: note: the type was expected to be found in module 'A' at '
+// CHECK-WORKAROUND: note: the type was expected to be found in module 'A' at '
 // CHECK-WORKAROUND-SAME: A.swiftmodule'
-// CHECK-WORKAROUND: <unknown>:0: note: the type was actually found in module 'B' at '
+// CHECK-WORKAROUND: note: the type was actually found in module 'B' at '
 // CHECK-WORKAROUND-SAME: B.swiftmodule'
-// CHECK-WORKAROUND: <unknown>:0: note: attempting forced recovery enabled by -experimental-force-workaround-broken-modules
+// CHECK-WORKAROUND: note: attempting forced recovery enabled by -experimental-force-workaround-broken-modules
 // CHECK-WORKAROUND: func foo() -> some Proto
 
 /// Change MyType into a function.


### PR DESCRIPTION
Make sure we flush the diagnostics consumers to prevent the new diagnostic style to buffer the deserialization errors without printing them. These errors may be emitted right before an `abort()`, which would bypass the usual printing of the errors.

Take advantage of the new style to make these diagnostics more readable as well:

```
.../LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'A_related'
1 │ A.MyType
  │ ├─ error: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'A_related'
  │ ├─ note: the type was expected to be found in module 'A' at ‘.../A.swiftmodule'
  │ ├─ note: or expected to be found in the underlying module 'A' defined at ‘.../module.modulemap'
  │ ├─ note: the type was actually found in module 'A_related' at ‘.../A_related.swiftmodule'
  │ ├─ note: the module 'LibWithXRef' was built with a Swift language version set to 5.10 while the current invocation uses 4.1.50; APINotes may change how clang declarations are imported
  │ ├─ note: the module 'LibWithXRef' has enabled library-evolution; the following file may need to be deleted if the SDK was modified: ‘.../LibWithXRef.swiftmodule'
  │ ├─ note: declarations in the underlying clang module 'A' may be hidden by clang preprocessor macros
  │ ├─ note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by header maps or search paths
  │ ╰─ note: the type 'MyType' moved between related modules; clang preprocessor macros may affect headers shared between these modules
.../LibWithXRef.swiftmodule:1:1: note: could not deserialize type for 'foo()'
1 │ A.MyType
  │ ╰─ note: could not deserialize type for 'foo()'
```

rdar://124700605