### PR TITLE
[6.0] Parse: Diagnose empty version numbers

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4089,6 +4089,11 @@ bool Parser::parseVersionTuple(llvm::VersionTuple &Version,
     Version = llvm::VersionTuple(major);
     Range = SourceRange(StartLoc, Tok.getLoc());
     consumeToken();
+    if (Version.empty()) {
+      // Versions cannot be empty (e.g. "0").
+      diagnose(Range.Start, D).warnUntilSwiftVersion(6);
+      return true;
+    }
     return false;
   }
 
@@ -4123,6 +4128,12 @@ bool Parser::parseVersionTuple(llvm::VersionTuple &Version,
     Version = llvm::VersionTuple(major, minor, micro);
   } else {
     Version = llvm::VersionTuple(major, minor);
+  }
+
+  if (Version.empty()) {
+    // Versions cannot be empty (e.g. "0.0").
+    diagnose(Range.Start, D).warnUntilSwiftVersion(6);
+    return true;
   }
 
   return false;

--- a/test/Parse/availability_query.swift
+++ b/test/Parse/availability_query.swift
@@ -36,6 +36,12 @@ if #available(OSX { // expected-error {{expected version number}} expected-error
 if #available(OSX) { // expected-error {{expected version number}}
 }
 
+if #available(OSX 0) { // expected-warning {{expected version number; this is an error in the Swift 6 language mode}}
+}
+
+if #available(OSX 0.0) { // expected-warning {{expected version number; this is an error in the Swift 6 language mode}}
+}
+
 if #available(OSX 10.51 { // expected-error {{expected ')'}} expected-note {{to match this opening '('}} expected-error {{must handle potential future platforms with '*'}} {{24-24=, *}}
 }
 

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -139,7 +139,7 @@ let x: () = ()
 // https://github.com/apple/swift/issues/50734
 
 func f1_50734(@NSApplicationMain x: Int) {} // expected-error {{@NSApplicationMain may only be used on 'class' declarations}}
-func f2_50734(@available(iOS, deprecated: 0) x: Int) {} // expected-error {{'@available' attribute cannot be applied to this declaration}}
+func f2_50734(@available(iOS, deprecated: 1) x: Int) {} // expected-error {{'@available' attribute cannot be applied to this declaration}}
 func f3_50734(@discardableResult x: Int) {} // expected-error {{'@discardableResult' attribute cannot be applied to this declaration}}
 func f4_50734(@objcMembers x: String) {} // expected-error {{@objcMembers may only be used on 'class' declarations}}
 func f5_50734(@weak x: String) {} // expected-error {{'weak' is a declaration modifier, not an attribute}} expected-error {{'weak' may only be used on 'var' declarations}}

--- a/test/Sema/diag_originally_definedin.swift
+++ b/test/Sema/diag_originally_definedin.swift
@@ -16,6 +16,12 @@ public class C {
 @_originallyDefinedIn(module: "original", OSX 10.13)
 public class D {}
 
+@_originallyDefinedIn(module: "original", macOS) // expected-error {{expected version number in '@_originallyDefinedIn' attribute}}
+public func missingVersion() {}
+
+@_originallyDefinedIn(module: "original", macOS 0) // expected-warning {{expected version number in '@_originallyDefinedIn' attribute; this is an error in the Swift 6 language mode}}
+public func versionZero() {}
+
 @available(macOS 10.9, *)
 @_originallyDefinedIn(module: "original", _myProject 2.0) // expected-error {{reference to undefined version '2.0' for availability macro '_myProject'}}
 public func macroVersioned() {}

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -146,6 +146,15 @@ let _: Int
 @available(OSX, introduced: 1.0.0x4) // expected-error{{expected version number in 'available' attribute}}
 let _: Int
 
+@available(OSX, introduced: 0) // expected-warning{{expected version number in 'available' attribute; this is an error in the Swift 6 language mode}}
+let _: Int
+
+@available(OSX, introduced: 0.0) // expected-warning{{expected version number in 'available' attribute; this is an error in the Swift 6 language mode}}
+let _: Int
+
+@available(OSX, introduced: 0.0.0) // expected-warning{{expected version number in 'available' attribute; this is an error in the Swift 6 language mode}}
+let _: Int
+
 @available(*, renamed: "bad name") // expected-error{{'renamed' argument of 'available' attribute must be an operator, identifier, or full function name, optionally prefixed by a type name}}
 let _: Int
 

--- a/test/attr/attr_backDeployed.swift
+++ b/test/attr/attr_backDeployed.swift
@@ -384,6 +384,9 @@ public func missingVersionFunc2() {}
 @backDeployed(before: macOS, iOS) // expected-error 2{{expected version number in '@backDeployed' attribute}}
 public func missingVersionFunc3() {}
 
+@backDeployed(before: macOS 0) // expected-warning {{expected version number in '@backDeployed' attribute; this is an error in the Swift 6 language mode}}
+public func missingVersionFunc4() {}
+
 @backDeployed(before: macOS 12.0, iOS 15.0,) // expected-error {{unexpected ',' separator}}
 public func unexpectedSeparatorFunc() {}
 


### PR DESCRIPTION
- **Explanation:** The compiler treats version tuples that are all zeros as empty, or the same as not having a version. Diagnose attempts to specify all-zeroes versions in attributes and availability queries to prevent surprising behavior.
- **Scope:** New diagnostics for a rare pattern in source code. The diagnostics are warnings until Swift 6. 
- **Radar:** rdar://124661151
- **Original PR:** https://github.com/apple/swift/pull/72449
- **Risk:** Low because the diagnostics are warnings until Swift 6. 
- **Testing:** Added new test cases to the compiler test suite.
- **Reviewer:** @nkcsgexi 