### PR TITLE
[OpaqueValues] Pass direct to willThrowTyped.

### DIFF
--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -1591,7 +1591,7 @@ void SILGenFunction::emitThrow(SILLocation loc, ManagedValue exnMV,
             }, LookUpConformanceInModule(getModule().getSwiftModule()));
 
         // Generic errors are passed indirectly.
-        if (!exnMV.getType().isAddress()) {
+        if (!exnMV.getType().isAddress() && useLoweredAddresses()) {
           // Materialize the error so we can pass the address down to the
           // swift_willThrowTyped.
           exnMV = exnMV.materialize(*this, loc);

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -874,3 +874,14 @@ struct Twople<T> {
     self.storage = (t1, t2)
   }
 }
+
+// CHECK-LABEL: sil{{.*}} [ossa] @throwTypedValue : {{.*}} {
+// CHECK:       bb0([[E:%[^,]+]] :
+// CHECK:         [[SWIFT_WILL_THROW_TYPED:%[^,]+]] = function_ref @swift_willThrowTyped
+// CHECK:         apply [[SWIFT_WILL_THROW_TYPED]]<Err>([[E]])
+// CHECK:         throw [[E]]
+// CHECK-LABEL: } // end sil function 'throwTypedValue'
+@_silgen_name("throwTypedValue")
+func throwTypedValue(_ e: Err) throws(Err) { throw e }
+
+struct Err : Error {}


### PR DESCRIPTION
The runtime function `swift_willThrowTyped` takes its argument `@in_guaranteed`.  In opaque values SIL, that's passed directly.  Don't store non-address errors before passing them to the function.
