### PR TITLE
[SIL] Delete ref-counting insts just before unreachables.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/CMakeLists.txt
@@ -30,4 +30,5 @@ swift_compiler_sources(Optimizer
   SimplificationPasses.swift
   StackPromotion.swift
   StripObjectHeaders.swift
+  UnreachableBlockOptimization.swift
 )

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/UnreachableBlockOptimization.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/UnreachableBlockOptimization.swift
@@ -1,0 +1,104 @@
+//===--- UnreachableBlockOptimization.swift --------------------------------==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+let unreachableBlockOptimization = FunctionPass(name: "unreachable-block-optimization", 
+                                                UnreachableBlockOptimization.perform)
+
+// Remove instructions that don't have strongly ordered side effects from
+// dead-end blocks.
+fileprivate struct UnreachableBlockOptimization {
+  static func perform(function: Function, context: FunctionPassContext) {
+    var pass = UnreachableBlockOptimization(function: function, context: context)
+    defer { pass.deinitialize() }
+    pass.run()
+  }
+
+  let function: Function
+  let context: FunctionPassContext
+  let deadEndBlocks: DeadEndBlocksAnalysis
+  var worklist: InstructionWorklist
+  var found: [Instruction]
+
+  init(function: Function, context: FunctionPassContext) {
+    self.function = function
+    self.context = context
+
+    self.deadEndBlocks = context.deadEndBlocks
+    self.worklist = .init(context)
+    self.found = []
+  }
+
+  mutating func run() {
+    // Walk backwards, within dead-end blocks, from each unreachable until
+    // finding an "interesting" instruction, deleting each uninteresting
+    // instruction along the way.
+    initializeWorklist()
+    findInstructions()
+    deleteInstructions()
+  }
+
+  mutating func deinitialize() {
+    worklist.deinitialize()
+  }
+
+  mutating func initializeWorklist() {
+    for block in function.blocks where block.terminator is UnreachableInst {
+      addInstructions(before: block.terminator)
+    }
+  }
+
+  mutating func findInstructions() {
+    while let instruction = worklist.pop() {
+      if canSkip(instruction) {
+        addInstructions(before: instruction)
+        continue
+      }
+      if !canDelete(instruction) {
+        continue
+      }
+      found.append(instruction)
+      addInstructions(before: instruction)
+    }
+  }
+
+  func deleteInstructions() {
+    for instruction in found {
+      context.erase(instruction: instruction)
+    }
+  }
+
+  mutating func addInstructions(before instruction: Instruction) {
+    if let previous = instruction.previous {
+      worklist.pushIfNotVisited(previous)
+      return
+    }
+    for predecessor in instruction.parentBlock.predecessors {
+      if !deadEndBlocks.isDeadEnd(predecessor) {
+        continue
+      }
+      worklist.pushIfNotVisited(predecessor.terminator)
+    }
+  }
+
+  func canDelete(_ instruction: Instruction) -> Bool {
+    return instruction is RefCountingInst
+        || instruction is DestroyAddrInst
+        || instruction is DeallocStackInst
+  }
+
+  func canSkip(_ instruction: Instruction) -> Bool {
+    return instruction is BranchInst
+        || instruction is CondBranchInst
+  }
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/PassRegistration.swift
@@ -93,6 +93,7 @@ private func registerSwiftPasses() {
   registerPass(lifetimeDependenceDiagnosticsPass, { lifetimeDependenceDiagnosticsPass.run($0) })
   registerPass(lifetimeDependenceInsertionPass, { lifetimeDependenceInsertionPass.run($0) })
   registerPass(lifetimeDependenceScopeFixupPass, { lifetimeDependenceScopeFixupPass.run($0) })
+  registerPass(unreachableBlockOptimization, { unreachableBlockOptimization.run($0) })
   // Instruction passes
   registerForSILCombine(BeginCOWMutationInst.self, { run(BeginCOWMutationInst.self, $0) })
   registerForSILCombine(GlobalValueInst.self,      { run(GlobalValueInst.self, $0) })

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -422,6 +422,8 @@ SWIFT_FUNCTION_PASS(StripObjectHeaders, "strip-object-headers",
     "Sets the bare flag on objects which don't need their headers")
 SWIFT_FUNCTION_PASS(AllocVectorLowering, "alloc-vector-lowering",
      "lowering of allocVector builtins")
+SWIFT_FUNCTION_PASS(UnreachableBlockOptimization, "unreachable-block-optimization",
+    "Delete instructions withiout strongly ordered side-effects from dead-end blocks")
 PASS(SimplifyBBArgs, "simplify-bb-args",
      "SIL Block Argument Simplification")
 PASS(SimplifyCFG, "simplify-cfg",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -922,6 +922,10 @@ SILPassPipelinePlan::getIRGenPreparePassPipeline(const SILOptions &Options) {
   // boundaries as required by the ABI.
   P.addLoadableByAddress();
 
+  // Delete instructions without strongly ordered side effects that appear
+  // "directly before" an unreachable.
+  P.addUnreachableBlockOptimization();
+
   if (Options.EnablePackMetadataStackPromotion) {
     // Insert marker instructions indicating where on-stack pack metadata
     // deallocation must occur.

--- a/test/SILOptimizer/unreachable_block_optimization.sil
+++ b/test/SILOptimizer/unreachable_block_optimization.sil
@@ -1,0 +1,116 @@
+// RUN: %target-sil-opt                     \
+// RUN:     %s                              \
+// RUN:     -enable-sil-verify-all          \
+// RUN:     -unreachable-block-optimization \
+// RUN: | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+sil_stage lowered
+
+import Builtin
+
+typealias NO = Builtin.NativeObject
+
+// CHECK-LABEL: sil @oneblock1_strongrelease_1 : {{.*}} {
+// CHECK:         cond_br undef, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK-NOT:     strong_release
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'oneblock1_strongrelease_1'
+sil @oneblock1_strongrelease_1 : $@convention(thin) (@owned NO) -> () {
+entry(%no : $NO):
+  cond_br undef, die, exit
+
+die:
+  strong_release %no : $NO
+  unreachable
+
+exit:
+  strong_release %no : $NO
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @oneblock1_strongretain_1 : {{.*}} {
+// CHECK:         cond_br undef, [[DIE:bb[0-9]+]]
+// CHECK:       [[DIE]]:
+// CHECK:         strong_retain
+// CHECK:         apply undef
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'oneblock1_strongretain_1'
+sil @oneblock1_strongretain_1 : $@convention(thin) (@owned NO) -> () {
+entry(%no : $NO):
+  cond_br undef, die, exit
+
+die:
+  strong_retain %no : $NO
+  apply undef(%no) : $@convention(thin) (@owned NO) -> ()
+  strong_release %no : $NO
+  unreachable
+
+exit:
+  strong_release %no : $NO
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @twoblock1_strongrelease : {{.*}} {
+// CHECK:         cond_br undef, [[TO_DIE:bb[0-9]+]]
+// CHECK:       [[TO_DIE]]
+// CHECK:         br [[DIE:bb[0-9]+]]
+// CHECK-NOT:     strong_release
+// CHECK:       [[DIE]]:
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'twoblock1_strongrelease'
+sil @twoblock1_strongrelease : $@convention(thin) (@owned NO) -> () {
+entry(%no : $NO):
+  cond_br undef, to_die, exit
+
+to_die:
+  strong_release %no : $NO
+  br die
+
+die:
+  unreachable
+
+exit:
+  strong_release %no : $NO
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil @threeblock1_strongrelease : {{.*}} {
+// CHECK:         cond_br undef, [[DEAD:bb[0-9]+]]
+// CHECK:       [[DEAD]]:
+// CHECK-NOT:     strong_release
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         br [[DIE:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         br [[DIE]]
+// CHECK:       [[DIE]]:
+// CHECK:         unreachable
+// CHECK-LABEL: } // end sil function 'threeblock1_strongrelease'
+sil @threeblock1_strongrelease : $@convention(thin) (@owned NO) -> () {
+entry(%no : $NO):
+  cond_br undef, dead, exit
+
+dead:
+  strong_release %no : $NO
+  cond_br undef, left, right
+
+left:
+  br die
+
+right:
+  br die
+
+die:
+  unreachable
+
+exit:
+  strong_release %no : $NO
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Add a pass to delete certain instructions (for now, ref-counting instructions, `destroy_addr`s, and `dealloc_stack`s) which appear "immediately before" an `unreachable`.
