### PR TITLE
[CSDiagnostics] Add a diagnostic for same-type/supertype requirement failures in…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2687,6 +2687,9 @@ ERROR(type_does_not_conform_anyobject_decl_owner,none,
 ERROR(type_does_not_conform_in_opaque_return,none,
       "return type of %kind0 requires that %1 %select{conform to %2|be a class type}3",
       (const ValueDecl *, Type, Type, bool))
+ERROR(type_is_not_equal_in_opaque_return,none,
+      "return type of %kind0 requires the types %1 and %2 be equivalent",
+      (const ValueDecl *, Type, Type))
 ERROR(types_not_equal_decl,none,
       "%kind0 requires the types %1 and %2 be equivalent",
       (const ValueDecl *, Type, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2690,6 +2690,9 @@ ERROR(type_does_not_conform_in_opaque_return,none,
 ERROR(type_is_not_equal_in_opaque_return,none,
       "return type of %kind0 requires the types %1 and %2 be equivalent",
       (const ValueDecl *, Type, Type))
+ERROR(types_not_inherited_in_opaque_return,none,
+      "return type of %kind0 requires that %1 inherit from %2",
+      (const ValueDecl *, Type, Type))
 ERROR(types_not_equal_decl,none,
       "%kind0 requires the types %1 and %2 be equivalent",
       (const ValueDecl *, Type, Type))

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -457,12 +457,25 @@ bool RequirementFailure::diagnoseAsError() {
     auto *namingDecl = OTD->getNamingDecl();
 
     auto &req = getRequirement();
-    if (req.getKind() == RequirementKind::SameType) {
-      emitDiagnostic(diag::type_is_not_equal_in_opaque_return, namingDecl, lhs,
-                     rhs);
-    } else {
+    switch (req.getKind()) {
+    case RequirementKind::Conformance:
+    case RequirementKind::Layout:
       emitDiagnostic(diag::type_does_not_conform_in_opaque_return, namingDecl,
                      lhs, rhs, rhs->isAnyObject());
+      break;
+
+    case RequirementKind::Superclass:
+      emitDiagnostic(diag::types_not_inherited_in_opaque_return, namingDecl,
+                    lhs, rhs);
+      break;
+
+    case RequirementKind::SameType:
+      emitDiagnostic(diag::type_is_not_equal_in_opaque_return, namingDecl, lhs,
+                     rhs);
+      break;
+
+    case RequirementKind::SameShape:
+      return false;
     }
 
     if (auto *repr = namingDecl->getOpaqueResultTypeRepr()) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -455,8 +455,15 @@ bool RequirementFailure::diagnoseAsError() {
 
   if (auto *OTD = dyn_cast<OpaqueTypeDecl>(AffectedDecl)) {
     auto *namingDecl = OTD->getNamingDecl();
-    emitDiagnostic(diag::type_does_not_conform_in_opaque_return,
-                   namingDecl, lhs, rhs, rhs->isAnyObject());
+
+    auto &req = getRequirement();
+    if (req.getKind() == RequirementKind::SameType) {
+      emitDiagnostic(diag::type_is_not_equal_in_opaque_return, namingDecl, lhs,
+                     rhs);
+    } else {
+      emitDiagnostic(diag::type_does_not_conform_in_opaque_return, namingDecl,
+                     lhs, rhs, rhs->isAnyObject());
+    }
 
     if (auto *repr = namingDecl->getOpaqueResultTypeRepr()) {
       emitDiagnosticAt(repr->getLoc(), diag::opaque_return_type_declared_here)

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -601,6 +601,8 @@ do {
 
   struct S: P1 {}
 
+  class A {}
+
   func test1() -> some P3<Int> { // expected-note {{opaque return type declared here}}
     return G<S>()
     // expected-error@-1 {{return type of local function 'test1()' requires the types 'S' and 'Int' be equivalent}}
@@ -609,5 +611,10 @@ do {
   func test2() -> some P3<G<S>> { // expected-note {{opaque return type declared here}}
     return G<S>()
     // expected-error@-1 {{return type of local function 'test2()' requires the types 'S' and 'G<S>' be equivalent}}
+  }
+
+  func test3() -> some P1 & A { // expected-note {{opaque return type declared here}}
+    S()
+    // expected-error@-1 {{return type of local function 'test3()' requires that 'S' inherit from 'A'}}
   }
 }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -603,11 +603,11 @@ do {
 
   func test1() -> some P3<Int> { // expected-note {{opaque return type declared here}}
     return G<S>()
-    // expected-error@-1 {{type of local function 'test1()' requires that 'S' conform to 'Int'}}
+    // expected-error@-1 {{return type of local function 'test1()' requires the types 'S' and 'Int' be equivalent}}
   }
 
   func test2() -> some P3<G<S>> { // expected-note {{opaque return type declared here}}
     return G<S>()
-    // expected-error@-1 {{return type of local function 'test2()' requires that 'S' conform to 'G<S>'}}
+    // expected-error@-1 {{return type of local function 'test2()' requires the types 'S' and 'G<S>' be equivalent}}
   }
 }

--- a/test/type/parameterized_protocol.swift
+++ b/test/type/parameterized_protocol.swift
@@ -158,7 +158,7 @@ struct OpaqueTypes<E> {
   func returnSequenceOfIntBad() -> some Sequence<Int> {
     // expected-note@-1 {{opaque return type declared here}}
     return ConcreteSequence<E>()
-    // expected-error@-1 {{return type of instance method 'returnSequenceOfIntBad()' requires that 'E' conform to 'Int'}}
+    // expected-error@-1 {{return type of instance method 'returnSequenceOfIntBad()' requires the types 'E' and 'Int' be equivalent}}
   }
 
   // Invalid


### PR DESCRIPTION
… opaque return type

Follow-up to https://github.com/apple/swift/pull/72493

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
