### PR TITLE
[Associated type inference] Resolve `@_implements` on AsyncSequence.Failure

### DIFF
--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -119,3 +119,15 @@ public struct ReaderSeq: AsyncSequence, Sendable {
 func test1() -> Error {
   return ReaderSeq.Failure.x
 }
+
+@available(SwiftStdlib 5.1, *)
+public struct MineOwnIterator<Element>: AsyncSequence, AsyncIteratorProtocol {
+  public mutating func next() async -> Element? { nil }
+  public func makeAsyncIterator() -> Self { self }
+
+  @_implements(AsyncIteratorProtocol, Failure)
+  public typealias __AsyncIteratorProtocol_Failure = Never
+
+  @_implements(AsyncSequence, Failure)
+  public typealias __AsyncSequence_Failure = Never
+}


### PR DESCRIPTION
* **Explanation**: A source-compatibility hack to not resolve AsyncSequence.Failure via lookup accidentally disabled the `@_implements`-based lookup that we use to avoid having to run inference again in Swift textual interfaces. Tweak the logic here to narrow the source-compatibility hack, so we don't need to run inference again when (e.g.) building Swift interfaces.
* **Issue**: rdar://125320522, introduced by https://github.com/apple/swift/pull/72234
* **Original PR**: https://github.com/apple/swift/pull/72551
* **Risk**: Low. The change only impacts `AsyncSequence.Failure`'s interaction with associated type inference.
* **Testing**: New tests for `@_implements`-based associated type witness lookup.
