### PR TITLE
6.0: [MoveOnlyAddressChecker] Fix representation for consumed fields.

### DIFF
--- a/include/swift/SIL/FieldSensitivePrunedLiveness.h
+++ b/include/swift/SIL/FieldSensitivePrunedLiveness.h
@@ -351,18 +351,6 @@ struct TypeTreeLeafTypeRange {
                                   deinitBitOffset}};
   }
 
-  /// Given a type \p rootType and a set of needed elements specified by the bit
-  /// vector \p neededElements, place into \p foundContiguousTypeRanges a set of
-  /// TypeTreeLeafTypeRanges that are associated with the bit vectors
-  /// elements. As a constraint, we ensure that if \p neededElements has bits
-  /// set that are part of subsequent fields of a type that is only partially
-  /// needed, the two fields are represented as separate ranges. This ensures
-  /// that it is easy to use this API to correspond to independent operations
-  /// for the fields.
-  static void convertNeededElementsToContiguousTypeRanges(
-      SILFunction *fn, SILType rootType, SmallBitVector &neededElements,
-      SmallVectorImpl<TypeTreeLeafTypeRange> &foundContiguousTypeRanges);
-
   static void constructProjectionsForNeededElements(
       SILValue rootValue, SILInstruction *insertPt,
       SmallBitVector &neededElements,

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -473,6 +473,50 @@ void TypeTreeLeafTypeRange::constructFilteredProjections(
   llvm_unreachable("Not understand subtype");
 }
 
+std::optional<TypeTreeLeafTypeRange>
+TypeTreeLeafTypeRange::get(Operand *op, SILValue rootValue) {
+  auto projectedValue = op->get();
+  auto startEltOffset = SubElementOffset::compute(projectedValue, rootValue);
+  if (!startEltOffset)
+    return std::nullopt;
+
+  // A drop_deinit only consumes the deinit bit of its operand.
+  if (isa<DropDeinitInst>(op->getUser())) {
+    auto upperBound = *startEltOffset + TypeSubElementCount(projectedValue);
+    return {{upperBound - 1, upperBound}};
+  }
+
+  // An `inject_enum_addr` only initializes the enum tag.
+  if (auto inject = dyn_cast<InjectEnumAddrInst>(op->getUser())) {
+    auto upperBound = *startEltOffset + TypeSubElementCount(projectedValue);
+    unsigned payloadUpperBound = 0;
+    if (inject->getElement()->hasAssociatedValues()) {
+      auto payloadTy = projectedValue->getType().getEnumElementType(
+          inject->getElement(), op->getFunction());
+
+      payloadUpperBound =
+          *startEltOffset + TypeSubElementCount(payloadTy, op->getFunction());
+    }
+    // TODO: account for deinit component if enum has deinit.
+    assert(!projectedValue->getType().isValueTypeWithDeinit());
+    return {{payloadUpperBound, upperBound}};
+  }
+
+  // Uses that borrow a value do not involve the deinit bit.
+  //
+  // FIXME: This shouldn't be limited to applies.
+  unsigned deinitBitOffset = 0;
+  if (op->get()->getType().isValueTypeWithDeinit() &&
+      op->getOperandOwnership() == OperandOwnership::Borrow &&
+      ApplySite::isa(op->getUser())) {
+    deinitBitOffset = 1;
+  }
+
+  return {{*startEltOffset, *startEltOffset +
+                                TypeSubElementCount(projectedValue) -
+                                deinitBitOffset}};
+}
+
 void TypeTreeLeafTypeRange::constructProjectionsForNeededElements(
     SILValue rootValue, SILInstruction *insertPt,
     SmallBitVector &neededElements,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1382,6 +1382,12 @@ public:
       iter = finalBlockConsumes.insert({block, {}}).first;
     }
     LLVM_DEBUG(llvm::dbgs() << "Recorded Final Consume: " << *inst);
+    for (auto &pair : iter->second) {
+      if (pair.first == inst) {
+        pair.second |= bits;
+        return;
+      }
+    }
     iter->second.emplace_back(inst, bits);
   }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -604,7 +604,9 @@ void Implementation::checkDestructureUsesOnBoundary() const {
                << "    DestructureNeedingUse: " << *use->getUser());
 
     auto destructureUseSpan = *TypeTreeLeafTypeRange::get(use, getRootValue());
-    if (!liveness.isWithinBoundary(use->getUser(), destructureUseSpan)) {
+    SmallBitVector destructureUseBits(liveness.getNumSubElements());
+    destructureUseSpan.setBits(destructureUseBits);
+    if (!liveness.isWithinBoundary(use->getUser(), destructureUseBits)) {
       LLVM_DEBUG(llvm::dbgs()
                  << "        On boundary or within boundary! No error!\n");
       continue;

--- a/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
@@ -1,4 +1,12 @@
-// RUN: %target-sil-opt -module-name moveonly_addresschecker -enable-experimental-feature MoveOnlyPartialConsumption -sil-move-only-address-checker -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -move-only-address-checker-disable-lifetime-extension=true | %FileCheck %s
+// RUN: %target-sil-opt                                                \
+// RUN:     -sil-move-only-address-checker                             \
+// RUN:     %s                                                         \
+// RUN:     -module-name moveonly_addresschecker                       \
+// RUN:     -enable-experimental-feature MoveOnlyPartialConsumption    \
+// RUN:     -enable-experimental-feature MoveOnlyClasses               \
+// RUN:     -enable-sil-verify-all                                     \
+// RUN:     -move-only-address-checker-disable-lifetime-extension=true \
+// RUN: | %FileCheck %s
 
 @_moveOnly
 struct M {

--- a/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_unmaximized.sil
@@ -26,6 +26,7 @@ sil @end_2 : $@convention(thin) (@owned M, @owned M) -> ()
 sil @see_addr_2 : $@convention(thin) (@in_guaranteed M, @in_guaranteed M) -> ()
 sil @replace_2 : $@convention(thin) (@inout M, @inout M) -> ()
 sil @get_out_2 : $@convention(thin) () -> (@out M, @out M)
+sil @take_addr_2 : $@convention(thin) (@in M, @in M) -> ()
 
 /// Two non-contiguous fields (#M4.s2, #M4.s4) are borrowed by @see_addr_2.
 /// Two non-contiguous fields (#M4.s1, #M$.s3) are consumed by @end_2.
@@ -155,4 +156,27 @@ sil [ossa] @rdar111391893 : $@convention(thin) () -> () {
   dealloc_stack %stack_addr : $*M4
   %22 = tuple ()
   return %22 : $()
+}
+
+// Two non-contiguous fields (#M4.s2, #M$.s4) are consumed by @take_addr_2.
+// CHECK-LABEL: sil [ossa] @consume_noncontiguous : $@convention(thin) (@in M4) -> () {
+// CHECK:       bb0([[M4:%[^,]+]] :
+// CHECK:         [[S1:%[^,]+]] = struct_element_addr [[M4]] : $*M4, #M4.s1
+// CHECK:         [[S3:%[^,]+]] = struct_element_addr [[M4]] : $*M4, #M4.s3
+// CHECK:         [[TAKE_ADDR_2:%[^,]+]] = function_ref @take_addr_2
+// CHECK:         apply [[TAKE_ADDR_2]]([[S1]], [[S3]])
+// CHECK-LABEL: } // end sil function 'consume_noncontiguous'
+sil [ossa] @consume_noncontiguous : $@convention(thin) (@in M4) -> () {
+entry(%m4_addr : $*M4):
+  %m4 = mark_unresolved_non_copyable_value [consumable_and_assignable] %m4_addr : $*M4
+  %s1 = struct_element_addr %m4 : $*M4, #M4.s1
+  %s2 = struct_element_addr %m4 : $*M4, #M4.s2
+  %s3 = struct_element_addr %m4 : $*M4, #M4.s3
+  %s4 = struct_element_addr %m4 : $*M4, #M4.s4
+  %take_addr_2 = function_ref @take_addr_2 : $@convention(thin) (@in M, @in M) -> ()
+  apply %take_addr_2(%s1, %s3) : $@convention(thin) (@in M, @in M) -> ()
+  destroy_addr %s2 : $*M
+  destroy_addr %s4 : $*M
+  %retval = tuple ()
+  return %retval : $()
 }


### PR DESCRIPTION
**Explanation**: Fix a class of overconsumes by teaching the move-only address checker that an instruction can consume multiple fields.

An instruction can consume multiple fields of an aggregate which is being checked.  For example, `apply %fn(%field1, %field3)`.  Where `%field1` and `%field3` are noncontiguous fields of some struct.  

Previously, for a single instruction, the checker only tracked a single contiguous range of bits which the instruction consumed.  It couldn't represent instructions such as this apply.  Consequently, it failed to recognize that fields of the aggregate beyond the first it examined were consumed by the instruction.  The result was an overconsume of each field beyond the first.

Here, this is fixed by associating a vector of bits with each instruction.
**Scope**: Affects move-only checking.
**Issue**: rdar://125103951
**Original PR**: https://github.com/apple/swift/pull/72463
**Risk**: Low.
**Testing**: Added test case that was previously miscompiled.
**Reviewer**: Joe Groff ( @jckarter )
