### PR TITLE
[unittests] Enable debug info when compiling unittests when debug info is enabled.

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -111,6 +111,9 @@ function(add_swift_unittest test_dirname)
     endif()
   endif()
 
+  is_build_type_with_debuginfo("${CMAKE_BUILD_TYPE}" HAS_DEBUG_INFO)
+  target_compile_options("${test_dirname}" PRIVATE $<$<BOOL:${HAS_DEBUG_INFO}>:-g>)
+
   file(RELATIVE_PATH relative_lib_path "${CMAKE_CURRENT_BINARY_DIR}" "${SWIFT_LIBRARY_OUTPUT_INTDIR}")
 
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)


### PR DESCRIPTION
I noticed this while I was debugging a failure in unittest.
