### PR TITLE
[6.0][Parse] Disallow specifiers in front of parameter declarations

### DIFF
--- a/test/Parse/parameter_specifier_before_param_name.swift
+++ b/test/Parse/parameter_specifier_before_param_name.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: concurrency
+
+@available(SwiftStdlib 5.1, *)
+actor MyActor {}
+
+class MyClass {}
+
+// Lifetime specifiers before parameter names were disallowed in Swift 3 (SE-0031).
+// `isolated`, `transferring` and `_const` got added after Swift 3 without a diagnostic 
+// to disallow them before parameter names.
+
+func foo(inout x b: MyClass) {} // expected-error {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}
+
+func foo(borrowing x b: MyClass) {} // expected-error {{'borrowing' before a parameter name is not allowed, place it before the parameter type instead}}
+
+@available(SwiftStdlib 5.1, *)
+func foo(isolated x b: MyActor) {} // expected-warning {{'isolated' before a parameter name is not allowed, place it before the parameter type instead; this is an error in the Swift 6 language mode}}
+
+func foo(_const x b: MyClass) {} // expected-warning {{'_const' before a parameter name is not allowed, place it before the parameter type instead; this is an error in the Swift 6 language mode}}
+
+// expected-error@+3 {{expected ',' separator}}
+// expected-error@+2 {{expected ':' following argument label and parameter name}}
+@available(SwiftStdlib 5.1, *)
+func foo(transferring x b: MyActor) {}

--- a/test/Sema/const_keypath.swift
+++ b/test/Sema/const_keypath.swift
@@ -6,7 +6,8 @@ struct Article {
 
 let keypath = \Article.id
 func keypath_generator() -> KeyPath<Article, String> { return \.id }
-func const_map(_const _ map: KeyPath<Article, String>) {}
+func const_map(_ map: _const KeyPath<Article, String>) {}
+func const_map_in_wrong_position(_const _ map: KeyPath<Article, String>) {} // expected-warning {{'_const' before a parameter name is not allowed, place it before the parameter type instead; this is an error in the Swift 6 language mode}}
 
 const_map(\.id)
 const_map(\Article.id)


### PR DESCRIPTION
* **Explanation**: Lifetime specifiers before parameter names were disallowed in Swift 3 (SE-0031). `isolated`, `transferring` and `_const` got added after Swift 3 without a diagnostic to disallow them before parameter names.
* **Scope**: Parsing of `isolated`, `_const` and `transferring` in front of parameter declarations (not parameter types), eg. `func foo(isolated x b: MyActor) {}`
* **Risk**: Low, only adds a warning in Swift 5 mode
* **Testing**: Added a test case
* **Issue**: rdar://124794993
* **Reviewer**:  @rintaro on https://github.com/apple/swift/pull/72340