### PR TITLE
[6.0] [Demangle-to-type] Properly match extensions of conditionally-copyable types

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1282,8 +1282,19 @@ ASTBuilder::findDeclContext(NodePointer node) {
         continue;
       }
 
-      if (ext->getGenericSignature().getCanonicalSignature() == genericSig) {
+      auto extSig = ext->getGenericSignature().getCanonicalSignature();
+      if (extSig == genericSig) {
         return ext;
+      }
+
+      // If the extension mangling doesn't include a generic signature, it
+      // might be because the nominal type suppresses conformance.
+      if (!genericSig) {
+        SmallVector<Requirement, 2> requirements;
+        SmallVector<InverseRequirement, 2> inverses;
+        extSig->getRequirementsWithInverses(requirements, inverses);
+        if (requirements.empty())
+          return ext;
       }
     }
 

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -76,3 +76,13 @@ open class ManagedBuffer<Header, Element: ~Copyable> {
     fatalError("boom")
   }
 }
+
+extension UnsafePointer {
+  struct AtomicRepresentation { }
+}
+
+// CHECK: $sSP4testE20AtomicRepresentationVySi_GD
+func useAtomicRepresentation() {
+  let x = UnsafePointer<Int>.AtomicRepresentation()
+  print(x)
+}


### PR DESCRIPTION
* **Explanation**: Demangling a name involving extensions of a conditionally-`Copyable` type from a different module were not being properly matched to extensions within the AST, causing a mangling <-> AST round-tripping failure for such types (like `Optional`).
* **Issue**: rdar://125015930.
* **Original PR**: https://github.com/apple/swift/pull/72433
* **Risk**: Low. The change only has an impact when extending a conditionally-copyable type; other types are still matched in the same way.
* **Testing**: New tests; additionally, this addressed a number of assertion failures observed in the source compatibility suite.
