### PR TITLE
[6.0] [Test] Update SymbolGraphGen test to handle nondeterminism

### DIFF
--- a/test/SymbolGraph/Relationships/Synthesized/ConditionalConformance.swift
+++ b/test/SymbolGraph/Relationships/Synthesized/ConditionalConformance.swift
@@ -7,9 +7,9 @@
 // RUN: %FileCheck %s --input-file %t/ConditionalConformance.symbols.json --check-prefix=CONFORMS
 // RUN: %FileCheck %s --input-file %t/ConditionalConformance.symbols.json --check-prefix=MEMBER
 
-// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=SYNTHEXT,EBSOff_SYNTHEXT
-// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=CONFORMSEXT,EBSOff_CONFORMSEXT
-// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=MEMBEREXT,EBSOff_MEMBEREXT
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=SYNTHEXT -DEXTID=s:Sa
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=CONFORMSEXT -DEXTID=s:Sa
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=MEMBEREXT -DEXTID=s:Sa
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name ConditionalConformance -emit-module -emit-module-path %t/
@@ -20,9 +20,9 @@
 // RUN: %FileCheck %s --input-file %t/ConditionalConformance.symbols.json --check-prefix=CONFORMS
 // RUN: %FileCheck %s --input-file %t/ConditionalConformance.symbols.json --check-prefix=MEMBER
 
-// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=SYNTHEXT,EBSOn_SYNTHEXT
-// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=CONFORMSEXT,EBSOn_CONFORMSEXT
-// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=MEMBEREXT,EBSOn_MEMBEREXT
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=SYNTHEXT -DEXTID=s:e:s:Sa22ConditionalConformanceSiRszlE3baryyF
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=CONFORMSEXT -DEXTID=s:e:s:Sa22ConditionalConformanceSiRszlE3baryyF
+// RUN: %FileCheck %s --input-file %t/ConditionalConformance@Swift.symbols.json --check-prefixes=MEMBEREXT -DEXTID=s:e:s:Sa22ConditionalConformanceSiRszlE3baryyF
 
 // Relationships to Swift.Array should only go into the @Swift file.
 // C\HECK-NOT: "s:Sa"
@@ -42,10 +42,9 @@ public struct S<T> {
   }
 }
 
-// CONFORMS: "kind": "conformsTo"
-// CONFORMS-NEXT: "source": "s:22ConditionalConformance1SV"
-// CONFORMS-NEXT: "target": "s:22ConditionalConformance1PP"
-// CONFORMS-NEXT: swiftConstraints
+// S<Int> will also have synthesized conformances to Copyable and Escapable, so match multiple lines
+// at once to make sure we only find the conformance we want to see
+// CONFORMS: "kind": "conformsTo"{{.*[[:space:]].*}} "source": "s:22ConditionalConformance1SV"{{.*[[:space:]].*}} "target": "s:22ConditionalConformance1PP"{{.*[[:space:]].*}} "swiftConstraints"
 // CONFORMS: "kind": "sameType"
 // CONFORMS-NEXT: "lhs": "T"
 // CONFORMS-NEXT: "rhs": "Int"
@@ -61,22 +60,16 @@ extension S: P where T == Int {
   }
 }
 
-// CONFORMSEXT: "kind": "conformsTo"
-// EBSOff_CONFORMSEXT-NEXT: "source": "s:Sa"
-// EBSOn_CONFORMSEXT-NEXT: "source": "s:e:s:Sa22ConditionalConformanceSiRszlE3baryyF"
-// CONFORMSEXT-NEXT: "target": "s:22ConditionalConformance1PP"
-// CONFORMSEXT-NEXT: swiftConstraints
+// CONFORMSEXT: "kind": "conformsTo"{{.*[[:space:]].*}} "source": "[[EXTID]]"{{.*[[:space:]].*}} "target": "s:22ConditionalConformance1PP"{{.*[[:space:]].*}} "swiftConstraints"
 // CONFORMSEXT: "kind": "sameType"
 // CONFORMSEXT-NEXT: "lhs": "Element"
 // CONFORMSEXT-NEXT: "rhs": "Int"
 
 extension Array: P where Element == Int {
   // SYNTHEXT: "source": "s:22ConditionalConformance1PPAAE3fooyyF::SYNTHESIZED::s:Sa"
-  // EBSOff_SYNTHEXT-NEXT: "target": "s:Sa"
-  // EBSOn_SYNTHEXT-NEXT: "target": "s:e:s:Sa22ConditionalConformanceSiRszlE3baryyF"
+  // SYNTHEXT-NEXT: "target": "[[EXTID]]"
 
   // MEMBEREXT: "source": "s:Sa22ConditionalConformanceSiRszlE3baryyF"
-  // EBSOff_MEMBEREXT-NEXT: "target": "s:Sa"
-  // EBSOn_MEMBEREXT-NEXT: "target": "s:e:s:Sa22ConditionalConformanceSiRszlE3baryyF"
+  // MEMBEREXT-NEXT: "target": "[[EXTID]]"
   public func bar() {}
 }


### PR DESCRIPTION
Cherry-pick of #72396

- **Explanation**: Test change to fix nondeterminism issue that caused CI to fail.
- **Scope**: Test-only change; the checks are equivalent but now are more flexible for the requested block not being first in the relationships list.
- **Issue**: None
- **Risk**: None. This is a test-only change to unblock CI.
- **Testing**: Test continues to pass at-desk and in smoke tests, as well as in the preset that was failing.
- **Reviewer**: @kavon 
