### PR TITLE
[region-isolation] Convert more diagnostics from type isolation form to named variable form

### DIFF
--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -479,9 +479,6 @@ public:
                  diag::regionbasedisolation_named_info_transfer_yields_race,
                  name, isolationCrossing.getCallerIsolation(),
                  isolationCrossing.getCalleeIsolation());
-    // Then emit the note about where the variable is defined.
-    diagnoseNote(variableDefinedLoc, diag::variable_defined_here,
-                 false /*variable*/);
     emitRequireInstDiagnostics();
   }
 

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -27,7 +27,7 @@ struct Test2: TestProtocol { // expected-warning{{conformance of 'C2' to 'Sendab
 
 @MainActor
 func iterate(stream: AsyncStream<Int>) async {
-  nonisolated(unsafe) var it = stream.makeAsyncIterator() // expected-region-isolation-note {{variable defined here}}
+  nonisolated(unsafe) var it = stream.makeAsyncIterator()
   // FIXME: Region isolation should consider a value from a 'nonisolated(unsafe)'
   // declaration to be in a disconnected region
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -274,7 +274,7 @@ final class NonSendable {
 
 @available(SwiftStdlib 5.1, *)
 func testNonSendableBaseArg() async {
-  let t = NonSendable() // expected-tns-note {{variable defined here}}
+  let t = NonSendable()
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{transferring 't' may cause a race}}

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -107,7 +107,7 @@ extension FinalActor {
 
 // This test makes sure that we can properly pattern match project_box.
 func formClosureWithoutCrashing() {
-  var c = NonSendableKlass() // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
+ var c = NonSendableKlass() // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
   let _ = { print(c) }
 }
 
@@ -115,7 +115,7 @@ func formClosureWithoutCrashing() {
 // treat assignments into contents as a merge operation rather than an assign.
 func closureInOut(_ a: Actor) async {
   var contents = NonSendableKlass()
-  let ns0 = NonSendableKlass() // expected-tns-note {{variable defined here}}
+  let ns0 = NonSendableKlass()
   let ns1 = NonSendableKlass()
 
   contents = ns0
@@ -141,8 +141,8 @@ func closureInOut(_ a: Actor) async {
 
 func closureInOut2(_ a: Actor) async {
   var contents = NonSendableKlass()
-  let ns0 = NonSendableKlass() // expected-tns-note {{variable defined here}}
-  let ns1 = NonSendableKlass() // expected-tns-note {{variable defined here}}
+  let ns0 = NonSendableKlass()
+  let ns1 = NonSendableKlass()
 
   contents = ns0
   contents = ns1
@@ -165,7 +165,7 @@ func closureInOut2(_ a: Actor) async {
 func closureNonInOut(_ a: Actor) async {
   var contents = NonSendableKlass()
   let ns0 = NonSendableKlass()
-  let ns1 = NonSendableKlass() // expected-tns-note {{variable defined here}}
+  let ns1 = NonSendableKlass()
 
   contents = ns0
   contents = ns1
@@ -298,7 +298,7 @@ extension Actor {
   }
 
   func simpleClosureCaptureSelfWithReinit3() async {
-    var closure: () -> () = {} // expected-tns-note {{variable defined here}}
+    var closure: () -> () = {}
 
     // We get a transfer after use error.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
@@ -498,7 +498,7 @@ extension Actor {
 
 extension Actor {
   func testVarReassignStopActorDerived() async {
-    var closure: () -> () = { // expected-tns-note {{variable defined here}}
+    var closure: () -> () = {
       print(self)
     }
 
@@ -566,7 +566,7 @@ func testSendableClosureCapturesNonSendable2(a: MainActorIsolatedKlass) {
 /////////////////////////////////////////////////////
 
 func singleFieldVarMergeTest() async {
-  var box = SingleFieldKlassBox() // expected-tns-note {{variable defined here}}
+  var box = SingleFieldKlassBox()
   box = SingleFieldKlassBox()
 
   // This transfers the entire region.
@@ -599,7 +599,7 @@ func singleFieldVarMergeTest() async {
 }
 
 func multipleFieldVarMergeTest1() async {
-  var box = TwoFieldKlassBox() // expected-tns-note {{variable defined here}}
+  var box = TwoFieldKlassBox()
   box = TwoFieldKlassBox()
 
   // This transfers the entire region.
@@ -640,7 +640,7 @@ func multipleFieldVarMergeTest2() async {
 }
 
 func multipleFieldTupleMergeTest1() async {
-  var box = (NonSendableKlass(), NonSendableKlass()) // expected-tns-note {{variable defined here}}
+  var box = (NonSendableKlass(), NonSendableKlass())
   box = (NonSendableKlass(), NonSendableKlass())
 
   // This transfers the entire region.
@@ -844,7 +844,7 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
 }
 
 func letSendableTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
@@ -854,7 +854,7 @@ func letSendableTrivialVarStructFieldTest() async {
 }
 
 func letSendableNonTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
@@ -864,7 +864,7 @@ func letSendableNonTrivialVarStructFieldTest() async {
 }
 
 func letNonSendableNonTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
@@ -921,7 +921,7 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
 }
 
 func varSendableTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
@@ -931,7 +931,7 @@ func varSendableTrivialVarStructFieldTest() async {
 }
 
 func varSendableNonTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
@@ -941,7 +941,7 @@ func varSendableNonTrivialVarStructFieldTest() async {
 }
 
 func varNonSendableNonTrivialVarStructFieldTest() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
@@ -953,7 +953,7 @@ func varNonSendableNonTrivialVarStructFieldTest() async {
 
 // vars cannot access sendable let/var if captured in a closure.
 func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   let cls = {
     test = StructFieldTests()
@@ -968,7 +968,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   let cls = {
     test = StructFieldTests()
@@ -983,7 +983,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   let cls = {
     test = StructFieldTests()
@@ -998,7 +998,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
 
 // vars cannot access sendable let/var if captured in a closure.
 func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
   cls = {
@@ -1014,7 +1014,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
   cls = {
@@ -1030,7 +1030,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
   cls = {
@@ -1045,7 +1045,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
   cls = {
@@ -1060,7 +1060,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
   cls = {
@@ -1075,7 +1075,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
   cls = {
@@ -1090,7 +1090,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
 
@@ -1111,7 +1111,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
 
@@ -1133,7 +1133,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
 // We do not error when accessing the sendable field in this example since the
 // transfer is not reachable from the closure. Instead we emit an error on test.
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
 
@@ -1153,7 +1153,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
 
@@ -1179,7 +1179,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
-  var test = StructFieldTests() // expected-tns-note {{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
 
   // The reason why we error here is that even though we reassign at the end of
@@ -1202,7 +1202,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
-  var test = StructFieldTests() // expected-tns-note 2{{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
 
@@ -1230,7 +1230,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
 // In this case since we are tracking the transfer from the else statement, we
 // track the closure.
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
-  var test = StructFieldTests() // expected-tns-note 2{{variable defined here}}
+  var test = StructFieldTests()
   test = StructFieldTests()
   var cls = {}
 
@@ -1341,7 +1341,7 @@ func controlFlowTest1() async {
 // as well afterwards since if we exit from the loop header, we have that large
 // merge region leave the for loop.
 func controlFlowTest2() async {
-  var x = NonSendableKlass() // expected-tns-note {{variable defined here}}
+  var x = NonSendableKlass()
 
   for _ in 0..<1024 {
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -15,7 +15,7 @@
 ////////////////////////
 
 /// Classes are always non-sendable, so this is non-sendable
-class NonSendableKlass { // expected-complete-note 35{{}}
+class NonSendableKlass { // expected-complete-note 36{{}}
   // expected-typechecker-only-note @-1 4{{}}
   // expected-tns-note @-2 2{{}}
   var field: NonSendableKlass? = nil
@@ -1275,8 +1275,9 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
 
 func varSendableTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.0
   useValue(z)
   useValue(test) // expected-tns-note {{access here could race}}
@@ -1284,8 +1285,9 @@ func varSendableTrivialLetTupleFieldTest() async {
 
 func varSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.1
   useValue(z)
   useValue(test) // expected-tns-note {{access here could race}}
@@ -1293,8 +1295,9 @@ func varSendableNonTrivialLetTupleFieldTest() async {
 
 func varNonSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2
   // The SIL emitted for the assignment of the tuple is just a jumble of
   // instructions that are not semantically significant. The result is that we
@@ -1306,8 +1309,19 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
 func varSendableTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  _ = test.0
+  useValue(test) // expected-tns-note {{access here could race}}
+}
+
+func varSendableTrivialVarTupleFieldTest2() async {
+  var test = (0, SendableKlass(), NonSendableKlass()) 
+  test = (0, SendableKlass(), NonSendableKlass())
+  await transferToMain(test.2) // expected-tns-warning {{transferring 'test.2' may cause a race}}
+  // expected-tns-note @-1 {{'test.2' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   _ = test.0
   useValue(test) // expected-tns-note {{access here could race}}
 }
@@ -1315,8 +1329,9 @@ func varSendableTrivialVarTupleFieldTest() async {
 func varSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.1
   useValue(test) // expected-tns-note {{access here could race}}
 }
@@ -1324,8 +1339,9 @@ func varSendableNonTrivialVarTupleFieldTest() async {
 func varNonSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type '(Int, SendableKlass, NonSendableKlass)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2 // expected-tns-note {{access here could race}}
   useValue(z)
   useValue(test)

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -213,7 +213,6 @@ extension Actor {
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
-  // TODO: Why is this task-isolated?
   func simpleClosureCaptureSelfAndTransferThroughTuple() async {
     let closure: () -> () = {
       print(self.klass)
@@ -224,7 +223,6 @@ extension Actor {
     // expected-tns-warning @-2 {{actor-isolated value of type '(Int, () -> ())' transferred to main actor-isolated context}}
   }
 
-  // TODO: Why is this task-isolated?
   func simpleClosureCaptureSelfAndTransferThroughTupleBackwards() async {
     let closure: () -> () = {
       print(self.klass)
@@ -697,16 +695,18 @@ class ClassFieldTests { // expected-complete-note 6{{}}
 
 func letSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func letSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
 
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
@@ -714,32 +714,36 @@ func letSendableNonTrivialClassFieldTest() async {
 
 func letNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   useValue(test)
 }
@@ -759,48 +763,54 @@ final class FinalClassFieldTests { // expected-complete-note 6 {{}}
 
 func letSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func letSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func letNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{access here could race}}
   useValue(test)
 }
 
 func varNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'FinalClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   useValue(test)
 }
@@ -820,24 +830,27 @@ struct StructFieldTests { // expected-complete-note 31 {{}}
 
 func letSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func letSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func letNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
   useValue(test)
@@ -886,8 +899,9 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
     print(test)
   }
   _ = cls2
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial
   _ = z
   let z2 = test.varSendableNonTrivial
@@ -897,24 +911,27 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
 
 func varSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func varSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
   useValue(test) // expected-tns-note {{access here could race}}
 }
 
 func varNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'StructFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
   _ = z
   useValue(test)
@@ -1322,11 +1339,13 @@ func controlFlowTest1() async {
   let x = NonSendableKlass()
 
   if await booleanFlag {
-    await transferToMain(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   useValue(x) // expected-tns-note 2{{access here could race}}
@@ -1369,22 +1388,25 @@ actor ActorWithSetter {
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}    
-    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}    
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1403,8 +1425,9 @@ actor ActorWithSetter {
   func classBox() async {
     let x = NonSendableKlass()
     self.classBox.k1 = x
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
 
@@ -1418,22 +1441,25 @@ final actor FinalActorWithSetter {
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
   // This triggers a crash in SILGen with tns enabled.
@@ -1452,8 +1478,9 @@ final actor FinalActorWithSetter {
   func classBox() async {
     let x = NonSendableKlass()
     self.classBox.k1 = x
-    await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
 

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -290,12 +290,13 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
 func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-tns-note @-1:67 {{access here could race}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-tns-note @-2:67 {{access here could race}}
 
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
 }
@@ -745,7 +746,8 @@ func asyncLetWithoutCapture() async {
   async let x: NonSendableKlass = await returnValueFromMain()
   // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by implicitly asynchronous call to main actor-isolated function cannot cross actor boundary}}
   let y = await x
-  await transferToMain(y) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  await transferToMain(y) // expected-tns-warning {{transferring 'y' may cause a race}}
+  // expected-tns-note @-1 {{'y' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(y) // expected-tns-note {{access here could race}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -103,7 +103,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 }
 
 @GlobalActor func useGlobalActor6() async {
-  var x = StructContainingValue() // expected-tns-note {{variable defined here}}
+  var x = StructContainingValue()
   x = StructContainingValue()
 
   await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -130,9 +130,10 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = (NonSendableLinkedList<Int>(), NonSendableLinkedList<Int>())
   x = (NonSendableLinkedList<Int>(), NonSendableLinkedList<Int>())
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' from global actor 'GlobalActor'-isolated context to nonisolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{'x' is transferred from global actor 'GlobalActor'-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
   useValue(x) // expected-tns-note {{access here could race}}
 }
@@ -142,10 +143,10 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 
   x.1 = firstList
 
-  // TODO: This should be a global actor isolated error, not a task-isolated error.
-  await transferToNonIsolated(x) // expected-tns-warning {{global actor 'GlobalActor'-isolated value of type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' transferred to nonisolated context}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring global actor 'GlobalActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'GlobalActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
   useValue(x)
 }

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -48,14 +48,15 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 @GlobalActor func useGlobalActor1() async {
   let x = firstList
 
-  // TODO: This should say global actor isolated isolated.
-  await transferToMainActor(x) // expected-tns-warning {{global actor 'GlobalActor'-isolated value of type 'NonSendableLinkedList<Int>' transferred to main actor-isolated context}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
+  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring global actor 'GlobalActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'GlobalActor'-isolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
 
   let y = secondList.listHead!.next!
 
-  await transferToMainActor(y) // expected-tns-warning {{global actor 'GlobalActor'-isolated value of type 'NonSendableLinkedListNode<Int>' transferred to main actor-isolated context}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
+  await transferToMainActor(y) // expected-tns-warning {{transferring 'y' may cause a race}}
+  // expected-tns-note @-1 {{transferring global actor 'GlobalActor'-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and global actor 'GlobalActor'-isolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
 
 @GlobalActor func useGlobalActor2() async {
@@ -91,8 +92,9 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 @GlobalActor func useGlobalActor5() async {
   let x = NonSendableLinkedListNode<Int>()
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableLinkedListNode<Int>' from global actor 'GlobalActor'-isolated context to nonisolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{'x' is transferred from global actor 'GlobalActor'-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
   useValue(x) // expected-tns-note {{access here could race}}
 }

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -93,7 +93,8 @@ func normalFunc_testLocal_2() {
 // diagnostic.
 func transferBeforeCaptureErrors() async {
   let x = NonSendableKlass()
-  await transferToCustom(x) // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor 'CustomActor'-isolated context}}
+  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{'x' is transferred from nonisolated caller to global actor 'CustomActor'-isolated callee. Later uses in caller could race with potential uses in callee}}
   let _ = { @MainActor in // expected-note {{access here could race}}
     useValue(x)
   }

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -67,23 +67,25 @@ func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected
 }
 
 func testBorrowing(_ x: borrowing Klass) async {
-  await transferToMain(x) // expected-warning {{task-isolated value of type 'Klass' transferred to main actor-isolated context}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testBorrowingError(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
-  await transferToMain(x) // expected-warning {{task-isolated value of type 'Klass' transferred to main actor-isolated context}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 @CustomActor func testBorrowingErrorGlobalActor(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
-  await transferToMain(x) // expected-warning {{global actor 'CustomActor'-isolated value of type 'Klass' transferred to main actor-isolated context}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 func testInOut(_ x: inout Klass) async {
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
-  // TODO: This is wrong. Should say task isolated!
-  // expected-note @-2 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
+  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testInOutError(_ x: inout Klass) async {

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -246,8 +246,8 @@ func test_indirect_regions(a : A, b : Bool) async {
 
     // same aux value points to both 0 and 1
     let ns5_aux = NonSendable();
-    let ns5_0 = ns5_aux.x; // expected-tns-note {{variable defined here}}
-    let ns5_1 = ns5_aux.y; // expected-tns-note {{variable defined here}}
+    let ns5_0 = ns5_aux.x;
+    let ns5_1 = ns5_aux.y;
 
     // now check for each pair that consuming half of it consumed the other half
 

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -107,7 +107,8 @@ func testNonStrongTransferDoesntMerge() async {
 
 func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x)
-  await transferToMain(y) // expected-warning {{task-isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
+  await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
+  // expected-note @-1 {{transferring task-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
@@ -127,7 +128,8 @@ actor MyActor {
 
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
     await transferToMain(x)
-    await transferToMain(y) // expected-warning {{actor-isolated value of type 'Klass' transferred to main actor-isolated context; later accesses to value could race}}
+    await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
+    // expected-note @-1 {{transferring actor-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
@@ -206,7 +208,8 @@ func assigningIsAMergeError(_ x: transferring Klass) async {
   x = y
 
   // We can still transfer y since x is disconnected.
-  await transferToMain(y) // expected-warning {{transferring value of non-Sendable type 'Klass' from nonisolated context to main actor-isolated context}}
+  await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
+  // expected-note @-1 {{'y' is transferred from nonisolated caller to main actor-isolated callee}}
 
   useValue(x) // expected-note {{access here could race}}
 }
@@ -312,7 +315,8 @@ func doubleArgument() async {
 
 func testTransferSrc(_ x: transferring Klass) async {
   let y = Klass()
-  await transferToMain(y) // expected-warning {{transferring value of non-Sendable type 'Klass' from nonisolated context to main actor-isolated context}}
+  await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
+  // expected-note @-1 {{'y' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   x = y // expected-note {{access here could race}}
 }
 

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -111,14 +111,12 @@ func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) 
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
-  // expected-note @-1:54 {{variable defined here}}
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   await transferToMain(x) // expected-note {{access here could race}}
 }
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
-  // expected-note @-1 {{variable defined here}}
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   useValue(x) // expected-note {{access here could race}}
@@ -133,14 +131,12 @@ actor MyActor {
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
-    // expected-note @-1 {{variable defined here}}
     await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
     // expected-note @-1 {{'x' is transferred from actor-isolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     await transferToMain(x) // expected-note {{access here could race}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
-    // expected-note @-1 {{variable defined here}}
     await transferToMain(x)  // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from actor-isolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
     useValue(x) // expected-note {{access here could race}}
@@ -182,7 +178,7 @@ func canTransferAssigningIntoLocal(_ x: transferring Klass) async {
 }
 
 func canTransferAssigningIntoLocal2(_ x: transferring Klass) async {
-  // expected-note @-1 {{variable defined here}}
+
   let _ = x
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
@@ -226,7 +222,7 @@ func assigningIsAMergeAny(_ x: transferring Any) async {
 
 func assigningIsAMergeAnyError(_ x: transferring Any) async {
   // Ok, this is disconnected.
-  let y = getAny() // expected-note {{variable defined here}}
+  let y = getAny()
 
   x = y
 
@@ -249,8 +245,6 @@ func canTransferAfterAssign(_ x: transferring Any) async {
 }
 
 func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
-  // expected-note @-1:44 {{variable defined here}}
-
   // Ok, this is disconnected.
   let y = getAny()
 
@@ -280,7 +274,7 @@ func assignToEntireValueEliminatesEarlierTransfer(_ x: transferring Any) async {
 }
 
 func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) async {
-  // expected-note @-1 {{variable defined here}}
+
 
   // Ok, this is disconnected.
   let y = Klass()
@@ -298,8 +292,6 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
 }
 
 func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) async {
-  // expected-note @-1 {{variable defined here}}
-
   // Ok, this is disconnected.
   let y = Klass()
 

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -83,7 +83,7 @@ func simpleTest() async {
 // emit the first seen error on a path, so if we were to emit an error on
 // useValue(y), we would have emitted that error.
 func simpleTest2() async {
-  let x = NonSendableKlass() // expected-note {{variable defined here}}
+  let x = NonSendableKlass()
   let y = transferResultWithArg(x)
   await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
@@ -94,7 +94,7 @@ func simpleTest2() async {
 // Make sure that later errors with y can happen.
 func simpleTest3() async {
   let x = NonSendableKlass()
-  let y = transferResultWithArg(x) // expected-note {{variable defined here}}
+  let y = transferResultWithArg(x)
   await transferToMainDirect(x)
   await transferToMainDirect(y) // expected-warning {{transferring 'y' may cause a race}}
   // expected-note @-1 {{'y' is transferred from nonisolated caller to main actor-isolated callee}}
@@ -102,7 +102,7 @@ func simpleTest3() async {
 }
 
 func transferResult() async -> transferring NonSendableKlass {
-  let x = NonSendableKlass() // expected-note {{variable defined here}}
+  let x = NonSendableKlass()
   await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   return x // expected-note {{access here could race}}

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -18,7 +18,7 @@ actor Bar {
   init(_ _: NonSendable) {
   }
   func bar() async {
-    let ns = NonSendable() // expected-note {{variable defined here}}
+    let ns = NonSendable()
     _ = Bar(ns) // expected-warning {{transferring 'ns' may cause a race}}
     // TODO: This needs to be:
     // disconnected 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -20,12 +20,14 @@ func transferValue<T>(_ t: transferring T) {}
 
 func testIsolationError() async {
   let x = NonSendableType()
-  await transferToMain(x) // expected-error {{transferring value of non-Sendable type 'NonSendableType' from nonisolated context to main actor-isolated context; later accesses could race}}
+  await transferToMain(x) // expected-error {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
   useValue(x) // expected-note {{access here could race}}
 }
 
 func testTransferArgumentError(_ x: NonSendableType) async {
-  await transferToMain(x) // expected-error {{task-isolated value of type 'NonSendableType' transferred to main actor-isolated context; later accesses to value could race}}
+  await transferToMain(x) // expected-error {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testPassArgumentAsTransferringParameter(_ x: NonSendableType) async {

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics_library_evolution.swift
@@ -103,7 +103,7 @@ public func callerConsumeClassLetFieldForArgumentSpillingTestInOutArg(_ x: inout
 
 // TODO: more specific error message path than "unknown"
 public func callerConsumeClassLetFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
-    consumeVal(x.letS.e) // expected-error{{cannot partially consume 'unknown'}}
+  consumeVal(x.letS.e) // expected-error{{cannot partially consume 'x.letS'}}
 }
 
 public func callerConsumeClassLetFieldForArgumentSpillingTestLetGlobal() {
@@ -170,7 +170,7 @@ public func callerConsumeClassVarFieldForArgumentSpillingTestInOutArg(_ x: inout
 
 // TODO: more precise error path reporting than 'unknown'
 public func callerConsumeClassVarFieldForArgumentSpillingTestConsumingArg(_ x: consuming CopyableKlass) {
-    consumeVal(x.varS.e) // expected-error{{cannot partially consume 'unknown'}}
+  consumeVal(x.varS.e) // expected-error{{cannot partially consume 'x.varS'}}
 }
 
 public func callerConsumeClassVarFieldForArgumentSpillingTestLetGlobal() {

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -597,3 +597,30 @@ bb8:
   debug_value [trace] %4 : $FirstSecondThirdEnum<Klass>
   return %4 : $FirstSecondThirdEnum<Klass>
 }
+
+// Test that we can properly handle code generation from a borrowing loadable parameter
+//
+// CHECK-LABEL: begin running test 1 of 1 on loadable_borrowing_test: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %8 = store_borrow %6 to %7 : $*Klass            // user: %9
+// CHECK: Name: 'x'
+// CHECK: Root: %3 = mark_unresolved_non_copyable_value [no_consume_or_assign] %2
+// CHECK: end running test 1 of 1 on loadable_borrowing_test: variable-name-inference with: @trace[0]
+sil hidden [ossa] @loadable_borrowing_test : $@convention(thin) @async (@guaranteed Klass) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Klass):
+  specify_test "variable-name-inference @trace[0]"
+  %1 = copyable_to_moveonlywrapper [guaranteed] %0 : $Klass
+  %2 = copy_value %1 : $@moveOnly Klass
+  %3 = mark_unresolved_non_copyable_value [no_consume_or_assign] %2 : $@moveOnly Klass
+  debug_value %3 : $@moveOnly Klass, let, name "x", argno 1
+  %7 = begin_borrow %3 : $@moveOnly Klass
+  %8 = moveonlywrapper_to_copyable [guaranteed] %7 : $@moveOnly Klass
+  %9 = alloc_stack $Klass
+  %10 = store_borrow %8 to %9 : $*Klass
+  debug_value [trace] %10 : $*Klass  
+  end_borrow %10 : $*Klass
+  dealloc_stack %9 : $*Klass
+  end_borrow %7 : $@moveOnly Klass
+  destroy_value %3 : $@moveOnly Klass
+  %25 = tuple ()
+  return %25 : $()
+}

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -616,11 +616,121 @@ bb0(%0 : @noImplicitCopy @guaranteed $Klass):
   %8 = moveonlywrapper_to_copyable [guaranteed] %7 : $@moveOnly Klass
   %9 = alloc_stack $Klass
   %10 = store_borrow %8 to %9 : $*Klass
-  debug_value [trace] %10 : $*Klass  
+  debug_value [trace] %10 : $*Klass
   end_borrow %10 : $*Klass
   dealloc_stack %9 : $*Klass
   end_borrow %7 : $@moveOnly Klass
   destroy_value %3 : $@moveOnly Klass
   %25 = tuple ()
   return %25 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on store_borrow_tuple_test: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %25 = store_borrow %23 to %24 : $*Klass
+// CHECK: Name: 'z'
+// CHECK: Root: %20 = move_value [lexical] [var_decl] %19 : $Klass
+// CHECK: end running test 1 of 1 on store_borrow_tuple_test: variable-name-inference with: @trace[0]
+sil hidden [ossa] @store_borrow_tuple_test : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %2 = integer_literal $Builtin.IntLiteral, 0
+  %7 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %8 = apply %7() : $@convention(thin) () -> @owned Klass
+  %9 = tuple (%2 : $Builtin.IntLiteral, %8 : $Klass)
+  %10 = move_value [lexical] [var_decl] %9 : $(Builtin.IntLiteral, Klass)
+  debug_value %10 : $(Builtin.IntLiteral, Klass), let, name "test"
+  %12 = begin_borrow %10 : $(Builtin.IntLiteral, Klass)
+  (%13, %14) = destructure_tuple %12 : $(Builtin.IntLiteral, Klass)
+  %15 = copy_value %14 : $Klass
+  %16 = tuple (%13 : $Builtin.IntLiteral, %15 : $Klass)
+  %17 = alloc_stack $(Builtin.IntLiteral, Klass)
+  store %16 to [init] %17 : $*(Builtin.IntLiteral, Klass)
+  // original location of use.
+  destroy_addr %17 : $*(Builtin.IntLiteral, Klass)
+  dealloc_stack %17 : $*(Builtin.IntLiteral, Klass)
+  end_borrow %12 : $(Builtin.IntLiteral, Klass)
+  %25 = begin_borrow %10 : $(Builtin.IntLiteral, Klass)
+  %26 = copy_value %25 : $(Builtin.IntLiteral, Klass)
+  (%27, %28) = destructure_tuple %26 : $(Builtin.IntLiteral, Klass)
+  %29 = move_value [lexical] [var_decl] %28 : $Klass
+  debug_value %29 : $Klass, let, name "z"
+  end_borrow %25 : $(Builtin.IntLiteral, Klass)
+  %32 = begin_borrow %29 : $Klass
+  %33 = alloc_stack $Klass
+  %34 = store_borrow %32 to %33 : $*Klass
+  debug_value [trace] %34 : $*Klass
+  %35 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %36 = apply %35<Klass>(%34) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  end_borrow %34 : $*Klass
+  dealloc_stack %33 : $*Klass
+  end_borrow %32 : $Klass
+  %40 = begin_borrow %10 : $(Builtin.IntLiteral, Klass)
+  (%41, %42) = destructure_tuple %40 : $(Builtin.IntLiteral, Klass)
+  %43 = copy_value %42 : $Klass
+  %44 = tuple (%41 : $Builtin.IntLiteral, %43 : $Klass)
+  %45 = alloc_stack $(Builtin.IntLiteral, Klass)
+  store %44 to [init] %45 : $*(Builtin.IntLiteral, Klass)
+  %48 = apply %35<(Builtin.IntLiteral, Klass)>(%45) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %45 : $*(Builtin.IntLiteral, Klass)
+  dealloc_stack %45 : $*(Builtin.IntLiteral, Klass)
+  end_borrow %40 : $(Builtin.IntLiteral, Klass)
+  destroy_value %29 : $Klass
+  destroy_value %10 : $(Builtin.IntLiteral, Klass)
+  %54 = tuple ()
+  return %54 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on store_borrow_tuple_test_2: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %11 = alloc_stack $(Builtin.IntLiteral, Klass)
+// CHECK: Name: 'test'
+// CHECK: Root:   %4 = move_value [lexical] [var_decl] %3 : $(Builtin.IntLiteral, Klass)
+// CHECK: end running test 1 of 1 on store_borrow_tuple_test_2: variable-name-inference with: @trace[0]
+sil hidden [ossa] @store_borrow_tuple_test_2 : $@convention(thin) @async () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %2 = integer_literal $Builtin.IntLiteral, 0
+  %7 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %8 = apply %7() : $@convention(thin) () -> @owned Klass
+  %9 = tuple (%2 : $Builtin.IntLiteral, %8 : $Klass)
+  %10 = move_value [lexical] [var_decl] %9 : $(Builtin.IntLiteral, Klass)
+  debug_value %10 : $(Builtin.IntLiteral, Klass), let, name "test"
+  %12 = begin_borrow %10 : $(Builtin.IntLiteral, Klass)
+  (%13, %14) = destructure_tuple %12 : $(Builtin.IntLiteral, Klass)
+  %15 = copy_value %14 : $Klass
+  %16 = tuple (%13 : $Builtin.IntLiteral, %15 : $Klass)
+  %17 = alloc_stack $(Builtin.IntLiteral, Klass)
+  store %16 to [init] %17 : $*(Builtin.IntLiteral, Klass)
+  debug_value [trace] %17 : $*(Builtin.IntLiteral, Klass)
+  // original location of use.
+  destroy_addr %17 : $*(Builtin.IntLiteral, Klass)
+  dealloc_stack %17 : $*(Builtin.IntLiteral, Klass)
+  end_borrow %12 : $(Builtin.IntLiteral, Klass)
+  %25 = begin_borrow %10 : $(Builtin.IntLiteral, Klass)
+  %26 = copy_value %25 : $(Builtin.IntLiteral, Klass)
+  (%27, %28) = destructure_tuple %26 : $(Builtin.IntLiteral, Klass)
+  %29 = move_value [lexical] [var_decl] %28 : $Klass
+  debug_value %29 : $Klass, let, name "z"
+  end_borrow %25 : $(Builtin.IntLiteral, Klass)
+  %32 = begin_borrow %29 : $Klass
+  %33 = alloc_stack $Klass
+  %34 = store_borrow %32 to %33 : $*Klass
+  %35 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  %36 = apply %35<Klass>(%34) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  end_borrow %34 : $*Klass
+  dealloc_stack %33 : $*Klass
+  end_borrow %32 : $Klass
+  %40 = begin_borrow %10 : $(Builtin.IntLiteral, Klass)
+  (%41, %42) = destructure_tuple %40 : $(Builtin.IntLiteral, Klass)
+  %43 = copy_value %42 : $Klass
+  %44 = tuple (%41 : $Builtin.IntLiteral, %43 : $Klass)
+  %45 = alloc_stack $(Builtin.IntLiteral, Klass)
+  store %44 to [init] %45 : $*(Builtin.IntLiteral, Klass)
+  %48 = apply %35<(Builtin.IntLiteral, Klass)>(%45) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  destroy_addr %45 : $*(Builtin.IntLiteral, Klass)
+  dealloc_stack %45 : $*(Builtin.IntLiteral, Klass)
+  end_borrow %40 : $(Builtin.IntLiteral, Klass)
+  destroy_value %29 : $Klass
+  destroy_value %10 : $(Builtin.IntLiteral, Klass)
+  %54 = tuple ()
+  return %54 : $()
 }


### PR DESCRIPTION
Just chopping off parts of a larger PR that can exist independently.

In this PR, I eliminate a ton more of the cases where we failed to identify a value name resulting in us emitting a type isolation error. Example:

```swift
// After
func letSendableTrivialClassFieldTest() async {
  let test = ClassFieldTests()
  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
  // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
  _ = test.letSendableTrivial
  useValue(test) // expected-tns-note {{access here could race}}
}
```

from,

```swift
// Before
func letSendableTrivialClassFieldTest() async {
  let test = ClassFieldTests()
  await transferToMain(test) // expected-tns-warning {{transferring value of non-Sendable type 'ClassFieldTests' from nonisolated context to main actor-isolated context; later accesses could race}}
  // expected-complete-warning @-1 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
  _ = test.letSendableTrivial
  useValue(test) // expected-tns-note {{access here could race}}
}
```

I still need to change that specific diagnostic to use IsolationRegionInformation rather than pure callee information, but this an improvement (and more importantly just what I needed to add to do some other work). Once I am able to loop back around that would cause the note diagnostic to be transformed as follows:

```
  // expected-tns-note @-1 {{'test' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}

->

  // expected-tns-note @-1 {{disconnected 'test' is transferred to main actor-isolated callee. Later uses in caller could race with actor-isolated uses in callee}}
```