### PR TITLE
[6.0] Replace two `reduce`s with explicit loops in SIMD implementations.

### DIFF
--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -850,7 +850,11 @@ extension SIMD where Scalar: FixedWidthInteger {
   /// Equivalent to `indices.reduce(into: 0) { $0 &+= self[$1] }`.
   @_alwaysEmitIntoClient
   public func wrappedSum() -> Scalar {
-    return indices.reduce(into: 0) { $0 &+= self[$1] }
+    var result: Scalar = 0
+    for i in indices {
+      result &+= self[i]
+    }
+    return result
   }
 }
 
@@ -927,7 +931,13 @@ extension SIMD where Scalar: FloatingPoint {
     // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
     // coding the tree sum is problematic, we probably need to define a
     // Swift Builtin to support it.
-    return indices.reduce(into: 0) { $0 += self[$1] }
+    //
+    // Use -0 so that LLVM can optimize away initial value + self[0].
+    var result: Scalar = -0.0
+    for i in indices {
+      result += self[i]
+    }
+    return result
   }
 }
 

--- a/stdlib/public/core/SIMDVector.swift
+++ b/stdlib/public/core/SIMDVector.swift
@@ -933,7 +933,7 @@ extension SIMD where Scalar: FloatingPoint {
     // Swift Builtin to support it.
     //
     // Use -0 so that LLVM can optimize away initial value + self[0].
-    var result: Scalar = -0.0
+    var result = -Scalar.zero
     for i in indices {
       result += self[i]
     }


### PR DESCRIPTION
`reduce` has enough machinery that it pushes us over some inlining thresholds before optimizations happen, resulting in much worse codegen for String breadcrumbs. So a nice pickup there, but also generally applicable to other code as well.

Cherry-pick from https://github.com/apple/swift/pull/72423