### PR TITLE
[region-isolation] Clean up use after transfer error to use the dynamic isolation information of the transfered operand value in its diagnostic message.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -970,8 +970,8 @@ ERROR(regionbasedisolation_named_transfer_yields_race, none,
       (Identifier))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,
-     "%0 is transferred from %1 caller to %2 callee. Later uses in caller could race with potential uses in callee",
-     (Identifier, ActorIsolation, ActorIsolation))
+     "transferring %1 %0 to %2 callee could cause races in between callee %2 and local %3 uses",
+     (Identifier, StringRef, ActorIsolation, ActorIsolation))
 NOTE(regionbasedisolation_named_transfer_non_transferrable, none,
       "transferring %1 %0 to %2 callee could cause races between %2 and %1 uses",
       (Identifier, StringRef, ActorIsolation))

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2967,6 +2967,10 @@ bool BlockPartitionState::recomputeExitFromEntry(
         : PartitionOpEvaluatorBaseImpl(workingPartition, ptrSetFactory),
           translator(translator) {}
 
+    SILIsolationInfo getIsolationRegionInfo(Element elt) const {
+      return translator.getValueMap().getIsolationRegion(elt);
+    }
+
     bool isClosureCaptured(Element elt, Operand *op) const {
       auto iter = translator.getValueForId(elt);
       if (!iter)

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -32,7 +32,7 @@ func iterate(stream: AsyncStream<Int>) async {
   // declaration to be in a disconnected region
 
   // expected-region-isolation-warning @+3 {{transferring 'it' may cause a race}}
-  // expected-region-isolation-note @+2 {{'it' is transferred from main actor-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-region-isolation-note @+2 {{transferring disconnected 'it' to nonisolated callee could cause races in between callee nonisolated and local main actor-isolated uses}}
   // expected-region-isolation-note @+1 {{access here could race}}
   while let element = await it.next() {
     print(element)

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -278,7 +278,7 @@ func testNonSendableBaseArg() async {
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
   // expected-tns-warning @-2 {{transferring 't' may cause a race}}
-  // expected-tns-note @-3 {{'t' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-tns-note @-3 {{transferring disconnected 't' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -291,7 +291,7 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a race}}
-  // expected-tns-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-tns-note @-2:67 {{access here could race}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -747,7 +747,7 @@ func asyncLetWithoutCapture() async {
   // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by implicitly asynchronous call to main actor-isolated function cannot cross actor boundary}}
   let y = await x
   await transferToMain(y) // expected-tns-warning {{transferring 'y' may cause a race}}
-  // expected-tns-note @-1 {{'y' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-tns-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(y) // expected-tns-note {{access here could race}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -93,7 +93,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
   let x = NonSendableLinkedListNode<Int>()
 
   await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
-  // expected-tns-note @-1 {{'x' is transferred from global actor 'GlobalActor'-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to nonisolated callee could cause races in between callee nonisolated and local global actor 'GlobalActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
   useValue(x) // expected-tns-note {{access here could race}}
@@ -109,7 +109,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   x = StructContainingValue()
 
   await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
-  // expected-tns-note @-1 {{'x' is transferred from global actor 'GlobalActor'-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to nonisolated callee could cause races in between callee nonisolated and local global actor 'GlobalActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
   useValue(x) // expected-tns-note {{access here could race}}
@@ -131,7 +131,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   x = (NonSendableLinkedList<Int>(), NonSendableLinkedList<Int>())
 
   await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
-  // expected-tns-note @-1 {{'x' is transferred from global actor 'GlobalActor'-isolated caller to nonisolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to nonisolated callee could cause races in between callee nonisolated and local global actor 'GlobalActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -94,7 +94,7 @@ func normalFunc_testLocal_2() {
 func transferBeforeCaptureErrors() async {
   let x = NonSendableKlass()
   await transferToCustom(x) // expected-warning {{transferring 'x' may cause a race}}
-  // expected-note @-1 {{'x' is transferred from nonisolated caller to global actor 'CustomActor'-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-note @-1 {{transferring disconnected 'x' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{access here could race}}
     useValue(x)
   }

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -353,7 +353,7 @@ func test_indirect_regions(a : A, b : Bool) async {
 
     if (b) {
         await a.foo(ns5_0) // expected-tns-warning {{transferring 'ns5_0' may cause a race}}
-        // expected-tns-note @-1 {{'ns5_0' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+        // expected-tns-note @-1 {{transferring disconnected 'ns5_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
         if b {
@@ -363,7 +363,7 @@ func test_indirect_regions(a : A, b : Bool) async {
         }
     } else {
         await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' may cause a race}}
-        // expected-tns-note @-1 {{'ns5_1' is transferred from nonisolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+        // expected-tns-note @-1 {{transferring disconnected 'ns5_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
         if b {

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -86,7 +86,7 @@ func simpleTest2() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x)
   await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
-  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y)
   useValue(x) // expected-note {{access here could race}}
 }
@@ -97,14 +97,14 @@ func simpleTest3() async {
   let y = transferResultWithArg(x)
   await transferToMainDirect(x)
   await transferToMainDirect(y) // expected-warning {{transferring 'y' may cause a race}}
-  // expected-note @-1 {{'y' is transferred from nonisolated caller to main actor-isolated callee}}
+  // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y) // expected-note {{access here could race}}
 }
 
 func transferResult() async -> transferring NonSendableKlass {
   let x = NonSendableKlass()
   await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
-  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   return x // expected-note {{access here could race}}
 }
 

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -22,7 +22,7 @@ actor Bar {
     _ = Bar(ns) // expected-warning {{transferring 'ns' may cause a race}}
     // TODO: This needs to be:
     // disconnected 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
-    // expected-note @-3 {{'ns' is transferred from actor-isolated caller to actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+    // expected-note @-3 {{transferring disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local actor-isolated uses}}
     ns.foo() // expected-note {{access here could race}}
   }
 }

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -21,7 +21,7 @@ func transferValue<T>(_ t: transferring T) {}
 func testIsolationError() async {
   let x = NonSendableType()
   await transferToMain(x) // expected-error {{transferring 'x' may cause a race}}
-  // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}
+  // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{access here could race}}
 }
 


### PR DESCRIPTION
As an example of the change:

 // expected-note @-1 {{'x' is transferred from nonisolated caller to main actor-isolated callee. Later uses in caller could race with potential uses in callee}}

--> 

// expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}


Part of the reason I am doing this is that I am going to be ensuring that we handle a bunch more cases and I wanted to fix this diagnostic before I added more incaranations of it to the tests.
