### PR TITLE
[region-isolation] Wordsmith "{access,use} here could race".

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -930,7 +930,7 @@ NOTE(sil_referencebinding_inout_binding_here, none,
 //===----------------------------------------------------------------------===//
 
 NOTE(regionbasedisolation_maybe_race, none,
-     "access here could race", ())
+     "use here could race", ())
 ERROR(regionbasedisolation_unknown_pattern, none,
       "pattern that the region based isolation checker does not understand how to check. Please file a bug",
       ())

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -33,7 +33,7 @@ func iterate(stream: AsyncStream<Int>) async {
 
   // expected-region-isolation-warning @+3 {{transferring 'it' may cause a race}}
   // expected-region-isolation-note @+2 {{transferring disconnected 'it' to nonisolated callee could cause races in between callee nonisolated and local main actor-isolated uses}}
-  // expected-region-isolation-note @+1 {{access here could race}}
+  // expected-region-isolation-note @+1 {{use here could race}}
   while let element = await it.next() {
     print(element)
   }

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -282,7 +282,7 @@ func testNonSendableBaseArg() async {
 
   _ = await t.x
   // expected-warning @-1 {{non-sendable type 'NonSendable' passed in implicitly asynchronous call to main actor-isolated property 'x' cannot cross actor boundary}}
-  // expected-tns-note@-2 {{access here could race}}
+  // expected-tns-note@-2 {{use here could race}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -160,7 +160,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
   %useIndirect = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %useIndirect<NonSendableKlass>(%1) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_addr %1 : $*NonSendableKlass
   dealloc_stack %1 : $*NonSendableKlass

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -132,10 +132,10 @@ func closureInOut(_ a: Actor) async {
   // We only emit a warning on the first use we see, so make sure we do both
   // klass and the closure.
   if await booleanFlag {
-    await a.useKlass(ns1) // expected-tns-note {{access here could race}}
+    await a.useKlass(ns1) // expected-tns-note {{use here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
   } else {
-    closure() // expected-tns-note {{access here could race}}
+    closure() // expected-tns-note {{use here could race}}
   }
 }
 
@@ -153,13 +153,13 @@ func closureInOut2(_ a: Actor) async {
   // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
-  closure = { useInOut(&contents) } // expected-tns-note {{access here could race}}
+  closure = { useInOut(&contents) } // expected-tns-note {{use here could race}}
 
   await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
-  closure() // expected-tns-note {{access here could race}}
+  closure() // expected-tns-note {{use here could race}}
 }
 
 func closureNonInOut(_ a: Actor) async {
@@ -181,7 +181,7 @@ func closureNonInOut(_ a: Actor) async {
   // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
-  closure() // expected-tns-note {{access here could race}}
+  closure() // expected-tns-note {{use here could race}}
 }
 
 // TODO: Rework the nonisolated closure so we only treat nonisolated closures
@@ -312,7 +312,7 @@ extension Actor {
 
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-note @-2 {{access here could race}}
+    // expected-tns-note @-2 {{use here could race}}
     // expected-tns-warning @-3 {{transferring 'closure' may cause a race}}
     // expected-tns-note @-4 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
@@ -521,7 +521,7 @@ extension Actor {
     // expected-tns-note @-3 {{transferring disconnected 'closure' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
 
     // But this will error since we race.
-    closure() // expected-tns-note {{access here could race}}
+    closure() // expected-tns-note {{use here could race}}
   }
 }
 
@@ -593,7 +593,7 @@ func singleFieldVarMergeTest() async {
 
   // But if we use box.k here, we emit an error since we didn't reinitialize at
   // all.
-  useValue(box.k) // expected-tns-note {{access here could race}}
+  useValue(box.k) // expected-tns-note {{use here could race}}
 }
 
 func multipleFieldVarMergeTest1() async {
@@ -607,7 +607,7 @@ func multipleFieldVarMergeTest1() async {
   
 
   // So even if we reassign over k1, since we did a merge, this should error.
-  box.k1 = NonSendableKlass() // expected-tns-note {{access here could race}}
+  box.k1 = NonSendableKlass() // expected-tns-note {{use here could race}}
   useValue(box)
 }
 
@@ -647,7 +647,7 @@ func multipleFieldTupleMergeTest1() async {
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // So even if we reassign over k1, since we did a merge, this should error.
-  box.0 = NonSendableKlass() // expected-tns-note {{access here could race}}
+  box.0 = NonSendableKlass() // expected-tns-note {{use here could race}}
   useValue(box)
 }
 
@@ -699,7 +699,7 @@ func letSendableTrivialClassFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func letSendableNonTrivialClassFieldTest() async {
@@ -709,7 +709,7 @@ func letSendableNonTrivialClassFieldTest() async {
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
 
   _ = test.letSendableNonTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func letNonSendableNonTrivialClassFieldTest() async {
@@ -717,7 +717,7 @@ func letNonSendableNonTrivialClassFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
+  _ = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -726,7 +726,7 @@ func varSendableTrivialClassFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableTrivial // expected-tns-note {{access here could race}}
+  _ = test.varSendableTrivial // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -735,7 +735,7 @@ func varSendableNonTrivialClassFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableNonTrivial  // expected-tns-note {{access here could race}}
+  _ = test.varSendableNonTrivial  // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -744,7 +744,7 @@ func varNonSendableNonTrivialClassFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
+  _ = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -767,7 +767,7 @@ func letSendableTrivialFinalClassFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func letSendableNonTrivialFinalClassFieldTest() async {
@@ -776,7 +776,7 @@ func letSendableNonTrivialFinalClassFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func letNonSendableNonTrivialFinalClassFieldTest() async {
@@ -784,7 +784,7 @@ func letNonSendableNonTrivialFinalClassFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
+  _ = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -793,7 +793,7 @@ func varSendableTrivialFinalClassFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableTrivial // expected-tns-note {{access here could race}}
+  _ = test.varSendableTrivial // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -802,7 +802,7 @@ func varSendableNonTrivialFinalClassFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varSendableNonTrivial  // expected-tns-note {{access here could race}}
+  _ = test.varSendableNonTrivial  // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -811,7 +811,7 @@ func varNonSendableNonTrivialFinalClassFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
-  _ = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
+  _ = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -834,7 +834,7 @@ func letSendableTrivialLetStructFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func letSendableNonTrivialLetStructFieldTest() async {
@@ -843,7 +843,7 @@ func letSendableNonTrivialLetStructFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func letNonSendableNonTrivialLetStructFieldTest() async {
@@ -851,7 +851,7 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
+  let z = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
   useValue(test)
 }
@@ -863,7 +863,7 @@ func letSendableTrivialVarStructFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func letSendableNonTrivialVarStructFieldTest() async {
@@ -873,7 +873,7 @@ func letSendableNonTrivialVarStructFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func letNonSendableNonTrivialVarStructFieldTest() async {
@@ -882,7 +882,7 @@ func letNonSendableNonTrivialVarStructFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.letNonSendableNonTrivial // expected-tns-note {{access here could race}}
+  let z = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
   useValue(test)
 }
@@ -906,7 +906,7 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
   _ = z
   let z2 = test.varSendableNonTrivial
   _ = z2
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varSendableTrivialLetStructFieldTest() async {
@@ -915,7 +915,7 @@ func varSendableTrivialLetStructFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varSendableNonTrivialLetStructFieldTest() async {
@@ -924,7 +924,7 @@ func varSendableNonTrivialLetStructFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varNonSendableNonTrivialLetStructFieldTest() async {
@@ -932,7 +932,7 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
+  let z = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
   useValue(test)
 }
@@ -944,7 +944,7 @@ func varSendableTrivialVarStructFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varSendableNonTrivialVarStructFieldTest() async {
@@ -954,7 +954,7 @@ func varSendableNonTrivialVarStructFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varNonSendableNonTrivialVarStructFieldTest() async {
@@ -963,7 +963,7 @@ func varNonSendableNonTrivialVarStructFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.varNonSendableNonTrivial // expected-tns-note {{access here could race}}
+  let z = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
   useValue(test)
 }
@@ -979,7 +979,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
+  let z = test.letSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
   useValue(test)
 }
@@ -994,7 +994,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
+  let z = test.varSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
   useValue(test)
 }
@@ -1009,7 +1009,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -1025,7 +1025,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.letSendableNonTrivial // expected-tns-note {{access here could race}}
+  let z = test.letSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
   useValue(test)
 }
@@ -1041,7 +1041,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  let z = test.varSendableNonTrivial // expected-tns-note {{access here could race}}
+  let z = test.varSendableNonTrivial // expected-tns-note {{use here could race}}
   _ = z
   useValue(test)
 }
@@ -1057,7 +1057,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -1072,7 +1072,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -1087,7 +1087,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -1102,7 +1102,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -1124,7 +1124,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
     test.varSendableNonTrivial = SendableKlass()
   }
 
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
@@ -1143,7 +1143,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -1166,7 +1166,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
   }
 
   test.varSendableNonTrivial = SendableKlass()
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
@@ -1182,7 +1182,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
     // good... that is QoI though.
     await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
     // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-    // expected-tns-note @-2 {{access here could race}}
+    // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests()
     cls = {
@@ -1209,7 +1209,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   for _ in 0..<1024 {
     await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-    // expected-tns-note @-2 {{access here could race}}
+    // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
     test = StructFieldTests()
   }
@@ -1240,8 +1240,8 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
-  useValue(test)  // expected-tns-note {{access here could race}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
+  useValue(test)  // expected-tns-note {{use here could race}}
 }
 
 // In this case since we are tracking the transfer from the else statement, we
@@ -1265,8 +1265,8 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
 
-  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{access here could race}}
-  useValue(test) // expected-tns-note {{access here could race}}
+  test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 ////////////////////////////
@@ -1280,7 +1280,7 @@ func varSendableTrivialLetTupleFieldTest() async {
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.0
   useValue(z)
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varSendableNonTrivialLetTupleFieldTest() async {
@@ -1290,7 +1290,7 @@ func varSendableNonTrivialLetTupleFieldTest() async {
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.1
   useValue(z)
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varNonSendableNonTrivialLetTupleFieldTest() async {
@@ -1302,7 +1302,7 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
   // The SIL emitted for the assignment of the tuple is just a jumble of
   // instructions that are not semantically significant. The result is that we
   // need a useValue here to actual provide something for the pass to chew on.
-  useValue(z)  // expected-tns-note {{access here could race}}
+  useValue(z)  // expected-tns-note {{use here could race}}
   useValue(test)
 }
 
@@ -1313,7 +1313,7 @@ func varSendableTrivialVarTupleFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.0
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varSendableTrivialVarTupleFieldTest2() async {
@@ -1323,7 +1323,7 @@ func varSendableTrivialVarTupleFieldTest2() async {
   // expected-tns-note @-1 {{transferring disconnected 'test.2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   _ = test.0
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varSendableNonTrivialVarTupleFieldTest() async {
@@ -1333,7 +1333,7 @@ func varSendableNonTrivialVarTupleFieldTest() async {
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.1
-  useValue(test) // expected-tns-note {{access here could race}}
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varNonSendableNonTrivialVarTupleFieldTest() async {
@@ -1342,7 +1342,7 @@ func varNonSendableNonTrivialVarTupleFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
-  let z = test.2 // expected-tns-note {{access here could race}}
+  let z = test.2 // expected-tns-note {{use here could race}}
   useValue(z)
   useValue(test)
 }
@@ -1364,7 +1364,7 @@ func controlFlowTest1() async {
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
-  useValue(x) // expected-tns-note 2{{access here could race}}
+  useValue(x) // expected-tns-note 2{{use here could race}}
 }
 
 // This test seems like something that we should not error upon. What is
@@ -1381,7 +1381,7 @@ func controlFlowTest2() async {
   for _ in 0..<1024 {
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
     // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-    // expected-tns-note @-2 {{access here could race}}
+    // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
     x = NonSendableKlass()

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -68,7 +68,7 @@ func asyncLet_Let_ActorIsolated_Simple1() async {
   async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -78,7 +78,7 @@ func asyncLet_Let_ActorIsolated_Simple2() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   let _ = await y
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
 }
 
 func asyncLet_Let_ActorIsolated_Simple3() async {
@@ -95,9 +95,9 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
   if await booleanFlag {
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{access here could race}}
+    useValue(x) // expected-tns-note {{use here could race}}
   }
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
 }
 
 func asyncLet_Let_ActorIsolated_Simple4() async {
@@ -106,10 +106,10 @@ func asyncLet_Let_ActorIsolated_Simple4() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
-    useValue(x) // expected-tns-note {{access here could race}}
+    useValue(x) // expected-tns-note {{use here could race}}
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{access here could race}}
+    useValue(x) // expected-tns-note {{use here could race}}
   }
 }
 
@@ -120,9 +120,9 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
     let _ = await y
-    useValue(x) // expected-tns-note {{access here could race}}
+    useValue(x) // expected-tns-note {{use here could race}}
   } else {
-    useValue(x) // expected-tns-note {{access here could race}}
+    useValue(x) // expected-tns-note {{use here could race}}
   }
 }
 
@@ -133,7 +133,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -142,7 +142,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x.field) // expected-tns-note {{access here could race}}
+  useValue(x.field) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -151,7 +151,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x.field2) // expected-tns-note {{access here could race}}
+  useValue(x.field2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -162,7 +162,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -171,7 +171,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x.k1) // expected-tns-note {{access here could race}}
+  useValue(x.k1) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -180,7 +180,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x.k2) // expected-tns-note {{access here could race}}
+  useValue(x.k2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -189,7 +189,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  useValue(x.k1.field) // expected-tns-note {{access here could race}}
+  useValue(x.k1.field) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -201,7 +201,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -211,7 +211,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.1) // expected-tns-note {{access here could race}}
+  useValue(x.1) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -221,7 +221,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.1.k2) // expected-tns-note {{access here could race}}
+  useValue(x.1.k2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -231,7 +231,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.0.k2.field) // expected-tns-note {{access here could race}}
+  useValue(x.0.k2.field) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -245,9 +245,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
 }
 
 func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
@@ -260,9 +260,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await y
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
 }
 
 // Make sure we emit separate errors for x and x2.
@@ -280,8 +280,8 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
 
   // We only error on the first value captured if multiple values are captured
   // since we track a single partial_apply as a transfer instruction.
-  useValue(x) // expected-tns-note {{access here could race}}
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -292,7 +292,7 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
 
   async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-note @-2:67 {{access here could race}}
+  // expected-tns-note @-2:67 {{use here could race}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -307,7 +307,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-tns-note @-1:53 {{access here could race}}
+  // expected-tns-note @-1:53 {{use here could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -345,7 +345,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
   // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await y
   let _ = await z
 }
@@ -364,8 +364,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
 
   let _ = await y
   let _ = await z
-  useValue(x) // expected-tns-note {{access here could race}}
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
 }
 
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
@@ -381,9 +381,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await z
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
 }
 
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
@@ -400,8 +400,8 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
   // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
-  useValue(x) // expected-tns-note {{access here could race}}
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await z
 }
 
@@ -414,7 +414,7 @@ func asyncLet_Let_NonIsolated_Simple1() async {
   async let y = transferToNonIsolatedInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -440,9 +440,9 @@ func asyncLet_Let_NonIsolated_Simple3() async {
   if await booleanFlag {
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{access here could race}}
+    useValue(x) // expected-tns-note {{use here could race}}
   }
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
 }
 
 func asyncLet_Let_NonIsolated_Simple4() async {
@@ -451,10 +451,10 @@ func asyncLet_Let_NonIsolated_Simple4() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
   if await booleanFlag {
-    useValue(x) // expected-tns-note {{access here could race}}
+    useValue(x) // expected-tns-note {{use here could race}}
     let _ = await y
   } else {
-    useValue(x) // expected-tns-note {{access here could race}}
+    useValue(x) // expected-tns-note {{use here could race}}
   }
 }
 
@@ -467,7 +467,7 @@ func asyncLet_Let_NonIsolated_Simple5() async {
     let _ = await y
     useValue(x)
   } else {
-    useValue(x) // expected-tns-note {{access here could race}}
+    useValue(x) // expected-tns-note {{use here could race}}
   }
 }
 
@@ -478,7 +478,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass1() async {
   async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -487,7 +487,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass2() async {
   async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x.field) // expected-tns-note {{access here could race}}
+  useValue(x.field) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -496,7 +496,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsClass3() async {
   async let y = transferToNonIsolatedInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x.field2) // expected-tns-note {{access here could race}}
+  useValue(x.field2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -507,7 +507,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct1() async {
   async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -516,7 +516,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct2() async {
   async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
-  useValue(x.k1) // expected-tns-note {{access here could race}}
+  useValue(x.k1) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -525,7 +525,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct3() async {
   async let y = transferToNonIsolatedInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
-  useValue(x.k2) // expected-tns-note {{access here could race}}
+  useValue(x.k2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -534,7 +534,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsStruct4() async {
   async let y = transferToNonIsolatedInt(x.k2.field2) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
 
-  useValue(x.k1.field) // expected-tns-note {{access here could race}}
+  useValue(x.k1.field) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -546,7 +546,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple1() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -555,7 +555,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple2() async {
   async let y = transferToNonIsolatedInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.1) // expected-tns-note {{access here could race}}
+  useValue(x.1) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -565,7 +565,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple3() async {
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
 
-  useValue(x.1.k2) // expected-tns-note {{access here could race}}
+  useValue(x.1.k2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -574,7 +574,7 @@ func asyncLet_Let_NonIsolated_AccessFieldsTuple4() async {
   async let y = transferToNonIsolatedInt(x.1.k1.field2) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  useValue(x.0.k2.field) // expected-tns-note {{access here could race}}
+  useValue(x.0.k2.field) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -585,7 +585,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr1() async {
   async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
   useValue(x2)
 }
@@ -597,7 +597,7 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr2() async {
   async let y = useValue(transferToNonIsolatedInt(x) + transferToNonIsolatedInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-2 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await y
   useValue(x)
 }
@@ -615,8 +615,8 @@ func asyncLet_Let_NonIsolated_CallBuriedInOtherExpr3() async {
 
   // We only error on the first value captured if multiple values are captured
   // since we track a single partial_apply as a transfer instruction.
-  useValue(x) // expected-tns-note {{access here could race}}
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
@@ -637,7 +637,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
   async let y = useValue(transferToNonIsolatedInt(x)), z = useValue(transferToNonIsolatedInt(x)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
-  // expected-tns-note @-1:60 {{access here could race}}
+  // expected-tns-note @-1:60 {{use here could race}}
 
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -669,7 +669,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet3() async {
   // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
 
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await y
   let _ = await z
 }
@@ -714,7 +714,7 @@ func asyncLet_Let_NonIsolated_MultipleAsyncLet6() async {
 
   let _ = await y
   useValue(x)
-  useValue(x2) // expected-tns-note {{access here could race}}
+  useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await z
 }
 
@@ -726,7 +726,7 @@ func asyncLet_Let_NormalUse_Simple1() async {
   let x = NonSendableKlass()
   async let y = x // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass'; later accesses could race}}
   // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 
 }
@@ -749,5 +749,5 @@ func asyncLetWithoutCapture() async {
   await transferToMain(y) // expected-tns-warning {{transferring 'y' may cause a race}}
   // expected-tns-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  useValue(y) // expected-tns-note {{access here could race}}
+  useValue(y) // expected-tns-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable_cfg.sil
+++ b/test/Concurrency/transfernonsendable_cfg.sil
@@ -47,7 +47,7 @@ bb3:
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %useKlass = function_ref @useKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %useKlass(%klass) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   destroy_value %klass : $NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -96,7 +96,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to nonisolated callee could cause races in between callee nonisolated and local global actor 'GlobalActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
 }
 
 private struct StructContainingValue { // expected-complete-note 2{{}}
@@ -112,7 +112,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to nonisolated callee could cause races in between callee nonisolated and local global actor 'GlobalActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
 }
 
 @GlobalActor func useGlobalActor7() async {
@@ -135,7 +135,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'GlobalActor'-isolated context may introduce data races}}
 
-  useValue(x) // expected-tns-note {{access here could race}}
+  useValue(x) // expected-tns-note {{use here could race}}
 }
 
 @GlobalActor func useGlobalActor9() async {

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -93,7 +93,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   destroy_value %1 : $NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
@@ -109,7 +109,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   yield %3 : $*NonSendableKlass, resume bb1, unwind bb2
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
 bb1:
   end_borrow %3 : $*NonSendableKlass
@@ -136,7 +136,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %4<FakeOptional<NonSendableKlass>>(%2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'FakeOptional<NonSendableKlass>' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   switch_enum_addr %2 : $*FakeOptional<NonSendableKlass>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
 bb1:
   destroy_addr %2 : $*FakeOptional<NonSendableKlass>
@@ -163,7 +163,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   destroy_value %1a : $NonSendableKlass
   destroy_value %1 : $NonSendableKlass
   %9999 = tuple ()
@@ -180,7 +180,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
   apply %3(%1a) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   destroy_value %1a : $NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
@@ -199,7 +199,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableMoveOnlyStruct' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %5 = function_ref @useMoveOnlyStructIndirectly : $@convention(thin) (@in_guaranteed NonSendableMoveOnlyStruct) -> ()
   apply %5(%unresolved) : $@convention(thin) (@in_guaranteed NonSendableMoveOnlyStruct) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   destroy_value %box : ${ var NonSendableMoveOnlyStruct }
   %9999 = tuple ()
   return %9999 : $()
@@ -219,7 +219,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%project) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   destroy_value %binding : ${ var NonSendableKlass }
   %9999 = tuple ()
   return %9999 : $()
@@ -241,7 +241,7 @@ bb0:
   %0bb = begin_borrow %0a : $@moveOnly NonSendableKlass
   %0d = moveonlywrapper_to_copyable [guaranteed] %0bb : $@moveOnly NonSendableKlass
   apply %3(%0d) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   end_borrow %0bb : $@moveOnly NonSendableKlass
   destroy_value %0a : $@moveOnly NonSendableKlass
   %9999 = tuple ()
@@ -264,7 +264,7 @@ bb0:
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%unwrappedProject) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   end_borrow %bb : ${ var @moveOnly NonSendableKlass }
   destroy_value %box : ${ var @moveOnly NonSendableKlass }
@@ -298,7 +298,7 @@ bb0:
   %p2 = project_box %bb2 : ${ var NonSendableKlass }, 0
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%p2) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   end_borrow %bb2 : ${ var NonSendableKlass }
 
   destroy_value %pa : $@callee_owned () -> ()
@@ -366,7 +366,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   fix_lifetime %1 : $NonSendableKlass
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   destroy_value %1 : $NonSendableKlass
   %9999 = tuple ()
   return %9999 : $()
@@ -386,7 +386,7 @@ bb0:
 
   %5 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %5<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_addr %3 : $*NonSendableKlass
   dealloc_stack %3 : $*NonSendableKlass
@@ -427,7 +427,7 @@ bb0:
 
   // But we have an error here since we store through the value.c
   apply %useNonSendableKlass(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   end_borrow %1a : $NonSendableKlass
   destroy_value %0 : $NonSendableKlass
@@ -454,7 +454,7 @@ sil [ossa] @mark_dependence_test_base_has_a_require : $@convention(thin) @async 
 
   // But we have an error here since we store through the value.c
   apply %useNonSendableKlass(%1) : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   end_borrow %1a : $NonSendableKlass
   destroy_value %0 : $NonSendableKlass
@@ -474,7 +474,7 @@ sil [ossa] @mark_dependence_test_base_is_a_require : $@convention(thin) @async (
 
   %1a = begin_borrow %1 : $NonSendableKlass
   %2 = mark_dependence %1a : $NonSendableKlass on %0 : $NonSendableKlass
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   end_borrow %1a : $NonSendableKlass
   destroy_value %0 : $NonSendableKlass
@@ -580,9 +580,9 @@ bb0(%0 : $Builtin.RawPointer):
 
   %useRawPointer = function_ref @useRawPointer : $@convention(thin) (Builtin.RawPointer) -> ()
   apply %useRawPointer(%3a) : $@convention(thin) (Builtin.RawPointer) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   apply %useRawPointer(%5a) : $@convention(thin) (Builtin.RawPointer) -> ()
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_value %4 : $SendableKlass
   destroy_value %6 : $SendableKlass
@@ -606,7 +606,7 @@ bb0:
 
   // Test that this is viewed as a use of %construct
   %3 = raw_pointer_to_ref %3a : $Builtin.RawPointer to $SendableKlass
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -625,7 +625,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -647,10 +647,10 @@ bb0:
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
-  // expected-note @-2 {{access here could race}}
+  // expected-note @-2 {{use here could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_value %value : $SendableKlass
   %9999 = tuple ()
@@ -667,7 +667,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %word = unchecked_trivial_bit_cast %value : $NonSendableKlass to $Builtin.Word
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -701,7 +701,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -723,10 +723,10 @@ bb0:
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
-  // expected-note @-2 {{access here could race}}
+  // expected-note @-2 {{use here could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_value %value : $SendableKlass
   %9999 = tuple ()
@@ -743,7 +743,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %word = unchecked_bitwise_cast %value : $NonSendableKlass to $Builtin.Word
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   destroy_value %value : $NonSendableKlass
   %9999 = tuple ()
@@ -778,7 +778,7 @@ bb0:
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   fix_lifetime %value : $NonSendableKlass
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   end_borrow %valueB : $NonSendableKlass
   destroy_value %value : $NonSendableKlass
@@ -802,10 +802,10 @@ bb0:
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
-  // expected-note @-2 {{access here could race}}
+  // expected-note @-2 {{use here could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   end_borrow %valueB : $SendableKlass
   destroy_value %value : $SendableKlass
@@ -824,7 +824,7 @@ bb0:
 
   %valueB = begin_borrow %value : $NonSendableKlass
   %word = unchecked_value_cast %valueB : $NonSendableKlass to $Builtin.Word
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
   end_borrow %valueB : $NonSendableKlass
 
   destroy_value %value : $NonSendableKlass
@@ -894,7 +894,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %value2 = unchecked_ref_cast %value : $NonSendableKlass to $Builtin.BridgeObject
-  %1 = classify_bridge_object %value2 : $Builtin.BridgeObject // expected-note {{access here could race}}
+  %1 = classify_bridge_object %value2 : $Builtin.BridgeObject // expected-note {{use here could race}}
   destroy_value %value2 : $Builtin.BridgeObject
 
   %9999 = tuple ()
@@ -910,7 +910,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %value2 = unchecked_ref_cast %value : $NonSendableKlass to $Builtin.BridgeObject
-  %1 = bridge_object_to_word %value2 : $Builtin.BridgeObject to $Builtin.Word // expected-note {{access here could race}}
+  %1 = bridge_object_to_word %value2 : $Builtin.BridgeObject to $Builtin.Word // expected-note {{use here could race}}
   destroy_value %value2 : $Builtin.BridgeObject
 
   %9999 = tuple ()
@@ -937,7 +937,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   destroy_value %value : $NonSendableKlass
-  %1 = is_unique %a : $*NonSendableKlass // expected-note {{access here could race}}
+  %1 = is_unique %a : $*NonSendableKlass // expected-note {{use here could race}}
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
 
@@ -959,7 +959,7 @@ bb0:
 
   %s = struct_element_addr %a : $*NonSendableStruct, #NonSendableStruct.ns
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f2<NonSendableKlass>(%s) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply %f2<NonSendableKlass>(%s) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   destroy_addr %a : $*NonSendableStruct
   dealloc_stack %a : $*NonSendableStruct
@@ -985,7 +985,7 @@ bb0:
 
   %s = tuple_element_addr %a : $*(NonSendableKlass, NonSendableKlass), 0
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f2<NonSendableKlass>(%s) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply %f2<NonSendableKlass>(%s) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   destroy_addr %a : $*(NonSendableKlass, NonSendableKlass)
   dealloc_stack %a : $*(NonSendableKlass, NonSendableKlass)
@@ -1043,7 +1043,7 @@ bb0:
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %2 = begin_borrow %1 : $NonSendableKlass
-  %3 = ref_tail_addr %2 : $NonSendableKlass, $*SendableKlass // expected-note {{access here could race}}
+  %3 = ref_tail_addr %2 : $NonSendableKlass, $*SendableKlass // expected-note {{use here could race}}
 
   // Since our type is Sendable, we shouldn't see errors here.
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
@@ -1079,14 +1079,14 @@ bb0:
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %2 = begin_borrow %1 : $NonSendableKlass
-  %3 = ref_tail_addr [immutable] %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{access here could race}}
+  %3 = ref_tail_addr [immutable] %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{use here could race}}
 
   // Since this is as assign, we should be able to get a separate error on the ref_tail_addr
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   end_borrow %2 : $NonSendableKlass
   destroy_value %1 : $NonSendableKlass
@@ -1101,14 +1101,14 @@ bb0:
   %f = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %2 = begin_borrow %1 : $NonSendableKlass
-  %3 = ref_tail_addr %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{access here could race}}
+  %3 = ref_tail_addr %2 : $NonSendableKlass, $*NonSendableKlass // expected-note {{use here could race}}
 
   // Since this is as assign, we should be able to get a separate error on the ref_tail_addr
   %f2 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   end_borrow %2 : $NonSendableKlass
   destroy_value %1 : $NonSendableKlass
@@ -1128,7 +1128,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   end_borrow %2 : $KlassContainingKlasses
 
@@ -1149,7 +1149,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f2<NonSendableKlass>(%3) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %f3 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply %f3<NonSendableKlass>(%3) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   end_borrow %2 : $KlassContainingKlasses
 
@@ -1169,7 +1169,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor]  %f(%1) : $@convention(thin) @async (@guaranteed KlassContainingKlasses) -> () // expected-warning {{transferring value of non-Sendable type 'KlassContainingKlasses' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %2 = begin_borrow %1 : $KlassContainingKlasses
-  %3 = ref_element_addr %2 : $KlassContainingKlasses, #KlassContainingKlasses.sMutable // expected-note {{access here could race}}
+  %3 = ref_element_addr %2 : $KlassContainingKlasses, #KlassContainingKlasses.sMutable // expected-note {{use here could race}}
   end_borrow %2 : $KlassContainingKlasses
 
   destroy_value %1 : $KlassContainingKlasses
@@ -1214,7 +1214,7 @@ bb0:
   %3a = copy_value %1 : $NonSendableKlass
   (%uniq2, %3) = begin_cow_mutation %3a : $NonSendableKlass
   %f3 = function_ref @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
-  apply %f3(%3) : $@convention(thin) (@guaranteed NonSendableKlass) -> () // expected-note {{access here could race}}
+  apply %f3(%3) : $@convention(thin) (@guaranteed NonSendableKlass) -> () // expected-note {{use here could race}}
   destroy_value %3 : $NonSendableKlass
 
   destroy_value %1 : $NonSendableKlass
@@ -1235,10 +1235,10 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   // This is a copy_addr [take] [init] + cast.
-  unchecked_ref_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{access here could race}}
+  unchecked_ref_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{use here could race}}
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   destroy_addr %b : $*NonSendableKlass
   dealloc_stack %b : $*NonSendableKlass
@@ -1261,10 +1261,10 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%a) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
   // This is a copy_addr [take] [init] + cast.
-  unconditional_checked_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{access here could race}}
+  unconditional_checked_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{use here could race}}
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   destroy_addr %b : $*NonSendableKlass
   dealloc_stack %b : $*NonSendableKlass
@@ -1286,11 +1286,11 @@ bb0:
 
 
   %b = alloc_stack $@sil_unowned NonSendableKlass
-  store_unowned %aValue to [init] %b : $*@sil_unowned NonSendableKlass // expected-note {{access here could race}}
+  store_unowned %aValue to [init] %b : $*@sil_unowned NonSendableKlass // expected-note {{use here could race}}
   destroy_value %aValue : $NonSendableKlass
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   destroy_addr %b : $*@sil_unowned NonSendableKlass
   destroy_addr %a : $*NonSendableKlass
@@ -1320,7 +1320,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   destroy_value %value : $NonSendableKlass
-  mark_function_escape %a : $*NonSendableKlass // expected-note {{access here could race}}
+  mark_function_escape %a : $*NonSendableKlass // expected-note {{use here could race}}
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
 
@@ -1339,7 +1339,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  unmanaged_retain_value %value : $NonSendableKlass // expected-note {{access here could race}}
+  unmanaged_retain_value %value : $NonSendableKlass // expected-note {{use here could race}}
   destroy_value %value : $NonSendableKlass
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
@@ -1359,7 +1359,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  unmanaged_release_value %value : $NonSendableKlass // expected-note {{access here could race}}
+  unmanaged_release_value %value : $NonSendableKlass // expected-note {{use here could race}}
   destroy_value %value : $NonSendableKlass
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
@@ -1379,7 +1379,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  unmanaged_autorelease_value %value : $NonSendableKlass // expected-note {{access here could race}}
+  unmanaged_autorelease_value %value : $NonSendableKlass // expected-note {{use here could race}}
   destroy_value %value : $NonSendableKlass
   destroy_addr %a : $*NonSendableKlass
   dealloc_stack %a : $*NonSendableKlass
@@ -1401,7 +1401,7 @@ bb0:
   %2 = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (Builtin.RawPointer) -> () // expected-warning {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %4 = integer_literal $Builtin.Word, 1
-  %5 = bind_memory %1 : $Builtin.RawPointer, %4 : $Builtin.Word to $NonSendableKlass // expected-note {{access here could race}}
+  %5 = bind_memory %1 : $Builtin.RawPointer, %4 : $Builtin.Word to $NonSendableKlass // expected-note {{use here could race}}
   %9999 = tuple ()
   return %9999 : $()
 }
@@ -1413,7 +1413,7 @@ bb0:
   %2 = function_ref @transferRawPointer : $@convention(thin) @async (Builtin.RawPointer) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %2(%1) : $@convention(thin) @async (Builtin.RawPointer) -> () // expected-warning {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %4 = integer_literal $Builtin.Word, 1
-  %5 = rebind_memory %1 : $Builtin.RawPointer to %4 : $Builtin.Word // expected-note {{access here could race}}
+  %5 = rebind_memory %1 : $Builtin.RawPointer to %4 : $Builtin.Word // expected-note {{use here could race}}
   %9999 = tuple ()
   return %9999 : $()
 }
@@ -1432,7 +1432,7 @@ bb0:
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  %addr2 = pack_element_get %index of %pack : $*Pack{NonSendableKlass, repeat each T} as $*NonSendableKlass // expected-note {{access here could race}}
+  %addr2 = pack_element_get %index of %pack : $*Pack{NonSendableKlass, repeat each T} as $*NonSendableKlass // expected-note {{use here could race}}
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply %f2<NonSendableKlass>(%addr2) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 
@@ -1463,7 +1463,7 @@ bb0:
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr0) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  %addr2 = pack_element_get %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} as $*SendableKlass // expected-note {{access here could race}}
+  %addr2 = pack_element_get %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} as $*SendableKlass // expected-note {{use here could race}}
   dealloc_pack %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T}
 
   %9999 = tuple ()
@@ -1487,12 +1487,12 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   pack_element_set %addr : $*NonSendableKlass into %index of %pack2 : $*Pack{NonSendableKlass, repeat each T}
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 
   // Now transfer %addr and use it.
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
   %f2 = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  apply %f2<NonSendableKlass>(%addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply %f2<NonSendableKlass>(%addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   dealloc_pack %pack2 : $*Pack{NonSendableKlass, repeat each T}
   dealloc_pack %pack : $*Pack{NonSendableKlass, repeat each T}
@@ -1521,7 +1521,7 @@ bb0:
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%addr) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  pack_element_set %alloc : $*SendableKlass into %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} // expected-note {{access here could race}}
+  pack_element_set %alloc : $*SendableKlass into %index1 of %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T} // expected-note {{use here could race}}
 
   dealloc_pack %pack : $*Pack{NonSendableKlass, SendableKlass, repeat each T}
   destroy_addr %alloc : $*SendableKlass
@@ -1544,7 +1544,7 @@ bb0(%index : $Builtin.Word):
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'τ_1_0' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  %elt2 = tuple_pack_element_addr %pi of %tuple : $*(NonSendableKlass, T, T, Int) as $*@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1 // expected-note {{access here could race}}
+  %elt2 = tuple_pack_element_addr %pi of %tuple : $*(NonSendableKlass, T, T, Int) as $*@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1 // expected-note {{use here could race}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("31FF306C-BF88-11ED-A03F-ACDE48001122") U_1>(%elt2) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 
   dealloc_stack %tuple : $*(NonSendableKlass, T, T, Int)
@@ -1580,7 +1580,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
   %9 = alloc_stack $Builtin.UnsafeValueBuffer
-  begin_unpaired_access [read] [dynamic] [no_nested_conflict] %a : $*NonSendableKlass, %9 : $*Builtin.UnsafeValueBuffer // expected-note {{access here could race}}
+  begin_unpaired_access [read] [dynamic] [no_nested_conflict] %a : $*NonSendableKlass, %9 : $*Builtin.UnsafeValueBuffer // expected-note {{use here could race}}
   destroy_value %value : $NonSendableKlass
   dealloc_stack %9 : $*Builtin.UnsafeValueBuffer
   destroy_addr %a : $*NonSendableKlass
@@ -1624,7 +1624,7 @@ bb0:
   %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
 
-  %b = load_unowned [take] %a : $*@sil_unowned NonSendableKlass // expected-note {{access here could race}}
+  %b = load_unowned [take] %a : $*@sil_unowned NonSendableKlass // expected-note {{use here could race}}
   destroy_value %b : $NonSendableKlass
   destroy_value %value : $NonSendableKlass
   dealloc_stack %a : $*@sil_unowned NonSendableKlass
@@ -1645,7 +1645,7 @@ bb0:
   %v2 = unmanaged_to_ref %v : $@sil_unmanaged NonSendableKlass to $ NonSendableKlass
   %v3 = ref_to_unmanaged %v2 : $NonSendableKlass to $@sil_unmanaged NonSendableKlass
   %useFunc = function_ref @useUnmanagedNonSendableKlass : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> ()
-  apply %useFunc(%v3) : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> () // expected-note {{access here could race}}
+  apply %useFunc(%v3) : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> () // expected-note {{use here could race}}
   end_borrow %borrowedValue : $NonSendableKlass
   destroy_value %value : $NonSendableKlass
 
@@ -1667,7 +1667,7 @@ bb0(%arg : $Builtin.Word):
 
   %b = ref_to_bridge_object %value : $NonSendableKlass, %arg : $Builtin.Word
   %bridgeUse = function_ref @use_bridge_object : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
-  apply %bridgeUse(%b) : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> () // expected-note {{access here could race}}
+  apply %bridgeUse(%b) : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> () // expected-note {{use here could race}}
   destroy_value %b : $Builtin.BridgeObject
   %9999 = tuple ()
   return %9999 : $()

--- a/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
@@ -90,7 +90,7 @@ bb0:
   %1 = begin_borrow %0 : $@differentiable(_linear) @callee_guaranteed (Float) -> Float
   %2 = linear_function_extract [original] %1 : $@differentiable(_linear) @callee_guaranteed (Float) -> Float
   %f = function_ref @useFunction : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> ()
-  apply %f(%2) : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-note {{access here could race}}
+  apply %f(%2) : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-note {{use here could race}}
   end_borrow %1 : $@differentiable(_linear) @callee_guaranteed (Float) -> Float
   destroy_value %0 : $@differentiable(_linear) @callee_guaranteed (Float) -> Float
 
@@ -110,7 +110,7 @@ bb0:
   %1 = begin_borrow %0 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
   %2 = differentiable_function_extract [original] %1 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
   %f = function_ref @useFunction : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> ()
-  apply %f(%2) : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-note {{access here could race}}
+  apply %f(%2) : $@convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-note {{use here could race}}
   end_borrow %1 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
   destroy_value %0 : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
 
@@ -127,7 +127,7 @@ bb0:
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transfer(%1) : $@async @convention(thin) (@guaranteed @callee_guaranteed (Float) -> Float) -> () // expected-warning {{transferring value of non-Sendable type '@callee_guaranteed (Float) -> Float' from nonisolated context to global actor '<null>'-isolated context}}
 
   %2 = begin_borrow %1 : $@callee_guaranteed (Float) -> Float
-  %3 = linear_function [parameters 0] %2 : $@callee_guaranteed (Float) -> Float // expected-note {{access here could race}}
+  %3 = linear_function [parameters 0] %2 : $@callee_guaranteed (Float) -> Float // expected-note {{use here could race}}
 
   end_borrow %2 : $@callee_guaranteed (Float) -> Float
   destroy_value %1 : $@callee_guaranteed (Float) -> Float
@@ -150,7 +150,7 @@ bb0:
   %derivative = function_ref @derivative : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %vjp = function_ref @vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
   %2 = begin_borrow %1 : $@callee_guaranteed (Float) -> Float
-  %3 = differentiable_function [parameters 0] [results 0] %2 : $@callee_guaranteed (Float) -> Float with_derivative {%derivative : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)} // expected-note {{access here could race}}
+  %3 = differentiable_function [parameters 0] [results 0] %2 : $@callee_guaranteed (Float) -> Float with_derivative {%derivative : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)} // expected-note {{use here could race}}
 
   end_borrow %2 : $@callee_guaranteed (Float) -> Float
   destroy_value %1 : $@callee_guaranteed (Float) -> Float

--- a/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_opaquevalues.sil
@@ -104,7 +104,7 @@ bb0:
   %f = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("00000000-0000-0000-0000-000000000000") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'τ_1_0' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
 
-  %elt2 = tuple_pack_extract %index of %1 : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000000") U_1 // expected-note {{access here could race}}
+  %elt2 = tuple_pack_extract %index of %1 : $(repeat each T) as $@pack_element("00000000-0000-0000-0000-000000000000") U_1 // expected-note {{use here could race}}
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@pack_element("00000000-0000-0000-0000-000000000000") U_1>(%elt) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
 
   end_borrow %1 : $(repeat each T)
@@ -124,7 +124,7 @@ bb0:
   %b = begin_borrow %p : $P
   %v = open_existential_value %b : $P to $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self
   %w = witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self, #P.doSomething, %v : $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
-  apply %w<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self>(%v) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> () // expected-note {{access here could race}}
+  apply %w<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", P) Self>(%v) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
   end_borrow %b : $P
   destroy_value %p : $P
 
@@ -144,7 +144,7 @@ bb0:
 
   %w = weak_copy_value %pBorrowed : $Optional<PAnyObject>
   %weakFunc = function_ref @usePAnyObjectWeak : $@convention(thin) (@guaranteed @sil_weak Optional<PAnyObject>) -> ()
-  apply %weakFunc(%w) : $@convention(thin) (@guaranteed @sil_weak Optional<PAnyObject>) -> () // expected-note {{access here could race}}
+  apply %weakFunc(%w) : $@convention(thin) (@guaranteed @sil_weak Optional<PAnyObject>) -> () // expected-note {{use here could race}}
   destroy_value %w : $@sil_weak Optional<PAnyObject>
 
   end_borrow %pBorrowed : $Optional<PAnyObject>
@@ -167,7 +167,7 @@ bb0:
   %w = weak_copy_value %pBorrowed : $Optional<PAnyObject>
   %s = strong_copy_weak_value %w : $@sil_weak Optional<PAnyObject>
   %weakFunc = function_ref @usePAnyObject : $@convention(thin) (@guaranteed Optional<PAnyObject>) -> ()
-  apply %weakFunc(%s) : $@convention(thin) (@guaranteed Optional<PAnyObject>) -> () // expected-note {{access here could race}}
+  apply %weakFunc(%s) : $@convention(thin) (@guaranteed Optional<PAnyObject>) -> () // expected-note {{use here could race}}
   destroy_value %s : $Optional<PAnyObject>
   destroy_value %w : $@sil_weak Optional<PAnyObject>
 
@@ -189,7 +189,7 @@ bb0:
 
   %i = init_existential_value %1 : $NonSendableKlass, $NonSendableKlass, $P
   %f2 = function_ref @useP : $@convention(thin) (@in_guaranteed P) -> ()
-  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> () // expected-note {{access here could race}}
+  apply %f2(%i) : $@convention(thin) (@in_guaranteed P) -> () // expected-note {{use here could race}}
   destroy_value %i : $P
 
   %9999 = tuple ()

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -68,7 +68,7 @@ actor ProtectsNonSendable {
       isolatedSelf.ns = l // expected-warning {{actor-isolated closure captures value of non-Sendable type 'NonSendableKlass' from nonisolated context; later accesses to value could race}}
     }
 
-    useValue(l) // expected-note {{access here could race}}
+    useValue(l) // expected-note {{use here could race}}
   }
 }
 
@@ -84,7 +84,7 @@ func normalFunc_testLocal_2() {
   let _ = { @MainActor in
     useValue(x) // expected-warning {{main actor-isolated closure captures value of non-Sendable type 'NonSendableKlass' from nonisolated context; later accesses to value could race}}
   }
-  useValue(x) // expected-note {{access here could race}}
+  useValue(x) // expected-note {{use here could race}}
 }
 
 // We error here since we are performing a double transfer.
@@ -95,7 +95,7 @@ func transferBeforeCaptureErrors() async {
   let x = NonSendableKlass()
   await transferToCustom(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'x' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
-  let _ = { @MainActor in // expected-note {{access here could race}}
+  let _ = { @MainActor in // expected-note {{use here could race}}
     useValue(x)
   }
 }

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -62,7 +62,7 @@ func test_isolation_crossing_sensitivity(a : A) async {
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
     print(ns0);
-    print(ns1); // expected-tns-note {{access here could race}}
+    print(ns1); // expected-tns-note {{use here could race}}
 }
 
 func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
@@ -105,7 +105,7 @@ func test_closure_capture(a : A) async {
     // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-    print(ns0) // expected-tns-note {{access here could race}}
+    print(ns0) // expected-tns-note {{use here could race}}
     print(ns1)
     print(ns2)
     print(ns3)
@@ -117,7 +117,7 @@ func test_closure_capture(a : A) async {
 
     // This only touches ns1/ns2 so we get an error on ns1 since it is first.
     print(ns0)
-    print(ns1) // expected-tns-note {{access here could race}}
+    print(ns1) // expected-tns-note {{use here could race}}
     print(ns2)
     print(ns3)
 
@@ -130,7 +130,7 @@ func test_closure_capture(a : A) async {
     print(ns0)
     print(ns1)
     print(ns2)
-    print(ns3) // expected-tns-note {{access here could race}}
+    print(ns3) // expected-tns-note {{use here could race}}
 }
 
 func test_regions(a : A, b : Bool) async {
@@ -157,18 +157,18 @@ func test_regions(a : A, b : Bool) async {
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if (b) {
-          print(ns0_0) // expected-tns-note {{access here could race}}
+          print(ns0_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns0_1) // expected-tns-note {{access here could race}}
+          print(ns0_1) // expected-tns-note {{use here could race}}
         }
     } else {
         await a.foo(ns0_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns0_0) // expected-tns-note {{access here could race}}
+          print(ns0_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns0_1) // expected-tns-note {{access here could race}}
+          print(ns0_1) // expected-tns-note {{use here could race}}
         }
     }
 
@@ -177,18 +177,18 @@ func test_regions(a : A, b : Bool) async {
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns1_0) // expected-tns-note {{access here could race}}
+          print(ns1_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns1_1) // expected-tns-note {{access here could race}}
+          print(ns1_1) // expected-tns-note {{use here could race}}
         }
     } else {
         await a.foo(ns1_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
       // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns1_0) // expected-tns-note {{access here could race}}
+          print(ns1_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns1_1) // expected-tns-note {{access here could race}}
+          print(ns1_1) // expected-tns-note {{use here could race}}
         }
     }
 
@@ -197,18 +197,18 @@ func test_regions(a : A, b : Bool) async {
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns2_0) // expected-tns-note {{access here could race}}
+          print(ns2_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns2_1) // expected-tns-note {{access here could race}}
+          print(ns2_1) // expected-tns-note {{use here could race}}
         }
     } else {
         await a.foo(ns2_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns2_0) // expected-tns-note {{access here could race}}
+          print(ns2_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns2_1) // expected-tns-note {{access here could race}}
+          print(ns2_1) // expected-tns-note {{use here could race}}
         }
     }
 }
@@ -256,18 +256,18 @@ func test_indirect_regions(a : A, b : Bool) async {
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns0_0) // expected-tns-note {{access here could race}}
+          print(ns0_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns0_1) // expected-tns-note {{access here could race}}
+          print(ns0_1) // expected-tns-note {{use here could race}}
         }
     } else {
         await a.foo(ns0_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns0_0) // expected-tns-note {{access here could race}}
+          print(ns0_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns0_1) // expected-tns-note {{access here could race}}
+          print(ns0_1) // expected-tns-note {{use here could race}}
         }
     }
 
@@ -276,18 +276,18 @@ func test_indirect_regions(a : A, b : Bool) async {
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns1_0) // expected-tns-note {{access here could race}}
+          print(ns1_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns1_1) // expected-tns-note {{access here could race}}
+          print(ns1_1) // expected-tns-note {{use here could race}}
         }
     } else {
         await a.foo(ns1_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns1_0) // expected-tns-note {{access here could race}}
+          print(ns1_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns1_1) // expected-tns-note {{access here could race}}
+          print(ns1_1) // expected-tns-note {{use here could race}}
         }
     }
 
@@ -296,18 +296,18 @@ func test_indirect_regions(a : A, b : Bool) async {
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns2_0) // expected-tns-note {{access here could race}}
+          print(ns2_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns2_1) // expected-tns-note {{access here could race}}
+          print(ns2_1) // expected-tns-note {{use here could race}}
         }
     } else {
         await a.foo(ns2_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns2_0) // expected-tns-note {{access here could race}}
+          print(ns2_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns2_1) // expected-tns-note {{access here could race}}
+          print(ns2_1) // expected-tns-note {{use here could race}}
         }
     }
 
@@ -316,18 +316,18 @@ func test_indirect_regions(a : A, b : Bool) async {
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns3_0) // expected-tns-note {{access here could race}}
+          print(ns3_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns3_1) // expected-tns-note {{access here could race}}
+          print(ns3_1) // expected-tns-note {{use here could race}}
         }
     } else {
         await a.foo(ns3_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns3_0) // expected-tns-note {{access here could race}}
+          print(ns3_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns3_1) // expected-tns-note {{access here could race}}
+          print(ns3_1) // expected-tns-note {{use here could race}}
         }
     }
 
@@ -336,18 +336,18 @@ func test_indirect_regions(a : A, b : Bool) async {
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns4_0) // expected-tns-note {{access here could race}}
+          print(ns4_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns4_1) // expected-tns-note {{access here could race}}
+          print(ns4_1) // expected-tns-note {{use here could race}}
         }
     } else {
         await a.foo(ns4_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns4_0) // expected-tns-note {{access here could race}}
+          print(ns4_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns4_1) // expected-tns-note {{access here could race}}
+          print(ns4_1) // expected-tns-note {{use here could race}}
         }
     }
 
@@ -357,9 +357,9 @@ func test_indirect_regions(a : A, b : Bool) async {
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns5_0) // expected-tns-note {{access here could race}}
+          print(ns5_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns5_1) // expected-tns-note {{access here could race}}
+          print(ns5_1) // expected-tns-note {{use here could race}}
         }
     } else {
         await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' may cause a race}}
@@ -367,9 +367,9 @@ func test_indirect_regions(a : A, b : Bool) async {
         // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
         if b {
-          print(ns5_0) // expected-tns-note {{access here could race}}
+          print(ns5_0) // expected-tns-note {{use here could race}}
         } else {
-          print(ns5_1) // expected-tns-note {{access here could race}}
+          print(ns5_1) // expected-tns-note {{use here could race}}
         }
     }
 }
@@ -434,7 +434,7 @@ func basic_loopiness(a : A, b : Bool) async {
     while (b) {
         await a.foo(ns)
         // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-tns-note @-2 {{access here could race}}
+        // expected-tns-note @-2 {{use here could race}}
         // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
     }
 }
@@ -452,7 +452,7 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
 
     await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns3) // expected-tns-note {{access here could race}}
+    await a.foo(ns3) // expected-tns-note {{use here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
@@ -516,7 +516,7 @@ func test_class_assign_merges(a : A, b : Bool) async {
 
     await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns1) // expected-tns-note {{access here could race}}
+    await a.foo(ns1) // expected-tns-note {{use here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
@@ -552,7 +552,7 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
 
     await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns1) // expected-tns-note {{access here could race}}
+    await a.foo(ns1) // expected-tns-note {{use here could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
@@ -571,57 +571,57 @@ func test_tuple_formation(a : A, i : Int) async {
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if bool {
-          foo_noniso(ns0); // expected-tns-note {{access here could race}}
+          foo_noniso(ns0); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{access here could race}}
+          foo_noniso(ns1); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{access here could race}}
+          foo_noniso(ns2); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{access here could race}}
+          foo_noniso(ns3); // expected-tns-note {{use here could race}}
         } else if bool {
           foo_noniso(ns4);
         } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{access here could race}}
+          foo_noniso(ns012); // expected-tns-note {{use here could race}}
         } else {
-          foo_noniso(ns13); // expected-tns-note {{access here could race}}
+          foo_noniso(ns13); // expected-tns-note {{use here could race}}
         }
     case 1:
         await a.foo(ns1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if bool {
-          foo_noniso(ns0); // expected-tns-note {{access here could race}}
+          foo_noniso(ns0); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{access here could race}}
+          foo_noniso(ns1); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{access here could race}}
+          foo_noniso(ns2); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{access here could race}}
+          foo_noniso(ns3); // expected-tns-note {{use here could race}}
         } else if bool {
           foo_noniso(ns4);
         } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{access here could race}}
+          foo_noniso(ns012); // expected-tns-note {{use here could race}}
         } else {
-          foo_noniso(ns13); // expected-tns-note {{access here could race}}
+          foo_noniso(ns13); // expected-tns-note {{use here could race}}
         }
     case 2:
         await a.foo(ns2) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
         if bool {
-          foo_noniso(ns0); // expected-tns-note {{access here could race}}
+          foo_noniso(ns0); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{access here could race}}
+          foo_noniso(ns1); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{access here could race}}
+          foo_noniso(ns2); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{access here could race}}
+          foo_noniso(ns3); // expected-tns-note {{use here could race}}
         } else if bool {
           foo_noniso(ns4);
         } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{access here could race}}
+          foo_noniso(ns012); // expected-tns-note {{use here could race}}
         } else {
-          foo_noniso(ns13); // expected-tns-note {{access here could race}}
+          foo_noniso(ns13); // expected-tns-note {{use here could race}}
         }
     case 3:
         await a.foo(ns4) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
@@ -630,7 +630,7 @@ func test_tuple_formation(a : A, i : Int) async {
         foo_noniso(ns0);
         foo_noniso(ns1);
         foo_noniso(ns2);
-        foo_noniso(ns4); // expected-tns-note {{access here could race}}
+        foo_noniso(ns4); // expected-tns-note {{use here could race}}
         foo_noniso(ns012);
         foo_noniso(ns13);
     case 4:
@@ -639,38 +639,38 @@ func test_tuple_formation(a : A, i : Int) async {
         // expected-complete-warning @-2 3{{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
         if bool {
-          foo_noniso(ns0); // expected-tns-note {{access here could race}}
+          foo_noniso(ns0); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{access here could race}}
+          foo_noniso(ns1); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{access here could race}}
+          foo_noniso(ns2); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{access here could race}}
+          foo_noniso(ns3); // expected-tns-note {{use here could race}}
         } else if bool {
           foo_noniso(ns4);
         } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{access here could race}}
+          foo_noniso(ns012); // expected-tns-note {{use here could race}}
         } else {
-          foo_noniso(ns13); // expected-tns-note {{access here could race}}
+          foo_noniso(ns13); // expected-tns-note {{use here could race}}
         }
     default:
         await a.foo(ns13) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
         // expected-complete-warning @-1 2{{passing argument of non-sendable type '(NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
 
         if bool {
-          foo_noniso(ns0); // expected-tns-note {{access here could race}}
+          foo_noniso(ns0); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{access here could race}}
+          foo_noniso(ns1); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{access here could race}}
+          foo_noniso(ns2); // expected-tns-note {{use here could race}}
         } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{access here could race}}
+          foo_noniso(ns3); // expected-tns-note {{use here could race}}
         } else if bool {
           foo_noniso(ns4);
         } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{access here could race}}
+          foo_noniso(ns012); // expected-tns-note {{use here could race}}
         } else  {
-          foo_noniso(ns13); // expected-tns-note {{access here could race}}
+          foo_noniso(ns13); // expected-tns-note {{use here could race}}
         }
     }
 }
@@ -698,9 +698,9 @@ func one_consume_many_require(a : A) async {
     // expected-tns-warning @-1 3{{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{access here could race}}
-    foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{access here could race}}
-    foo_noniso_multi(ns4, ns3, ns2); // expected-tns-note {{access here could race}}
+    foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
+    foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
+    foo_noniso_multi(ns4, ns3, ns2); // expected-tns-note {{use here could race}}
 }
 
 func one_consume_one_require(a : A) async {
@@ -712,7 +712,7 @@ func one_consume_one_require(a : A) async {
     // expected-tns-warning @-1 3{{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{access here could race}}
+    foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
 }
 
 func many_consume_one_require(a : A) async {
@@ -732,7 +732,7 @@ func many_consume_one_require(a : A) async {
     await a.foo_multi(ns5, ns5, ns2)
     // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{access here could race}}
+    foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{use here could race}}
 }
 
 func many_consume_many_require(a : A) async {
@@ -755,9 +755,9 @@ func many_consume_many_require(a : A) async {
     // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{access here could race}}
-    foo_noniso_multi(ns6, ns1, ns7); // expected-tns-note {{access here could race}}
-    foo_noniso_multi(ns7, ns6, ns2); // expected-tns-note {{access here could race}}
+    foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
+    foo_noniso_multi(ns6, ns1, ns7); // expected-tns-note {{use here could race}}
+    foo_noniso_multi(ns7, ns6, ns2); // expected-tns-note {{use here could race}}
 }
 
 
@@ -786,11 +786,11 @@ func one_consume_many_require_varag(a : A) async {
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
     if bool {
-      foo_noniso_vararg(ns0, ns3, ns4); // expected-tns-note {{access here could race}}
+      foo_noniso_vararg(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
     } else if bool {
-      foo_noniso_vararg(ns3, ns1, ns4); // expected-tns-note {{access here could race}}
+      foo_noniso_vararg(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
     } else {
-      foo_noniso_vararg(ns4, ns3, ns2); // expected-tns-note {{access here could race}}
+      foo_noniso_vararg(ns4, ns3, ns2); // expected-tns-note {{use here could race}}
     }
 }
 
@@ -803,7 +803,7 @@ func one_consume_one_require_vararg(a : A) async {
     // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 1{{access here could race}}
+    foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 1{{use here could race}}
 }
 
 func many_consume_one_require_vararg(a : A) async {
@@ -824,7 +824,7 @@ func many_consume_one_require_vararg(a : A) async {
     // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{access here could race}}
+    foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
 }
 
 func many_consume_many_require_vararg(a : A) async {
@@ -848,11 +848,11 @@ func many_consume_many_require_vararg(a : A) async {
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
     if bool {
-      foo_noniso_vararg(ns0, ns6, ns7); // expected-tns-note {{access here could race}}
+      foo_noniso_vararg(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
     } else if bool {
-      foo_noniso_vararg(ns6, ns1, ns7);  // expected-tns-note {{access here could race}}
+      foo_noniso_vararg(ns6, ns1, ns7);  // expected-tns-note {{use here could race}}
     } else {
-      foo_noniso_vararg(ns7, ns6, ns2);  // expected-tns-note {{access here could race}}
+      foo_noniso_vararg(ns7, ns6, ns2);  // expected-tns-note {{use here could race}}
     }
 }
 
@@ -894,7 +894,7 @@ func enum_test(a : A) async {
 
     await a.foo(e1); // expected-tns-warning {{transferring value of non-Sendable type 'E' from nonisolated context to actor-isolated context; later accesses could race}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
-    foo_noniso(e2); // expected-tns-note {{access here could race}}
-    foo_noniso(e3); // expected-tns-note {{access here could race}}
+    foo_noniso(e2); // expected-tns-note {{use here could race}}
+    foo_noniso(e3); // expected-tns-note {{use here could race}}
     foo_noniso(e4);
 }

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -69,14 +69,14 @@ func twoTransferArg(_ x: transferring Klass, _ y: transferring Klass) {}
 func testSimpleTransferLet() {
   let k = Klass()
   transferArg(k) // expected-warning {{binding of non-Sendable type 'Klass' accessed after being transferred; later accesses could race}}
-  useValue(k) // expected-note {{access here could race}}
+  useValue(k) // expected-note {{use here could race}}
 }
 
 func testSimpleTransferVar() {
   var k = Klass()
   k = Klass()
   transferArg(k) // expected-warning {{binding of non-Sendable type 'Klass' accessed after being transferred; later accesses could race}}
-  useValue(k) // expected-note {{access here could race}}
+  useValue(k) // expected-note {{use here could race}}
 }
 
 func testSimpleTransferUseOfOtherParamNoError() {
@@ -116,13 +116,13 @@ func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y:
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // TODO: We should not error on this since we are transferring to the same place.
-  await transferToMain(x) // expected-note {{access here could race}}
+  await transferToMain(x) // expected-note {{use here could race}}
 }
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  useValue(x) // expected-note {{access here could race}}
+  useValue(x) // expected-note {{use here could race}}
 }
 
 actor MyActor {
@@ -137,13 +137,13 @@ actor MyActor {
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
     await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
     // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
-    await transferToMain(x) // expected-note {{access here could race}}
+    await transferToMain(x) // expected-note {{use here could race}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
     await transferToMain(x)  // expected-warning {{transferring 'x' may cause a race}}
     // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
-    useValue(x) // expected-note {{access here could race}}
+    useValue(x) // expected-note {{use here could race}}
   }
 
   // After assigning into the actor, we can still use x in the actor as long as
@@ -186,7 +186,7 @@ func canTransferAssigningIntoLocal2(_ x: transferring Klass) async {
   let _ = x
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  let _ = x // expected-note {{access here could race}}
+  let _ = x // expected-note {{use here could race}}
 }
 
 
@@ -213,7 +213,7 @@ func assigningIsAMergeError(_ x: transferring Klass) async {
   await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
-  useValue(x) // expected-note {{access here could race}}
+  useValue(x) // expected-note {{use here could race}}
 }
 
 func assigningIsAMergeAny(_ x: transferring Any) async {
@@ -234,7 +234,7 @@ func assigningIsAMergeAnyError(_ x: transferring Any) async {
   await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
-  useValue(x) // expected-note {{access here could race}}
+  useValue(x) // expected-note {{use here could race}}
 }
 
 func canTransferAfterAssign(_ x: transferring Any) async {
@@ -260,7 +260,7 @@ func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
-  useValue(x) // expected-note {{access here could race}}
+  useValue(x) // expected-note {{use here could race}}
 }
 
 func assignToEntireValueEliminatesEarlierTransfer(_ x: transferring Any) async {
@@ -291,7 +291,7 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // y is assigned into a field of x.
-  x.first = y // expected-note {{access here could race}}
+  x.first = y // expected-note {{use here could race}}
 
   useValue(x)
 }
@@ -306,20 +306,20 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
-  x.first = y  // expected-note {{access here could race}}
+  x.first = y  // expected-note {{use here could race}}
 }
 
 func doubleArgument() async {
   let x = Klass()
   twoTransferArg(x, x) // expected-warning {{binding of non-Sendable type 'Klass' accessed after being transferred}}
-  // expected-note @-1 {{access here could race}}
+  // expected-note @-1 {{use here could race}}
 }
 
 func testTransferSrc(_ x: transferring Klass) async {
   let y = Klass()
   await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  x = y // expected-note {{access here could race}}
+  x = y // expected-note {{use here could race}}
 }
 
 func testTransferOtherParam(_ x: transferring Klass, y: Klass) async {

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -88,7 +88,7 @@ func simpleTest2() async {
   await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y)
-  useValue(x) // expected-note {{access here could race}}
+  useValue(x) // expected-note {{use here could race}}
 }
 
 // Make sure that later errors with y can happen.
@@ -98,14 +98,14 @@ func simpleTest3() async {
   await transferToMainDirect(x)
   await transferToMainDirect(y) // expected-warning {{transferring 'y' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  useValue(y) // expected-note {{access here could race}}
+  useValue(y) // expected-note {{use here could race}}
 }
 
 func transferResult() async -> transferring NonSendableKlass {
   let x = NonSendableKlass()
   await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  return x // expected-note {{access here could race}}
+  return x // expected-note {{use here could race}}
 }
 
 func transferInAndOut(_ x: transferring NonSendableKlass) -> transferring NonSendableKlass {

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -23,6 +23,6 @@ actor Bar {
     // TODO: This needs to be:
     // disconnected 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
     // expected-note @-3 {{transferring disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local actor-isolated uses}}
-    ns.foo() // expected-note {{access here could race}}
+    ns.foo() // expected-note {{use here could race}}
   }
 }

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -22,7 +22,7 @@ func testIsolationError() async {
   let x = NonSendableType()
   await transferToMain(x) // expected-error {{transferring 'x' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  useValue(x) // expected-note {{access here could race}}
+  useValue(x) // expected-note {{use here could race}}
 }
 
 func testTransferArgumentError(_ x: NonSendableType) async {
@@ -51,7 +51,7 @@ func testIsolationCrossingDueToCapture() async {
   let _ = { @MainActor in
     print(x) // expected-error {{main actor-isolated closure captures value of non-Sendable type 'NonSendableType' from nonisolated context; later accesses to value could race}}
   }
-  useValue(x) // expected-note {{access here could race}}
+  useValue(x) // expected-note {{use here could race}}
 }
 
 func testIsolationCrossingDueToCaptureParameter(_ x: NonSendableType) async {


### PR DESCRIPTION
I am doing this since it isn't always going to be an access. We may not have memory. We are talking about uses here!

I was able to just use sed so it was an easy fix.
