### PR TITLE
[Cherry-pick] [DebugInfo] Generate debug info for specialized types

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5887,8 +5887,10 @@ namespace {
     std::optional<SpareBitsMaskInfo> calculateSpareBitsMask() const override {
       SpareBitVector spareBits;
       for (auto enumCase : getElementsWithPayload()) {
-        cast<FixedTypeInfo>(enumCase.ti)
-            ->applyFixedSpareBitsMask(IGM, spareBits);
+        if (auto fixedTI = llvm::dyn_cast<FixedTypeInfo>(enumCase.ti))
+          fixedTI->applyFixedSpareBitsMask(IGM, spareBits);
+        else
+          return {};
       }
       // Trim leading/trailing zero bytes, then pad to a multiple of 32 bits
       llvm::APInt bits = spareBits.asAPInt();

--- a/test/DebugInfo/BoundGenericStruct.swift
+++ b/test/DebugInfo/BoundGenericStruct.swift
@@ -25,6 +25,35 @@ public let s = S<Int>(t: 0)
 // DWARF: !DICompositeType(tag: DW_TAG_structure_type, name: "S", 
 // DWARF-SAME:             identifier: "$s18BoundGenericStruct1SVyxGD")
 // DWARF: !DIDerivedType(tag: DW_TAG_member, name: "t"
-// DWARF: !DICompositeType(tag: DW_TAG_structure_type, name: "$sxD"
+// DWARF: ![[GENERIC_PARAM_TYPE:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$sxD"
 
 
+public struct S2<T> {
+  public struct Inner {
+    let t: T
+  }
+}
+public let inner = S2<Double>.Inner(t:4.2)
+
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "Inner", 
+// CHECK-SAME: size: 64, {{.*}}identifier: "$s18BoundGenericStruct2S2V5InnerVySd_GD")
+// CHECK: !DICompositeType(tag: DW_TAG_structure_type, name: "$s18BoundGenericStruct2S2VyxGD", 
+// CHECK-SAME: flags: DIFlagFwdDecl, runtimeLang: DW_LANG_Swift)
+
+// DWARF: !DICompositeType(tag: DW_TAG_structure_type, scope: ![[SCOPE1:[0-9]+]],
+// DWARF-SAME: size: 64, {{.*}}, templateParams: ![[PARAMS2:[0-9]+]], identifier: "$s18BoundGenericStruct2S2V5InnerVySd_GD"
+// DWARF-SAME: specification_of: ![[SPECIFICATION:[0-9]+]]
+
+// DWARF: ![[SCOPE1]] = !DICompositeType(tag: DW_TAG_structure_type, name: "$s18BoundGenericStruct2S2VyxGD", 
+
+// DWARF: ![[PARAMS2]] = !{![[PARAMS3:[0-9]+]]}
+// DWARF: ![[PARAMS3]] = !DITemplateTypeParameter(type: ![[PARAMS4:[0-9]+]])
+// DWARF: ![[PARAMS4]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Double",
+// DWARF-SAME: size: 64, {{.*}}runtimeLang: DW_LANG_Swift, identifier: "$sSdD")
+
+// DWARF: [[SPECIFICATION]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Inner", 
+// DWARF-SAME: elements: ![[ELEMENTS1:[0-9]+]], runtimeLang: DW_LANG_Swift, identifier: "$s18BoundGenericStruct2S2V5InnerVyx_GD")
+
+// DWARF: ![[ELEMENTS1]] = !{![[ELEMENTS2:[0-9]+]]}
+
+// DWARF: ![[ELEMENTS2]] = !DIDerivedType(tag: DW_TAG_member, name: "t", scope: !27, file: !3, baseType: ![[GENERIC_PARAM_TYPE]])


### PR DESCRIPTION
Specialized types are generic types, or types whose parent is specialized.

IRGenDebugInfo was previously mistankenly emitting debug info for nominal specialized types as if they regular nominal types, which caused problems as that code path does not handle references to generic parameters.

(cherry picked from commit ae5e341db4884526e3ec2152f301487df2a7e6b5)