### PR TITLE
[Diagnostics] Add support for updating the existing 'available' attribute.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6725,6 +6725,9 @@ ERROR(availability_variadic_type_only_version_newer, none,
 NOTE(availability_guard_with_version_check, none,
      "add 'if #available' version check", ())
 
+NOTE(availability_update_attribute, none,
+     "update @available attribute for %0 from '%1' to '%2' to meet the requirements of '%3'", (StringRef, StringRef, StringRef, StringRef))
+
 NOTE(availability_add_attribute, none,
      "add @available attribute to enclosing %0", (DescriptiveDeclKind))
 FIXIT(insert_available_attr,

--- a/test/Sema/api-availability-only.swift
+++ b/test/Sema/api-availability-only.swift
@@ -8,6 +8,7 @@ public struct S {}
 
 @available(macOS 10.51, *)
 public func newFunc() {
+  // expected-note @-1 {{update @available attribute for macOS from '10.51' to '10.52' to meet the requirements of 'S'}} {{9:18-23=10.52}}
   _ = S() // expected-error {{'S' is only available in}}
   // expected-note @-1 {{add 'if #available' version check}}
 }

--- a/test/Sema/availability_swiftui.swift
+++ b/test/Sema/availability_swiftui.swift
@@ -13,3 +13,4 @@ class AnyColorBox: LessAvailable {} // Ok, exception specifically for AnyColorBo
 @available(macOS 10.15, *)
 @usableFromInline
 class OtherClass: LessAvailable {} // expected-error {{'LessAvailable' is only available in macOS 11 or newer; clients of 'SwiftUI' may have a lower deployment target}}
+// expected-note @-1 {{update @available attribute for macOS from '10.15' to '11' to meet the requirements of 'LessAvailable'}} {{13:18-23=11}}

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -42,6 +42,7 @@ func functionWithoutAvailability() {
 // Functions with annotations should refine their bodies.
 @available(OSX, introduced: 10.51)
 func functionAvailableOn10_51() {
+  // expected-note@-1 {{update @available attribute for macOS from '10.51' to '10.52' to meet the requirements of 'globalFuncAvailableOn10_52'}} {{43:29-34=10.52}}
   let _: Int = globalFuncAvailableOn10_9()
   let _: Int = globalFuncAvailableOn10_51()
 
@@ -324,10 +325,11 @@ class ClassWithPotentiallyUnavailableProperties {
 
   @available(OSX, introduced: 10.9)
   var availableOn10_9Computed: Int {
+    // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.51' to meet the requirements of 'availableOn10_51Stored'}} {{326:31-35=10.51}}
     get {
       let _: Int = availableOn10_51Stored // expected-error {{'availableOn10_51Stored' is only available in macOS 10.51 or newer}}
           // expected-note@-1 {{add 'if #available' version check}}
-      
+
       if #available(OSX 10.51, *) {
         let _: Int = availableOn10_51Stored
       }
@@ -406,6 +408,7 @@ class ClassWithPotentiallyUnavailableProperties {
 
 @available(OSX, introduced: 10.51)
 class ClassWithReferencesInInitializers {
+  // expected-note@-1 2 {{update @available attribute for macOS from '10.51' to '10.52' to meet the requirements of 'globalFuncAvailableOn10_52'}} {{409:29-34=10.52}}
   var propWithInitializer10_51: Int = globalFuncAvailableOn10_51()
 
   var propWithInitializer10_52: Int = globalFuncAvailableOn10_52() // expected-error {{'globalFuncAvailableOn10_52()' is only available in macOS 10.52 or newer}}
@@ -522,6 +525,8 @@ enum EnumIntroducedOn10_52 {
 
 @available(OSX, introduced: 10.51)
 enum CompassPoint {
+  // expected-note@-1 3 {{update @available attribute for macOS from '10.51' to '10.52' to meet the requirements of 'EnumIntroducedOn10_52'}} {{526:29-34=10.52}}
+
   case North
   case South
   case East
@@ -542,7 +547,7 @@ enum CompassPoint {
   case WithPotentiallyUnavailablePayload(p : EnumIntroducedOn10_52) // expected-error {{'EnumIntroducedOn10_52' is only available in macOS 10.52 or newer}}
 
   case WithPotentiallyUnavailablePayload1(p : EnumIntroducedOn10_52), WithPotentiallyUnavailablePayload2(p : EnumIntroducedOn10_52) // expected-error 2{{'EnumIntroducedOn10_52' is only available in macOS 10.52 or newer}}
-  
+
   @available(OSX, unavailable)
   case WithPotentiallyUnavailablePayload3(p : EnumIntroducedOn10_52)
 }
@@ -876,9 +881,10 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
         // expected-note@-1 2{{add @available attribute to enclosing class}}
   @available(OSX, introduced: 10.9)
   override func someMethod() {
+    // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.51' to meet the requirements of 'someMethod'}} {{882:31-35=10.51}}
     super.someMethod() // expected-error {{'someMethod()' is only available in macOS 10.51 or newer}}
         // expected-note@-1 {{add 'if #available' version check}}
-    
+
     if #available(OSX 10.51, *) {
       super.someMethod()
     }
@@ -886,10 +892,10 @@ class SubWithLargerMemberAvailability : SuperWithLimitedMemberAvailability {
   
   @available(OSX, introduced: 10.9)
   override var someProperty: Int {
-    get { 
+    // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.51' to meet the requirements of 'someProperty'}} {{893:31-35=10.51}}
+    get {
       let _ = super.someProperty // expected-error {{'someProperty' is only available in macOS 10.51 or newer}}
-          // expected-note@-1 {{add 'if #available' version check}}
-      
+        // expected-note@-1 {{add 'if #available' version check}}
       if #available(OSX 10.51, *) {
         let _ = super.someProperty
       }
@@ -961,6 +967,7 @@ protocol ProtocolAvailableOn10_51 {
 
 @available(OSX, introduced: 10.9)
 protocol ProtocolAvailableOn10_9InheritingFromProtocolAvailableOn10_51 : ProtocolAvailableOn10_51 { // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.51' to meet the requirements of 'ProtocolAvailableOn10_51'}} {{968:29-33=10.51}}
 }
 
 @available(OSX, introduced: 10.51)
@@ -973,6 +980,7 @@ protocol UnavailableProtocolInheritingFromProtocolAvailableOn10_51 : ProtocolAva
 
 @available(OSX, introduced: 10.9)
 class SubclassAvailableOn10_9OfClassAvailableOn10_51 : ClassAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.51' to meet the requirements of 'ClassAvailableOn10_51'}} {{981:29-33=10.51}}
 }
 
 @available(OSX, unavailable)
@@ -997,12 +1005,14 @@ func castToPotentiallyUnavailableProtocol() {
 
 @available(OSX, introduced: 10.9)
 class SubclassAvailableOn10_9OfClassAvailableOn10_51AlsoAdoptingProtocolAvailableOn10_51 : ClassAvailableOn10_51, ProtocolAvailableOn10_51 { // expected-error {{'ClassAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.51' to meet the requirements of 'ClassAvailableOn10_51'}} {{1006:29-33=10.51}}
 }
 
 class SomeGenericClass<T> { }
 
 @available(OSX, introduced: 10.9)
 class SubclassAvailableOn10_9OfSomeGenericClassOfProtocolAvailableOn10_51 : SomeGenericClass<ProtocolAvailableOn10_51> { // expected-error {{'ProtocolAvailableOn10_51' is only available in macOS 10.51 or newer}}
+  // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.51' to meet the requirements of 'ProtocolAvailableOn10_51'}} {{1013:29-33=10.51}}
 }
 
 @available(OSX, unavailable)
@@ -1049,6 +1059,7 @@ extension ClassAvailableOn10_51 { }
 
 @available(OSX, introduced: 10.51)
 extension ClassAvailableOn10_51 {
+  // expected-note@-1 {{update @available attribute for macOS from '10.51' to '10.52' to meet the requirements of 'globalFuncAvailableOn10_52'}} {{1060:29-34=10.52}}
   func m() {
       // expected-note@-1 {{add @available attribute to enclosing instance method}}
     let _ = globalFuncAvailableOn10_51()
@@ -1653,6 +1664,7 @@ class ClassWithShortFormAvailableOn10_54 {
 
 @available(OSX 10.9, *)
 func funcWithShortFormAvailableOn10_9() {
+  // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.51' to meet the requirements of 'ClassWithShortFormAvailableOn10_51'}} {{1665:16-20=10.51}}
   let _ = ClassWithShortFormAvailableOn10_51() // expected-error {{'ClassWithShortFormAvailableOn10_51' is only available in macOS 10.51 or newer}}
       // expected-note@-1 {{add 'if #available' version check}}
 }
@@ -1685,6 +1697,7 @@ func funcWithMultipleShortFormAnnotationsForDifferentPlatforms() {
 @available(OSX 10.53, *)
 @available(OSX 10.52, *)
 func funcWithMultipleShortFormAnnotationsForTheSamePlatform() {
+  // expected-note@-1 {{update @available attribute for macOS from '10.52' to '10.54' to meet the requirements of 'ClassWithShortFormAvailableOn10_54'}} {{1698:16-21=10.54}}
   let _ = ClassWithShortFormAvailableOn10_53()
 
   let _ = ClassWithShortFormAvailableOn10_54() // expected-error {{'ClassWithShortFormAvailableOn10_54' is only available in macOS 10.54 or newer}}

--- a/test/Sema/availability_versions_multi.swift
+++ b/test/Sema/availability_versions_multi.swift
@@ -25,6 +25,11 @@ let ignored3: Int = globalAvailableOn99_52 // expected-error {{'globalAvailableO
 
 @available(OSX, introduced: 99.51)
 func useFromOtherOn99_51() {
+  // expected-note@-1 {{update @available attribute for macOS from '99.51' to '99.52' to meet the requirements of 'returns99_52Introduced99_52'}} {{26:29-34=99.52}}
+  // expected-note@-2 {{update @available attribute for macOS from '99.51' to '99.52' to meet the requirements of 'OtherIntroduced99_52'}} {{26:29-34=99.52}}
+  // expected-note@-3 {{update @available attribute for macOS from '99.51' to '99.52' to meet the requirements of 'extensionMethodOnOtherIntroduced99_51AvailableOn99_52'}} {{26:29-34=99.52}}
+  // expected-note@-4 {{update @available attribute for macOS from '99.51' to '99.52' to meet the requirements of 'NestedIntroduced99_52'}} {{26:29-34=99.52}}
+
   // This will trigger validation of OtherIntroduced99_51 in
   // in availability_multi_other.swift
   let o99_51 = OtherIntroduced99_51()
@@ -49,6 +54,7 @@ func useFromOtherOn99_51() {
 
 @available(OSX, introduced: 99.52)
 func useFromOtherOn99_52() {
+  // expected-note@-1 {{update @available attribute for macOS from '99.52' to '99.53' to meet the requirements of 'returns99_53'}} {{55:29-34=99.53}}
   _ = OtherIntroduced99_52()
 
   let n99_52 = OtherIntroduced99_51.NestedIntroduced99_52()

--- a/test/attr/ApplicationMain/attr_main_struct_available_future.swift
+++ b/test/attr/ApplicationMain/attr_main_struct_available_future.swift
@@ -4,7 +4,7 @@
 
 @main // expected-error {{'main()' is only available in macOS 10.99 or newer}}
 @available(OSX 10.0, *)
-struct EntryPoint {
+struct EntryPoint { // expected-note {{update @available attribute for macOS from '10.0' to '10.99' to meet the requirements of '@main'}} {{6:16-20=10.99}}
   @available(OSX 10.99, *)
   static func main() {
   }

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -115,7 +115,7 @@ extension TestStruct {
 }
 
 @available(macOS 10.11, *)
-func testMemberAvailability() {
+func testMemberAvailability() { // expected-note {{update @available attribute for macOS from '10.11' to '10.12' to meet the requirements of 'doFourthThing'}} {{117:18-23=10.12}}
   TestStruct().doTheThing() // expected-error {{'doTheThing()' is unavailable}}
   TestStruct().doAnotherThing() // expected-error {{'doAnotherThing()' is unavailable}}
   TestStruct().doThirdThing() // expected-error {{'doThirdThing()' is unavailable}}

--- a/test/attr/attr_availability_update.swift
+++ b/test/attr/attr_availability_update.swift
@@ -1,0 +1,69 @@
+// RUN: %swift -typecheck -verify -parse-stdlib -module-name Swift -target x86_64-apple-macosx10.10 %s
+
+@available(SwiftStdlib 5.1, *)
+func FooForDefineAvailability() {}
+
+@available(SwiftStdlib 5.0, *)
+func FooForDefineAvailabilityTest() {  
+    FooForDefineAvailability()
+    // expected-error@-1 {{'FooForDefineAvailability()' is only available in macOS 10.15 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}}
+}
+
+@available(*, unavailable)
+func FooForUnavailable() {} // expected-note {{'FooForUnavailable()' has been explicitly marked unavailable here}}
+
+func FooForUnavailableTest() {
+    FooForUnavailable()
+    // expected-error@-1 {{'FooForUnavailable()' is unavailable}}
+}
+
+@available(macOS, introduced: 10.15)
+func FooForAvailability() {}
+
+@available(macOS, introduced: 10.10)
+func FooForAvailabilityTest() {
+    // expected-note@-1 {{update @available attribute for macOS from '10.10' to '10.15' to meet the requirements of 'FooForAvailability'}} {{24:31-36=10.15}}
+    FooForAvailability()
+    // expected-error@-1 {{'FooForAvailability()' is only available in macOS 10.15 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}}
+ }
+
+@available(macOS 10.15, iOS 13, *)
+func FooForAvailability2() {
+}
+
+@available(macOS 10.10, *)
+func FooForAvailability2Test() {
+    // expected-note@-1 {{update @available attribute for macOS from '10.10' to '10.15' to meet the requirements of 'FooForAvailability2'}} {{36:18-23=10.15}}
+    FooForAvailability2()
+    // expected-error@-1 {{'FooForAvailability2()' is only available in macOS 10.15 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}}
+}
+
+@available(macOS 10.15, *)
+func FooForUnavailable2() {} 
+
+@available(macOS, unavailable)
+func FooForUnavailable2Test() {
+    FooForUnavailable2()
+    // expected-error@-1 {{'FooForUnavailable2()' is only available in macOS 10.15 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}}
+}
+
+@available(macOS 10.15, *)
+func FooForDeprecated() {}
+
+@available(macOS, deprecated: 12)
+func FooForDeprecatedTest() {
+    FooForDeprecated()
+    // expected-error@-1 {{'FooForDeprecated()' is only available in macOS 10.15 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}}
+}
+
+@available(*, deprecated)
+func FooForDeprecatedTest2() {
+    FooForDeprecated()
+    // expected-error@-1 {{'FooForDeprecated()' is only available in macOS 10.15 or newer}}
+    // expected-note@-2 {{add 'if #available' version check}}
+}

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -190,6 +190,9 @@ public func deployedUseNoAvailable( // expected-note 5 {{add @available attribut
 
 @available(macOS 10.9, *)
 public func deployedUseBeforeInliningTarget(
+  // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.14.5' to meet the requirements of 'BetweenTargets'}} {{191:18-22=10.14.5}}
+  // expected-note@-2 3 {{update @available attribute for macOS from '10.9' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{191:18-22=11}}
+  // expected-note@-3 {{update @available attribute for macOS from '10.9' to '10.15' to meet the requirements of 'AtDeploymentTarget'}} {{191:18-22=10.15}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -215,6 +218,9 @@ public func deployedUseBeforeInliningTarget(
 
 @available(macOS 10.10, *)
 public func deployedUseAtInliningTarget(
+  // expected-note@-1 3 {{update @available attribute for macOS from '10.10' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{219:18-23=11}}
+  // expected-note@-2 {{update @available attribute for macOS from '10.10' to '10.14.5' to meet the requirements of 'BetweenTargets'}} {{219:18-23=10.14.5}}
+  // expected-note@-3 {{update @available attribute for macOS from '10.10' to '10.15' to meet the requirements of 'AtDeploymentTarget'}} {{219:18-23=10.15}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -240,6 +246,8 @@ public func deployedUseAtInliningTarget(
 
 @available(macOS 10.14.5, *)
 public func deployedUseBetweenTargets(
+  // expected-note@-1 3 {{update @available attribute for macOS from '10.14.5' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{247:18-25=11}}
+  // expected-note@-2 {{update @available attribute for macOS from '10.14.5' to '10.15' to meet the requirements of 'AtDeploymentTarget'}} {{247:18-25=10.15}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -265,6 +273,7 @@ public func deployedUseBetweenTargets(
 
 @available(macOS 10.15, *)
 public func deployedUseAtDeploymentTarget(
+  // expected-note@-1 3 {{update @available attribute for macOS from '10.15' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{274:18-23=11}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -422,6 +431,9 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 
 @available(macOS 10.9, *)
 @inlinable public func inlinedUseBeforeInliningTarget(
+  // expected-note@-1 3 {{update @available attribute for macOS from '10.9' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{432:18-22=11}}
+  // expected-note@-2 2 {{update @available attribute for macOS from '10.9' to '10.14.5' to meet the requirements of 'BetweenTargets'}} {{432:18-22=10.14.5}}
+  // expected-note@-3 3 {{update @available attribute for macOS from '10.9' to '10.15' to meet the requirements of 'AtDeploymentTarget'}} {{432:18-22=10.15}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -453,6 +465,9 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 
 @available(macOS 10.10, *)
 @inlinable public func inlinedUseAtInliningTarget(
+  // expected-note@-1 3 {{update @available attribute for macOS from '10.10' to '10.15' to meet the requirements of 'AtDeploymentTarget'}} {{466:18-23=10.15}}
+  // expected-note@-2 3 {{update @available attribute for macOS from '10.10' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{466:18-23=11}}
+  // expected-note@-3 2 {{update @available attribute for macOS from '10.10' to '10.14.5' to meet the requirements of 'BetweenTargets'}} {{466:18-23=10.14.5}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -484,6 +499,8 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 
 @available(macOS 10.14.5, *)
 @inlinable public func inlinedUseBetweenTargets(
+  // expected-note@-1 3 {{update @available attribute for macOS from '10.14.5' to '10.15' to meet the requirements of 'AtDeploymentTarget'}} {{500:18-25=10.15}}
+  // expected-note@-2 3 {{update @available attribute for macOS from '10.14.5' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{500:18-25=11}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -512,6 +529,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 
 @available(macOS 10.15, *)
 @inlinable public func inlinedUseAtDeploymentTarget(
+  // expected-note@-1 3 {{update @available attribute for macOS from '10.15' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{530:18-23=11}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -644,6 +662,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 
 @available(macOS 10.15, *)
 @inlinable public var inlinedAtDeploymentTargetGlobal: Any {
+  // expected-note@-1 {{update @available attribute for macOS from '10.15' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{663:18-23=11}}
   _ = NoAvailable()
   _ = BeforeInliningTarget()
   _ = AtInliningTarget()
@@ -788,6 +807,9 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 @available(macOS 10.10, *)
 @backDeployed(before: macOS 999.0)
 public func backDeployedToInliningTarget(
+  // expected-note@-1 3 {{update @available attribute for macOS from '10.10' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{807:18-23=11}}
+  // expected-note@-2 2 {{update @available attribute for macOS from '10.10' to '10.14.5' to meet the requirements of 'BetweenTargets'}} {{807:18-23=10.14.5}}
+  // expected-note@-3 3 {{update @available attribute for macOS from '10.10' to '10.15' to meet the requirements of 'AtDeploymentTarget'}} {{807:18-23=10.15}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -1042,6 +1064,8 @@ public struct PublicStruct { // expected-note 21 {{add @available attribute}}
 
   @available(macOS 10.14.5, *)
   public internal(set) var internalSetter: Void {
+    // expected-note@-1 {{update @available attribute for macOS from '10.14.5' to '10.15' to meet the requirements of 'AtDeploymentTarget'}} {{1065:20-27=10.15}}
+    // expected-note@-2 2 {{update @available attribute for macOS from '10.14.5' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{1065:20-27=11}}
     @inlinable get {
       // Public inlinable getter acts like @inlinable
       _ = NoAvailable()
@@ -1294,6 +1318,7 @@ extension BetweenTargets { // expected-note 2 {{add @available attribute to encl
 
 @available(macOS 10.15, *)
 extension BetweenTargets {
+  // expected-note@-1 {{update @available attribute for macOS from '10.15' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{1319:18-23=11}}
   public func publicFuncInExtensionWithExplicitAvailability( // expected-note {{add @available attribute to enclosing instance method}}
     _: NoAvailable,
     _: BeforeInliningTarget,
@@ -1307,6 +1332,7 @@ extension BetweenTargets {
 extension BetweenTargets { // expected-note {{add @available attribute to enclosing extension}}
   @available(macOS 10.15, *)
   public func publicFuncWithExplicitAvailabilityInExtension(
+    // expected-note@-1 {{update @available attribute for macOS from '10.15' to '11' to meet the requirements of 'AfterDeploymentTarget'}} {{1333:20-25=11}}
     _: NoAvailable,
     _: BeforeInliningTarget,
     _: AtInliningTarget,
@@ -1356,6 +1382,7 @@ extension BetweenTargets {
 
 @available(macOS 10.10, *)
 extension BetweenTargets { // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}}
+  // expected-note@-1 {{update @available attribute for macOS from '10.10' to '10.14.5' to meet the requirements of 'BetweenTargets'}} {{1383:18-23=10.14.5}}
   public func publicFuncInExcessivelyAvailableExtension() {}
 }
 
@@ -1498,6 +1525,9 @@ public protocol NoAvailableProtoWithAssoc { // expected-note 3 {{add @available 
 
 @available(macOS 10.9, *)
 public protocol BeforeInliningTargetProtoWithAssoc {
+  // expected-note@-1 {{update @available attribute for macOS from '10.9' to '10.14.5' to meet the requirements of 'BetweenTargetsProto'}} {1526:18-22=10.14.5}}
+  // expected-note@-2 {{update @available attribute for macOS from '10.9' to '10.15' to meet the requirements of 'AtDeploymentTargetProto'}} {{1526:18-22=10.15}}
+  // expected-note@-3 {{update @available attribute for macOS from '10.9' to '11' to meet the requirements of 'AfterDeploymentTargetProto'}} {{1526:18-22=11}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
@@ -1511,6 +1541,9 @@ public protocol BeforeInliningTargetProtoWithAssoc {
 
 @available(macOS 10.10, *)
 public protocol AtInliningTargetProtoWithAssoc {
+  // expected-note@-1 {{update @available attribute for macOS from '10.10' to '10.15' to meet the requirements of 'AtDeploymentTargetProto'}} {{1542:18-23=10.15}}
+  // expected-note@-2 {{update @available attribute for macOS from '10.10' to '10.14.5' to meet the requirements of 'BetweenTargetsProto'}}  {{1542:18-23=10.14.5}}
+  // expected-note@-3 {{update @available attribute for macOS from '10.10' to '11' to meet the requirements of 'AfterDeploymentTargetProto'}}  {{1542:18-23=11}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
@@ -1524,6 +1557,8 @@ public protocol AtInliningTargetProtoWithAssoc {
 
 @available(macOS 10.14.5, *)
 public protocol BetweenTargetsProtoWithAssoc {
+  // expected-note@-1 {{update @available attribute for macOS from '10.14.5' to '10.15' to meet the requirements of 'AtDeploymentTargetProto'}} {{1558:18-25=10.15}}
+  // expected-note@-2 {{update @available attribute for macOS from '10.14.5' to '11' to meet the requirements of 'AfterDeploymentTargetProto'}} {{1558:18-25=11}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto
@@ -1536,6 +1571,7 @@ public protocol BetweenTargetsProtoWithAssoc {
 
 @available(macOS 10.15, *)
 public protocol AtDeploymentTargetProtoWithAssoc {
+  // expected-note@-1 {{update @available attribute for macOS from '10.15' to '11' to meet the requirements of 'AfterDeploymentTargetProto'}} {{1572:18-23=11}}
   associatedtype A: NoAvailableProto
   associatedtype B: BeforeInliningTargetProto
   associatedtype C: AtInliningTargetProto

--- a/test/attr/typed_throws_availability_osx.swift
+++ b/test/attr/typed_throws_availability_osx.swift
@@ -8,5 +8,5 @@ enum MyError: Error {
 }
 
 @available(macOS 12, *)
-func throwMyErrorBadly() throws(MyError) { }
+func throwMyErrorBadly() throws(MyError) { } // expected-note {{update @available attribute for macOS from '12' to '13' to meet the requirements of 'MyError'}} {{10:18-20=13}}
 // expected-error@-1{{'MyError' is only available in macOS 13 or newer}}


### PR DESCRIPTION
Revise the context to recommend an update to the existing 'available' attribute.

Consider the following code:
```swift
@available(macOS 42, *) 
func foo() {}

@available(macOS 12, *) 
func bar() {
    foo()
}
```

A new fix-it suggests altering the '@available' attribute of the global function on macOS from 12 to 42.
```swift
11 │ @available(macOS 12, *) 
12 │ func bar() {
13 │     foo()
   │     ├─ error: 'foo()' is only available in macOS 42 or newer
   │     ├─ note: add 'if #available' version check
   │     ╰─ note: change the @available attribute of the global function on macOS from 12 to 42
14 │ }
```

Resolves #57378 