### PR TITLE
AST: `#if hasAttribute(retroactive)` should evaluate true

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3022,6 +3022,9 @@ public:
   /// corresponds to it.
   static std::optional<TypeAttrKind> getAttrKindFromString(StringRef Str);
 
+  /// Returns true if type attributes of the given kind only appear in SIL.
+  static bool isSilOnly(TypeAttrKind TK);
+
   /// Return the name (like "autoclosure") for an attribute ID.
   static const char *getAttrName(TypeAttrKind kind);
 

--- a/test/attr/has_attribute.swift
+++ b/test/attr/has_attribute.swift
@@ -23,3 +23,23 @@ UserInaccessibleAreNotAttributes
 #if hasAttribute(17)
 // expected-error@-1:18 {{unexpected platform condition argument: expected attribute name}}
 #endif
+
+#if !hasAttribute(escaping)
+#error("type attributes are valid")
+#endif
+
+#if !hasAttribute(convention)
+#error("type attributes are valid")
+#endif
+
+#if !hasAttribute(retroactive)
+#error("type attributes are valid")
+#endif
+
+#if hasAttribute(in_guaranteed)
+#error("SIL type attributes are invalid")
+#endif
+
+#if hasAttribute(opened)
+#error("SIL type attributes are invalid")
+#endif


### PR DESCRIPTION
The implementation of `#if hasAttribute(...)` only accepted declaration attributes. It should also accept type attributes, like `@retroactive`.

Resolves rdar://125195051
