### PR TITLE
[6.0][Refactoring] Skip failed witness decls in "add codable implementation"

### DIFF
--- a/lib/Refactoring/AddExplicitCodableImplementation.cpp
+++ b/lib/Refactoring/AddExplicitCodableImplementation.cpp
@@ -133,7 +133,7 @@ class AddCodableContext {
           kind == KnownProtocolKind::Decodable) {
         for (auto requirement : protocol->getProtocolRequirements()) {
           auto witness = conformance->getWitnessDecl(requirement);
-          if (witness->isSynthesized()) {
+          if (witness && witness->isSynthesized()) {
             Printer.printNewline();
             witness->print(Printer, Options);
             Printer.printNewline();

--- a/test/refactoring/AddCodableImplementation/Outputs/has_error/invalid_member.swift.expected
+++ b/test/refactoring/AddCodableImplementation/Outputs/has_error/invalid_member.swift.expected
@@ -1,0 +1,9 @@
+
+struct Foo: Codable {
+    var other: Unknown
+
+    private enum CodingKeys: CodingKey {
+      case other
+    }
+}
+

--- a/test/refactoring/AddCodableImplementation/has_error.swift
+++ b/test/refactoring/AddCodableImplementation/has_error.swift
@@ -1,0 +1,8 @@
+// RUN: %empty-directory(%t.result)
+
+// RUN: %refactor -add-explicit-codable-implementation -source-filename %s -pos=%(line + 2):8 > %t.result/invalid_member.swift
+// RUN: diff -u %S/Outputs/has_error/invalid_member.swift.expected %t.result/invalid_member.swift
+struct Foo: Codable {
+    var other: Unknown
+}
+


### PR DESCRIPTION
cherry-pick https://github.com/apple/swift/pull/72392 into `release/6.0`

* **Explanation**: Previously "Add Explicit Codable Implementation" refactoring used to crash if there was missing witnesses. It happens on when there was an invalid member, for example, a member with invalid type. Skip trying to print such witness and avoid crash.
* **Scope**: SourceKit refactoring
* **Risk**: Very low, just added null pointer guard
* **Testing**: Added a regression test case
* **Issues**: rdar://125045414 #72387
* **Reviewer**: Hamish Knight (@hamishknight), Alex Hoopen (@ahoppen)