### PR TITLE
[Documentation] Expand documentation for withTaskCancellationHandler

### DIFF
--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -58,6 +58,8 @@ import Swift
 ///
 /// If cancellation occurs while the operation is running, the cancellation
 /// handler executes *concurrently* with the operation.
+/// In that case, the cancellation handler is guaranteed to have finished executing
+/// by the time `withTaskCancellationHandler(operation:onCancel:)` returns.
 ///
 /// ### Cancellation handlers and locks
 ///


### PR DESCRIPTION
Document that the cancellation handler, if executed, runs to completion before `withTaskCancellationHandler` returns.

This is a very useful guarantee which I think merits calling out in the documentation explicitly.

Presumably this could also be inferred as the cancellation handler is not `@escaping` but explicit documentation is much more obvious.

Someone with knowledge of the implementation should also verify that my understanding is actually correct. My understanding here is based at a cursory look at the implementation, particularly the following [comment](https://github.com/apple/swift/blob/bf685b49e1e551f0ef2b0b62198425fb2c7a3314/include/swift/ABI/TaskStatus.h#L231).

Feel free to request changes, directly make changes to the PR or replace this PR with a differently worded version.