### PR TITLE
[Windows] windows version options are not path

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -246,7 +246,7 @@ def windows_sdk_root : Separate<["-"], "windows-sdk-root">,
          SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Windows SDK Root">, MetaVarName<"<root>">;
 def windows_sdk_version : Separate<["-"], "windows-sdk-version">,
-  Flags<[ArgumentIsPath, FrontendOption, SwiftAPIExtractOption,
+  Flags<[FrontendOption, SwiftAPIExtractOption,
          SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Windows SDK Version">, MetaVarName<"<version>">;
 def visualc_tools_root : Separate<["-"], "visualc-tools-root">,
@@ -254,7 +254,7 @@ def visualc_tools_root : Separate<["-"], "visualc-tools-root">,
          SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"VisualC++ Tools Root">, MetaVarName<"<root>">;
 def visualc_tools_version : Separate<["-"], "visualc-tools-version">,
-  Flags<[ArgumentIsPath, FrontendOption, SwiftAPIExtractOption,
+  Flags<[FrontendOption, SwiftAPIExtractOption,
          SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"VisualC++ ToolSet Version">, MetaVarName<"<version>">;
 


### PR DESCRIPTION
Fix the wrong flag on windows version options. Those options are not paths.
