### PR TITLE
[6.0]  Parse explicit lifetime dependence specifiers in SIL

### DIFF
--- a/include/swift/AST/LifetimeDependence.h
+++ b/include/swift/AST/LifetimeDependence.h
@@ -30,6 +30,7 @@ namespace swift {
 
 class AbstractFunctionDecl;
 class LifetimeDependentReturnTypeRepr;
+class SILParameterInfo;
 
 enum class LifetimeDependenceKind : uint8_t {
   Copy = 0,
@@ -138,12 +139,6 @@ class LifetimeDependenceInfo {
                                                  unsigned index,
                                                  ValueOwnership ownership);
 
-  static std::optional<LifetimeDependenceInfo>
-  fromTypeRepr(AbstractFunctionDecl *afd, Type resultType, bool allowIndex);
-
-  static std::optional<LifetimeDependenceInfo> infer(AbstractFunctionDecl *afd,
-                                                     Type resultType);
-
 public:
   LifetimeDependenceInfo()
       : inheritLifetimeParamIndices(nullptr),
@@ -193,12 +188,30 @@ public:
   std::optional<LifetimeDependenceKind>
   getLifetimeDependenceOnParam(unsigned paramIndex);
 
+  /// Builds LifetimeDependenceInfo from a swift decl, either from the explicit
+  /// lifetime dependence specifiers or by inference based on types and
+  /// ownership modifiers.
   static std::optional<LifetimeDependenceInfo>
   get(AbstractFunctionDecl *decl, Type resultType, bool allowIndex = false);
 
+  /// Builds LifetimeDependenceInfo from the bitvectors passes as parameters.
   static LifetimeDependenceInfo
   get(ASTContext &ctx, const SmallBitVector &inheritLifetimeIndices,
       const SmallBitVector &scopeLifetimeIndices);
+
+  /// Builds LifetimeDependenceInfo from a swift decl
+  static std::optional<LifetimeDependenceInfo>
+  fromTypeRepr(AbstractFunctionDecl *afd, Type resultType, bool allowIndex);
+
+  /// Builds LifetimeDependenceInfo from SIL
+  static std::optional<LifetimeDependenceInfo>
+  fromTypeRepr(LifetimeDependentReturnTypeRepr *lifetimeDependentRepr,
+               SmallVectorImpl<SILParameterInfo> &params, bool hasSelfParam,
+               DeclContext *dc);
+
+  /// Infer LifetimeDependenceInfo
+  static std::optional<LifetimeDependenceInfo> infer(AbstractFunctionDecl *afd,
+                                                     Type resultType);
 };
 
 } // namespace swift

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4155,6 +4155,25 @@ inline bool isGuaranteedParameter(ParameterConvention conv) {
   llvm_unreachable("bad convention kind");
 }
 
+inline bool isMutatingParameter(ParameterConvention conv) {
+  switch (conv) {
+  case ParameterConvention::Indirect_Inout:
+  case ParameterConvention::Indirect_InoutAliasable:
+  case ParameterConvention::Pack_Inout:
+    return true;
+
+  case ParameterConvention::Direct_Guaranteed:
+  case ParameterConvention::Indirect_In_Guaranteed:
+  case ParameterConvention::Pack_Guaranteed:
+  case ParameterConvention::Indirect_In:
+  case ParameterConvention::Direct_Unowned:
+  case ParameterConvention::Direct_Owned:
+  case ParameterConvention::Pack_Owned:
+    return false;
+  }
+  llvm_unreachable("bad convention kind");
+}
+
 /// Returns true if conv indicates a pack parameter.
 inline bool isPackParameter(ParameterConvention conv) {
   switch (conv) {
@@ -4174,6 +4193,8 @@ inline bool isPackParameter(ParameterConvention conv) {
   }
   llvm_unreachable("bad convention kind");
 }
+
+StringRef getStringForParameterConvention(ParameterConvention conv);
 
 /// A parameter type and the rules for passing it.
 class SILParameterInfo {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1212,7 +1212,7 @@ public:
       return true;
     if (Context.LangOpts.hasFeature(Feature::NonescapableTypes) &&
         (Tok.isContextualKeyword("_resultDependsOn") ||
-         Tok.isLifetimeDependenceToken()))
+         Tok.isLifetimeDependenceToken(isInSILMode())))
       return true;
     return false;
   }

--- a/include/swift/Parse/Token.h
+++ b/include/swift/Parse/Token.h
@@ -267,9 +267,14 @@ public:
     return MultilineString;
   }
 
-  bool isLifetimeDependenceToken() const {
+  bool isLifetimeDependenceToken(bool isInSILMode) const {
     return isContextualKeyword("_copy") || isContextualKeyword("_consume") ||
-           isContextualKeyword("_borrow") || isContextualKeyword("_mutate");
+           isContextualKeyword("_borrow") || isContextualKeyword("_mutate") ||
+           // SIL tests are currently written with _inherit/_scope
+           // Once we have dependsOn()/dependsOn(borrowed:) other tokens go
+           // away.
+           (isInSILMode &&
+            (isContextualKeyword("_inherit") || isContextualKeyword("_scope")));
   }
 
   /// Count of extending escaping '#'.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7486,7 +7486,7 @@ std::string GenericSignature::getAsString() const {
   return out.str();
 }
 
-static StringRef getStringForParameterConvention(ParameterConvention conv) {
+StringRef swift::getStringForParameterConvention(ParameterConvention conv) {
   switch (conv) {
   case ParameterConvention::Indirect_In: return "@in ";
   case ParameterConvention::Indirect_In_Guaranteed:  return "@in_guaranteed ";

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5048,13 +5048,13 @@ ParserStatus Parser::parseTypeAttribute(TypeOrCustomAttr &result,
 
 static std::optional<LifetimeDependenceKind>
 getLifetimeDependenceKind(const Token &T) {
-  if (T.isContextualKeyword("_copy")) {
+  if (T.isContextualKeyword("_copy") || T.isContextualKeyword("_inherit")) {
     return LifetimeDependenceKind::Copy;
   }
   if (T.isContextualKeyword("_consume")) {
     return LifetimeDependenceKind::Consume;
   }
-  if (T.isContextualKeyword("_borrow")) {
+  if (T.isContextualKeyword("_borrow") || T.isContextualKeyword("_scope")) {
     return LifetimeDependenceKind::Borrow;
   }
   if (T.isContextualKeyword("_mutate")) {
@@ -5454,7 +5454,7 @@ ParserStatus Parser::ParsedTypeAttributeList::slowParse(Parser &P) {
       continue;
     }
 
-    if (Tok.isLifetimeDependenceToken()) {
+    if (Tok.isLifetimeDependenceToken(P.isInSILMode())) {
       if (!P.Context.LangOpts.hasFeature(Feature::NonescapableTypes)) {
         P.diagnose(Tok, diag::requires_experimental_feature,
                    "lifetime dependence specifier", false,

--- a/test/SIL/Parser/lifetime_dependence.sil
+++ b/test/SIL/Parser/lifetime_dependence.sil
@@ -1,0 +1,77 @@
+// RUN: %target-sil-opt %s \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct BufferView : ~Escapable {
+  @_hasStorage let ptr: UnsafeRawBufferPointer { get }
+  @_unsafeNonescapableResult @inlinable init(_ ptr: UnsafeRawBufferPointer)
+  init(_ ptr: UnsafeRawBufferPointer, _ a: borrowing Array<Int>) -> _borrow(a) Self
+}
+
+func derive(_ x: borrowing BufferView) ->  _borrow(x) BufferView
+
+func consumeAndCreate(_ x: consuming BufferView) ->  _copy(x) BufferView
+
+sil hidden [unsafe_nonescapable_result] @bufferviewinit1 : $@convention(method) (UnsafeRawBufferPointer, @thin BufferView.Type) -> @owned BufferView {
+bb0(%0 : $UnsafeRawBufferPointer, %1 : $@thin BufferView.Type):
+  %2 = alloc_stack [var_decl] $BufferView, var, name "self", implicit 
+  debug_value %0 : $UnsafeRawBufferPointer, let, name "ptr", argno 1 
+  %4 = begin_access [modify] [static] %2 : $*BufferView 
+  %5 = struct_element_addr %4 : $*BufferView, #BufferView.ptr 
+  store %0 to %5 : $*UnsafeRawBufferPointer       
+  end_access %4 : $*BufferView                    
+  %8 = struct $BufferView (%0 : $UnsafeRawBufferPointer) 
+  destroy_addr %2 : $*BufferView                  
+  dealloc_stack %2 : $*BufferView                 
+  return %8 : $BufferView                         
+} 
+
+// CHECK-LABEL: sil hidden @bufferviewtest2 : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(2) @owned BufferView {
+sil hidden @bufferviewtest2 : $@convention(method) (UnsafeRawBufferPointer, @guaranteed Array<Int>, @thin BufferView.Type) -> _scope(2) @owned BufferView {
+bb0(%0 : $UnsafeRawBufferPointer, %1 : @noImplicitCopy $Array<Int>, %2 : $@thin BufferView.Type):
+  %3 = alloc_stack [var_decl] $BufferView, var, name "self", implicit 
+  %6 = begin_access [modify] [static] %3 : $*BufferView 
+  %7 = struct_element_addr %6 : $*BufferView, #BufferView.ptr 
+  store %0 to %7 : $*UnsafeRawBufferPointer       
+  end_access %6 : $*BufferView                    
+  %10 = struct $BufferView (%0 : $UnsafeRawBufferPointer) 
+  destroy_addr %3 : $*BufferView                  
+  dealloc_stack %3 : $*BufferView                 
+  return %10 : $BufferView                        
+} 
+
+// CHECK-LABEL: sil hidden @derive : $@convention(thin) (@guaranteed BufferView) -> _scope(1) @owned BufferView {
+sil hidden @derive : $@convention(thin) (@guaranteed BufferView) -> _scope(1) @owned BufferView {
+bb0(%0 : @noImplicitCopy $BufferView):
+  %2 = metatype $@thin BufferView.Type            
+  %3 = struct_extract %0 : $BufferView, #BufferView.ptr 
+  %4 = function_ref @bufferviewinit1 : $@convention(method) (UnsafeRawBufferPointer, @thin BufferView.Type) -> @owned BufferView 
+  %5 = apply %4(%3, %2) : $@convention(method) (UnsafeRawBufferPointer, @thin BufferView.Type) -> @owned BufferView 
+  return %5 : $BufferView                         
+} 
+
+// CHECK-LABEL: sil hidden @consumeAndCreate : $@convention(thin) (@owned BufferView) -> _inherit(1) @owned BufferView {
+sil hidden @consumeAndCreate : $@convention(thin) (@owned BufferView) -> _inherit(1) @owned BufferView {
+bb0(%0 : @noImplicitCopy @_eagerMove $BufferView):
+  %1 = alloc_stack [var_decl] [moveable_value_debuginfo] $BufferView, var, name "x" 
+  %2 = struct_extract %0 : $BufferView, #BufferView.ptr 
+  %3 = struct_extract %2 : $UnsafeRawBufferPointer, #UnsafeRawBufferPointer._position 
+  %4 = struct_extract %0 : $BufferView, #BufferView.ptr 
+  %5 = struct_extract %4 : $UnsafeRawBufferPointer, #UnsafeRawBufferPointer._end 
+  store %0 to %1 : $*BufferView                   
+  %7 = metatype $@thin BufferView.Type            
+  %8 = begin_access [read] [static] %1 : $*BufferView 
+  %9 = struct $UnsafeRawBufferPointer (%3 : $Optional<UnsafeRawPointer>, %5 : $Optional<UnsafeRawPointer>) 
+  end_access %8 : $*BufferView                    
+  %11 = function_ref @bufferviewinit1 : $@convention(method) (UnsafeRawBufferPointer, @thin BufferView.Type) -> @owned BufferView 
+  %12 = apply %11(%9, %7) : $@convention(method) (UnsafeRawBufferPointer, @thin BufferView.Type) -> @owned BufferView 
+  destroy_addr %1 : $*BufferView                  
+  dealloc_stack %1 : $*BufferView                 
+  return %12 : $BufferView                        
+} 
+


### PR DESCRIPTION
Explanation: Allow parsing explicit lifetime dependence specifiers in SIL
Scope: Allows writing SIL tests for bug fixes related to lifetime dependence in SIL
Issue: rdar://122696504
Original PR: https://github.com/apple/swift/pull/72431
Risk: Low. Under experimental feature.
Testing: Swift CI
Reviewer: @atrick



