### PR TITLE
[stdlib] Undo the generalization of `Result.map` & `.flatMap` for now

### DIFF
--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -49,8 +49,7 @@ extension Result {
   /// - Returns: A `Result` instance with the result of evaluating `transform`
   ///   as the new success value if this instance represents a success.
   @inlinable
-  @_preInverseGenerics
-  public func map<NewSuccess: ~Copyable>(
+  public func map<NewSuccess>(
     _ transform: (Success) -> NewSuccess
   ) -> Result<NewSuccess, Failure> {
     switch self {
@@ -175,8 +174,7 @@ extension Result {
   /// - Returns: A `Result` instance, either from the closure or the previous
   ///   `.failure`.
   @inlinable
-  @_preInverseGenerics
-  public func flatMap<NewSuccess: ~Copyable>(
+  public func flatMap<NewSuccess>(
     _ transform: (Success) -> Result<NewSuccess, Failure>
   ) -> Result<NewSuccess, Failure> {
     switch self {

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -253,10 +253,8 @@ Func Optional.==(_:_:) has parameter 0 changing from Default to Shared
 Func Optional.==(_:_:) has parameter 1 changing from Default to Shared
 Func Optional.~=(_:_:) has generic signature change from <Wrapped> to <Wrapped where Wrapped : ~Copyable>
 Func Optional.~=(_:_:) has parameter 1 changing from Default to Shared
-Func Result.flatMap(_:) has generic signature change from <Success, Failure, NewSuccess where Failure : Swift.Error> to <Success, Failure, NewSuccess where Failure : Swift.Error, NewSuccess : ~Copyable>
 Func Result.get() has generic signature change from <Success, Failure where Failure : Swift.Error> to <Success, Failure where Failure : Swift.Error, Success : ~Copyable>
 Func Result.get() has self access kind changing from NonMutating to Consuming
-Func Result.map(_:) has generic signature change from <Success, Failure, NewSuccess where Failure : Swift.Error> to <Success, Failure, NewSuccess where Failure : Swift.Error, NewSuccess : ~Copyable>
 Func Result.mapError(_:) has self access kind changing from NonMutating to Consuming
 Func UnsafeBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeBufferPointer.distance(from:to:) has generic signature change from <Element> to <Element where Element : ~Copyable>

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -605,13 +605,7 @@ Func Optional.~=(_:_:) has generic signature change from <Wrapped> to <Wrapped w
 Func Optional.~=(_:_:) has mangled name changing from 'static Swift.Optional.~= infix(Swift._OptionalNilComparisonType, Swift.Optional<A>) -> Swift.Bool' to 'static (extension in Swift):Swift.Optional< where A: ~Swift.Copyable>.~= infix(Swift._OptionalNilComparisonType, Swift.Optional<A>) -> Swift.Bool'
 Func Optional.~=(_:_:) has parameter 1 changing from Default to Shared
 Func Optional.~=(_:_:) is now with @_preInverseGenerics
-Func Result.flatMap(_:) has generic signature change from <Success, Failure, NewSuccess where Failure : Swift.Error> to <Success, Failure, NewSuccess where Failure : Swift.Error, NewSuccess : ~Copyable>
-Func Result.flatMap(_:) has mangled name changing from 'Swift.Result.flatMap<A>((A) -> Swift.Result<A1, B>) -> Swift.Result<A1, B>' to 'Swift.Result.flatMap<A where A1: ~Swift.Copyable>((A) -> Swift.Result<A1, B>) -> Swift.Result<A1, B>'
-Func Result.flatMap(_:) is now with @_preInverseGenerics
 Func Result.get() has been removed
-Func Result.map(_:) has generic signature change from <Success, Failure, NewSuccess where Failure : Swift.Error> to <Success, Failure, NewSuccess where Failure : Swift.Error, NewSuccess : ~Copyable>
-Func Result.map(_:) has mangled name changing from 'Swift.Result.map<A>((A) -> A1) -> Swift.Result<A1, B>' to 'Swift.Result.map<A where A1: ~Swift.Copyable>((A) -> A1) -> Swift.Result<A1, B>'
-Func Result.map(_:) is now with @_preInverseGenerics
 Func Result.mapError(_:) has been removed
 Func UnsafeBufferPointer.deallocate() has generic signature change from <Element> to <Element where Element : ~Copyable>
 Func UnsafeBufferPointer.deallocate() has mangled name changing from 'Swift.UnsafeBufferPointer.deallocate() -> ()' to '(extension in Swift):Swift.UnsafeBufferPointer< where A: ~Swift.Copyable>.deallocate() -> ()'


### PR DESCRIPTION
The generalization of `Result.map` is currently causing source compatibility issues, as `map` variants defined in downstream projects are no longer considered to shadow the stdlib original. (rdar://125016028)

Similar issues can affect pretty much every API generalized for `~Copyable`, so the right thing to do is probably to adjust the compiler to maintain the original shadowing semantics. But for now, we can take out the cases that we see causing problems as we encounter them.

We have not generalized `Optional`’s `map` and `flatMap` yet, so it seems premature to do it for `Result`, anyway.
