### PR TITLE
SILGen: Emit empty type initialization for conditionally-copyable type inits.

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -759,7 +759,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
                                            {selfDecl->getTypeInContext()},
                                            LookUpConformanceInModule(module)),
                       selfLV.getLValueAddress());
-    } else if (isa<StructDecl>(nominal) && !nominal->canBeCopyable()
+    } else if (isa<StructDecl>(nominal)
+               && lowering.getLoweredType().isMoveOnly()
                && nominal->getStoredProperties().empty()) {
       auto *si = B.createStruct(ctor, lowering.getLoweredType(), {});
       B.emitStoreValueOperation(ctor, si, selfLV.getLValueAddress(),

--- a/test/SILGen/moveonly_empty_conditionally_copyable.swift
+++ b/test/SILGen/moveonly_empty_conditionally_copyable.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -emit-sil -verify -primary-file %s
+
+struct G<T: ~Copyable>: ~Copyable { }
+
+extension G: Copyable {}


### PR DESCRIPTION
Fix the check here to go by `isMoveOnly` on the lowered type rather than `canBeCopyable` on the declaration so that we correctly emit the semantic initialization for types that are `~Copyable` in their most generic form. Fixes rdar://125101955.