### PR TITLE
Options for complete OSSA lifetimes.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -185,6 +185,9 @@ public:
   /// Require linear OSSA lifetimes after SILGen
   bool OSSACompleteLifetimes = false;
 
+  /// Verify linear OSSA lifetimes after SILGen
+  bool OSSAVerifyComplete = false;
+
   /// Enable pack metadata stack "promotion".
   ///
   /// More accurately, enable skipping mandatory heapification of pack metadata

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1319,6 +1319,16 @@ def experimental_spi_only_imports :
 def enable_ossa_complete_lifetimes :
   Flag<["-"], "enable-ossa-complete-lifetimes">,
   HelpText<"Require linear OSSA lifetimes after SILGen">;
+def disable_ossa_complete_lifetimes :
+  Flag<["-"], "disable-ossa-complete-lifetimes">,
+  HelpText<"Do not require linear OSSA lifetimes after SILGen">;
+
+def enable_ossa_verify_complete :
+  Flag<["-"], "enable-ossa-verify-complete">,
+  HelpText<"Verify linear OSSA lifetimes after SILGen">;
+def disable_ossa_verify_complete :
+  Flag<["-"], "disable-ossa-verify-complete">,
+  HelpText<"Do not verify linear OSSA lifetimes after SILGen">;
 
 def platform_c_calling_convention :
     Separate<["-"], "experimental-platform-c-calling-convention">,

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -209,7 +209,10 @@ struct SILOptOptions {
 
   llvm::cl::opt<bool>
   EnableOSSACompleteLifetimes = llvm::cl::opt<bool>("enable-ossa-complete-lifetimes",
-                        llvm::cl::desc("Compile the module with sil-opaque-values enabled."));
+                        llvm::cl::desc("Require linear OSSA lifetimes after SILGenCleanup."));
+  llvm::cl::opt<bool>
+  EnableOSSAVerifyComplete = llvm::cl::opt<bool>("enable-ossa-verify-complete",
+                        llvm::cl::desc("Verify linear OSSA lifetimes after SILGenCleanup."));
 
   llvm::cl::opt<bool>
   EnableObjCInterop = llvm::cl::opt<bool>("enable-objc-interop",
@@ -759,6 +762,7 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
   SILOpts.EnableOSSAModules = options.EnableOSSAModules;
   SILOpts.EnableSILOpaqueValues = options.EnableSILOpaqueValues;
   SILOpts.OSSACompleteLifetimes = options.EnableOSSACompleteLifetimes;
+  SILOpts.OSSAVerifyComplete = options.EnableOSSAVerifyComplete;
 
   if (options.CopyPropagationState) {
     SILOpts.CopyPropagation = *options.CopyPropagationState;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2528,7 +2528,15 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     parseExclusivityEnforcementOptions(A, Opts, Diags);
   }
 
-  Opts.OSSACompleteLifetimes |= Args.hasArg(OPT_enable_ossa_complete_lifetimes);
+  Opts.OSSACompleteLifetimes =
+      Args.hasFlag(OPT_enable_ossa_complete_lifetimes,
+                   OPT_disable_ossa_complete_lifetimes,
+                   Opts.OSSACompleteLifetimes);
+
+  Opts.OSSAVerifyComplete =
+      Args.hasFlag(OPT_enable_ossa_verify_complete,
+                   OPT_disable_ossa_verify_complete,
+                   Opts.OSSAVerifyComplete);
 
   Opts.NoAllocations = Args.hasArg(OPT_no_allocations);
 

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -902,7 +902,7 @@ void SILModule::verifyOwnership() const {
 
   for (const SILFunction &function : *this) {
     std::unique_ptr<DeadEndBlocks> deBlocks;
-    if (!getOptions().OSSACompleteLifetimes) {
+    if (!getOptions().OSSAVerifyComplete) {
       deBlocks =
         std::make_unique<DeadEndBlocks>(const_cast<SILFunction *>(&function));
     }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -7045,7 +7045,7 @@ public:
   }
 
   void verify(bool isCompleteOSSA) {
-    if (!isCompleteOSSA || !F.getModule().getOptions().OSSACompleteLifetimes) {
+    if (!isCompleteOSSA || !F.getModule().getOptions().OSSAVerifyComplete) {
       DEBlocks = std::make_unique<DeadEndBlocks>(const_cast<SILFunction *>(&F));
     }
     visitSILFunction(const_cast<SILFunction*>(&F));

--- a/lib/SILOptimizer/PassManager/Passes.cpp
+++ b/lib/SILOptimizer/PassManager/Passes.cpp
@@ -58,7 +58,7 @@ bool swift::runSILDiagnosticPasses(SILModule &Module) {
                           SILPassPipelinePlan::getSILGenPassPipeline(opts),
                           /*isMandatory*/ true);
 
-  if (opts.VerifyAll && opts.OSSACompleteLifetimes)
+  if (opts.VerifyAll && opts.OSSAVerifyComplete)
     Module.verifyOwnership();
 
   executePassPipelinePlan(&Module,


### PR DESCRIPTION
Adds
-disable-ossa-complete-lifetimes,
-enable-ossa-verify-complete,
-disable-ossa-verify-complete

If we can begin enabling OSSA lifetime completion, that will define away many latent OSSA bugs and vastly simplify lifetime-related diagnostics.