### PR TITLE
[CMake] Move ClangOverlays (_Builtin_float) to Core

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -241,16 +241,16 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(stubs)
   add_subdirectory(core)
   add_subdirectory(SwiftOnoneSupport)
+
+  if(SWIFT_BUILD_CLANG_OVERLAYS)
+    add_subdirectory(ClangOverlays)
+  endif()
 endif()
 
 if(SWIFT_BUILD_STDLIB AND NOT SWIFT_STDLIB_BUILD_ONLY_CORE_MODULES)
   # In some internal Apple configurations we have the need
   # to build Core and Onone separately from the rest
   # of the stdlib
-  if(SWIFT_BUILD_CLANG_OVERLAYS)
-    add_subdirectory(ClangOverlays)
-  endif()
-
   if(SWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING)
     add_subdirectory(Differentiation)
   endif()


### PR DESCRIPTION
The _Builtin_float overlay layers under the Libc overlays, and so it needs to be in the core stdlib group.

rdar://125068518