### PR TITLE
[6.0] FieldSensitivePrunedLiveness: Handle conditionality of `try_apply` defs.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2816,6 +2816,7 @@ bool GlobalLivenessChecker::testInstVectorLiveness(
       for (auto isLive : isLiveArray) {
         switch (isLive) {
         case IsLive::Dead:
+        case IsLive::DeadToLiveEdge:
           LLVM_DEBUG(llvm::dbgs() << "    Dead block!\n");
           // Ignore a dead block. Our error use could not be in such a block.
           //

--- a/test/Interpreter/moveonly_resilient_deinit_on_throw_same_module.swift
+++ b/test/Interpreter/moveonly_resilient_deinit_on_throw_same_module.swift
@@ -3,11 +3,9 @@
 // RUN: %target-codesign %t/a.out.fragile
 // RUN: %target-run %t/a.out.fragile | %FileCheck %s
 
-// FIXME: miscompiles cause extra deinits with library evolution enabled
-
-// R/UN: %target-build-swift -enable-library-evolution -o %t/a.out.resilient %s 
-// R/UN: %target-codesign %t/a.out.resilient
-// R/UN: %target-run %t/a.out.resilient | %FileCheck %s
+// RUN: %target-build-swift -enable-library-evolution -o %t/a.out.resilient %s 
+// RUN: %target-codesign %t/a.out.resilient
+// RUN: %target-run %t/a.out.resilient | %FileCheck %s
 
 // REQUIRES: executable_test
 


### PR DESCRIPTION
- *Explanation:* Fixes an overrelease bug when a value of resilient noncopyable type would be returned from a throwing function, and that function throws instead.
- *Scope:* Fixes a miscompile.
- *Issue:* rdar://118567869
- *Original PR:* https://github.com/apple/swift/pull/72452
- *Risk:* Low, fixes a miscompile in a specific situation.
- *Testing:* Swift CI
- *Reviewer:* Michael Gottesman @gottesmm 
