### PR TITLE
[cmake] Prevent linker errors by linking libswiftAST into SwiftBasicTests since libswiftBasic can include contents from libswiftAST.

### DIFF
--- a/unittests/Basic/CMakeLists.txt
+++ b/unittests/Basic/CMakeLists.txt
@@ -48,6 +48,10 @@ add_dependencies(SwiftBasicTests "${gyb_dependency_targets}")
 target_link_libraries(SwiftBasicTests
   PRIVATE
   swiftBasic
+  # SwiftBasic can include symbols from swiftAST due to swiftBasic including
+  # headers from AST. Just include SwiftAST so that we do not have linker
+  # failures.
+  swiftAST
   swiftThreading
   clangBasic
   LLVMTestingSupport


### PR DESCRIPTION
I hit this in https://github.com/apple/swift/pull/72476. I put the declaration that hit this in a header, but as I thought about it... there was no real harm in just fixing the issue and preventing future breakage.