### PR TITLE
[6.0][Tests] NFC: Gate preconcurrency conformances runtime test on presenc…

### DIFF
--- a/test/Interpreter/preconcurrency_conformances.swift
+++ b/test/Interpreter/preconcurrency_conformances.swift
@@ -32,6 +32,7 @@
 
 // REQUIRES: asserts
 // REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
…e of concurrency runtime

Resolves: rdar://123810657
(cherry picked from commit 34f96242fed5003650a375121e8eff0b2c677ab4)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
