### PR TITLE
[Compile Time Constant Extraction] Extract macro added extensions

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -560,6 +560,11 @@ gatherConstValuesForPrimary(const std::unordered_set<std::string> &Protocols,
                                                        ConformanceDecls);
   for (auto D : SF->getTopLevelDecls())
     D->walk(ConformanceCollector);
+  // Visit macro expanded extensions
+  if (auto *synthesizedSF = SF->getSynthesizedFile())
+    for (auto D : synthesizedSF->getTopLevelDecls())
+      if (isa<ExtensionDecl>(D))
+        D->walk(ConformanceCollector);
 
   for (auto *CD : ConformanceDecls)
     Result.emplace_back(evaluateOrDefault(

--- a/test/ConstExtraction/ExtractFromMacroExpansion.swift
+++ b/test/ConstExtraction/ExtractFromMacroExpansion.swift
@@ -43,6 +43,9 @@ struct MyStruct {
   #AddMacroAddedVar
   
   @AddPeerVar
+  @AddExtension
+  @AddMemberVar
+  @AddPeerStruct
   struct Inner { }
 }
 
@@ -128,6 +131,47 @@ extension MyStruct {
 // CHECK:   "value": "5"
 
 // CHECK:   "label": "_extension__Peer_MyStruct",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "3"
+
+
+// CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct.Inner",
+// CHECK: "properties": [
+// CHECK:   "label": "_member_Inner",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "5"
+
+// CHECK:   "label": "_extension_Inner",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "3"
+
+
+// CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct._Peer_Inner",
+// CHECK: "properties": [
+// CHECK:   "label": "peerMacroVar",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "7"
+
+// CHECK:   "label": "macroAddedVar",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "2"
+
+// CHECK:   "label": "_peer_peerMacroVar",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "4"
+
+// CHECK:   "label": "_member__Peer_Inner",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "5"
+
+// CHECK:   "label": "_extension__Peer_Inner",
 // CHECK:   "type": "Swift.Int",
 // CHECK:   "valueKind": "RawLiteral",
 // CHECK:   "value": "3"

--- a/test/ConstExtraction/ExtractFromMacroExpansion.swift
+++ b/test/ConstExtraction/ExtractFromMacroExpansion.swift
@@ -15,7 +15,7 @@ macro AddMacroAddedStruct() = #externalMacro(module: "MacroDefinition", type: "A
 @freestanding(declaration, names: named(macroAddedVar))
 macro AddMacroAddedVar() = #externalMacro(module: "MacroDefinition", type: "AddVarDeclMacro")
 
-@attached(extension, conformances: MyProto, names: prefixed(_extension_))
+@attached(extension, conformances: MyProto, names: prefixed(_extension_), named(_Extension_MyProto))
 macro AddExtension() = #externalMacro(module: "MacroDefinition", type: "AddExtensionMacro")
 
 @attached(peer, names: prefixed(_peer_))
@@ -175,3 +175,42 @@ extension MyStruct {
 // CHECK:   "type": "Swift.Int",
 // CHECK:   "valueKind": "RawLiteral",
 // CHECK:   "value": "3"
+
+
+// CHECK: "typeName": "ExtractFromMacroExpansion.MacroAddedStruct._Extension_MyProto",
+// CHECK: "properties": [
+// CHECK:   "label": "nested",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "8"
+
+
+// CHECK: "typeName": "ExtractFromMacroExpansion._Peer_MyStruct._Extension_MyProto",
+// CHECK: "properties": [
+// CHECK:   "label": "nested",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "8"
+
+// CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct._Extension_MyProto",
+// CHECK: "properties": [
+// CHECK:   "label": "nested",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "8"
+
+
+// CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct._Peer_Inner._Extension_MyProto",
+// CHECK: "properties": [
+// CHECK:   "label": "nested",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "8"
+
+
+// CHECK: "typeName": "ExtractFromMacroExpansion.MyStruct.Inner._Extension_MyProto",
+// CHECK: "properties": [
+// CHECK:   "label": "nested",
+// CHECK:   "type": "Swift.Int",
+// CHECK:   "valueKind": "RawLiteral",
+// CHECK:   "value": "8"

--- a/test/ConstExtraction/Inputs/Macros.swift
+++ b/test/ConstExtraction/Inputs/Macros.swift
@@ -43,8 +43,14 @@ public struct AddExtensionMacro: ExtensionMacro {
   ) throws -> [ExtensionDeclSyntax] {
     let typeName = declaration.declGroupName
     return protocols.map {
-      ("extension \(typeName): \($0) { }" as DeclSyntax)
-        .cast(ExtensionDeclSyntax.self)
+      ("""
+      extension \(typeName): \($0) {
+        struct _Extension_\($0): \($0) {
+          var nested = 8
+        }
+      }
+      """ as DeclSyntax)
+      .cast(ExtensionDeclSyntax.self)
     } + [
     ("""
     extension \(typeName) {


### PR DESCRIPTION
<!-- What's in this pull request? -->

Visit synthesized source file to extract from types declared in macro added extensions.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves rdar://124119745

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
