### PR TITLE
[ScanDependency] Set context hash for source module

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -816,9 +816,6 @@ static void writeJSON(llvm::raw_ostream &out,
       if (!moduleInterfacePath.empty()) {
         writeJSONSingleField(out, "moduleInterfacePath", moduleInterfacePath, 5,
                              /*trailingComma=*/true);
-        writeJSONSingleField(out, "contextHash", swiftTextualDeps->context_hash,
-                             5,
-                             /*trailingComma=*/true);
         out.indent(5 * 2);
         out << "\"compiledModuleCandidates\": [\n";
         for (int i = 0,
@@ -849,6 +846,9 @@ static void writeJSON(llvm::raw_ostream &out,
       }
       out.indent(5 * 2);
       out << "],\n";
+      writeJSONSingleField(out, "contextHash", swiftTextualDeps->context_hash,
+                           5,
+                           /*trailingComma=*/true);
       bool hasBridgingHeaderPath =
           swiftTextualDeps->bridging_header_path.data &&
           get_C_string(swiftTextualDeps->bridging_header_path)[0] != '\0';
@@ -1244,9 +1244,7 @@ generateFullDependencyGraph(const CompilerInstance &instance,
                             bridgedOverlayDependencyNames);
 
         details->swift_textual_details = {
-            moduleInterfacePath,
-            create_empty_set(),
-            bridgingHeaderPath,
+            moduleInterfacePath, create_empty_set(), bridgingHeaderPath,
             create_set(
                 swiftSourceDeps->textualModuleDetails.bridgingSourceFiles),
             create_set(swiftSourceDeps->textualModuleDetails
@@ -1255,7 +1253,9 @@ generateFullDependencyGraph(const CompilerInstance &instance,
             create_set(swiftSourceDeps->textualModuleDetails.buildCommandLine),
             create_set(swiftSourceDeps->bridgingHeaderBuildCommandLine),
             create_set(swiftSourceDeps->textualModuleDetails.extraPCMArgs),
-            /*contextHash*/ create_null(),
+            /*contextHash*/
+            create_clone(
+                instance.getInvocation().getModuleScanningHash().c_str()),
             /*isFramework*/ false,
             /*CASFS*/
             create_clone(swiftSourceDeps->textualModuleDetails

--- a/test/CAS/module_deps.swift
+++ b/test/CAS/module_deps.swift
@@ -133,7 +133,6 @@ import SubE
 // CHECK: ],
 // CHECK-NEXT: "details": {
 
-// CHECK: "contextHash": "{{.*}}",
 // CHECK: "commandLine": [
 // CHECK: "-compile-module-from-interface"
 // CHECK: "-target"
@@ -144,6 +143,7 @@ import SubE
 // CHECK: "-swift-version"
 // CHECK: "5"
 // CHECK: ],
+// CHECK: "contextHash": "{{.*}}",
 // CHECK_NO_CLANG_TARGET: "extraPcmArgs": [
 // CHECK_NO_CLANG_TARGET-NEXT:   "-Xcc",
 // CHECK_NO_CLANG_TARGET-NEXT:   "-target",

--- a/test/CAS/module_deps_include_tree.swift
+++ b/test/CAS/module_deps_include_tree.swift
@@ -127,7 +127,6 @@ import SubE
 // CHECK: ],
 // CHECK-NEXT: "details": {
 
-// CHECK: "contextHash": "{{.*}}",
 // CHECK: "commandLine": [
 // CHECK: "-compile-module-from-interface"
 // CHECK: "-target"
@@ -138,6 +137,7 @@ import SubE
 // CHECK: "-swift-version"
 // CHECK: "5"
 // CHECK: ],
+// CHECK: "contextHash": "{{.*}}",
 // CHECK_NO_CLANG_TARGET: "extraPcmArgs": [
 // CHECK_NO_CLANG_TARGET-NEXT:   "-Xcc",
 // CHECK_NO_CLANG_TARGET-NEXT:   "-target",

--- a/test/CAS/plugin_cas.swift
+++ b/test/CAS/plugin_cas.swift
@@ -115,7 +115,6 @@ import SubE
 // CHECK: ],
 // CHECK-NEXT: "details": {
 
-// CHECK: "contextHash": "{{.*}}",
 // CHECK: "commandLine": [
 // CHECK: "-compile-module-from-interface"
 // CHECK: "-target"
@@ -124,6 +123,7 @@ import SubE
 // CHECK: "-swift-version"
 // CHECK: "5"
 // CHECK: ],
+// CHECK: "contextHash": "{{.*}}",
 // CHECK_NO_CLANG_TARGET: "extraPcmArgs": [
 // CHECK_NO_CLANG_TARGET-NEXT:   "-Xcc",
 // CHECK_NO_CLANG_TARGET-NEXT:   "-target",

--- a/test/ModuleInterface/clang-session-transitive.swift
+++ b/test/ModuleInterface/clang-session-transitive.swift
@@ -33,7 +33,6 @@ import TestModule
  // CHECK-NEXT:      "details": {
  // CHECK-NEXT:        "swift": {
  // CHECK-NEXT:          "moduleInterfacePath": 
- // CHECK-NEXT:          "contextHash":
  // CHECK-NEXT:          "compiledModuleCandidates": [
  // CHECK-NEXT:            TestModule.swiftmodule
  // CHECK-NEXT:          ],

--- a/test/ModuleInterface/extension-transitive-availability.swift
+++ b/test/ModuleInterface/extension-transitive-availability.swift
@@ -34,7 +34,6 @@ func foo() {
 // CHECK-NEXT:      "details": {
 // CHECK-NEXT:        "swift": {
 // CHECK-NEXT:          "moduleInterfacePath": 
-// CHECK-NEXT:          "contextHash":
 // CHECK-NEXT:          "compiledModuleCandidates": [
 // CHECK-NEXT:          ],
 // CHECK-NEXT:          "commandLine": [

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -57,6 +57,7 @@ import SubE
 // CHECK-DAG:     "swift": "_cross_import_E"
 // CHECK: ],
 
+// CHECK:      "contextHash":
 // CHECK:      "extraPcmArgs": [
 // CHECK-NEXT:    "-Xcc",
 // CHECK-NEXT:    "-target",

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -44,6 +44,7 @@ import SubE
 // CHECK-DAG:     "clang": "_SwiftConcurrencyShims"
 // CHECK: ],
 
+// CHECK:      "contextHash":
 // CHECK:      "extraPcmArgs": [
 // CHECK-NEXT:    "-Xcc",
 // CHECK-NEXT:    "-target",
@@ -95,7 +96,6 @@ import SubE
 // CHECK: ],
 // CHECK-NEXT: "details": {
 
-// CHECK: "contextHash": "{{.*}}",
 // CHECK: "commandLine": [
 // CHECK: "-compile-module-from-interface"
 // CHECK: "-target"
@@ -104,6 +104,7 @@ import SubE
 // CHECK: "-swift-version"
 // CHECK: "5"
 // CHECK: ],
+// CHECK: "contextHash": "{{.*}}",
 // CHECK" "extraPcmArgs": [
 // CHECK"   "-target",
 // CHECK"   "-fapinotes-swift-version=5"


### PR DESCRIPTION
Set context hash for source module so swift-driver can use the hash to compute output path if needed.

rdar://119202702
