### PR TITLE
AST: Remove ProtocolDecl::getSuperclass()

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5122,10 +5122,6 @@ class ProtocolDecl final : public NominalTypeDecl {
     /// The superclass decl and a bit to indicate whether the
     /// superclass was computed yet or not.
     llvm::PointerIntPair<ClassDecl *, 1, bool> SuperclassDecl;
-
-    /// The superclass type and a bit to indicate whether the
-    /// superclass was computed yet or not.
-    llvm::PointerIntPair<Type, 1, bool> SuperclassType;
   } LazySemanticInfo;
 
   /// The generic signature representing exactly the new requirements introduced
@@ -5217,15 +5213,9 @@ public:
   /// Determine whether this protocol has a superclass.
   bool hasSuperclass() const { return (bool)getSuperclassDecl(); }
 
-  /// Retrieve the superclass of this protocol, or null if there is no superclass.
-  Type getSuperclass() const;
-
   /// Retrieve the ClassDecl for the superclass of this protocol, or null if there
   /// is no superclass.
   ClassDecl *getSuperclassDecl() const;
-
-  /// Set the superclass of this protocol.
-  void setSuperclass(Type superclass);
 
   /// Retrieve the set of AssociatedTypeDecl members of this protocol; this
   /// saves loading the set of members in cases where there's no possibility of

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -598,7 +598,7 @@ protected:
     IsComputingSemanticMembers : 1
   );
 
-  SWIFT_INLINE_BITFIELD_FULL(ProtocolDecl, NominalTypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+8,
+  SWIFT_INLINE_BITFIELD_FULL(ProtocolDecl, NominalTypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+8,
     /// Whether the \c RequiresClass bit is valid.
     RequiresClassValid : 1,
 
@@ -624,6 +624,9 @@ protected:
 
     /// Whether we've computed the inherited protocols list yet.
     InheritedProtocolsValid : 1,
+
+    /// Whether we have computed a requirement signature.
+    HasRequirementSignature : 1,
 
     /// Whether we have a lazy-loaded requirement signature.
     HasLazyRequirementSignature : 1,
@@ -5126,7 +5129,7 @@ class ProtocolDecl final : public NominalTypeDecl {
 
   /// The generic signature representing exactly the new requirements introduced
   /// by this protocol.
-  std::optional<RequirementSignature> RequirementSig;
+  RequirementSignature RequirementSig;
 
   /// Returns the cached result of \c requiresClass or \c None if it hasn't yet
   /// been computed.
@@ -5435,7 +5438,7 @@ public:
 
   /// Has the requirement signature been computed yet?
   bool isRequirementSignatureComputed() const {
-    return RequirementSig.has_value();
+    return Bits.ProtocolDecl.HasRequirementSignature;
   }
 
   void setRequirementSignature(RequirementSignature requirementSig);

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -113,7 +113,7 @@ public:
 /// Request the superclass type for the given class.
 class SuperclassTypeRequest
     : public SimpleRequest<
-          SuperclassTypeRequest, Type(NominalTypeDecl *, TypeResolutionStage),
+          SuperclassTypeRequest, Type(ClassDecl *, TypeResolutionStage),
           RequestFlags::SeparatelyCached | RequestFlags::DependencySink> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -123,7 +123,7 @@ private:
 
   // Evaluation.
   Type
-  evaluate(Evaluator &evaluator, NominalTypeDecl *classDecl,
+  evaluate(Evaluator &evaluator, ClassDecl *classDecl,
            TypeResolutionStage stage) const;
 
 public:

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -7766,7 +7766,9 @@ static void getSyntacticInheritanceClause(const ProtocolDecl *proto,
                                           llvm::SmallVectorImpl<InheritedEntry> &Results) {
   auto &ctx = proto->getASTContext();
 
-  if (auto superclassTy = proto->getSuperclass()) {
+  auto genericSig = proto->getGenericSignature();
+  if (auto superclassTy = genericSig->getSuperclassBound(
+        proto->getSelfInterfaceType())) {
     Results.emplace_back(TypeLoc::withoutLoc(superclassTy),
                          /*isUnchecked=*/false,
                          /*isRetroactive=*/false,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6436,6 +6436,8 @@ ProtocolDecl::ProtocolDecl(DeclContext *DC, SourceLoc ProtocolLoc,
   Bits.ProtocolDecl.KnownProtocol = 0;
   Bits.ProtocolDecl.HasAssociatedTypes = 0;
   Bits.ProtocolDecl.HasLazyAssociatedTypes = 0;
+  Bits.ProtocolDecl.HasRequirementSignature = 0;
+  Bits.ProtocolDecl.HasLazyRequirementSignature = 0;
   Bits.ProtocolDecl.ProtocolRequirementsValid = false;
   setTrailingWhereClause(TrailingWhere);
 }
@@ -6682,12 +6684,13 @@ bool ProtocolDecl::isComputingRequirementSignature() const {
 
 void ProtocolDecl::setRequirementSignature(RequirementSignature requirementSig) {
   RequirementSig = requirementSig;
+  Bits.ProtocolDecl.HasRequirementSignature = 1;
 }
 
 void
 ProtocolDecl::setLazyRequirementSignature(LazyMemberLoader *lazyLoader,
                                           uint64_t requirementSignatureData) {
-  assert(!RequirementSig && "requirement signature already set");
+  assert(!isRequirementSignatureComputed() && "requirement signature already set");
 
   auto contextData = static_cast<LazyProtocolData *>(
       getASTContext().getOrCreateLazyContextData(this, lazyLoader));

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6545,27 +6545,10 @@ AssociatedTypeDecl *ProtocolDecl::getAssociatedType(Identifier name) const {
   return nullptr;
 }
 
-Type ProtocolDecl::getSuperclass() const {
-  ASTContext &ctx = getASTContext();
-  return evaluateOrDefault(ctx.evaluator,
-    SuperclassTypeRequest{const_cast<ProtocolDecl *>(this),
-                          TypeResolutionStage::Interface},
-    Type());
-}
-
 ClassDecl *ProtocolDecl::getSuperclassDecl() const {
   ASTContext &ctx = getASTContext();
   return evaluateOrDefault(ctx.evaluator,
     SuperclassDeclRequest{const_cast<ProtocolDecl *>(this)}, nullptr);
-}
-
-void ProtocolDecl::setSuperclass(Type superclass) {
-  assert((!superclass || !superclass->hasArchetype())
-         && "superclass must be interface type");
-  LazySemanticInfo.SuperclassType.setPointerAndInt(superclass, true);
-  LazySemanticInfo.SuperclassDecl.setPointerAndInt(
-    superclass ? superclass->getClassOrBoundGenericClass() : nullptr,
-    true);
 }
 
 bool ProtocolDecl::walkInheritedProtocols(

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3219,16 +3219,8 @@ SuperclassDeclRequest::evaluate(Evaluator &evaluator,
   // Protocols may get their superclass bound from a `where Self : Superclass`
   // clause.
   if (auto *proto = dyn_cast<ProtocolDecl>(subject)) {
-    // If the protocol came from a serialized module, compute the superclass via
-    // its generic signature.
-    if (proto->wasDeserialized()) {
-      auto superTy = proto->getGenericSignature()
-          ->getSuperclassBound(proto->getSelfInterfaceType());
-      if (superTy)
-        return superTy->getClassOrBoundGenericClass();
-    }
+    assert(!proto->wasDeserialized());
 
-    // Otherwise check the where clause.
     auto selfBounds = getSelfBoundsFromWhereClause(proto);
     for (auto inheritedNominal : selfBounds.decls)
       if (auto classDecl = dyn_cast<ClassDecl>(inheritedNominal))

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -407,14 +407,9 @@ Type ExistentialLayout::getSuperclass() const {
     return explicitSuperclass;
 
   for (auto protoDecl : getProtocols()) {
-    // If we have a generic signature, check there, because it
-    // will pick up superclass constraints from protocols that we
-    // refine as well.
-    if (auto genericSig = protoDecl->getGenericSignature()) {
-      if (auto superclass = genericSig->getSuperclassBound(
-            protoDecl->getSelfInterfaceType()))
-        return superclass;
-    } else if (auto superclass = protoDecl->getSuperclass())
+    auto genericSig = protoDecl->getGenericSignature();
+    if (auto superclass = genericSig->getSuperclassBound(
+          protoDecl->getSelfInterfaceType()))
       return superclass;
   }
 

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -143,27 +143,16 @@ bool SuperclassTypeRequest::isCached() const {
 }
 
 std::optional<Type> SuperclassTypeRequest::getCachedResult() const {
-  auto nominalDecl = std::get<0>(getStorage());
-
-  if (auto *classDecl = dyn_cast<ClassDecl>(nominalDecl))
-    if (classDecl->LazySemanticInfo.SuperclassType.getInt())
-      return classDecl->LazySemanticInfo.SuperclassType.getPointer();
-
-  if (auto *protocolDecl = dyn_cast<ProtocolDecl>(nominalDecl))
-    if (protocolDecl->LazySemanticInfo.SuperclassType.getInt())
-      return protocolDecl->LazySemanticInfo.SuperclassType.getPointer();
+  auto classDecl = std::get<0>(getStorage());
+  if (classDecl->LazySemanticInfo.SuperclassType.getInt())
+    return classDecl->LazySemanticInfo.SuperclassType.getPointer();
 
   return std::nullopt;
 }
 
 void SuperclassTypeRequest::cacheResult(Type value) const {
-  auto nominalDecl = std::get<0>(getStorage());
-
-  if (auto *classDecl = dyn_cast<ClassDecl>(nominalDecl))
-    classDecl->LazySemanticInfo.SuperclassType.setPointerAndInt(value, true);
-
-  if (auto *protocolDecl = dyn_cast<ProtocolDecl>(nominalDecl))
-    protocolDecl->LazySemanticInfo.SuperclassType.setPointerAndInt(value, true);
+  auto classDecl = std::get<0>(getStorage());
+  classDecl->LazySemanticInfo.SuperclassType.setPointerAndInt(value, true);
 }
 
 void SuperclassTypeRequest::writeDependencySink(

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -330,7 +330,7 @@ std::optional<RequirementSignature>
 RequirementSignatureRequest::getCachedResult() const {
   auto proto = std::get<0>(getStorage());
   if (proto->isRequirementSignatureComputed())
-    return *proto->RequirementSig;
+    return proto->RequirementSig;
 
   return std::nullopt;
 }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4118,14 +4118,6 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
   }
 
   for (auto *protoDecl : layout.getProtocols()) {
-    if (auto superclass = protoDecl->getSuperclass()) {
-      auto subKind = std::min(ConstraintKind::Subtype, kind);
-      auto result = matchTypes(type1, superclass, subKind,
-                               subflags, locator);
-      if (result.isFailure())
-        return result;
-    }
-
     switch (simplifyConformsToConstraint(type1, protoDecl, kind, locator,
                                          subflags)) {
       case SolutionKind::Solved:

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -7076,20 +7076,25 @@ void AttributeChecker::visitMarkerAttr(MarkerAttr *attr) {
   if (!proto)
     return;
 
-  // A marker protocol cannot inherit a non-marker protocol.
-  for (auto inheritedProto : proto->getInheritedProtocols()) {
-    if (!inheritedProto->isMarkerProtocol()) {
-      proto->diagnose(
-          diag::marker_protocol_inherit_nonmarker,
-          proto->getName(), inheritedProto->getName());
-      inheritedProto->diagnose( diag::decl_declared_here, inheritedProto);
-    }
-  }
+  for (auto req : proto->getRequirementSignature().getRequirements()) {
+    if (!req.getFirstType()->isEqual(proto->getSelfInterfaceType()))
+      continue;
 
-  if (Type superclass = proto->getSuperclass()) {
-    proto->diagnose(
+    if (req.getKind() == RequirementKind::Superclass) {
+      // A marker protocol cannot have a superclass requirement.
+      proto->diagnose(
         diag::marker_protocol_inherit_class,
-        proto->getName(), superclass);
+        proto->getName(), req.getSecondType());
+    } else if (req.getKind() == RequirementKind::Conformance) {
+      // A marker protocol cannot inherit a non-marker protocol.
+      auto inheritedProto = req.getProtocolDecl();
+      if (!inheritedProto->isMarkerProtocol()) {
+        proto->diagnose(
+            diag::marker_protocol_inherit_nonmarker,
+            proto->getName(), inheritedProto->getName());
+        inheritedProto->diagnose( diag::decl_declared_here, inheritedProto);
+      }
+    }
   }
 
   // A marker protocol cannot have any requirements.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4461,14 +4461,14 @@ public:
     IdentifierID nameID;
     DeclContextID contextID;
     bool isImplicit, isClassBounded, isObjC, hasSelfOrAssocTypeRequirements;
-    TypeID superclassID;
+    DeclID superclassDeclID;
     uint8_t rawAccessLevel;
     ArrayRef<uint64_t> dependencyIDs;
 
     decls_block::ProtocolLayout::readRecord(scratch, nameID, contextID,
                                             isImplicit, isClassBounded, isObjC,
                                             hasSelfOrAssocTypeRequirements,
-                                            superclassID,
+                                            superclassDeclID,
                                             rawAccessLevel,
                                             dependencyIDs);
 
@@ -4493,8 +4493,10 @@ public:
         /*TrailingWhere=*/nullptr);
     declOrOffset = proto;
 
-    proto->setSuperclass(MF.getType(superclassID));
+    auto *superclassDecl = dyn_cast_or_null<ClassDecl>(MF.getDecl(superclassDeclID));
 
+    ctx.evaluator.cacheOutput(SuperclassDeclRequest{proto},
+                              std::move(superclassDecl));
     ctx.evaluator.cacheOutput(ProtocolRequiresClassRequest{proto},
                               std::move(isClassBounded));
     ctx.evaluator.cacheOutput(HasSelfOrAssociatedTypeRequirementsRequest{proto},

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 865; // removal of noncopyable generics control block
+const uint16_t SWIFTMODULE_VERSION_MINOR = 866; // protocol superclass fix
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1535,7 +1535,7 @@ namespace decls_block {
     BCFixed<1>,             // class-bounded?
     BCFixed<1>,             // objc?
     BCFixed<1>,             // existential-type-supported?
-    TypeIDField,            // superclass
+    DeclIDField,            // superclass decl
     AccessLevelField,       // access level
     BCArray<TypeIDField>    // dependency types
     // Trailed by the inherited protocols, the generic parameters (if any),

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4353,7 +4353,7 @@ public:
                                  ->requiresClass(),
                                proto->isObjC(),
                                proto->hasSelfOrAssociatedTypeRequirements(),
-                               S.addTypeRef(proto->getSuperclass()),
+                               S.addDeclRef(proto->getSuperclassDecl()),
                                rawAccessLevel,
                                dependencyTypeIDs);
 

--- a/test/Generics/marker_self_conformance.swift
+++ b/test/Generics/marker_self_conformance.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift
+
+@_marker protocol Q {}
+struct G<T: Q> {}
+
+typealias A1 = G<any Q>
+
+//
+
+class C: Q {}
+typealias A2 = G<C>
+
+//
+
+protocol Q2: Q {}
+typealias A3 = G<any Q2>
+
+//
+
+protocol P1: C {}
+protocol P2 where Self: C {}
+
+typealias A4 = G<any P1>
+typealias A5 = G<any P2>

--- a/test/Generics/protocol_superclass_cycle.swift
+++ b/test/Generics/protocol_superclass_cycle.swift
@@ -52,3 +52,9 @@ func foo5<T : SubSuperP>(_: T) {}
 // CHECK-NEXT: Generic signature: <T where T : Q, T.[Q]T : SubSuperP>
 func foo6<T : Q>(_: T) where T.T : SubSuperP {}
 
+protocol POther where Self : COther {}
+class COther : POther {}
+
+// CHECK-LABEL: .foo7@
+// CHECK-NEXT: Generic signature: <T where T : POther>
+func foo7<T>(_: T) where T : COther, T : POther {}

--- a/test/Serialization/Inputs/class-bound-protocol.swift
+++ b/test/Serialization/Inputs/class-bound-protocol.swift
@@ -1,15 +1,39 @@
-public protocol P: C {}
+//
 
-public class C: P {
+public protocol Base {}
+
+extension Base {
+  public func funcInBaseProtocol() {}
+}
+
+//
+
+public class C: Base {
   public init() {}
   public func funcInClass() {}
 }
 
-public protocol GenericP: GenericC<Int> {}
+//
 
-public class GenericC<T> {
+public protocol P1: C {}
+
+public protocol P2 where Self: C {}
+
+public class D: C, P1, P2 {}
+
+//
+
+public class GenericC<T>: Base {
   public init() {}
   public func funcInClass() {}
 }
 
-extension GenericC: GenericP where T == Int {}
+//
+
+public protocol GenericP1: GenericC<Int> {}
+
+public protocol GenericP2 where Self: GenericC<Int> {}
+
+public class GenericD<T>: GenericC<T> {}
+
+extension GenericD: GenericP1, GenericP2 where T == Int {}

--- a/test/Serialization/use-class-bound-protocol.swift
+++ b/test/Serialization/use-class-bound-protocol.swift
@@ -6,9 +6,19 @@
 import ClassBoundProtocol
 
 func f() {
-  let p: P = C()
-  p.funcInClass()
+  let p1: any P1 = D()
+  p1.funcInClass()
+  p1.funcInBaseProtocol()
 
-  let genericP: GenericP = GenericC<Int>()
-  genericP.funcInClass()
+  let p2: any P2 = D()
+  p2.funcInClass()
+  p2.funcInBaseProtocol()
+
+  let genericP1: any GenericP1 = GenericD<Int>()
+  genericP1.funcInClass()
+  genericP1.funcInBaseProtocol()
+
+  let genericP2: any GenericP2 = GenericD<Int>()
+  genericP2.funcInClass()
+  genericP2.funcInBaseProtocol()
 }

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -20,6 +20,7 @@ protocol P4 { } // expected-note{{'P4' declared here}}
 class C { }
 @_marker protocol P5a: AnyObject { }  // okay
 @_marker protocol P5b: C { }   // expected-error{{marker protocol 'P5b' cannot inherit class 'C'}}
+@_marker protocol P5c where Self: C { }   // expected-error{{marker protocol 'P5c' cannot inherit class 'C'}}
 
 // Legitimate uses of marker protocols.
 extension P3 {


### PR DESCRIPTION
Cleaning up my own technical debt from 2018.

There are two ways to spell a class-constrained protocol:
```swift
class C {}
protocol P1: C {}
protocol P2 where Self: C {}
```
The `ProtocolDecl::getSuperclass()` method only handled the first case, returning a null Type in the second case.

This remained an issue for as long as it did because most clients would either use the lower-level `getSuperclassDecl()`, which correctly visited the where clause, or they would process requirement signature requirements or whatever.

This problem surfaced again because there was a recent regression with the `where Self: C` form because a new call to getSuperclass() was introduced in serialization.

Also it turns out all existing other callers of `getSuperclass()` either suffered from the same problem, or were unnecessary. So this PR just removes `ProtocolDecl::getSuperclass()`.

Fixes rdar://problem/124478687.