### PR TITLE
[6.0] SILGen: Emit empty type initialization for conditionally-copyable type inits.

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -754,7 +754,8 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
                                            {selfDecl->getTypeInContext()},
                                            LookUpConformanceInModule(module)),
                       selfLV.getLValueAddress());
-    } else if (isa<StructDecl>(nominal) && !nominal->canBeCopyable()
+    } else if (isa<StructDecl>(nominal)
+               && lowering.getLoweredType().isMoveOnly()
                && nominal->getStoredProperties().empty()) {
       auto *si = B.createStruct(ctor, lowering.getLoweredType(), {});
       B.emitStoreValueOperation(ctor, si, selfLV.getLValueAddress(),

--- a/test/SILGen/moveonly_empty_conditionally_copyable.swift
+++ b/test/SILGen/moveonly_empty_conditionally_copyable.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -emit-sil -verify -primary-file %s
+
+struct G<T: ~Copyable>: ~Copyable { }
+
+extension G: Copyable {}


### PR DESCRIPTION
**Explanation**: Fixes a crash when an empty `~Copyable` type has a conditional `Copyable` conformance.
**Scope**: Fixes an assertion failure that could potentially lead to miscompiles in a release build.
**Issue**: rdar://125101955
**Original PR**: https://github.com/apple/swift/pull/72464
**Risk**: Low. One line bug fix.
**Testing**: Swift CI
**Reviewer**: @nate-chandler 