### PR TITLE
[SourceKit] Stop printing normal comments in clang generated interface

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -502,9 +502,6 @@ struct PrintOptions {
   /// (e.g. the overridden method in the superclass) if such comment is found.
   bool PrintDocumentationComments = false;
 
-  /// Whether to print regular comments from clang module headers.
-  bool PrintRegularClangComments = false;
-
   /// When true, printing interface from a source file will print the original
   /// source text for applicable declarations, in order to preserve the
   /// formatting.
@@ -645,7 +642,6 @@ struct PrintOptions {
     result.TypeDefinitions = true;
     result.VarInitializers = true;
     result.PrintDocumentationComments = true;
-    result.PrintRegularClangComments = true;
     result.PrintLongAttrsOnSeparateLines = true;
     result.AlwaysTryPrintParameterLabels = true;
     return result;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1138,9 +1138,7 @@ public:
     // handles this, but we need to insert it for clang doc comments when not
     // printing other clang comments. Do it now so the printDeclPre callback
     // happens after the newline.
-    if (Options.PrintDocumentationComments &&
-        !Options.PrintRegularClangComments &&
-        D->hasClangNode()) {
+    if (Options.PrintDocumentationComments && D->hasClangNode()) {
       auto clangNode = D->getClangNode();
       auto clangDecl = clangNode.getAsDecl();
       if (clangDecl &&
@@ -1149,7 +1147,6 @@ public:
         indent();
       }
     }
-
 
     Printer.callPrintDeclPre(D, Options.BracketOptions);
 

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -118,7 +118,6 @@ PrintOptions PrintOptions::printDocInterface() {
   result.ArgAndParamPrinting =
       PrintOptions::ArgAndParamPrintingMode::BothAlways;
   result.PrintDocumentationComments = false;
-  result.PrintRegularClangComments = false;
   result.PrintFunctionRepresentationAttrs =
     PrintOptions::FunctionRepresentationMode::None;
   return result;

--- a/test/APINotes/properties.swift
+++ b/test/APINotes/properties.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 5 | %FileCheck -check-prefix=CHECK-SWIFT-5 -check-prefix=CHECK-BOTH %s
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 5 | %FileCheck -check-prefix=CHECK-SWIFT-5 -check-prefix=CHECK-BOTH %s
 
-// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 -check-prefix=CHECK-BOTH %s
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 -check-prefix=CHECK-BOTH %s
 
 // REQUIRES: objc_interop
 

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test  -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 5 | %FileCheck -check-prefix=CHECK-SWIFT-5 %s
+// RUN: %target-swift-ide-test  -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 5 | %FileCheck -check-prefix=CHECK-SWIFT-5 %s
 
-// RUN: %target-swift-ide-test  -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 %s
+// RUN: %target-swift-ide-test  -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 %s
 
 // CHECK-SWIFT-5: func jumpTo(x: Double, y: Double, z: Double)
 // CHECK-SWIFT-4: func jumpTo(x: Double, y: Double, z: Double)

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -12,9 +12,9 @@
 // RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-error.h -DERRORS -verify
 
 // RUN: echo '#include "enum-error.h"' > %t.m
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h -print-regular-comments --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
 // RUN: %FileCheck -check-prefix=HEADER %s < %t.txt
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h -print-regular-comments --skip-private-stdlib-decls -skip-underscored-stdlib-protocols --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t2.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h --skip-private-stdlib-decls -skip-underscored-stdlib-protocols --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t2.txt
 // RUN: %FileCheck -check-prefix=HEADER-NO-PRIVATE %s < %t2.txt
 
 import Foundation

--- a/test/ClangImporter/nested_protocol_name.swift
+++ b/test/ClangImporter/nested_protocol_name.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/nested_protocol_name.h -typecheck -verify %s
 
 // RUN: echo '#include "nested_protocol_name.h"' > %t.m
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/nested_protocol_name.h -import-objc-header %S/Inputs/nested_protocol_name.h -print-regular-comments --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/nested_protocol_name.h -import-objc-header %S/Inputs/nested_protocol_name.h --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
 // RUN: %FileCheck -check-prefix=HEADER %s < %t.txt
 
 // rdar://59431058
@@ -15,7 +15,6 @@
 // HEADER:   func addLimb(_ limb: (any Trunk.Branch)!)
 // HEADER:   func addLimbs(_ limbs: [any Trunk.Branch]!)
 // HEADER: }
-// HEADER: // NS_SWIFT_NAME(Trunk.Branch)
 // HEADER: protocol Branch {
 // HEADER:   func flower()
 // HEADER: }

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
@@ -1,13 +1,9 @@
 import Foundation
 import CoreFoundation
 import Dispatch
-
 var MY_MACRO: Int32 { get }
-
 var MACRO_DUP: Int32 { get }
-
 func doSomethingInHead(_ arg: Int32)
-
 class BaseInHead {
   class func doIt(_ arg: Int32)
   func doIt(_ arg: Int32)
@@ -18,15 +14,12 @@ class SameName {
 }
 protocol SameNameProtocol {
 }
-
 extension BaseInHead {
   class func doItInCategory()
   func doItInCategory()
 }
-
 protocol Superproto {
   func lala()
 }
-
 class MyLittleCFType {
 }

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
@@ -1,10 +1,6 @@
-
 var MY_MACRO: Int32 { get }
-
 var MACRO_DUP: Int32 { get }
-
 func doSomethingInHead(_ arg: Int32)
-
 class BaseInHead {
   class func doIt(_ arg: Int32)
   func doIt(_ arg: Int32)
@@ -15,15 +11,12 @@ class SameName {
 }
 protocol SameNameProtocol {
 }
-
 extension BaseInHead {
   class func doItInCategory()
   func doItInCategory()
 }
-
 protocol Superproto {
   func lala()
 }
-
 class MyLittleCFType : _CFObject {
 }

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
@@ -1,13 +1,9 @@
 import Foundation
 import CoreFoundation
 import Dispatch
-
 var MY_MACRO: Int32 { get }
-
 var MACRO_DUP: Int32 { get }
-
 func doSomethingInHead(_ arg: Int32)
-
 class BaseInHead {
   class func doIt(_ arg: Int32)
   func doIt(_ arg: Int32)
@@ -18,15 +14,12 @@ class SameName {
 }
 protocol SameNameProtocol {
 }
-
 extension BaseInHead {
   class func doItInCategory()
   func doItInCategory()
 }
-
 protocol Superproto {
   func lala()
 }
-
 class MyLittleCFType : _CFObject {
 }

--- a/test/IDE/print_clang_bool_bridging.swift
+++ b/test/IDE/print_clang_bool_bridging.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=BoolBridgingTests -function-definitions=false -print-regular-comments -skip-unavailable -F %S/Inputs/mock-sdk > %t.txt
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=BoolBridgingTests -function-definitions=false -skip-unavailable -F %S/Inputs/mock-sdk > %t.txt
 // RUN: diff -u <(tail -n +9 %s) %t.txt
 
 // REQUIRES: objc_interop
@@ -8,76 +8,57 @@
 // EXPECTED OUTPUT STARTS BELOW THIS LINE.
 @_exported import Foundation
 
-// stdbool.h uses #define, so this test does as well.
-
 func testCBool(_: Bool) -> Bool
 func testObjCBool(_: Bool) -> Bool
 func testDarwinBoolean(_: Bool) -> Bool
-
 typealias CBoolTypedef = Bool
 typealias ObjCBoolTypedef = ObjCBool
 typealias DarwinBooleanTypedef = DarwinBoolean
-
 func testCBoolTypedef(_: CBoolTypedef) -> CBoolTypedef
 func testObjCBoolTypedef(_: Bool) -> Bool
 func testDarwinBooleanTypedef(_: Bool) -> Bool
-
 func testCBoolPointer(_: UnsafeMutablePointer<Bool>) -> UnsafePointer<Bool>
 func testObjCBoolPointer(_: UnsafeMutablePointer<ObjCBool>) -> UnsafePointer<ObjCBool>
 func testDarwinBooleanPointer(_: UnsafeMutablePointer<DarwinBoolean>) -> UnsafePointer<DarwinBoolean>
-
 typealias CBoolFn = @convention(c) (Bool) -> Bool
 typealias ObjCBoolFn = @convention(c) (ObjCBool) -> ObjCBool
 typealias DarwinBooleanFn = @convention(c) (DarwinBoolean) -> DarwinBoolean
-
 typealias CBoolBlock = (Bool) -> Bool
 typealias ObjCBoolBlock = (Bool) -> Bool
 typealias DarwinBooleanBlock = (Bool) -> Bool
-
 func testCBoolFnToBlock(_: @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
 func testObjCBoolFnToBlock(_: @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
 func testDarwinBooleanFnToBlock(_: @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
-
 func testCBoolFnToBlockTypedef(_: CBoolFn) -> CBoolBlock
 func testObjCBoolFnToBlockTypedef(_: ObjCBoolFn) -> ObjCBoolBlock
 func testDarwinBooleanFnToBlockTypedef(_: DarwinBooleanFn) -> DarwinBooleanBlock
-
 typealias CBoolFnToBlockType = (CBoolFn) -> (Bool) -> Bool
 typealias ObjCBoolFnToBlockType = (ObjCBoolFn) -> (ObjCBool) -> ObjCBool
 typealias DarwinBooleanFnToBlockType = (DarwinBooleanFn) -> (DarwinBoolean) -> DarwinBoolean
-
 var globalObjCBoolFnToBlockFP: @convention(c) (ObjCBoolFn) -> (ObjCBool) -> ObjCBool
 var globalObjCBoolFnToBlockFPP: UnsafeMutablePointer<@convention(c) (ObjCBoolFn) -> (ObjCBool) -> ObjCBool>?
 var globalObjCBoolFnToBlockBP: @convention(block) (ObjCBoolFn) -> (ObjCBool) -> ObjCBool
-
 var globalCBoolFn: CBoolFn
 var globalObjCBoolFn: ObjCBoolFn
 var globalDarwinBooleanFn: DarwinBooleanFn
-
 var globalCBoolBlock: @convention(block) (Bool) -> Bool
 var globalObjCBoolBlock: @convention(block) (ObjCBool) -> ObjCBool
 var globalDarwinBooleanBlock: @convention(block) (DarwinBoolean) -> DarwinBoolean
-
 class Test : NSObject {
   var propCBool: Bool
   var propObjCBool: Bool
   var propDarwinBoolean: Bool
-  
   func testCBool(_ b: Bool) -> Bool
   func testObjCBool(_ b: Bool) -> Bool
   func testDarwinBoolean(_ b: Bool) -> Bool
-  
   var propCBoolBlock: (Bool) -> Bool
   var propObjCBoolBlock: (Bool) -> Bool
   var propDarwinBooleanBlock: (Bool) -> Bool
-  
   func testCBoolFn(toBlock fp: @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
   func testObjCBoolFn(toBlock fp: @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
   func testDarwinBooleanFn(toBlock fp: @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
-  
   func produceCBoolBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (Bool) -> Bool)?>)
   func produceObjCBoolBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (ObjCBool) -> ObjCBool)?>)
   func produceDarwinBooleanBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (DarwinBoolean) -> DarwinBoolean)?>)
-  
   init()
 }

--- a/test/IDE/print_clang_foundation.swift
+++ b/test/IDE/print_clang_foundation.swift
@@ -17,7 +17,7 @@
 // CHECK_NSARRAY: class NSMutableArray : NSArray
 // CHECK_NSARRAY:   func setArray(_ otherArray: [Any])
 
-// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=Foundation.NSKeyValueCoding -function-definitions=false -print-regular-comments > %t/Foundation.NSKeyValueCoding.printed.txt
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=Foundation.NSKeyValueCoding -function-definitions=false > %t/Foundation.NSKeyValueCoding.printed.txt
 // RUN: %FileCheck -input-file %t/Foundation.NSKeyValueCoding.printed.txt -check-prefix=CHECK2 %s
 
 // CHECK2: extension NSObject

--- a/test/IDE/print_clang_framework.swift
+++ b/test/IDE/print_clang_framework.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-module -source-filename %s -module-to-print=Foo -function-definitions=false -print-regular-comments > %t/Foo.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-module -source-filename %s -module-to-print=Foo -function-definitions=false > %t/Foo.printed.txt
 // RUN: diff -u %S/Inputs/mock-sdk/Foo.printed.txt %t/Foo.printed.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-interface -print-module -source-filename %s -module-to-print=Foo -function-definitions=false -print-regular-comments > %t/Foo.interface.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-interface -print-module -source-filename %s -module-to-print=Foo -function-definitions=false > %t/Foo.interface.printed.txt
 // RUN: %FileCheck %s -check-prefix=INTERFACE1 < %t/Foo.interface.printed.txt
 
 // RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-module -source-filename %s -module-to-print=Foo -function-definitions=false -prefer-type-repr=true -module-print-submodules > %t/Foo.printed.recursive.txt

--- a/test/IDE/print_clang_header.swift
+++ b/test/IDE/print_clang_header.swift
@@ -2,21 +2,21 @@
 // REQUIRES: objc_interop
 
 // RUN: echo '#include "header-to-print.h"' > %t.m
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs/print_clang_header > %t.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs/print_clang_header > %t.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.txt
 
 // RUN: %clang %target-cc-options -isysroot %clang-importer-sdk-path -fmodules -x objective-c-header %S/Inputs/print_clang_header/header-to-print.h -o %t.h.pch
 // RUN: touch %t.empty.m
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.empty.m -I %S/Inputs/print_clang_header -include %t.h > %t.with-pch.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.empty.m -I %S/Inputs/print_clang_header -include %t.h > %t.with-pch.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt %t.with-pch.txt
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.empty.m -I %S/Inputs/print_clang_header -include %S/Inputs/print_clang_header/header-to-print.h > %t.with-include.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.empty.m -I %S/Inputs/print_clang_header -include %S/Inputs/print_clang_header/header-to-print.h > %t.with-include.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt %t.with-include.txt
 
 // RUN: echo '#include <Foo/header-to-print.h>' > %t.framework.m
 // RUN: sed -e "s:INPUT_DIR:%S/Inputs/print_clang_header:g" -e "s:OUT_DIR:%t:g" %S/Inputs/print_clang_header/Foo-vfsoverlay.yaml > %t.yaml
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml -Xclang -fmodule-name=Foo > %t.framework.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml -Xclang -fmodule-name=Foo > %t.framework.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.framework.txt
 
 // Test header interface printing from a clang module.
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml > %t.module.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml > %t.module.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.module.printed.txt %t.module.txt

--- a/test/IDE/print_clang_header_availability.swift
+++ b/test/IDE/print_clang_header_availability.swift
@@ -4,10 +4,10 @@
 
 // RUN: echo '#include "header-to-print-availability.h"' > %t.m
 // RUN: cp %S/Inputs/print_clang_header/header-to-print-availability.h %t/
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %t/header-to-print-availability.h -print-regular-comments --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %t > %t.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %t/header-to-print-availability.h --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %t > %t.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print-availability.h.printed.txt %t.txt
 
 // RUN: echo '@import HeaderToPrintAvailability;' > %t.module.m
 // Test header interface printing from a clang module.
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print-availability.h -print-regular-comments --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.module.m -I %S/Inputs/print_clang_header > %t.module.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print-availability.h --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.module.m -I %S/Inputs/print_clang_header > %t.module.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print-availability.h.module.printed.txt %t.module.txt

--- a/test/IDE/print_clang_header_i386.swift
+++ b/test/IDE/print_clang_header_i386.swift
@@ -5,5 +5,5 @@
 // RUN: echo '#include "header-to-print.h"' > %t.i386.m
 // RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -I %t --cc-args -arch i386 -isysroot %clang-importer-sdk-path -fsyntax-only %t.i386.m -I %S/Inputs/print_clang_header > %t.i386.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -I %t --cc-args -arch i386 -isysroot %clang-importer-sdk-path -fsyntax-only %t.i386.m -I %S/Inputs/print_clang_header > %t.i386.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.i386.txt

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=SwiftNameTests -function-definitions=false -print-regular-comments -F %S/Inputs/mock-sdk > %t.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=SwiftNameTests -function-definitions=false -F %S/Inputs/mock-sdk > %t.txt
 // RUN: diff -u <(tail -n +9 %s) %t.txt
 
 // REQUIRES: objc_interop
@@ -8,10 +8,7 @@
 // EXPECTED OUTPUT STARTS BELOW THIS LINE.
 @_exported import Foundation
 
-
 class Test : NSObject {
-  
-  // "Factory methods" that we'd rather have as initializers.
   @available(*, unavailable, message: "superseded by import of -[NSObject init]")
   convenience init()
   @available(*, unavailable, renamed: "init()", message: "Not available in Swift")
@@ -19,23 +16,18 @@ class Test : NSObject {
   convenience init(dummyParam: ())
   @available(*, unavailable, renamed: "init(dummyParam:)", message: "Not available in Swift")
   class func b() -> Self
-  
   convenience init(cc x: Any)
   @available(*, unavailable, renamed: "init(cc:)", message: "Not available in Swift")
   class func c(_ x: Any) -> Self
   convenience init(_ x: Any)
   @available(*, unavailable, renamed: "init(_:)", message: "Not available in Swift")
   class func d(_ x: Any) -> Self
-  
   convenience init(aa a: Any, _ b: Any, cc c: Any)
   @available(*, unavailable, renamed: "init(aa:_:cc:)", message: "Not available in Swift")
   class func e(_ a: Any, e b: Any, e c: Any) -> Self
-  
   /*not inherited*/ init(fixedType: ())
   @available(*, unavailable, renamed: "init(fixedType:)", message: "Not available in Swift")
   class func f() -> Test
-  
-  // Would-be initializers.
   class func zz() -> Self
   @available(swift, obsoleted: 3, renamed: "zz()")
   class func testZ() -> Self
@@ -45,12 +37,9 @@ class Test : NSObject {
   class func xx(_ x: Any, bb xx: Any) -> Self
   @available(*, unavailable, renamed: "xx(_:bb:)", message: "Not available in Swift")
   class func testX(_ x: Any, xx: Any) -> Self
-  
   init()
 }
-
 class TestError : NSObject {
-  // Factory methods with NSError.
   convenience init(error: ()) throws
   @available(*, unavailable, renamed: "init(error:)", message: "Not available in Swift")
   class func err1() throws -> Self
@@ -63,7 +52,6 @@ class TestError : NSObject {
   convenience init(error: (), block: @escaping () -> Void) throws
   @available(*, unavailable, renamed: "init(error:block:)", message: "Not available in Swift")
   class func err4(callback block: @escaping () -> Void) throws -> Self
-  
   convenience init(aa x: Any?) throws
   @available(*, unavailable, renamed: "init(aa:)", message: "Not available in Swift")
   class func err5(_ x: Any?) throws -> Self
@@ -73,8 +61,6 @@ class TestError : NSObject {
   convenience init(block: @escaping () -> Void) throws
   @available(*, unavailable, renamed: "init(block:)", message: "Not available in Swift")
   class func err7(callback block: @escaping () -> Void) throws -> Self
-  
-  // Would-be initializers.
   class func ww(_ x: Any?) throws -> Self
   @available(swift, obsoleted: 3, renamed: "ww(_:)")
   class func testW(_ x: Any?) throws -> Self
@@ -89,7 +75,6 @@ class TestError : NSObject {
   class func testV2() throws -> Self
   init()
 }
-
 class TestSub : Test {
   @available(*, unavailable, message: "superseded by import of -[NSObject init]")
   convenience init()
@@ -99,7 +84,6 @@ class TestSub : Test {
   convenience init(aa a: Any, _ b: Any, cc c: Any)
   init()
 }
-
 class TestErrorSub : TestError {
   convenience init(error: ()) throws
   convenience init(aa x: Any?, error: ()) throws

--- a/test/SourceKit/CursorInfo/cursor_generated_interface.swift
+++ b/test/SourceKit/CursorInfo/cursor_generated_interface.swift
@@ -41,7 +41,7 @@ public class ASwiftType {
 }
 
 // LibA is a mixed framework with no source info and a submodule
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:36 -print-raw-response | %FileCheck %s --check-prefix=CHECKA
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:36 -print-raw-response | %FileCheck %s --check-prefix=CHECKA
 // CHECKA: key.name: "ASwiftType"
 // CHECKA: key.modulename: "LibA"
 // CHECKA: key.decl_lang: source.lang.swift
@@ -60,7 +60,7 @@ framework module LibA {
 @interface AObjcType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:54 -print-raw-response | %FileCheck %s --check-prefix=CHECKAOBJ
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:54 -print-raw-response | %FileCheck %s --check-prefix=CHECKAOBJ
 // CHECKAOBJ: key.name: "AObjcType"
 // CHECKAOBJ: key.line: [[@LINE-5]]
 // CHECKAOBJ: key.column: 12
@@ -72,7 +72,7 @@ framework module LibA {
 @interface ASubType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:70 -print-raw-response | %FileCheck %s --check-prefix=CHECKASUB
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:70 -print-raw-response | %FileCheck %s --check-prefix=CHECKASUB
 // CHECKASUB: key.name: "ASubType"
 // CHECKASUB: key.line: [[@LINE-5]]
 // CHECKASUB: key.column: 12
@@ -84,7 +84,7 @@ framework module LibA {
 public class BType {}
 
 // LibB has source info
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:32 -print-raw-response | %FileCheck %s --check-prefix=CHECKB
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:32 -print-raw-response | %FileCheck %s --check-prefix=CHECKB
 // CHECKB: key.name: "BType"
 // CHECKB: key.line: [[@LINE-5]]
 // CHECKB: key.column: 14
@@ -96,7 +96,7 @@ public class BType {}
 public class CType {}
 
 // LibC has no source info
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:47 -print-raw-response | %FileCheck %s --check-prefix=CHECKC
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:47 -print-raw-response | %FileCheck %s --check-prefix=CHECKC
 // CHECKC: key.name: "CType"
 // CHECKC: key.modulename: "LibC"
 // CHECKC: key.decl_lang: source.lang.swift
@@ -105,7 +105,7 @@ public class CType {}
 @interface DType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:57 -print-raw-response | %FileCheck %s --check-prefix=CHECKD
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:57 -print-raw-response | %FileCheck %s --check-prefix=CHECKD
 // CHECKD: key.name: "DType"
 // CHECKD: key.line: [[@LINE-5]]
 // CHECKD: key.column: 12

--- a/test/SourceKit/CursorInfo/cursor_info_async.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_async.swift
@@ -11,14 +11,14 @@ import Foo
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- \
 // RUN:                  -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:                   -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 | %FileCheck %s -check-prefix=CHECK-FOO
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 | %FileCheck %s -check-prefix=CHECK-FOO
 
 // CHECK-FOO: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooRuncingOptions
 // CHECK-FOO: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooRuncingOptions

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -31,7 +31,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=204:67 | %FileCheck -check-prefix=CHECK1 %s
+// RUN:      == -req=cursor -pos=176:67 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooClassBase' inside the list of base classes, see 'gen_clang_module.swift.response'
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
@@ -47,7 +47,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=231:20 | %FileCheck -check-prefix=CHECK2 %s
+// RUN:      == -req=cursor -pos=196:20 | %FileCheck -check-prefix=CHECK2 %s
 // The cursor points inside the interface, see 'gen_clang_module.swift.response'
 
 // CHECK2: source.lang.swift.decl.function.method.instance ({{.*}}Foo.framework/Headers/Foo.h:170:10-170:27)
@@ -61,7 +61,7 @@ var x: FooClassBase
 // RUN:      == -req=find-usr -usr "c:objc(cs)FooClassDerived(im)fooInstanceFunc0" | %FileCheck -check-prefix=CHECK-USR %s
 // The returned line:col points inside the interface, see 'gen_clang_module.swift.response'
 
-// CHECK-USR: (231:15-231:33)
+// CHECK-USR: (196:15-196:33)
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
@@ -1,14 +1,7 @@
 import Foundation
 
-
 open class Foo : NSObject {
 }
-// ===-------------------------------------------------------------------------
-// class Payload
-// ===-------------------------------------------------------------------------
-
-// 3: Payload
-// 4: Namespace.Payload
 open class GlobalToMember_Class_Container : NSObject {
 }
 public typealias GlobalToMember_Class_Payload = GlobalToMember_Class_Container.Payload
@@ -17,9 +10,6 @@ extension GlobalToMember_Class_Container {
     open class Payload : NSObject {
     }
 }
-
-// 3: Namespace.Payload
-// 4: Payload
 open class MemberToGlobal_Class_Container : NSObject {
 }
 open class MemberToGlobal_Class_Payload : NSObject {
@@ -28,9 +18,6 @@ extension MemberToGlobal_Class_Container {
 
     public typealias Payload = MemberToGlobal_Class_Payload
 }
-
-// 3: Namespace_Swift3.PayloadFor3
-// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Class_Swift3 : NSObject {
 }
 open class MemberToMember_Class_Swift4 : NSObject {
@@ -44,9 +31,6 @@ extension MemberToMember_Class_Swift4 {
     open class PayloadFor4 : NSObject {
     }
 }
-
-// 3: Namespace.PayloadFor3
-// 4: Namespace.PayloadFor4
 open class MemberToMember_SameContainer_Class_Container : NSObject {
 }
 extension MemberToMember_SameContainer_Class_Container {
@@ -56,9 +40,6 @@ extension MemberToMember_SameContainer_Class_Container {
     open class PayloadFor4 : NSObject {
     }
 }
-
-// 3: Namespace_Swift3.Payload
-// 4: Namespace_Swift4.Payload
 open class MemberToMember_SameName_Class_Swift3 : NSObject {
 }
 open class MemberToMember_SameName_Class_Swift4 : NSObject {
@@ -72,13 +53,6 @@ extension MemberToMember_SameName_Class_Swift4 {
     open class Payload : NSObject {
     }
 }
-
-// ===-------------------------------------------------------------------------
-// typealias Payload
-// ===-------------------------------------------------------------------------
-
-// 3: Payload
-// 4: Namespace.Payload
 open class GlobalToMember_Typedef_Container : NSObject {
 }
 public typealias GlobalToMember_Typedef_Payload = GlobalToMember_Typedef_Container.Payload
@@ -86,9 +60,6 @@ extension GlobalToMember_Typedef_Container {
 
     public typealias Payload = Foo
 }
-
-// 3: Namespace.Payload
-// 4: Payload
 open class MemberToGlobal_Typedef_Container : NSObject {
 }
 public typealias MemberToGlobal_Typedef_Payload = Foo
@@ -96,9 +67,6 @@ extension MemberToGlobal_Typedef_Container {
 
     public typealias Payload = MemberToGlobal_Typedef_Payload
 }
-
-// 3: Namespace_Swift3.PayloadFor3
-// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_Typedef_Swift4 : NSObject {
@@ -111,9 +79,6 @@ extension MemberToMember_Typedef_Swift4 {
 
     public typealias PayloadFor4 = Foo
 }
-
-// 3: Namespace.PayloadFor3
-// 4: Namespace.PayloadFor4
 open class MemberToMember_SameContainer_Typedef_Container : NSObject {
 }
 extension MemberToMember_SameContainer_Typedef_Container {
@@ -122,9 +87,6 @@ extension MemberToMember_SameContainer_Typedef_Container {
 
     public typealias PayloadFor4 = Foo
 }
-
-// 3: Namespace_Swift3.Payload
-// 4: Namespace_Swift4.Payload
 open class MemberToMember_SameName_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_SameName_Typedef_Swift4 : NSObject {
@@ -151,363 +113,423 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 20,
+    key.offset: 19,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 25,
+    key.offset: 24,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 30,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 37,
+    key.offset: 36,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 50,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 130,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 147,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 228,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 242,
-    key.length: 24
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 266,
+    key.offset: 49,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 271,
+    key.offset: 54,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 277,
+    key.offset: 60,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 310,
+    key.offset: 93,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 323,
+    key.offset: 106,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 330,
+    key.offset: 113,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 340,
+    key.offset: 123,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 371,
+    key.offset: 154,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 402,
+    key.offset: 185,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 410,
+    key.offset: 193,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 420,
+    key.offset: 203,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 241,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 246,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 252,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 262,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 281,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 286,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 292,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 325,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 338,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 343,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 349,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 380,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 393,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 403,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 441,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 448,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 458,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 463,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 469,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 479,
-    key.length: 8
+    key.offset: 468,
+    key.length: 28
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 499,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 523,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 537,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 542,
+    key.offset: 504,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 548,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 581,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 594,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 599,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 605,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 636,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 649,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 659,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 697,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 704,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 714,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 724,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 756,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 791,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 826,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 831,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 837,
+    key.offset: 510,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 867,
+    key.offset: 540,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 880,
+    key.offset: 553,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 558,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 564,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 594,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 607,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 617,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 652,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 659,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 669,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 683,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 711,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 725,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 735,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 770,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 775,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 781,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 795,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 814,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 819,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 825,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 872,
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 885,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 891,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 921,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 934,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 944,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 979,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 986,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 996,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1010,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1038,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1052,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1062,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1097,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1102,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1108,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1122,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1142,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1170,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1198,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1203,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1209,
-    key.length: 44
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1256,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1269,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1279,
+    key.offset: 895,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1331,
+    key.offset: 947,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 954,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 964,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 978,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1023,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1040,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1045,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1051,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1065,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1084,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1089,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1095,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1134,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1147,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1152,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1158,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1197,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1210,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1220,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1264,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1271,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1281,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1291,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1328,
+    key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -515,648 +537,458 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.length: 9
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1348,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1362,
-    key.length: 44
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1407,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1424,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1429,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1435,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1449,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1469,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1500,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1531,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1536,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1542,
     key.length: 36
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1581,
-    key.length: 8
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1594,
+    key.offset: 1392,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1599,
+    key.offset: 1397,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1605,
-    key.length: 36
+    key.offset: 1403,
+    key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1644,
+    key.offset: 1413,
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1432,
+    key.length: 4
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1657,
+    key.offset: 1437,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1443,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1478,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1491,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1498,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1508,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1541,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1574,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1582,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1667,
-    key.length: 36
+    key.offset: 1592,
+    key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1632,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1639,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1649,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1659,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1665,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1670,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1676,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1711,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1724,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1718,
+    key.offset: 1731,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1728,
-    key.length: 7
+    key.offset: 1741,
+    key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1738,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1775,
-    key.length: 7
+    key.offset: 1774,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1785,
+    key.offset: 1778,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1795,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1839,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1844,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1850,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1860,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1880,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1960,
-    key.length: 21
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1981,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2062,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2076,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2100,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2105,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2111,
+    key.offset: 1788,
     key.length: 32
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2146,
-    key.length: 8
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2159,
+    key.offset: 1828,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2166,
+    key.offset: 1835,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1845,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1855,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1888,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1893,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1899,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1931,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1944,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1949,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1955,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1987,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2000,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2010,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2047,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2054,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2064,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2078,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2108,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2122,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2132,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2169,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 2176,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2209,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2242,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2250,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2260,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2300,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2307,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2317,
-    key.length: 7
+    key.offset: 2186,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2327,
+    key.offset: 2200,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2334,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2358,
-    key.length: 14
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2372,
+    key.offset: 2206,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2377,
+    key.offset: 2211,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2383,
-    key.length: 32
+    key.offset: 2217,
+    key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2418,
+    key.offset: 2266,
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2279,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2289,
+    key.length: 46
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2431,
+    key.offset: 2343,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2350,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2360,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2374,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2421,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 2438,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2448,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2481,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2485,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2495,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2535,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2542,
+    key.offset: 2445,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2552,
-    key.length: 7
+    key.offset: 2455,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2562,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2596,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2631,
-    key.length: 35
+    key.offset: 2469,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2666,
+    key.offset: 2475,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2671,
+    key.offset: 2480,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2677,
-    key.length: 29
+    key.offset: 2486,
+    key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2709,
+    key.offset: 2527,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2722,
+    key.offset: 2540,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2545,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2551,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2592,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2605,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2615,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2661,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2668,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2678,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2688,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 2727,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2733,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2765,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2778,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2788,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2825,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2832,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2842,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2856,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2886,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2900,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2910,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2947,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2954,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2964,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2978,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2985,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 3013,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3041,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3046,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3052,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3101,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3114,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3124,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3178,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3185,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3195,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3209,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3256,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3273,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3280,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3290,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3304,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 3311,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 3342,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3373,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3378,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3384,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3425,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3438,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3443,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3449,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3490,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3503,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3513,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3559,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3566,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3576,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3586,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3625,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3635,
+    key.offset: 2737,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3645,
+    key.offset: 2747,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3691,
+    key.offset: 2793,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3698,
+    key.offset: 2800,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3708,
+    key.offset: 2810,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3718,
+    key.offset: 2820,
     key.length: 3
   }
 ]
@@ -1169,307 +1001,307 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 37,
+    key.offset: 36,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 310,
+    key.offset: 93,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 371,
+    key.offset: 154,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 402,
+    key.offset: 185,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 420,
+    key.offset: 203,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 479,
+    key.offset: 262,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 581,
+    key.offset: 325,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 636,
+    key.offset: 380,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 659,
+    key.offset: 403,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 724,
+    key.offset: 468,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 867,
+    key.offset: 540,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 921,
+    key.offset: 594,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 944,
+    key.offset: 617,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1010,
+    key.offset: 683,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1038,
+    key.offset: 711,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1062,
+    key.offset: 735,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1122,
+    key.offset: 795,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1256,
+    key.offset: 872,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1279,
+    key.offset: 895,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1362,
+    key.offset: 978,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1407,
+    key.offset: 1023,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1449,
+    key.offset: 1065,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1581,
+    key.offset: 1134,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1644,
+    key.offset: 1197,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1667,
+    key.offset: 1220,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1738,
+    key.offset: 1291,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1775,
+    key.offset: 1328,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1795,
+    key.offset: 1348,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1860,
+    key.offset: 1413,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2146,
+    key.offset: 1478,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2209,
+    key.offset: 1541,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2242,
+    key.offset: 1574,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2260,
+    key.offset: 1592,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2327,
+    key.offset: 1659,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2418,
+    key.offset: 1711,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2481,
+    key.offset: 1774,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2495,
+    key.offset: 1788,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2562,
+    key.offset: 1855,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2709,
+    key.offset: 1931,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2765,
+    key.offset: 1987,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2788,
+    key.offset: 2010,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2856,
+    key.offset: 2078,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2886,
+    key.offset: 2108,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2910,
+    key.offset: 2132,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2978,
+    key.offset: 2200,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3101,
+    key.offset: 2266,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3124,
+    key.offset: 2289,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3209,
+    key.offset: 2374,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 3256,
+    key.offset: 2421,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3304,
+    key.offset: 2469,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3425,
+    key.offset: 2527,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3490,
+    key.offset: 2592,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3513,
+    key.offset: 2615,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3586,
+    key.offset: 2688,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 3625,
+    key.offset: 2727,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3645,
+    key.offset: 2747,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3718,
+    key.offset: 2820,
     key.length: 3
   }
 ]
@@ -1478,11 +1310,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "Foo",
-    key.offset: 25,
+    key.offset: 24,
     key.length: 24,
-    key.nameoffset: 31,
+    key.nameoffset: 30,
     key.namelength: 3,
-    key.bodyoffset: 47,
+    key.bodyoffset: 46,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1491,7 +1323,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 20,
+        key.offset: 19,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1499,7 +1331,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 37,
+        key.offset: 36,
         key.length: 8
       }
     ]
@@ -1508,11 +1340,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 271,
+    key.offset: 54,
     key.length: 51,
-    key.nameoffset: 277,
+    key.nameoffset: 60,
     key.namelength: 30,
-    key.bodyoffset: 320,
+    key.bodyoffset: 103,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1521,7 +1353,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 266,
+        key.offset: 49,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1529,7 +1361,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 310,
+        key.offset: 93,
         key.length: 8
       }
     ]
@@ -1538,13 +1370,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "GlobalToMember_Class_Payload",
-    key.offset: 330,
+    key.offset: 113,
     key.length: 79,
-    key.nameoffset: 340,
+    key.nameoffset: 123,
     key.namelength: 28,
     key.attributes: [
       {
-        key.offset: 323,
+        key.offset: 106,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1553,22 +1385,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 410,
+    key.offset: 193,
     key.length: 87,
-    key.nameoffset: 420,
+    key.nameoffset: 203,
     key.namelength: 30,
-    key.bodyoffset: 452,
+    key.bodyoffset: 235,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 463,
+        key.offset: 246,
         key.length: 32,
-        key.nameoffset: 469,
+        key.nameoffset: 252,
         key.namelength: 7,
-        key.bodyoffset: 489,
+        key.bodyoffset: 272,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1577,7 +1409,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 458,
+            key.offset: 241,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1585,7 +1417,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 479,
+            key.offset: 262,
             key.length: 8
           }
         ]
@@ -1596,11 +1428,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 542,
+    key.offset: 286,
     key.length: 51,
-    key.nameoffset: 548,
+    key.nameoffset: 292,
     key.namelength: 30,
-    key.bodyoffset: 591,
+    key.bodyoffset: 335,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1609,7 +1441,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 537,
+        key.offset: 281,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1617,7 +1449,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 581,
+        key.offset: 325,
         key.length: 8
       }
     ]
@@ -1626,11 +1458,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Payload",
-    key.offset: 599,
+    key.offset: 343,
     key.length: 49,
-    key.nameoffset: 605,
+    key.nameoffset: 349,
     key.namelength: 28,
-    key.bodyoffset: 646,
+    key.bodyoffset: 390,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1639,7 +1471,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 594,
+        key.offset: 338,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1647,7 +1479,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 636,
+        key.offset: 380,
         key.length: 8
       }
     ]
@@ -1655,24 +1487,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 649,
+    key.offset: 393,
     key.length: 105,
-    key.nameoffset: 659,
+    key.nameoffset: 403,
     key.namelength: 30,
-    key.bodyoffset: 691,
+    key.bodyoffset: 435,
     key.bodylength: 62,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 704,
+        key.offset: 448,
         key.length: 48,
-        key.nameoffset: 714,
+        key.nameoffset: 458,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 697,
+            key.offset: 441,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1684,11 +1516,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 831,
+    key.offset: 504,
     key.length: 48,
-    key.nameoffset: 837,
+    key.nameoffset: 510,
     key.namelength: 27,
-    key.bodyoffset: 877,
+    key.bodyoffset: 550,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1697,7 +1529,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 826,
+        key.offset: 499,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1705,7 +1537,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 867,
+        key.offset: 540,
         key.length: 8
       }
     ]
@@ -1714,11 +1546,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 885,
+    key.offset: 558,
     key.length: 48,
-    key.nameoffset: 891,
+    key.nameoffset: 564,
     key.namelength: 27,
-    key.bodyoffset: 931,
+    key.bodyoffset: 604,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1727,7 +1559,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 880,
+        key.offset: 553,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1735,7 +1567,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 921,
+        key.offset: 594,
         key.length: 8
       }
     ]
@@ -1743,24 +1575,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 934,
+    key.offset: 607,
     key.length: 117,
-    key.nameoffset: 944,
+    key.nameoffset: 617,
     key.namelength: 27,
-    key.bodyoffset: 973,
+    key.bodyoffset: 646,
     key.bodylength: 77,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 986,
+        key.offset: 659,
         key.length: 63,
-        key.nameoffset: 996,
+        key.nameoffset: 669,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 979,
+            key.offset: 652,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1771,22 +1603,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 1052,
+    key.offset: 725,
     key.length: 88,
-    key.nameoffset: 1062,
+    key.nameoffset: 735,
     key.namelength: 27,
-    key.bodyoffset: 1091,
+    key.bodyoffset: 764,
     key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 1102,
+        key.offset: 775,
         key.length: 36,
-        key.nameoffset: 1108,
+        key.nameoffset: 781,
         key.namelength: 11,
-        key.bodyoffset: 1132,
+        key.bodyoffset: 805,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1795,7 +1627,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1097,
+            key.offset: 770,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1803,7 +1635,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1122,
+            key.offset: 795,
             key.length: 8
           }
         ]
@@ -1814,11 +1646,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 1203,
+    key.offset: 819,
     key.length: 65,
-    key.nameoffset: 1209,
+    key.nameoffset: 825,
     key.namelength: 44,
-    key.bodyoffset: 1266,
+    key.bodyoffset: 882,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1827,7 +1659,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1198,
+        key.offset: 814,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1835,7 +1667,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1256,
+        key.offset: 872,
         key.length: 8
       }
     ]
@@ -1843,24 +1675,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 1269,
+    key.offset: 885,
     key.length: 198,
-    key.nameoffset: 1279,
+    key.nameoffset: 895,
     key.namelength: 44,
-    key.bodyoffset: 1325,
+    key.bodyoffset: 941,
     key.bodylength: 141,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 1338,
+        key.offset: 954,
         key.length: 80,
-        key.nameoffset: 1348,
+        key.nameoffset: 964,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 1331,
+            key.offset: 947,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1870,11 +1702,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 1429,
+        key.offset: 1045,
         key.length: 36,
-        key.nameoffset: 1435,
+        key.nameoffset: 1051,
         key.namelength: 11,
-        key.bodyoffset: 1459,
+        key.bodyoffset: 1075,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1883,7 +1715,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1424,
+            key.offset: 1040,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1891,7 +1723,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1449,
+            key.offset: 1065,
             key.length: 8
           }
         ]
@@ -1902,11 +1734,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift3",
-    key.offset: 1536,
+    key.offset: 1089,
     key.length: 57,
-    key.nameoffset: 1542,
+    key.nameoffset: 1095,
     key.namelength: 36,
-    key.bodyoffset: 1591,
+    key.bodyoffset: 1144,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1915,7 +1747,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1531,
+        key.offset: 1084,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1923,7 +1755,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1581,
+        key.offset: 1134,
         key.length: 8
       }
     ]
@@ -1932,11 +1764,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1599,
+    key.offset: 1152,
     key.length: 57,
-    key.nameoffset: 1605,
+    key.nameoffset: 1158,
     key.namelength: 36,
-    key.bodyoffset: 1654,
+    key.bodyoffset: 1207,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1945,7 +1777,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1594,
+        key.offset: 1147,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1953,7 +1785,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1644,
+        key.offset: 1197,
         key.length: 8
       }
     ]
@@ -1961,24 +1793,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Class_Swift3",
-    key.offset: 1657,
+    key.offset: 1210,
     key.length: 127,
-    key.nameoffset: 1667,
+    key.nameoffset: 1220,
     key.namelength: 36,
-    key.bodyoffset: 1705,
+    key.bodyoffset: 1258,
     key.bodylength: 78,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1718,
+        key.offset: 1271,
         key.length: 64,
-        key.nameoffset: 1728,
+        key.nameoffset: 1281,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1711,
+            key.offset: 1264,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1989,22 +1821,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1785,
+    key.offset: 1338,
     key.length: 93,
-    key.nameoffset: 1795,
+    key.nameoffset: 1348,
     key.namelength: 36,
-    key.bodyoffset: 1833,
+    key.bodyoffset: 1386,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 1844,
+        key.offset: 1397,
         key.length: 32,
-        key.nameoffset: 1850,
+        key.nameoffset: 1403,
         key.namelength: 7,
-        key.bodyoffset: 1870,
+        key.bodyoffset: 1423,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -2013,7 +1845,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1839,
+            key.offset: 1392,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -2021,7 +1853,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1860,
+            key.offset: 1413,
             key.length: 8
           }
         ]
@@ -2032,11 +1864,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 2105,
+    key.offset: 1437,
     key.length: 53,
-    key.nameoffset: 2111,
+    key.nameoffset: 1443,
     key.namelength: 32,
-    key.bodyoffset: 2156,
+    key.bodyoffset: 1488,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2045,7 +1877,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2100,
+        key.offset: 1432,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2053,7 +1885,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2146,
+        key.offset: 1478,
         key.length: 8
       }
     ]
@@ -2062,13 +1894,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "GlobalToMember_Typedef_Payload",
-    key.offset: 2166,
+    key.offset: 1498,
     key.length: 83,
-    key.nameoffset: 2176,
+    key.nameoffset: 1508,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 2159,
+        key.offset: 1491,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -2077,24 +1909,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 2250,
+    key.offset: 1582,
     key.length: 82,
-    key.nameoffset: 2260,
+    key.nameoffset: 1592,
     key.namelength: 32,
-    key.bodyoffset: 2294,
+    key.bodyoffset: 1626,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2307,
+        key.offset: 1639,
         key.length: 23,
-        key.nameoffset: 2317,
+        key.nameoffset: 1649,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2300,
+            key.offset: 1632,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2106,11 +1938,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 2377,
+    key.offset: 1670,
     key.length: 53,
-    key.nameoffset: 2383,
+    key.nameoffset: 1676,
     key.namelength: 32,
-    key.bodyoffset: 2428,
+    key.bodyoffset: 1721,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2119,7 +1951,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2372,
+        key.offset: 1665,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2127,7 +1959,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2418,
+        key.offset: 1711,
         key.length: 8
       }
     ]
@@ -2136,13 +1968,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MemberToGlobal_Typedef_Payload",
-    key.offset: 2438,
+    key.offset: 1731,
     key.length: 46,
-    key.nameoffset: 2448,
+    key.nameoffset: 1741,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 2431,
+        key.offset: 1724,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -2151,24 +1983,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 2485,
+    key.offset: 1778,
     key.length: 109,
-    key.nameoffset: 2495,
+    key.nameoffset: 1788,
     key.namelength: 32,
-    key.bodyoffset: 2529,
+    key.bodyoffset: 1822,
     key.bodylength: 64,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2542,
+        key.offset: 1835,
         key.length: 50,
-        key.nameoffset: 2552,
+        key.nameoffset: 1845,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2535,
+            key.offset: 1828,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2180,11 +2012,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 2671,
+    key.offset: 1893,
     key.length: 50,
-    key.nameoffset: 2677,
+    key.nameoffset: 1899,
     key.namelength: 29,
-    key.bodyoffset: 2719,
+    key.bodyoffset: 1941,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2193,7 +2025,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2666,
+        key.offset: 1888,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2201,7 +2033,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2709,
+        key.offset: 1931,
         key.length: 8
       }
     ]
@@ -2210,11 +2042,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 2727,
+    key.offset: 1949,
     key.length: 50,
-    key.nameoffset: 2733,
+    key.nameoffset: 1955,
     key.namelength: 29,
-    key.bodyoffset: 2775,
+    key.bodyoffset: 1997,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2223,7 +2055,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2722,
+        key.offset: 1944,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2231,7 +2063,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2765,
+        key.offset: 1987,
         key.length: 8
       }
     ]
@@ -2239,24 +2071,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 2778,
+    key.offset: 2000,
     key.length: 121,
-    key.nameoffset: 2788,
+    key.nameoffset: 2010,
     key.namelength: 29,
-    key.bodyoffset: 2819,
+    key.bodyoffset: 2041,
     key.bodylength: 79,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 2832,
+        key.offset: 2054,
         key.length: 65,
-        key.nameoffset: 2842,
+        key.nameoffset: 2064,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2825,
+            key.offset: 2047,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2267,24 +2099,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 2900,
+    key.offset: 2122,
     key.length: 83,
-    key.nameoffset: 2910,
+    key.nameoffset: 2132,
     key.namelength: 29,
-    key.bodyoffset: 2941,
+    key.bodyoffset: 2163,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 2954,
+        key.offset: 2176,
         key.length: 27,
-        key.nameoffset: 2964,
+        key.nameoffset: 2186,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2947,
+            key.offset: 2169,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2296,11 +2128,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 3046,
+    key.offset: 2211,
     key.length: 67,
-    key.nameoffset: 3052,
+    key.nameoffset: 2217,
     key.namelength: 46,
-    key.bodyoffset: 3111,
+    key.bodyoffset: 2276,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2309,7 +2141,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 3041,
+        key.offset: 2206,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2317,7 +2149,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3101,
+        key.offset: 2266,
         key.length: 8
       }
     ]
@@ -2325,24 +2157,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 3114,
+    key.offset: 2279,
     key.length: 195,
-    key.nameoffset: 3124,
+    key.nameoffset: 2289,
     key.namelength: 46,
-    key.bodyoffset: 3172,
+    key.bodyoffset: 2337,
     key.bodylength: 136,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 3185,
+        key.offset: 2350,
         key.length: 82,
-        key.nameoffset: 3195,
+        key.nameoffset: 2360,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 3178,
+            key.offset: 2343,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2352,13 +2184,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 3280,
+        key.offset: 2445,
         key.length: 27,
-        key.nameoffset: 3290,
+        key.nameoffset: 2455,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 3273,
+            key.offset: 2438,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2370,11 +2202,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 3378,
+    key.offset: 2480,
     key.length: 59,
-    key.nameoffset: 3384,
+    key.nameoffset: 2486,
     key.namelength: 38,
-    key.bodyoffset: 3435,
+    key.bodyoffset: 2537,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2383,7 +2215,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 3373,
+        key.offset: 2475,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2391,7 +2223,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3425,
+        key.offset: 2527,
         key.length: 8
       }
     ]
@@ -2400,11 +2232,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 3443,
+    key.offset: 2545,
     key.length: 59,
-    key.nameoffset: 3449,
+    key.nameoffset: 2551,
     key.namelength: 38,
-    key.bodyoffset: 3500,
+    key.bodyoffset: 2602,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2413,7 +2245,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 3438,
+        key.offset: 2540,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2421,7 +2253,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3490,
+        key.offset: 2592,
         key.length: 8
       }
     ]
@@ -2429,24 +2261,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 3503,
+    key.offset: 2605,
     key.length: 131,
-    key.nameoffset: 3513,
+    key.nameoffset: 2615,
     key.namelength: 38,
-    key.bodyoffset: 3553,
+    key.bodyoffset: 2655,
     key.bodylength: 80,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 3566,
+        key.offset: 2668,
         key.length: 66,
-        key.nameoffset: 3576,
+        key.nameoffset: 2678,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3559,
+            key.offset: 2661,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2457,24 +2289,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 3635,
+    key.offset: 2737,
     key.length: 88,
-    key.nameoffset: 3645,
+    key.nameoffset: 2747,
     key.namelength: 38,
-    key.bodyoffset: 3685,
+    key.bodyoffset: 2787,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 3698,
+        key.offset: 2800,
         key.length: 23,
-        key.nameoffset: 3708,
+        key.nameoffset: 2810,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3691,
+            key.offset: 2793,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
@@ -1,14 +1,7 @@
 import Foundation
 
-
 open class Foo : NSObject {
 }
-// ===-------------------------------------------------------------------------
-// class Payload
-// ===-------------------------------------------------------------------------
-
-// 3: Payload
-// 4: Namespace.Payload
 open class GlobalToMember_Class_Container : NSObject {
 }
 extension GlobalToMember_Class_Container {
@@ -16,16 +9,10 @@ extension GlobalToMember_Class_Container {
     open class Payload : NSObject {
     }
 }
-
-// 3: Namespace.Payload
-// 4: Payload
 open class MemberToGlobal_Class_Container : NSObject {
 }
 open class MemberToGlobal_Class_Payload : NSObject {
 }
-
-// 3: Namespace_Swift3.PayloadFor3
-// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Class_Swift3 : NSObject {
 }
 open class MemberToMember_Class_Swift4 : NSObject {
@@ -35,9 +22,6 @@ extension MemberToMember_Class_Swift4 {
     open class PayloadFor4 : NSObject {
     }
 }
-
-// 3: Namespace.PayloadFor3
-// 4: Namespace.PayloadFor4
 open class MemberToMember_SameContainer_Class_Container : NSObject {
 }
 extension MemberToMember_SameContainer_Class_Container {
@@ -45,9 +29,6 @@ extension MemberToMember_SameContainer_Class_Container {
     open class PayloadFor4 : NSObject {
     }
 }
-
-// 3: Namespace_Swift3.Payload
-// 4: Namespace_Swift4.Payload
 open class MemberToMember_SameName_Class_Swift3 : NSObject {
 }
 open class MemberToMember_SameName_Class_Swift4 : NSObject {
@@ -57,28 +38,15 @@ extension MemberToMember_SameName_Class_Swift4 {
     open class Payload : NSObject {
     }
 }
-
-// ===-------------------------------------------------------------------------
-// typealias Payload
-// ===-------------------------------------------------------------------------
-
-// 3: Payload
-// 4: Namespace.Payload
 open class GlobalToMember_Typedef_Container : NSObject {
 }
 extension GlobalToMember_Typedef_Container {
 
     public typealias Payload = Foo
 }
-
-// 3: Namespace.Payload
-// 4: Payload
 open class MemberToGlobal_Typedef_Container : NSObject {
 }
 public typealias MemberToGlobal_Typedef_Payload = Foo
-
-// 3: Namespace_Swift3.PayloadFor3
-// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_Typedef_Swift4 : NSObject {
@@ -87,18 +55,12 @@ extension MemberToMember_Typedef_Swift4 {
 
     public typealias PayloadFor4 = Foo
 }
-
-// 3: Namespace.PayloadFor3
-// 4: Namespace.PayloadFor4
 open class MemberToMember_SameContainer_Typedef_Container : NSObject {
 }
 extension MemberToMember_SameContainer_Typedef_Container {
 
     public typealias PayloadFor4 = Foo
 }
-
-// 3: Namespace_Swift3.Payload
-// 4: Namespace_Swift4.Payload
 open class MemberToMember_SameName_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_SameName_Typedef_Swift4 : NSObject {
@@ -121,712 +83,582 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 20,
+    key.offset: 19,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 25,
+    key.offset: 24,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 30,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 37,
+    key.offset: 36,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 50,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 130,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 147,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 228,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 242,
-    key.length: 24
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 266,
+    key.offset: 49,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 271,
+    key.offset: 54,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 277,
+    key.offset: 60,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 310,
+    key.offset: 93,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 323,
+    key.offset: 106,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 333,
+    key.offset: 116,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 154,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 159,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 165,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 175,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 194,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 199,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 205,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 238,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 251,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 256,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 262,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 293,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 306,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 311,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 317,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 347,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 360,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 365,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 371,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 401,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 414,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 424,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 459,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 376,
+    key.offset: 464,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 382,
+    key.offset: 470,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 484,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 503,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 508,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 514,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 561,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 574,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 584,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 636,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 641,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 647,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 661,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 680,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 685,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 691,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 730,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 743,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 748,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 754,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 793,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 806,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 816,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 860,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 865,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 871,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 392,
+    key.offset: 881,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 412,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 436,
-    key.length: 14
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 450,
+    key.offset: 900,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 455,
+    key.offset: 905,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 461,
+    key.offset: 911,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 946,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 959,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 969,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1009,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1016,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1026,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1036,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1042,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1047,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1053,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1088,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1101,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1108,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1118,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 494,
-    key.length: 8
+    key.offset: 1151,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 507,
+    key.offset: 1155,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 512,
+    key.offset: 1160,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 518,
-    key.length: 28
+    key.offset: 1166,
+    key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 549,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 563,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 598,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 633,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 638,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 644,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 674,
+    key.offset: 1198,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 687,
+    key.offset: 1211,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 692,
+    key.offset: 1216,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 698,
-    key.length: 27
+    key.offset: 1222,
+    key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 728,
+    key.offset: 1254,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 741,
+    key.offset: 1267,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 751,
-    key.length: 27
+    key.offset: 1277,
+    key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 786,
-    key.length: 4
+    key.offset: 1314,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 791,
-    key.length: 5
+    key.offset: 1321,
+    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 797,
+    key.offset: 1331,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 811,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 831,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 859,
-    key.length: 28
+    key.offset: 1345,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 887,
+    key.offset: 1351,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 892,
+    key.offset: 1356,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 898,
-    key.length: 44
+    key.offset: 1362,
+    key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 945,
+    key.offset: 1411,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 958,
+    key.offset: 1424,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 968,
-    key.length: 44
+    key.offset: 1434,
+    key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1020,
-    key.length: 4
+    key.offset: 1488,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1025,
-    key.length: 5
+    key.offset: 1495,
+    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1031,
+    key.offset: 1505,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1045,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1065,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1096,
-    key.length: 31
+    key.offset: 1519,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1127,
+    key.offset: 1525,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1132,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1138,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1177,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1190,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1195,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1201,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1240,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1253,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1263,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1307,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1312,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1318,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1328,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1348,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1428,
-    key.length: 21
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1449,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
     key.offset: 1530,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1544,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1568,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1573,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1579,
-    key.length: 32
+    key.offset: 1536,
+    key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1614,
+    key.offset: 1577,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1590,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1595,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1601,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1642,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1627,
+    key.offset: 1655,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1637,
-    key.length: 32
+    key.offset: 1665,
+    key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1677,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1684,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1694,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1704,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
     key.offset: 1711,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1735,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1749,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1754,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1760,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1795,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1808,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1815,
+    key.offset: 1718,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1825,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1858,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1863,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1898,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1933,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1938,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1944,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1976,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1989,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1994,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2000,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2032,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2045,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2055,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2092,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2099,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2109,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2123,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2130,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2158,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2186,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2191,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2197,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2246,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2259,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2269,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2323,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2330,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2340,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2354,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2361,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2392,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2423,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2428,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2434,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2475,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2488,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2493,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2499,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2540,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2553,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2563,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2609,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2616,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2626,
+    key.offset: 1728,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2636,
+    key.offset: 1738,
     key.length: 3
   }
 ]
@@ -839,187 +671,187 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 37,
+    key.offset: 36,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 310,
+    key.offset: 93,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 333,
+    key.offset: 116,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 392,
+    key.offset: 175,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 494,
+    key.offset: 238,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 549,
+    key.offset: 293,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 674,
+    key.offset: 347,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 728,
+    key.offset: 401,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 751,
+    key.offset: 424,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 811,
+    key.offset: 484,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 945,
+    key.offset: 561,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 968,
+    key.offset: 584,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1045,
+    key.offset: 661,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1177,
+    key.offset: 730,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1240,
+    key.offset: 793,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1263,
+    key.offset: 816,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1328,
+    key.offset: 881,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1614,
+    key.offset: 946,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1637,
+    key.offset: 969,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1704,
+    key.offset: 1036,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1795,
+    key.offset: 1088,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1858,
+    key.offset: 1151,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1976,
+    key.offset: 1198,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2032,
+    key.offset: 1254,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2055,
+    key.offset: 1277,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2123,
+    key.offset: 1345,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2246,
+    key.offset: 1411,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2269,
+    key.offset: 1434,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2354,
+    key.offset: 1519,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2475,
+    key.offset: 1577,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2540,
+    key.offset: 1642,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2563,
+    key.offset: 1665,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2636,
+    key.offset: 1738,
     key.length: 3
   }
 ]
@@ -1028,11 +860,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "Foo",
-    key.offset: 25,
+    key.offset: 24,
     key.length: 24,
-    key.nameoffset: 31,
+    key.nameoffset: 30,
     key.namelength: 3,
-    key.bodyoffset: 47,
+    key.bodyoffset: 46,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1041,7 +873,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 20,
+        key.offset: 19,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1049,7 +881,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 37,
+        key.offset: 36,
         key.length: 8
       }
     ]
@@ -1058,11 +890,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 271,
+    key.offset: 54,
     key.length: 51,
-    key.nameoffset: 277,
+    key.nameoffset: 60,
     key.namelength: 30,
-    key.bodyoffset: 320,
+    key.bodyoffset: 103,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1071,7 +903,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 266,
+        key.offset: 49,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1079,7 +911,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 310,
+        key.offset: 93,
         key.length: 8
       }
     ]
@@ -1087,22 +919,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 323,
+    key.offset: 106,
     key.length: 87,
-    key.nameoffset: 333,
+    key.nameoffset: 116,
     key.namelength: 30,
-    key.bodyoffset: 365,
+    key.bodyoffset: 148,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 376,
+        key.offset: 159,
         key.length: 32,
-        key.nameoffset: 382,
+        key.nameoffset: 165,
         key.namelength: 7,
-        key.bodyoffset: 402,
+        key.bodyoffset: 185,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1111,7 +943,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 371,
+            key.offset: 154,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1119,7 +951,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 392,
+            key.offset: 175,
             key.length: 8
           }
         ]
@@ -1130,11 +962,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 455,
+    key.offset: 199,
     key.length: 51,
-    key.nameoffset: 461,
+    key.nameoffset: 205,
     key.namelength: 30,
-    key.bodyoffset: 504,
+    key.bodyoffset: 248,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1143,7 +975,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 450,
+        key.offset: 194,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1151,7 +983,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 494,
+        key.offset: 238,
         key.length: 8
       }
     ]
@@ -1160,11 +992,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Payload",
-    key.offset: 512,
+    key.offset: 256,
     key.length: 49,
-    key.nameoffset: 518,
+    key.nameoffset: 262,
     key.namelength: 28,
-    key.bodyoffset: 559,
+    key.bodyoffset: 303,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1173,7 +1005,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 507,
+        key.offset: 251,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1181,7 +1013,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 549,
+        key.offset: 293,
         key.length: 8
       }
     ]
@@ -1190,11 +1022,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 638,
+    key.offset: 311,
     key.length: 48,
-    key.nameoffset: 644,
+    key.nameoffset: 317,
     key.namelength: 27,
-    key.bodyoffset: 684,
+    key.bodyoffset: 357,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1203,7 +1035,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 633,
+        key.offset: 306,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1211,7 +1043,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 674,
+        key.offset: 347,
         key.length: 8
       }
     ]
@@ -1220,11 +1052,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 692,
+    key.offset: 365,
     key.length: 48,
-    key.nameoffset: 698,
+    key.nameoffset: 371,
     key.namelength: 27,
-    key.bodyoffset: 738,
+    key.bodyoffset: 411,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1233,7 +1065,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 687,
+        key.offset: 360,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1241,7 +1073,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 728,
+        key.offset: 401,
         key.length: 8
       }
     ]
@@ -1249,22 +1081,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 741,
+    key.offset: 414,
     key.length: 88,
-    key.nameoffset: 751,
+    key.nameoffset: 424,
     key.namelength: 27,
-    key.bodyoffset: 780,
+    key.bodyoffset: 453,
     key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 791,
+        key.offset: 464,
         key.length: 36,
-        key.nameoffset: 797,
+        key.nameoffset: 470,
         key.namelength: 11,
-        key.bodyoffset: 821,
+        key.bodyoffset: 494,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1273,7 +1105,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 786,
+            key.offset: 459,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1281,7 +1113,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 811,
+            key.offset: 484,
             key.length: 8
           }
         ]
@@ -1292,11 +1124,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 892,
+    key.offset: 508,
     key.length: 65,
-    key.nameoffset: 898,
+    key.nameoffset: 514,
     key.namelength: 44,
-    key.bodyoffset: 955,
+    key.bodyoffset: 571,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1305,7 +1137,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 887,
+        key.offset: 503,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1313,7 +1145,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 945,
+        key.offset: 561,
         key.length: 8
       }
     ]
@@ -1321,22 +1153,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 958,
+    key.offset: 574,
     key.length: 105,
-    key.nameoffset: 968,
+    key.nameoffset: 584,
     key.namelength: 44,
-    key.bodyoffset: 1014,
+    key.bodyoffset: 630,
     key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 1025,
+        key.offset: 641,
         key.length: 36,
-        key.nameoffset: 1031,
+        key.nameoffset: 647,
         key.namelength: 11,
-        key.bodyoffset: 1055,
+        key.bodyoffset: 671,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1345,7 +1177,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1020,
+            key.offset: 636,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1353,7 +1185,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1045,
+            key.offset: 661,
             key.length: 8
           }
         ]
@@ -1364,11 +1196,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift3",
-    key.offset: 1132,
+    key.offset: 685,
     key.length: 57,
-    key.nameoffset: 1138,
+    key.nameoffset: 691,
     key.namelength: 36,
-    key.bodyoffset: 1187,
+    key.bodyoffset: 740,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1377,7 +1209,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1127,
+        key.offset: 680,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1385,7 +1217,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1177,
+        key.offset: 730,
         key.length: 8
       }
     ]
@@ -1394,11 +1226,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1195,
+    key.offset: 748,
     key.length: 57,
-    key.nameoffset: 1201,
+    key.nameoffset: 754,
     key.namelength: 36,
-    key.bodyoffset: 1250,
+    key.bodyoffset: 803,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1407,7 +1239,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1190,
+        key.offset: 743,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1415,7 +1247,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1240,
+        key.offset: 793,
         key.length: 8
       }
     ]
@@ -1423,22 +1255,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1253,
+    key.offset: 806,
     key.length: 93,
-    key.nameoffset: 1263,
+    key.nameoffset: 816,
     key.namelength: 36,
-    key.bodyoffset: 1301,
+    key.bodyoffset: 854,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 1312,
+        key.offset: 865,
         key.length: 32,
-        key.nameoffset: 1318,
+        key.nameoffset: 871,
         key.namelength: 7,
-        key.bodyoffset: 1338,
+        key.bodyoffset: 891,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1447,7 +1279,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1307,
+            key.offset: 860,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1455,7 +1287,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1328,
+            key.offset: 881,
             key.length: 8
           }
         ]
@@ -1466,11 +1298,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 1573,
+    key.offset: 905,
     key.length: 53,
-    key.nameoffset: 1579,
+    key.nameoffset: 911,
     key.namelength: 32,
-    key.bodyoffset: 1624,
+    key.bodyoffset: 956,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1479,7 +1311,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1568,
+        key.offset: 900,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1487,7 +1319,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1614,
+        key.offset: 946,
         key.length: 8
       }
     ]
@@ -1495,24 +1327,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 1627,
+    key.offset: 959,
     key.length: 82,
-    key.nameoffset: 1637,
+    key.nameoffset: 969,
     key.namelength: 32,
-    key.bodyoffset: 1671,
+    key.bodyoffset: 1003,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1684,
+        key.offset: 1016,
         key.length: 23,
-        key.nameoffset: 1694,
+        key.nameoffset: 1026,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1677,
+            key.offset: 1009,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1524,11 +1356,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 1754,
+    key.offset: 1047,
     key.length: 53,
-    key.nameoffset: 1760,
+    key.nameoffset: 1053,
     key.namelength: 32,
-    key.bodyoffset: 1805,
+    key.bodyoffset: 1098,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1537,7 +1369,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1749,
+        key.offset: 1042,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1545,7 +1377,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1795,
+        key.offset: 1088,
         key.length: 8
       }
     ]
@@ -1554,13 +1386,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MemberToGlobal_Typedef_Payload",
-    key.offset: 1815,
+    key.offset: 1108,
     key.length: 46,
-    key.nameoffset: 1825,
+    key.nameoffset: 1118,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 1808,
+        key.offset: 1101,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1570,11 +1402,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 1938,
+    key.offset: 1160,
     key.length: 50,
-    key.nameoffset: 1944,
+    key.nameoffset: 1166,
     key.namelength: 29,
-    key.bodyoffset: 1986,
+    key.bodyoffset: 1208,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1583,7 +1415,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1933,
+        key.offset: 1155,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1591,7 +1423,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1976,
+        key.offset: 1198,
         key.length: 8
       }
     ]
@@ -1600,11 +1432,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 1994,
+    key.offset: 1216,
     key.length: 50,
-    key.nameoffset: 2000,
+    key.nameoffset: 1222,
     key.namelength: 29,
-    key.bodyoffset: 2042,
+    key.bodyoffset: 1264,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1613,7 +1445,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1989,
+        key.offset: 1211,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1621,7 +1453,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2032,
+        key.offset: 1254,
         key.length: 8
       }
     ]
@@ -1629,24 +1461,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 2045,
+    key.offset: 1267,
     key.length: 83,
-    key.nameoffset: 2055,
+    key.nameoffset: 1277,
     key.namelength: 29,
-    key.bodyoffset: 2086,
+    key.bodyoffset: 1308,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 2099,
+        key.offset: 1321,
         key.length: 27,
-        key.nameoffset: 2109,
+        key.nameoffset: 1331,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2092,
+            key.offset: 1314,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1658,11 +1490,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 2191,
+    key.offset: 1356,
     key.length: 67,
-    key.nameoffset: 2197,
+    key.nameoffset: 1362,
     key.namelength: 46,
-    key.bodyoffset: 2256,
+    key.bodyoffset: 1421,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1671,7 +1503,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2186,
+        key.offset: 1351,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1679,7 +1511,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2246,
+        key.offset: 1411,
         key.length: 8
       }
     ]
@@ -1687,24 +1519,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 2259,
+    key.offset: 1424,
     key.length: 100,
-    key.nameoffset: 2269,
+    key.nameoffset: 1434,
     key.namelength: 46,
-    key.bodyoffset: 2317,
+    key.bodyoffset: 1482,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 2330,
+        key.offset: 1495,
         key.length: 27,
-        key.nameoffset: 2340,
+        key.nameoffset: 1505,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2323,
+            key.offset: 1488,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1716,11 +1548,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 2428,
+    key.offset: 1530,
     key.length: 59,
-    key.nameoffset: 2434,
+    key.nameoffset: 1536,
     key.namelength: 38,
-    key.bodyoffset: 2485,
+    key.bodyoffset: 1587,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1729,7 +1561,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2423,
+        key.offset: 1525,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1737,7 +1569,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2475,
+        key.offset: 1577,
         key.length: 8
       }
     ]
@@ -1746,11 +1578,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 2493,
+    key.offset: 1595,
     key.length: 59,
-    key.nameoffset: 2499,
+    key.nameoffset: 1601,
     key.namelength: 38,
-    key.bodyoffset: 2550,
+    key.bodyoffset: 1652,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1759,7 +1591,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2488,
+        key.offset: 1590,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1767,7 +1599,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2540,
+        key.offset: 1642,
         key.length: 8
       }
     ]
@@ -1775,24 +1607,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 2553,
+    key.offset: 1655,
     key.length: 88,
-    key.nameoffset: 2563,
+    key.nameoffset: 1665,
     key.namelength: 38,
-    key.bodyoffset: 2603,
+    key.bodyoffset: 1705,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2616,
+        key.offset: 1718,
         key.length: 23,
-        key.nameoffset: 2626,
+        key.nameoffset: 1728,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2609,
+            key.offset: 1711,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
@@ -1,9 +1,7 @@
 import FooHelper.FooHelperExplicit
 import FooHelper.FooHelperSub
 
-
 public func fooHelperFunc1(_ a: Int32) -> Int32
-
 public var FooHelperUnnamedEnumeratorA1: Int { get }
 public var FooHelperUnnamedEnumeratorA2: Int { get }
 
@@ -40,87 +38,87 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 67,
+    key.offset: 66,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 74,
+    key.offset: 73,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 79,
+    key.offset: 78,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 94,
+    key.offset: 93,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 96,
+    key.offset: 95,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 99,
+    key.offset: 98,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 109,
+    key.offset: 108,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 116,
+    key.offset: 114,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 123,
+    key.offset: 121,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 127,
+    key.offset: 125,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 157,
+    key.offset: 155,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 163,
+    key.offset: 161,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 169,
+    key.offset: 167,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 176,
+    key.offset: 174,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 180,
+    key.offset: 178,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 210,
+    key.offset: 208,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 216,
+    key.offset: 214,
     key.length: 3
   }
 ]
@@ -147,25 +145,25 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 99,
+    key.offset: 98,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 109,
+    key.offset: 108,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 157,
+    key.offset: 155,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 210,
+    key.offset: 208,
     key.length: 3,
     key.is_system: 1
   }
@@ -175,14 +173,14 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooHelperFunc1(_:)",
-    key.offset: 74,
+    key.offset: 73,
     key.length: 40,
     key.typename: "Int32",
-    key.nameoffset: 79,
+    key.nameoffset: 78,
     key.namelength: 26,
     key.attributes: [
       {
-        key.offset: 67,
+        key.offset: 66,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -191,7 +189,7 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 94,
+        key.offset: 93,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -201,16 +199,16 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooHelperUnnamedEnumeratorA1",
-    key.offset: 123,
+    key.offset: 121,
     key.length: 45,
     key.typename: "Int",
-    key.nameoffset: 127,
+    key.nameoffset: 125,
     key.namelength: 28,
-    key.bodyoffset: 162,
+    key.bodyoffset: 160,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 116,
+        key.offset: 114,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -220,16 +218,16 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooHelperUnnamedEnumeratorA2",
-    key.offset: 176,
+    key.offset: 174,
     key.length: 45,
     key.typename: "Int",
-    key.nameoffset: 180,
+    key.nameoffset: 178,
     key.namelength: 28,
-    key.bodyoffset: 215,
+    key.bodyoffset: 213,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 169,
+        key.offset: 167,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -2,14 +2,6 @@ import Foo.FooSub
 import FooHelper
 import SwiftOnoneSupport
 
-/*  Foo.h
-  Copyright (c) 1815, Napoleon Bonaparte. All rights reserved.
-*/
-
-// Types.
-
-// and stuff.
-// Yo.
 
 /// Aaa.  FooEnum1.  Bbb.
 public struct FooEnum1 : Equatable, RawRepresentable {
@@ -23,7 +15,6 @@ public struct FooEnum1 : Equatable, RawRepresentable {
 
 /// Aaa.  FooEnum1X.  Bbb.
 public var FooEnum1X: FooEnum1 { get }
-
 public struct FooEnum2 : Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
@@ -48,11 +39,9 @@ public var FooEnum3Y: FooEnum3 { get }
 /// Aaa.  FooComparisonResult.  Bbb.
 public enum FooComparisonResult : Int {
 
-    
-    // This is ascending
     case orderedAscending = -1
 
-    case orderedSame = 0 // But this is the same.
+    case orderedSame = 0
 
     case orderedDescending = 1
 }
@@ -62,13 +51,10 @@ public struct FooRuncingOptions : OptionSet {
 
     public init(rawValue: Int)
 
-    
-    // This is mince.
     public static var enableMince: FooRuncingOptions { get }
 
-    public static var enableQuince: FooRuncingOptions { get } /* But this is quince */
+    public static var enableQuince: FooRuncingOptions { get }
 }
-
 public struct FooStruct1 {
 
     public init()
@@ -80,7 +66,6 @@ public struct FooStruct1 {
     public var y: Double
 }
 public typealias FooStruct1Pointer = UnsafeMutablePointer<FooStruct1>
-
 public struct FooStruct2 {
 
     public init()
@@ -92,7 +77,6 @@ public struct FooStruct2 {
     public var y: Double
 }
 public typealias FooStructTypedef1 = FooStruct2
-
 public struct FooStructTypedef2 {
 
     public init()
@@ -112,18 +96,10 @@ public var fooIntVar: Int32
 
 /// Aaa.  fooFunc1.  Bbb.
 public func fooFunc1(_ a: Int32) -> Int32
-
 public func fooFunc1AnonymousParam(_: Int32) -> Int32
 public func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
-
-/*
-  Very good
-  fooFuncWithBlock function.
-*/
 public func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
-
 public func fooFuncWithFunctionPointer(_ fptr: (@convention(c) (Float) -> Int32)!)
-
 public func fooFuncNoreturn1() -> Never
 public func fooFuncNoreturn2() -> Never
 
@@ -166,37 +142,33 @@ public func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32
 /// Aaa.  FooProtocolBase.  Bbb.
 public protocol FooProtocolBase {
 
-    
+
     /// Aaa.  fooProtoFunc.  Bbb.
     /// Ccc.
     func fooProtoFunc()
 
-    
+
     /// Aaa.  fooProtoFuncWithExtraIndentation1.  Bbb.
     /// Ccc.
     func fooProtoFuncWithExtraIndentation1()
 
-    
+
     /**
      * Aaa.  fooProtoFuncWithExtraIndentation2.  Bbb.
      * Ccc.
      */
     func fooProtoFuncWithExtraIndentation2()
 
-    
     static func fooProtoClassFunc()
 
-    
     var fooProperty1: Int32 { get set }
 
     var fooProperty2: Int32 { get set }
 
     var fooProperty3: Int32 { get }
 }
-
 public protocol FooProtocolDerived : FooProtocolBase {
 }
-
 open class FooClassBase {
 
     open func fooBaseInstanceFunc0()
@@ -209,44 +181,32 @@ open class FooClassBase {
 
     open func fooBaseInstanceFuncOverridden()
 
-    
     open class func fooBaseClassFunc0()
 }
 
 /// Aaa.  FooClassDerived.  Bbb.
 open class FooClassDerived : FooClassBase, FooProtocolDerived {
 
-    
     open var fooProperty1: Int32
 
     open var fooProperty2: Int32
 
     open var fooProperty3: Int32 { get }
 
-    
-    /* Blah..
-       for fooInstanceFunc0..
-       blah blah.
-    */
     open func fooInstanceFunc0()
 
     open func fooInstanceFunc1(_ a: Int32)
 
     open func fooInstanceFunc2(_ a: Int32, withB b: Int32)
 
-    
     open func fooBaseInstanceFuncOverridden()
 
-    
     open class func fooClassFunc0()
 }
-
 public typealias typedef_int_t = Int32
-
-/* FOO_MACRO_1 is the answer */
 public var FOO_MACRO_1: Int32 { get }
 public var FOO_MACRO_2: Int32 { get }
-public var FOO_MACRO_3: Int32 { get } // Don't use FOO_MACRO_3 on Saturdays.
+public var FOO_MACRO_3: Int32 { get }
 public var FOO_MACRO_4: UInt32 { get }
 public var FOO_MACRO_5: UInt64 { get }
 public var FOO_MACRO_6: typedef_int_t { get }
@@ -259,15 +219,10 @@ public var FOO_MACRO_OR: Int32 { get }
 public var FOO_MACRO_AND: Int32 { get }
 public var FOO_MACRO_BITWIDTH: UInt64 { get }
 public var FOO_MACRO_SIGNED: UInt32 { get }
-
 public var FOO_MACRO_REDEF_1: Int32 { get }
-
 public var FOO_MACRO_REDEF_2: Int32 { get }
-
 public func theLastDeclInFoo()
-
 public func _internalTopLevelFunc()
-
 public struct _InternalStruct {
 
     public init()
@@ -276,31 +231,24 @@ public struct _InternalStruct {
 
     public var x: Int32
 }
-
 extension FooClassBase {
 
     open func _internalMeth1() -> Any!
 }
-
-/* Extending FooClassBase with cool stuff */
 extension FooClassBase {
 
     open func _internalMeth2() -> Any!
 
     open func nonInternalMeth() -> Any!
 }
-
 extension FooClassBase {
 
     open func _internalMeth3() -> Any!
 }
-
 public protocol _InternalProt {
 }
-
 open class ClassWithInternalProt : _InternalProt {
 }
-
 open class FooClassPropertyOwnership : FooClassBase {
 
     unowned(unsafe) open var assignable: AnyObject!
@@ -317,34 +265,27 @@ open class FooClassPropertyOwnership : FooClassBase {
 
     open var scalar: Int32
 }
-
 open class FooUnavailableMembers : FooClassBase {
 
     public convenience init!(int i: Int32)
 
-    
     @available(*, deprecated, message: "x")
     open func deprecated()
 
-    
     @available(macOS 10.1, *)
     open func availabilityIntroduced()
 
-    
     @available(macOS, introduced: 10.1, message: "x")
     open func availabilityIntroducedMsg()
 }
-
 public class FooCFType {
 }
-
 @available(*, deprecated, message: "use CNAuthorizationStatus")
 public enum ABAuthorizationStatus : Int {
 
-    
-    case notDetermined = 0 // deprecated, use CNAuthorizationStatusNotDetermined
+    case notDetermined = 0
 
-    case restricted = 1 // deprecated, use CNAuthorizationStatusRestricted
+    case restricted = 1
 }
 public class FooOverlayClassBase {
 
@@ -394,584 +335,664 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 17
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 61,
-    key.length: 75
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 138,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 149,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 163,
-    key.length: 7
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 171,
+    key.offset: 62,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 197,
+    key.offset: 88,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 204,
+    key.offset: 95,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 211,
+    key.offset: 102,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 222,
+    key.offset: 113,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 233,
+    key.offset: 124,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 257,
+    key.offset: 148,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 264,
+    key.offset: 155,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 269,
+    key.offset: 160,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 271,
+    key.offset: 162,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 281,
+    key.offset: 172,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 294,
+    key.offset: 185,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 301,
+    key.offset: 192,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 306,
+    key.offset: 197,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 316,
+    key.offset: 207,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 329,
+    key.offset: 220,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 336,
+    key.offset: 227,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 340,
+    key.offset: 231,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 350,
+    key.offset: 241,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 360,
+    key.offset: 251,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 387,
+    key.offset: 278,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 394,
+    key.offset: 285,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 398,
+    key.offset: 289,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 409,
+    key.offset: 300,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 420,
+    key.offset: 311,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 427,
+    key.offset: 317,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 434,
+    key.offset: 324,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 441,
+    key.offset: 331,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 452,
+    key.offset: 342,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 463,
+    key.offset: 353,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 487,
+    key.offset: 377,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 494,
+    key.offset: 384,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 499,
+    key.offset: 389,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 391,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 401,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 414,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 421,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 426,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 436,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 449,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 456,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 460,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 470,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 479,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 486,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 490,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 501,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 511,
-    key.length: 6
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 512,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 524,
+    key.offset: 518,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 531,
+    key.offset: 525,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 529,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 540,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 551,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 557,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 564,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 571,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 582,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 593,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 617,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 624,
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 629,
+    key.length: 1
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 536,
+    key.offset: 631,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 546,
+    key.offset: 641,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 559,
+    key.offset: 654,
     key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 566,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 570,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 580,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 589,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 596,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 600,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 611,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 622,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 628,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 635,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 639,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 650,
-    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 661,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 667,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 674,
-    key.length: 6
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 681,
+    key.offset: 666,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 692,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 703,
-    key.length: 16
+    key.offset: 676,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 727,
+    key.offset: 689,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 734,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 739,
-    key.length: 1
+    key.offset: 696,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 700,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 710,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 719,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 726,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 730,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 741,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 751,
-    key.length: 6
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 752,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 764,
+    key.offset: 758,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 771,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 776,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 786,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 799,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 806,
+    key.offset: 765,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 810,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 820,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 829,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 836,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 840,
+    key.offset: 769,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 851,
+    key.offset: 780,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 862,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 868,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 875,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 879,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 890,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 901,
+    key.offset: 791,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 908,
+    key.offset: 798,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 945,
+    key.offset: 835,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 952,
+    key.offset: 842,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 957,
+    key.offset: 847,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 979,
+    key.offset: 869,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 995,
-    key.length: 21
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1020,
+    key.offset: 880,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1025,
+    key.offset: 885,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1044,
+    key.offset: 904,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1052,
+    key.offset: 912,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1057,
+    key.offset: 917,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1071,
+    key.offset: 931,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1073,
-    key.length: 25
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1103,
+    key.offset: 938,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1108,
+    key.offset: 943,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1128,
+    key.offset: 963,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1133,
+    key.offset: 968,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1168,
+    key.offset: 1003,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1175,
+    key.offset: 1010,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1182,
+    key.offset: 1017,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1202,
+    key.offset: 1037,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1219,
+    key.offset: 1054,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1226,
+    key.offset: 1061,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1231,
+    key.offset: 1066,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1241,
+    key.offset: 1076,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1256,
-    key.length: 18
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1278,
+    key.offset: 1086,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1285,
+    key.offset: 1093,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1292,
+    key.offset: 1100,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1296,
+    key.offset: 1104,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1309,
+    key.offset: 1117,
     key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1137,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1148,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1155,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1162,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1166,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1180,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1200,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1208,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1215,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1222,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1240,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1247,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1259,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1266,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1271,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1274,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1281,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1284,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1297,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1304,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1308,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1311,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1322,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -979,204 +1000,219 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1340,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1347,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1354,
-    key.length: 3
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1358,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1372,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1392,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1398,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1426,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1433,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1440,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1458,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1465,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1477,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1484,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1489,
+    key.offset: 1333,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1492,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1499,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1502,
+    key.offset: 1336,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1515,
+    key.offset: 1345,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1522,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1526,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1529,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1540,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1547,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1551,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1554,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1563,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1570,
+    key.offset: 1352,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1580,
+    key.offset: 1362,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1600,
+    key.offset: 1382,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1621,
+    key.offset: 1403,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1634,
+    key.offset: 1415,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1641,
+    key.offset: 1422,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1648,
+    key.offset: 1429,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1666,
+    key.offset: 1447,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1673,
+    key.offset: 1454,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1685,
+    key.offset: 1466,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1692,
+    key.offset: 1473,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1697,
+    key.offset: 1478,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1700,
+    key.offset: 1481,
     key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1488,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1491,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1504,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1511,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1515,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1518,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1529,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1536,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1540,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1543,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1552,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1559,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1569,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1589,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1600,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1607,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1614,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1639,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1646,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1658,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1665,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1670,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1673,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1680,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1683,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1696,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1703,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
@@ -1186,137 +1222,112 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1710,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1723,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1730,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1734,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1737,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1748,
+    key.offset: 1721,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1755,
+    key.offset: 1728,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1759,
+    key.offset: 1732,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1762,
+    key.offset: 1735,
     key.length: 6
   },
   {
+    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.offset: 1745,
+    key.length: 29
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1771,
+    key.offset: 1774,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1778,
+    key.offset: 1781,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1788,
-    key.length: 17
+    key.offset: 1791,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1808,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1820,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1827,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1834,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1859,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1866,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1878,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1885,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1890,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1893,
+    key.offset: 1805,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1900,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1903,
-    key.length: 6
+    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.offset: 1812,
+    key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1916,
+    key.offset: 1839,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1923,
+    key.offset: 1846,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1927,
+    key.offset: 1850,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1861,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.offset: 1868,
+    key.length: 26
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1894,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1901,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1906,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1915,
     key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1917,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1920,
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
@@ -1325,103 +1336,148 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1941,
+    key.offset: 1936,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1948,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1952,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1955,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1965,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1994,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2001,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2011,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2025,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2032,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2059,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2066,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2070,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2081,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2088,
-    key.length: 26
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2114,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2121,
+    key.offset: 1943,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2126,
+    key.offset: 1948,
+    key.length: 22
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1971,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1974,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1984,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1990,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1997,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2002,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2135,
+    key.offset: 2011,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2137,
+    key.offset: 2013,
     key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2016,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2023,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2025,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2028,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2035,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2037,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2040,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2048,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2050,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2053,
+    key.length: 20
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2074,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2086,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2092,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2099,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2104,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2121,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2123,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2130,
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
@@ -1429,799 +1485,809 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2150,
-    key.length: 5
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2157,
+    key.offset: 2149,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2164,
+    key.offset: 2156,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2169,
-    key.length: 22
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2192,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2195,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2205,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2211,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2218,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2223,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2232,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2234,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2237,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2244,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2246,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2249,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2256,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2258,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2261,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2269,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2271,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2274,
-    key.length: 20
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2295,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2307,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2314,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2361,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2368,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2373,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2390,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2392,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2399,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2409,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2419,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2426,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2431,
+    key.offset: 2161,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2458,
+    key.offset: 2188,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2460,
+    key.offset: 2190,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2467,
+    key.offset: 2197,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2479,
+    key.offset: 2209,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2483,
+    key.offset: 2213,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2493,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2503,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2510,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2515,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2537,
+    key.offset: 2223,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2543,
+    key.offset: 2232,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2550,
+    key.offset: 2239,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2555,
+    key.offset: 2244,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2577,
+    key.offset: 2266,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2272,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2279,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2284,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2306,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2584,
+    key.offset: 2313,
     key.length: 62
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2647,
+    key.offset: 2376,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2654,
+    key.offset: 2383,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2659,
+    key.offset: 2388,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2682,
+    key.offset: 2411,
     key.length: 42
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2725,
+    key.offset: 2454,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2732,
+    key.offset: 2461,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2737,
+    key.offset: 2466,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2760,
+    key.offset: 2489,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2804,
+    key.offset: 2533,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2820,
+    key.offset: 2549,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2827,
+    key.offset: 2556,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2832,
+    key.offset: 2561,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2855,
+    key.offset: 2584,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2899,
+    key.offset: 2628,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2908,
+    key.offset: 2637,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2915,
+    key.offset: 2644,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2920,
+    key.offset: 2649,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2943,
+    key.offset: 2672,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2980,
+    key.offset: 2709,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2989,
+    key.offset: 2718,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2993,
+    key.offset: 2722,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3002,
+    key.offset: 2731,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3009,
+    key.offset: 2738,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3014,
+    key.offset: 2743,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3037,
+    key.offset: 2766,
     key.length: 50
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3087,
+    key.offset: 2816,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3094,
+    key.offset: 2823,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3099,
+    key.offset: 2828,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3132,
+    key.offset: 2861,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3134,
+    key.offset: 2863,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3137,
+    key.offset: 2866,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3147,
+    key.offset: 2876,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3154,
+    key.offset: 2883,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3187,
+    key.offset: 2916,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3194,
+    key.offset: 2923,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3203,
+    key.offset: 2932,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3231,
+    key.offset: 2956,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3265,
+    key.offset: 2990,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3278,
+    key.offset: 3003,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3283,
+    key.offset: 3008,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3308,
+    key.offset: 3029,
     key.length: 51
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3363,
+    key.offset: 3084,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3376,
+    key.offset: 3097,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3381,
+    key.offset: 3102,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3427,
+    key.offset: 3144,
     key.length: 77
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3509,
+    key.offset: 3226,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3514,
+    key.offset: 3231,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3560,
+    key.offset: 3272,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3567,
+    key.offset: 3279,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3572,
+    key.offset: 3284,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3602,
+    key.offset: 3309,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3606,
+    key.offset: 3313,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3620,
+    key.offset: 3327,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3628,
+    key.offset: 3335,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3632,
+    key.offset: 3339,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3643,
+    key.offset: 3350,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3647,
+    key.offset: 3354,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3661,
+    key.offset: 3368,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3669,
+    key.offset: 3376,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3673,
+    key.offset: 3380,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3684,
+    key.offset: 3391,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3688,
+    key.offset: 3395,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3702,
+    key.offset: 3409,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3710,
+    key.offset: 3417,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3719,
+    key.offset: 3425,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3726,
+    key.offset: 3432,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3735,
+    key.offset: 3441,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3756,
+    key.offset: 3462,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3777,
+    key.offset: 3482,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3782,
+    key.offset: 3487,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3788,
+    key.offset: 3493,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3808,
+    key.offset: 3513,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3813,
+    key.offset: 3518,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3818,
+    key.offset: 3523,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3846,
+    key.offset: 3551,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3851,
+    key.offset: 3556,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3856,
+    key.offset: 3561,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3877,
+    key.offset: 3582,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3879,
+    key.offset: 3584,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3889,
+    key.offset: 3594,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3898,
+    key.offset: 3603,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3917,
+    key.offset: 3622,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3924,
+    key.offset: 3629,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3937,
+    key.offset: 3642,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3944,
+    key.offset: 3649,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3956,
+    key.offset: 3661,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3962,
+    key.offset: 3667,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3968,
+    key.offset: 3673,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3971,
+    key.offset: 3676,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3983,
+    key.offset: 3688,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3988,
+    key.offset: 3693,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3993,
+    key.offset: 3698,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4035,
+    key.offset: 3735,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4040,
+    key.offset: 3740,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4046,
+    key.offset: 3746,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4051,
+    key.offset: 3751,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 4074,
+    key.offset: 3774,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4107,
+    key.offset: 3807,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4112,
+    key.offset: 3812,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4118,
+    key.offset: 3818,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4136,
+    key.offset: 3836,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4150,
+    key.offset: 3850,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4181,
+    key.offset: 3876,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4186,
+    key.offset: 3881,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4190,
+    key.offset: 3885,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4204,
+    key.offset: 3899,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4215,
+    key.offset: 3910,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4220,
+    key.offset: 3915,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4224,
+    key.offset: 3919,
     key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3933,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3944,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3949,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3953,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3967,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3975,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3986,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3991,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3996,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4020,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4025,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4030,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4047,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4049,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4052,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4064,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4069,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4074,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4091,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4093,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4096,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4103,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4109,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4112,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4124,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4129,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4134,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4171,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4176,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4182,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4187,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4205,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4212,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4222,
+    key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
@@ -2230,188 +2296,273 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4249,
-    key.length: 4
+    key.offset: 4244,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4254,
+    key.offset: 4251,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4258,
-    key.length: 12
+    key.offset: 4255,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4272,
+    key.offset: 4268,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4280,
+    key.offset: 4276,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4296,
-    key.length: 64
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4365,
-    key.length: 4
+    key.offset: 4282,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4370,
-    key.length: 4
+    key.offset: 4289,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4375,
-    key.length: 16
+    key.offset: 4293,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4306,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4314,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4399,
-    key.length: 4
+    key.offset: 4320,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4327,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4331,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4344,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4352,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4358,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4365,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4369,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4382,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4391,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4397,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4404,
-    key.length: 4
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4409,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4426,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4428,
-    key.length: 1
+    key.offset: 4408,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4431,
-    key.length: 5
+    key.offset: 4421,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4430,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4436,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4443,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4448,
-    key.length: 4
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4453,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4470,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4472,
-    key.length: 1
+    key.offset: 4447,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4475,
-    key.length: 5
+    key.offset: 4460,
+    key.length: 13
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4476,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 4482,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4488,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4491,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4508,
-    key.length: 4
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4513,
-    key.length: 4
+    key.offset: 4489,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4518,
-    key.length: 29
+    key.offset: 4493,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4506,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4522,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4528,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4535,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4539,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4552,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4560,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4565,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4571,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4576,
-    key.length: 13
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4595,
+    key.offset: 4566,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4602,
-    key.length: 9
+    key.offset: 4573,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4612,
-    key.length: 13
+    key.offset: 4577,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4628,
+    key.offset: 4590,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4635,
-    key.length: 31
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4598,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4667,
+    key.offset: 4604,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4611,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4615,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4629,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4637,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4643,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4650,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4654,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4668,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2419,1188 +2570,903 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4678,
-    key.length: 11
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4680,
+    key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4687,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4691,
-    key.length: 5
+    key.length: 12
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4699,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 4705,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4712,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4716,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4729,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4737,
+    key.offset: 4713,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4743,
+    key.offset: 4719,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4750,
+    key.offset: 4726,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4754,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4767,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4775,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4781,
-    key.length: 39
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4820,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4827,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4831,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4844,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4853,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4859,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4866,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4870,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4883,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4892,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4898,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4905,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4909,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4922,
-    key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4938,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4944,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4951,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4955,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4968,
-    key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4984,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4990,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4997,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5001,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5014,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5022,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5028,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5035,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5039,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5052,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5060,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5066,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5073,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5077,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5091,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5099,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5105,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5112,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5116,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5130,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5136,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5142,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5149,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5153,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5167,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5175,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5181,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5188,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5192,
+    key.offset: 4730,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5207,
+    key.offset: 4745,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5215,
+    key.offset: 4753,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5221,
+    key.offset: 4759,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5228,
+    key.offset: 4766,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5232,
+    key.offset: 4770,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5252,
+    key.offset: 4790,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5261,
+    key.offset: 4799,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5267,
+    key.offset: 4805,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5274,
+    key.offset: 4812,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5278,
+    key.offset: 4816,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5296,
+    key.offset: 4834,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5305,
+    key.offset: 4843,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5312,
+    key.offset: 4849,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4856,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4860,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4879,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4887,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4893,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4900,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4904,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4923,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4931,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4937,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4944,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4949,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4968,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4975,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4980,
+    key.length: 21
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5004,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5011,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5018,
+    key.length: 15
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5041,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5048,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5060,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5067,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5072,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5075,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5087,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5094,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5098,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5101,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5109,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5119,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5139,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5144,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5149,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5169,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5176,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5186,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5206,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5211,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5216,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5236,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5246,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5251,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5256,
+    key.length: 15
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5277,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5284,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5294,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5314,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5319,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5323,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5342,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5350,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5357,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5364,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5368,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5387,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5395,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5402,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5409,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5414,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5434,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5441,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5446,
-    key.length: 21
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5471,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5478,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5485,
-    key.length: 15
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5508,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5515,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5527,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5534,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5539,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5542,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5554,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5561,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5565,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5568,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5577,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5587,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5607,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5612,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5617,
+    key.offset: 5324,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5637,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 5645,
-    key.length: 44
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5690,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5700,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5720,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5725,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5730,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5750,
+    key.offset: 5344,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5760,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5765,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5770,
-    key.length: 15
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5791,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5799,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5809,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5829,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5834,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5839,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5859,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5867,
+    key.offset: 5351,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5874,
+    key.offset: 5358,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5883,
+    key.offset: 5367,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5902,
+    key.offset: 5385,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5907,
+    key.offset: 5390,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5913,
+    key.offset: 5396,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5937,
+    key.offset: 5420,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5956,
+    key.offset: 5438,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5961,
+    key.offset: 5443,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5967,
+    key.offset: 5449,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5995,
+    key.offset: 5477,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6015,
+    key.offset: 5497,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6031,
+    key.offset: 5513,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6036,
+    key.offset: 5518,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6040,
+    key.offset: 5522,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6052,
+    key.offset: 5534,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6068,
+    key.offset: 5550,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6084,
+    key.offset: 5566,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6089,
+    key.offset: 5571,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6093,
+    key.offset: 5575,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5593,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5609,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5614,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5618,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5630,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5640,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5645,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5649,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5660,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5670,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5675,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5679,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5689,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5699,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5704,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5709,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5713,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5722,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5738,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5743,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5747,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5755,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5763,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5768,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5774,
+    key.length: 21
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5798,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5818,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5825,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5837,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5843,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5847,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5850,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5862,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 5873,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5876,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5888,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.string,
+    key.offset: 5897,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5906,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5911,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5916,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5934,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5945,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.number,
+    key.offset: 5951,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 5957,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5964,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5969,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5974,
+    key.length: 22
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6004,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6015,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6022,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.number,
+    key.offset: 6034,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6040,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.string,
+    key.offset: 6049,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6058,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6063,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6068,
+    key.length: 25
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6098,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6105,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 6111,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6127,
-    key.length: 4
+    key.offset: 6125,
+    key.length: 10
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6132,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.operator,
     key.offset: 6136,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6148,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6158,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6163,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6167,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6178,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6188,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6193,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6197,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6207,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6217,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6222,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6227,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6231,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6240,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6256,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6261,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6265,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6273,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6282,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6287,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6293,
-    key.length: 21
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6317,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6337,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6344,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6356,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6362,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6366,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6369,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6386,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 6397,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6400,
+    key.offset: 6139,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6412,
+    key.offset: 6151,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6421,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6430,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6435,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6440,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6463,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6474,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6480,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 6486,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6493,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6498,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6503,
-    key.length: 22
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6538,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6549,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6556,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6568,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6574,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6583,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6592,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6597,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6602,
-    key.length: 25
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6633,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6640,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6646,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6661,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 6672,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6675,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6687,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6696,
+    key.offset: 6160,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6725,
+    key.offset: 6189,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6732,
+    key.offset: 6196,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6737,
+    key.offset: 6201,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6761,
+    key.offset: 6225,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6777,
+    key.offset: 6236,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6782,
+    key.offset: 6241,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6798,
+    key.offset: 6257,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 6800,
-    key.length: 54
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6859,
+    key.offset: 6264,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6864,
+    key.offset: 6269,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6877,
+    key.offset: 6282,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 6879,
-    key.length: 51
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6932,
+    key.offset: 6286,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6939,
+    key.offset: 6293,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6945,
+    key.offset: 6299,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6972,
+    key.offset: 6326,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6979,
+    key.offset: 6333,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6984,
+    key.offset: 6338,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6991,
+    key.offset: 6345,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6998,
+    key.offset: 6352,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7004,
+    key.offset: 6358,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 7029,
+    key.offset: 6383,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 7033,
+    key.offset: 6387,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7060,
+    key.offset: 6414,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7069,
+    key.offset: 6423,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7076,
+    key.offset: 6430,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7081,
+    key.offset: 6435,
     key.length: 1
   }
 ]
@@ -3628,221 +3494,251 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 222,
+    key.offset: 113,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 233,
+    key.offset: 124,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 281,
+    key.offset: 172,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 316,
+    key.offset: 207,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 350,
+    key.offset: 241,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 409,
+    key.offset: 300,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 452,
+    key.offset: 342,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 463,
+    key.offset: 353,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 511,
+    key.offset: 401,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 546,
+    key.offset: 436,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 580,
+    key.offset: 470,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 611,
+    key.offset: 501,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 650,
+    key.offset: 540,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 692,
+    key.offset: 582,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 703,
+    key.offset: 593,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 751,
+    key.offset: 641,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 786,
+    key.offset: 676,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 820,
+    key.offset: 710,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 851,
+    key.offset: 741,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 890,
+    key.offset: 780,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 979,
+    key.offset: 869,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 1202,
+    key.offset: 1037,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1241,
+    key.offset: 1076,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1309,
+    key.offset: 1117,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1372,
+    key.offset: 1180,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1492,
+    key.offset: 1274,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1502,
+    key.offset: 1284,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1529,
+    key.offset: 1311,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1554,
+    key.offset: 1336,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1600,
+    key.offset: 1382,
     key.length: 20,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1621,
+    key.offset: 1403,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1700,
+    key.offset: 1481,
     key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1491,
+    key.length: 6,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1518,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1543,
+    key.length: 6,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1589,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1673,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1683,
+    key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.offset: 1710,
-    key.length: 6,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 1737,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1762,
+    key.offset: 1735,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1808,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 1893,
+    key.offset: 1805,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1903,
-    key.length: 6,
+    key.offset: 1861,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1920,
+    key.length: 5,
     key.is_system: 1
   },
   {
@@ -3853,19 +3749,55 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1955,
-    key.length: 6,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2025,
+    key.offset: 1974,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2081,
+    key.offset: 1984,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2016,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2028,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2040,
+    key.length: 6,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2053,
+    key.length: 20,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2074,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2086,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2130,
     key.length: 5,
     key.is_system: 1
   },
@@ -3877,153 +3809,117 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2150,
+    key.offset: 2213,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2195,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2205,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2237,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2249,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2261,
-    key.length: 6,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2274,
-    key.length: 20,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2295,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2307,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2399,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2409,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2483,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2493,
+    key.offset: 2223,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2537,
+    key.offset: 2266,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2577,
+    key.offset: 2306,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3137,
+    key.offset: 2866,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3147,
+    key.offset: 2876,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3620,
+    key.offset: 3327,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3661,
+    key.offset: 3368,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3702,
+    key.offset: 3409,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3756,
+    key.offset: 3462,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3898,
+    key.offset: 3603,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3971,
+    key.offset: 3676,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 4136,
+    key.offset: 3836,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 4150,
+    key.offset: 3850,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4204,
+    key.offset: 3899,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 3933,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 3967,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 4052,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 4096,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 4112,
     key.length: 5,
     key.is_system: 1
   },
@@ -4035,202 +3931,172 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4272,
+    key.offset: 4268,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4431,
+    key.offset: 4306,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4475,
+    key.offset: 4344,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4491,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4628,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4691,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4729,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4767,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4844,
+    key.offset: 4382,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4883,
+    key.offset: 4421,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4922,
+    key.offset: 4460,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4968,
+    key.offset: 4506,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 5014,
+    key.offset: 4552,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5052,
+    key.offset: 4590,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5091,
+    key.offset: 4629,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5130,
+    key.offset: 4668,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5167,
+    key.offset: 4705,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5207,
+    key.offset: 4745,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5252,
+    key.offset: 4790,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5296,
+    key.offset: 4834,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5342,
+    key.offset: 4879,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5387,
+    key.offset: 4923,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5542,
+    key.offset: 5075,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5568,
+    key.offset: 5101,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5587,
+    key.offset: 5119,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5700,
+    key.offset: 5186,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5809,
+    key.offset: 5294,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5937,
+    key.offset: 5420,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5995,
+    key.offset: 5477,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6273,
+    key.offset: 5755,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 6317,
+    key.offset: 5798,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6369,
+    key.offset: 5850,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6761,
+    key.offset: 6225,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 7029,
+    key.offset: 6383,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 7033,
+    key.offset: 6387,
     key.length: 19
   }
 ]
@@ -4239,13 +4105,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1",
-    key.offset: 204,
+    key.offset: 95,
     key.length: 154,
-    key.nameoffset: 211,
+    key.nameoffset: 102,
     key.namelength: 8,
-    key.bodyoffset: 251,
+    key.bodyoffset: 142,
     key.bodylength: 106,
-    key.docoffset: 171,
+    key.docoffset: 62,
     key.doclength: 26,
     key.inheritedtypes: [
       {
@@ -4257,7 +4123,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 197,
+        key.offset: 88,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4265,12 +4131,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 222,
+        key.offset: 113,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 233,
+        key.offset: 124,
         key.length: 16
       }
     ],
@@ -4279,13 +4145,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 264,
+        key.offset: 155,
         key.length: 24,
-        key.nameoffset: 264,
+        key.nameoffset: 155,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 257,
+            key.offset: 148,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4294,7 +4160,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 269,
+            key.offset: 160,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4304,13 +4170,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 301,
+        key.offset: 192,
         key.length: 22,
-        key.nameoffset: 301,
+        key.nameoffset: 192,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 294,
+            key.offset: 185,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4319,10 +4185,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 306,
+            key.offset: 197,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 306,
+            key.nameoffset: 197,
             key.namelength: 8
           }
         ]
@@ -4332,14 +4198,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 336,
+        key.offset: 227,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 340,
+        key.nameoffset: 231,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 329,
+            key.offset: 220,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4351,18 +4217,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1X",
-    key.offset: 394,
+    key.offset: 285,
     key.length: 31,
     key.typename: "FooEnum1",
-    key.nameoffset: 398,
+    key.nameoffset: 289,
     key.namelength: 9,
-    key.bodyoffset: 419,
+    key.bodyoffset: 310,
     key.bodylength: 5,
-    key.docoffset: 360,
+    key.docoffset: 251,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 387,
+        key.offset: 278,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4372,11 +4238,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2",
-    key.offset: 434,
+    key.offset: 324,
     key.length: 154,
-    key.nameoffset: 441,
+    key.nameoffset: 331,
     key.namelength: 8,
-    key.bodyoffset: 481,
+    key.bodyoffset: 371,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -4388,7 +4254,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 427,
+        key.offset: 317,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4396,12 +4262,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 452,
+        key.offset: 342,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 463,
+        key.offset: 353,
         key.length: 16
       }
     ],
@@ -4410,13 +4276,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 494,
+        key.offset: 384,
         key.length: 24,
-        key.nameoffset: 494,
+        key.nameoffset: 384,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 487,
+            key.offset: 377,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4425,7 +4291,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 499,
+            key.offset: 389,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4435,13 +4301,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 531,
+        key.offset: 421,
         key.length: 22,
-        key.nameoffset: 531,
+        key.nameoffset: 421,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 524,
+            key.offset: 414,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4450,10 +4316,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 536,
+            key.offset: 426,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 536,
+            key.nameoffset: 426,
             key.namelength: 8
           }
         ]
@@ -4463,14 +4329,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 566,
+        key.offset: 456,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 570,
+        key.nameoffset: 460,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 559,
+            key.offset: 449,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4482,16 +4348,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2X",
-    key.offset: 596,
+    key.offset: 486,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 600,
+    key.nameoffset: 490,
     key.namelength: 9,
-    key.bodyoffset: 621,
+    key.bodyoffset: 511,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 589,
+        key.offset: 479,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4501,16 +4367,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2Y",
-    key.offset: 635,
+    key.offset: 525,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 639,
+    key.nameoffset: 529,
     key.namelength: 9,
-    key.bodyoffset: 660,
+    key.bodyoffset: 550,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 628,
+        key.offset: 518,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4520,11 +4386,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3",
-    key.offset: 674,
+    key.offset: 564,
     key.length: 154,
-    key.nameoffset: 681,
+    key.nameoffset: 571,
     key.namelength: 8,
-    key.bodyoffset: 721,
+    key.bodyoffset: 611,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -4536,7 +4402,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 667,
+        key.offset: 557,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4544,12 +4410,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 692,
+        key.offset: 582,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 703,
+        key.offset: 593,
         key.length: 16
       }
     ],
@@ -4558,13 +4424,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 734,
+        key.offset: 624,
         key.length: 24,
-        key.nameoffset: 734,
+        key.nameoffset: 624,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 727,
+            key.offset: 617,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4573,7 +4439,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 739,
+            key.offset: 629,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4583,13 +4449,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 771,
+        key.offset: 661,
         key.length: 22,
-        key.nameoffset: 771,
+        key.nameoffset: 661,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 764,
+            key.offset: 654,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4598,10 +4464,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 776,
+            key.offset: 666,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 776,
+            key.nameoffset: 666,
             key.namelength: 8
           }
         ]
@@ -4611,14 +4477,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 806,
+        key.offset: 696,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 810,
+        key.nameoffset: 700,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 799,
+            key.offset: 689,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4630,16 +4496,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3X",
-    key.offset: 836,
+    key.offset: 726,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 840,
+    key.nameoffset: 730,
     key.namelength: 9,
-    key.bodyoffset: 861,
+    key.bodyoffset: 751,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 829,
+        key.offset: 719,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4649,16 +4515,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3Y",
-    key.offset: 875,
+    key.offset: 765,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 879,
+    key.nameoffset: 769,
     key.namelength: 9,
-    key.bodyoffset: 900,
+    key.bodyoffset: 790,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 868,
+        key.offset: 758,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4668,13 +4534,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooComparisonResult",
-    key.offset: 952,
-    key.length: 179,
-    key.nameoffset: 957,
+    key.offset: 842,
+    key.length: 124,
+    key.nameoffset: 847,
     key.namelength: 19,
-    key.bodyoffset: 984,
-    key.bodylength: 146,
-    key.docoffset: 908,
+    key.bodyoffset: 874,
+    key.bodylength: 91,
+    key.docoffset: 798,
     key.doclength: 37,
     key.inheritedtypes: [
       {
@@ -4683,7 +4549,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 945,
+        key.offset: 835,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4691,28 +4557,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 979,
+        key.offset: 869,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 1020,
+        key.offset: 880,
         key.length: 26,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedAscending",
-            key.offset: 1025,
+            key.offset: 885,
             key.length: 21,
-            key.nameoffset: 1025,
+            key.nameoffset: 885,
             key.namelength: 16,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 1044,
+                key.offset: 904,
                 key.length: 2
               }
             ]
@@ -4721,21 +4587,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 1052,
+        key.offset: 912,
         key.length: 20,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedSame",
-            key.offset: 1057,
+            key.offset: 917,
             key.length: 15,
-            key.nameoffset: 1057,
+            key.nameoffset: 917,
             key.namelength: 11,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 1071,
+                key.offset: 931,
                 key.length: 1
               }
             ]
@@ -4744,21 +4610,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 1103,
+        key.offset: 938,
         key.length: 26,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedDescending",
-            key.offset: 1108,
+            key.offset: 943,
             key.length: 21,
-            key.nameoffset: 1108,
+            key.nameoffset: 943,
             key.namelength: 17,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 1128,
+                key.offset: 963,
                 key.length: 1
               }
             ]
@@ -4771,13 +4637,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooRuncingOptions",
-    key.offset: 1175,
-    key.length: 249,
-    key.nameoffset: 1182,
+    key.offset: 1010,
+    key.length: 197,
+    key.nameoffset: 1017,
     key.namelength: 17,
-    key.bodyoffset: 1213,
-    key.bodylength: 210,
-    key.docoffset: 1133,
+    key.bodyoffset: 1048,
+    key.bodylength: 158,
+    key.docoffset: 968,
     key.doclength: 35,
     key.inheritedtypes: [
       {
@@ -4786,7 +4652,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 1168,
+        key.offset: 1003,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4794,7 +4660,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1202,
+        key.offset: 1037,
         key.length: 9
       }
     ],
@@ -4803,13 +4669,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 1226,
+        key.offset: 1061,
         key.length: 19,
-        key.nameoffset: 1226,
+        key.nameoffset: 1061,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 1219,
+            key.offset: 1054,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4818,10 +4684,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 1231,
+            key.offset: 1066,
             key.length: 13,
             key.typename: "Int",
-            key.nameoffset: 1231,
+            key.nameoffset: 1066,
             key.namelength: 8
           }
         ]
@@ -4830,16 +4696,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableMince",
-        key.offset: 1285,
+        key.offset: 1093,
         key.length: 49,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1296,
+        key.nameoffset: 1104,
         key.namelength: 11,
-        key.bodyoffset: 1328,
+        key.bodyoffset: 1136,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1278,
+            key.offset: 1086,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4849,16 +4715,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableQuince",
-        key.offset: 1347,
+        key.offset: 1155,
         key.length: 50,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1358,
+        key.nameoffset: 1166,
         key.namelength: 12,
-        key.bodyoffset: 1391,
+        key.bodyoffset: 1199,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1340,
+            key.offset: 1148,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4870,15 +4736,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1",
-    key.offset: 1433,
+    key.offset: 1215,
     key.length: 129,
-    key.nameoffset: 1440,
+    key.nameoffset: 1222,
     key.namelength: 10,
-    key.bodyoffset: 1452,
+    key.bodyoffset: 1234,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1426,
+        key.offset: 1208,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4888,13 +4754,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1465,
+        key.offset: 1247,
         key.length: 6,
-        key.nameoffset: 1465,
+        key.nameoffset: 1247,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1458,
+            key.offset: 1240,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4904,13 +4770,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1484,
+        key.offset: 1266,
         key.length: 25,
-        key.nameoffset: 1484,
+        key.nameoffset: 1266,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1477,
+            key.offset: 1259,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4919,19 +4785,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1489,
+            key.offset: 1271,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1489,
+            key.nameoffset: 1271,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1499,
+            key.offset: 1281,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1499,
+            key.nameoffset: 1281,
             key.namelength: 1
           }
         ]
@@ -4941,14 +4807,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1522,
+        key.offset: 1304,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1526,
+        key.nameoffset: 1308,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1515,
+            key.offset: 1297,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4959,14 +4825,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1547,
+        key.offset: 1329,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1551,
+        key.nameoffset: 1333,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1540,
+            key.offset: 1322,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4978,13 +4844,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1Pointer",
-    key.offset: 1570,
+    key.offset: 1352,
     key.length: 62,
-    key.nameoffset: 1580,
+    key.nameoffset: 1362,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1563,
+        key.offset: 1345,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4994,15 +4860,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct2",
-    key.offset: 1641,
+    key.offset: 1422,
     key.length: 129,
-    key.nameoffset: 1648,
+    key.nameoffset: 1429,
     key.namelength: 10,
-    key.bodyoffset: 1660,
+    key.bodyoffset: 1441,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1634,
+        key.offset: 1415,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5012,13 +4878,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1673,
+        key.offset: 1454,
         key.length: 6,
-        key.nameoffset: 1673,
+        key.nameoffset: 1454,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1666,
+            key.offset: 1447,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5028,13 +4894,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1692,
+        key.offset: 1473,
         key.length: 25,
-        key.nameoffset: 1692,
+        key.nameoffset: 1473,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1685,
+            key.offset: 1466,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5043,19 +4909,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1697,
+            key.offset: 1478,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1697,
+            key.nameoffset: 1478,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1707,
+            key.offset: 1488,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1707,
+            key.nameoffset: 1488,
             key.namelength: 1
           }
         ]
@@ -5065,14 +4931,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1730,
+        key.offset: 1511,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1734,
+        key.nameoffset: 1515,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1723,
+            key.offset: 1504,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5083,14 +4949,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1755,
+        key.offset: 1536,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1759,
+        key.nameoffset: 1540,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1748,
+            key.offset: 1529,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5102,13 +4968,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef1",
-    key.offset: 1778,
+    key.offset: 1559,
     key.length: 40,
-    key.nameoffset: 1788,
+    key.nameoffset: 1569,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1771,
+        key.offset: 1552,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5118,15 +4984,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef2",
-    key.offset: 1827,
+    key.offset: 1607,
     key.length: 136,
-    key.nameoffset: 1834,
+    key.nameoffset: 1614,
     key.namelength: 17,
-    key.bodyoffset: 1853,
+    key.bodyoffset: 1633,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1820,
+        key.offset: 1600,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5136,13 +5002,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1866,
+        key.offset: 1646,
         key.length: 6,
-        key.nameoffset: 1866,
+        key.nameoffset: 1646,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1859,
+            key.offset: 1639,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5152,13 +5018,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1885,
+        key.offset: 1665,
         key.length: 25,
-        key.nameoffset: 1885,
+        key.nameoffset: 1665,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1878,
+            key.offset: 1658,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5167,19 +5033,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1890,
+            key.offset: 1670,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1890,
+            key.nameoffset: 1670,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1900,
+            key.offset: 1680,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1900,
+            key.nameoffset: 1680,
             key.namelength: 1
           }
         ]
@@ -5189,14 +5055,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1923,
+        key.offset: 1703,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1927,
+        key.nameoffset: 1707,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1916,
+            key.offset: 1696,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5207,14 +5073,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1948,
+        key.offset: 1728,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1952,
+        key.nameoffset: 1732,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1941,
+            key.offset: 1721,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5226,15 +5092,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooTypedef1",
-    key.offset: 2001,
+    key.offset: 1781,
     key.length: 29,
-    key.nameoffset: 2011,
+    key.nameoffset: 1791,
     key.namelength: 11,
-    key.docoffset: 1965,
+    key.docoffset: 1745,
     key.doclength: 29,
     key.attributes: [
       {
-        key.offset: 1994,
+        key.offset: 1774,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5245,16 +5111,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "fooIntVar",
-    key.offset: 2066,
+    key.offset: 1846,
     key.length: 20,
     key.typename: "Int32",
-    key.nameoffset: 2070,
+    key.nameoffset: 1850,
     key.namelength: 9,
-    key.docoffset: 2032,
+    key.docoffset: 1812,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 2059,
+        key.offset: 1839,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5264,16 +5130,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1(_:)",
-    key.offset: 2121,
+    key.offset: 1901,
     key.length: 34,
     key.typename: "Int32",
-    key.nameoffset: 2126,
+    key.nameoffset: 1906,
     key.namelength: 20,
-    key.docoffset: 2088,
+    key.docoffset: 1868,
     key.doclength: 26,
     key.attributes: [
       {
-        key.offset: 2114,
+        key.offset: 1894,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5282,7 +5148,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2135,
+        key.offset: 1915,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -5292,14 +5158,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1AnonymousParam(_:)",
-    key.offset: 2164,
+    key.offset: 1943,
     key.length: 46,
     key.typename: "Int32",
-    key.nameoffset: 2169,
+    key.nameoffset: 1948,
     key.namelength: 32,
     key.attributes: [
       {
-        key.offset: 2157,
+        key.offset: 1936,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5307,7 +5173,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
-        key.offset: 2192,
+        key.offset: 1971,
         key.length: 8,
         key.typename: "Int32"
       }
@@ -5317,14 +5183,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc3(_:_:_:_:)",
-    key.offset: 2218,
+    key.offset: 1997,
     key.length: 94,
     key.typename: "Int32",
-    key.nameoffset: 2223,
+    key.nameoffset: 2002,
     key.namelength: 80,
     key.attributes: [
       {
-        key.offset: 2211,
+        key.offset: 1990,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5333,28 +5199,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2232,
+        key.offset: 2011,
         key.length: 10,
         key.typename: "Int32"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "b",
-        key.offset: 2244,
+        key.offset: 2023,
         key.length: 10,
         key.typename: "Float"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "c",
-        key.offset: 2256,
+        key.offset: 2035,
         key.length: 11,
         key.typename: "Double"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "d",
-        key.offset: 2269,
+        key.offset: 2048,
         key.length: 33,
         key.typename: "UnsafeMutablePointer<Int32>!"
       }
@@ -5364,13 +5230,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithBlock(_:)",
-    key.offset: 2368,
+    key.offset: 2099,
     key.length: 49,
-    key.nameoffset: 2373,
+    key.nameoffset: 2104,
     key.namelength: 44,
     key.attributes: [
       {
-        key.offset: 2361,
+        key.offset: 2092,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5379,7 +5245,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "blk",
-        key.offset: 2390,
+        key.offset: 2121,
         key.length: 26,
         key.typename: "((Float) -> Int32)!"
       }
@@ -5389,13 +5255,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithFunctionPointer(_:)",
-    key.offset: 2426,
+    key.offset: 2156,
     key.length: 75,
-    key.nameoffset: 2431,
+    key.nameoffset: 2161,
     key.namelength: 70,
     key.attributes: [
       {
-        key.offset: 2419,
+        key.offset: 2149,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5404,7 +5270,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "fptr",
-        key.offset: 2458,
+        key.offset: 2188,
         key.length: 42,
         key.typename: "(@convention(c) (Float) -> Int32)!"
       }
@@ -5414,14 +5280,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn1()",
-    key.offset: 2510,
+    key.offset: 2239,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2515,
+    key.nameoffset: 2244,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2503,
+        key.offset: 2232,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5431,14 +5297,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn2()",
-    key.offset: 2550,
+    key.offset: 2279,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2555,
+    key.nameoffset: 2284,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2543,
+        key.offset: 2272,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5448,15 +5314,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment1()",
-    key.offset: 2654,
+    key.offset: 2383,
     key.length: 26,
-    key.nameoffset: 2659,
+    key.nameoffset: 2388,
     key.namelength: 21,
-    key.docoffset: 2584,
+    key.docoffset: 2313,
     key.doclength: 62,
     key.attributes: [
       {
-        key.offset: 2647,
+        key.offset: 2376,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5466,15 +5332,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment2()",
-    key.offset: 2732,
+    key.offset: 2461,
     key.length: 26,
-    key.nameoffset: 2737,
+    key.nameoffset: 2466,
     key.namelength: 21,
-    key.docoffset: 2682,
+    key.docoffset: 2411,
     key.doclength: 42,
     key.attributes: [
       {
-        key.offset: 2725,
+        key.offset: 2454,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5484,15 +5350,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment3()",
-    key.offset: 2827,
+    key.offset: 2556,
     key.length: 26,
-    key.nameoffset: 2832,
+    key.nameoffset: 2561,
     key.namelength: 21,
-    key.docoffset: 2760,
+    key.docoffset: 2489,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 2820,
+        key.offset: 2549,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5502,15 +5368,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment4()",
-    key.offset: 2915,
+    key.offset: 2644,
     key.length: 26,
-    key.nameoffset: 2920,
+    key.nameoffset: 2649,
     key.namelength: 21,
-    key.docoffset: 2855,
+    key.docoffset: 2584,
     key.doclength: 53,
     key.attributes: [
       {
-        key.offset: 2908,
+        key.offset: 2637,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5520,15 +5386,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment5()",
-    key.offset: 3009,
+    key.offset: 2738,
     key.length: 26,
-    key.nameoffset: 3014,
+    key.nameoffset: 2743,
     key.namelength: 21,
-    key.docoffset: 2943,
+    key.docoffset: 2672,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 3002,
+        key.offset: 2731,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5538,16 +5404,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
-    key.offset: 3094,
+    key.offset: 2823,
     key.length: 58,
     key.typename: "Int32",
-    key.nameoffset: 3099,
+    key.nameoffset: 2828,
     key.namelength: 44,
-    key.docoffset: 3037,
+    key.docoffset: 2766,
     key.doclength: 50,
     key.attributes: [
       {
-        key.offset: 3087,
+        key.offset: 2816,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5556,7 +5422,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 3132,
+        key.offset: 2861,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -5566,17 +5432,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolBase",
-    key.offset: 3194,
-    key.length: 523,
-    key.nameoffset: 3203,
+    key.offset: 2923,
+    key.length: 501,
+    key.nameoffset: 2932,
     key.namelength: 15,
-    key.bodyoffset: 3220,
-    key.bodylength: 496,
-    key.docoffset: 3154,
+    key.bodyoffset: 2949,
+    key.bodylength: 474,
+    key.docoffset: 2883,
     key.doclength: 33,
     key.attributes: [
       {
-        key.offset: 3187,
+        key.offset: 2916,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5586,42 +5452,42 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFunc()",
-        key.offset: 3278,
+        key.offset: 3003,
         key.length: 19,
-        key.nameoffset: 3283,
+        key.nameoffset: 3008,
         key.namelength: 14,
-        key.docoffset: 3231,
+        key.docoffset: 2956,
         key.doclength: 43
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation1()",
-        key.offset: 3376,
+        key.offset: 3097,
         key.length: 40,
-        key.nameoffset: 3381,
+        key.nameoffset: 3102,
         key.namelength: 35,
-        key.docoffset: 3308,
+        key.docoffset: 3029,
         key.doclength: 64
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation2()",
-        key.offset: 3509,
+        key.offset: 3226,
         key.length: 40,
-        key.nameoffset: 3514,
+        key.nameoffset: 3231,
         key.namelength: 35,
-        key.docoffset: 3427,
+        key.docoffset: 3144,
         key.doclength: 77
       },
       {
         key.kind: source.lang.swift.decl.function.method.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoClassFunc()",
-        key.offset: 3560,
+        key.offset: 3272,
         key.length: 31,
-        key.nameoffset: 3572,
+        key.nameoffset: 3284,
         key.namelength: 19
       },
       {
@@ -5629,12 +5495,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty1",
-        key.offset: 3602,
+        key.offset: 3309,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3606,
+        key.nameoffset: 3313,
         key.namelength: 12,
-        key.bodyoffset: 3627,
+        key.bodyoffset: 3334,
         key.bodylength: 9
       },
       {
@@ -5642,24 +5508,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty2",
-        key.offset: 3643,
+        key.offset: 3350,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3647,
+        key.nameoffset: 3354,
         key.namelength: 12,
-        key.bodyoffset: 3668,
+        key.bodyoffset: 3375,
         key.bodylength: 9
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty3",
-        key.offset: 3684,
+        key.offset: 3391,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 3688,
+        key.nameoffset: 3395,
         key.namelength: 12,
-        key.bodyoffset: 3709,
+        key.bodyoffset: 3416,
         key.bodylength: 5
       }
     ]
@@ -5668,11 +5534,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolDerived",
-    key.offset: 3726,
+    key.offset: 3432,
     key.length: 49,
-    key.nameoffset: 3735,
+    key.nameoffset: 3441,
     key.namelength: 18,
-    key.bodyoffset: 3773,
+    key.bodyoffset: 3479,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -5681,7 +5547,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 3719,
+        key.offset: 3425,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5689,7 +5555,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3756,
+        key.offset: 3462,
         key.length: 15
       }
     ]
@@ -5698,15 +5564,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassBase",
-    key.offset: 3782,
-    key.length: 290,
-    key.nameoffset: 3788,
+    key.offset: 3487,
+    key.length: 285,
+    key.nameoffset: 3493,
     key.namelength: 12,
-    key.bodyoffset: 3802,
-    key.bodylength: 269,
+    key.bodyoffset: 3507,
+    key.bodylength: 264,
     key.attributes: [
       {
-        key.offset: 3777,
+        key.offset: 3482,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5716,13 +5582,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc0()",
-        key.offset: 3813,
+        key.offset: 3518,
         key.length: 27,
-        key.nameoffset: 3818,
+        key.nameoffset: 3523,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 3808,
+            key.offset: 3513,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5732,14 +5598,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc1(_:)",
-        key.offset: 3851,
+        key.offset: 3556,
         key.length: 60,
         key.typename: "FooClassBase!",
-        key.nameoffset: 3856,
+        key.nameoffset: 3561,
         key.namelength: 38,
         key.attributes: [
           {
-            key.offset: 3846,
+            key.offset: 3551,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5748,7 +5614,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "anObject",
-            key.offset: 3877,
+            key.offset: 3582,
             key.length: 16,
             key.typename: "Any!"
           }
@@ -5758,13 +5624,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 3924,
+        key.offset: 3629,
         key.length: 7,
-        key.nameoffset: 3924,
+        key.nameoffset: 3629,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3917,
+            key.offset: 3622,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5774,18 +5640,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(float:)",
-        key.offset: 3956,
+        key.offset: 3661,
         key.length: 21,
-        key.nameoffset: 3956,
+        key.nameoffset: 3661,
         key.namelength: 21,
         key.attributes: [
           {
-            key.offset: 3944,
+            key.offset: 3649,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 3937,
+            key.offset: 3642,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5794,10 +5660,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "f",
-            key.offset: 3962,
+            key.offset: 3667,
             key.length: 14,
             key.typename: "Float",
-            key.nameoffset: 3962,
+            key.nameoffset: 3667,
             key.namelength: 5
           }
         ]
@@ -5806,13 +5672,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 3988,
+        key.offset: 3693,
         key.length: 36,
-        key.nameoffset: 3993,
+        key.nameoffset: 3698,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 3983,
+            key.offset: 3688,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5822,13 +5688,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseClassFunc0()",
-        key.offset: 4040,
+        key.offset: 3740,
         key.length: 30,
-        key.nameoffset: 4051,
+        key.nameoffset: 3751,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 4035,
+            key.offset: 3735,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5840,13 +5706,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassDerived",
-    key.offset: 4112,
-    key.length: 481,
-    key.nameoffset: 4118,
+    key.offset: 3812,
+    key.length: 392,
+    key.nameoffset: 3818,
     key.namelength: 15,
-    key.bodyoffset: 4170,
-    key.bodylength: 422,
-    key.docoffset: 4074,
+    key.bodyoffset: 3870,
+    key.bodylength: 333,
+    key.docoffset: 3774,
     key.doclength: 33,
     key.inheritedtypes: [
       {
@@ -5858,7 +5724,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 4107,
+        key.offset: 3807,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5866,12 +5732,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4136,
+        key.offset: 3836,
         key.length: 12
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4150,
+        key.offset: 3850,
         key.length: 18
       }
     ],
@@ -5881,14 +5747,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty1",
-        key.offset: 4186,
+        key.offset: 3881,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4190,
+        key.nameoffset: 3885,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 4181,
+            key.offset: 3876,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5899,14 +5765,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty2",
-        key.offset: 4220,
+        key.offset: 3915,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4224,
+        key.nameoffset: 3919,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 4215,
+            key.offset: 3910,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5916,16 +5782,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty3",
-        key.offset: 4254,
+        key.offset: 3949,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 4258,
+        key.nameoffset: 3953,
         key.namelength: 12,
-        key.bodyoffset: 4279,
+        key.bodyoffset: 3974,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 4249,
+            key.offset: 3944,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5935,13 +5801,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc0()",
-        key.offset: 4370,
+        key.offset: 3991,
         key.length: 23,
-        key.nameoffset: 4375,
+        key.nameoffset: 3996,
         key.namelength: 18,
         key.attributes: [
           {
-            key.offset: 4365,
+            key.offset: 3986,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5951,13 +5817,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc1(_:)",
-        key.offset: 4404,
+        key.offset: 4025,
         key.length: 33,
-        key.nameoffset: 4409,
+        key.nameoffset: 4030,
         key.namelength: 28,
         key.attributes: [
           {
-            key.offset: 4399,
+            key.offset: 4020,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5966,7 +5832,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4426,
+            key.offset: 4047,
             key.length: 10,
             key.typename: "Int32"
           }
@@ -5976,13 +5842,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc2(_:withB:)",
-        key.offset: 4448,
+        key.offset: 4069,
         key.length: 49,
-        key.nameoffset: 4453,
+        key.nameoffset: 4074,
         key.namelength: 44,
         key.attributes: [
           {
-            key.offset: 4443,
+            key.offset: 4064,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5991,17 +5857,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4470,
+            key.offset: 4091,
             key.length: 10,
             key.typename: "Int32"
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "b",
-            key.offset: 4482,
+            key.offset: 4103,
             key.length: 14,
             key.typename: "Int32",
-            key.nameoffset: 4482,
+            key.nameoffset: 4103,
             key.namelength: 5
           }
         ]
@@ -6010,13 +5876,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 4513,
+        key.offset: 4129,
         key.length: 36,
-        key.nameoffset: 4518,
+        key.nameoffset: 4134,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 4508,
+            key.offset: 4124,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6026,13 +5892,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooClassFunc0()",
-        key.offset: 4565,
+        key.offset: 4176,
         key.length: 26,
-        key.nameoffset: 4576,
+        key.nameoffset: 4187,
         key.namelength: 15,
         key.attributes: [
           {
-            key.offset: 4560,
+            key.offset: 4171,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6044,13 +5910,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "typedef_int_t",
-    key.offset: 4602,
+    key.offset: 4212,
     key.length: 31,
-    key.nameoffset: 4612,
+    key.nameoffset: 4222,
     key.namelength: 13,
     key.attributes: [
       {
-        key.offset: 4595,
+        key.offset: 4205,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6060,16 +5926,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_1",
-    key.offset: 4674,
+    key.offset: 4251,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4678,
+    key.nameoffset: 4255,
     key.namelength: 11,
-    key.bodyoffset: 4698,
+    key.bodyoffset: 4275,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4667,
+        key.offset: 4244,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6079,16 +5945,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_2",
-    key.offset: 4712,
+    key.offset: 4289,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4716,
+    key.nameoffset: 4293,
     key.namelength: 11,
-    key.bodyoffset: 4736,
+    key.bodyoffset: 4313,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4705,
+        key.offset: 4282,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6098,16 +5964,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_3",
-    key.offset: 4750,
+    key.offset: 4327,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4754,
+    key.nameoffset: 4331,
     key.namelength: 11,
-    key.bodyoffset: 4774,
+    key.bodyoffset: 4351,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4743,
+        key.offset: 4320,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6117,16 +5983,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_4",
-    key.offset: 4827,
+    key.offset: 4365,
     key.length: 31,
     key.typename: "UInt32",
-    key.nameoffset: 4831,
+    key.nameoffset: 4369,
     key.namelength: 11,
-    key.bodyoffset: 4852,
+    key.bodyoffset: 4390,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4820,
+        key.offset: 4358,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6136,16 +6002,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_5",
-    key.offset: 4866,
+    key.offset: 4404,
     key.length: 31,
     key.typename: "UInt64",
-    key.nameoffset: 4870,
+    key.nameoffset: 4408,
     key.namelength: 11,
-    key.bodyoffset: 4891,
+    key.bodyoffset: 4429,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4859,
+        key.offset: 4397,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6155,16 +6021,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_6",
-    key.offset: 4905,
+    key.offset: 4443,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4909,
+    key.nameoffset: 4447,
     key.namelength: 11,
-    key.bodyoffset: 4937,
+    key.bodyoffset: 4475,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4898,
+        key.offset: 4436,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6174,16 +6040,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_7",
-    key.offset: 4951,
+    key.offset: 4489,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4955,
+    key.nameoffset: 4493,
     key.namelength: 11,
-    key.bodyoffset: 4983,
+    key.bodyoffset: 4521,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4944,
+        key.offset: 4482,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6193,16 +6059,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_8",
-    key.offset: 4997,
+    key.offset: 4535,
     key.length: 30,
     key.typename: "CChar",
-    key.nameoffset: 5001,
+    key.nameoffset: 4539,
     key.namelength: 11,
-    key.bodyoffset: 5021,
+    key.bodyoffset: 4559,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4990,
+        key.offset: 4528,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6212,16 +6078,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_9",
-    key.offset: 5035,
+    key.offset: 4573,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 5039,
+    key.nameoffset: 4577,
     key.namelength: 11,
-    key.bodyoffset: 5059,
+    key.bodyoffset: 4597,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5028,
+        key.offset: 4566,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6231,16 +6097,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_10",
-    key.offset: 5073,
+    key.offset: 4611,
     key.length: 31,
     key.typename: "Int16",
-    key.nameoffset: 5077,
+    key.nameoffset: 4615,
     key.namelength: 12,
-    key.bodyoffset: 5098,
+    key.bodyoffset: 4636,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5066,
+        key.offset: 4604,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6250,16 +6116,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_11",
-    key.offset: 5112,
+    key.offset: 4650,
     key.length: 29,
     key.typename: "Int",
-    key.nameoffset: 5116,
+    key.nameoffset: 4654,
     key.namelength: 12,
-    key.bodyoffset: 5135,
+    key.bodyoffset: 4673,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5105,
+        key.offset: 4643,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6269,16 +6135,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_OR",
-    key.offset: 5149,
+    key.offset: 4687,
     key.length: 31,
     key.typename: "Int32",
-    key.nameoffset: 5153,
+    key.nameoffset: 4691,
     key.namelength: 12,
-    key.bodyoffset: 5174,
+    key.bodyoffset: 4712,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5142,
+        key.offset: 4680,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6288,16 +6154,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_AND",
-    key.offset: 5188,
+    key.offset: 4726,
     key.length: 32,
     key.typename: "Int32",
-    key.nameoffset: 5192,
+    key.nameoffset: 4730,
     key.namelength: 13,
-    key.bodyoffset: 5214,
+    key.bodyoffset: 4752,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5181,
+        key.offset: 4719,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6307,16 +6173,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_BITWIDTH",
-    key.offset: 5228,
+    key.offset: 4766,
     key.length: 38,
     key.typename: "UInt64",
-    key.nameoffset: 5232,
+    key.nameoffset: 4770,
     key.namelength: 18,
-    key.bodyoffset: 5260,
+    key.bodyoffset: 4798,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5221,
+        key.offset: 4759,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6326,16 +6192,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_SIGNED",
-    key.offset: 5274,
+    key.offset: 4812,
     key.length: 36,
     key.typename: "UInt32",
-    key.nameoffset: 5278,
+    key.nameoffset: 4816,
     key.namelength: 16,
-    key.bodyoffset: 5304,
+    key.bodyoffset: 4842,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5267,
+        key.offset: 4805,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6345,16 +6211,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_1",
-    key.offset: 5319,
+    key.offset: 4856,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 5323,
+    key.nameoffset: 4860,
     key.namelength: 17,
-    key.bodyoffset: 5349,
+    key.bodyoffset: 4886,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5312,
+        key.offset: 4849,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6364,16 +6230,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_2",
-    key.offset: 5364,
+    key.offset: 4900,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 5368,
+    key.nameoffset: 4904,
     key.namelength: 17,
-    key.bodyoffset: 5394,
+    key.bodyoffset: 4930,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5357,
+        key.offset: 4893,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6383,13 +6249,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "theLastDeclInFoo()",
-    key.offset: 5409,
+    key.offset: 4944,
     key.length: 23,
-    key.nameoffset: 5414,
+    key.nameoffset: 4949,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 5402,
+        key.offset: 4937,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6399,13 +6265,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_internalTopLevelFunc()",
-    key.offset: 5441,
+    key.offset: 4975,
     key.length: 28,
-    key.nameoffset: 5446,
+    key.nameoffset: 4980,
     key.namelength: 23,
     key.attributes: [
       {
-        key.offset: 5434,
+        key.offset: 4968,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6415,15 +6281,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalStruct",
-    key.offset: 5478,
+    key.offset: 5011,
     key.length: 97,
-    key.nameoffset: 5485,
+    key.nameoffset: 5018,
     key.namelength: 15,
-    key.bodyoffset: 5502,
+    key.bodyoffset: 5035,
     key.bodylength: 72,
     key.attributes: [
       {
-        key.offset: 5471,
+        key.offset: 5004,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6433,13 +6299,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 5515,
+        key.offset: 5048,
         key.length: 6,
-        key.nameoffset: 5515,
+        key.nameoffset: 5048,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 5508,
+            key.offset: 5041,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6449,13 +6315,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:)",
-        key.offset: 5534,
+        key.offset: 5067,
         key.length: 14,
-        key.nameoffset: 5534,
+        key.nameoffset: 5067,
         key.namelength: 14,
         key.attributes: [
           {
-            key.offset: 5527,
+            key.offset: 5060,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6464,10 +6330,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 5539,
+            key.offset: 5072,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 5539,
+            key.nameoffset: 5072,
             key.namelength: 1
           }
         ]
@@ -6477,14 +6343,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 5561,
+        key.offset: 5094,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 5565,
+        key.nameoffset: 5098,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 5554,
+            key.offset: 5087,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6495,25 +6361,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5577,
+    key.offset: 5109,
     key.length: 66,
-    key.nameoffset: 5587,
+    key.nameoffset: 5119,
     key.namelength: 12,
-    key.bodyoffset: 5601,
+    key.bodyoffset: 5133,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth1()",
-        key.offset: 5612,
+        key.offset: 5144,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5617,
+        key.nameoffset: 5149,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5607,
+            key.offset: 5139,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6524,25 +6390,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5690,
+    key.offset: 5176,
     key.length: 107,
-    key.nameoffset: 5700,
+    key.nameoffset: 5186,
     key.namelength: 12,
-    key.bodyoffset: 5714,
+    key.bodyoffset: 5200,
     key.bodylength: 82,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth2()",
-        key.offset: 5725,
+        key.offset: 5211,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5730,
+        key.nameoffset: 5216,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5720,
+            key.offset: 5206,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6552,14 +6418,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "nonInternalMeth()",
-        key.offset: 5765,
+        key.offset: 5251,
         key.length: 30,
         key.typename: "Any!",
-        key.nameoffset: 5770,
+        key.nameoffset: 5256,
         key.namelength: 17,
         key.attributes: [
           {
-            key.offset: 5760,
+            key.offset: 5246,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6570,25 +6436,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5799,
+    key.offset: 5284,
     key.length: 66,
-    key.nameoffset: 5809,
+    key.nameoffset: 5294,
     key.namelength: 12,
-    key.bodyoffset: 5823,
+    key.bodyoffset: 5308,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth3()",
-        key.offset: 5834,
+        key.offset: 5319,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5839,
+        key.nameoffset: 5324,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5829,
+            key.offset: 5314,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6600,15 +6466,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalProt",
-    key.offset: 5874,
+    key.offset: 5358,
     key.length: 26,
-    key.nameoffset: 5883,
+    key.nameoffset: 5367,
     key.namelength: 13,
-    key.bodyoffset: 5898,
+    key.bodyoffset: 5382,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 5867,
+        key.offset: 5351,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6618,11 +6484,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "ClassWithInternalProt",
-    key.offset: 5907,
+    key.offset: 5390,
     key.length: 47,
-    key.nameoffset: 5913,
+    key.nameoffset: 5396,
     key.namelength: 21,
-    key.bodyoffset: 5952,
+    key.bodyoffset: 5435,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -6631,7 +6497,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5902,
+        key.offset: 5385,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6639,7 +6505,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5937,
+        key.offset: 5420,
         key.length: 13
       }
     ]
@@ -6648,11 +6514,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassPropertyOwnership",
-    key.offset: 5961,
+    key.offset: 5443,
     key.length: 319,
-    key.nameoffset: 5967,
+    key.nameoffset: 5449,
     key.namelength: 25,
-    key.bodyoffset: 6009,
+    key.bodyoffset: 5491,
     key.bodylength: 270,
     key.inheritedtypes: [
       {
@@ -6661,7 +6527,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5956,
+        key.offset: 5438,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6669,7 +6535,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5995,
+        key.offset: 5477,
         key.length: 12
       }
     ],
@@ -6679,19 +6545,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "assignable",
-        key.offset: 6036,
+        key.offset: 5518,
         key.length: 26,
         key.typename: "AnyObject!",
-        key.nameoffset: 6040,
+        key.nameoffset: 5522,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 6031,
+            key.offset: 5513,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6015,
+            key.offset: 5497,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6702,19 +6568,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "unsafeAssignable",
-        key.offset: 6089,
+        key.offset: 5571,
         key.length: 32,
         key.typename: "AnyObject!",
-        key.nameoffset: 6093,
+        key.nameoffset: 5575,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 6084,
+            key.offset: 5566,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6068,
+            key.offset: 5550,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6725,14 +6591,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "retainable",
-        key.offset: 6132,
+        key.offset: 5614,
         key.length: 20,
         key.typename: "Any!",
-        key.nameoffset: 6136,
+        key.nameoffset: 5618,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 6127,
+            key.offset: 5609,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6743,14 +6609,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "strongRef",
-        key.offset: 6163,
+        key.offset: 5645,
         key.length: 19,
         key.typename: "Any!",
-        key.nameoffset: 6167,
+        key.nameoffset: 5649,
         key.namelength: 9,
         key.attributes: [
           {
-            key.offset: 6158,
+            key.offset: 5640,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6761,14 +6627,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "copyable",
-        key.offset: 6193,
+        key.offset: 5675,
         key.length: 18,
         key.typename: "Any!",
-        key.nameoffset: 6197,
+        key.nameoffset: 5679,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 6188,
+            key.offset: 5670,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6779,19 +6645,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "weakRef",
-        key.offset: 6227,
+        key.offset: 5709,
         key.length: 23,
         key.typename: "AnyObject!",
-        key.nameoffset: 6231,
+        key.nameoffset: 5713,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 6222,
+            key.offset: 5704,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6217,
+            key.offset: 5699,
             key.length: 4,
             key.attribute: source.decl.attribute.weak
           }
@@ -6802,14 +6668,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "scalar",
-        key.offset: 6261,
+        key.offset: 5743,
         key.length: 17,
         key.typename: "Int32",
-        key.nameoffset: 6265,
+        key.nameoffset: 5747,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 6256,
+            key.offset: 5738,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6821,12 +6687,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooUnavailableMembers",
-    key.offset: 6287,
-    key.length: 344,
-    key.nameoffset: 6293,
+    key.offset: 5768,
+    key.length: 329,
+    key.nameoffset: 5774,
     key.namelength: 21,
-    key.bodyoffset: 6331,
-    key.bodylength: 299,
+    key.bodyoffset: 5812,
+    key.bodylength: 284,
     key.inheritedtypes: [
       {
         key.name: "FooClassBase"
@@ -6834,7 +6700,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6282,
+        key.offset: 5763,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6842,7 +6708,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6317,
+        key.offset: 5798,
         key.length: 12
       }
     ],
@@ -6851,18 +6717,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(int:)",
-        key.offset: 6356,
+        key.offset: 5837,
         key.length: 19,
-        key.nameoffset: 6356,
+        key.nameoffset: 5837,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 6344,
+            key.offset: 5825,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 6337,
+            key.offset: 5818,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6871,10 +6737,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "i",
-            key.offset: 6362,
+            key.offset: 5843,
             key.length: 12,
             key.typename: "Int32",
-            key.nameoffset: 6362,
+            key.nameoffset: 5843,
             key.namelength: 3
           }
         ]
@@ -6883,18 +6749,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "deprecated()",
-        key.offset: 6435,
+        key.offset: 5911,
         key.length: 17,
-        key.nameoffset: 6440,
+        key.nameoffset: 5916,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 6430,
+            key.offset: 5906,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6386,
+            key.offset: 5862,
             key.length: 39,
             key.attribute: source.decl.attribute.available
           }
@@ -6904,18 +6770,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroduced()",
-        key.offset: 6498,
+        key.offset: 5969,
         key.length: 29,
-        key.nameoffset: 6503,
+        key.nameoffset: 5974,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 6493,
+            key.offset: 5964,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6463,
+            key.offset: 5934,
             key.length: 25,
             key.attribute: source.decl.attribute.available
           }
@@ -6925,18 +6791,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroducedMsg()",
-        key.offset: 6597,
+        key.offset: 6063,
         key.length: 32,
-        key.nameoffset: 6602,
+        key.nameoffset: 6068,
         key.namelength: 27,
         key.attributes: [
           {
-            key.offset: 6592,
+            key.offset: 6058,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6538,
+            key.offset: 6004,
             key.length: 49,
             key.attribute: source.decl.attribute.available
           }
@@ -6948,15 +6814,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooCFType",
-    key.offset: 6640,
+    key.offset: 6105,
     key.length: 19,
-    key.nameoffset: 6646,
+    key.nameoffset: 6111,
     key.namelength: 9,
-    key.bodyoffset: 6657,
+    key.bodyoffset: 6122,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 6633,
+        key.offset: 6098,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6966,12 +6832,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "ABAuthorizationStatus",
-    key.offset: 6732,
-    key.length: 199,
-    key.nameoffset: 6737,
+    key.offset: 6196,
+    key.length: 89,
+    key.nameoffset: 6201,
     key.namelength: 21,
-    key.bodyoffset: 6766,
-    key.bodylength: 164,
+    key.bodyoffset: 6230,
+    key.bodylength: 54,
     key.inheritedtypes: [
       {
         key.name: "Int"
@@ -6979,12 +6845,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6725,
+        key.offset: 6189,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       },
       {
-        key.offset: 6661,
+        key.offset: 6125,
         key.length: 63,
         key.attribute: source.decl.attribute.available
       }
@@ -6992,28 +6858,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6761,
+        key.offset: 6225,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6777,
+        key.offset: 6236,
         key.length: 22,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "notDetermined",
-            key.offset: 6782,
+            key.offset: 6241,
             key.length: 17,
-            key.nameoffset: 6782,
+            key.nameoffset: 6241,
             key.namelength: 13,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6798,
+                key.offset: 6257,
                 key.length: 1
               }
             ]
@@ -7022,21 +6888,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6859,
+        key.offset: 6264,
         key.length: 19,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "restricted",
-            key.offset: 6864,
+            key.offset: 6269,
             key.length: 14,
-            key.nameoffset: 6864,
+            key.nameoffset: 6269,
             key.namelength: 10,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6877,
+                key.offset: 6282,
                 key.length: 1
               }
             ]
@@ -7049,15 +6915,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassBase",
-    key.offset: 6939,
+    key.offset: 6293,
     key.length: 50,
-    key.nameoffset: 6945,
+    key.nameoffset: 6299,
     key.namelength: 19,
-    key.bodyoffset: 6966,
+    key.bodyoffset: 6320,
     key.bodylength: 22,
     key.attributes: [
       {
-        key.offset: 6932,
+        key.offset: 6286,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -7067,13 +6933,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6979,
+        key.offset: 6333,
         key.length: 8,
-        key.nameoffset: 6984,
+        key.nameoffset: 6338,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 6972,
+            key.offset: 6326,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -7085,11 +6951,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassDerived",
-    key.offset: 6998,
+    key.offset: 6352,
     key.length: 88,
-    key.nameoffset: 7004,
+    key.nameoffset: 6358,
     key.namelength: 22,
-    key.bodyoffset: 7054,
+    key.bodyoffset: 6408,
     key.bodylength: 31,
     key.inheritedtypes: [
       {
@@ -7098,7 +6964,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6991,
+        key.offset: 6345,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -7106,7 +6972,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 7029,
+        key.offset: 6383,
         key.length: 23
       }
     ],
@@ -7115,18 +6981,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 7076,
+        key.offset: 6430,
         key.length: 8,
-        key.nameoffset: 7081,
+        key.nameoffset: 6435,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 7069,
+            key.offset: 6423,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           },
           {
-            key.offset: 7060,
+            key.offset: 6414,
             key.length: 8,
             key.attribute: source.decl.attribute.override
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -1,8 +1,6 @@
 import FooHelper
 
-
 public func fooSubFunc1(_ a: Int32) -> Int32
-
 public struct FooSubEnum1 : Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
@@ -13,7 +11,6 @@ public struct FooSubEnum1 : Equatable, RawRepresentable {
 }
 public var FooSubEnum1X: FooSubEnum1 { get }
 public var FooSubEnum1Y: FooSubEnum1 { get }
-
 public var FooSubUnnamedEnumeratorA1: Int { get }
 
 [
@@ -29,202 +26,202 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 19,
+    key.offset: 18,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
+    key.offset: 25,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 30,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 43,
+    key.offset: 42,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 45,
+    key.offset: 44,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 48,
+    key.offset: 47,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 58,
+    key.offset: 57,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 65,
+    key.offset: 63,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 72,
+    key.offset: 70,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 79,
+    key.offset: 77,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 93,
+    key.offset: 91,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 104,
+    key.offset: 102,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 128,
+    key.offset: 126,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 135,
+    key.offset: 133,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 140,
+    key.offset: 138,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 142,
+    key.offset: 140,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 152,
+    key.offset: 150,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 165,
+    key.offset: 163,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 172,
+    key.offset: 170,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 177,
+    key.offset: 175,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 187,
+    key.offset: 185,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 200,
+    key.offset: 198,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 207,
+    key.offset: 205,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 211,
+    key.offset: 209,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 221,
+    key.offset: 219,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 230,
+    key.offset: 228,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 237,
+    key.offset: 235,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 241,
+    key.offset: 239,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 255,
+    key.offset: 253,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 269,
+    key.offset: 267,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 275,
+    key.offset: 273,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 282,
+    key.offset: 280,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 286,
+    key.offset: 284,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 300,
+    key.offset: 298,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 314,
+    key.offset: 312,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 321,
+    key.offset: 318,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 328,
+    key.offset: 325,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 332,
+    key.offset: 329,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 359,
+    key.offset: 356,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 365,
+    key.offset: 362,
     key.length: 3
   }
 ]
@@ -236,59 +233,59 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 48,
+    key.offset: 47,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 58,
+    key.offset: 57,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 93,
+    key.offset: 91,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 104,
+    key.offset: 102,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 152,
+    key.offset: 150,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 187,
+    key.offset: 185,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 221,
+    key.offset: 219,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 255,
+    key.offset: 253,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 300,
+    key.offset: 298,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 359,
+    key.offset: 356,
     key.length: 3,
     key.is_system: 1
   }
@@ -298,14 +295,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooSubFunc1(_:)",
-    key.offset: 26,
+    key.offset: 25,
     key.length: 37,
     key.typename: "Int32",
-    key.nameoffset: 31,
+    key.nameoffset: 30,
     key.namelength: 23,
     key.attributes: [
       {
-        key.offset: 19,
+        key.offset: 18,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -314,7 +311,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 43,
+        key.offset: 42,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -324,11 +321,11 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1",
-    key.offset: 72,
+    key.offset: 70,
     key.length: 157,
-    key.nameoffset: 79,
+    key.nameoffset: 77,
     key.namelength: 11,
-    key.bodyoffset: 122,
+    key.bodyoffset: 120,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -340,7 +337,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     ],
     key.attributes: [
       {
-        key.offset: 65,
+        key.offset: 63,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -348,12 +345,12 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 93,
+        key.offset: 91,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 104,
+        key.offset: 102,
         key.length: 16
       }
     ],
@@ -362,13 +359,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 135,
+        key.offset: 133,
         key.length: 24,
-        key.nameoffset: 135,
+        key.nameoffset: 133,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 128,
+            key.offset: 126,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -377,7 +374,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 140,
+            key.offset: 138,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -387,13 +384,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 172,
+        key.offset: 170,
         key.length: 22,
-        key.nameoffset: 172,
+        key.nameoffset: 170,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 165,
+            key.offset: 163,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -402,10 +399,10 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 177,
+            key.offset: 175,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 177,
+            key.nameoffset: 175,
             key.namelength: 8
           }
         ]
@@ -415,14 +412,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 207,
+        key.offset: 205,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 211,
+        key.nameoffset: 209,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 200,
+            key.offset: 198,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -434,16 +431,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1X",
-    key.offset: 237,
+    key.offset: 235,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 241,
+    key.nameoffset: 239,
     key.namelength: 12,
-    key.bodyoffset: 268,
+    key.bodyoffset: 266,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 230,
+        key.offset: 228,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -453,16 +450,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1Y",
-    key.offset: 282,
+    key.offset: 280,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 286,
+    key.nameoffset: 284,
     key.namelength: 12,
-    key.bodyoffset: 313,
+    key.bodyoffset: 311,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 275,
+        key.offset: 273,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -472,16 +469,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubUnnamedEnumeratorA1",
-    key.offset: 328,
+    key.offset: 325,
     key.length: 42,
     key.typename: "Int",
-    key.nameoffset: 332,
+    key.nameoffset: 329,
     key.namelength: 25,
-    key.bodyoffset: 364,
+    key.bodyoffset: 361,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 321,
+        key.offset: 318,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
@@ -1,12 +1,13 @@
-
 public struct NUPixelSize {
 
     public init()
 
     public init(width: Int, height: Int)
 
+
     /** Some clang-style comments */
     public var width: Int
+
 
     /**
      * Some clang-style comments
@@ -17,57 +18,57 @@ public struct NUPixelSize {
 [
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8,
+    key.offset: 7,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 15,
+    key.offset: 14,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 34,
+    key.offset: 33,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 41,
+    key.offset: 40,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 53,
+    key.offset: 52,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 60,
+    key.offset: 59,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 65,
+    key.offset: 64,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 72,
+    key.offset: 71,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 77,
+    key.offset: 76,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 85,
+    key.offset: 84,
     key.length: 3
   },
   {
@@ -97,40 +98,40 @@ public struct NUPixelSize {
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 159,
+    key.offset: 160,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 208,
+    key.offset: 209,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 215,
+    key.offset: 216,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 219,
+    key.offset: 220,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 227,
+    key.offset: 228,
     key.length: 3
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 72,
+    key.offset: 71,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 85,
+    key.offset: 84,
     key.length: 3,
     key.is_system: 1
   },
@@ -142,7 +143,7 @@ public struct NUPixelSize {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 227,
+    key.offset: 228,
     key.length: 3,
     key.is_system: 1
   }
@@ -152,15 +153,15 @@ public struct NUPixelSize {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "NUPixelSize",
-    key.offset: 8,
-    key.length: 224,
-    key.nameoffset: 15,
+    key.offset: 7,
+    key.length: 226,
+    key.nameoffset: 14,
     key.namelength: 11,
-    key.bodyoffset: 28,
-    key.bodylength: 203,
+    key.bodyoffset: 27,
+    key.bodylength: 205,
     key.attributes: [
       {
-        key.offset: 1,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -170,13 +171,13 @@ public struct NUPixelSize {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 41,
+        key.offset: 40,
         key.length: 6,
-        key.nameoffset: 41,
+        key.nameoffset: 40,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 34,
+            key.offset: 33,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -186,13 +187,13 @@ public struct NUPixelSize {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(width:height:)",
-        key.offset: 60,
+        key.offset: 59,
         key.length: 29,
-        key.nameoffset: 60,
+        key.nameoffset: 59,
         key.namelength: 29,
         key.attributes: [
           {
-            key.offset: 53,
+            key.offset: 52,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -201,19 +202,19 @@ public struct NUPixelSize {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "width",
-            key.offset: 65,
+            key.offset: 64,
             key.length: 10,
             key.typename: "Int",
-            key.nameoffset: 65,
+            key.nameoffset: 64,
             key.namelength: 5
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "height",
-            key.offset: 77,
+            key.offset: 76,
             key.length: 11,
             key.typename: "Int",
-            key.nameoffset: 77,
+            key.nameoffset: 76,
             key.namelength: 6
           }
         ]
@@ -243,16 +244,16 @@ public struct NUPixelSize {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "height",
-        key.offset: 215,
+        key.offset: 216,
         key.length: 15,
         key.typename: "Int",
-        key.nameoffset: 219,
+        key.nameoffset: 220,
         key.namelength: 6,
-        key.docoffset: 159,
+        key.docoffset: 160,
         key.doclength: 44,
         key.attributes: [
           {
-            key.offset: 208,
+            key.offset: 209,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header3.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header3.response
@@ -1,7 +1,5 @@
-
 public enum SKFuelKind : UInt32 {
 
-    
     case H2 = 0
 
     case CH4 = 1
@@ -18,151 +16,151 @@ extension SKFuelKind {
 [
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8,
+    key.offset: 7,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 13,
+    key.offset: 12,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 26,
+    key.offset: 25,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 45,
+    key.offset: 39,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 50,
+    key.offset: 44,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 55,
+    key.offset: 49,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 62,
+    key.offset: 56,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 67,
+    key.offset: 61,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 73,
+    key.offset: 67,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 80,
+    key.offset: 74,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 85,
+    key.offset: 79,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 94,
+    key.offset: 88,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 98,
+    key.offset: 92,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 108,
+    key.offset: 102,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 126,
+    key.offset: 120,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 133,
+    key.offset: 127,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 137,
+    key.offset: 131,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 150,
+    key.offset: 144,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 159,
+    key.offset: 153,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 170,
+    key.offset: 164,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 177,
+    key.offset: 171,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 181,
+    key.offset: 175,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 197,
+    key.offset: 191,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 206,
+    key.offset: 200,
     key.length: 3
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 26,
+    key.offset: 25,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 108,
+    key.offset: 102,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 150,
+    key.offset: 144,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 197,
+    key.offset: 191,
     key.length: 6,
     key.is_system: 1
   }
@@ -172,12 +170,12 @@ extension SKFuelKind {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "SKFuelKind",
-    key.offset: 8,
-    key.length: 89,
-    key.nameoffset: 13,
+    key.offset: 7,
+    key.length: 84,
+    key.nameoffset: 12,
     key.namelength: 10,
-    key.bodyoffset: 34,
-    key.bodylength: 62,
+    key.bodyoffset: 33,
+    key.bodylength: 57,
     key.inheritedtypes: [
       {
         key.name: "UInt32"
@@ -185,7 +183,7 @@ extension SKFuelKind {
     ],
     key.attributes: [
       {
-        key.offset: 1,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -193,28 +191,28 @@ extension SKFuelKind {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 26,
+        key.offset: 25,
         key.length: 6
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 45,
+        key.offset: 39,
         key.length: 11,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "H2",
-            key.offset: 50,
+            key.offset: 44,
             key.length: 6,
-            key.nameoffset: 50,
+            key.nameoffset: 44,
             key.namelength: 2,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 55,
+                key.offset: 49,
                 key.length: 1
               }
             ]
@@ -223,21 +221,21 @@ extension SKFuelKind {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 62,
+        key.offset: 56,
         key.length: 12,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "CH4",
-            key.offset: 67,
+            key.offset: 61,
             key.length: 7,
-            key.nameoffset: 67,
+            key.nameoffset: 61,
             key.namelength: 3,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 73,
+                key.offset: 67,
                 key.length: 1
               }
             ]
@@ -246,21 +244,21 @@ extension SKFuelKind {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 80,
+        key.offset: 74,
         key.length: 15,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "C12H26",
-            key.offset: 85,
+            key.offset: 79,
             key.length: 10,
-            key.nameoffset: 85,
+            key.nameoffset: 79,
             key.namelength: 6,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 94,
+                key.offset: 88,
                 key.length: 1
               }
             ]
@@ -272,27 +270,27 @@ extension SKFuelKind {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "SKFuelKind",
-    key.offset: 98,
+    key.offset: 92,
     key.length: 115,
-    key.nameoffset: 108,
+    key.nameoffset: 102,
     key.namelength: 10,
-    key.bodyoffset: 120,
+    key.bodyoffset: 114,
     key.bodylength: 92,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "isCryogenic",
-        key.offset: 133,
+        key.offset: 127,
         key.length: 31,
         key.typename: "UInt32",
-        key.nameoffset: 137,
+        key.nameoffset: 131,
         key.namelength: 11,
-        key.bodyoffset: 158,
+        key.bodyoffset: 152,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 126,
+            key.offset: 120,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -302,16 +300,16 @@ extension SKFuelKind {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "isNotCryogenic",
-        key.offset: 177,
+        key.offset: 171,
         key.length: 34,
         key.typename: "UInt32",
-        key.nameoffset: 181,
+        key.nameoffset: 175,
         key.namelength: 14,
-        key.bodyoffset: 205,
+        key.bodyoffset: 199,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 170,
+            key.offset: 164,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_header.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.response
@@ -1,5 +1,4 @@
 public func doSomethingInHead(_ arg: Int32)
-
 open class BaseInHead {
 
     open func doIt(_ arg: Int32)
@@ -10,9 +9,6 @@ open class BaseInHead {
 /// Awesome name.
 open class SameName {
 }
-
-// random comment.
-
 public protocol SameNameProtocol {
 }
 
@@ -49,97 +45,92 @@ public protocol SameNameProtocol {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 45,
+    key.offset: 44,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 50,
+    key.offset: 49,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 56,
+    key.offset: 55,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 74,
+    key.offset: 73,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 79,
+    key.offset: 78,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 84,
+    key.offset: 83,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 89,
+    key.offset: 88,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 91,
+    key.offset: 90,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 96,
+    key.offset: 95,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 106,
+    key.offset: 105,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 124,
+    key.offset: 123,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 150,
+    key.offset: 149,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 168,
+    key.offset: 167,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 173,
+    key.offset: 172,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 179,
+    key.offset: 178,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 193,
-    key.length: 19
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 213,
+    key.offset: 191,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 220,
+    key.offset: 198,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 229,
+    key.offset: 207,
     key.length: 16
   }
 ]
@@ -152,7 +143,7 @@ public protocol SameNameProtocol {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 96,
+    key.offset: 95,
     key.length: 5,
     key.is_system: 1
   }
@@ -187,15 +178,15 @@ public protocol SameNameProtocol {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "BaseInHead",
-    key.offset: 50,
+    key.offset: 49,
     key.length: 54,
-    key.nameoffset: 56,
+    key.nameoffset: 55,
     key.namelength: 10,
-    key.bodyoffset: 68,
+    key.bodyoffset: 67,
     key.bodylength: 35,
     key.attributes: [
       {
-        key.offset: 45,
+        key.offset: 44,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -205,13 +196,13 @@ public protocol SameNameProtocol {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "doIt(_:)",
-        key.offset: 79,
+        key.offset: 78,
         key.length: 23,
-        key.nameoffset: 84,
+        key.nameoffset: 83,
         key.namelength: 18,
         key.attributes: [
           {
-            key.offset: 74,
+            key.offset: 73,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -220,7 +211,7 @@ public protocol SameNameProtocol {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "arg",
-            key.offset: 89,
+            key.offset: 88,
             key.length: 12,
             key.typename: "Int32"
           }
@@ -232,17 +223,17 @@ public protocol SameNameProtocol {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "SameName",
-    key.offset: 173,
+    key.offset: 172,
     key.length: 18,
-    key.nameoffset: 179,
+    key.nameoffset: 178,
     key.namelength: 8,
-    key.bodyoffset: 189,
+    key.bodyoffset: 188,
     key.bodylength: 1,
-    key.docoffset: 106,
+    key.docoffset: 105,
     key.doclength: 62,
     key.attributes: [
       {
-        key.offset: 168,
+        key.offset: 167,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -252,15 +243,15 @@ public protocol SameNameProtocol {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "SameNameProtocol",
-    key.offset: 220,
+    key.offset: 198,
     key.length: 29,
-    key.nameoffset: 229,
+    key.nameoffset: 207,
     key.namelength: 16,
-    key.bodyoffset: 247,
+    key.bodyoffset: 225,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 213,
+        key.offset: 191,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -699,12 +699,6 @@ SkipDocumentationComments("skip-print-doc-comments",
     llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
-PrintRegularComments("print-regular-comments",
-    llvm::cl::desc("Print regular comments from clang module headers"),
-    llvm::cl::cat(Category),
-    llvm::cl::init(false));
-
-static llvm::cl::opt<bool>
 PrintOriginalSourceText("print-original-source",
     llvm::cl::desc("print the original source text for applicable declarations"),
     llvm::cl::cat(Category),
@@ -4599,7 +4593,6 @@ int main(int argc, char *argv[]) {
     PrintOpts.PrintAccess = options::PrintAccess;
     PrintOpts.AccessFilter = options::AccessFilter;
     PrintOpts.PrintDocumentationComments = !options::SkipDocumentationComments;
-    PrintOpts.PrintRegularClangComments = options::PrintRegularComments;
     PrintOpts.SkipPrivateStdlibDecls = options::SkipPrivateStdlibDecls;
     PrintOpts.SkipUnsafeCXXMethods = options::SkipUnsafeCXXMethods;
     PrintOpts.SkipUnavailable = options::SkipUnavailable;


### PR DESCRIPTION
Generated interfaces for Clang modules used to try printing normal
comments between decls extracted from the header text. That was because
doc-comment was not common in C/ObjC headers. But mainly because of
"import as member feature" Clang decls aren't printed in the order as
they appear in the header file, the logic determinig which comment
belongs to which decl was not working property. We've decided to remove
that feature and only print the proper doc-comments as it has been
getting common.

rdar://93731287