### PR TITLE
[6.0][Test] Disable flakey test

### DIFF
--- a/test/SourceKit/Diagnostics/cancel_diags.swift
+++ b/test/SourceKit/Diagnostics/cancel_diags.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar116486638
+
 // RUN: not %sourcekitd-test -req=diags %s -print-raw-response -id=diag -async -- %s == -cancel=diag 2>&1 | %FileCheck --dump-input=always %s
 
 func foo(x: Invalid1, y: Invalid2) {


### PR DESCRIPTION
Cherry-pick of #72428

- **Explanation**: Disables a known-flakey test that we've been unable to reproduce at desk.
- **Scope**: Test only change.
- **Risk**: None. This is a test only change to unblock CI.
