### PR TITLE
[Target Info] Compute resource-directory relative to the SDK on non-Darwin targets

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -262,6 +262,10 @@ public:
       StringRef mainExecutablePath, bool shared,
       llvm::SmallVectorImpl<char> &runtimeResourcePath);
 
+  /// Computes the runtime resource path relative to the given Swift
+  /// executable.
+  std::string computeRuntimeResourcePathForTargetInfo();
+
   /// Appends `lib/swift[_static]` to the given path
   static void appendSwiftLibDir(llvm::SmallVectorImpl<char> &path, bool shared);
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -63,6 +63,28 @@ getVersionTuple(const llvm::Triple &triple) {
   return triple.getOSVersion();
 }
 
+std::string CompilerInvocation::computeRuntimeResourcePathForTargetInfo() {
+  const auto &frontendOpts = getFrontendOptions();
+  const auto &searchPathOpts = getSearchPathOptions();
+  const auto &langOpts = getLangOptions();
+  SmallString<128> resourceDirPath;
+  if (!searchPathOpts.RuntimeResourcePath.empty()) {
+    resourceDirPath =  searchPathOpts.RuntimeResourcePath;
+  } else if (!langOpts.Target.isOSDarwin() &&
+             !searchPathOpts.getSDKPath().empty()) {
+    StringRef value = searchPathOpts.getSDKPath();
+    resourceDirPath.append(value.begin(), value.end());
+    llvm::sys::path::append(resourceDirPath, "usr");
+    CompilerInvocation::appendSwiftLibDir(resourceDirPath,
+                                          frontendOpts.UseSharedResourceFolder);
+  } else {
+    CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(frontendOpts.MainExecutablePath,
+                                                                     frontendOpts.UseSharedResourceFolder,
+                                                                     resourceDirPath);
+  }
+  return resourceDirPath.str().str();
+}
+
 void CompilerInvocation::computeRuntimeResourcePathFromExecutablePath(
     StringRef mainExecutablePath, bool shared,
     llvm::SmallVectorImpl<char> &runtimeResourcePath) {
@@ -84,7 +106,9 @@ void CompilerInvocation::setMainExecutablePath(StringRef Path) {
   llvm::SmallString<128> LibPath;
   computeRuntimeResourcePathFromExecutablePath(
       Path, FrontendOpts.UseSharedResourceFolder, LibPath);
-  setRuntimeResourcePath(LibPath.str());
+  // Target info query computes the resource path wholesale
+  if (!FrontendOpts.PrintTargetInfo)
+    setRuntimeResourcePath(LibPath.str());
 
   llvm::SmallString<128> clangPath(Path);
   llvm::sys::path::remove_filename(clangPath);
@@ -3551,6 +3575,9 @@ bool CompilerInvocation::parseArgs(
                         SearchPathOpts.RuntimeResourcePath, ParsedArgs, Diags)) {
     return true;
   }
+
+  if (FrontendOpts.PrintTargetInfo)
+    setRuntimeResourcePath(computeRuntimeResourcePathForTargetInfo());
 
   updateRuntimeLibraryPaths(SearchPathOpts, FrontendOpts, LangOpts);
   setDefaultPrebuiltCacheIfNecessary();


### PR DESCRIPTION
Since the new driver uses `-print-target-info` for the resource directory and the legacy C++ driver used the logic in `getResourceDirPath()`, mimic that logic now in the print-target-info job itself.
