### PR TITLE
Correctly apply `@isolated(any)` even when converting to an optional type

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5388,19 +5388,18 @@ synthesizeBaseClassFieldGetterOrAddressGetterBody(AbstractFunctionDecl *afd,
   auto *baseMemberCallExpr =
       CallExpr::createImplicit(ctx, baseMemberDotCallExpr, argumentList);
   Type resultType = baseGetterMethod->getResultInterfaceType();
-  if (kind == AccessorKind::Address && resultType->isUnsafeMutablePointer()) {
-    resultType = getterDecl->getResultInterfaceType();
-  }
   baseMemberCallExpr->setType(resultType);
   baseMemberCallExpr->setThrows(nullptr);
 
   Expr *returnExpr = baseMemberCallExpr;
   // Cast an 'address' result from a mutable pointer if needed.
   if (kind == AccessorKind::Address &&
-      baseGetterMethod->getResultInterfaceType()->isUnsafeMutablePointer())
+      baseGetterMethod->getResultInterfaceType()->isUnsafeMutablePointer()) {
+    auto finalResultType = getterDecl->getResultInterfaceType();
     returnExpr = SwiftDeclSynthesizer::synthesizeReturnReinterpretCast(
-        ctx, baseGetterMethod->getResultInterfaceType(), resultType,
+        ctx, baseGetterMethod->getResultInterfaceType(), finalResultType,
         returnExpr);
+  }
 
   auto *returnStmt = ReturnStmt::createImplicit(ctx, returnExpr);
 

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -81,8 +81,10 @@ ManagedValue ArgumentSource::getAsSingleValue(SILGenFunction &SGF,
                                               SILType loweredTy,
                                               SGFContext C) && {
   auto substFormalType = getSubstRValueType();
+  auto loweredFormalTy = SGF.getLoweredType(substFormalType);
   auto conversion =
-    Conversion::getSubstToOrig(origFormalType, substFormalType, loweredTy);
+    Conversion::getSubstToOrig(origFormalType, substFormalType,
+                               loweredFormalTy, loweredTy);
   return std::move(*this).getConverted(SGF, conversion, C);
 }
 

--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -319,6 +319,21 @@ public:
     return getReabstractionOutputLoweredType();
   }
 
+  /// Given that this conversion is not one of the specialized bridging
+  /// conversion (i.e. it is either a reabstraction or a subtype conversion),
+  /// rebuild it with the given source type.
+  Conversion withSourceType(AbstractionPattern origSourceType,
+                            CanType sourceType,
+                            SILType loweredSourceTy) const;
+  Conversion withSourceType(SILGenFunction &SGF, CanType sourceType) const;
+
+  /// Given that this conversion is not one of the specialized bridging
+  /// conversion (i.e. it is either a reabstraction or a subtype conversion),
+  /// rebuild it with the given result type.
+  Conversion withResultType(AbstractionPattern origResultType,
+                            CanType sourceType,
+                            SILType loweredSourceTy) const;
+
   ManagedValue emit(SILGenFunction &SGF, SILLocation loc,
                     ManagedValue source, SGFContext ctxt) const;
 

--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -37,6 +37,9 @@ public:
     /// implicit force cast.
     ForceAndBridgeToObjC,
 
+    /// Force an optional value.
+    ForceOptional,
+
     /// A bridging conversion from a foreign type.
     BridgeFromObjC,
 
@@ -61,6 +64,7 @@ public:
     switch (kind) {
     case BridgeToObjC:
     case ForceAndBridgeToObjC:
+    case ForceOptional:
     case BridgeFromObjC:
     case BridgeResultFromObjC:
     case AnyErasure:
@@ -80,6 +84,7 @@ public:
 
     case BridgeToObjC:
     case ForceAndBridgeToObjC:
+    case ForceOptional:
     case BridgeFromObjC:
     case BridgeResultFromObjC:
     case AnyErasure:
@@ -114,6 +119,7 @@ private:
     switch (kind) {
     case BridgeToObjC:
     case ForceAndBridgeToObjC:
+    case ForceOptional:
     case BridgeFromObjC:
     case BridgeResultFromObjC:
     case AnyErasure:
@@ -236,6 +242,24 @@ public:
 
   SILType getBridgingLoweredResultType() const {
     return Types.get<BridgingTypes>(Kind).LoweredResultType;
+  }
+
+  CanType getSourceType() const {
+    if (isBridging())
+      return getBridgingSourceType();
+    return getReabstractionInputSubstType();
+  }
+
+  CanType getResultType() const {
+    if (isBridging())
+      return getBridgingResultType();
+    return getReabstractionOutputSubstType();
+  }
+
+  SILType getLoweredResultType() const {
+    if (isBridging())
+      return getBridgingLoweredResultType();
+    return getReabstractionOutputLoweredType();
   }
 
   ManagedValue emit(SILGenFunction &SGF, SILLocation loc,

--- a/lib/SILGen/Conversion.h
+++ b/lib/SILGen/Conversion.h
@@ -294,9 +294,9 @@ public:
   bool isForced() const { return Forced; }
 };
 
-std::optional<ConversionPeepholeHint>
-canPeepholeConversions(SILGenFunction &SGF, const Conversion &outerConversion,
-                       const Conversion &innerConversion);
+bool canPeepholeConversions(SILGenFunction &SGF,
+                            const Conversion &outer,
+                            const Conversion &inner);
 
 /// An initialization where we ultimately want to apply a conversion to
 /// the value before completing the initialization.

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -234,6 +234,11 @@ public:
   /// The values must not require any cleanups.
   SILValue getUnmanagedSingleValue(SILGenFunction &SGF, SILLocation l) const &;
 
+  SILType getTypeOfSingleValue() const & {
+    assert(isComplete() && values.size() == 1);
+    return values[0].getType();
+  }
+
   ManagedValue getScalarValue() && {
     if (isInContext()) {
       makeUsed();

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -306,7 +306,7 @@ public:
                                          loweredResultTy);
         } else {
           return Conversion::getOrigToSubst(origType, substType,
-                                            loweredResultTy);
+                                            value.getType(), loweredResultTy);
         }
       }();
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3826,6 +3826,7 @@ private:
         case SILFunctionLanguage::Swift:
           return Conversion::getSubstToOrig(origParamType,
                                             arg.getSubstRValueType(),
+                                            loweredSubstArgType,
                                             param.getSILStorageInterfaceType());
         case SILFunctionLanguage::C:
           return Conversion::getBridging(Conversion::BridgeToObjC,
@@ -4051,7 +4052,9 @@ private:
         convertingInit.emplace(
             Conversion::getSubstToOrig(
                 origExpansionType.getPackExpansionPatternType(),
-                substPatternType, expectedElementType),
+                substPatternType,
+                SILType::getPrimitiveObjectType(loweredPatternTy),
+                expectedElementType),
             SGFContext(innermostInit));
         innermostInit = &*convertingInit;
       }
@@ -7273,6 +7276,7 @@ ManagedValue SILGenFunction::emitAsyncLetStart(
       origParamType);
   
   auto conversion = Conversion::getSubstToOrig(origParam, substParamType,
+                                     getLoweredType(asyncLetEntryPoint->getType()),
                                      getLoweredType(origParam, substParamType));
   auto taskFunction = emitConvertedRValue(asyncLetEntryPoint, conversion);
 

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -1637,8 +1637,18 @@ static ManagedValue emitCreateAsyncTask(SILGenFunction &SGF, SILLocation loc,
     CanType substParamType = fnArg.getSubstRValueType();
     auto loweredParamTy = SGF.getLoweredType(origParamType, substParamType);
 
+    // The main actor path doesn't give us a value that actually matches the
+    // formal type at all, so this is the best we can do.
+    SILType loweredSubstParamTy;
+    if (fnArg.isRValue()) {
+      loweredSubstParamTy = fnArg.peekRValue().getTypeOfSingleValue();
+    } else {
+      loweredSubstParamTy = SGF.getLoweredType(substParamType);
+    }
+
     auto conversion =
-      Conversion::getSubstToOrig(origParamType, substParamType, loweredParamTy);
+      Conversion::getSubstToOrig(origParamType, substParamType,
+                                 loweredSubstParamTy, loweredParamTy);
     return std::move(fnArg).getConverted(SGF, conversion);
   }();
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1635,7 +1635,8 @@ void SILGenFunction::emitMemberInitializer(DeclContext *dc, VarDecl *selfDecl,
 
     if (needsConvertingInit) {
       Conversion conversion =
-          Conversion::getSubstToOrig(origType, substType, loweredResultTy);
+          Conversion::getSubstToOrig(origType, substType,
+                                     loweredSubstTy, loweredResultTy);
 
       ConvertingInitialization convertingInit(conversion,
                                               SGFContext(memberInit.get()));

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1258,8 +1258,8 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
   case AnyErasure:
   case BridgingSubtype:
   case Subtype:
-    return SGF.emitTransformedValue(loc, value, getBridgingSourceType(),
-                                    getBridgingResultType(), C);
+    return SGF.emitTransformedValue(loc, value, getSourceType(),
+                                    getResultType(), C);
 
   case ForceOptional: {
     auto &optTL = SGF.getTypeLowering(value.getType());
@@ -1270,32 +1270,30 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
 
   case BridgeToObjC:
     return SGF.emitNativeToBridgedValue(loc, value,
-                                        getBridgingSourceType(),
-                                        getBridgingResultType(),
-                                        getBridgingLoweredResultType(), C);
+                                        getSourceType(),
+                                        getResultType(),
+                                        getLoweredResultType(), C);
 
   case ForceAndBridgeToObjC: {
     auto &tl = SGF.getTypeLowering(value.getType());
-    auto sourceValueType = getBridgingSourceType().getOptionalObjectType();
+    auto sourceValueType = getSourceType().getOptionalObjectType();
     value = SGF.emitCheckedGetOptionalValueFrom(loc, value,
                                                 /*isImplicitUnwrap*/ true,
                                                 tl, SGFContext());
     return SGF.emitNativeToBridgedValue(loc, value, sourceValueType,
-                                        getBridgingResultType(),
-                                        getBridgingLoweredResultType(), C);
+                                        getResultType(),
+                                        getLoweredResultType(), C);
   }
 
   case BridgeFromObjC:
     return SGF.emitBridgedToNativeValue(loc, value,
-                                        getBridgingSourceType(),
-                                        getBridgingResultType(),
-                                        getBridgingLoweredResultType(), C);
+                                        getSourceType(), getResultType(),
+                                        getLoweredResultType(), C);
 
   case BridgeResultFromObjC:
     return SGF.emitBridgedToNativeValue(loc, value,
-                                        getBridgingSourceType(),
-                                        getBridgingResultType(),
-                                        getBridgingLoweredResultType(), C,
+                                        getSourceType(), getResultType(),
+                                        getLoweredResultType(), C,
                                         /*isResult*/ true);
 
   case Reabstract:
@@ -1328,9 +1326,9 @@ Conversion::adjustForInitialOptionalInjection() const {
   case Subtype:
     return OptionalInjectionConversion::forValue(
       getSubtype(
-        getBridgingSourceType().getOptionalObjectType(),
-        getBridgingResultType().getOptionalObjectType(),
-        getBridgingLoweredResultType().getOptionalObjectType())
+        getSourceType().getOptionalObjectType(),
+        getResultType().getOptionalObjectType(),
+        getLoweredResultType().getOptionalObjectType())
     );
 
   // TODO: can these actually happen?
@@ -1344,9 +1342,8 @@ Conversion::adjustForInitialOptionalInjection() const {
   case BridgeFromObjC:
   case BridgeResultFromObjC:
     return OptionalInjectionConversion::forInjection(
-      getBridging(getKind(), getBridgingSourceType().getOptionalObjectType(),
-                  getBridgingResultType(),
-                  getBridgingLoweredResultType(),
+      getBridging(getKind(), getSourceType().getOptionalObjectType(),
+                  getResultType(), getLoweredResultType(),
                   isBridgingExplicit())
     );
   }
@@ -1371,8 +1368,7 @@ Conversion::adjustForInitialOptionalConversions(CanType newSourceType) const {
   case BridgeFromObjC:
   case BridgeResultFromObjC:
     return Conversion::getBridging(getKind(), newSourceType,
-                                   getBridgingResultType(),
-                                   getBridgingLoweredResultType(),
+                                   getResultType(), getLoweredResultType(),
                                    isBridgingExplicit());
   }
   llvm_unreachable("bad kind");
@@ -1391,12 +1387,10 @@ std::optional<Conversion> Conversion::adjustForInitialForceValue() const {
     return std::nullopt;
 
   case BridgeToObjC: {
-    auto sourceOptType =
-      OptionalType::get(getBridgingSourceType())->getCanonicalType();
+    auto sourceOptType = getSourceType().wrapInOptionalType();
     return Conversion::getBridging(ForceAndBridgeToObjC,
-                                   sourceOptType,
-                                   getBridgingResultType(),
-                                   getBridgingLoweredResultType(),
+                                   sourceOptType, getResultType(),
+                                   getLoweredResultType(),
                                    isBridgingExplicit());
   }
   }
@@ -1428,9 +1422,9 @@ static void printReabstraction(const Conversion &conversion,
 static void printBridging(const Conversion &conversion, llvm::raw_ostream &out,
                           StringRef name) {
   out << name << "(from: ";
-  conversion.getBridgingSourceType().print(out);
+  conversion.getSourceType().print(out);
   out << ", to: ";
-  conversion.getBridgingResultType().print(out);
+  conversion.getResultType().print(out);
   out << ", explicit: " << conversion.isBridgingExplicit() << ')';
 }
 
@@ -1784,7 +1778,7 @@ combineSubtypeIntoReabstract(SILGenFunction &SGF,
   if (!isCombinableConversion(inner, outer))
     return salvageUncombinableConversion(SGF, inner, outer);
 
-  auto inputSubstType = inner.getBridgingSourceType();
+  auto inputSubstType = inner.getSourceType();
   auto inputOrigType = AbstractionPattern(inputSubstType);
   auto inputLoweredTy = SGF.getLoweredType(inputOrigType, inputSubstType);
 
@@ -1804,9 +1798,8 @@ combineSubtype(SILGenFunction &SGF,
     return salvageUncombinableConversion(SGF, inner, outer);
 
   return CombinedConversions(
-    Conversion::getSubtype(inner.getBridgingSourceType(),
-                           outer.getBridgingResultType(),
-                           outer.getBridgingLoweredResultType())
+    Conversion::getSubtype(inner.getSourceType(), outer.getResultType(),
+                           outer.getLoweredResultType())
   );
 }
 
@@ -1824,9 +1817,9 @@ combineBridging(SILGenFunction &SGF,
   // Otherwise, we can peephole if we understand the resulting conversion
   // and applying the peephole doesn't change semantics.
 
-  CanType sourceType = inner.getBridgingSourceType();
-  CanType intermediateType = inner.getBridgingResultType();
-  assert(intermediateType == outer.getBridgingSourceType());
+  CanType sourceType = inner.getSourceType();
+  CanType intermediateType = inner.getResultType();
+  assert(intermediateType == outer.getSourceType());
 
   // If we're doing a peephole involving a force, we want to propagate
   // the force to the source value.  If it's not in fact optional, that
@@ -1841,9 +1834,9 @@ combineBridging(SILGenFunction &SGF,
     assert(intermediateType);
   }
 
-  CanType resultType = outer.getBridgingResultType();
+  CanType resultType = outer.getResultType();
   SILType loweredSourceTy = SGF.getLoweredType(sourceType);
-  SILType loweredResultTy = outer.getBridgingLoweredResultType();
+  SILType loweredResultTy = outer.getLoweredResultType();
 
   auto applyPeephole = [&](const std::optional<Conversion> &conversion) {
     if (!forced) {
@@ -1854,7 +1847,7 @@ combineBridging(SILGenFunction &SGF,
 
     auto forceConversion =
       Conversion::getBridging(Conversion::ForceOptional,
-                              inner.getBridgingSourceType(), sourceType,
+                              inner.getSourceType(), sourceType,
                               loweredSourceTy);
     if (conversion)
       return CombinedConversions(forceConversion, *conversion);

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1538,9 +1538,45 @@ static bool isMatchedAnyToAnyObjectConversion(CanType from, CanType to) {
   return false;
 }
 
+static Conversion withNewInputType(const Conversion &conv,
+                                   AbstractionPattern origType,
+                                   CanType substType,
+                                   SILType loweredType) {
+  switch (conv.getKind()) {
+  case Conversion::Reabstract:
+    return Conversion::getReabstract(origType, substType, loweredType,
+                                     conv.getReabstractionOutputOrigType(),
+                                     conv.getReabstractionOutputSubstType(),
+                                     conv.getReabstractionOutputLoweredType());
+  case Conversion::Subtype:
+    return Conversion::getSubtype(substType, conv.getBridgingResultType(),
+                                  conv.getBridgingLoweredResultType());
+  default:
+    llvm_unreachable("shouldn't be trying to combine these kinds");
+  }
+}
+
+static Conversion withNewOutputType(const Conversion &conv,
+                                    AbstractionPattern origType,
+                                    CanType substType,
+                                    SILType loweredType) {
+  switch (conv.getKind()) {
+  case Conversion::Reabstract:
+    return Conversion::getReabstract(conv.getReabstractionInputOrigType(),
+                                     conv.getReabstractionInputSubstType(),
+                                     conv.getReabstractionInputLoweredType(),
+                                     origType, substType, loweredType);
+  case Conversion::Subtype:
+    return Conversion::getSubtype(conv.getBridgingSourceType(),
+                                  substType, loweredType);
+  default:
+    llvm_unreachable("shouldn't be trying to combine these kinds");
+  }
+}
+
 /// Can a sequence of conversions from type1 -> type2 -> type3 be represented
 /// as a conversion from type1 -> type3, or does that lose critical information?
-static bool isPeepholeableConversionImpl(CanType type1,
+static bool isCombinableConversionImpl(CanType type1,
                                          CanType type2,
                                          CanType type3) {
   if (type1 == type2 || type2 == type3) return true;
@@ -1555,12 +1591,12 @@ static bool isPeepholeableConversionImpl(CanType type1,
       // If we have optional -> optional conversions at both stages,
       // look through them all.
       if (auto object1 = type1.getOptionalObjectType()) {
-        return isPeepholeableConversionImpl(object1, object2, object3);
+        return isCombinableConversionImpl(object1, object2, object3);
 
       // If we have an injection in the first stage, we'll still know we have
       // an injection in the overall conversion.
       } else {
-        return isPeepholeableConversionImpl(type1, object2, object3);
+        return isCombinableConversionImpl(type1, object2, object3);
       }
 
     // We have an injection in the second stage.  If we lose optionality
@@ -1572,7 +1608,7 @@ static bool isPeepholeableConversionImpl(CanType type1,
 
     // Otherwise, we're preserving that we have an injection overall.
     } else {
-      return isPeepholeableConversionImpl(type1, type2, object3);
+      return isCombinableConversionImpl(type1, type2, object3);
     }
   }
 
@@ -1612,9 +1648,9 @@ static bool isPeepholeableConversionImpl(CanType type1,
     assert(tuple1->getNumElements() == tuple3->getNumElements());
     assert(tuple2->getNumElements() == tuple3->getNumElements());
     for (auto i : range(tuple3->getNumElements())) {
-      if (!isPeepholeableConversionImpl(tuple1.getElementType(i),
-                                        tuple2.getElementType(i),
-                                        tuple3.getElementType(i)))
+      if (!isCombinableConversionImpl(tuple1.getElementType(i),
+                                      tuple2.getElementType(i),
+                                      tuple3.getElementType(i)))
         return false;
     }
     return true;
@@ -1625,15 +1661,15 @@ static bool isPeepholeableConversionImpl(CanType type1,
     auto fn1 = cast<AnyFunctionType>(type1);
     assert(fn1->getNumParams() == fn3->getNumParams());
     assert(fn2->getNumParams() == fn3->getNumParams());
-    if (!isPeepholeableConversionImpl(fn1.getResult(),
-                                      fn2.getResult(),
-                                      fn3.getResult()))
+    if (!isCombinableConversionImpl(fn1.getResult(),
+                                    fn2.getResult(),
+                                    fn3.getResult()))
       return false;
     for (auto i : range(fn3->getNumParams())) {
       // Note the reversal for invariance.
-      if (!isPeepholeableConversionImpl(fn3.getParams()[i].getParameterType(),
-                                        fn2.getParams()[i].getParameterType(),
-                                        fn1.getParams()[i].getParameterType()))
+      if (!isCombinableConversionImpl(fn3.getParams()[i].getParameterType(),
+                                      fn2.getParams()[i].getParameterType(),
+                                      fn1.getParams()[i].getParameterType()))
         return false;
     }
     return true;
@@ -1642,9 +1678,9 @@ static bool isPeepholeableConversionImpl(CanType type1,
   if (auto exp3 = dyn_cast<PackExpansionType>(type3)) {
     auto exp2 = cast<PackExpansionType>(type2);
     auto exp1 = cast<PackExpansionType>(type1);
-    return isPeepholeableConversionImpl(exp1.getPatternType(),
-                                        exp2.getPatternType(),
-                                        exp3.getPatternType());
+    return isCombinableConversionImpl(exp1.getPatternType(),
+                                      exp2.getPatternType(),
+                                      exp3.getPatternType());
   }
 
   // The only remaining types that support subtyping are classes and
@@ -1654,12 +1690,61 @@ static bool isPeepholeableConversionImpl(CanType type1,
 
 /// Can we combine the given conversions so that we go straight from
 /// innerSrcType to outerDestType, or does that lose information?
-static bool isPeepholeableConversion(CanType innerSrcType, CanType innerDestType,
-                                     CanType outerSrcType, CanType outerDestType) {
-  assert(innerDestType == outerSrcType &&
+static bool isCombinableConversion(const Conversion &inner,
+                                   const Conversion &outer) {
+  assert(inner.getResultType() == outer.getSourceType() &&
          "unexpected intermediate conversion");
 
-  return isPeepholeableConversionImpl(innerSrcType, innerDestType, outerDestType);
+  return isCombinableConversionImpl(inner.getSourceType(),
+                                    inner.getResultType(),
+                                    outer.getResultType());
+}
+
+/// Given that we cannot combine the given conversions, at least
+/// "salvage" them to propagate semantically-critical contextual
+/// type information inward.
+static std::optional<CombinedConversions>
+salvageUncombinableConversion(SILGenFunction &SGF,
+                              const Conversion &inner,
+                              const Conversion &outer) {
+  // If the outer type is `@isolated(any)`, and the intermediate type
+  // is non-isolated, propagate the `@isolated(any)` conversion inwards.
+  // We don't want to do this if the intermediate function has some
+  // explicit isolation because we need to honor that conversion even
+  // if it's not the formal isolation of the source function (e.g. if
+  // the user coerces a nonisolated function to a @MainActor function
+  // type).  But if the intermediate function type is non-isolated, the
+  // actual closure might still be isolated, either because we're
+  // type-checking in some mode that doesn't propagate isolation in types
+  // or because the isolation isn't representable in the type system
+  // (e.g. it's isolated to some capture).
+  if (auto outerOutputFnType =
+        dyn_cast<AnyFunctionType>(outer.getResultType())) {
+    auto intermediateFnType = cast<AnyFunctionType>(outer.getSourceType());
+    if (outerOutputFnType->getIsolation().isErased() &&
+        intermediateFnType->getIsolation().isNonIsolated()) {
+      // Construct new intermediate orig/subst/lowered types that are
+      // just the old intermediate type with `@isolated(any)`.
+      auto newIntermediateSubstType = intermediateFnType.withExtInfo(
+        intermediateFnType->getExtInfo().withIsolation(
+          FunctionTypeIsolation::forErased()));
+      auto newIntermediateOrigType =
+        AbstractionPattern(newIntermediateSubstType);
+      auto newIntermediateLoweredType =
+        SGF.getLoweredType(newIntermediateSubstType);
+
+      // Construct the new conversions with the new intermediate type.
+      return CombinedConversions(
+               withNewOutputType(inner, newIntermediateOrigType,
+                                 newIntermediateSubstType,
+                                 newIntermediateLoweredType),
+               withNewInputType(outer, newIntermediateOrigType,
+                                newIntermediateSubstType,
+                                newIntermediateLoweredType));
+    }
+  }
+
+  return std::nullopt;
 }
 
 static std::optional<CombinedConversions>
@@ -1668,11 +1753,8 @@ combineReabstract(SILGenFunction &SGF,
                   const Conversion &inner) {
   // We can never combine conversions in a way that would lose information
   // about the intermediate types.
-  if (!isPeepholeableConversion(inner.getReabstractionInputSubstType(),
-                                inner.getReabstractionOutputSubstType(),
-                                outer.getReabstractionInputSubstType(),
-                                outer.getReabstractionOutputSubstType()))
-    return std::nullopt;
+  if (!isCombinableConversion(inner, outer))
+    return salvageUncombinableConversion(SGF, inner, outer);
 
   // Recognize when the whole conversion is an identity.
   if (inner.getReabstractionInputLoweredType().getObjectType() ==
@@ -1697,11 +1779,8 @@ combineSubtypeIntoReabstract(SILGenFunction &SGF,
                              const Conversion &inner) {
   // We can never combine conversions in a way that would lose information
   // about the intermediate types.
-  if (!isPeepholeableConversion(inner.getBridgingSourceType(),
-                                inner.getBridgingResultType(),
-                                outer.getReabstractionInputSubstType(),
-                                outer.getReabstractionOutputSubstType()))
-    return std::nullopt;
+  if (!isCombinableConversion(inner, outer))
+    return salvageUncombinableConversion(SGF, inner, outer);
 
   auto inputSubstType = inner.getBridgingSourceType();
   auto inputOrigType = AbstractionPattern(inputSubstType);
@@ -1719,11 +1798,8 @@ combineSubtypeIntoReabstract(SILGenFunction &SGF,
 static std::optional<CombinedConversions>
 combineSubtype(SILGenFunction &SGF,
                const Conversion &outer, const Conversion &inner) {
-  if (!isPeepholeableConversion(inner.getBridgingSourceType(),
-                                inner.getBridgingResultType(),
-                                outer.getBridgingSourceType(),
-                                outer.getBridgingResultType()))
-    return std::nullopt;
+  if (!isCombinableConversion(inner, outer))
+    return salvageUncombinableConversion(SGF, inner, outer);
 
   return CombinedConversions(
     Conversion::getSubtype(inner.getBridgingSourceType(),

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -34,6 +34,11 @@
 using namespace swift;
 using namespace Lowering;
 
+static std::optional<ConversionPeepholeHint>
+combineConversions(SILGenFunction &SGF, const Conversion &outer,
+                   const Conversion &inner);
+
+
 // FIXME: With some changes to their callers, all of the below functions
 // could be re-worked to use emitInjectEnum().
 ManagedValue
@@ -1247,7 +1252,7 @@ bool ConvertingInitialization::tryPeephole(SILGenFunction &SGF, SILLocation loc,
                                            Conversion innerConversion,
                                            ValueProducerRef produceValue) {
   const auto &outerConversion = getConversion();
-  auto hint = canPeepholeConversions(SGF, outerConversion, innerConversion);
+  auto hint = combineConversions(SGF, outerConversion, innerConversion);
   if (!hint)
     return false;
 
@@ -1655,58 +1660,168 @@ static bool isPeepholeableConversion(CanType innerSrcType, CanType innerDestType
   return isPeepholeableConversionImpl(innerSrcType, innerDestType, outerDestType);
 }
 
-/// TODO: this would really be a lot cleaner if it just returned a
-/// std::optional<Conversion>.
-std::optional<ConversionPeepholeHint>
-Lowering::canPeepholeConversions(SILGenFunction &SGF,
-                                 const Conversion &outerConversion,
-                                 const Conversion &innerConversion) {
-  switch (outerConversion.getKind()) {
-  case Conversion::Reabstract:
-    switch (innerConversion.getKind()) {
-    case Conversion::Reabstract:
-      // We can never combine conversions in a way that would lose information
-      // about the intermediate types.
-      if (!isPeepholeableConversion(
-             innerConversion.getReabstractionInputSubstType(),
-             innerConversion.getReabstractionOutputSubstType(),
-             outerConversion.getReabstractionInputSubstType(),
-             outerConversion.getReabstractionOutputSubstType()))
-        return std::nullopt;
-
-      // Recognize when the whole conversion is an identity.
-      if (innerConversion.getReabstractionInputLoweredType().getObjectType() ==
-          outerConversion.getReabstractionOutputLoweredType().getObjectType())
-        return ConversionPeepholeHint(ConversionPeepholeHint::Identity, false);
-
-      return ConversionPeepholeHint(ConversionPeepholeHint::Reabstract, false);
-
-    case Conversion::Subtype:
-      // We can never combine conversions in a way that would lose information
-      // about the intermediate types.
-      if (!isPeepholeableConversion(
-             innerConversion.getBridgingSourceType(),
-             innerConversion.getBridgingResultType(),
-             outerConversion.getReabstractionInputSubstType(),
-             outerConversion.getReabstractionOutputSubstType()))
-        return std::nullopt;
-
-      return ConversionPeepholeHint(
-               ConversionPeepholeHint::SubtypeIntoReabstract, false);
-
-    default:
-      break;
-    }
-
+static std::optional<ConversionPeepholeHint>
+combineReabstract(SILGenFunction &SGF,
+                  const Conversion &outer,
+                  const Conversion &inner) {
+  // We can never combine conversions in a way that would lose information
+  // about the intermediate types.
+  if (!isPeepholeableConversion(inner.getReabstractionInputSubstType(),
+                                inner.getReabstractionOutputSubstType(),
+                                outer.getReabstractionInputSubstType(),
+                                outer.getReabstractionOutputSubstType()))
     return std::nullopt;
 
+  // Recognize when the whole conversion is an identity.
+  if (inner.getReabstractionInputLoweredType().getObjectType() ==
+      outer.getReabstractionOutputLoweredType().getObjectType())
+    return ConversionPeepholeHint(ConversionPeepholeHint::Identity, false);
+
+  return ConversionPeepholeHint(ConversionPeepholeHint::Reabstract, false);
+}
+
+static std::optional<ConversionPeepholeHint>
+combineSubtypeIntoReabstract(SILGenFunction &SGF,
+                             const Conversion &outer,
+                             const Conversion &inner) {
+  // We can never combine conversions in a way that would lose information
+  // about the intermediate types.
+  if (!isPeepholeableConversion(inner.getBridgingSourceType(),
+                                inner.getBridgingResultType(),
+                                outer.getReabstractionInputSubstType(),
+                                outer.getReabstractionOutputSubstType()))
+    return std::nullopt;
+
+  return ConversionPeepholeHint(
+           ConversionPeepholeHint::SubtypeIntoReabstract, false);
+}
+
+static std::optional<ConversionPeepholeHint>
+combineSubtype(SILGenFunction &SGF,
+               const Conversion &outer, const Conversion &inner) {
+  if (!isPeepholeableConversion(inner.getBridgingSourceType(),
+                                inner.getBridgingResultType(),
+                                outer.getBridgingSourceType(),
+                                outer.getBridgingResultType()))
+    return std::nullopt;
+
+  return ConversionPeepholeHint(ConversionPeepholeHint::Subtype, false);
+}
+
+static std::optional<ConversionPeepholeHint>
+combineBridging(SILGenFunction &SGF,
+               const Conversion &outer, const Conversion &inner) {
+  bool outerExplicit = outer.isBridgingExplicit();
+  bool innerExplicit = inner.isBridgingExplicit();
+
+  // Never peephole if both conversions are explicit; there might be
+  // something the user's trying to do which we don't understand.
+  if (outerExplicit && innerExplicit)
+    return std::nullopt;
+
+  // Otherwise, we can peephole if we understand the resulting conversion
+  // and applying the peephole doesn't change semantics.
+
+  CanType sourceType = inner.getBridgingSourceType();
+  CanType intermediateType = inner.getBridgingResultType();
+  assert(intermediateType == outer.getBridgingSourceType());
+
+  // If we're doing a peephole involving a force, we want to propagate
+  // the force to the source value.  If it's not in fact optional, that
+  // won't work.
+  bool forced = outer.getKind() == Conversion::ForceAndBridgeToObjC;
+  if (forced) {
+    sourceType = sourceType.getOptionalObjectType();
+    if (!sourceType)
+      return std::nullopt;
+    intermediateType = intermediateType.getOptionalObjectType();
+    assert(intermediateType);
+  }
+
+  CanType resultType = outer.getBridgingResultType();
+  SILType loweredSourceTy = SGF.getLoweredType(sourceType);
+  SILType loweredResultTy = outer.getBridgingLoweredResultType();
+
+  auto applyPeephole = [&](ConversionPeepholeHint::Kind kind) {
+    return ConversionPeepholeHint(kind, forced);
+  };
+
+  // Converting to Any doesn't do anything semantically special, so we
+  // can apply the peephole unconditionally.
+  if (isMatchedAnyToAnyObjectConversion(intermediateType, resultType)) {
+    if (loweredSourceTy == loweredResultTy) {
+      return applyPeephole(ConversionPeepholeHint::Identity);
+    } else if (isValueToAnyConversion(sourceType, intermediateType)) {
+      return applyPeephole(ConversionPeepholeHint::BridgeToAnyObject);
+    } else {
+      return applyPeephole(ConversionPeepholeHint::Subtype);
+    }
+  }
+
+  // Otherwise, undoing a bridging conversions can change semantics by
+  // e.g. removing a copy, so we shouldn't do it unless the special
+  // syntactic bridging peephole applies.  That requires one of the
+  // conversions to be explicit.
+  // TODO: use special SILGen to preserve semantics in this case,
+  // e.g. by making a copy.
+  if (!outerExplicit && !innerExplicit) {
+    return std::nullopt;
+  }
+
+  // Okay, now we're in the domain of the bridging peephole: an
+  // explicit bridging conversion can cancel out an implicit bridge
+  // between related types.
+
+  // If the source and destination types have exactly the same
+  // representation, then (1) they're related and (2) we can directly
+  // emit into the context.
+  if (loweredSourceTy.getObjectType() == loweredResultTy.getObjectType()) {
+    return applyPeephole(ConversionPeepholeHint::Identity);
+  }
+
+  // Look for a subtype relationship between the source and destination.
+  if (areRelatedTypesForBridgingPeephole(sourceType, resultType)) {
+    return applyPeephole(ConversionPeepholeHint::Subtype);
+  }
+
+  // If the inner conversion is a result conversion that removes
+  // optionality, and the non-optional source type is a subtype of the
+  // value type, this is just an implicit force.
+  if (!forced &&
+      inner.getKind() == Conversion::BridgeResultFromObjC) {
+    if (auto sourceValueType = sourceType.getOptionalObjectType()) {
+      if (!intermediateType.getOptionalObjectType() &&
+          areRelatedTypesForBridgingPeephole(sourceValueType, resultType)) {
+        forced = true;
+        return applyPeephole(ConversionPeepholeHint::Subtype);
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
+/// TODO: this would really be a lot cleaner if it just returned a
+/// std::optional<Conversion>.
+static std::optional<ConversionPeepholeHint>
+combineConversions(SILGenFunction &SGF, const Conversion &outer,
+                   const Conversion &inner) {
+  switch (outer.getKind()) {
+  case Conversion::Reabstract:
+    switch (inner.getKind()) {
+    case Conversion::Reabstract:
+      return combineReabstract(SGF, outer, inner);
+
+    case Conversion::Subtype:
+      return combineSubtypeIntoReabstract(SGF, outer, inner);
+
+    default:
+      return std::nullopt;
+    }
+
   case Conversion::Subtype:
-    if (innerConversion.getKind() == Conversion::Subtype &&
-        isPeepholeableConversion(innerConversion.getBridgingSourceType(),
-                                 innerConversion.getBridgingResultType(),
-                                 outerConversion.getBridgingSourceType(),
-                                 outerConversion.getBridgingResultType()))
-      return ConversionPeepholeHint(ConversionPeepholeHint::Subtype, false);
+    if (inner.getKind() == Conversion::Subtype)
+      return combineSubtype(SGF, outer, inner);
     return std::nullopt;
 
   case Conversion::AnyErasure:
@@ -1718,104 +1833,21 @@ Lowering::canPeepholeConversions(SILGenFunction &SGF,
 
   case Conversion::ForceAndBridgeToObjC:
   case Conversion::BridgeToObjC:
-    switch (innerConversion.getKind()) {
+    switch (inner.getKind()) {
     case Conversion::AnyErasure:
     case Conversion::BridgeFromObjC:
-    case Conversion::BridgeResultFromObjC: {
-      bool outerExplicit = outerConversion.isBridgingExplicit();
-      bool innerExplicit = innerConversion.isBridgingExplicit();
-
-      // Never peephole if both conversions are explicit; there might be
-      // something the user's trying to do which we don't understand.
-      if (outerExplicit && innerExplicit)
-        return std::nullopt;
-
-      // Otherwise, we can peephole if we understand the resulting conversion
-      // and applying the peephole doesn't change semantics.
-
-      CanType sourceType = innerConversion.getBridgingSourceType();
-      CanType intermediateType = innerConversion.getBridgingResultType();
-      assert(intermediateType == outerConversion.getBridgingSourceType());
-
-      // If we're doing a peephole involving a force, we want to propagate
-      // the force to the source value.  If it's not in fact optional, that
-      // won't work.
-      bool forced =
-        outerConversion.getKind() == Conversion::ForceAndBridgeToObjC;
-      if (forced) {
-        sourceType = sourceType.getOptionalObjectType();
-        if (!sourceType)
-          return std::nullopt;
-        intermediateType = intermediateType.getOptionalObjectType();
-        assert(intermediateType);
-      }
-
-      CanType resultType = outerConversion.getBridgingResultType();
-      SILType loweredSourceTy = SGF.getLoweredType(sourceType);
-      SILType loweredResultTy = outerConversion.getBridgingLoweredResultType();
-
-      auto applyPeephole = [&](ConversionPeepholeHint::Kind kind) {
-        return ConversionPeepholeHint(kind, forced);
-      };
-
-      // Converting to Any doesn't do anything semantically special, so we
-      // can apply the peephole unconditionally.
-      if (isMatchedAnyToAnyObjectConversion(intermediateType, resultType)) {
-        if (loweredSourceTy == loweredResultTy) {
-          return applyPeephole(ConversionPeepholeHint::Identity);
-        } else if (isValueToAnyConversion(sourceType, intermediateType)) {
-          return applyPeephole(ConversionPeepholeHint::BridgeToAnyObject);
-        } else {
-          return applyPeephole(ConversionPeepholeHint::Subtype);
-        }
-      }
-
-      // Otherwise, undoing a bridging conversions can change semantics by
-      // e.g. removing a copy, so we shouldn't do it unless the special
-      // syntactic bridging peephole applies.  That requires one of the
-      // conversions to be explicit.
-      // TODO: use special SILGen to preserve semantics in this case,
-      // e.g. by making a copy.
-      if (!outerExplicit && !innerExplicit) {
-        return std::nullopt;
-      }
-
-      // Okay, now we're in the domain of the bridging peephole: an
-      // explicit bridging conversion can cancel out an implicit bridge
-      // between related types.
-
-      // If the source and destination types have exactly the same
-      // representation, then (1) they're related and (2) we can directly
-      // emit into the context.
-      if (loweredSourceTy.getObjectType() == loweredResultTy.getObjectType()) {
-        return applyPeephole(ConversionPeepholeHint::Identity);
-      }
-
-      // Look for a subtype relationship between the source and destination.
-      if (areRelatedTypesForBridgingPeephole(sourceType, resultType)) {
-        return applyPeephole(ConversionPeepholeHint::Subtype);
-      }
-
-      // If the inner conversion is a result conversion that removes
-      // optionality, and the non-optional source type is a subtype of the
-      // value type, this is just an implicit force.
-      if (!forced &&
-          innerConversion.getKind() == Conversion::BridgeResultFromObjC) {
-        if (auto sourceValueType = sourceType.getOptionalObjectType()) {
-          if (!intermediateType.getOptionalObjectType() &&
-              areRelatedTypesForBridgingPeephole(sourceValueType, resultType)) {
-            forced = true;
-            return applyPeephole(ConversionPeepholeHint::Subtype);
-          }
-        }
-      }
-
-      return std::nullopt;
-    }
+    case Conversion::BridgeResultFromObjC:
+      return combineBridging(SGF, outer, inner);
 
     default:
       return std::nullopt;
     }
   }
   llvm_unreachable("bad kind");
+}
+
+bool Lowering::canPeepholeConversions(SILGenFunction &SGF,
+                                      const Conversion &outer,
+                                      const Conversion &inner) {
+  return combineConversions(SGF, outer, inner).has_value();
 }

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1538,39 +1538,43 @@ static bool isMatchedAnyToAnyObjectConversion(CanType from, CanType to) {
   return false;
 }
 
-static Conversion withNewInputType(const Conversion &conv,
-                                   AbstractionPattern origType,
-                                   CanType substType,
-                                   SILType loweredType) {
-  switch (conv.getKind()) {
-  case Conversion::Reabstract:
-    return Conversion::getReabstract(origType, substType, loweredType,
-                                     conv.getReabstractionOutputOrigType(),
-                                     conv.getReabstractionOutputSubstType(),
-                                     conv.getReabstractionOutputLoweredType());
-  case Conversion::Subtype:
-    return Conversion::getSubtype(substType, conv.getBridgingResultType(),
-                                  conv.getBridgingLoweredResultType());
+Conversion
+Conversion::withSourceType(SILGenFunction &SGF, CanType substType) const {
+  return withSourceType(AbstractionPattern(substType), substType,
+                        SGF.getLoweredType(substType));
+}
+
+Conversion
+Conversion::withSourceType(AbstractionPattern origType,
+                           CanType substType, SILType loweredType) const {
+  switch (getKind()) {
+  case Reabstract:
+    return getReabstract(origType, substType, loweredType,
+                         getReabstractionOutputOrigType(),
+                         getReabstractionOutputSubstType(),
+                         getReabstractionOutputLoweredType());
+  case Subtype:
+    return getSubtype(substType, getResultType(), getLoweredResultType());
   default:
-    llvm_unreachable("shouldn't be trying to combine these kinds");
+    llvm_unreachable("operation not supported on specialized bridging "
+                     "conversions");
   }
 }
 
-static Conversion withNewOutputType(const Conversion &conv,
-                                    AbstractionPattern origType,
-                                    CanType substType,
-                                    SILType loweredType) {
-  switch (conv.getKind()) {
-  case Conversion::Reabstract:
-    return Conversion::getReabstract(conv.getReabstractionInputOrigType(),
-                                     conv.getReabstractionInputSubstType(),
-                                     conv.getReabstractionInputLoweredType(),
-                                     origType, substType, loweredType);
-  case Conversion::Subtype:
-    return Conversion::getSubtype(conv.getBridgingSourceType(),
-                                  substType, loweredType);
+Conversion
+Conversion::withResultType(AbstractionPattern origType,
+                           CanType substType, SILType loweredType) const {
+  switch (getKind()) {
+  case Reabstract:
+    return getReabstract(getReabstractionInputOrigType(),
+                         getReabstractionInputSubstType(),
+                         getReabstractionInputLoweredType(),
+                         origType, substType, loweredType);
+  case Subtype:
+    return getSubtype(getSourceType(), substType, loweredType);
   default:
-    llvm_unreachable("shouldn't be trying to combine these kinds");
+    llvm_unreachable("operation not supported on specialized bridging "
+                     "conversions");
   }
 }
 
@@ -1735,12 +1739,10 @@ salvageUncombinableConversion(SILGenFunction &SGF,
 
       // Construct the new conversions with the new intermediate type.
       return CombinedConversions(
-               withNewOutputType(inner, newIntermediateOrigType,
-                                 newIntermediateSubstType,
-                                 newIntermediateLoweredType),
-               withNewInputType(outer, newIntermediateOrigType,
-                                newIntermediateSubstType,
-                                newIntermediateLoweredType));
+               inner.withResultType(newIntermediateOrigType,
+                                    newIntermediateSubstType,
+                                    newIntermediateLoweredType),
+               outer.withSourceType(SGF, newIntermediateSubstType));
     }
   }
 

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -34,11 +34,6 @@
 using namespace swift;
 using namespace Lowering;
 
-static std::optional<ConversionPeepholeHint>
-combineConversions(SILGenFunction &SGF, const Conversion &outer,
-                   const Conversion &inner);
-
-
 // FIXME: With some changes to their callers, all of the below functions
 // could be re-worked to use emitInjectEnum().
 ManagedValue
@@ -1138,96 +1133,23 @@ void ConvertingInitialization::
   });
 }
 
-static ManagedValue
-emitPeepholedConversions(SILGenFunction &SGF, SILLocation loc,
-                                   const Conversion &outerConversion,
-                                   const Conversion &innerConversion,
-                                   ConversionPeepholeHint hint,
-                                   SGFContext C,
-                                   ValueProducerRef produceOrigValue) {
-  auto produceValue = [&](SGFContext C) {
-    if (!hint.isForced()) {
-      return produceOrigValue(SGF, loc, C);
-    }
+namespace {
+struct CombinedConversions {
+  std::optional<Conversion> first;
+  std::optional<Conversion> second;
 
-    auto value = produceOrigValue(SGF, loc, SGFContext());
-    auto &optTL = SGF.getTypeLowering(value.getType());
-    // isForceUnwrap is hardcoded true because hint.isForced() is only
-    // set by implicit force unwraps.
-    return SGF.emitCheckedGetOptionalValueFrom(loc, value,
-                                               /*isForceUnwrap*/ true,
-                                               optTL, C);
+  explicit CombinedConversions() {}
+  explicit CombinedConversions(const Conversion &first)
+    : first(first) {}
+  explicit CombinedConversions(const Conversion &first,
+                               const Conversion &second)
+    : first(first), second(second) {}
   };
-
-  auto getBridgingSourceType = [&] {
-    CanType sourceType = innerConversion.getBridgingSourceType();
-    if (hint.isForced())
-      sourceType = sourceType.getOptionalObjectType();
-    return sourceType;
-  };
-  auto getBridgingResultType = [&] {
-    return outerConversion.getBridgingResultType();
-  };
-  auto getBridgingLoweredResultType = [&] {
-    return outerConversion.getBridgingLoweredResultType();
-  };
-
-  switch (hint.getKind()) {
-  case ConversionPeepholeHint::Identity:
-    return produceValue(C);
-
-  case ConversionPeepholeHint::SubtypeIntoReabstract: {
-    assert(!hint.isForced());
-    assert(innerConversion.getKind() == Conversion::Subtype);
-    assert(outerConversion.getKind() == Conversion::Reabstract);
-
-    auto inputSubstType = innerConversion.getBridgingSourceType();
-    auto inputOrigType = AbstractionPattern(inputSubstType);
-    auto inputLoweredTy = SGF.getLoweredType(inputOrigType, inputSubstType);
-    auto newConversion = Conversion::getReabstract(
-      inputOrigType, inputSubstType, inputLoweredTy,
-      outerConversion.getReabstractionOutputOrigType(),
-      outerConversion.getReabstractionOutputSubstType(),
-      outerConversion.getReabstractionOutputLoweredType());
-    return SGF.emitConvertedRValue(loc, newConversion, C, produceOrigValue);
-  }
-
-  case ConversionPeepholeHint::Reabstract: {
-    auto newConversion = Conversion::getReabstract(
-      innerConversion.getReabstractionInputOrigType(),
-      innerConversion.getReabstractionInputSubstType(),
-      innerConversion.getReabstractionInputLoweredType(),
-      outerConversion.getReabstractionOutputOrigType(),
-      outerConversion.getReabstractionOutputSubstType(),
-      outerConversion.getReabstractionOutputLoweredType());
-    return SGF.emitConvertedRValue(loc, newConversion, C, produceOrigValue);
-  }
-
-  case ConversionPeepholeHint::BridgeToAnyObject: {
-    auto value = produceValue(SGFContext());
-    return SGF.emitNativeToBridgedValue(loc, value, getBridgingSourceType(),
-                                        getBridgingResultType(),
-                                        getBridgingLoweredResultType(), C);
-  }
-
-  case ConversionPeepholeHint::Subtype: {
-    // Otherwise, emit and convert.
-    // TODO: if the context allows +0, use it in more situations.
-    auto value = produceValue(SGFContext());
-
-    SILType loweredResultTy = getBridgingLoweredResultType();
-
-    // Nothing to do if the value already has the right representation.
-    if (value.getType().getObjectType() == loweredResultTy.getObjectType())
-      return value;
-
-    CanType sourceType = getBridgingSourceType();
-    CanType resultType = getBridgingResultType();
-    return SGF.emitTransformedValue(loc, value, sourceType, resultType, C);
-  }
-  }
-  llvm_unreachable("bad kind");
 }
+
+static std::optional<CombinedConversions>
+combineConversions(SILGenFunction &SGF, const Conversion &outer,
+                   const Conversion &inner);
 
 bool ConvertingInitialization::tryPeephole(SILGenFunction &SGF,
                                            SILLocation loc,
@@ -1250,16 +1172,32 @@ bool ConvertingInitialization::tryPeephole(SILGenFunction &SGF,
 
 bool ConvertingInitialization::tryPeephole(SILGenFunction &SGF, SILLocation loc,
                                            Conversion innerConversion,
-                                           ValueProducerRef produceValue) {
+                                           ValueProducerRef produceOrigValue) {
   const auto &outerConversion = getConversion();
-  auto hint = combineConversions(SGF, outerConversion, innerConversion);
-  if (!hint)
+  auto combined = combineConversions(SGF, outerConversion, innerConversion);
+  if (!combined)
     return false;
 
-  ManagedValue value = emitPeepholedConversions(SGF, loc, outerConversion,
-                                                innerConversion, *hint,
-                                                FinalContext, produceValue);
-  initWithConvertedValue(SGF, loc, value);
+  assert(!combined->second || combined->first);
+
+  ManagedValue result;
+  if (!combined->first) {
+    result = produceOrigValue(SGF, loc, FinalContext);
+  } else if (!combined->second) {
+    result = SGF.emitConvertedRValue(loc, *combined->first, FinalContext,
+                                     produceOrigValue);
+  } else {
+    // Compute the first result without any context.  We know that we won't
+    // be able to combine these conversions, so computing them together
+    // is just a waste of time, and it runs the risk of an infinite recursion
+    // if we screwed something up.
+    auto firstResult =
+      SGF.emitConvertedRValue(loc, *combined->first, SGFContext(),
+                              produceOrigValue);
+    result = combined->second->emit(SGF, loc, firstResult, FinalContext);
+  }
+
+  initWithConvertedValue(SGF, loc, result);
   return true;
 }
 
@@ -1316,6 +1254,13 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
     return SGF.emitTransformedValue(loc, value, getBridgingSourceType(),
                                     getBridgingResultType(), C);
 
+  case ForceOptional: {
+    auto &optTL = SGF.getTypeLowering(value.getType());
+    return SGF.emitCheckedGetOptionalValueFrom(loc, value,
+                                               /*isForceUnwrap*/ true,
+                                               optTL, C);
+  }
+
   case BridgeToObjC:
     return SGF.emitNativeToBridgedValue(loc, value,
                                         getBridgingSourceType(),
@@ -1366,6 +1311,7 @@ Conversion::adjustForInitialOptionalConversions(CanType newSourceType) const {
     // TODO: handle reabstraction conversions here, too.
     return std::nullopt;
 
+  case ForceOptional:
   case ForceAndBridgeToObjC:
     return std::nullopt;
 
@@ -1388,6 +1334,7 @@ std::optional<Conversion> Conversion::adjustForInitialForceValue() const {
   case AnyErasure:
   case BridgeFromObjC:
   case BridgeResultFromObjC:
+  case ForceOptional:
   case ForceAndBridgeToObjC:
   case Subtype:
     return std::nullopt;
@@ -1444,6 +1391,8 @@ void Conversion::print(llvm::raw_ostream &out) const {
     return printBridging(*this, out, "AnyErasure");
   case Subtype:
     return printBridging(*this, out, "Subtype");
+  case ForceOptional:
+    return printBridging(*this, out, "ForceOptional");
   case BridgeToObjC:
     return printBridging(*this, out, "BridgeToObjC");
   case ForceAndBridgeToObjC:
@@ -1660,7 +1609,7 @@ static bool isPeepholeableConversion(CanType innerSrcType, CanType innerDestType
   return isPeepholeableConversionImpl(innerSrcType, innerDestType, outerDestType);
 }
 
-static std::optional<ConversionPeepholeHint>
+static std::optional<CombinedConversions>
 combineReabstract(SILGenFunction &SGF,
                   const Conversion &outer,
                   const Conversion &inner) {
@@ -1675,12 +1624,21 @@ combineReabstract(SILGenFunction &SGF,
   // Recognize when the whole conversion is an identity.
   if (inner.getReabstractionInputLoweredType().getObjectType() ==
       outer.getReabstractionOutputLoweredType().getObjectType())
-    return ConversionPeepholeHint(ConversionPeepholeHint::Identity, false);
+    return CombinedConversions();
 
-  return ConversionPeepholeHint(ConversionPeepholeHint::Reabstract, false);
+  // Produce a single conversion that goes straight from the inner input
+  // to the outer output.
+  return CombinedConversions(
+    Conversion::getReabstract(inner.getReabstractionInputOrigType(),
+                              inner.getReabstractionInputSubstType(),
+                              inner.getReabstractionInputLoweredType(),
+                              outer.getReabstractionOutputOrigType(),
+                              outer.getReabstractionOutputSubstType(),
+                              outer.getReabstractionOutputLoweredType())
+  );
 }
 
-static std::optional<ConversionPeepholeHint>
+static std::optional<CombinedConversions>
 combineSubtypeIntoReabstract(SILGenFunction &SGF,
                              const Conversion &outer,
                              const Conversion &inner) {
@@ -1692,11 +1650,20 @@ combineSubtypeIntoReabstract(SILGenFunction &SGF,
                                 outer.getReabstractionOutputSubstType()))
     return std::nullopt;
 
-  return ConversionPeepholeHint(
-           ConversionPeepholeHint::SubtypeIntoReabstract, false);
+  auto inputSubstType = inner.getBridgingSourceType();
+  auto inputOrigType = AbstractionPattern(inputSubstType);
+  auto inputLoweredTy = SGF.getLoweredType(inputOrigType, inputSubstType);
+
+  return CombinedConversions(
+    Conversion::getReabstract(
+      inputOrigType, inputSubstType, inputLoweredTy,
+      outer.getReabstractionOutputOrigType(),
+      outer.getReabstractionOutputSubstType(),
+      outer.getReabstractionOutputLoweredType())
+  );
 }
 
-static std::optional<ConversionPeepholeHint>
+static std::optional<CombinedConversions>
 combineSubtype(SILGenFunction &SGF,
                const Conversion &outer, const Conversion &inner) {
   if (!isPeepholeableConversion(inner.getBridgingSourceType(),
@@ -1705,10 +1672,14 @@ combineSubtype(SILGenFunction &SGF,
                                 outer.getBridgingResultType()))
     return std::nullopt;
 
-  return ConversionPeepholeHint(ConversionPeepholeHint::Subtype, false);
+  return CombinedConversions(
+    Conversion::getSubtype(inner.getBridgingSourceType(),
+                           outer.getBridgingResultType(),
+                           outer.getBridgingLoweredResultType())
+  );
 }
 
-static std::optional<ConversionPeepholeHint>
+static std::optional<CombinedConversions>
 combineBridging(SILGenFunction &SGF,
                const Conversion &outer, const Conversion &inner) {
   bool outerExplicit = outer.isBridgingExplicit();
@@ -1734,6 +1705,7 @@ combineBridging(SILGenFunction &SGF,
     sourceType = sourceType.getOptionalObjectType();
     if (!sourceType)
       return std::nullopt;
+
     intermediateType = intermediateType.getOptionalObjectType();
     assert(intermediateType);
   }
@@ -1742,19 +1714,34 @@ combineBridging(SILGenFunction &SGF,
   SILType loweredSourceTy = SGF.getLoweredType(sourceType);
   SILType loweredResultTy = outer.getBridgingLoweredResultType();
 
-  auto applyPeephole = [&](ConversionPeepholeHint::Kind kind) {
-    return ConversionPeepholeHint(kind, forced);
+  auto applyPeephole = [&](const std::optional<Conversion> &conversion) {
+    if (!forced) {
+      if (!conversion)
+        return CombinedConversions();
+      return CombinedConversions(*conversion);
+    }
+
+    auto forceConversion =
+      Conversion::getBridging(Conversion::ForceOptional,
+                              inner.getBridgingSourceType(), sourceType,
+                              loweredSourceTy);
+    if (conversion)
+      return CombinedConversions(forceConversion, *conversion);
+    return CombinedConversions(forceConversion);
   };
 
   // Converting to Any doesn't do anything semantically special, so we
   // can apply the peephole unconditionally.
   if (isMatchedAnyToAnyObjectConversion(intermediateType, resultType)) {
     if (loweredSourceTy == loweredResultTy) {
-      return applyPeephole(ConversionPeepholeHint::Identity);
+      return applyPeephole(std::nullopt);
     } else if (isValueToAnyConversion(sourceType, intermediateType)) {
-      return applyPeephole(ConversionPeepholeHint::BridgeToAnyObject);
+      return applyPeephole(
+        Conversion::getBridging(Conversion::BridgeToObjC,
+                                sourceType, resultType, loweredResultTy));
     } else {
-      return applyPeephole(ConversionPeepholeHint::Subtype);
+      return applyPeephole(
+        Conversion::getSubtype(sourceType, resultType, loweredResultTy));
     }
   }
 
@@ -1776,12 +1763,13 @@ combineBridging(SILGenFunction &SGF,
   // representation, then (1) they're related and (2) we can directly
   // emit into the context.
   if (loweredSourceTy.getObjectType() == loweredResultTy.getObjectType()) {
-    return applyPeephole(ConversionPeepholeHint::Identity);
+    return applyPeephole(std::nullopt);
   }
 
   // Look for a subtype relationship between the source and destination.
   if (areRelatedTypesForBridgingPeephole(sourceType, resultType)) {
-    return applyPeephole(ConversionPeepholeHint::Subtype);
+    return applyPeephole(
+      Conversion::getSubtype(sourceType, resultType, loweredResultTy));
   }
 
   // If the inner conversion is a result conversion that removes
@@ -1793,7 +1781,10 @@ combineBridging(SILGenFunction &SGF,
       if (!intermediateType.getOptionalObjectType() &&
           areRelatedTypesForBridgingPeephole(sourceValueType, resultType)) {
         forced = true;
-        return applyPeephole(ConversionPeepholeHint::Subtype);
+        sourceType = sourceValueType;
+        loweredSourceTy = loweredSourceTy.getOptionalObjectType();
+        return applyPeephole(
+          Conversion::getSubtype(sourceValueType, resultType, loweredResultTy));
       }
     }
   }
@@ -1803,7 +1794,7 @@ combineBridging(SILGenFunction &SGF,
 
 /// TODO: this would really be a lot cleaner if it just returned a
 /// std::optional<Conversion>.
-static std::optional<ConversionPeepholeHint>
+static std::optional<CombinedConversions>
 combineConversions(SILGenFunction &SGF, const Conversion &outer,
                    const Conversion &inner) {
   switch (outer.getKind()) {
@@ -1829,6 +1820,9 @@ combineConversions(SILGenFunction &SGF, const Conversion &outer,
   case Conversion::BridgeResultFromObjC:
     // TODO: maybe peephole bridging through a Swift type?
     // This isn't actually something that happens in normal code generation.
+    return std::nullopt;
+
+  case Conversion::ForceOptional:
     return std::nullopt;
 
   case Conversion::ForceAndBridgeToObjC:

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -1034,7 +1034,8 @@ ManagedValue SILGenFunction::emitAsOrig(SILLocation loc,
                                         ValueProducerRef produceValue) {
   // If the lowered substituted type already matches the substitution,
   // we can just emit directly.
-  if (getLoweredType(substType).getASTType() == expectedTy.getASTType()) {
+  auto loweredSubstTy = getLoweredType(substType);
+  if (loweredSubstTy.getASTType() == expectedTy.getASTType()) {
     auto result = produceValue(*this, loc, C);
 
     // For convenience, force the result into the destination.
@@ -1046,7 +1047,7 @@ ManagedValue SILGenFunction::emitAsOrig(SILLocation loc,
   }
 
   auto conversion =
-    Conversion::getSubstToOrig(origType, substType, expectedTy);
+    Conversion::getSubstToOrig(origType, substType, loweredSubstTy, expectedTy);
   auto result = emitConvertedRValue(loc, conversion, C, produceValue);
 
   // emitConvertedRValue always forces results into the context.
@@ -1170,19 +1171,30 @@ emitPeepholedConversions(SILGenFunction &SGF, SILLocation loc,
   case ConversionPeepholeHint::Identity:
     return produceValue(C);
 
-  case ConversionPeepholeHint::SubtypeIntoSubstToOrig: {
+  case ConversionPeepholeHint::SubtypeIntoReabstract: {
     assert(!hint.isForced());
     assert(innerConversion.getKind() == Conversion::Subtype);
-    assert(outerConversion.getKind() == Conversion::SubstToOrig);
-    // The outer conversion's source type is somewhere between
-    // the inner conversion's source type and the outer conversion's result
-    // type, but subtyping is not path-dependent (right?) so we shouldn't
-    // have to preserve it.
-    auto newConversion = Conversion::getSubstToOrig(
-      innerConversion.getBridgingSourceType(),
-      outerConversion.getReabstractionOrigType(),
-      outerConversion.getReabstractionSubstResultType(),
-      outerConversion.getReabstractionLoweredResultType());
+    assert(outerConversion.getKind() == Conversion::Reabstract);
+
+    auto inputSubstType = innerConversion.getBridgingSourceType();
+    auto inputOrigType = AbstractionPattern(inputSubstType);
+    auto inputLoweredTy = SGF.getLoweredType(inputOrigType, inputSubstType);
+    auto newConversion = Conversion::getReabstract(
+      inputOrigType, inputSubstType, inputLoweredTy,
+      outerConversion.getReabstractionOutputOrigType(),
+      outerConversion.getReabstractionOutputSubstType(),
+      outerConversion.getReabstractionOutputLoweredType());
+    return SGF.emitConvertedRValue(loc, newConversion, C, produceOrigValue);
+  }
+
+  case ConversionPeepholeHint::Reabstract: {
+    auto newConversion = Conversion::getReabstract(
+      innerConversion.getReabstractionInputOrigType(),
+      innerConversion.getReabstractionInputSubstType(),
+      innerConversion.getReabstractionInputLoweredType(),
+      outerConversion.getReabstractionOutputOrigType(),
+      outerConversion.getReabstractionOutputSubstType(),
+      outerConversion.getReabstractionOutputLoweredType());
     return SGF.emitConvertedRValue(loc, newConversion, C, produceOrigValue);
   }
 
@@ -1329,21 +1341,15 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
                                         getBridgingLoweredResultType(), C,
                                         /*isResult*/ true);
 
-  case SubstToOrig:
+  case Reabstract:
+    assert(value.getType().getObjectType() ==
+           getReabstractionInputLoweredType().getObjectType());
     return SGF.emitTransformedValue(loc, value,
-                 AbstractionPattern(getReabstractionSubstSourceType()),
-                                    getReabstractionSubstSourceType(),
-                                    getReabstractionOrigType(),
-                                    getReabstractionSubstResultType(),
-                                    getReabstractionLoweredResultType(), C);
-
-  case OrigToSubst:
-    return SGF.emitTransformedValue(loc, value,
-                                    getReabstractionOrigType(),
-                                    getReabstractionSubstSourceType(),
-                 AbstractionPattern(getReabstractionSubstResultType()),
-                                    getReabstractionSubstResultType(),
-                                    getReabstractionLoweredResultType(), C);
+                                    getReabstractionInputOrigType(),
+                                    getReabstractionInputSubstType(),
+                                    getReabstractionOutputOrigType(),
+                                    getReabstractionOutputSubstType(),
+                                    getReabstractionOutputLoweredType(), C);
   }
   llvm_unreachable("bad kind");
 }
@@ -1351,8 +1357,7 @@ ManagedValue Conversion::emit(SILGenFunction &SGF, SILLocation loc,
 std::optional<Conversion>
 Conversion::adjustForInitialOptionalConversions(CanType newSourceType) const {
   switch (getKind()) {
-  case SubstToOrig:
-  case OrigToSubst:
+  case Reabstract:
     // TODO: handle reabstraction conversions here, too.
     return std::nullopt;
 
@@ -1374,8 +1379,7 @@ Conversion::adjustForInitialOptionalConversions(CanType newSourceType) const {
 
 std::optional<Conversion> Conversion::adjustForInitialForceValue() const {
   switch (getKind()) {
-  case SubstToOrig:
-  case OrigToSubst:
+  case Reabstract:
   case AnyErasure:
   case BridgeFromObjC:
   case BridgeResultFromObjC:
@@ -1403,14 +1407,18 @@ void Conversion::dump() const {
 
 static void printReabstraction(const Conversion &conversion,
                                llvm::raw_ostream &out, StringRef name) {
-  out << name << "(orig: ";
-  conversion.getReabstractionOrigType().print(out);
-  out << ", substSource: ";
-  conversion.getReabstractionSubstSourceType().print(out);
-  out << ", substResult: ";
-  conversion.getReabstractionSubstResultType().print(out);
-  out << ", loweredResult: ";
-  conversion.getReabstractionLoweredResultType().print(out);
+  out << name << "(inputOrig: ";
+  conversion.getReabstractionInputOrigType().print(out);
+  out << ", inputSubst: ";
+  conversion.getReabstractionInputSubstType().print(out);
+  out << ", inputLowered: ";
+  conversion.getReabstractionInputLoweredType().print(out);
+  out << ", outputOrig: ";
+  conversion.getReabstractionOutputOrigType().print(out);
+  out << ", outputSubst: ";
+  conversion.getReabstractionOutputSubstType().print(out);
+  out << ", outputLowered: ";
+  conversion.getReabstractionOutputLoweredType().print(out);
   out << ')';
 }
 
@@ -1425,10 +1433,8 @@ static void printBridging(const Conversion &conversion, llvm::raw_ostream &out,
 
 void Conversion::print(llvm::raw_ostream &out) const {
   switch (getKind()) {
-  case SubstToOrig:
-    return printReabstraction(*this, out, "SubstToOrig");
-  case OrigToSubst:
-    return printReabstraction(*this, out, "OrigToSubst");
+  case Reabstract:
+    return printReabstraction(*this, out, "Reabstract");
   case AnyErasure:
     return printBridging(*this, out, "AnyErasure");
   case Subtype:
@@ -1525,6 +1531,130 @@ static bool isMatchedAnyToAnyObjectConversion(CanType from, CanType to) {
   return false;
 }
 
+/// Can a sequence of conversions from type1 -> type2 -> type3 be represented
+/// as a conversion from type1 -> type3, or does that lose critical information?
+static bool isPeepholeableConversionImpl(CanType type1,
+                                         CanType type2,
+                                         CanType type3) {
+  if (type1 == type2 || type2 == type3) return true;
+
+  // If the final result type is optional, then either we've got two
+  // optional->optional conversions or we injected into optional in at
+  // least one of the stages.  Our analysis of how to do the conversion is
+  // going to be sensitive to the static optional depth, so make sure we
+  // don't lose that.
+  if (auto object3 = type3.getOptionalObjectType()) {
+    if (auto object2 = type2.getOptionalObjectType()) {
+      // If we have optional -> optional conversions at both stages,
+      // look through them all.
+      if (auto object1 = type1.getOptionalObjectType()) {
+        return isPeepholeableConversionImpl(object1, object2, object3);
+
+      // If we have an injection in the first stage, we'll still know we have
+      // an injection in the overall conversion.
+      } else {
+        return isPeepholeableConversionImpl(type1, object2, object3);
+      }
+
+    // We have an injection in the second stage.  If we lose optionality
+    // in the first stage (i.e. we're converting an optional to an
+    // existential), then the combined conversion will be misinterpreted
+    // as an optional-to-optional conversion.
+    } else if (type1.getOptionalObjectType()) {
+      return false;
+
+    // Otherwise, we're preserving that we have an injection overall.
+    } else {
+      return isPeepholeableConversionImpl(type1, type2, object3);
+    }
+  }
+
+  // When we open an existential, we bind the erased type; this type should
+  // not change if we combine the conversions.  The binding looks
+  // polymorphically through certain types but not through others.
+  if (type3.isExistentialType()) {
+    // We need to consider type2 to see if it has structure that
+    // would make it non-polymorphic, like if it's an optional.
+
+    // Existentials (including existential metatypes) are polymorphic.
+    if (type2.isAnyExistentialType())
+      return true;
+
+    // Class types are polymorphic.
+    if (type2.isAnyClassReferenceType())
+      return true;
+
+    // Metatypes are polymorphic.
+    if (isa<MetatypeType>(type2))
+      return true;
+
+    // Otherwise, no.  Since we know that type1 != type2, we know that type2
+    // must have some kind of subtype-supporting structure; with the cases
+    // above ruled out, that must be either an optional or a function type.
+    // Note that, with an optional, we can probably still dynamically cast
+    // successfully, but that's not the standard we need to enforce here.
+    return false;
+  }
+
+  // If we have a function or tuple type, we need to see if we have a
+  // non-peepholeable conversion in the subconversions.
+
+  if (auto tuple3 = dyn_cast<TupleType>(type3)) {
+    auto tuple2 = cast<TupleType>(type2);
+    auto tuple1 = cast<TupleType>(type1);
+    assert(tuple1->getNumElements() == tuple3->getNumElements());
+    assert(tuple2->getNumElements() == tuple3->getNumElements());
+    for (auto i : range(tuple3->getNumElements())) {
+      if (!isPeepholeableConversionImpl(tuple1.getElementType(i),
+                                        tuple2.getElementType(i),
+                                        tuple3.getElementType(i)))
+        return false;
+    }
+    return true;
+  }
+
+  if (auto fn3 = dyn_cast<AnyFunctionType>(type3)) {
+    auto fn2 = cast<AnyFunctionType>(type2);
+    auto fn1 = cast<AnyFunctionType>(type1);
+    assert(fn1->getNumParams() == fn3->getNumParams());
+    assert(fn2->getNumParams() == fn3->getNumParams());
+    if (!isPeepholeableConversionImpl(fn1.getResult(),
+                                      fn2.getResult(),
+                                      fn3.getResult()))
+      return false;
+    for (auto i : range(fn3->getNumParams())) {
+      // Note the reversal for invariance.
+      if (!isPeepholeableConversionImpl(fn3.getParams()[i].getParameterType(),
+                                        fn2.getParams()[i].getParameterType(),
+                                        fn1.getParams()[i].getParameterType()))
+        return false;
+    }
+    return true;
+  }
+
+  if (auto exp3 = dyn_cast<PackExpansionType>(type3)) {
+    auto exp2 = cast<PackExpansionType>(type2);
+    auto exp1 = cast<PackExpansionType>(type1);
+    return isPeepholeableConversionImpl(exp1.getPatternType(),
+                                        exp2.getPatternType(),
+                                        exp3.getPatternType());
+  }
+
+  // The only remaining types that support subtyping are classes and
+  // metatypes, and we can definitely just convert those.
+  return true;
+}
+
+/// Can we combine the given conversions so that we go straight from
+/// innerSrcType to outerDestType, or does that lose information?
+static bool isPeepholeableConversion(CanType innerSrcType, CanType innerDestType,
+                                     CanType outerSrcType, CanType outerDestType) {
+  assert(innerDestType == outerSrcType &&
+         "unexpected intermediate conversion");
+
+  return isPeepholeableConversionImpl(innerSrcType, innerDestType, outerDestType);
+}
+
 /// TODO: this would really be a lot cleaner if it just returned a
 /// std::optional<Conversion>.
 std::optional<ConversionPeepholeHint>
@@ -1532,28 +1662,37 @@ Lowering::canPeepholeConversions(SILGenFunction &SGF,
                                  const Conversion &outerConversion,
                                  const Conversion &innerConversion) {
   switch (outerConversion.getKind()) {
-  case Conversion::OrigToSubst:
-  case Conversion::SubstToOrig:
+  case Conversion::Reabstract:
     switch (innerConversion.getKind()) {
-    case Conversion::OrigToSubst:
-    case Conversion::SubstToOrig:
-      if (innerConversion.getKind() == outerConversion.getKind())
-        break;
+    case Conversion::Reabstract:
+      // We can never combine conversions in a way that would lose information
+      // about the intermediate types.
+      if (!isPeepholeableConversion(
+             innerConversion.getReabstractionInputSubstType(),
+             innerConversion.getReabstractionOutputSubstType(),
+             outerConversion.getReabstractionInputSubstType(),
+             outerConversion.getReabstractionOutputSubstType()))
+        return std::nullopt;
 
-      if (innerConversion.getReabstractionOrigType().getCachingKey() !=
-          outerConversion.getReabstractionOrigType().getCachingKey() ||
-          innerConversion.getReabstractionSubstSourceType() !=
-          outerConversion.getReabstractionSubstResultType()) {
-        break;
-      }
+      // Recognize when the whole conversion is an identity.
+      if (innerConversion.getReabstractionInputLoweredType().getObjectType() ==
+          outerConversion.getReabstractionOutputLoweredType().getObjectType())
+        return ConversionPeepholeHint(ConversionPeepholeHint::Identity, false);
 
-      return ConversionPeepholeHint(ConversionPeepholeHint::Identity, false);
+      return ConversionPeepholeHint(ConversionPeepholeHint::Reabstract, false);
 
     case Conversion::Subtype:
-      if (outerConversion.getKind() == Conversion::SubstToOrig)
-        return ConversionPeepholeHint(
-                 ConversionPeepholeHint::SubtypeIntoSubstToOrig, false);
-      break;
+      // We can never combine conversions in a way that would lose information
+      // about the intermediate types.
+      if (!isPeepholeableConversion(
+             innerConversion.getBridgingSourceType(),
+             innerConversion.getBridgingResultType(),
+             outerConversion.getReabstractionInputSubstType(),
+             outerConversion.getReabstractionOutputSubstType()))
+        return std::nullopt;
+
+      return ConversionPeepholeHint(
+               ConversionPeepholeHint::SubtypeIntoReabstract, false);
 
     default:
       break;
@@ -1562,7 +1701,11 @@ Lowering::canPeepholeConversions(SILGenFunction &SGF,
     return std::nullopt;
 
   case Conversion::Subtype:
-    if (innerConversion.getKind() == Conversion::Subtype)
+    if (innerConversion.getKind() == Conversion::Subtype &&
+        isPeepholeableConversion(innerConversion.getBridgingSourceType(),
+                                 innerConversion.getBridgingResultType(),
+                                 outerConversion.getBridgingSourceType(),
+                                 outerConversion.getBridgingResultType()))
       return ConversionPeepholeHint(ConversionPeepholeHint::Subtype, false);
     return std::nullopt;
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -679,7 +679,7 @@ static BridgingConversion getBridgingConversion(Expr *E) {
 
   // If we peeked through an opening, and we didn't recognize a specific
   // pattern above involving the opaque value, make sure we use the opening
-  // as the final expression instead of accidentally look through it.
+  // as the final expression instead of accidentally looking through it.
   if (open)
     return {open, std::nullopt, 0};
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2840,24 +2840,18 @@ wrappedValueAutoclosurePlaceholder(const AbstractClosureExpr *e) {
 static std::optional<FunctionTypeInfo>
 tryGetSpecializedClosureTypeFromContext(CanAnyFunctionType closureType,
                                         const Conversion &conv) {
-  if (conv.getKind() == Conversion::Reabstract) {
+  // Note that the kinds of conversion we work on here have to be kinds
+  // that we can call withSourceType on later.
+  if (conv.getKind() == Conversion::Reabstract ||
+      conv.getKind() == Conversion::Subtype) {
     // We don't care about the input type here; we'll be emitting that
     // based on the closure.
-    auto destType =
-      cast<AnyFunctionType>(conv.getReabstractionOutputSubstType());
+    auto destType = cast<AnyFunctionType>(conv.getResultType());
     auto origType =
-      conv.getReabstractionOutputOrigType();
-    auto expectedTy =
-      conv.getReabstractionOutputLoweredType().castTo<SILFunctionType>();
-    return FunctionTypeInfo{origType, destType, expectedTy};
-  }
-
-  if (conv.getKind() == Conversion::Subtype) {
-    assert(closureType == conv.getBridgingSourceType());
-    auto destType = cast<AnyFunctionType>(conv.getBridgingResultType());
-    auto origType = AbstractionPattern(destType);
-    auto expectedTy =
-      conv.getBridgingLoweredResultType().castTo<SILFunctionType>();
+      conv.getKind() == Conversion::Reabstract
+        ? conv.getReabstractionOutputOrigType()
+        : AbstractionPattern(destType);
+    auto expectedTy = conv.getLoweredResultType().castTo<SILFunctionType>();
     return FunctionTypeInfo{origType, destType, expectedTy};
   }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2840,9 +2840,6 @@ wrappedValueAutoclosurePlaceholder(const AbstractClosureExpr *e) {
 static std::optional<FunctionTypeInfo>
 tryGetSpecializedClosureTypeFromContext(CanAnyFunctionType closureType,
                                         const Conversion &conv) {
-  // NOTE: if you support new kinds of conversion here, make sure you can
-  // rewrite them in narrowClosureConvention below
-
   if (conv.getKind() == Conversion::Reabstract) {
     // We don't care about the input type here; we'll be emitting that
     // based on the closure.
@@ -2866,33 +2863,6 @@ tryGetSpecializedClosureTypeFromContext(CanAnyFunctionType closureType,
 
   // No other kinds of conversion.
   return std::nullopt;
-}
-
-/// Given that tryGetSpecializedClosureTypeFromContext was able to return
-/// specialized closure type information from the given contextual conversion,
-/// construct a new conversion that starts from the given type, which is a
-/// supertype of the previous closure type but a subtype of the final type.
-/// The conversion should end with the same type.
-static Conversion narrowClosureConversion(SILGenFunction &SGF,
-                                          CanAnyFunctionType newClosureType,
-                                          const Conversion &conv) {
-  if (conv.getKind() == Conversion::Reabstract) {
-    auto inputOrigType = conv.getReabstractionInputOrigType();
-    auto inputLoweredTy = SGF.getLoweredType(inputOrigType, newClosureType);
-    return Conversion::getReabstract(inputOrigType, newClosureType,
-                                     inputLoweredTy,
-                                     conv.getReabstractionOutputOrigType(),
-                                     conv.getReabstractionOutputSubstType(),
-                                     conv.getReabstractionOutputLoweredType());
-  }
-
-  if (conv.getKind() == Conversion::Subtype) {
-    return Conversion::getSubtype(newClosureType,
-                                  conv.getBridgingResultType(),
-                                  conv.getBridgingLoweredResultType());
-  }
-
-  llvm_unreachable("mismatch with tryGetSpecializedClosureTypeFromContext");
 }
 
 /// Whether the given abstraction pattern as an opaque thrown error.
@@ -3007,7 +2977,7 @@ RValueEmitter::tryEmitConvertedClosure(AbstractClosureExpr *e,
     auto erasedResult = emitClosureReference(e, erasureInfo);
 
     // Narrow the original conversion to start from the erased closure type.
-    auto convAfterErasure = narrowClosureConversion(SGF, erasedClosureType, conv);
+    auto convAfterErasure = conv.withSourceType(SGF, erasedClosureType);
 
     // Apply the narrowed conversion.
     return convAfterErasure.emit(SGF, e, erasedResult, SGFContext());

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2843,11 +2843,15 @@ tryGetSpecializedClosureTypeFromContext(CanAnyFunctionType closureType,
   // NOTE: if you support new kinds of conversion here, make sure you can
   // rewrite them in narrowClosureConvention below
 
-  if (conv.getKind() == Conversion::SubstToOrig) {
-    auto destType = cast<AnyFunctionType>(conv.getReabstractionSubstResultType());
-    auto origType = conv.getReabstractionOrigType();
+  if (conv.getKind() == Conversion::Reabstract) {
+    // We don't care about the input type here; we'll be emitting that
+    // based on the closure.
+    auto destType =
+      cast<AnyFunctionType>(conv.getReabstractionOutputSubstType());
+    auto origType =
+      conv.getReabstractionOutputOrigType();
     auto expectedTy =
-      conv.getReabstractionLoweredResultType().castTo<SILFunctionType>();
+      conv.getReabstractionOutputLoweredType().castTo<SILFunctionType>();
     return FunctionTypeInfo{origType, destType, expectedTy};
   }
 
@@ -2869,13 +2873,17 @@ tryGetSpecializedClosureTypeFromContext(CanAnyFunctionType closureType,
 /// construct a new conversion that starts from the given type, which is a
 /// supertype of the previous closure type but a subtype of the final type.
 /// The conversion should end with the same type.
-static Conversion narrowClosureConversion(CanAnyFunctionType newClosureType,
+static Conversion narrowClosureConversion(SILGenFunction &SGF,
+                                          CanAnyFunctionType newClosureType,
                                           const Conversion &conv) {
-  if (conv.getKind() == Conversion::SubstToOrig) {
-    return Conversion::getSubstToOrig(newClosureType,
-                                      conv.getReabstractionOrigType(),
-                                      conv.getReabstractionSubstResultType(),
-                                      conv.getReabstractionLoweredResultType());
+  if (conv.getKind() == Conversion::Reabstract) {
+    auto inputOrigType = conv.getReabstractionInputOrigType();
+    auto inputLoweredTy = SGF.getLoweredType(inputOrigType, newClosureType);
+    return Conversion::getReabstract(inputOrigType, newClosureType,
+                                     inputLoweredTy,
+                                     conv.getReabstractionOutputOrigType(),
+                                     conv.getReabstractionOutputSubstType(),
+                                     conv.getReabstractionOutputLoweredType());
   }
 
   if (conv.getKind() == Conversion::Subtype) {
@@ -2999,7 +3007,7 @@ RValueEmitter::tryEmitConvertedClosure(AbstractClosureExpr *e,
     auto erasedResult = emitClosureReference(e, erasureInfo);
 
     // Narrow the original conversion to start from the erased closure type.
-    auto convAfterErasure = narrowClosureConversion(erasedClosureType, conv);
+    auto convAfterErasure = narrowClosureConversion(SGF, erasedClosureType, conv);
 
     // Apply the narrowed conversion.
     return convAfterErasure.emit(SGF, e, erasedResult, SGFContext());

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -4594,7 +4594,8 @@ ManagedValue SILGenFunction::emitLoad(SILLocation loc, SILValue addr,
                                 origFormalType.getType(),
                                 substFormalType, rvalueTL.getLoweredType())
       : Conversion::getOrigToSubst(origFormalType, substFormalType,
-                                   rvalueTL.getLoweredType());
+                                   /*input*/addrRValueType,
+                                   /*output*/rvalueTL.getLoweredType());
 
   return emitConvertedRValue(loc, conversion, C,
       [&](SILGenFunction &SGF, SILLocation loc, SGFContext C) {

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -461,9 +461,12 @@ static void wrapInSubstToOrigInitialization(SILGenFunction &SGF,
                                     AbstractionPattern origType,
                                     CanType substType,
                                     SILType expectedTy) {
-  if (expectedTy.getASTType() != SGF.getLoweredRValueType(substType)) {
+  auto loweredSubstTy = SGF.getLoweredRValueType(substType);
+  if (expectedTy.getASTType() != loweredSubstTy) {
     auto conversion =
-      Conversion::getSubstToOrig(origType, substType, expectedTy);
+      Conversion::getSubstToOrig(origType, substType,
+                                 SILType::getPrimitiveObjectType(loweredSubstTy),
+                                 expectedTy);
     auto convertingInit = new ConvertingInitialization(conversion,
                                                        std::move(init));
     init.reset(convertingInit);
@@ -733,10 +736,11 @@ void SILGenFunction::emitReturnExpr(SILLocation branchLoc,
     // Does the return context require reabstraction?
     RValue RV;
     
-    auto loweredRetTy = getLoweredType(origRetTy, retTy);
-    if (loweredRetTy != getLoweredType(retTy)) {
+    auto loweredRetTy = getLoweredType(retTy);
+    auto loweredResultTy = getLoweredType(origRetTy, retTy);
+    if (loweredResultTy != loweredRetTy) {
       auto conversion = Conversion::getSubstToOrig(origRetTy, retTy,
-                                                   loweredRetTy);
+                                                   loweredRetTy, loweredResultTy);
       RV = RValue(*this, ret, emitConvertedRValue(ret, conversion));
     } else {
       RV = emitRValue(ret);

--- a/test/SILGen/isolated_any.swift
+++ b/test/SILGen/isolated_any.swift
@@ -383,6 +383,29 @@ extension MyActor {
   func asyncAction() async {}
 }
 
+func takeInheritingOptionalAsyncIsolatedAny(@_inheritActorContext fn: Optional<@isolated(any) () async -> ()>) {}
+
+// CHECK-LABEL: sil hidden [ossa] @$s4test7MyActorC0a20EraseInheritingAsyncC19ClosureIntoOptionalyyF
+// CHECK:         // function_ref closure #1
+// CHECK-NEXT:    [[CLOSURE_FN:%.*]] = function_ref @$s4test7MyActorC0a20EraseInheritingAsyncC19ClosureIntoOptionalyyFyyYaYbcfU_ : $@convention(thin) @Sendable @async (@guaranteed Optional<any Actor>, @sil_isolated @guaranteed MyActor) -> ()
+// CHECK-NEXT:    [[CAPTURE:%.*]] = copy_value %0 : $MyActor
+// CHECK-NEXT:    [[CAPTURE_FOR_ISOLATION:%.*]] = copy_value [[CAPTURE]] : $MyActor
+// CHECK-NEXT:    [[ISOLATION_OBJECT:%.*]] = init_existential_ref [[CAPTURE_FOR_ISOLATION]] : $MyActor : $MyActor, $any Actor
+// CHECK-NEXT:    [[ISOLATION:%.*]] = enum $Optional<any Actor>, #Optional.some!enumelt, [[ISOLATION_OBJECT]] : $any Actor
+// CHECK-NEXT:    [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [isolated_any] [[CLOSURE_FN]]([[ISOLATION]], [[CAPTURE]])
+// CHECK-NEXT:    [[OPT_CLOSURE:%.*]] = enum $Optional<@isolated(any) @Sendable @async @callee_guaranteed () -> ()>, #Optional.some!enumelt, [[CLOSURE]] :
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    [[TAKE_FN:%.*]] = function_ref @$s4test38takeInheritingOptionalAsyncIsolatedAny2fnyyyYaYbYAcSg_tF
+// CHECK-NEXT:    apply [[TAKE_FN]]([[OPT_CLOSURE]])
+// CHECK-NEXT:    destroy_value [[OPT_CLOSURE]]
+extension MyActor {
+  func testEraseInheritingAsyncActorClosureIntoOptional() {
+    takeInheritingOptionalAsyncIsolatedAny {
+      await self.asyncAction()
+    }
+  }
+}
+
 func takeInheritingAsyncIsolatedAny_optionalResult(@_inheritActorContext fn: @escaping @isolated(any) () async -> Int?) {}
 
 // Test that we correctly handle isolation erasure from closures even when


### PR DESCRIPTION
Also, a bunch of general improvements to the `Conversion` machinery.