### PR TITLE
[6.0] Fix SILCombine of inject_enum_addr to correctly check for unreferenceable storage 

### DIFF
--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -604,6 +604,10 @@ bool specializeAppliesInFunction(SILFunction &F,
 /// types aggregated together at each level.
 SILValue createEmptyAndUndefValue(SILType ty, SILInstruction *insertionPoint,
                                   SILBuilderContext &ctx, bool noUndef = false);
+
+/// Check if a struct or its fields can have unreferenceable storage.
+bool findUnreferenceableStorage(StructDecl *decl, SILType structType,
+                                SILFunction *func);
 } // end namespace swift
 
 #endif // SWIFT_SILOPTIMIZER_UTILS_INSTOPTUTILS_H

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1246,7 +1246,7 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
 
   // We cannot create a struct when it has unreferenceable storage.
   if (elemType.isEmpty(*IEAI->getFunction()) && structDecl &&
-      structDecl->hasUnreferenceableStorage()) {
+      findUnreferenceableStorage(structDecl, elemType, IEAI->getFunction())) {
     return nullptr;
   }
 

--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -362,3 +362,33 @@ bb3:
   %8 = tuple ()
   return %8 : $()
 }
+
+struct NestedUnreferenceableStorage {
+  let e: EmptyCUnion
+}
+
+sil @no_init_nested_c_union : $@convention(thin) () -> (@out NestedUnreferenceableStorage)
+
+// CHECK-LABEL: sil @test_empty_nested_c_union : $@convention(thin) () -> () {
+// CHECK: inject_enum_addr
+// CHECK-LABEL: } // end sil function 'test_empty_nested_c_union'
+sil @test_empty_nested_c_union : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_stack $Optional<NestedUnreferenceableStorage>
+  %1 = init_enum_data_addr %0 : $*Optional<NestedUnreferenceableStorage>, #Optional.some!enumelt
+  %f = function_ref @no_init_nested_c_union : $@convention(thin) () -> (@out NestedUnreferenceableStorage)
+  apply %f(%1) : $@convention(thin) () -> (@out NestedUnreferenceableStorage)
+  inject_enum_addr %0 : $*Optional<NestedUnreferenceableStorage>, #Optional.some!enumelt
+  switch_enum_addr %0 : $*Optional<NestedUnreferenceableStorage>, case #Optional.some!enumelt: bb1, case #Optional.none!enumelt: bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  dealloc_stack %0 : $*Optional<NestedUnreferenceableStorage>
+  %8 = tuple ()
+  return %8 : $()
+}


### PR DESCRIPTION
Explanation: We can't create struct values if they have unreferenceable storage. Previously `hasUnreferenceableStorage` was used to determine if the StructDecl had unreferenceable storage. This isn't sufficient because the api doesn't look in nested structs. Added a new api called `findUnreferenceableStorage` and use it instead
Scope: Effects optionals of empty types that may have nested unreferenceable storage
Issue: rdar://125125245
Original PR: https://github.com/apple/swift/pull/72479
Risk: Low. 
Testing: Swift CI
Reviewer: @atrick @nate-chandler 