### PR TITLE
[DebugInfo] Always emit unsubsituted generic types with size 0

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1125,11 +1125,13 @@ private:
   llvm::DICompositeType *createUnsubstitutedGenericStructOrClassType(
       DebugTypeInfo DbgTy, NominalTypeDecl *Decl, Type UnsubstitutedType,
       llvm::DIScope *Scope, llvm::DIFile *File, unsigned Line,
-      unsigned SizeInBits, unsigned AlignInBits, llvm::DINode::DIFlags Flags,
-      llvm::DIType *DerivedFrom, unsigned RuntimeLang, StringRef UniqueID) {
+      llvm::DINode::DIFlags Flags, llvm::DIType *DerivedFrom,
+      unsigned RuntimeLang, StringRef UniqueID) {
     // FIXME: ideally, we'd like to emit this type with no size and alignment at
     // all (instead of emitting them as 0). Fix this by changing DIBuilder to
     // allow for struct types that have optional size and alignment.
+    unsigned SizeInBits = 0;
+    unsigned AlignInBits = 0;
     StringRef Name = Decl->getName().str();
     auto FwdDecl = createStructForwardDecl(DbgTy, Decl, Scope, File, Line,
                                            SizeInBits, Flags, UniqueID, Name);
@@ -1172,8 +1174,7 @@ private:
     std::string DeclTypeMangledName = Mangler.mangleTypeForDebugger(
         UnsubstitutedTy->mapTypeOutOfContext(), {});
     if (DeclTypeMangledName == MangledName) {
-      return createUnsubstitutedVariantType(DbgTy, Decl, MangledName,
-                                            SizeInBits, AlignInBits, Scope,
+      return createUnsubstitutedVariantType(DbgTy, Decl, MangledName, Scope,
                                             File, 0, Flags);
     }
     auto FwdDecl = llvm::TempDIType(DBuilder.createReplaceableCompositeType(
@@ -1232,9 +1233,8 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
       Mangler.mangleTypeForDebugger(UnsubstitutedTy->mapTypeOutOfContext(), {});
   if (DeclTypeMangledName == MangledName) {
     return createUnsubstitutedGenericStructOrClassType(
-        DbgTy, Decl, UnsubstitutedTy, Scope, File, Line, SizeInBits,
-        AlignInBits, Flags, nullptr, llvm::dwarf::DW_LANG_Swift,
-        DeclTypeMangledName);
+        DbgTy, Decl, UnsubstitutedTy, Scope, File, Line, Flags, nullptr,
+        llvm::dwarf::DW_LANG_Swift, DeclTypeMangledName);
   }
   // Force the creation of the unsubstituted type, don't create it
   // directly so it goes through all the caching/verification logic.
@@ -1327,7 +1327,7 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
                                            llvm::DIFile *File, unsigned Line,
                                            llvm::DINode::DIFlags Flags) {
     assert(!Decl->getRawType() &&
-           "Attempting to create variant debug info from raw enum!");
+           "Attempting to create variant debug info from raw enum!");;
 
     StringRef Name = Decl->getName().str();
     unsigned SizeInBits = DbgTy.getSizeInBits();
@@ -1399,7 +1399,6 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
   llvm::DICompositeType *
   createUnsubstitutedVariantType(DebugTypeInfo DbgTy, EnumDecl *Decl,
                                  StringRef MangledName,
-                                 unsigned SizeInBits, unsigned AlignInBits,
                                  llvm::DIScope *Scope, llvm::DIFile *File,
                                  unsigned Line, llvm::DINode::DIFlags Flags) {
     assert(!Decl->getRawType() &&
@@ -1408,6 +1407,8 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
     StringRef Name = Decl->getName().str();
     auto NumExtraInhabitants = DbgTy.getNumExtraInhabitants();
 
+    unsigned SizeInBits = 0;
+    unsigned AlignInBits = 0;
     // A variant part should actually be a child to a DW_TAG_structure_type
     // according to the DWARF spec.
     auto FwdDecl = llvm::TempDIType(DBuilder.createReplaceableCompositeType(
@@ -2082,7 +2083,7 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
       auto L = getFileAndLocation(Decl);
       unsigned FwdDeclLine = 0;
       if (Opts.DebugInfoLevel > IRGenDebugInfoLevel::ASTTypes) {
-        if (EnumTy->isSpecialized())
+        if (EnumTy->isSpecialized() && !Decl->hasRawType())
           return createSpecializedEnumType(EnumTy, Decl, MangledName,
                                            SizeInBits, AlignInBits, Scope, File,
                                            FwdDeclLine, Flags);
@@ -2262,6 +2263,12 @@ createSpecializedStructOrClassType(NominalOrBoundGenericNominalType *Type,
     unsigned CachedSizeInBits = getSizeInBits(CachedType);
     if ((SizeInBits && CachedSizeInBits != *SizeInBits) ||
         (!SizeInBits && CachedSizeInBits)) {
+      // In some situation a specialized type is emitted with size 0, even if the real 
+      // type has a size.
+      if (DbgTy.getType()->isSpecialized() && SizeInBits && *SizeInBits > 0 &&
+          CachedSizeInBits == 0)
+        return true;
+
       CachedType->dump();
       DbgTy.dump();
       llvm::errs() << "SizeInBits = " << SizeInBits << "\n";


### PR DESCRIPTION
Unsubstituted generic types shouldn't have a size, precisely because the generic parameters aren't substituted in. Always emit them with a size 0.
