### PR TITLE
[debuginfo][codeview] avoid using line zero artificial location for t…

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -642,6 +642,10 @@ public:
   bool hasMultipleIRGenThreads() const { return !UseSingleModuleLLVMEmission && NumThreads > 1; }
   bool shouldPerformIRGenerationInParallel() const { return !UseSingleModuleLLVMEmission && NumThreads != 0; }
   bool hasMultipleIGMs() const { return hasMultipleIRGenThreads(); }
+
+  bool isDebugInfoCodeView() const {
+    return DebugInfoFormat == IRGenDebugInfoFormat::CodeView;
+  }
 };
 
 } // end namespace swift

--- a/test/DebugInfo/doubleinlines.swift
+++ b/test/DebugInfo/doubleinlines.swift
@@ -12,9 +12,13 @@ func callCondFail(arg: Builtin.Int1, msg: Builtin.RawPointer) {
 
 // CHECK: define hidden swiftcc void @"$s13DoubleInlines12callCondFail3arg3msgyBi1__BptF"{{.*}} !dbg ![[FUNC:.*]] {
 // CHECK: tail call void asm sideeffect "", "n"(i32 0) #3, !dbg ![[SCOPEONE:.*]]
+// CHECK: tail call void @llvm.trap(), !dbg ![[LOCTRAP:.*]]
+
 // CHECK: ![[FUNCSCOPEOTHER:.*]] = distinct !DISubprogram(name: "condFail",{{.*}}
-// CHECK: ![[SCOPEONE]] = !DILocation(line: 0, scope: ![[SCOPETWO:.*]], inlinedAt: ![[SCOPETHREE:.*]])
+// CHECK: ![[SCOPEONE]] = distinct !DILocation(line: 6, scope: ![[SCOPETWO:.*]], inlinedAt: ![[SCOPETHREE:.*]])
 // CHECK: ![[SCOPETHREE]] = !DILocation(line: 6, scope: ![[FUNCSCOPE:.*]])
 // CHECK: ![[FUNCSCOPE:[0-9]+]] = distinct !DILexicalBlock(scope: ![[FUNC]],
+// CHECK: ![[LOCTRAP]] = !DILocation(line: 6, scope: ![[SCOPETRAP:.*]], inlinedAt: ![[SCOPEONE]])
+// CHECK: ![[SCOPETRAP]] = distinct !DISubprogram(name: "Swift runtime failure: unknown program error"
 
 import Builtin

--- a/test/DebugInfo/linetable-codeview.swift
+++ b/test/DebugInfo/linetable-codeview.swift
@@ -78,11 +78,10 @@ func foo() {
 
 // CHECK-DAG: ![[ADD]] = !DILocation(line: 6, scope:
 // CHECK-DAG: ![[DIV]] = !DILocation(line: 7, scope:
-// FIXME: The location of ``@llvm.trap`` should be in Integers.swift.gyb
-//        instead of being artificial.
-// CHECK: ![[INLINEDADD]] = !DILocation(line: 0, scope: ![[FAILURE_FUNC:[0-9]+]], inlinedAt: ![[INLINELOC:[0-9]+]]
+
+// CHECK: ![[INLINEDADD]] = !DILocation(line: 6, scope: ![[FAILURE_FUNC:[0-9]+]], inlinedAt: ![[INLINELOC:[0-9]+]]
 // CHECK-DAG: !{{.*}} = distinct !DISubprogram(name: "Swift runtime failure: arithmetic overflow", scope: {{.*}}, flags: DIFlagArtificial, spFlags: DISPFlagDefinition, {{.*}})
-// CHECK-DAG: ![[INLINELOC]] = !DILocation(line: 0, scope: !{{[0-9]+}}, inlinedAt: ![[ADD]]
+// CHECK-DAG: ![[INLINELOC]] = distinct !DILocation(line: 6, scope: !{{[0-9]+}}, inlinedAt: ![[ADD]]
 
 // NOTE: These prologue instructions are given artificial line locations for
 //       LLDB, but for CodeView they should have the location of the function


### PR DESCRIPTION
…raps when emitting codeview

This fixes an issue where the debug locations for Swift traps were dropped in the produced PDB files, as they were pointing to line 0

I validated this on a sample project using WinDbgx, which can now correctly trap on the same line in multiple places.

Before:
<img width="1097" alt="Screenshot 2024-03-22 at 12 58 48 PM" src="https://github.com/apple/swift/assets/820551/c2ea2103-7e60-42f4-8a44-510bb1aa7391">

After:
<img width="1099" alt="Screenshot 2024-03-22 at 1 36 33 PM" src="https://github.com/apple/swift/assets/820551/cb270e4c-76e5-4f22-983b-c9fd31c08e61">
