### PR TITLE
[6.0] AST: `#if hasAttribute(retroactive)` should evaluate true

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -3022,6 +3022,9 @@ public:
   /// corresponds to it.
   static std::optional<TypeAttrKind> getAttrKindFromString(StringRef Str);
 
+  /// Returns true if type attributes of the given kind only appear in SIL.
+  static bool isSilOnly(TypeAttrKind TK);
+
   /// Return the name (like "autoclosure") for an attribute ID.
   static const char *getAttrName(TypeAttrKind kind);
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -124,6 +124,16 @@ TypeAttribute::getAttrKindFromString(StringRef Str) {
       .Default(std::nullopt);
 }
 
+bool TypeAttribute::isSilOnly(TypeAttrKind TK){
+  switch (TK) {
+#define SIL_TYPE_ATTR(X, C) case TypeAttrKind::C:
+#include "swift/AST/TypeAttr.def"
+    return true;
+  default:
+    return false;
+  }
+}
+
 /// Return the name (like "autoclosure") for an attribute ID.
 const char *TypeAttribute::getAttrName(TypeAttrKind kind) {
   switch (kind) {
@@ -2947,7 +2957,7 @@ void swift::simple_display(llvm::raw_ostream &out, const DeclAttribute *attr) {
     attr->print(out);
 }
 
-bool swift::hasAttribute(
+static bool hasDeclAttribute(
     const LangOptions &langOpts, llvm::StringRef attributeName) {
   std::optional<DeclAttrKind> kind =
       DeclAttribute::getAttrKindFromString(attributeName);
@@ -2966,4 +2976,26 @@ bool swift::hasAttribute(
     return false;
 
   return true;
+}
+
+static bool hasTypeAttribute(const LangOptions &langOpts, llvm::StringRef attributeName) {
+  std::optional<TypeAttrKind> kind =
+  TypeAttribute::getAttrKindFromString(attributeName);
+  if (!kind)
+    return false;
+
+  if (TypeAttribute::isSilOnly(*kind))
+    return false;
+
+  return true;
+}
+
+bool swift::hasAttribute(const LangOptions &langOpts, llvm::StringRef attributeName) {
+  if (hasDeclAttribute(langOpts, attributeName))
+    return true;
+
+  if (hasTypeAttribute(langOpts, attributeName))
+    return true;
+
+  return false;
 }

--- a/test/attr/has_attribute.swift
+++ b/test/attr/has_attribute.swift
@@ -23,3 +23,23 @@ UserInaccessibleAreNotAttributes
 #if hasAttribute(17)
 // expected-error@-1:18 {{unexpected platform condition argument: expected attribute name}}
 #endif
+
+#if !hasAttribute(escaping)
+#error("type attributes are valid")
+#endif
+
+#if !hasAttribute(convention)
+#error("type attributes are valid")
+#endif
+
+#if !hasAttribute(retroactive)
+#error("type attributes are valid")
+#endif
+
+#if hasAttribute(in_guaranteed)
+#error("SIL type attributes are invalid")
+#endif
+
+#if hasAttribute(opened)
+#error("SIL type attributes are invalid")
+#endif


### PR DESCRIPTION
- **Explanation:** The implementation of `#if hasAttribute(...)` only accepted declaration attributes. It should also accept type attributes, like `@retroactive`.
- **Scope:** Affects use of `hasAttributes` with any type attribute. Fixing this is important because multiple new type attributes are being introduced in Swift 6 (`@retroactive` and `@isolated`) and package owners may need to conditionalize code that uses these attributes.
- **Issue/Radar:** rdar://125195051
- **Original PR:** https://github.com/apple/swift/pull/72571/
- **Risk:** Low. The main risk is that existing code could be written with `hasAttribute` checks that failed due to this bug but will now unexpectedly succeed.
- **Testing:** Added tests in the compiler test suite. Ran source compatibility testing.
- **Reviewer:** @rintaro @bnbarham 

