### PR TITLE
[6.0] [Demangle-to-AST type] Make sure we can find the original nominal type in its own module

### DIFF
--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -86,3 +86,16 @@ func useAtomicRepresentation() {
   let x = UnsafePointer<Int>.AtomicRepresentation()
   print(x)
 }
+
+struct Box<Wrapped: ~Copyable>: ~Copyable { }
+
+struct List<Element: ~Copyable>: ~Copyable {
+  // CHECK: $s4test4ListVAARiczrlE4NodeVwst
+  struct Node: ~Copyable {
+    var element: Element
+    var next: Link
+  }
+  typealias Link = Box<Node>?
+
+  var head: Link
+}


### PR DESCRIPTION
* **Explanation**: With noncopyable generics, we can end up using an extension mangling to refer to the original nominal type, even in its own module. Make sure we resolve that to the original nominal type declaration, rather than hunting for an extension that might not be there.
* **Issue**: rdar://125015930, which was incompletely fixed by the original PR https://github.com/apple/swift/pull/72526
* **Original PR**: https://github.com/apple/swift/pull/72541
* **Risk**: Low. The change only has an impact when extending a conditionally-copyable type; other types are still matched in the same way.
* **Testing**: New tests.
