### PR TITLE
[LifetimeCompletion] Handle project_box.

### DIFF
--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -391,6 +391,11 @@ bool OwnershipUseVisitor<Impl>::visitGuaranteedUse(Operand *use) {
     return true;
 
   case OperandOwnership::PointerEscape:
+    // TODO: Change ProjectBox ownership to InteriorPointer and allow them to
+    // take owned values.
+    if (isa<ProjectBoxInst>(use->getUser())) {
+      return visitInteriorPointerUses(use);
+    }
     if (!asImpl().handlePointerEscape(use))
       return false;
 
@@ -443,7 +448,8 @@ bool OwnershipUseVisitor<Impl>::visitGuaranteedUse(Operand *use) {
 
 template <typename Impl>
 bool OwnershipUseVisitor<Impl>::visitInteriorPointerUses(Operand *use) {
-  assert(use->getOperandOwnership() == OperandOwnership::InteriorPointer);
+  assert(use->getOperandOwnership() == OperandOwnership::InteriorPointer ||
+         isa<ProjectBoxInst>(use->getUser()));
 
   if (auto scopedAddress = ScopedAddressValue::forUse(use)) {
     // e.g. client may need to insert end_borrow if scopedAddress is a store_borrow.

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -266,12 +266,12 @@ exit:
 }
 
 // CHECK-LABEL: sil [ossa] @availability_boundary_2_after_loop : {{.*}} {
-// CHECK:         [[REGISTER_1:%[^,]+]] = move_value [lexical]
+// CHECK:         [[LEXICAL:%[^,]+]] = move_value [lexical]
 // CHECK:         br [[CONDITION_1:bb[0-9]+]]
 // CHECK:       [[CONDITION_1]]:
 // CHECK:         cond_br undef, [[CONDITION_2:bb[0-9]+]], [[PREHEADER:bb[0-9]+]]
 // CHECK:       [[CONDITION_2]]:
-// CHECK:         destroy_value [[REGISTER_1]]
+// CHECK:         destroy_value [[LEXICAL]]
 // CHECK:         cond_br undef, [[EXIT:bb[0-9]+]], [[TO_DIE_2:bb[0-9]+]]
 // CHECK:       [[PREHEADER]]:
 // CHECK:         br [[HEADER:bb[0-9]+]]
@@ -282,7 +282,7 @@ exit:
 // CHECK:       [[BACKEDGE]]:
 // CHECK:         br [[HEADER]]
 // CHECK:       [[TO_DIE_1]]:
-// CHECK:         destroy_value [[REGISTER_1]]
+// CHECK:         destroy_value [[LEXICAL]]
 // CHECK:         br [[DIE:bb[0-9]+]]
 // CHECK:       [[TO_DIE_2]]:
 // CHECK:         br [[DIE]]

--- a/test/SILOptimizer/ossa_lifetime_completion.sil
+++ b/test/SILOptimizer/ossa_lifetime_completion.sil
@@ -395,3 +395,22 @@ exit:
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: sil [ossa] @project_box_deadend : {{.*}} {
+// CHECK:       bb0([[C:%[^,]+]] :
+// CHECK:         [[BOX:%[^,]+]] = alloc_box
+// CHECK:         [[BOX_BORROW:%[^,]+]] = begin_borrow [[BOX]]
+// CHECK:         [[ADDR:%[^,]+]] = project_box [[BOX_BORROW]]
+// CHECK:         store [[C]] to [init] [[ADDR]]
+// CHECK:         end_borrow [[BOX_BORROW]]
+// CHECK:         unreachable                                     
+// CHECK-LABEL: } // end sil function 'project_box_deadend'
+sil [ossa] @project_box_deadend : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  %2 = alloc_box ${ var C }
+  %3 = begin_borrow %2 : ${ var C }
+  specify_test "ossa-lifetime-completion %3"
+  %4 = project_box %3 : ${ var C }, 0
+  store %0 to [init] %4 : $*C
+  unreachable
+}


### PR DESCRIPTION
Port a0c85be52c609c0f3edda8ec7dde958e31ecdf09 to C++ InteriorLiveness to treat `project_box` like an interior pointer use and fix lifetime completion of a borrow that encloses one.
