### PR TITLE
[6.0] Serialization: update for new diagnostics format

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -213,23 +213,24 @@ void
 ModularizationError::diagnose(const ModuleFile *MF,
                               DiagnosticBehavior limit) const {
   auto &ctx = MF->getContext();
+  auto loc = getSourceLoc();
 
   auto diagnoseError = [&](Kind errorKind) {
     switch (errorKind) {
     case Kind::DeclMoved:
-      return ctx.Diags.diagnose(getSourceLoc(),
+      return ctx.Diags.diagnose(loc,
                                 diag::modularization_issue_decl_moved,
                                 declIsType, name, expectedModule,
                                 foundModule);
     case Kind::DeclKindChanged:
       return
-        ctx.Diags.diagnose(getSourceLoc(),
+        ctx.Diags.diagnose(loc,
                            diag::modularization_issue_decl_type_changed,
                            declIsType, name, expectedModule,
                            referenceModule->getName(), foundModule,
                            foundModule != expectedModule);
     case Kind::DeclNotFound:
-      return ctx.Diags.diagnose(getSourceLoc(),
+      return ctx.Diags.diagnose(loc,
                                 diag::modularization_issue_decl_not_found,
                                 declIsType, name, expectedModule);
     }
@@ -245,7 +246,7 @@ ModularizationError::diagnose(const ModuleFile *MF,
   // expected module name and the decl name from the diagnostic.
 
   // Show context with relevant file paths.
-  ctx.Diags.diagnose(SourceLoc(),
+  ctx.Diags.diagnose(loc,
                      diag::modularization_issue_note_expected,
                      declIsType, expectedModule,
                      expectedModule->getModuleSourceFilename());
@@ -257,14 +258,14 @@ ModularizationError::diagnose(const ModuleFile *MF,
     auto CML = ctx.getClangModuleLoader();
     auto &CSM = CML->getClangASTContext().getSourceManager();
     StringRef filename = CSM.getFilename(expectedUnderlying->DefinitionLoc);
-    ctx.Diags.diagnose(SourceLoc(),
+    ctx.Diags.diagnose(loc,
                        diag::modularization_issue_note_expected_underlying,
                        expectedUnderlying->Name,
                        filename);
   }
 
   if (foundModule)
-    ctx.Diags.diagnose(SourceLoc(),
+    ctx.Diags.diagnose(loc,
                        diag::modularization_issue_note_found,
                        declIsType, foundModule,
                        foundModule->getModuleSourceFilename());
@@ -277,7 +278,7 @@ ModularizationError::diagnose(const ModuleFile *MF,
     clientLangVersion = MF->getContext().LangOpts.EffectiveLanguageVersion;
   ModuleDecl *referenceModuleDecl = referenceModule->getAssociatedModule();
   if (clientLangVersion != moduleLangVersion) {
-    ctx.Diags.diagnose(SourceLoc(),
+    ctx.Diags.diagnose(loc,
                        diag::modularization_issue_swift_version,
                        referenceModuleDecl, moduleLangVersion,
                        clientLangVersion);
@@ -292,7 +293,7 @@ ModularizationError::diagnose(const ModuleFile *MF,
   if (referenceModule->getResilienceStrategy() ==
                                                ResilienceStrategy::Resilient &&
       referenceModuleIsDistributed) {
-    ctx.Diags.diagnose(SourceLoc(),
+    ctx.Diags.diagnose(loc,
                        diag::modularization_issue_stale_module,
                        referenceModuleDecl,
                        referenceModule->getModuleFilename());
@@ -302,7 +303,7 @@ ModularizationError::diagnose(const ModuleFile *MF,
   // it may be hidden by some clang defined passed via `-Xcc` affecting how
   // headers are seen.
   if (expectedUnderlying) {
-    ctx.Diags.diagnose(SourceLoc(),
+    ctx.Diags.diagnose(loc,
                        diag::modularization_issue_audit_headers,
                        expectedModule->isNonSwiftModule(), expectedModule);
   }
@@ -313,11 +314,11 @@ ModularizationError::diagnose(const ModuleFile *MF,
   // Local modules can reference both local modules and distributed modules.
   if (referenceModuleIsDistributed) {
     if (!expectedModule->isNonUserModule()) {
-      ctx.Diags.diagnose(SourceLoc(),
+      ctx.Diags.diagnose(loc,
                          diag::modularization_issue_layering_expected_local,
                          referenceModuleDecl, expectedModule);
     } else if (foundModule && !foundModule->isNonUserModule()) {
-      ctx.Diags.diagnose(SourceLoc(),
+      ctx.Diags.diagnose(loc,
                          diag::modularization_issue_layering_found_local,
                          referenceModuleDecl, foundModule);
     }
@@ -335,11 +336,13 @@ ModularizationError::diagnose(const ModuleFile *MF,
          expectedModuleName.starts_with(foundModuleName)) &&
         (expectedUnderlying ||
          expectedModule->findUnderlyingClangModule())) {
-      ctx.Diags.diagnose(SourceLoc(),
+      ctx.Diags.diagnose(loc,
                          diag::modularization_issue_related_modules,
                          declIsType, name);
     }
   }
+
+  ctx.Diags.flushConsumers();
 }
 
 void TypeError::diagnose(const ModuleFile *MF) const {

--- a/test/Serialization/Recovery/module-recovery-remarks.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks.swift
@@ -17,22 +17,22 @@
 // CHECK-MOVED: LibWithXRef.swiftmodule:1:1: remark: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'A_related'
 
 /// Contextual notes about the modules involved.
-// CHECK-MOVED: <unknown>:0: note: the type was expected to be found in module 'A' at '
+// CHECK-MOVED: note: the type was expected to be found in module 'A' at '
 // CHECK-MOVED-SAME: A.swiftmodule'
-// CHECK-MOVED: <unknown>:0: note: or expected to be found in the underlying module 'A' defined at '
+// CHECK-MOVED: note: or expected to be found in the underlying module 'A' defined at '
 // CHECK-MOVED-SAME: module.modulemap'
-// CHECK-MOVED: <unknown>:0: note: the type was actually found in module 'A_related' at '
+// CHECK-MOVED: note: the type was actually found in module 'A_related' at '
 // CHECK-MOVED-SAME: A_related.swiftmodule'
 
 /// More notes depending on the context
-// CHECK-MOVED: <unknown>:0: note: the module 'LibWithXRef' was built with a Swift language version set to 5
+// CHECK-MOVED: note: the module 'LibWithXRef' was built with a Swift language version set to 5
 // CHECK-MOVED-SAME: while the current invocation uses 4
 
-// CHECK-MOVED: <unknown>:0: note: the module 'LibWithXRef' has enabled library-evolution; the following file may need to be deleted if the SDK was modified: '
+// CHECK-MOVED: note: the module 'LibWithXRef' has enabled library-evolution; the following file may need to be deleted if the SDK was modified: '
 // CHECK-MOVED-SAME: LibWithXRef.swiftmodule'
-// CHECK-MOVED: <unknown>:0: note: declarations in the underlying clang module 'A' may be hidden by clang preprocessor macros
-// CHECK-MOVED: <unknown>:0: note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by header maps or search paths
-// CHECK-MOVED: <unknown>:0: note: the type 'MyType' moved between related modules; clang preprocessor macros may affect headers shared between these modules
+// CHECK-MOVED: note: declarations in the underlying clang module 'A' may be hidden by clang preprocessor macros
+// CHECK-MOVED: note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by header maps or search paths
+// CHECK-MOVED: note: the type 'MyType' moved between related modules; clang preprocessor macros may affect headers shared between these modules
 // CHECK-MOVED: note: could not deserialize type for 'foo()'
 // CHECK-MOVED: error: cannot find 'foo' in scope
 
@@ -40,7 +40,7 @@
 // RUN: mv %t/A.swiftmodule %t/sdk/A.swiftmodule
 // RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK-LAYERING-FOUND %s
-// CHECK-LAYERING-FOUND: <unknown>:0: note: the reference may break layering; the candidate was found in the local module 'A_related' for a reference from the distributed module 'LibWithXRef'
+// CHECK-LAYERING-FOUND: note: the reference may break layering; the candidate was found in the local module 'A_related' for a reference from the distributed module 'LibWithXRef'
 // CHECK-LAYERING-FOUND: error: cannot find 'foo' in scope
 
 /// Delete A, keep only the underlying clangmodule for notes about clang modules.
@@ -48,7 +48,7 @@
 // RUN: %target-swift-frontend %t/Empty.swift -emit-module-path %t/A_related.swiftmodule -module-name A_related
 // RUN: not %target-swift-frontend -c -O %t/Client.swift -I %t -I %t/sdk -Rmodule-recovery -sdk %t/sdk 2>&1 \
 // RUN:   | %FileCheck --check-prefixes CHECK-CLANG %s
-// CHECK-CLANG: <unknown>:0: note: declarations in the clang module 'A' may be hidden by clang preprocessor macros
+// CHECK-CLANG: note: declarations in the clang module 'A' may be hidden by clang preprocessor macros
 // CHECK-CLANG: error: cannot find 'foo' in scope
 
 

--- a/test/Serialization/modularization-error.swift
+++ b/test/Serialization/modularization-error.swift
@@ -21,11 +21,11 @@
 // CHECK-WORKAROUND: LibWithXRef.swiftmodule:1:1: warning: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'B'
 // CHECK-WORKAROUND-NEXT: A.MyType
 // CHECK-WORKAROUND-NEXT: ^
-// CHECK-WORKAROUND: <unknown>:0: note: the type was expected to be found in module 'A' at '
+// CHECK-WORKAROUND: note: the type was expected to be found in module 'A' at '
 // CHECK-WORKAROUND-SAME: A.swiftmodule'
-// CHECK-WORKAROUND: <unknown>:0: note: the type was actually found in module 'B' at '
+// CHECK-WORKAROUND: note: the type was actually found in module 'B' at '
 // CHECK-WORKAROUND-SAME: B.swiftmodule'
-// CHECK-WORKAROUND: <unknown>:0: note: attempting forced recovery enabled by -experimental-force-workaround-broken-modules
+// CHECK-WORKAROUND: note: attempting forced recovery enabled by -experimental-force-workaround-broken-modules
 // CHECK-WORKAROUND: func foo() -> some Proto
 
 /// Change MyType into a function.


### PR DESCRIPTION
Make sure we flush the diagnostics consumers to prevent the new diagnostic style to buffer the deserialization errors without printing them. These errors may be emitted right before an `abort()`, which would bypass the usual printing of the errors.

Take advantage of the new style to make these diagnostics more readable as well:

```
.../LibWithXRef.swiftmodule:1:1: error: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'A_related'
1 │ A.MyType
  │ ├─ error: reference to type 'MyType' broken by a context change; 'MyType' was expected to be in 'A', but now a candidate is found only in 'A_related'
  │ ├─ note: the type was expected to be found in module 'A' at ‘.../A.swiftmodule'
  │ ├─ note: or expected to be found in the underlying module 'A' defined at ‘.../module.modulemap'
  │ ├─ note: the type was actually found in module 'A_related' at ‘.../A_related.swiftmodule'
  │ ├─ note: the module 'LibWithXRef' was built with a Swift language version set to 5.10 while the current invocation uses 4.1.50; APINotes may change how clang declarations are imported
  │ ├─ note: the module 'LibWithXRef' has enabled library-evolution; the following file may need to be deleted if the SDK was modified: ‘.../LibWithXRef.swiftmodule'
  │ ├─ note: declarations in the underlying clang module 'A' may be hidden by clang preprocessor macros
  │ ├─ note: the distributed module 'LibWithXRef' refers to the local module 'A'; this may be caused by header maps or search paths
  │ ╰─ note: the type 'MyType' moved between related modules; clang preprocessor macros may affect headers shared between these modules
.../LibWithXRef.swiftmodule:1:1: note: could not deserialize type for 'foo()'
1 │ A.MyType
  │ ╰─ note: could not deserialize type for 'foo()'
```

rdar://124700605

Cherry-pick of https://github.com/apple/swift/pull/72408