### PR TITLE
[test] Change availability guarding test in StringGraphemeBreaking.swift

### DIFF
--- a/validation-test/stdlib/StringGraphemeBreaking.swift
+++ b/validation-test/stdlib/StringGraphemeBreaking.swift
@@ -115,9 +115,7 @@ if #available(SwiftStdlib 5.9, *) {
       check(string, test.pieces)
     }
   }
-}
 
-if #available(SwiftStdlib 5.8, *) {
   StringGraphemeBreaking.test("GB11") {
     // MAN, ZERO WIDTH JOINER, ZERO WIDTH JOINER, GIRL
     let string = "\u{1f468}\u{200d}\u{200d}\u{1f467}"


### PR DESCRIPTION
The change to fix this behavior never actually landed in Swift 5.8, so bump the availability of the test to 5.9.

Resolves: rdar://125041033