### PR TITLE
[6.0] Serialization: report type mismatch when it causes a deserialization failure

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -954,6 +954,10 @@ NOTE(modularization_issue_stale_module,none,
      "the module %0 has enabled library-evolution; "
      "the following file may need to be deleted if the SDK was modified: '%1'",
      (const ModuleDecl *, StringRef))
+NOTE(modularization_issue_type_mismatch,none,
+     "a candidate was filtered out because of a type mismatch; "
+     "expected: %0, found: %1",
+     (const Type, const Type))
 NOTE(modularization_issue_swift_version,none,
      "the module %0 was built with a Swift language version set to %1 "
      "while the current invocation uses %2; "

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -367,16 +367,21 @@ private:
 
   XRefTracePath path;
 
+  /// Expected vs found type if the mismatch caused a decl to be rejected.
+  std::optional<std::pair<Type, Type>> mismatchingTypes;
+
 public:
   explicit ModularizationError(DeclName name, bool declIsType, Kind errorKind,
                                const ModuleDecl *expectedModule,
                                const ModuleFile *referenceModule,
                                const ModuleDecl *foundModule,
-                               XRefTracePath path):
+                               XRefTracePath path,
+                               std::optional<std::pair<Type, Type>> mismatchingTypes):
     name(name), declIsType(declIsType), errorKind(errorKind),
     expectedModule(expectedModule),
     referenceModule(referenceModule),
-    foundModule(foundModule), path(path) {}
+    foundModule(foundModule), path(path),
+    mismatchingTypes(mismatchingTypes) {}
 
   void diagnose(const ModuleFile *MF,
                 DiagnosticBehavior limit = DiagnosticBehavior::Fatal) const;

--- a/test/Serialization/Recovery/module-recovery-remarks-on-type-changed.swift
+++ b/test/Serialization/Recovery/module-recovery-remarks-on-type-changed.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Compile two libraries A and LibWithXRef.
+// RUN: %target-swift-frontend -emit-module %t/LibWithXRef.swift -I %t \
+// RUN:   -module-name LibWithXRef -o %t/LibWithXRef.swiftmodule \
+// RUN:   -swift-version 5
+// RUN: %target-swift-frontend -c -O %t/Client.swift -I %t \
+// RUN:   -validate-tbd-against-ir=none -swift-version 5
+
+// Replace headers, changing the type of `foo`.
+// RUN: mv %t/A_DifferentAPI.h %t/A.h
+// RUN: not --crash %target-swift-frontend -c -O %t/Client.swift -I %t \
+// RUN:   -validate-tbd-against-ir=none -swift-version 5 2>&1 \
+// RUN:   | %FileCheck %s
+// CHECK: error: reference to top-level declaration 'foo' broken by a context change; the declaration kind of 'foo' from 'A' changed since building 'LibWithXRef'
+// CHECK: note: the declaration was expected to be found in module 'A' at '{{.*}}module.modulemap'
+// CHECK: note: the declaration was actually found in module 'A' at '{{.*}}module.modulemap'
+// CHECK: note: a candidate was filtered out because of a type mismatch; expected: '() -> ()', found: '() -> Float'
+
+//--- module.modulemap
+module A {
+    header "A.h"
+}
+
+//--- A.h
+void foo() {}
+
+//--- A_DifferentAPI.h
+float foo() {
+    return 1.2;
+}
+
+//--- LibWithXRef.swift
+import A
+
+@inlinable
+public func bar() {
+    foo()
+}
+
+//--- Client.swift
+import LibWithXRef
+
+bar()


### PR DESCRIPTION
Deserialization may fail if a decl in a dependency changed type between the time a swiftmodule was built and when it was imported. This can happen because of changes to the SDK or use of C preprocessor macros. To help understand these problems, note the specific types causing the mismatch when it leads to a deserialization failure.

```
.../LibWithXRef.swiftmodule:1:1: error: reference to top-level declaration 'foo' broken by a context change; the declaration kind of 'foo' from 'A' changed since building 'LibWithXRef'
1 │ A.foo
  │ ├─ ...
  │ ├─ note: a candidate was filtered out because of a type mismatch; expected: '() -> ()', found: '() -> Float'
```

Scope: Affects the failure mode after deserialization recovers from an issue.
Risk: Low, it changes the behavior of already failing compilation runs.
Issue: rdar://125094362
Original PR: #72439
