### PR TITLE
[Concurrency] Infer `nonisolated` for a mutable storage of a value type accessed from within the module.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -337,6 +337,9 @@ EXPERIMENTAL_FEATURE(BorrowingSwitch, true)
 // Enable isolated(any) attribute on function types.
 CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedAny, true)
 
+// Enable usability improvements for global-actor-isolated types.
+EXPERIMENTAL_FEATURE(GlobalActorIsolatedTypesUsability, false)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -654,6 +654,10 @@ static bool usesFeatureIsolatedAny(Decl *decl) {
   });
 }
 
+static bool usesFeatureGlobalActorIsolatedTypesUsability(Decl *decl) {
+  return false;
+}
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -508,14 +508,17 @@ static bool varIsSafeAcrossActors(const ModuleDecl *fromModule,
       (fromModule == var->getDeclContext()->getParentModule());
 
   if (!var->isLet()) {
-    // A mutable storage of a value type accessed from within the module is
-    // okay.
-    if (dyn_cast_or_null<StructDecl>(var->getDeclContext()->getAsDecl()) &&
-        !var->isStatic() &&
-        var->hasStorage() &&
-        var->getTypeInContext()->isSendableType() &&
-        accessWithinModule) {
-      return true;
+    ASTContext &ctx = var->getASTContext();
+    if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {
+      // A mutable storage of a value type accessed from within the module is
+      // okay.
+      if (dyn_cast_or_null<StructDecl>(var->getDeclContext()->getAsDecl()) &&
+          !var->isStatic() && 
+          var->hasStorage() &&
+          var->getTypeInContext()->isSendableType() &&
+          accessWithinModule) {
+        return true;
+      }
     }
     // Otherwise, must be immutable.
     return false;

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -156,7 +156,7 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
                              _ anno: NoGlobalActorValueType) async {
   // these still do need an await in Swift 5
   _ = await ext.point // expected-warning {{non-sendable type 'Point' in implicitly asynchronous access to main actor-isolated property 'point' cannot cross actor boundary}}
-  _ = await formance.counter
+  _ = formance.counter
   _ = await anno.point // expected-warning {{non-sendable type 'Point' in implicitly asynchronous access to global actor 'SomeGlobalActor'-isolated property 'point' cannot cross actor boundary}}
   // expected-warning@-1 {{non-sendable type 'NoGlobalActorValueType' passed in implicitly asynchronous call to global actor 'SomeGlobalActor'-isolated property 'point' cannot cross actor boundary}}
   _ = anno.counter // expected-warning {{non-sendable type 'NoGlobalActorValueType' passed in call to main actor-isolated property 'counter' cannot cross actor boundary}}

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -2,8 +2,8 @@
 
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-experimental-feature GlobalActorIsolatedTypesUsability %s
+// RUN: %target-swift-frontend -I %t  -disable-availability-checking -strict-concurrency=complete -parse-as-library -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature GlobalActorIsolatedTypesUsability %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -1,6 +1,7 @@
-// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 -emit-sil -o /dev/null -verify %s
+// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 -emit-sil -o /dev/null -verify -enable-experimental-feature GlobalActorIsolatedTypesUsability %s
 
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 final class ImmutablePoint: Sendable {
   let x : Int = 0

--- a/test/Concurrency/actor_isolation_swift6.swift
+++ b/test/Concurrency/actor_isolation_swift6.swift
@@ -55,13 +55,12 @@ func checkIsolationValueType(_ formance: InferredFromConformance,
   _ = await ext.point // expected-warning {{no 'async' operations occur within 'await' expression}}
   _ = await formance.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}
   _ = await anno.counter  // expected-warning {{no 'async' operations occur within 'await' expression}}
-
-  // We could extend the 'nonisolated within the module' rule to vars
-  // value types types if the property type is 'Sendable'.
+  
+  // this does not need an await, since the property is 'Sendable' and of a
+  // value type
   _ = anno.point
-  // expected-error@-1 {{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-2 {{property access is 'async'}}
   _ = await anno.point
+  // expected-warning@-1 {{no 'async' operations occur within 'await' expression}}
 
   // these do need await, regardless of reference or value type
   _ = await (formance as any MainCounter).counter

--- a/test/Concurrency/derived_conformances_nonisolated.swift
+++ b/test/Concurrency/derived_conformances_nonisolated.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/derived_conformances_nonisolated.swift
+++ b/test/Concurrency/derived_conformances_nonisolated.swift
@@ -10,14 +10,32 @@ struct X1: Equatable, Hashable, Codable {
   let y: String
 }
 
-// expected-error@+5 3{{main actor-isolated property 'y' can not be referenced from a non-isolated context}}
-// expected-note@+4{{in static method '==' for derived conformance to 'Equatable'}}
-// expected-error@+3{{main actor-isolated property 'y' can not be referenced from a non-isolated context}}
-// expected-note@+2{{in static method '==' for derived conformance to 'Equatable'}}
+// okay
 @MainActor
 struct X2: Equatable, Hashable, Codable {
   let x: Int
-  var y: String // expected-note 4 {{property declared here}}
+  var y: String
+}
+
+class NonSendable {
+  let x: Int
+
+  init(x: Int) {
+    self.x = x
+  }
+}
+
+extension NonSendable: Equatable {
+  static func == (lhs: NonSendable, rhs: NonSendable) -> Bool {
+    return lhs.x == rhs.x
+  }
+}
+
+// expected-warning@+3 2{{main actor-isolated property 'x' can not be referenced from a non-isolated context}}
+// expected-note@+2 2{{in static method '==' for derived conformance to 'Equatable'}}
+@MainActor
+struct X2NonSendable: Equatable {
+  let x: NonSendable // expected-note 2 {{property declared here}}
 }
 
 @MainActor
@@ -26,12 +44,9 @@ enum X3: Hashable, Comparable, Codable {
   case b(Int)
 }
 
-// expected-warning@+5{{main actor-isolated property 'y' can not be referenced from a non-isolated context}}
-// expected-note@+4{{in static method '==' for derived conformance to 'Equatable'}}
-// expected-warning@+3{{main actor-isolated property 'y' can not be referenced from a non-isolated context}}
-// expected-note@+2{{in static method '==' for derived conformance to 'Equatable'}}
+// okay
 @preconcurrency @MainActor
 struct X4: Equatable {
   let x: Int
-  var y: String // expected-note 2 {{property declared here}}
+  var y: String
 }

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -1,10 +1,10 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted-
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted-
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns-
-// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -verify-additional-prefix complete-tns-
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/other_global_actor_inference.swiftmodule -module-name other_global_actor_inference -strict-concurrency=complete %S/Inputs/other_global_actor_inference.swift -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted- -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -verify-additional-prefix minimal-targeted- -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -verify-additional-prefix complete-tns- -enable-experimental-feature GlobalActorIsolatedTypesUsability
+// RUN: %target-swift-frontend -I %t -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -verify-additional-prefix complete-tns- -enable-experimental-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -285,14 +285,14 @@ func barSync() {
 
 @OtherGlobalActor
 struct Observed {
-  var thing: Int = 0 { // expected-note {{property declared here}}
+  var thing: Int = 0 {
     didSet {}
     willSet {}
   }
 }
 
-func checkObserved(_ o: Observed) { // expected-note {{add '@OtherGlobalActor' to make global function 'checkObserved' part of global actor 'OtherGlobalActor'}}
-  _ = o.thing // expected-error {{global actor 'OtherGlobalActor'-isolated property 'thing' can not be referenced from a non-isolated context}}
+func checkObserved(_ o: Observed) {
+  _ = o.thing // okay
 }
 
 // ----------------------------------------------------------------------
@@ -376,13 +376,13 @@ actor WrapperActor<Wrapped: Sendable> {
 
 struct HasWrapperOnActor {
   @WrapperOnActor var synced: Int = 0
-  // expected-note@-1 3{{property declared here}}
+  // expected-note@-1 2{{property declared here}}
 
-  // expected-note@+1 3{{to make instance method 'testErrors()'}}
+  // expected-note@+1 2{{to make instance method 'testErrors()'}}
   func testErrors() {
     _ = synced // expected-error{{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
     _ = $synced // expected-error{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
-    _ = _synced // expected-error{{global actor 'OtherGlobalActor'-isolated property '_synced' can not be referenced from a non-isolated context}}
+    _ = _synced // okay
   }
 
   @MainActor mutating func testOnMain() {
@@ -566,22 +566,21 @@ struct HasWrapperOnUnsafeActor {
 // expected-complete-tns-warning@-2 {{default initializer for 'HasWrapperOnUnsafeActor' cannot be both nonisolated and global actor 'OtherGlobalActor'-isolated; this is an error in the Swift 6 language mode}}
 
   @WrapperOnUnsafeActor var synced: Int = 0 // expected-complete-tns-note 2 {{initializer for property '_synced' is global actor 'OtherGlobalActor'-isolated}}
-  // expected-note @-1 3{{property declared here}}
-  // expected-complete-tns-note @-2 3{{property declared here}}
+  // expected-note @-1 2{{property declared here}}
+  // expected-complete-tns-note @-2 2{{property declared here}}
 
   func testUnsafeOkay() {
-    // expected-complete-tns-note @-1 {{add '@OtherGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'OtherGlobalActor'}}
-    // expected-complete-tns-note @-2 {{add '@SomeGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'SomeGlobalActor'}}
-    // expected-complete-tns-note @-3 {{add '@MainActor' to make instance method 'testUnsafeOkay()' part of global actor 'MainActor'}}
+    // expected-complete-tns-note @-1 {{add '@SomeGlobalActor' to make instance method 'testUnsafeOkay()' part of global actor 'SomeGlobalActor'}}
+    // expected-complete-tns-note @-2 {{add '@MainActor' to make instance method 'testUnsafeOkay()' part of global actor 'MainActor'}}
     _ = synced // expected-complete-tns-warning {{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
     _ = $synced // expected-complete-tns-warning {{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
-    _ = _synced // expected-complete-tns-warning {{global actor 'OtherGlobalActor'-isolated property '_synced' can not be referenced from a non-isolated context}}
+    _ = _synced // okay
   }
 
   nonisolated func testErrors() {
     _ = synced // expected-warning{{main actor-isolated property 'synced' can not be referenced from a non-isolated context}}
     _ = $synced // expected-warning{{global actor 'SomeGlobalActor'-isolated property '$synced' can not be referenced from a non-isolated context}}
-    _ = _synced // expected-warning{{global actor 'OtherGlobalActor'-isolated property '_synced' can not be referenced from a non-isolated context}}
+    _ = _synced // okay
   }
 
   @MainActor mutating func testOnMain() {

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-upcoming-feature InferSendableFromCaptures -strict-concurrency=complete
+// RUN: %target-typecheck-verify-swift -enable-upcoming-feature InferSendableFromCaptures -strict-concurrency=complete -enable-experimental-feature GlobalActorIsolatedTypesUsability
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -147,8 +147,7 @@ func testGlobalActorIsolatedReferences() {
     subscript(v: Int) -> Bool { false }
   }
 
-  let dataKP = \Isolated.data
-  // expected-warning@-1 {{cannot form key path to main actor-isolated property 'data'; this is an error in the Swift 6 language mode}}
+  let dataKP = \Isolated.data // Ok
   let subscriptKP = \Isolated.[42]
   // expected-warning@-1 {{cannot form key path to main actor-isolated subscript 'subscript(_:)'; this is an error in the Swift 6 language mode}}
 
@@ -158,8 +157,7 @@ func testGlobalActorIsolatedReferences() {
   // expected-warning@-1 {{type 'KeyPath<Isolated, Bool>' does not conform to the 'Sendable' protocol}}
 
   func testNonIsolated() {
-    _ = \Isolated.data
-    // expected-warning@-1 {{cannot form key path to main actor-isolated property 'data'; this is an error in the Swift 6 language mode}}
+    _ = \Isolated.data // Ok
   }
 
   @MainActor func testIsolated() {


### PR DESCRIPTION
A mutable storage of a globally-isolated value type is data-race safe because it is copied every time it crosses an isolation boundary.

Thus, treat such storage as `nonisolated` when accessed from within the module. 

I have removed redundant errors from the tests that access such properties, and it seems like the `derived_conformances_nonisolated.swift` test becomes the primary test for this PR. 
I am not fully convinced that removing errors from `global_actor_inference.swift` is right, so I would appreciate feedback on that!

This PR is the first part of the implementation of this [pitch](https://forums.swift.org/t/pitch-usability-of-global-actor-isolated-types/70799)