### PR TITLE
[AST] Improve diagnostic message about `constructor` expression

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4663,7 +4663,7 @@ ERROR(value_of_module_type,none,
       "expected module member name after module name", ())
 
 ERROR(value_of_metatype_type,none,
-      "expected member name or constructor call after type name%select{|; this "
+      "expected member name or initializer call after type name%select{|; this "
       "will be an error in Swift 6}0", (bool))
 
 NOTE(add_parens_to_type,none,
@@ -6510,9 +6510,9 @@ ERROR(dynamic_replacement_replaced_not_objc_dynamic, none,
 ERROR(dynamic_replacement_replacement_not_objc_dynamic, none,
       "%0 is marked @objc dynamic", (DeclName))
 ERROR(dynamic_replacement_replaced_constructor_is_convenience, none,
-      "replaced constructor %0 is marked as convenience", (DeclNameRef))
+      "replaced initializer %0 is marked as convenience", (DeclNameRef))
 ERROR(dynamic_replacement_replaced_constructor_is_not_convenience, none,
-      "replaced constructor %0 is not marked as convenience", (DeclNameRef))
+      "replaced initializer %0 is not marked as convenience", (DeclNameRef))
 
 //------------------------------------------------------------------------------
 // MARK: @_typeEraser()

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -454,11 +454,11 @@ func test_dynamic_subscript_accepts_type_name_argument() {
   }
 
   func test(a: AnyObject, optA: AnyObject?) {
-    let _ = a[A] // expected-warning {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+    let _ = a[A] // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
 
-    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+    let _ = optA?[A] // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
   }

--- a/test/Constraints/dynamic_lookup_swift6.swift
+++ b/test/Constraints/dynamic_lookup_swift6.swift
@@ -13,11 +13,11 @@ func test_dynamic_subscript_accepts_type_name_argument() {
   }
 
   func test(a: AnyObject, optA: AnyObject?) {
-    let _ = a[A] // expected-error {{expected member name or constructor call after type name}}
+    let _ = a[A] // expected-error {{expected member name or initializer call after type name}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
 
-    let _ = optA?[A] // expected-error {{expected member name or constructor call after type name}}
+    let _ = optA?[A] // expected-error {{expected member name or initializer call after type name}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
   }

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -617,7 +617,7 @@ func rdar50679161() {
 
     _ = { () -> Void in
       var foo = S
-      // expected-error@-1 {{expected member name or constructor call after type name}}
+      // expected-error@-1 {{expected member name or initializer call after type name}}
       // expected-note@-2 {{add arguments after the type to construct a value of the type}}
       // expected-note@-3 {{use '.self' to reference the type object}}
       print(foo)

--- a/test/Constraints/metatypes.swift
+++ b/test/Constraints/metatypes.swift
@@ -15,11 +15,11 @@ let test5 : S.Type = S.self
 let test6 : AnyClass = S.self // expected-error {{cannot convert value of type 'S.Type' to specified type 'AnyClass' (aka 'any AnyObject.Type')}}
 
 func acceptMeta<T>(_ meta: T.Type) { }
-acceptMeta(A) // expected-error {{expected member name or constructor call after type name}}
+acceptMeta(A) // expected-error {{expected member name or initializer call after type name}}
 // expected-note@-1 {{add arguments after the type to construct a value of the type}}
 // expected-note@-2 {{use '.self' to reference the type object}}
 
-acceptMeta((A) -> Void) // expected-error {{expected member name or constructor call after type name}}
+acceptMeta((A) -> Void) // expected-error {{expected member name or initializer call after type name}}
 // expected-note@-1 {{use '.self' to reference the type object}}
 
 func id<T>(_ x: T.Type) -> T.Type { x }

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -313,9 +313,9 @@ func acceptMetatype<T>(_: T.Type) -> Bool { true }
 
 func syntacticUses<T>(_: T) {
   tuplify(true) { x in
-    if x && acceptMetatype(T) { // expected-error{{expected member name or constructor call after type name}}
+    if x && acceptMetatype(T) { // expected-error{{expected member name or initializer call after type name}}
       // expected-note@-1{{use '.self' to reference the type object}}
-      acceptMetatype(T) // expected-error{{expected member name or constructor call after type name}}
+      acceptMetatype(T) // expected-error{{expected member name or initializer call after type name}}
       // expected-note@-1{{use '.self' to reference the type object}}
     }
   }

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -229,11 +229,11 @@ func test_subscript_accepts_type_name_argument() {
   }
 
   func test(a: A, optA: A?) {
-    let _ = a[A] // expected-warning {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+    let _ = a[A] // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
 
-    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+    let _ = optA?[A] // expected-warning {{expected member name or initializer call after type name; this will be an error in Swift 6}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
   }

--- a/test/Constraints/subscript_swift6.swift
+++ b/test/Constraints/subscript_swift6.swift
@@ -7,11 +7,11 @@ func test_subscript_accepts_type_name_argument() {
   }
 
   func test(a: A, optA: A?) {
-    let _ = a[A] // expected-error {{expected member name or constructor call after type name}}
+    let _ = a[A] // expected-error {{expected member name or initializer call after type name}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
 
-    let _ = optA?[A] // expected-error {{expected member name or constructor call after type name}}
+    let _ = optA?[A] // expected-error {{expected member name or initializer call after type name}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
   }

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -87,10 +87,10 @@ func unqualifiedType() {
   let _ : () = Foo.meth()
   _ = Foo.instMeth
 
-  _ = Foo // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{10-10=()}} expected-note{{use '.self'}} {{10-10=.self}}
+  _ = Foo // expected-error{{expected member name or initializer call after type name}} expected-note{{add arguments}} {{10-10=()}} expected-note{{use '.self'}} {{10-10=.self}}
   _ = Foo.dynamicType // expected-error {{type 'Foo' has no member 'dynamicType'}}
 
-  _ = Bad // expected-error{{expected member name or constructor call after type name}}
+  _ = Bad // expected-error{{expected member name or initializer call after type name}}
   // expected-note@-1{{use '.self' to reference the type object}}{{10-10=.self}}
 
   CheckType<Foo>.matches((Foo).self)
@@ -106,7 +106,7 @@ func qualifiedType() {
   let _ : () = Foo.Bar.meth()
   _ = Foo.Bar.instMeth
 
-  _ = Foo.Bar // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{14-14=()}} expected-note{{use '.self'}} {{14-14=.self}}
+  _ = Foo.Bar // expected-error{{expected member name or initializer call after type name}} expected-note{{add arguments}} {{14-14=()}} expected-note{{use '.self'}} {{14-14=.self}}
   _ = Foo.Bar.dynamicType // expected-error {{type 'Foo.Bar' has no member 'dynamicType'}}
 
   CheckType<Foo.Bar>.matches((Foo).Bar.self)
@@ -120,10 +120,10 @@ func metaType() {
   let _ = Foo.Type.self
   let _ = Foo.Type.self
 
-  let _ = Foo.Type // expected-error{{expected member name or constructor call after type name}}
+  let _ = Foo.Type // expected-error{{expected member name or initializer call after type name}}
   // expected-note@-1 {{use '.self' to reference the type object}}
 
-  let _ = type(of: Foo.Type) // expected-error{{expected member name or constructor call after type name}}
+  let _ = type(of: Foo.Type) // expected-error{{expected member name or initializer call after type name}}
   // expected-note@-1 {{use '.self' to reference the type object}}
 }
 
@@ -160,7 +160,7 @@ func genType() {
   CheckType<Gen<P1 & P2>>.matches(Gen<[Int : Foo].P1 & [Int : Foo].P2>.self)
 
   // FIXME?: This needs to go last or else it won't parse as intended.
-  _ = Gen<Foo> // expected-error{{expected member name or constructor call after type name}}
+  _ = Gen<Foo> // expected-error{{expected member name or initializer call after type name}}
                // expected-note@-1{{use '.self' to reference the type object}}
                // expected-note@-2{{add arguments after the type to construct a value of the type}}
 }
@@ -173,7 +173,7 @@ func genQualifiedType() {
   let _ : () = Gen<Foo>.Bar.meth()
   _ = Gen<Foo>.Bar.instMeth
 
-  _ = Gen<Foo>.Bar // expected-error{{expected member name or constructor call after type name}}
+  _ = Gen<Foo>.Bar // expected-error{{expected member name or initializer call after type name}}
                    // expected-note@-1{{add arguments after the type to construct a value of the type}}
                    // expected-note@-2{{use '.self' to reference the type object}}
   _ = Gen<Foo>.Bar.dynamicType // expected-error {{type 'Gen<Foo>.Bar' has no member 'dynamicType'}}
@@ -205,7 +205,7 @@ func typeOfShadowing() {
   }
 
   _ = type(of: Gen<Foo>.Bar) // expected-error{{missing argument for parameter 'flag' in call}} {{28-28=, flag: <#Bool#>}}
-  _ = type(Gen<Foo>.Bar) // expected-error{{expected member name or constructor call after type name}}
+  _ = type(Gen<Foo>.Bar) // expected-error{{expected member name or initializer call after type name}}
   // expected-note@-1{{add arguments after the type to construct a value of the type}}
   // expected-note@-2{{use '.self' to reference the type object}}
   _ = type(of: Gen<Foo>.Bar.self, flag: false) // No error here.
@@ -220,7 +220,7 @@ func archetype<T: Zim>(_: T) {
   _ = T.meth
   let _ : () = T.meth()
 
-  _ = T // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{8-8=()}} expected-note{{use '.self'}} {{8-8=.self}}
+  _ = T // expected-error{{expected member name or initializer call after type name}} expected-note{{add arguments}} {{8-8=()}} expected-note{{use '.self'}} {{8-8=.self}}
 }
 
 func assocType<T: Zim>(_: T) where T.Zang: Zim {
@@ -230,7 +230,7 @@ func assocType<T: Zim>(_: T) where T.Zang: Zim {
   _ = T.Zang.meth
   let _ : () = T.Zang.meth()
 
-  _ = T.Zang // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{13-13=()}} expected-note{{use '.self'}} {{13-13=.self}}
+  _ = T.Zang // expected-error{{expected member name or initializer call after type name}} expected-note{{add arguments}} {{13-13=()}} expected-note{{use '.self'}} {{13-13=.self}}
 }
 
 class B {
@@ -249,8 +249,8 @@ func derivedType() {
   _ = D.derivedMethod
   let _ : () = D.derivedMethod()
 
-  let _: B.Type = D // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{20-20=()}} expected-note{{use '.self'}} {{20-20=.self}}
-  let _: D.Type = D // expected-error{{expected member name or constructor call after type name}} expected-note{{add arguments}} {{20-20=()}} expected-note{{use '.self'}} {{20-20=.self}}
+  let _: B.Type = D // expected-error{{expected member name or initializer call after type name}} expected-note{{add arguments}} {{20-20=()}} expected-note{{use '.self'}} {{20-20=.self}}
+  let _: D.Type = D // expected-error{{expected member name or initializer call after type name}} expected-note{{add arguments}} {{20-20=()}} expected-note{{use '.self'}} {{20-20=.self}}
 }
 
 // Referencing a nonexistent member or constructor should not trigger errors
@@ -277,7 +277,7 @@ class E {
 }
 
 func inAccessibleInit() {
-  _ = E // expected-error {{expected member name or constructor call after type name}} expected-note {{use '.self'}} {{8-8=.self}}
+  _ = E // expected-error {{expected member name or initializer call after type name}} expected-note {{use '.self'}} {{8-8=.self}}
 }
 
 enum F: Int {
@@ -289,8 +289,8 @@ struct G {
 }
 
 func implicitInit() {
-  _ = F // expected-error {{expected member name or constructor call after type name}} expected-note {{add arguments}} {{8-8=()}} expected-note {{use '.self'}} {{8-8=.self}}
-  _ = G // expected-error {{expected member name or constructor call after type name}} expected-note {{add arguments}} {{8-8=()}} expected-note {{use '.self'}} {{8-8=.self}}
+  _ = F // expected-error {{expected member name or initializer call after type name}} expected-note {{add arguments}} {{8-8=()}} expected-note {{use '.self'}} {{8-8=.self}}
+  _ = G // expected-error {{expected member name or initializer call after type name}} expected-note {{add arguments}} {{8-8=()}} expected-note {{use '.self'}} {{8-8=.self}}
 }
 
 // https://github.com/apple/swift/issues/43119
@@ -315,9 +315,9 @@ func testFunctionCollectionTypes() {
 
   _ = 2 + () -> Int // expected-error {{expected type before '->'}}
   _ = () -> (Int, Int).2 // expected-error {{expected type after '->'}}
-  _ = (Int) -> Int // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self' to reference the type object}}
+  _ = (Int) -> Int // expected-error {{expected member name or initializer call after type name}} expected-note{{use '.self' to reference the type object}}
 
-  _ = @convention(c) () -> Int // expected-error{{expected member name or constructor call after type name}} expected-note{{use '.self' to reference the type object}}
+  _ = @convention(c) () -> Int // expected-error{{expected member name or initializer call after type name}} expected-note{{use '.self' to reference the type object}}
   _ = 1 + (@convention(c) () -> Int).self // expected-error{{cannot convert value of type '(@convention(c) () -> Int).Type' to expected argument type 'Int'}}
   _ = (@autoclosure () -> Int) -> (Int, Int).2 // expected-error {{expected type after '->'}}
   _ = ((@autoclosure () -> Int) -> (Int, Int)).1 // expected-error {{type '(@autoclosure () -> Int) -> (Int, Int)' has no member '1'}}
@@ -332,8 +332,8 @@ func testFunctionCollectionTypes() {
 }
 
 func compositionType() {
-  _ = P1 & P2 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{14-14=).self}}
-  _ = any P1 & P1 // expected-error {{expected member name or constructor call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{18-18=).self}}
+  _ = P1 & P2 // expected-error {{expected member name or initializer call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{14-14=).self}}
+  _ = any P1 & P1 // expected-error {{expected member name or initializer call after type name}} expected-note{{use '.self'}} {{7-7=(}} {{18-18=).self}}
   _ = P1 & P2.self // expected-error {{binary operator '&' cannot be applied to operands of type '(any P1).Type' and '(any P2).Type'}}
   _ = (P1 & P2).self // Ok.
   _ = (P1 & (P2)).self // Ok.
@@ -353,12 +353,12 @@ func compositionType() {
 
 func tupleType() {
   _ = (Foo, Foo)
-  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-error@-1 {{expected member name or initializer call after type name}}
   // expected-note@-2 {{use '.self' to reference the type object}} {{17-17=.self}}
   _ = (Foo, Foo).self
 
   CheckType<(Foo, Foo)>.matches((Foo, Foo))
-  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-error@-1 {{expected member name or initializer call after type name}}
   // expected-note@-2 {{use '.self' to reference the type object}} {{43-43=.self}}
 
   // Check that we resolve these type expressions correctly.
@@ -405,23 +405,23 @@ func tupleType() {
 func functionType() {
   _ = Foo -> Foo
   // expected-error@-1 {{single argument function types require parentheses}} {{7-7=(}} {{10-10=)}}
-  // expected-error@-2 {{expected member name or constructor call after type name}}
+  // expected-error@-2 {{expected member name or initializer call after type name}}
   // expected-note@-3 {{use '.self' to reference the type object}} {{7-7=(}} {{17-17=).self}}
   _ = (Foo) -> Foo
-  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-error@-1 {{expected member name or initializer call after type name}}
   // expected-note@-2 {{use '.self' to reference the type object}} {{7-7=(}} {{19-19=).self}}
   _ = (Foo) -> Foo -> Foo
   // expected-error@-1 {{single argument function types require parentheses}} {{16-16=(}} {{19-19=)}}
-  // expected-error@-2 {{expected member name or constructor call after type name}}
+  // expected-error@-2 {{expected member name or initializer call after type name}}
   // expected-note@-3 {{use '.self' to reference the type object}} {{7-7=(}} {{26-26=).self}}
   _ = P1 & P2 -> Foo
   // expected-error @-1 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
-  // expected-error @-2 {{expected member name or constructor call after type name}}
+  // expected-error @-2 {{expected member name or initializer call after type name}}
   // expected-note @-3 {{use '.self' to reference the type object}} {{7-7=(}} {{21-21=).self}}
   _ = P1 & P2 -> P3 & P1 -> Foo
   // expected-error @-1 {{single argument function types require parentheses}} {{18-18=(}} {{25-25=)}}
   // expected-error @-2 {{single argument function types require parentheses}} {{7-7=(}} {{14-14=)}}
-  // expected-error @-3 {{expected member name or constructor call after type name}}
+  // expected-error @-3 {{expected member name or initializer call after type name}}
   // expected-note @-4 {{use '.self'}} {{7-7=(}} {{32-32=).self}}
   _ = (Foo -> Foo).self // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{11-11=)}}
   _ = (P1 & P2 -> P3 & P2).self // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{15-15=)}}
@@ -482,7 +482,7 @@ func complexSequence() {
   _ = try P1 & P2 throws -> P3 & P1
   // expected-warning @-1 {{no calls to throwing functions occur within 'try' expression}}
   // expected-error @-2 {{single argument function types require parentheses}} {{11-11=(}} {{18-18=)}}
-  // expected-error @-3 {{expected member name or constructor call after type name}}
+  // expected-error @-3 {{expected member name or initializer call after type name}}
   // expected-note @-4 {{use '.self' to reference the type object}} {{11-11=(}} {{36-36=).self}}
 }
 
@@ -496,32 +496,32 @@ func testMissingSelf() {
   // See test/Compatibility/type_expr.swift.
 
   takesOneArg(Int)
-  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-error@-1 {{expected member name or initializer call after type name}}
   // expected-note@-2 {{add arguments after the type to construct a value of the type}}
   // expected-note@-3 {{use '.self' to reference the type object}}
 
   takesOneArg(Swift.Int)
-  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-error@-1 {{expected member name or initializer call after type name}}
   // expected-note@-2 {{add arguments after the type to construct a value of the type}}
   // expected-note@-3 {{use '.self' to reference the type object}}
 
   takesTwoArgs(Int, 0)
-  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-error@-1 {{expected member name or initializer call after type name}}
   // expected-note@-2 {{add arguments after the type to construct a value of the type}}
   // expected-note@-3 {{use '.self' to reference the type object}}
 
   takesTwoArgs(Swift.Int, 0)
-  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-error@-1 {{expected member name or initializer call after type name}}
   // expected-note@-2 {{add arguments after the type to construct a value of the type}}
   // expected-note@-3 {{use '.self' to reference the type object}}
 
   Swift.Int // expected-warning {{expression of type 'Int.Type' is unused}}
-  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-error@-1 {{expected member name or initializer call after type name}}
   // expected-note@-2 {{add arguments after the type to construct a value of the type}}
   // expected-note@-3 {{use '.self' to reference the type object}}
 
   _ = Swift.Int
-  // expected-error@-1 {{expected member name or constructor call after type name}}
+  // expected-error@-1 {{expected member name or initializer call after type name}}
   // expected-note@-2 {{add arguments after the type to construct a value of the type}}
   // expected-note@-3 {{use '.self' to reference the type object}}
 }

--- a/test/SourceKit/Sema/sema_module.swift
+++ b/test/SourceKit/Sema/sema_module.swift
@@ -4,4 +4,4 @@ Swift
 // CHECK: key.kind: source.lang.swift.ref.struct,
 // CHECK: key.severity: source.diagnostic.severity.error,
 // CHECK-NEXT: key.id: "value_of_metatype_type",
-// CHECK-NEXT: key.description: "expected member name or constructor call after type name",
+// CHECK-NEXT: key.description: "expected member name or initializer call after type name",

--- a/test/attr/dynamicReplacement.swift
+++ b/test/attr/dynamicReplacement.swift
@@ -40,10 +40,10 @@ extension TheReplaceables {
 }
 
 extension K {
-  @_dynamicReplacement(for: init(i:)) // expected-error{{replaced constructor 'init(i:)' is not marked as convenience}}
+  @_dynamicReplacement(for: init(i:)) // expected-error{{replaced initializer 'init(i:)' is not marked as convenience}}
   convenience init(ri: Int) { }
 
-  @_dynamicReplacement(for: init(c:)) // expected-error{{replaced constructor 'init(c:)' is marked as convenience}})
+  @_dynamicReplacement(for: init(c:)) // expected-error{{replaced initializer 'init(c:)' is marked as convenience}})
   init(rc: Int) { }
 
   @_dynamicReplacement(for:finalFunction())

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -214,7 +214,7 @@ func testAnyTypeExpr() {
   func test(_: (any P).Type) {}
   test((any P).self)
 
-  // expected-error@+2 {{expected member name or constructor call after type name}}
+  // expected-error@+2 {{expected member name or initializer call after type name}}
   // expected-note@+1 {{use '.self' to reference the type object}}
   let invalid = any P
   test(invalid)

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -237,7 +237,7 @@ func testAnyTypeExpr() {
   func test(_: (any P).Type) {}
   test((any P).self)
 
-  // expected-error@+2 {{expected member name or constructor call after type name}}
+  // expected-error@+2 {{expected member name or initializer call after type name}}
   // expected-note@+1 {{use '.self' to reference the type object}}
   let invalid = any P
   test(invalid)

--- a/test/type/implicit_some/explicit_existential.swift
+++ b/test/type/implicit_some/explicit_existential.swift
@@ -186,7 +186,7 @@ func testAnyTypeExpr() {
   func test(_: (any P).Type) {}
   test((any P).self)
 
-  // expected-error@+2 {{expected member name or constructor call after type name}}
+  // expected-error@+2 {{expected member name or initializer call after type name}}
   // expected-note@+1 {{use '.self' to reference the type object}}
   let invalid = any P
   test(invalid)

--- a/test/type/nested_types.swift
+++ b/test/type/nested_types.swift
@@ -95,20 +95,20 @@ do {
 
     func test() {
       blackHole(Self.E)
-      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       blackHole((Test).E)
-      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       blackHole([Test].Element)
-      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       // expected-note@-3 {{add arguments after the type to construct a value of the type}}
       blackHole([Int : Test].Element)
-      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       blackHole(Test?.Wrapped)
-      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-warning@-1 {{expected member name or initializer call after type name; this will be an error in Swift 6}}
       // expected-note@-2 {{use '.self' to reference the type object}}
       // expected-note@-3 {{add arguments after the type to construct a value of the type}}
     }


### PR DESCRIPTION
<!-- What's in this pull request? -->
<!--- Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate. --->

- In [this issue](https://github.com/apple/swift/issues/59928),  there are 3 points to make more clear error message.

- As for 1st point, I also agree that `constructor` can be replaced with `initializer` in terms of swift and fixed it in this PR.

> 1. "constructor" instead of "initializer"
> 2. Function types don't currently have members or initializers anyway
> 3. A function type as the first statement in a closure without a signature is probably intended to be a signature

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
