### PR TITLE
[6.0][Concurrency] Don't strip `@Sendable` when determining the actor isolation of a closure in a `@preconcurrency` context.

### DIFF
--- a/test/Concurrency/actor_data_race_checks_minimal.swift
+++ b/test/Concurrency/actor_data_race_checks_minimal.swift
@@ -1,0 +1,35 @@
+// RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking -enable-actor-data-race-checks -swift-version 5 -strict-concurrency=minimal) | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+@preconcurrency @MainActor
+protocol P {
+  func requirement()
+}
+
+class C: P {
+  func requirement() {
+    call {
+      print("don't crash!")
+    }
+  }
+
+  var task: Task<Void, Never>?
+
+  @preconcurrency func call(closure: @escaping @Sendable () -> Void) {
+    task = Task.detached {
+      closure()
+    }
+  }
+
+  func wait() async {
+    await task?.value
+  }
+}
+
+// CHECK: don't crash!
+let c = C()
+c.requirement()
+await c.wait()


### PR DESCRIPTION
* **Explanation**: Stripping `@Sendable` from closure types actually changes the isolation of the closure, because non-`Sendable` closures are isolated to the context they're formed in, which leads to bogus dynamic assertion failures under `-enable-actor-data-race-checks`. Instead, downgrade any diagnostics about non-`Sendable` captures using the `.limitBehaviorUntilSwiftVersion` mechanism like other preconcurrency errors that are suppressed in minimal checking.
* **Scope**: Only has an observable impact under `-strict-concurrency=minimal -enable-actor-data-race-checks`
* **Risk**: Low; the scope is narrow and the `limitBehavior` mechanism is already used extensively for preconcurrency diagnostic suppression and downgrading.
* **Testing**: Added new tests
* **Reviewer**: @xedin
* **Main branch PR**: https://github.com/apple/swift/pull/72437