### PR TITLE
[6.0 cherry-pick] [embedded] Compile-time (literal) KeyPaths for Embedded Swift

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/CMakeLists.txt
@@ -21,6 +21,7 @@ swift_compiler_sources(Optimizer
   SimplifyDestructure.swift
   SimplifyGlobalValue.swift
   SimplifyInitEnumDataAddr.swift
+  SimplifyKeyPath.swift
   SimplifyLoad.swift
   SimplifyPartialApply.swift
   SimplifyPointerToAddress.swift

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyApply.swift
@@ -17,6 +17,10 @@ extension ApplyInst : OnoneSimplifyable {
     if tryTransformThickToThinCallee(of: self, context) {
       return
     }
+    if context.tryOptimizeKeypath(apply: self) {
+      context.erase(instruction: self)
+      return
+    }
     _ = context.tryDevirtualize(apply: self, isMandatory: false)
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
@@ -15,6 +15,14 @@ import SIL
 extension KeyPathInst : OnoneSimplifyable {
   func simplify(_ context: SimplifyContext) {
     if allUsesRemovable(instruction: self) {
+      if parentFunction.hasOwnership {
+        let builder = Builder(after: self, context)
+        for operand in self.operands {
+          if !operand.value.type.isTrivial(in: parentFunction) {
+            builder.createDestroyValue(operand: operand.value)
+          }
+        }
+      }
       context.erase(instructionIncludingAllUsers: self)
     }
   }

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyKeyPath.swift
@@ -1,0 +1,35 @@
+//===--- SimplifyKeyPath.swift --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SIL
+
+extension KeyPathInst : OnoneSimplifyable {
+  func simplify(_ context: SimplifyContext) {
+    if allUsesRemovable(instruction: self) {
+      context.erase(instructionIncludingAllUsers: self)
+    }
+  }
+}
+
+fileprivate func allUsesRemovable(instruction: Instruction) -> Bool {
+  for result in instruction.results {
+    for use in result.uses {
+      if !(use.instruction is UpcastInst || use.instruction is DestroyValueInst || use.instruction is BeginBorrowInst || use.instruction is EndBorrowInst) {
+        return false
+      }
+      if !allUsesRemovable(instruction: use.instruction) {
+        return false
+      }
+    }
+  }
+  return true
+}

--- a/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/PassManager/Context.swift
@@ -170,6 +170,10 @@ extension MutatingContext {
     }
     return nil
   }
+  
+  func tryOptimizeKeypath(apply: FullApplySite) -> Bool {
+    return _bridged.tryOptimizeKeypath(apply.bridged)
+  }
 
   func inlineFunction(apply: FullApplySite, mandatoryInline: Bool) {
     // This is only a best-effort attempt to notity the new cloned instructions as changed.

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -379,6 +379,8 @@ ERROR(embedded_swift_metatype_type,none,
       "cannot use metatype of type %0 in embedded Swift", (Type))
 ERROR(embedded_swift_metatype,none,
       "cannot use metatype in embedded Swift", ())
+ERROR(embedded_swift_keypath,none,
+      "cannot use key path in embedded Swift", ())
 ERROR(embedded_swift_allocating_type,none,
       "cannot use allocating type %0 in -no-allocations mode", (Type))
 ERROR(embedded_swift_allocating,none,

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -214,6 +214,7 @@ struct BridgedPassContext {
   bool tryOptimizeApplyOfPartialApply(BridgedInstruction closure) const;
   bool tryDeleteDeadClosure(BridgedInstruction closure, bool needKeepArgsAlive) const;
   SWIFT_IMPORT_UNSAFE DevirtResult tryDevirtualizeApply(BridgedInstruction apply, bool isMandatory) const;
+  bool tryOptimizeKeypath(BridgedInstruction apply) const;
   SWIFT_IMPORT_UNSAFE OptionalBridgedValue constantFoldBuiltin(BridgedInstruction builtin) const;
   SWIFT_IMPORT_UNSAFE swift::SILVTable * _Nullable specializeVTableForType(BridgedType type,
                                                                            BridgedFunction function) const;

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -599,6 +599,13 @@ bool specializeAppliesInFunction(SILFunction &F,
                                  SILTransform *transform,
                                  bool isMandatory);
 
+bool tryOptimizeKeypath(ApplyInst *AI, SILBuilder Builder);
+bool tryOptimizeKeypathApplication(ApplyInst *AI, SILFunction *callee, SILBuilder Builder);
+bool tryOptimizeKeypathOffsetOf(ApplyInst *AI, FuncDecl *calleeFn,
+                                KeyPathInst *kp, SILBuilder Builder);
+bool tryOptimizeKeypathKVCString(ApplyInst *AI, FuncDecl *calleeFn,
+                                KeyPathInst *kp, SILBuilder Builder);
+
 /// Instantiate the specified type by recursively tupling and structing the
 /// unique instances of the empty types and undef "instances" of the non-empty
 /// types aggregated together at each level.

--- a/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/PerformanceDiagnostics.cpp
@@ -519,6 +519,10 @@ bool PerformanceDiagnostics::visitInst(SILInstruction *inst,
         diagnose(loc, diag::embedded_swift_value_deinit, impactType.getASTType());
         return true;
       }
+      if (isa<KeyPathInst>(inst)) {
+        diagnose(loc, diag::embedded_swift_keypath);
+        return true;
+      }
       if (!allowedMetadataUseInEmbeddedSwift(inst)) {
         PrettyStackTracePerformanceDiagnostics stackTrace("metatype", inst);
         if (impactType) {

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -1600,6 +1600,11 @@ BridgedPassContext::DevirtResult BridgedPassContext::tryDevirtualizeApply(Bridge
   return {{nullptr}, false};
 }
 
+bool BridgedPassContext::tryOptimizeKeypath(BridgedInstruction apply) const {
+  SILBuilder builder(apply.unbridged());
+  return ::tryOptimizeKeypath(apply.getAs<ApplyInst>(), builder);
+}
+
 OptionalBridgedValue BridgedPassContext::constantFoldBuiltin(BridgedInstruction builtin) const {
   auto bi = builtin.getAs<BuiltinInst>();
   std::optional<bool> resultsInError;

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -330,13 +330,7 @@ public:
   SILInstruction *optimizeApplyOfConvertFunctionInst(FullApplySite AI,
                                                      ConvertFunctionInst *CFI);
 
-  bool tryOptimizeKeypath(ApplyInst *AI);
   bool tryOptimizeInoutKeypath(BeginApplyInst *AI);
-  bool tryOptimizeKeypathApplication(ApplyInst *AI, SILFunction *callee);
-  bool tryOptimizeKeypathOffsetOf(ApplyInst *AI, FuncDecl *calleeFn,
-                                  KeyPathInst *kp);
-  bool tryOptimizeKeypathKVCString(ApplyInst *AI, FuncDecl *calleeFn,
-                                  KeyPathInst *kp);
 
   /// Sinks owned forwarding instructions to their uses if they do not have
   /// non-debug non-consuming uses. Deletes any debug_values and destroy_values

--- a/lib/SILOptimizer/Utils/KeyPathProjector.cpp
+++ b/lib/SILOptimizer/Utils/KeyPathProjector.cpp
@@ -20,6 +20,7 @@
 #include "swift/SILOptimizer/Utils/KeyPathProjector.h"
 
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/InstructionUtils.h"
 
 using namespace swift;
 
@@ -669,9 +670,10 @@ private:
 
 KeyPathInst *
 KeyPathProjector::getLiteralKeyPath(SILValue keyPath) {
-  if (auto *upCast = dyn_cast<UpcastInst>(keyPath))
-    keyPath = upCast->getOperand();
-  // TODO: Look through other conversions, copies, etc.?
+  while (auto *upCast = dyn_cast<UpcastInst>(keyPath)) {
+    keyPath = lookThroughOwnershipInsts(upCast->getOperand());
+  }
+
   return dyn_cast<KeyPathInst>(keyPath);
 }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -97,7 +97,7 @@ split_embedded_sources(
     NORMAL IntegerParsing.swift
   EMBEDDED Integers.swift
     NORMAL Join.swift
-    NORMAL KeyPath.swift
+  EMBEDDED KeyPath.swift
     NORMAL KeyValuePairs.swift
   EMBEDDED LazyCollection.swift
   EMBEDDED LazySequence.swift
@@ -125,7 +125,7 @@ split_embedded_sources(
     NORMAL PrefixWhile.swift
     NORMAL Prespecialize.swift
     NORMAL Print.swift
-    NORMAL PtrAuth.swift
+  EMBEDDED PtrAuth.swift
   EMBEDDED Random.swift
   EMBEDDED RandomAccessCollection.swift
   EMBEDDED Range.swift

--- a/stdlib/public/core/EmbeddedStubs.swift
+++ b/stdlib/public/core/EmbeddedStubs.swift
@@ -18,6 +18,7 @@ import SwiftShims
 public struct String: Hashable { 
     public var utf8CString: ContiguousArray<CChar> { fatalError() }
     public init() {}
+    public init(validatingCString: UnsafePointer<CChar>) { fatalError() }
 }
 
 @_unavailableInEmbedded
@@ -242,20 +243,3 @@ public enum DecodingError: Error {
   case keyNotFound(any CodingKey, Context)
   case dataCorrupted(Context)
 }
-
-/// KeyPath
-
-@_unavailableInEmbedded
-public class AnyKeyPath {
-  @usableFromInline
-  internal var _storedInlineOffset: Int? { fatalError() }
-}
-
-@_unavailableInEmbedded
-public class PartialKeyPath<Root>: AnyKeyPath { }
-
-@_unavailableInEmbedded
-public class KeyPath<Root, Value>: PartialKeyPath<Root> { }
-
-@_unavailableInEmbedded
-public class WritableKeyPath<Root, Value>: KeyPath<Root, Value> { }

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -237,7 +237,6 @@ extension MemoryLayout {
   ///   `nil`, it can be because `key` is computed, has observers, requires
   ///   reabstraction, or overlaps storage with other properties.
   @_transparent
-  @_unavailableInEmbedded
   public static func offset(of key: PartialKeyPath<T>) -> Int? {
     return key._storedInlineOffset
   }

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -442,7 +442,9 @@ extension UnsafePointer {
   /// - Returns: A pointer to the stored property represented
   ///            by the key path, or `nil`.
   @_alwaysEmitIntoClient
+  #if $Embedded
   @_transparent
+  #endif
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
@@ -1326,7 +1328,9 @@ extension UnsafeMutablePointer {
   /// - Returns: A pointer to the stored property represented
   ///            by the key path, or `nil`.
   @_alwaysEmitIntoClient
+  #if $Embedded
   @_transparent
+  #endif
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
@@ -1348,7 +1352,9 @@ extension UnsafeMutablePointer {
   /// - Returns: A mutable pointer to the stored property represented
   ///            by the key path, or `nil`.
   @_alwaysEmitIntoClient
+  #if $Embedded
   @_transparent
+  #endif
   public func pointer<Property>(
     to property: WritableKeyPath<Pointee, Property>
   ) -> UnsafeMutablePointer<Property>? {

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -442,7 +442,7 @@ extension UnsafePointer {
   /// - Returns: A pointer to the stored property represented
   ///            by the key path, or `nil`.
   @_alwaysEmitIntoClient
-  @_unavailableInEmbedded
+  @_transparent
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
@@ -1326,7 +1326,7 @@ extension UnsafeMutablePointer {
   /// - Returns: A pointer to the stored property represented
   ///            by the key path, or `nil`.
   @_alwaysEmitIntoClient
-  @_unavailableInEmbedded
+  @_transparent
   public func pointer<Property>(
     to property: KeyPath<Pointee, Property>
   ) -> UnsafePointer<Property>? {
@@ -1348,7 +1348,7 @@ extension UnsafeMutablePointer {
   /// - Returns: A mutable pointer to the stored property represented
   ///            by the key path, or `nil`.
   @_alwaysEmitIntoClient
-  @_unavailableInEmbedded
+  @_transparent
   public func pointer<Property>(
     to property: WritableKeyPath<Pointee, Property>
   ) -> UnsafeMutablePointer<Property>? {

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -318,34 +318,49 @@ sil @stored_property_fixed_offsets : $@convention(thin) () -> () {
 entry:
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_A]], ptr undef)
   %a = keypath $KeyPath<S, Int>, (root $S; stored_property #S.x : $Int)
+  strong_retain %a : $KeyPath<S, Int>
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_B]], ptr undef)
   %b = keypath $KeyPath<S, String>, (root $S; stored_property #S.y : $String)
+  strong_retain %b : $KeyPath<S, String>
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_C]], ptr undef)
   %c = keypath $KeyPath<S, C>, (root $S; stored_property #S.z : $C)
+  strong_retain %c : $KeyPath<S, C>
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_D]], ptr undef)
   %d = keypath $KeyPath<C, Int>, (root $C; stored_property #C.x : $Int)
+  strong_retain %d : $KeyPath<C, Int>
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_D1]], ptr undef)
   %d1 = keypath $KeyPath<C1, Int>, (root $C1; stored_property #C.x : $Int)
+  strong_retain %d1 : $KeyPath<C1, Int>
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_E]], ptr undef)
   %e = keypath $KeyPath<C, String>, (root $C; stored_property #C.y : $String)
+  strong_retain %e : $KeyPath<C, String>
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_F]], ptr undef)
   %f = keypath $KeyPath<C, S>, (root $C; stored_property #C.z : $S)
+  strong_retain %f : $KeyPath<C, S>
 
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_G]], ptr undef)
   %g = keypath $KeyPath<S, Int>, (root $S; stored_property #S.z : $C; stored_property #C.x : $Int)
+  strong_retain %g : $KeyPath<S, Int>
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_H]], ptr undef)
   %h = keypath $KeyPath<C, Int>, (root $C; stored_property #C.z : $S; stored_property #S.x : $Int)
+  strong_retain %h : $KeyPath<C, Int>
 
   %k = keypath $KeyPath<S, Int>, (root $S; gettable_property $Int, id @k_id : $@convention(thin) () -> (), getter @k_get : $@convention(keypath_accessor_getter) (@in_guaranteed S) -> @out Int)
+  strong_retain %k : $KeyPath<S, Int>
   %l = keypath $KeyPath<C, Int>, (root $C; settable_property $Int, id #C.w!getter, getter @l_get : $@convention(keypath_accessor_getter) (@in_guaranteed C) -> @out Int, setter @l_set : $@convention(keypath_accessor_setter) (@in_guaranteed Int, @in_guaranteed C) -> ())
+  strong_retain %l : $KeyPath<C, Int>
   %m = keypath $KeyPath<S, () -> ()>, (root $S; settable_property $() -> (), id ##S.reabstracted, getter @m_get : $@convention(keypath_accessor_getter) (@in_guaranteed S) -> @out @callee_guaranteed @substituted <A> () -> @out A for <()>, setter @m_set : $@convention(keypath_accessor_setter) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <()>, @inout S) -> ())
+  strong_retain %m : $KeyPath<S, () -> ()>
   %m2 = keypath $KeyPath<C2, () -> ()>, (root $C2; settable_property $() -> (), id ##C2.reabstracted, getter @m2_get : $@convention(keypath_accessor_getter) (@in_guaranteed C2) -> @out @callee_guaranteed @substituted <A> () -> @out A for <()>, setter @m2_set : $@convention(keypath_accessor_setter) (@in_guaranteed @callee_guaranteed @substituted <A> () -> @out A for <()>, @inout C2) -> ())
+  strong_retain %m2 : $KeyPath<C2, () -> ()>
 
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_T0]], ptr undef)
   %t0 = keypath $KeyPath<T, Int>, (root $T; stored_property #T.a : $(Int, String); tuple_element #0 : $Int)
+  strong_retain %t0 : $KeyPath<T, Int>
 
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_T1]], ptr undef)
   %t1 = keypath $KeyPath<T, Int>, (root $T; stored_property #T.b : $(f: String, g: Int); tuple_element #1 : $Int)
+  strong_retain %t1 : $KeyPath<T, Int>
 
   return undef : $()
 }
@@ -395,11 +410,13 @@ entry:
   // CHECK: store ptr %T, ptr [[ARGS]]
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_I]], ptr [[ARGS]])
   %i = keypath $KeyPath<Gen<T,T>, T>, <A> (root $Gen<A, A>; stored_property #Gen.x : $A) <T>
+  strong_retain %i : $KeyPath<Gen<T,T>, T>
 
   // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
   // CHECK: store ptr %U, ptr [[ARGS]]
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_J]], ptr [[ARGS]])
   %j = keypath $KeyPath<Gen<U,U>, U>, <A> (root $Gen<A, A>; stored_property #Gen.y : $A) <U>
+  strong_retain %j : $KeyPath<Gen<U,U>, U>
 
   // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
   // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$s8keypaths3FooVMa"([[WORD]] 0, ptr %T)
@@ -407,6 +424,7 @@ entry:
   // CHECK: store ptr [[FOO_T]], ptr [[ARGS]]
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_I]], ptr [[ARGS]])
   %i2 = keypath $KeyPath<Gen<Foo<T>,Foo<T>>, Foo<T>>, <A> (root $Gen<A, A>; stored_property #Gen.x : $A) <Foo<T>>
+  strong_retain %i2 : $KeyPath<Gen<Foo<T>,Foo<T>>, Foo<T>>
 
   return undef : $()
 }
@@ -418,16 +436,19 @@ entry:
   // CHECK: store ptr %T, ptr [[ARGS]]
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_TG0]], ptr [[ARGS]])
   %tg0 = keypath $KeyPath<TG<T,U,V>, T>, <A,B,C> (root $TG<A,B,C>; stored_property #TG.a : $(A,B,C); tuple_element #0 : $A) <T,U,V>
+  strong_retain %tg0 : $KeyPath<TG<T,U,V>, T>
 
   // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
   // CHECK: store ptr %T, ptr [[ARGS]]
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_TG1]], ptr [[ARGS]])
   %tg1 = keypath $KeyPath<TG<T,U,V>, V>, <A,B,C> (root $TG<A,B,C>; stored_property #TG.a : $(A,B,C); tuple_element #2 : $C) <T,U,V>
+  strong_retain %tg1 : $KeyPath<TG<T,U,V>, V>
 
   // CHECK: [[ARGS:%.*]] = alloca i{{.*}}
   // CHECK: store ptr %T, ptr [[ARGS]]
   // CHECK: call ptr @swift_getKeyPath(ptr [[KP_TG2]], ptr [[ARGS]])
   %tg2 = keypath $KeyPath<TGA<T,U>, U>, <A,B> (root $TGA<A,B>; tuple_element #1 : $B) <T,U>
+  strong_retain %tg2 : $KeyPath<TGA<T,U>, U>
 
   return undef : $()
 }
@@ -435,6 +456,7 @@ entry:
 sil @generic_class_stored_final : $@convention(thin) <T> () -> () {
 entry:
   %gcx = keypath $ReferenceWritableKeyPath<GC<T>, T>, <T> (root $GC<T>; stored_property #GC.x: $T) <T>
+  strong_retain %gcx : $ReferenceWritableKeyPath<GC<T>, T>
 
   return undef : $()
 }
@@ -541,6 +563,10 @@ entry(%0 : $*A, %1 : $*B, %2 : $*A, %3 : $*B, %4 : $*A, %5 : $*B):
       indices_equals @s_equals : $@convention(keypath_accessor_equals) <T: Hashable, U: Hashable> (@in_guaranteed Int, @in_guaranteed Int) -> Bool,
       indices_hash @s_hash : $@convention(keypath_accessor_hash) <T: Hashable, U: Hashable> (@in_guaranteed Int) -> Int
   ) <A, B> (%3, %4, %5)
+
+  strong_retain %s : $WritableKeyPath<A, B>
+  strong_retain %t : $WritableKeyPath<A, B>
+  strong_retain %v : $WritableKeyPath<A, A>
 
   return undef : $()
 }

--- a/test/IRGen/keypaths_external.sil
+++ b/test/IRGen/keypaths_external.sil
@@ -30,6 +30,9 @@ entry(%0 : $*A, %1 : $*B, %2 : $*A, %3 : $*B, %4 : $*A, %5 : $*B):
       external #G.subscript<Y, X>
   ) <B, A> (%1)
 
+  strong_retain %t : $KeyPath<G<B>, B>
+  strong_retain %u : $KeyPath<G<A>, A>
+
   return undef : $()
 }
 

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -32,6 +32,7 @@ sil @objc_only_property : $@convention(thin) () -> () {
 entry:
   // CHECK: call ptr @swift_getKeyPath({{.*}} [[KEYPATH_A]]
   %a = keypath $KeyPath<C, NSString>, (objc "x"; root $C; gettable_property $NSString, id #C.x!getter.foreign, getter @x_get : $@convention(keypath_accessor_getter) (@in_guaranteed C) -> @out NSString)
+  strong_retain %a : $KeyPath<C, NSString>
   unreachable
 }
 
@@ -55,5 +56,6 @@ sil @objc_stored_property : $@convention(thin) () -> () {
 entry:
   // CHECK: call ptr @swift_getKeyPath({{.*}} [[KEYPATH_B]]
   %b = keypath $KeyPath<C, Int>, (objc "stored"; root $C; stored_property #C.stored : $Int)
+  strong_retain %b : $KeyPath<C, Int>
   unreachable
 }

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -331,9 +331,9 @@ func testGetter<T : P>(_ s: GenStruct<T>) -> Int {
 }
 
 // CHECK-LABEL: sil {{.*}} [noinline] {{.*}}testClassMemberGetter
+// CHECK: [[A:%[0-9]+]] = alloc_stack $Int
 // CHECK: [[E:%[0-9]+]] = ref_element_addr
 // CHECK: [[M:%[0-9]+]] = begin_access [read] [dynamic] [[E]]
-// CHECK: [[A:%[0-9]+]] = alloc_stack $Int
 // CHECK: [[F:%[0-9]+]] = function_ref {{.*}}computed
 // CHECK: apply [[F]]<T>([[A]], [[M]])
 // CHECK: end_access

--- a/test/embedded/keypaths.swift
+++ b/test/embedded/keypaths.swift
@@ -1,0 +1,52 @@
+// RUN: %target-run-simple-swift(   -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none) | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+struct MyStruct {
+  var x: Int8
+  var y: Int16
+  var z: Int32
+}
+
+public func test1() -> Int {
+  return (\MyStruct.z)._storedInlineOffset!
+}
+
+print(test1() == 4 ? "OK!" : "FAIL") // CHECK: OK!
+
+public func test2() -> Int {
+  return MemoryLayout<MyStruct>.offset(of: \MyStruct.z)!
+}
+
+print(test2() == 4 ? "OK!" : "FAIL") // CHECK: OK!
+
+public func test3(input: UnsafePointer<MyStruct>) -> UnsafePointer<Int32> {
+  return input.pointer(to: \MyStruct.z)!
+}
+
+print(UInt(bitPattern: test3(input: UnsafePointer(bitPattern: 0x1000)!)) == 0x1004 ? "OK!" : "FAIL") // CHECK: OK!
+
+@dynamicMemberLookup
+struct StructWithDynamicMemberLookup<T>: ~Copyable {
+    private var value: UnsafeMutablePointer<T>
+    init(from t: T) { value = UnsafeMutablePointer<T>.allocate(capacity: 1); value.pointee = t }
+    deinit { value.deallocate() }
+    
+    subscript<U>(dynamicMember keyPath: KeyPath<T, U>) -> UnsafeMutablePointer<U> {
+        @_transparent
+        get {
+            return UnsafeMutablePointer(mutating: self.value.pointer(to: keyPath).unsafelyUnwrapped)
+        }
+    }
+}
+
+public func test4(arg: borrowing StructWithDynamicMemberLookup<MyStruct>) -> Int {
+  return Int(arg.z.pointee) + Int(arg.y.pointee)
+}
+
+let str = StructWithDynamicMemberLookup<MyStruct>(from: MyStruct(x: 10, y: 20, z: 30))
+print(str.z.pointee == 30 ? "OK!" : "FAIL") // CHECK: OK!


### PR DESCRIPTION
* **Explanation**: Enable KeyPath/AnyKeyPath/PartialKeyPath/WritableKeyPath in Embedded Swift, but for compile-time use only. Details at https://github.com/apple/swift/pull/72472.
* **Scope**: Enabling the keypath constant-folding optimization to kick in in more cases, Embedded Swift compilations in particular.
* **Risk**: Low. Stdlib changes are limited to Embedded Swift only. Compiler changes limited to keypath constant-folding optimization.
* **Testing**: Added test case.
* **Issue**: rdar://125363334
* **Reviewer**:  @eeckstein, @Azoy, @phausler on https://github.com/apple/swift/pull/72472
