### PR TITLE
[Tests] NFC: Add a couple of tests for parametrized opaque result types

### DIFF
--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -590,3 +590,24 @@ func f62787_1(x: Bool) -> Optional<some Collection<Int>> {
   } 
   return nil // expected-error{{underlying type for opaque result type 'Optional<some Collection<Int>>' could not be inferred from return expression}}
 }
+
+// rdar://124482122 - Make sure that constraints are respected by opaque types
+protocol P3<A> {
+  associatedtype A: P1
+}
+
+do {
+  struct G<A: P1>: P3 {}
+
+  struct S: P1 {}
+
+  func test1() -> some P3<Int> { // expected-note {{opaque return type declared here}}
+    return G<S>()
+    // expected-error@-1 {{type of local function 'test1()' requires that 'S' conform to 'Int'}}
+  }
+
+  func test2() -> some P3<G<S>> { // expected-note {{opaque return type declared here}}
+    return G<S>()
+    // expected-error@-1 {{return type of local function 'test2()' requires that 'S' conform to 'G<S>'}}
+  }
+}


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
