### PR TITLE
[Runtime] Fix _swift_validatePrespecializedMetadata when type lookup fails.

### DIFF
--- a/include/swift/Runtime/LibPrespecialized.h
+++ b/include/swift/Runtime/LibPrespecialized.h
@@ -61,7 +61,6 @@ Metadata *getLibPrespecializedMetadata(const TypeContextDescriptor *description,
 // were validated (which is the total number in the table), and outFailed is set
 // to the number that failed validation.
 SWIFT_RUNTIME_EXPORT
-void _swift_validatePrespecializedMetadata(unsigned *outValidated,
-                                           unsigned *outFailed);
+void _swift_validatePrespecializedMetadata();
 
 #endif // SWIFT_LIB_PRESPECIALIZED_H

--- a/stdlib/public/runtime/LibPrespecialized.cpp
+++ b/stdlib/public/runtime/LibPrespecialized.cpp
@@ -149,19 +149,16 @@ swift::getLibPrespecializedMetadata(const TypeContextDescriptor *description,
   return result;
 }
 
-void _swift_validatePrespecializedMetadata(unsigned *outValidated,
-                                           unsigned *outFailed) {
-  if (outValidated)
-    *outValidated = 0;
-  if (outFailed)
-    *outFailed = 0;
-
+void _swift_validatePrespecializedMetadata() {
   auto *data = getLibPrespecializedData();
   if (!data) {
     return;
   }
 
   disableForValidation = true;
+
+  unsigned validated = 0;
+  unsigned failed = 0;
 
   auto *metadataMap = data->getMetadataMap();
   auto metadataMapSize = metadataMap->arraySize;
@@ -171,8 +168,7 @@ void _swift_validatePrespecializedMetadata(unsigned *outValidated,
     if (!element.key || !element.value)
       continue;
 
-    if (outValidated)
-      (*outValidated)++;
+    validated++;
 
     const char *mangledName = element.key;
     // Skip the leading $.
@@ -186,12 +182,16 @@ void _swift_validatePrespecializedMetadata(unsigned *outValidated,
               "Prespecializations library validation: unable to build metadata "
               "for mangled name '%s'\n",
               mangledName);
-      if (outFailed)
-        (*outFailed)++;
+      failed++;
+      continue;
     }
 
     if (!compareGenericMetadata(result.getType().getMetadata(), element.value))
-      if (outFailed)
-        (*outFailed)++;
+      failed++;
   }
+
+  fprintf(stderr,
+          "Prespecializations library validation: validated %u entries, %u "
+          "failures.\n",
+          validated, failed);
 }


### PR DESCRIPTION
When we fail to look up a type by name, we print an error, then try to compare anyway, which crashes. Skip the comparison when that happens.

While we're in there, modify _swift_validatePrespecializedMetadata to be more useful for debugging, by removing the parameters and having it print the results directly.