### PR TITLE
[6.0][Parse] Adjust diagnostic location for platform condition arguments

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1945,7 +1945,7 @@ ERROR(platform_condition_expected_argument,none,
       "expected argument to platform condition",
       ())
 ERROR(platform_condition_expected_one_argument,none,
-      "expected only one argument to platform condition",
+      "expected only one unlabeled argument to platform condition",
       ())
 ERROR(unsupported_platform_runtime_condition_argument,none,
       "unexpected argument for the '_runtime' condition; "

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -299,10 +299,13 @@ public:
       if (E->getArgs()->empty()) {
         D.diagnose(E->getLoc(), diag::platform_condition_expected_argument);
       } else {
-        D.diagnose(E->getLoc(), diag::platform_condition_expected_one_argument);
+        SourceLoc DiagLoc = E->getArgs()->front().getStartLoc();
+        assert(DiagLoc.isValid() && "parsed Argument should have a location");
+        D.diagnose(DiagLoc, diag::platform_condition_expected_one_argument);
       }
       return nullptr;
     }
+    SourceLoc ArgLoc = Arg->getStartLoc();
     // '_compiler_version' '(' string-literal ')'
     if (*KindName == "_compiler_version") {
       if (auto SLE = dyn_cast<StringLiteralExpr>(Arg)) {
@@ -331,7 +334,7 @@ public:
               : std::nullopt;
       if (!isValidPrefixUnaryOperator(PrefixName)) {
         D.diagnose(
-            Arg->getLoc(), diag::unsupported_platform_condition_argument,
+            ArgLoc, diag::unsupported_platform_condition_argument,
             "a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'");
         return nullptr;
       }
@@ -352,7 +355,7 @@ public:
       }
 
       if (!isModulePath(Arg)) {
-        D.diagnose(E->getLoc(), diag::unsupported_platform_condition_argument,
+        D.diagnose(ArgLoc, diag::unsupported_platform_condition_argument,
                    "module name");
         return nullptr;
       }
@@ -361,7 +364,7 @@ public:
 
     if (*KindName == "hasFeature") {
       if (!getDeclRefStr(Arg, DeclRefKind::Ordinary)) {
-        D.diagnose(E->getLoc(), diag::unsupported_platform_condition_argument,
+        D.diagnose(ArgLoc, diag::unsupported_platform_condition_argument,
                    "feature name");
         return nullptr;
       }
@@ -371,7 +374,7 @@ public:
 
     if (*KindName == "hasAttribute") {
       if (!getDeclRefStr(Arg, DeclRefKind::Ordinary)) {
-        D.diagnose(E->getLoc(), diag::unsupported_platform_condition_argument,
+        D.diagnose(ArgLoc, diag::unsupported_platform_condition_argument,
                    "attribute name");
         return nullptr;
       }
@@ -388,7 +391,7 @@ public:
 
     auto ArgStr = getDeclRefStr(Arg, DeclRefKind::Ordinary);
     if (!ArgStr.has_value()) {
-      D.diagnose(E->getLoc(), diag::unsupported_platform_condition_argument,
+      D.diagnose(ArgLoc, diag::unsupported_platform_condition_argument,
                  "identifier");
       return nullptr;
     }
@@ -399,7 +402,7 @@ public:
                                                       suggestedKind, suggestedValues)) {
       if (Kind == PlatformConditionKind::Runtime) {
         // Error for _runtime()
-        D.diagnose(Arg->getLoc(),
+        D.diagnose(ArgLoc,
                    diag::unsupported_platform_runtime_condition_argument);
         return nullptr;
       }
@@ -426,27 +429,25 @@ public:
       case PlatformConditionKind::Runtime:
         llvm_unreachable("handled above");
       }
-      auto Loc = Arg->getLoc();
-      D.diagnose(Loc, diag::unknown_platform_condition_argument,
-                 DiagName, *KindName);
+      D.diagnose(ArgLoc, diag::unknown_platform_condition_argument, DiagName,
+                 *KindName);
       if (suggestedKind != *Kind) {
         auto suggestedKindName = getPlatformConditionName(suggestedKind);
-        D.diagnose(Loc, diag::note_typo_candidate, suggestedKindName)
-          .fixItReplace(E->getFn()->getSourceRange(), suggestedKindName);
+        D.diagnose(ArgLoc, diag::note_typo_candidate, suggestedKindName)
+            .fixItReplace(E->getFn()->getSourceRange(), suggestedKindName);
       }
       for (auto suggestion : suggestedValues)
-        D.diagnose(Loc, diag::note_typo_candidate, suggestion)
-          .fixItReplace(Arg->getSourceRange(), suggestion);
+        D.diagnose(ArgLoc, diag::note_typo_candidate, suggestion)
+            .fixItReplace(Arg->getSourceRange(), suggestion);
     }
     else if (!suggestedValues.empty()) {
       // The value the user gave has been replaced by something newer.
       assert(suggestedValues.size() == 1 && "only support one replacement");
       auto replacement = suggestedValues.front();
 
-      auto Loc = Arg->getLoc();
-      D.diagnose(Loc, diag::renamed_platform_condition_argument,
-                 *ArgStr, replacement)
-        .fixItReplace(Arg->getSourceRange(), replacement);
+      D.diagnose(ArgLoc, diag::renamed_platform_condition_argument, *ArgStr,
+                 replacement)
+          .fixItReplace(Arg->getSourceRange(), replacement);
     }
 
     return E;

--- a/test/Parse/ConditionalCompilation/can_import_submodule.swift
+++ b/test/Parse/ConditionalCompilation/can_import_submodule.swift
@@ -48,17 +48,17 @@ import A.B.C
 #endif
 
 
-#if canImport(A(_:).B) // expected-error {{unexpected platform condition argument: expected module name}}
+#if canImport(A(_:).B) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
 #endif
 
-#if canImport(A.B(c: "arg")) // expected-error {{unexpected platform condition argument: expected module name}}
+#if canImport(A.B(c: "arg")) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
 #endif
 
-#if canImport(A(b: 1, c: 2).B.C) // expected-error {{unexpected platform condition argument: expected module name}}
+#if canImport(A(b: 1, c: 2).B.C) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
 #endif
 
-#if canImport(A.B("arg")(3).C) // expected-error {{unexpected platform condition argument: expected module name}}
+#if canImport(A.B("arg")(3).C) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
 #endif
 
-#if canImport(A.B.C()) // expected-error {{unexpected platform condition argument: expected module name}}
+#if canImport(A.B.C()) // expected-error@:15 {{unexpected platform condition argument: expected module name}}
 #endif

--- a/test/Parse/ConditionalCompilation/compoundName_swift4.swift
+++ b/test/Parse/ConditionalCompilation/compoundName_swift4.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
 /// Reject compound names.
-#if BAR(_:) // expected-error {{invalid conditional compilation expression}}
-#elseif os(x:)(macOS) // expected-error {{unexpected platform condition (expected 'os', 'arch', or 'swift')}}
-#elseif os(Linux(foo:bar:)) // expected-error {{unexpected platform condition argument: expected identifier}}
+#if BAR(_:) // expected-error@:5 {{invalid conditional compilation expression}}
+#elseif os(x:)(macOS) // expected-error@:9 {{unexpected platform condition (expected 'os', 'arch', or 'swift')}}
+#elseif os(Linux(foo:bar:)) // expected-error@:12 {{unexpected platform condition argument: expected identifier}}
 #endif

--- a/test/Parse/ConditionalCompilation/language_version.swift
+++ b/test/Parse/ConditionalCompilation/language_version.swift
@@ -53,16 +53,16 @@
   %#^*&
 #endif
 
-#if swift(">=7.1") // expected-error {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#if swift(">=7.1") // expected-error@:11 {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
 #endif
 
-#if swift("<7.1") // expected-error {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#if swift("<7.1") // expected-error@:11 {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
 #endif
 
-#if swift(">=2n.2") // expected-error {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#if swift(">=2n.2") // expected-error@:11 {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
 #endif
 
-#if swift("") // expected-error {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
+#if swift("") // expected-error@:11 {{unexpected platform condition argument: expected a unary comparison '>=' or '<'; for example, '>=2.2' or '<2.2'}}
 #endif
 
 #if swift(>=2.2.1)
@@ -75,10 +75,13 @@ class C {
 #endif
 }
 
-#if swift(>=2.0, *) // expected-error {{expected only one argument to platform condition}}
+#if swift(>=2.0, *) // expected-error@:11 {{expected only one unlabeled argument to platform condition}}
 #endif
 
-#if swift(>=, 2.0) // expected-error {{expected only one argument to platform condition}}
+#if swift(>=, 2.0) // expected-error@:11 {{expected only one unlabeled argument to platform condition}}
+#endif
+
+#if swift(version: >=2.0) // expected-error@:11 {{expected only one unlabeled argument to platform condition}}
 #endif
 
 protocol P {

--- a/test/Parse/upcoming_feature.swift
+++ b/test/Parse/upcoming_feature.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
 
-// expected-error@+1{{unexpected platform condition argument: expected feature name}}
+// expected-error@+1:16{{unexpected platform condition argument: expected feature name}}
 #if hasFeature(17)
 #endif

--- a/test/attr/has_attribute.swift
+++ b/test/attr/has_attribute.swift
@@ -21,5 +21,5 @@ UserInaccessibleAreNotAttributes
 #endif
 
 #if hasAttribute(17)
-// expected-error@-1{{unexpected platform condition argument: expected attribute name}}
+// expected-error@-1:18 {{unexpected platform condition argument: expected attribute name}}
 #endif


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/72384 into `release/6.0`

* **Explanation**: Previously, diagnostics for arguments of platform conditions (e.g. 'os(macOS)') used to point the condition name position instead of the argument position. Adjust the position to the start of the argument.
* **Scope**: Diagnostics QoI
* **Risk**: Low, only charging diagnostics
* **Testing**: Updated regression test cases
* **Issues**: rdar://124160048
* **Reviewers**: Alex Hoppen (@ahoppen) Hamish Knight (@hamishknight)
