### PR TITLE
[6.0] build-script: add flag to pass arguments to dsymutil

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -75,6 +75,7 @@ KNOWN_SETTINGS=(
     use-gold-linker                               ""                "Enable using the gold linker"
     workspace                                     "${HOME}/src"     "source directory containing llvm, clang, swift"
     dsymutil-jobs                                 "1"               "number of parallel invocations of dsymutil"
+    extra-dsymutil-args                           ""                "additional arguments to pass to dsymutil"
 
     ## Build Tools
     host-cc                                       ""                "the path to CC, the 'clang' compiler for the host platform. **This argument is required**"
@@ -3238,7 +3239,7 @@ for host in "${ALL_HOSTS[@]}"; do
             printJSONStartTimestamp dsymutil
             (cd "${host_symroot}" &&
              find ./"${CURRENT_PREFIX}" -perm -0111 -type f -not -name "*.a" -not -name "*.py" -print | \
-               xargs -t -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path})
+               xargs -t -n 1 -P ${DSYMUTIL_JOBS} ${dsymutil_path} ${EXTRA_DSYMUTIL_ARGS[@]})
             printJSONEndTimestamp dsymutil
 
             # Strip executables, shared libraries and static libraries in

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -556,6 +556,12 @@ def create_argument_parser():
            help='the maximum number of parallel dsymutil jobs to use when '
                 'extracting symbols. Tweak with caution, since dsymutil '
                 'is memory intensive.')
+    option('--extra-dsymutil-args', append,
+           type=argparse.ShellSplitType(),
+           help='Pass through extra options to dsymutil when extracting '
+                'symbols, in the form of comma separated options '
+                'like "--verbose,--verify-dwarf=none". Can '
+                'be called multiple times to add multiple such options.')
 
     option('--disable-guaranteed-normal-arguments', store_true,
            help='Disable guaranteed normal arguments')

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -162,6 +162,7 @@ EXPECTED_DEFAULTS = {
     'sccache': False,
     'dry_run': False,
     'dsymutil_jobs': defaults.DSYMUTIL_JOBS,
+    'extra_dsymutil_args': [],
     'enable_asan': False,
     'enable_experimental_differentiable_programming': True,
     'enable_experimental_concurrency': True,
@@ -788,6 +789,7 @@ EXPECTED_OPTIONS = [
     IntOption('-j', dest='build_jobs'),
     IntOption('--lit-jobs', dest='lit_jobs'),
     IntOption('--dsymutil-jobs', dest='dsymutil_jobs'),
+    AppendOption('--extra-dsymutil-args', dest='extra_dsymutil_args'),
 
     AppendOption('--cross-compile-hosts'),
     SetTrueOption('--infer-cross-compile-hosts-on-darwin'),

--- a/utils/swift_build_support/swift_build_support/build_script_invocation.py
+++ b/utils/swift_build_support/swift_build_support/build_script_invocation.py
@@ -514,6 +514,12 @@ class BuildScriptInvocation(object):
                 ' '.join(args.darwin_symroot_path_filters)
             ]
 
+        if args.extra_dsymutil_args:
+            impl_args += [
+                "--extra-dsymutil-args=%s" % ' '.join(
+                    shlex.quote(opt) for opt in args.extra_dsymutil_args)
+            ]
+
         # Compute the set of host-specific variables, which we pass through to
         # the build script via environment variables.
         host_specific_variables = self.compute_host_specific_variables()

--- a/utils/swift_build_support/tests/test_cmake.py
+++ b/utils/swift_build_support/tests/test_cmake.py
@@ -68,9 +68,6 @@ class CMakeTestCase(unittest.TestCase):
                          build_ninja=False)
 
     def which_ninja(self, args):
-        toolchain = host_toolchain()
-        if toolchain.ninja is not None:
-            return '/path/to/installed/ninja'
         # Maybe we'll build a ninja, maybe we wont.
         # Fake it anyway for the tests.
         return '/path/to/built/ninja'

--- a/validation-test/BuildSystem/extra_dsymutil_args.test
+++ b/validation-test/BuildSystem/extra_dsymutil_args.test
@@ -1,0 +1,14 @@
+# REQUIRES: standalone_build,OS=macosx
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: mkdir -p %t/destdir
+# RUN: mkdir -p %t/symroot/macosx-%target-cpu
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=none --verbose"  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=--verify-dwarf=none,--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="--verify-dwarf=none" --extra-dsymutil-args=--verbose  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+
+# CHECK: --- Extracting symbols ---
+# CHECK: { "command": "dsymutil", "start": "
+# CHECK: xargs -t -n 1 -P 1 {{.*}}dsymutil --verify-dwarf=none --verbose
+# CHECK: { "command": "dsymutil", "end": "

--- a/validation-test/BuildSystem/extra_dsymutil_args_empty.test
+++ b/validation-test/BuildSystem/extra_dsymutil_args_empty.test
@@ -1,0 +1,15 @@
+# REQUIRES: standalone_build,OS=macosx
+
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: mkdir -p %t/destdir
+# RUN: mkdir -p %t/symroot/macosx-%target-cpu
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=""  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args=  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --extra-dsymutil-args="" --extra-dsymutil-args=""  --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --dry-run --enable-extract-symbol-dry-run-test=1 --host-target=macosx-%target-cpu --darwin-install-extract-symbols --cmake %cmake --install-symroot=%t/symroot --install-destdir=%t/destdir --toolchain-prefix= 2>&1 | %FileCheck %s
+
+# CHECK: --- Extracting symbols ---
+# CHECK: { "command": "dsymutil", "start": "
+# CHECK: xargs -t -n 1 -P 1 {{.*}}dsymutil{{$}}
+# CHECK: { "command": "dsymutil", "end": "


### PR DESCRIPTION
**Explanation**: add flag to pass arguments to dsymutil when extracting symbols for Darwin platforms
**Radar**: rdar://125092216
**Scope**: build logic that extract symbols in builds for Darwin platforms
**Risk**: low

* adding a flag is a well understood activity
* this affected logic is opt in and used by a limited subset of the presets running in CI (namely, jobs generating the macOS toolchain)

**Testing**: added tests to the Python and BuildSystem suites to ensure the flag is passed appropriately
**Reviewed By**: Mishal Shah on #72486