### PR TITLE
[Concurrency] Apply `@MainActor` to main dispatch queue operations without considering `Sendable`.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6050,6 +6050,7 @@ swift::isDispatchQueueOperationName(StringRef name) {
       .Case("sync", DispatchQueueOperation::Normal)
       .Case("async", DispatchQueueOperation::Sendable)
       .Case("asyncAndWait", DispatchQueueOperation::Normal)
+      .Case("asyncUnsafe", DispatchQueueOperation::Normal)
       .Case("asyncAfter", DispatchQueueOperation::Sendable)
       .Case("concurrentPerform", DispatchQueueOperation::Sendable)
       .Default(std::nullopt);
@@ -6147,8 +6148,7 @@ static AnyFunctionType *applyUnsafeConcurrencyToFunctionType(
     // @MainActor occurs in concurrency contexts or those where we have an
     // application.
     bool addSendable = knownUnsafeParams && inConcurrencyContext;
-    bool addMainActor =
-        (isMainDispatchQueue && knownUnsafeParams) &&
+    bool addMainActor = isMainDispatchQueue &&
         (inConcurrencyContext || numApplies >= 1);
     Type newParamType = param.getPlainType();
     if (addSendable || addMainActor) {

--- a/test/Concurrency/dispatch_inference.swift
+++ b/test/Concurrency/dispatch_inference.swift
@@ -17,6 +17,10 @@ func testMe() {
   DispatchQueue.main.async {
     onlyOnMainActor() // okay, due to inference of @MainActor-ness
   }
+
+  DispatchQueue.main.sync {
+    onlyOnMainActor()
+  }
 }
 
 func testUnsafeSendableInMainAsync() async {


### PR DESCRIPTION
Also, add `asyncUnsafe` to the list of main dispatch queue methods.

Resolves: rdar://114962194, rdar://125197325