### PR TITLE
[ScanDependencies] Do not inherit driver options in direct-cc1 mode

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1873,17 +1873,21 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   if (LoaderOpts.requestedAction ==
       FrontendOptions::ActionType::ScanDependencies) {
     // For a dependency scanning action, interface build command generation must
-    // inherit
-    // `-Xcc` flags used for configuration of the building instance's
+    // inherit `-Xcc` flags used for configuration of the building instance's
     // `ClangImporter`. However, we can ignore Clang search path flags because
     // explicit Swift module build tasks will not rely on them and they may be
     // source-target-context-specific and hinder module sharing across
     // compilation source targets.
-    // Clang module dependecies of this Swift dependency will be distinguished by
-    // their context hash for different variants, so would still cause a difference
-    // in the Swift compile commands, when different.
-    inheritedParentContextClangArgs =
-        clangImporterOpts.getReducedExtraArgsForSwiftModuleDependency();
+    // If using DirectCC1Scan, the command-line reduction is handled inside
+    // `getSwiftExplicitModuleDirectCC1Args()`, there is no need to inherit
+    // anything here as the ExtraArgs from the invocation are clang driver
+    // options, not cc1 options.
+    // Clang module dependecies of this Swift dependency will be distinguished
+    // by their context hash for different variants, so would still cause a
+    // difference in the Swift compile commands, when different.
+    if (!clangImporterOpts.ClangImporterDirectCC1Scan)
+      inheritedParentContextClangArgs =
+          clangImporterOpts.getReducedExtraArgsForSwiftModuleDependency();
     genericSubInvocation.getFrontendOptions()
         .DependencyScanningSubInvocation = true;
   } else if (LoaderOpts.strictImplicitModuleContext ||

--- a/test/ScanDependencies/direct_cc1_scan.swift
+++ b/test/ScanDependencies/direct_cc1_scan.swift
@@ -15,12 +15,15 @@
 
 // RUN: %target-swift-frontend -scan-dependencies -o %t/deps2.json -I %t \
 // RUN:   -disable-implicit-string-processing-module-import -disable-implicit-concurrency-module-import -parse-stdlib \
+// RUN:   -g -file-compilation-dir %t -Xcc -ferror-limit=1 \
 // RUN:   %t/test.swift -module-name Test -swift-version 5 -experimental-clang-importer-direct-cc1-scan
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps2.json A | %FileCheck %s --check-prefix CHECK-DIRECT-CC1-SCAN
 // RUN: %{python} %S/../CAS/Inputs/BuildCommandExtractor.py %t/deps2.json Test | %FileCheck %s --check-prefix CHECK-DIRECT-CC1-SCAN
 
 // CHECK-NO-DIRECT-CC1-NOT: -direct-clang-cc1-module-build
 // CHECK-DIRECT-CC1-SCAN: -direct-clang-cc1-module-build
+// CHECK-DIRECT-CC1-SCAN-NOT: -ffile-compilation-dir
+// CHECK-DIRECT-CC1-SCAN-NOT: -ferror-limit=1
 
 //--- A.swift
 func a() {}


### PR DESCRIPTION
When direct-cc1 scanning mode is enabled, do not inherit -Xcc options from the commandline as those are driver flags and clang importer already handle the conversion.

rdar://125194535
