### PR TITLE
[region-isolation] Add named variants to the rest of the diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -984,6 +984,9 @@ NOTE(regionbasedisolation_named_notransfer_transfer_into_result, none,
 NOTE(regionbasedisolation_named_stronglytransferred_binding, none,
       "%0 used after being passed as a transferring parameter; Later uses could race",
       (Identifier))
+NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
+      "%0 %1 is captured by %2 closure. %2 uses in closure may race against later %3 uses",
+      (StringRef, Identifier, ActorIsolation, ActorIsolation))
 
 // Misc Error.
 ERROR(regionbasedisolation_task_or_actor_isolated_transferred, none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -949,7 +949,7 @@ ERROR(regionbasedisolation_isolated_capture_yields_race, none,
       "%1 closure captures value of non-Sendable type %0 from %2 context; later accesses to value could race",
       (Type, ActorIsolation, ActorIsolation))
 ERROR(regionbasedisolation_transfer_yields_race_stronglytransferred_binding, none,
-      "binding of non-Sendable type %0 accessed after being transferred; later accesses could race",
+      "value of non-Sendable type %0 accessed after being transferred; later accesses could race",
       (Type))
 ERROR(regionbasedisolation_arg_transferred, none,
       "%0 value of type %1 transferred to %2 context; later accesses to value could race",
@@ -981,6 +981,9 @@ NOTE(regionbasedisolation_named_transfer_into_transferring_param, none,
 NOTE(regionbasedisolation_named_notransfer_transfer_into_result, none,
      "%0 %1 cannot be a transferring result. %0 uses may race with caller uses",
      (StringRef, Identifier))
+NOTE(regionbasedisolation_named_stronglytransferred_binding, none,
+      "%0 used after being passed as a transferring parameter; Later uses could race",
+      (Identifier))
 
 // Misc Error.
 ERROR(regionbasedisolation_task_or_actor_isolated_transferred, none,

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -493,8 +493,7 @@ public:
 
   void emitNamedIsolationCrossingError(SILLocation loc, Identifier name,
                                        SILIsolationInfo namesIsolationInfo,
-                                       ApplyIsolationCrossing isolationCrossing,
-                                       SILLocation variableDefinedLoc) {
+                                       ApplyIsolationCrossing isolationCrossing) {
     // Emit the short error.
     diagnoseError(loc, diag::regionbasedisolation_named_transfer_yields_race,
                   name)
@@ -523,7 +522,24 @@ public:
     emitRequireInstDiagnostics();
   }
 
-  void emitUseOfStronglyTransferredValue(SILLocation loc, Type inferredType) {
+  void emitNamedUseOfStronglyTransferredValue(SILLocation loc,
+                                              Identifier name) {
+    // Emit the short error.
+    diagnoseError(loc, diag::regionbasedisolation_named_transfer_yields_race,
+                  name)
+        .highlight(loc.getSourceRange());
+
+    // Then emit the note with greater context.
+    diagnoseNote(
+        loc, diag::regionbasedisolation_named_stronglytransferred_binding, name)
+        .highlight(loc.getSourceRange());
+
+    // Finally the require points.
+    emitRequireInstDiagnostics();
+  }
+
+  void emitTypedUseOfStronglyTransferredValue(SILLocation loc,
+                                              Type inferredType) {
     diagnoseError(
         loc,
         diag::
@@ -783,7 +799,16 @@ void UseAfterTransferDiagnosticInferrer::infer() {
            "We should never transfer an indirect out parameter");
     if (fas.getArgumentParameterInfo(*transferOp->getOperand())
             .hasOption(SILParameterInfo::Transferring)) {
-      return diagnosticEmitter.emitUseOfStronglyTransferredValue(
+
+      // First try to do the named diagnostic if we can find a name.
+      if (auto rootValueAndName =
+              inferNameAndRootFromValue(transferOp->get())) {
+        return diagnosticEmitter.emitNamedUseOfStronglyTransferredValue(
+            baseLoc, rootValueAndName->first);
+      }
+
+      // Otherwise, emit the typed diagnostic.
+      return diagnosticEmitter.emitTypedUseOfStronglyTransferredValue(
           baseLoc, baseInferredType);
     }
   }
@@ -804,20 +829,9 @@ void UseAfterTransferDiagnosticInferrer::infer() {
     // Before we do anything further, see if we can find a name and emit a name
     // error.
     if (auto rootValueAndName = inferNameAndRootFromValue(transferOp->get())) {
-      if (auto *svi =
-              dyn_cast<SingleValueInstruction>(rootValueAndName->second)) {
-        return diagnosticEmitter.emitNamedIsolationCrossingError(
-            baseLoc, rootValueAndName->first, transferOp->getIsolationInfo(),
-            *sourceApply->getIsolationCrossing(), svi->getLoc());
-      }
-
-      if (auto *fArg =
-              dyn_cast<SILFunctionArgument>(rootValueAndName->second)) {
-        return diagnosticEmitter.emitNamedIsolationCrossingError(
-            baseLoc, rootValueAndName->first, transferOp->getIsolationInfo(),
-            *sourceApply->getIsolationCrossing(),
-            RegularLocation(fArg->getDecl()->getLoc()));
-      }
+      return diagnosticEmitter.emitNamedIsolationCrossingError(
+          baseLoc, rootValueAndName->first, transferOp->getIsolationInfo(),
+          *sourceApply->getIsolationCrossing());
     }
 
     // Otherwise, try to infer from the ApplyExpr.

--- a/test/ClangImporter/transferring.swift
+++ b/test/ClangImporter/transferring.swift
@@ -28,11 +28,11 @@ func funcTestTransferringResult() async {
   let x2 = NonSendableCStruct()
   let y2 = returnUserDefinedFromGlobalFunction(x2)
   await transferToMain(x2) // expected-error {{transferring value of non-Sendable type 'NonSendableCStruct' from nonisolated context to main actor-isolated context}}
-  useValue(y2) // expected-note {{access here could race}}
+  useValue(y2) // expected-note {{use here could race}}
 }
 
 func funcTestTransferringArg() async {
   let x = NonSendableCStruct()
-  transferUserDefinedIntoGlobalFunction(x) // expected-error {{binding of non-Sendable type 'NonSendableCStruct' accessed after being transferred}}
-  useValue(x) // expected-note {{access here could race}}
+  transferUserDefinedIntoGlobalFunction(x) // expected-error {{value of non-Sendable type 'NonSendableCStruct' accessed after being transferred; later accesses could race}}
+  useValue(x) // expected-note {{use here could race}}
 }

--- a/test/ClangImporter/transferring_objc.swift
+++ b/test/ClangImporter/transferring_objc.swift
@@ -25,8 +25,9 @@ func methodTestTransferringResult() async {
 func methodTestTransferringArg() async {
   let x = MyType()
   let s = NSObject()
-  let _ = x.getResultWithTransferringArgument(s)  // expected-error {{binding of non-Sendable type 'NSObject' accessed after being transferred}}
-  useValue(s) // expected-note {{access here could race}}
+  let _ = x.getResultWithTransferringArgument(s)  // expected-error {{transferring 's' may cause a race}}
+  // expected-note @-1 {{'s' used after being passed as a transferring parameter; Later uses could race}}
+  useValue(s) // expected-note {{use here could race}}
 }
 
 // Make sure we just ignore the swift_attr if it is applied to something like a
@@ -46,11 +47,12 @@ func funcTestTransferringResult() async {
   let y2 = returnNSObjectFromGlobalFunction(x2)
   await transferToMain(x2) // expected-error {{transferring 'x2' may cause a race}}
   // expected-note @-1 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  useValue(y2) // expected-note {{access here could race}}
+  useValue(y2) // expected-note {{use here could race}}
 }
 
 func funcTestTransferringArg() async {
   let x = NSObject()
-  transferNSObjectToGlobalFunction(x) // expected-error {{binding of non-Sendable type 'NSObject' accessed after being transferred}}
-  useValue(x) // expected-note {{access here could race}}
+  transferNSObjectToGlobalFunction(x) // expected-error {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{'x' used after being passed as a transferring parameter; Later uses could race}}
+  useValue(x) // expected-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -65,27 +65,30 @@ struct TwoFieldKlassBox { // expected-complete-note 24{{}}
 
 func asyncLet_Let_ActorIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_Simple2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   let _ = await y
   useValue(x) // expected-tns-note {{use here could race}}
 }
 
 func asyncLet_Let_ActorIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // TODO: We shouldn't emit the 2nd error here given the current implementation
   // since it is only accessible along the else path but we already hit
@@ -102,9 +105,10 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
 
 func asyncLet_Let_ActorIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
     useValue(x) // expected-tns-note {{use here could race}}
     let _ = await y
@@ -115,9 +119,10 @@ func asyncLet_Let_ActorIsolated_Simple4() async {
 
 func asyncLet_Let_ActorIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   if await booleanFlag {
     let _ = await y
     useValue(x) // expected-tns-note {{use here could race}}
@@ -130,27 +135,30 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.field2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
@@ -159,36 +167,40 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k1) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x.k2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{transferring value of non-Sendable type 'TwoFieldKlassBox' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
   useValue(x.k1.field) // expected-tns-note {{use here could race}}
   let _ = await y
 }
@@ -197,40 +209,44 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x.1) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x.1.k2) // expected-tns-note {{use here could race}}
   let _ = await y
 }
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{transferring value of non-Sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-1 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
-  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
+  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   useValue(x.0.k2.field) // expected-tns-note {{use here could race}}
   let _ = await y
 }
@@ -239,12 +255,14 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{transferring 'x2' may cause a race}}
+  // expected-tns-note @-3 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x) // expected-tns-note {{use here could race}}
   let _ = await y
   useValue(x2) // expected-tns-note {{use here could race}}
@@ -254,12 +272,14 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-4 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{transferring 'x2' may cause a race}}
+  // expected-tns-note @-3 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await y
   useValue(x) // expected-tns-note {{use here could race}}
@@ -270,13 +290,14 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-2 {{transferring 'x2' may cause a race}}
+  // expected-tns-note @-3 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   // We only error on the first value captured if multiple values are captured
   // since we track a single partial_apply as a transfer instruction.
@@ -306,13 +327,14 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-tns-note @-1:53 {{use here could race}}
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-note @-2:53 {{use here could race}}
 
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
   let _ = await z
@@ -338,12 +360,13 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1:53 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{transferring 'x2' may cause a race}}
+  // expected-tns-note @-2 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   useValue(x2) // expected-tns-note {{use here could race}}
   let _ = await y
@@ -355,12 +378,14 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-tns-warning @-2 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
+  // expected-tns-note @-2 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-3 {{transferring 'x2' may cause a race}}
+  // expected-tns-note @-4 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}  
+  // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-8 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
   let _ = await z
@@ -373,12 +398,14 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-tns-warning @-2 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-complete-warning @-3 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-5 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
+  // expected-tns-note @-2 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-3 {{transferring 'x2' may cause a race}}
+  // expected-tns-note @-4 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-7 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-8 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
   useValue(x) // expected-tns-note {{use here could race}}
@@ -391,13 +418,15 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
-  // expected-tns-warning @-2 {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to main actor-isolated context; later accesses could race}}
+  // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
+  // expected-tns-note @-2 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-3 {{transferring 'x2' may cause a race}}
+  // expected-tns-note @-4 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
-  // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
-  // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
-  // expected-complete-warning @-6 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-6 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-7 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
+  // expected-complete-warning @-8 {{capture of 'x2' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
+  // expected-complete-warning @-9 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
   let _ = await y
   useValue(x) // expected-tns-note {{use here could race}}

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -65,7 +65,8 @@ actor ProtectsNonSendable {
 
     // This is not safe since we use l later.
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{actor-isolated closure captures value of non-Sendable type 'NonSendableKlass' from nonisolated context; later accesses to value could race}}
+      isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a race}}
+      // expected-note @-1 {{disconnected 'l' is captured by actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
 
     useValue(l) // expected-note {{use here could race}}
@@ -82,7 +83,8 @@ func normalFunc_testLocal_1() {
 func normalFunc_testLocal_2() {
   let x = NonSendableKlass()
   let _ = { @MainActor in
-    useValue(x) // expected-warning {{main actor-isolated closure captures value of non-Sendable type 'NonSendableKlass' from nonisolated context; later accesses to value could race}}
+    useValue(x) // expected-warning {{transferring 'x' may cause a race}}
+    // expected-note @-1 {{disconnected 'x' is captured by main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -68,14 +68,16 @@ func twoTransferArg(_ x: transferring Klass, _ y: transferring Klass) {}
 
 func testSimpleTransferLet() {
   let k = Klass()
-  transferArg(k) // expected-warning {{binding of non-Sendable type 'Klass' accessed after being transferred; later accesses could race}}
+  transferArg(k) // expected-warning {{transferring 'k' may cause a race}}
+  // expected-note @-1 {{'k' used after being passed as a transferring parameter}}
   useValue(k) // expected-note {{use here could race}}
 }
 
 func testSimpleTransferVar() {
   var k = Klass()
   k = Klass()
-  transferArg(k) // expected-warning {{binding of non-Sendable type 'Klass' accessed after being transferred; later accesses could race}}
+  transferArg(k) // expected-warning {{transferring 'k' may cause a race}}
+  // expected-note @-1 {{'k' used after being passed as a transferring parameter}}
   useValue(k) // expected-note {{use here could race}}
 }
 
@@ -311,8 +313,9 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
 
 func doubleArgument() async {
   let x = Klass()
-  twoTransferArg(x, x) // expected-warning {{binding of non-Sendable type 'Klass' accessed after being transferred}}
-  // expected-note @-1 {{use here could race}}
+  twoTransferArg(x, x) // expected-warning {{transferring 'x' may cause a race}}
+  // expected-note @-1 {{'x' used after being passed as a transferring parameter}}
+  // expected-note @-2 {{use here could race}}
 }
 
 func testTransferSrc(_ x: transferring Klass) async {

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -49,7 +49,8 @@ func testAssigningParameterIntoTransferringParameter(_ x: transferring NonSendab
 func testIsolationCrossingDueToCapture() async {
   let x = NonSendableType()
   let _ = { @MainActor in
-    print(x) // expected-error {{main actor-isolated closure captures value of non-Sendable type 'NonSendableType' from nonisolated context; later accesses to value could race}}
+    print(x) // expected-error {{transferring 'x' may cause a race}}
+    // expected-note @-1 {{disconnected 'x' is captured by main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
 }


### PR DESCRIPTION
Phew that was a bunch of work.

This is the last in a series of PRs that migrates TransferNonSendable to use named errors instead of type errors.

In this PR, I hit closure errors, auto closure async let errors, and use after strong transfer.