### PR TITLE
[6.0] PredictableMemOpt: fix a crash, caused by a wrong instruction cast

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -2570,7 +2570,9 @@ bool AllocOptimize::tryToRemoveDeadAllocation() {
       // Today if we promote, this is always a store, since we would have
       // blown up the copy_addr otherwise. Given that, always make sure we
       // clean up the src as appropriate after we optimize.
-      auto *si = cast<StoreInst>(pmoMemUse.Inst);
+      auto *si = dyn_cast<StoreInst>(pmoMemUse.Inst);
+      if (!si)
+        return false;
       auto src = si->getSrc();
 
       // Bail if src has any uses that are forwarding unowned uses. This

--- a/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
+++ b/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
@@ -21,6 +21,9 @@ case none
 case some(T)
 }
 
+protocol P {}
+struct S: P {}
+
 ///////////
 // Tests //
 ///////////
@@ -749,3 +752,13 @@ bb6:
   unreachable
 }
 
+// CHECK-LABEL: sil [ossa] @testStoredOnlyExistential :
+// CHECK:         alloc_stack
+// CHECK:       } // end sil function 'testStoredOnlyExistential'
+sil [ossa] @testStoredOnlyExistential : $@convention(thin) (S) -> () {
+bb0(%0 : $S):
+  %1 = alloc_stack $any P
+  %4 = init_existential_addr %1 : $*any P, $S
+  store %0 to [trivial] %4 : $*S
+  unreachable
+}


### PR DESCRIPTION
* **Explanation**:  Fixes a compiler crash in PredictableMemOpt caused by a wrong instruction cast. The fix is to check for the right instruction type and bail if the cast is failing.

* **Issue**: rdar://125166206

* **Risk**: Very low. The fix is a small change which checks for the right type to prevent the crash.

* **Reviewer**: @meg-gupta 

* **Main branch PR**: https://github.com/apple/swift/pull/72490
