### PR TITLE
[embedded] Do not emit calls to swift_deallocPartialClassInstance in embedded Swift

### DIFF
--- a/test/embedded/init-throwing.swift
+++ b/test/embedded/init-throwing.swift
@@ -1,0 +1,37 @@
+// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+struct FooError: Error {}
+
+class PrintingClass {
+    init() { print("PrintingClass.init") }
+    deinit { print("PrintingClass.deinit") }
+}
+
+class Foo {
+    var a: PrintingClass
+    var b: PrintingClass
+    init(shouldThrow: Bool) throws(FooError) {
+        a = PrintingClass()
+        if shouldThrow { throw FooError() }
+        b = PrintingClass()
+    }
+}
+
+_ = try? Foo(shouldThrow: true)
+print("OK 1")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: OK 1
+
+_ = try? Foo(shouldThrow: false)
+print("OK 2")
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.init
+// CHECK: PrintingClass.deinit
+// CHECK: PrintingClass.deinit
+// CHECK: OK 2


### PR DESCRIPTION
See the attached testcase, the early throw-return in the initializer ends up causing a call to swift_deallocPartialClassInstance which we do not have in Embedded Swift. My understanding is (I would appreciate double checking this, thanks 😁) that the only difference between swift_deallocPartialClassInstance and swift_deallocClassInstance (which we do have in Embedded Swift) is that swift_deallocPartialClassInstance runs IVarDestroyers on the class hierarchy, and that IVarDestroyer is only non-null on classes when Objective-C interop is enabled. Because Embedded Swift explicitly disallows Objective-C interop, we don't need to run IVarDestroyers and can just call swift_deallocClassInstance directly.

rdar://125193196

Fixes: #72502
