### PR TITLE
Warn if an unknown feature name is passed to `-enable-upcoming-feature` or `-enable-experimental-feature`

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -40,6 +40,14 @@ ERROR(error_upcoming_feature_on_by_default, none,
       "upcoming feature '%0' is already enabled as of Swift version %1",
       (StringRef, unsigned))
 
+WARNING(warning_unknown_upcoming_feature, none,
+      "unknown feature name '%0' passed to '-enable-upcoming-feature'",
+      (StringRef))
+
+WARNING(warning_unknown_experimental_feature, none,
+      "unknown feature name '%0' passed to '-enable-experimental-feature'",
+      (StringRef))
+
 ERROR(error_unknown_library_level, none,
       "unknown library level '%0', "
       "expected one of 'api', 'spi', 'ipi', or 'other'", (StringRef))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -881,6 +881,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 #else
       Opts.enableFeature(*feature);
 #endif
+    } else {
+      Diags.diagnose(SourceLoc(), diag::warning_unknown_experimental_feature,
+                     value);
     }
 
     // Hack: In order to support using availability macros in SPM packages, we
@@ -901,8 +904,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   for (const Arg *A : Args.filtered(OPT_enable_upcoming_feature)) {
     // Ignore unknown features.
     auto feature = getUpcomingFeature(A->getValue());
-    if (!feature)
+    if (!feature) {
+      Diags.diagnose(SourceLoc(), diag::warning_unknown_upcoming_feature,
+                     A->getValue());
       continue;
+    }
 
     // Check if this feature was introduced already in this language version.
     if (auto firstVersion = getFeatureLanguageVersion(*feature)) {


### PR DESCRIPTION
@hborla @DougGregor Do you remember if it was a deliberate design decision to not warn if an unknown feature name is passed. For example, did we want to support passing an upcoming feature unconditionally and make it build without warnings even in older compiler that don’t know about this upcoming feature?

rdar://125102468