### PR TITLE
Work around a memory leak caught by the LSAN bot.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -204,6 +204,12 @@ public:
                      IRGenModule &IGM, llvm::Module &M,
                      StringRef MainOutputFilenameForDebugInfo,
                      StringRef PrivateDiscriminator);
+  ~IRGenDebugInfoImpl() {
+    // FIXME: SILPassManager sometimes creates an IGM and doesn't finalize it.
+    if (!FwdDeclTypes.empty())
+      finalize();
+    assert(FwdDeclTypes.empty() && "finalize() was not called");
+  }
   void finalize();
 
   void setCurrentLoc(IRBuilder &Builder, const SILDebugScope *DS,
@@ -2478,6 +2484,7 @@ void IRGenDebugInfoImpl::finalize() {
     finalize(cast<llvm::MDNode>(Ty.second),
              llvm::cast_or_null<llvm::DIType>(DIRefMap.lookup(UID)), UID);
   }
+  FwdDeclTypes.clear();
 
   // Finalize the DIBuilder.
   DBuilder.finalize();

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1947,6 +1947,9 @@ bool IRGenModule::finalize() {
   // Finalize clang IR-generation.
   finalizeClangCodeGen();
 
+  if (DebugInfo)
+    DebugInfo->finalize();
+
   // If that failed, report failure up and skip the final clean-up.
   if (!ClangCodeGen->GetModule())
     return false;
@@ -1955,8 +1958,6 @@ bool IRGenModule::finalize() {
   emitAutolinkInfo();
   emitGlobalLists();
   emitUsedConditionals();
-  if (DebugInfo)
-    DebugInfo->finalize();
   cleanupClangCodeGenMetadata();
 
   // Clean up DSOLocal & DLLImport attributes, they cannot be applied together.


### PR DESCRIPTION
Fundamentally the problem here is that SILPassManager is creating an IRGenModule without calling finalize() on it under some circumstances. It would be better to fix that instead.

rdar://123923517
