### PR TITLE
[6.0][Concurrency] Apply `@MainActor` to main dispatch queue operations without considering `Sendable`.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -6050,6 +6050,7 @@ swift::isDispatchQueueOperationName(StringRef name) {
       .Case("sync", DispatchQueueOperation::Normal)
       .Case("async", DispatchQueueOperation::Sendable)
       .Case("asyncAndWait", DispatchQueueOperation::Normal)
+      .Case("asyncUnsafe", DispatchQueueOperation::Normal)
       .Case("asyncAfter", DispatchQueueOperation::Sendable)
       .Case("concurrentPerform", DispatchQueueOperation::Sendable)
       .Default(std::nullopt);
@@ -6147,8 +6148,7 @@ static AnyFunctionType *applyUnsafeConcurrencyToFunctionType(
     // @MainActor occurs in concurrency contexts or those where we have an
     // application.
     bool addSendable = knownUnsafeParams && inConcurrencyContext;
-    bool addMainActor =
-        (isMainDispatchQueue && knownUnsafeParams) &&
+    bool addMainActor = isMainDispatchQueue &&
         (inConcurrencyContext || numApplies >= 1);
     Type newParamType = param.getPlainType();
     if (addSendable || addMainActor) {

--- a/test/Concurrency/dispatch_inference.swift
+++ b/test/Concurrency/dispatch_inference.swift
@@ -17,6 +17,10 @@ func testMe() {
   DispatchQueue.main.async {
     onlyOnMainActor() // okay, due to inference of @MainActor-ness
   }
+
+  DispatchQueue.main.sync {
+    onlyOnMainActor()
+  }
 }
 
 func testUnsafeSendableInMainAsync() async {


### PR DESCRIPTION
* **Explanation**: The compiler has a heuristic to apply `@MainActor` to the closure parameters for various APIs on `DispatchQueue.main` since there isn't a way to represent that in the type system based on the dispatch queue value. This heuristic was accidentally checking whether or not the argument was `@Sendable` before applying `@MainActor`, which prevented `@MainActor` from being applied to `DispatchQueue.sync` and `DispatchQueue.asyncAndWait`. This change also adds `DispatchQueue.asyncUnsafe` to the list of methods to apply the heuristic to.
* **Scope**: Only impacts the `DispatchQueue` APIs listed in `isDispatchQueueOperationName` when called on `DispatchQueue.main` under complete concurrency checking or if the function is called directly.
* **Risk**: Low; this change only impacts 3 specific APIs on `DispatchQueue.main`, and only kicks in under specific conditions. This change also has no impact of the closure body only calls nonisolated methods, so the only effect should be lifting limitations if you call `@MainActor`-isolated methods.
* **Testing**: Added a new test to ensure `DispatchQueue.main.sync` is considered `@MainActor`-isolated.
* **Reviewer**: @ktoso
* **Main branch PR**: https://github.com/apple/swift/pull/72507