### PR TITLE
[6.0][SourceKit] Stop printing normal comments in clang generated interface 

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -447,7 +447,7 @@ struct PrintOptions {
   bool PrintInSILBody = false;
 
   /// Whether to use an empty line to separate two members in a single decl.
-  bool EmptyLineBetweenMembers = false;
+  bool EmptyLineBetweenDecls = false;
 
   /// Whether to print empty members of a declaration on a single line, e.g.:
   /// ```
@@ -692,7 +692,7 @@ struct PrintOptions {
     result.SkipUnderscoredStdlibProtocols = true;
     result.SkipUnsafeCXXMethods = true;
     result.SkipDeinit = true;
-    result.EmptyLineBetweenMembers = true;
+    result.EmptyLineBetweenDecls = true;
     result.CascadeDocComment = true;
     result.ShouldQualifyNestedDeclarations =
         QualifyNestedDeclarations::Always;
@@ -755,7 +755,7 @@ struct PrintOptions {
   static PrintOptions printSwiftFileInterface(bool printFullConvention) {
     PrintOptions result = printInterface(printFullConvention);
     result.AccessFilter = AccessLevel::Internal;
-    result.EmptyLineBetweenMembers = true;
+    result.EmptyLineBetweenDecls = true;
     return result;
   }
 

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -502,9 +502,6 @@ struct PrintOptions {
   /// (e.g. the overridden method in the superclass) if such comment is found.
   bool PrintDocumentationComments = false;
 
-  /// Whether to print regular comments from clang module headers.
-  bool PrintRegularClangComments = false;
-
   /// When true, printing interface from a source file will print the original
   /// source text for applicable declarations, in order to preserve the
   /// formatting.
@@ -645,7 +642,6 @@ struct PrintOptions {
     result.TypeDefinitions = true;
     result.VarInitializers = true;
     result.PrintDocumentationComments = true;
-    result.PrintRegularClangComments = true;
     result.PrintLongAttrsOnSeparateLines = true;
     result.AlwaysTryPrintParameterLabels = true;
     return result;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -705,6 +705,7 @@ class PrintAST : public ASTVisitor<PrintAST> {
     StringRef RawText =
         RC->getRawText(ClangContext.getSourceManager()).rtrim("\n\r");
     trimLeadingWhitespaceFromLines(RawText, WhitespaceToTrim, Lines);
+    indent();
     bool FirstLine = true;
     for (auto Line : Lines) {
       if (FirstLine)
@@ -1132,20 +1133,6 @@ public:
 
     if (Synthesize) {
       Printer.setSynthesizedTarget(Options.TransformContext->getDecl());
-    }
-
-    // We want to print a newline before doc comments.  Swift code already
-    // handles this, but we need to insert it for clang doc comments when not
-    // printing other clang comments. Do it now so the printDeclPre callback
-    // happens after the newline.
-    if (Options.PrintDocumentationComments && D->hasClangNode()) {
-      auto clangNode = D->getClangNode();
-      auto clangDecl = clangNode.getAsDecl();
-      if (clangDecl &&
-          clangDecl->getASTContext().getRawCommentForAnyRedecl(clangDecl)) {
-        Printer.printNewline();
-        indent();
-      }
     }
 
     Printer.callPrintDeclPre(D, Options.BracketOptions);
@@ -2724,7 +2711,7 @@ void PrintAST::printMembers(ArrayRef<Decl *> members, bool needComma,
       if (!member->shouldPrintInContext(Options))
         continue;
 
-      if (Options.EmptyLineBetweenMembers)
+      if (Options.EmptyLineBetweenDecls)
         Printer.printNewline();
       indent();
       visit(member);

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1138,9 +1138,7 @@ public:
     // handles this, but we need to insert it for clang doc comments when not
     // printing other clang comments. Do it now so the printDeclPre callback
     // happens after the newline.
-    if (Options.PrintDocumentationComments &&
-        !Options.PrintRegularClangComments &&
-        D->hasClangNode()) {
+    if (Options.PrintDocumentationComments && D->hasClangNode()) {
       auto clangNode = D->getClangNode();
       auto clangDecl = clangNode.getAsDecl();
       if (clangDecl &&
@@ -1149,7 +1147,6 @@ public:
         indent();
       }
     }
-
 
     Printer.callPrintDeclPre(D, Options.BracketOptions);
 

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -118,7 +118,6 @@ PrintOptions PrintOptions::printDocInterface() {
   result.ArgAndParamPrinting =
       PrintOptions::ArgAndParamPrintingMode::BothAlways;
   result.PrintDocumentationComments = false;
-  result.PrintRegularClangComments = false;
   result.PrintFunctionRepresentationAttrs =
     PrintOptions::FunctionRepresentationMode::None;
   return result;

--- a/test/APINotes/properties.swift
+++ b/test/APINotes/properties.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 5 | %FileCheck -check-prefix=CHECK-SWIFT-5 -check-prefix=CHECK-BOTH %s
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 5 | %FileCheck -check-prefix=CHECK-SWIFT-5 -check-prefix=CHECK-BOTH %s
 
-// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 -check-prefix=CHECK-BOTH %s
+// RUN: %target-swift-ide-test -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 -check-prefix=CHECK-BOTH %s
 
 // REQUIRES: objc_interop
 

--- a/test/APINotes/versioned.swift
+++ b/test/APINotes/versioned.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test  -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 5 | %FileCheck -check-prefix=CHECK-SWIFT-5 %s
+// RUN: %target-swift-ide-test  -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 5 | %FileCheck -check-prefix=CHECK-SWIFT-5 %s
 
-// RUN: %target-swift-ide-test  -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -print-regular-comments -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 %s
+// RUN: %target-swift-ide-test  -F %S/Inputs/custom-frameworks -print-module -source-filename %s -module-to-print=APINotesFrameworkTest -function-definitions=false -swift-version 4 | %FileCheck -check-prefix=CHECK-SWIFT-4 %s
 
 // CHECK-SWIFT-5: func jumpTo(x: Double, y: Double, z: Double)
 // CHECK-SWIFT-4: func jumpTo(x: Double, y: Double, z: Double)

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -12,9 +12,9 @@
 // RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-error.h -DERRORS -verify
 
 // RUN: echo '#include "enum-error.h"' > %t.m
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h -print-regular-comments --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
 // RUN: %FileCheck -check-prefix=HEADER %s < %t.txt
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h -print-regular-comments --skip-private-stdlib-decls -skip-underscored-stdlib-protocols --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t2.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/enum-error.h -import-objc-header %S/Inputs/enum-error.h --skip-private-stdlib-decls -skip-underscored-stdlib-protocols --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t2.txt
 // RUN: %FileCheck -check-prefix=HEADER-NO-PRIVATE %s < %t2.txt
 
 import Foundation

--- a/test/ClangImporter/nested_protocol_name.swift
+++ b/test/ClangImporter/nested_protocol_name.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/nested_protocol_name.h -typecheck -verify %s
 
 // RUN: echo '#include "nested_protocol_name.h"' > %t.m
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/nested_protocol_name.h -import-objc-header %S/Inputs/nested_protocol_name.h -print-regular-comments --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/nested_protocol_name.h -import-objc-header %S/Inputs/nested_protocol_name.h --cc-args %target-cc-options -fsyntax-only %t.m -I %S/Inputs > %t.txt
 // RUN: %FileCheck -check-prefix=HEADER %s < %t.txt
 
 // rdar://59431058
@@ -15,7 +15,6 @@
 // HEADER:   func addLimb(_ limb: (any Trunk.Branch)!)
 // HEADER:   func addLimbs(_ limbs: [any Trunk.Branch]!)
 // HEADER: }
-// HEADER: // NS_SWIFT_NAME(Trunk.Branch)
 // HEADER: protocol Branch {
 // HEADER:   func flower()
 // HEADER: }

--- a/test/IDE/Inputs/foo_swift_module.printed.comments.txt
+++ b/test/IDE/Inputs/foo_swift_module.printed.comments.txt
@@ -1,25 +1,19 @@
 import SwiftOnoneSupport
 
 func %%% (lhs: Int, rhs: Int) -> Int
-
 postfix func =-> (lhs: Int) -> Int
-
 postfix func => (lhs: Int) -> Int
-
 struct BarGenericSwiftStruct1<T> {
   init(t: T)
   func bar1InstanceFunc()
 }
-
 struct BarGenericSwiftStruct2<T, U> where T : BarProtocol {
   init(t: T, u: U)
   func bar2InstanceFunc()
 }
-
 protocol BarProtocol {
   func instanceFunc()
 }
-
 /// FooSwiftStruct Aaa.
 /**
  * Bbb.
@@ -36,7 +30,6 @@ struct FooSwiftStruct {
   func fooInstanceFunc()
   init()
 }
-
 /// rdar://18457785
 enum MyQuickLookObject {
   /// A rectangle.
@@ -44,23 +37,14 @@ enum MyQuickLookObject {
   /// Uses explicit coordinates to avoid coupling a particular Cocoa type.
   case Rectangle(Float64, Float64, Float64, Float64)
 }
-
 var globalVar: Int
-
 func hiddenImport()
-
 func overlayedFoo()
-
 func visibleImport()
-
 precedencegroup High {
   associativity: left
   higherThan: BitwiseShiftPrecedence
 }
-
 infix operator %%% : High
-
 postfix operator =>
-
 postfix operator =->
-

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
@@ -1,13 +1,9 @@
 import Foundation
 import CoreFoundation
 import Dispatch
-
 var MY_MACRO: Int32 { get }
-
 var MACRO_DUP: Int32 { get }
-
 func doSomethingInHead(_ arg: Int32)
-
 class BaseInHead {
   class func doIt(_ arg: Int32)
   func doIt(_ arg: Int32)
@@ -18,15 +14,12 @@ class SameName {
 }
 protocol SameNameProtocol {
 }
-
 extension BaseInHead {
   class func doItInCategory()
   func doItInCategory()
 }
-
 protocol Superproto {
   func lala()
 }
-
 class MyLittleCFType {
 }

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt
@@ -8,7 +8,6 @@ class BaseInHead {
   class func doIt(_ arg: Int32)
   func doIt(_ arg: Int32)
 }
-
 /// Awesome name.
 class SameName {
 }

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
@@ -1,10 +1,6 @@
-
 var MY_MACRO: Int32 { get }
-
 var MACRO_DUP: Int32 { get }
-
 func doSomethingInHead(_ arg: Int32)
-
 class BaseInHead {
   class func doIt(_ arg: Int32)
   func doIt(_ arg: Int32)
@@ -15,15 +11,12 @@ class SameName {
 }
 protocol SameNameProtocol {
 }
-
 extension BaseInHead {
   class func doItInCategory()
   func doItInCategory()
 }
-
 protocol Superproto {
   func lala()
 }
-
 class MyLittleCFType : _CFObject {
 }

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.module.printed.txt
@@ -5,7 +5,6 @@ class BaseInHead {
   class func doIt(_ arg: Int32)
   func doIt(_ arg: Int32)
 }
-
 /// Awesome name.
 class SameName {
 }

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
@@ -8,7 +8,6 @@ class BaseInHead {
   class func doIt(_ arg: Int32)
   func doIt(_ arg: Int32)
 }
-
 /// Awesome name.
 class SameName {
 }

--- a/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
+++ b/test/IDE/Inputs/print_clang_header/header-to-print.h.printed.txt
@@ -1,13 +1,9 @@
 import Foundation
 import CoreFoundation
 import Dispatch
-
 var MY_MACRO: Int32 { get }
-
 var MACRO_DUP: Int32 { get }
-
 func doSomethingInHead(_ arg: Int32)
-
 class BaseInHead {
   class func doIt(_ arg: Int32)
   func doIt(_ arg: Int32)
@@ -18,15 +14,12 @@ class SameName {
 }
 protocol SameNameProtocol {
 }
-
 extension BaseInHead {
   class func doItInCategory()
   func doItInCategory()
 }
-
 protocol Superproto {
   func lala()
 }
-
 class MyLittleCFType : _CFObject {
 }

--- a/test/IDE/print_clang_bool_bridging.swift
+++ b/test/IDE/print_clang_bool_bridging.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=BoolBridgingTests -function-definitions=false -print-regular-comments -skip-unavailable -F %S/Inputs/mock-sdk > %t.txt
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=BoolBridgingTests -function-definitions=false -skip-unavailable -F %S/Inputs/mock-sdk > %t.txt
 // RUN: diff -u <(tail -n +9 %s) %t.txt
 
 // REQUIRES: objc_interop
@@ -8,76 +8,57 @@
 // EXPECTED OUTPUT STARTS BELOW THIS LINE.
 @_exported import Foundation
 
-// stdbool.h uses #define, so this test does as well.
-
 func testCBool(_: Bool) -> Bool
 func testObjCBool(_: Bool) -> Bool
 func testDarwinBoolean(_: Bool) -> Bool
-
 typealias CBoolTypedef = Bool
 typealias ObjCBoolTypedef = ObjCBool
 typealias DarwinBooleanTypedef = DarwinBoolean
-
 func testCBoolTypedef(_: CBoolTypedef) -> CBoolTypedef
 func testObjCBoolTypedef(_: Bool) -> Bool
 func testDarwinBooleanTypedef(_: Bool) -> Bool
-
 func testCBoolPointer(_: UnsafeMutablePointer<Bool>) -> UnsafePointer<Bool>
 func testObjCBoolPointer(_: UnsafeMutablePointer<ObjCBool>) -> UnsafePointer<ObjCBool>
 func testDarwinBooleanPointer(_: UnsafeMutablePointer<DarwinBoolean>) -> UnsafePointer<DarwinBoolean>
-
 typealias CBoolFn = @convention(c) (Bool) -> Bool
 typealias ObjCBoolFn = @convention(c) (ObjCBool) -> ObjCBool
 typealias DarwinBooleanFn = @convention(c) (DarwinBoolean) -> DarwinBoolean
-
 typealias CBoolBlock = (Bool) -> Bool
 typealias ObjCBoolBlock = (Bool) -> Bool
 typealias DarwinBooleanBlock = (Bool) -> Bool
-
 func testCBoolFnToBlock(_: @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
 func testObjCBoolFnToBlock(_: @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
 func testDarwinBooleanFnToBlock(_: @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
-
 func testCBoolFnToBlockTypedef(_: CBoolFn) -> CBoolBlock
 func testObjCBoolFnToBlockTypedef(_: ObjCBoolFn) -> ObjCBoolBlock
 func testDarwinBooleanFnToBlockTypedef(_: DarwinBooleanFn) -> DarwinBooleanBlock
-
 typealias CBoolFnToBlockType = (CBoolFn) -> (Bool) -> Bool
 typealias ObjCBoolFnToBlockType = (ObjCBoolFn) -> (ObjCBool) -> ObjCBool
 typealias DarwinBooleanFnToBlockType = (DarwinBooleanFn) -> (DarwinBoolean) -> DarwinBoolean
-
 var globalObjCBoolFnToBlockFP: @convention(c) (ObjCBoolFn) -> (ObjCBool) -> ObjCBool
 var globalObjCBoolFnToBlockFPP: UnsafeMutablePointer<@convention(c) (ObjCBoolFn) -> (ObjCBool) -> ObjCBool>?
 var globalObjCBoolFnToBlockBP: @convention(block) (ObjCBoolFn) -> (ObjCBool) -> ObjCBool
-
 var globalCBoolFn: CBoolFn
 var globalObjCBoolFn: ObjCBoolFn
 var globalDarwinBooleanFn: DarwinBooleanFn
-
 var globalCBoolBlock: @convention(block) (Bool) -> Bool
 var globalObjCBoolBlock: @convention(block) (ObjCBool) -> ObjCBool
 var globalDarwinBooleanBlock: @convention(block) (DarwinBoolean) -> DarwinBoolean
-
 class Test : NSObject {
   var propCBool: Bool
   var propObjCBool: Bool
   var propDarwinBoolean: Bool
-  
   func testCBool(_ b: Bool) -> Bool
   func testObjCBool(_ b: Bool) -> Bool
   func testDarwinBoolean(_ b: Bool) -> Bool
-  
   var propCBoolBlock: (Bool) -> Bool
   var propObjCBoolBlock: (Bool) -> Bool
   var propDarwinBooleanBlock: (Bool) -> Bool
-  
   func testCBoolFn(toBlock fp: @convention(c) (Bool) -> Bool) -> (Bool) -> Bool
   func testObjCBoolFn(toBlock fp: @convention(c) (ObjCBool) -> ObjCBool) -> (Bool) -> Bool
   func testDarwinBooleanFn(toBlock fp: @convention(c) (DarwinBoolean) -> DarwinBoolean) -> (Bool) -> Bool
-  
   func produceCBoolBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (Bool) -> Bool)?>)
   func produceObjCBoolBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (ObjCBool) -> ObjCBool)?>)
   func produceDarwinBooleanBlockTypedef(_ outBlock: AutoreleasingUnsafeMutablePointer<(@convention(block) (DarwinBoolean) -> DarwinBoolean)?>)
-  
   init()
 }

--- a/test/IDE/print_clang_foundation.swift
+++ b/test/IDE/print_clang_foundation.swift
@@ -17,7 +17,7 @@
 // CHECK_NSARRAY: class NSMutableArray : NSArray
 // CHECK_NSARRAY:   func setArray(_ otherArray: [Any])
 
-// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=Foundation.NSKeyValueCoding -function-definitions=false -print-regular-comments > %t/Foundation.NSKeyValueCoding.printed.txt
+// RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=Foundation.NSKeyValueCoding -function-definitions=false > %t/Foundation.NSKeyValueCoding.printed.txt
 // RUN: %FileCheck -input-file %t/Foundation.NSKeyValueCoding.printed.txt -check-prefix=CHECK2 %s
 
 // CHECK2: extension NSObject

--- a/test/IDE/print_clang_framework.swift
+++ b/test/IDE/print_clang_framework.swift
@@ -3,10 +3,10 @@
 
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-module -source-filename %s -module-to-print=Foo -function-definitions=false -print-regular-comments > %t/Foo.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-module -source-filename %s -module-to-print=Foo -function-definitions=false > %t/Foo.printed.txt
 // RUN: diff -u %S/Inputs/mock-sdk/Foo.printed.txt %t/Foo.printed.txt
 
-// RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-interface -print-module -source-filename %s -module-to-print=Foo -function-definitions=false -print-regular-comments > %t/Foo.interface.printed.txt
+// RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-interface -print-module -source-filename %s -module-to-print=Foo -function-definitions=false > %t/Foo.interface.printed.txt
 // RUN: %FileCheck %s -check-prefix=INTERFACE1 < %t/Foo.interface.printed.txt
 
 // RUN: %target-swift-ide-test(mock-sdk: -F %S/Inputs/mock-sdk) -print-module -source-filename %s -module-to-print=Foo -function-definitions=false -prefer-type-repr=true -module-print-submodules > %t/Foo.printed.recursive.txt

--- a/test/IDE/print_clang_header.swift
+++ b/test/IDE/print_clang_header.swift
@@ -2,21 +2,21 @@
 // REQUIRES: objc_interop
 
 // RUN: echo '#include "header-to-print.h"' > %t.m
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs/print_clang_header > %t.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %S/Inputs/print_clang_header > %t.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.txt
 
 // RUN: %clang %target-cc-options -isysroot %clang-importer-sdk-path -fmodules -x objective-c-header %S/Inputs/print_clang_header/header-to-print.h -o %t.h.pch
 // RUN: touch %t.empty.m
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.empty.m -I %S/Inputs/print_clang_header -include %t.h > %t.with-pch.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.empty.m -I %S/Inputs/print_clang_header -include %t.h > %t.with-pch.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt %t.with-pch.txt
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.empty.m -I %S/Inputs/print_clang_header -include %S/Inputs/print_clang_header/header-to-print.h > %t.with-include.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.empty.m -I %S/Inputs/print_clang_header -include %S/Inputs/print_clang_header/header-to-print.h > %t.with-include.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.command-line-include.printed.txt %t.with-include.txt
 
 // RUN: echo '#include <Foo/header-to-print.h>' > %t.framework.m
 // RUN: sed -e "s:INPUT_DIR:%S/Inputs/print_clang_header:g" -e "s:OUT_DIR:%t:g" %S/Inputs/print_clang_header/Foo-vfsoverlay.yaml > %t.yaml
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml -Xclang -fmodule-name=Foo > %t.framework.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml -Xclang -fmodule-name=Foo > %t.framework.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.framework.txt
 
 // Test header interface printing from a clang module.
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml > %t.module.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -enable-objc-interop -disable-objc-attr-requires-foundation-module --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.framework.m -F %t -ivfsoverlay %t.yaml > %t.module.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.module.printed.txt %t.module.txt

--- a/test/IDE/print_clang_header_availability.swift
+++ b/test/IDE/print_clang_header_availability.swift
@@ -4,10 +4,10 @@
 
 // RUN: echo '#include "header-to-print-availability.h"' > %t.m
 // RUN: cp %S/Inputs/print_clang_header/header-to-print-availability.h %t/
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %t/header-to-print-availability.h -print-regular-comments --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %t > %t.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %t/header-to-print-availability.h --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.m -I %t > %t.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print-availability.h.printed.txt %t.txt
 
 // RUN: echo '@import HeaderToPrintAvailability;' > %t.module.m
 // Test header interface printing from a clang module.
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print-availability.h -print-regular-comments --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.module.m -I %S/Inputs/print_clang_header > %t.module.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print-availability.h --cc-args %target-cc-options -isysroot %clang-importer-sdk-path -fsyntax-only %t.module.m -I %S/Inputs/print_clang_header > %t.module.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print-availability.h.module.printed.txt %t.module.txt

--- a/test/IDE/print_clang_header_i386.swift
+++ b/test/IDE/print_clang_header_i386.swift
@@ -5,5 +5,5 @@
 // RUN: echo '#include "header-to-print.h"' > %t.i386.m
 // RUN: %empty-directory(%t)
 // RUN: %build-clang-importer-objc-overlays
-// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -print-regular-comments -I %t --cc-args -arch i386 -isysroot %clang-importer-sdk-path -fsyntax-only %t.i386.m -I %S/Inputs/print_clang_header > %t.i386.txt
+// RUN: %target-swift-ide-test -source-filename %s -print-header -header-to-print %S/Inputs/print_clang_header/header-to-print.h -I %t --cc-args -arch i386 -isysroot %clang-importer-sdk-path -fsyntax-only %t.i386.m -I %S/Inputs/print_clang_header > %t.i386.txt
 // RUN: diff -u %S/Inputs/print_clang_header/header-to-print.h.printed.txt %t.i386.txt

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=SwiftNameTests -function-definitions=false -print-regular-comments -F %S/Inputs/mock-sdk > %t.txt
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=SwiftNameTests -function-definitions=false -F %S/Inputs/mock-sdk > %t.txt
 // RUN: diff -u <(tail -n +9 %s) %t.txt
 
 // REQUIRES: objc_interop
@@ -8,10 +8,7 @@
 // EXPECTED OUTPUT STARTS BELOW THIS LINE.
 @_exported import Foundation
 
-
 class Test : NSObject {
-  
-  // "Factory methods" that we'd rather have as initializers.
   @available(*, unavailable, message: "superseded by import of -[NSObject init]")
   convenience init()
   @available(*, unavailable, renamed: "init()", message: "Not available in Swift")
@@ -19,23 +16,18 @@ class Test : NSObject {
   convenience init(dummyParam: ())
   @available(*, unavailable, renamed: "init(dummyParam:)", message: "Not available in Swift")
   class func b() -> Self
-  
   convenience init(cc x: Any)
   @available(*, unavailable, renamed: "init(cc:)", message: "Not available in Swift")
   class func c(_ x: Any) -> Self
   convenience init(_ x: Any)
   @available(*, unavailable, renamed: "init(_:)", message: "Not available in Swift")
   class func d(_ x: Any) -> Self
-  
   convenience init(aa a: Any, _ b: Any, cc c: Any)
   @available(*, unavailable, renamed: "init(aa:_:cc:)", message: "Not available in Swift")
   class func e(_ a: Any, e b: Any, e c: Any) -> Self
-  
   /*not inherited*/ init(fixedType: ())
   @available(*, unavailable, renamed: "init(fixedType:)", message: "Not available in Swift")
   class func f() -> Test
-  
-  // Would-be initializers.
   class func zz() -> Self
   @available(swift, obsoleted: 3, renamed: "zz()")
   class func testZ() -> Self
@@ -45,12 +37,9 @@ class Test : NSObject {
   class func xx(_ x: Any, bb xx: Any) -> Self
   @available(*, unavailable, renamed: "xx(_:bb:)", message: "Not available in Swift")
   class func testX(_ x: Any, xx: Any) -> Self
-  
   init()
 }
-
 class TestError : NSObject {
-  // Factory methods with NSError.
   convenience init(error: ()) throws
   @available(*, unavailable, renamed: "init(error:)", message: "Not available in Swift")
   class func err1() throws -> Self
@@ -63,7 +52,6 @@ class TestError : NSObject {
   convenience init(error: (), block: @escaping () -> Void) throws
   @available(*, unavailable, renamed: "init(error:block:)", message: "Not available in Swift")
   class func err4(callback block: @escaping () -> Void) throws -> Self
-  
   convenience init(aa x: Any?) throws
   @available(*, unavailable, renamed: "init(aa:)", message: "Not available in Swift")
   class func err5(_ x: Any?) throws -> Self
@@ -73,8 +61,6 @@ class TestError : NSObject {
   convenience init(block: @escaping () -> Void) throws
   @available(*, unavailable, renamed: "init(block:)", message: "Not available in Swift")
   class func err7(callback block: @escaping () -> Void) throws -> Self
-  
-  // Would-be initializers.
   class func ww(_ x: Any?) throws -> Self
   @available(swift, obsoleted: 3, renamed: "ww(_:)")
   class func testW(_ x: Any?) throws -> Self
@@ -89,7 +75,6 @@ class TestError : NSObject {
   class func testV2() throws -> Self
   init()
 }
-
 class TestSub : Test {
   @available(*, unavailable, message: "superseded by import of -[NSObject init]")
   convenience init()
@@ -99,7 +84,6 @@ class TestSub : Test {
   convenience init(aa a: Any, _ b: Any, cc c: Any)
   init()
 }
-
 class TestErrorSub : TestError {
   convenience init(error: ()) throws
   convenience init(aa x: Any?, error: ()) throws

--- a/test/IDE/print_module_comments.swift
+++ b/test/IDE/print_module_comments.swift
@@ -4,5 +4,5 @@
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -emit-module %S/Inputs/foo_swift_module.swift -emit-module-path %t/foo_swift_module.swiftmodule -emit-module-doc-path %t/foo_swift_module.swiftdoc
 //
 // RUN: %target-swift-ide-test -print-module -source-filename %s -I %t -module-to-print=foo_swift_module > %t.printed.txt
-// RUN: diff %t.printed.txt %S/Inputs/foo_swift_module.printed.comments.txt
+// RUN: diff -u %S/Inputs/foo_swift_module.printed.comments.txt %t.printed.txt
 

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
@@ -55,6 +55,7 @@ import ObjCxxModule
 // CHECK-EMPTY:
 // CHECK-NEXT:     public static func freeCxxFunction(_ x: Int32, _ y: Int32) -> Int32
 // CHECK-NEXT: }
+// CHECK-EMPTY:
 // CHECK-NEXT: open class ObjCClass : NSObject {
 // CHECK-EMPTY:
 // CHECK-NEXT:     open func myTestMethod()

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
@@ -41,4 +41,5 @@ public func useConcreteTemplate() {
 // CHECK-NEXT:    public func methodFunc(_ x: Any)
 // CHECK-NEXT:}
 // CHECK-NEXT:}
+// CHECK-EMPTY:
 // CHECK-NEXT: public typealias TemplateRecordInt = ns.TemplateRecord

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
@@ -158,5 +158,7 @@ import CxxModule
 // CHECK-EMPTY:
 // CHECK-NEXT:  static func freeFunction(_ x: Int32, _ y: Int32) -> Int32
 // CHECK-NEXT: }
+// CHECK-EMPTY:
 // CHECK-NEXT: typealias MyType = ns.TemplateRecord
+// CHECK-EMPTY:
 // CHECK-NEXT: typealias MyType2 = TransitiveStruct

--- a/test/SourceKit/CursorInfo/cursor_generated_interface.swift
+++ b/test/SourceKit/CursorInfo/cursor_generated_interface.swift
@@ -41,7 +41,7 @@ public class ASwiftType {
 }
 
 // LibA is a mixed framework with no source info and a submodule
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:36 -print-raw-response | %FileCheck %s --check-prefix=CHECKA
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:36 -print-raw-response | %FileCheck %s --check-prefix=CHECKA
 // CHECKA: key.name: "ASwiftType"
 // CHECKA: key.modulename: "LibA"
 // CHECKA: key.decl_lang: source.lang.swift
@@ -60,7 +60,7 @@ framework module LibA {
 @interface AObjcType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:54 -print-raw-response | %FileCheck %s --check-prefix=CHECKAOBJ
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:54 -print-raw-response | %FileCheck %s --check-prefix=CHECKAOBJ
 // CHECKAOBJ: key.name: "AObjcType"
 // CHECKAOBJ: key.line: [[@LINE-5]]
 // CHECKAOBJ: key.column: 12
@@ -72,7 +72,7 @@ framework module LibA {
 @interface ASubType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:70 -print-raw-response | %FileCheck %s --check-prefix=CHECKASUB
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:70 -print-raw-response | %FileCheck %s --check-prefix=CHECKASUB
 // CHECKASUB: key.name: "ASubType"
 // CHECKASUB: key.line: [[@LINE-5]]
 // CHECKASUB: key.column: 12
@@ -84,7 +84,7 @@ framework module LibA {
 public class BType {}
 
 // LibB has source info
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:32 -print-raw-response | %FileCheck %s --check-prefix=CHECKB
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:32 -print-raw-response | %FileCheck %s --check-prefix=CHECKB
 // CHECKB: key.name: "BType"
 // CHECKB: key.line: [[@LINE-5]]
 // CHECKB: key.column: 14
@@ -96,7 +96,7 @@ public class BType {}
 public class CType {}
 
 // LibC has no source info
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:47 -print-raw-response | %FileCheck %s --check-prefix=CHECKC
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:47 -print-raw-response | %FileCheck %s --check-prefix=CHECKC
 // CHECKC: key.name: "CType"
 // CHECKC: key.modulename: "LibC"
 // CHECKC: key.decl_lang: source.lang.swift
@@ -105,7 +105,7 @@ public class CType {}
 @interface DType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:57 -print-raw-response | %FileCheck %s --check-prefix=CHECKD
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:57 -print-raw-response | %FileCheck %s --check-prefix=CHECKD
 // CHECKD: key.name: "DType"
 // CHECKD: key.line: [[@LINE-5]]
 // CHECKD: key.column: 12

--- a/test/SourceKit/CursorInfo/cursor_generated_interface.swift
+++ b/test/SourceKit/CursorInfo/cursor_generated_interface.swift
@@ -41,7 +41,7 @@ public class ASwiftType {
 }
 
 // LibA is a mixed framework with no source info and a submodule
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:36 -print-raw-response | %FileCheck %s --check-prefix=CHECKA
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:36 -print-raw-response | %FileCheck %s --check-prefix=CHECKA
 // CHECKA: key.name: "ASwiftType"
 // CHECKA: key.modulename: "LibA"
 // CHECKA: key.decl_lang: source.lang.swift
@@ -60,7 +60,7 @@ framework module LibA {
 @interface AObjcType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:54 -print-raw-response | %FileCheck %s --check-prefix=CHECKAOBJ
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:54 -print-raw-response | %FileCheck %s --check-prefix=CHECKAOBJ
 // CHECKAOBJ: key.name: "AObjcType"
 // CHECKAOBJ: key.line: [[@LINE-5]]
 // CHECKAOBJ: key.column: 12
@@ -72,7 +72,7 @@ framework module LibA {
 @interface ASubType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=11:70 -print-raw-response | %FileCheck %s --check-prefix=CHECKASUB
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=12:70 -print-raw-response | %FileCheck %s --check-prefix=CHECKASUB
 // CHECKASUB: key.name: "ASubType"
 // CHECKASUB: key.line: [[@LINE-5]]
 // CHECKASUB: key.column: 12
@@ -84,7 +84,7 @@ framework module LibA {
 public class BType {}
 
 // LibB has source info
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:32 -print-raw-response | %FileCheck %s --check-prefix=CHECKB
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:32 -print-raw-response | %FileCheck %s --check-prefix=CHECKB
 // CHECKB: key.name: "BType"
 // CHECKB: key.line: [[@LINE-5]]
 // CHECKB: key.column: 14
@@ -96,7 +96,7 @@ public class BType {}
 public class CType {}
 
 // LibC has no source info
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:47 -print-raw-response | %FileCheck %s --check-prefix=CHECKC
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:47 -print-raw-response | %FileCheck %s --check-prefix=CHECKC
 // CHECKC: key.name: "CType"
 // CHECKC: key.modulename: "LibC"
 // CHECKC: key.decl_lang: source.lang.swift
@@ -105,7 +105,7 @@ public class CType {}
 @interface DType
 @end
 
-// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=13:57 -print-raw-response | %FileCheck %s --check-prefix=CHECKD
+// RUN: %sourcekitd-test -req=interface-gen-open -module LibA -- -F %t/frameworks -target %target-triple == -req=cursor -pos=14:57 -print-raw-response | %FileCheck %s --check-prefix=CHECKD
 // CHECKD: key.name: "DType"
 // CHECKD: key.line: [[@LINE-5]]
 // CHECKD: key.column: 12

--- a/test/SourceKit/CursorInfo/cursor_info_async.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_async.swift
@@ -11,14 +11,14 @@ import Foo
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- \
 // RUN:                  -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:                   -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 | %FileCheck %s -check-prefix=CHECK-FOO
+// RUN:   == -async -dont-print-request -req=cursor -pos=54:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=54:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=54:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=54:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=54:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=54:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=54:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=54:15 | %FileCheck %s -check-prefix=CHECK-FOO
 
 // CHECK-FOO: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooRuncingOptions
 // CHECK-FOO: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooRuncingOptions

--- a/test/SourceKit/CursorInfo/cursor_info_async.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_async.swift
@@ -11,14 +11,14 @@ import Foo
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- \
 // RUN:                  -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:                   -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
-// RUN:   == -async -dont-print-request -req=cursor -pos=60:15 | %FileCheck %s -check-prefix=CHECK-FOO
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 \
+// RUN:   == -async -dont-print-request -req=cursor -pos=49:15 | %FileCheck %s -check-prefix=CHECK-FOO
 
 // CHECK-FOO: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooRuncingOptions
 // CHECK-FOO: <decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooRuncingOptions

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.response
@@ -11,7 +11,9 @@ struct FooEnum1 : Equatable, RawRepresentable {
 
     static func != (_ lhs: FooEnum1, _ rhs: FooEnum1) -> Bool
 }
+
 var FooEnum1X: FooEnum1 { get }
+
 struct FooEnum2 : Equatable, RawRepresentable {
 
     init(_ rawValue: UInt32)
@@ -22,8 +24,11 @@ struct FooEnum2 : Equatable, RawRepresentable {
 
     static func != (_ lhs: FooEnum2, _ rhs: FooEnum2) -> Bool
 }
+
 var FooEnum2X: FooEnum2 { get }
+
 var FooEnum2Y: FooEnum2 { get }
+
 struct FooEnum3 : Equatable, RawRepresentable {
 
     init(_ rawValue: UInt32)
@@ -34,8 +39,11 @@ struct FooEnum3 : Equatable, RawRepresentable {
 
     static func != (_ lhs: FooEnum3, _ rhs: FooEnum3) -> Bool
 }
+
 var FooEnum3X: FooEnum3 { get }
+
 var FooEnum3Y: FooEnum3 { get }
+
 enum FooComparisonResult : Int {
 
     case orderedAscending = -1
@@ -50,6 +58,7 @@ enum FooComparisonResult : Int {
 
     static func != (_ lhs: FooComparisonResult, _ rhs: FooComparisonResult) -> Bool
 }
+
 struct FooRuncingOptions : OptionSet {
 
     init(rawValue rawValue: Int)
@@ -117,6 +126,7 @@ extension FooRuncingOptions {
 
     @inlinable mutating func formSymmetricDifference(_ other: FooRuncingOptions)
 }
+
 struct FooStruct1 {
 
     init()
@@ -127,7 +137,9 @@ struct FooStruct1 {
 
     var y: Double
 }
+
 typealias FooStruct1Pointer = UnsafeMutablePointer<FooStruct1>
+
 struct FooStruct2 {
 
     init()
@@ -138,7 +150,9 @@ struct FooStruct2 {
 
     var y: Double
 }
+
 typealias FooStructTypedef1 = FooStruct2
+
 struct FooStructTypedef2 {
 
     init()
@@ -149,21 +163,37 @@ struct FooStructTypedef2 {
 
     var y: Double
 }
+
 typealias FooTypedef1 = Int32
+
 var fooIntVar: Int32
+
 func fooFunc1(_ a: Int32) -> Int32
+
 func fooFunc1AnonymousParam(_ _: Int32) -> Int32
+
 func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
+
 func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
+
 func fooFuncWithFunctionPointer(_ fptr: ((Float) -> Int32)!)
+
 func fooFuncNoreturn1() -> Never
+
 func fooFuncNoreturn2() -> Never
+
 func fooFuncWithComment1()
+
 func fooFuncWithComment2()
+
 func fooFuncWithComment3()
+
 func fooFuncWithComment4()
+
 func fooFuncWithComment5()
+
 func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32
+
 protocol FooProtocolBase {
 
     func fooProtoFunc()
@@ -180,8 +210,10 @@ protocol FooProtocolBase {
 
     var fooProperty3: Int32 { get }
 }
+
 protocol FooProtocolDerived : FooProtocolBase {
 }
+
 class FooClassBase {
 
     func fooBaseInstanceFunc0()
@@ -204,6 +236,7 @@ class FooClassBase {
 
     func _internalMeth3() -> Any!
 }
+
 class FooClassDerived : FooClassBase, FooProtocolDerived {
 
     var fooProperty1: Int32
@@ -222,26 +255,47 @@ class FooClassDerived : FooClassBase, FooProtocolDerived {
 
     class func fooClassFunc0()
 }
+
 typealias typedef_int_t = Int32
+
 var FOO_MACRO_1: Int32 { get }
+
 var FOO_MACRO_2: Int32 { get }
+
 var FOO_MACRO_3: Int32 { get }
+
 var FOO_MACRO_4: UInt32 { get }
+
 var FOO_MACRO_5: UInt64 { get }
+
 var FOO_MACRO_6: typedef_int_t { get }
+
 var FOO_MACRO_7: typedef_int_t { get }
+
 var FOO_MACRO_8: CChar { get }
+
 var FOO_MACRO_9: Int32 { get }
+
 var FOO_MACRO_10: Int16 { get }
+
 var FOO_MACRO_11: Int { get }
+
 var FOO_MACRO_OR: Int32 { get }
+
 var FOO_MACRO_AND: Int32 { get }
+
 var FOO_MACRO_BITWIDTH: UInt64 { get }
+
 var FOO_MACRO_SIGNED: UInt32 { get }
+
 var FOO_MACRO_REDEF_1: Int32 { get }
+
 var FOO_MACRO_REDEF_2: Int32 { get }
+
 func theLastDeclInFoo()
+
 func _internalTopLevelFunc()
+
 struct _InternalStruct {
 
     init()
@@ -250,24 +304,30 @@ struct _InternalStruct {
 
     var x: Int32
 }
+
 extension FooClassBase {
 
     func _internalMeth1() -> Any!
 }
+
 extension FooClassBase {
 
     func _internalMeth2() -> Any!
 
     func nonInternalMeth() -> Any!
 }
+
 extension FooClassBase {
 
     func _internalMeth3() -> Any!
 }
+
 protocol _InternalProt {
 }
+
 class ClassWithInternalProt : _InternalProt {
 }
+
 class FooClassPropertyOwnership : FooClassBase {
 
     unowned(unsafe) var assignable: AnyObject!
@@ -284,7 +344,9 @@ class FooClassPropertyOwnership : FooClassBase {
 
     var scalar: Int32
 }
+
 var FOO_NIL: ()
+
 class FooUnavailableMembers : FooClassBase {
 
     convenience init!(int i: Int32)
@@ -311,9 +373,12 @@ class FooUnavailableMembers : FooClassBase {
 
     func availabilityUnavailableMsg()
 }
+
 class FooCFType {
 }
+
 func FooCFTypeRelease(_ _: FooCFType!)
+
 enum ABAuthorizationStatus : Int {
 
     case notDetermined = 0
@@ -326,7 +391,9 @@ enum ABAuthorizationStatus : Int {
 
     static func != (_ lhs: ABAuthorizationStatus, _ rhs: ABAuthorizationStatus) -> Bool
 }
+
 func fooSubFunc1(_ a: Int32) -> Int32
+
 struct FooSubEnum1 : Equatable, RawRepresentable {
 
     init(_ rawValue: UInt32)
@@ -337,9 +404,13 @@ struct FooSubEnum1 : Equatable, RawRepresentable {
 
     static func != (_ lhs: FooSubEnum1, _ rhs: FooSubEnum1) -> Bool
 }
+
 var FooSubEnum1X: FooSubEnum1 { get }
+
 var FooSubEnum1Y: FooSubEnum1 { get }
+
 var FooSubUnnamedEnumeratorA1: Int { get }
+
 
 [
   {
@@ -510,373 +581,368 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 242,
+    key.offset: 243,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 246,
+    key.offset: 247,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooEnum1",
     key.usr: "c:@E@FooEnum1",
-    key.offset: 257,
+    key.offset: 258,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 268,
+    key.offset: 269,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 274,
+    key.offset: 276,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 281,
+    key.offset: 283,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 292,
+    key.offset: 294,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "RawRepresentable",
     key.usr: "s:SY",
-    key.offset: 303,
+    key.offset: 305,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 327,
+    key.offset: 329,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 332,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
     key.offset: 334,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 336,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 344,
+    key.offset: 346,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 357,
+    key.offset: 359,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 362,
+    key.offset: 364,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 371,
+    key.offset: 373,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 381,
+    key.offset: 383,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 394,
+    key.offset: 396,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 398,
+    key.offset: 400,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 408,
+    key.offset: 410,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 420,
+    key.offset: 422,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 427,
+    key.offset: 429,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 432,
+    key.offset: 434,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 436,
+    key.offset: 438,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 438,
+    key.offset: 440,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooEnum2",
     key.usr: "c:@E@FooEnum2",
-    key.offset: 443,
+    key.offset: 445,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 453,
+    key.offset: 455,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 455,
+    key.offset: 457,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooEnum2",
     key.usr: "c:@E@FooEnum2",
-    key.offset: 460,
+    key.offset: 462,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 473,
+    key.offset: 475,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 480,
+    key.offset: 483,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 484,
+    key.offset: 487,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooEnum2",
     key.usr: "c:@E@FooEnum2",
-    key.offset: 495,
+    key.offset: 498,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 506,
+    key.offset: 509,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 512,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 516,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 520,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooEnum2",
     key.usr: "c:@E@FooEnum2",
-    key.offset: 527,
+    key.offset: 531,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 538,
+    key.offset: 542,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 544,
+    key.offset: 549,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 551,
+    key.offset: 556,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 562,
+    key.offset: 567,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "RawRepresentable",
     key.usr: "s:SY",
-    key.offset: 573,
+    key.offset: 578,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 597,
+    key.offset: 602,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 602,
+    key.offset: 607,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 604,
+    key.offset: 609,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 614,
+    key.offset: 619,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 627,
+    key.offset: 632,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 632,
+    key.offset: 637,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 641,
+    key.offset: 646,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 651,
+    key.offset: 656,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 664,
+    key.offset: 669,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 668,
+    key.offset: 673,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 678,
+    key.offset: 683,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 690,
+    key.offset: 695,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 697,
+    key.offset: 702,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 702,
+    key.offset: 707,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 706,
+    key.offset: 711,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 708,
+    key.offset: 713,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooEnum3",
     key.usr: "c:@E@FooEnum3",
-    key.offset: 713,
+    key.offset: 718,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 723,
+    key.offset: 728,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 725,
+    key.offset: 730,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooEnum3",
     key.usr: "c:@E@FooEnum3",
-    key.offset: 730,
+    key.offset: 735,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 743,
+    key.offset: 748,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 750,
+    key.offset: 756,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 754,
+    key.offset: 760,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooEnum3",
     key.usr: "c:@E@FooEnum3",
-    key.offset: 765,
+    key.offset: 771,
     key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 776,
-    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -884,430 +950,423 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 789,
+    key.length: 3
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 786,
+    key.offset: 793,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooEnum3",
     key.usr: "c:@E@FooEnum3",
-    key.offset: 797,
+    key.offset: 804,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 808,
+    key.offset: 815,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 814,
+    key.offset: 822,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 819,
+    key.offset: 827,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 841,
+    key.offset: 849,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 852,
+    key.offset: 860,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 857,
+    key.offset: 865,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 876,
+    key.offset: 884,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 884,
+    key.offset: 892,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 889,
+    key.offset: 897,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 903,
+    key.offset: 911,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 910,
+    key.offset: 918,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 915,
+    key.offset: 923,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 935,
+    key.offset: 943,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 942,
+    key.offset: 950,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 953,
+    key.offset: 961,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 957,
+    key.offset: 965,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 968,
+    key.offset: 976,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 974,
+    key.offset: 982,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 985,
+    key.offset: 993,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 996,
+    key.offset: 1004,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1001,
+    key.offset: 1009,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1006,
+    key.offset: 1014,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1011,
+    key.offset: 1019,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1019,
+    key.offset: 1027,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Hasher",
     key.usr: "s:s6HasherV",
-    key.offset: 1025,
+    key.offset: 1033,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1038,
+    key.offset: 1046,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1045,
+    key.offset: 1053,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 1050,
+    key.offset: 1058,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1054,
+    key.offset: 1062,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1056,
+    key.offset: 1064,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "FooComparisonResult",
     key.usr: "c:@E@FooComparisonResult",
-    key.offset: 1061,
+    key.offset: 1069,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1082,
+    key.offset: 1090,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1084,
+    key.offset: 1092,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "FooComparisonResult",
     key.usr: "c:@E@FooComparisonResult",
-    key.offset: 1089,
+    key.offset: 1097,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1113,
+    key.offset: 1121,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1120,
+    key.offset: 1129,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1127,
+    key.offset: 1136,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "OptionSet",
     key.usr: "s:s9OptionSetP",
-    key.offset: 1147,
+    key.offset: 1156,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1164,
+    key.offset: 1173,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1169,
+    key.offset: 1178,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1178,
+    key.offset: 1187,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1188,
+    key.offset: 1197,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1198,
+    key.offset: 1207,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1205,
+    key.offset: 1214,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1209,
+    key.offset: 1218,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1222,
+    key.offset: 1231,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1242,
+    key.offset: 1251,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1253,
+    key.offset: 1262,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1260,
+    key.offset: 1269,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1264,
+    key.offset: 1273,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1278,
+    key.offset: 1287,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1298,
+    key.offset: 1307,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1309,
+    key.offset: 1318,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1316,
+    key.offset: 1325,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 1321,
+    key.offset: 1330,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1325,
+    key.offset: 1334,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1327,
+    key.offset: 1336,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1332,
+    key.offset: 1341,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1351,
+    key.offset: 1360,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1353,
+    key.offset: 1362,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1358,
+    key.offset: 1367,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1380,
+    key.offset: 1389,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1390,
+    key.offset: 1399,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1401,
+    key.offset: 1410,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1406,
+    key.offset: 1415,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1419,
+    key.offset: 1428,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1433,
+    key.offset: 1442,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1458,
+    key.offset: 1467,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1468,
+    key.offset: 1477,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1493,
+    key.offset: 1502,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1504,
+    key.offset: 1513,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "S",
     key.usr: "s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp",
-    key.offset: 1509,
+    key.offset: 1518,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1512,
+    key.offset: 1521,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1514,
+    key.offset: 1523,
     key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.ref.generic_type_param,
-    key.name: "S",
-    key.usr: "s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp",
-    key.offset: 1524,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1527,
-    key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
@@ -1317,939 +1376,946 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 1
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1536,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.name: "S",
+    key.usr: "s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp",
+    key.offset: 1542,
+    key.length: 1
+  },
+  {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Sequence",
     key.usr: "s:ST",
-    key.offset: 1537,
+    key.offset: 1546,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1547,
+    key.offset: 1556,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 1565,
+    key.offset: 1574,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "S",
     key.usr: "s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp",
-    key.offset: 1568,
+    key.offset: 1577,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
     key.usr: "s:ST7ElementQa",
-    key.offset: 1570,
+    key.offset: 1579,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1583,
+    key.offset: 1592,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1594,
+    key.offset: 1603,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1603,
+    key.offset: 1612,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1608,
+    key.offset: 1617,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1617,
+    key.offset: 1626,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1619,
+    key.offset: 1628,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1626,
+    key.offset: 1635,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1650,
+    key.offset: 1659,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1661,
+    key.offset: 1670,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1666,
+    key.offset: 1675,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1675,
+    key.offset: 1684,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1678,
+    key.offset: 1687,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1685,
+    key.offset: 1694,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1707,
+    key.offset: 1716,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1717,
+    key.offset: 1726,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1728,
+    key.offset: 1737,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1733,
+    key.offset: 1742,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1744,
+    key.offset: 1753,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1747,
+    key.offset: 1756,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1754,
+    key.offset: 1763,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1776,
+    key.offset: 1785,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1786,
+    key.offset: 1795,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1797,
+    key.offset: 1806,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1802,
+    key.offset: 1811,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1813,
+    key.offset: 1822,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1818,
+    key.offset: 1827,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1825,
+    key.offset: 1834,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1847,
+    key.offset: 1856,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1857,
+    key.offset: 1866,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1868,
+    key.offset: 1877,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1873,
+    key.offset: 1882,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1885,
+    key.offset: 1894,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1887,
+    key.offset: 1896,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1894,
+    key.offset: 1903,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 1916,
+    key.offset: 1925,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1939,
+    key.offset: 1948,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1950,
+    key.offset: 1959,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1954,
+    key.offset: 1963,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1963,
+    key.offset: 1972,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1970,
+    key.offset: 1979,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1981,
+    key.offset: 1990,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1992,
+    key.offset: 2001,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1997,
+    key.offset: 2006,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2014,
+    key.offset: 2023,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2017,
+    key.offset: 2026,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2024,
+    key.offset: 2033,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 2046,
+    key.offset: 2055,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2056,
+    key.offset: 2065,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2067,
+    key.offset: 2076,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2072,
+    key.offset: 2081,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2087,
+    key.offset: 2096,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2090,
+    key.offset: 2099,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2097,
+    key.offset: 2106,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 2119,
+    key.offset: 2128,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2127,
+    key.offset: 2136,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2137,
+    key.offset: 2146,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2162,
+    key.offset: 2171,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2173,
+    key.offset: 2182,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2178,
+    key.offset: 2187,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2184,
+    key.offset: 2193,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2186,
+    key.offset: 2195,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2193,
+    key.offset: 2202,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2215,
+    key.offset: 2224,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2238,
+    key.offset: 2247,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2249,
+    key.offset: 2258,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2254,
+    key.offset: 2263,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2267,
+    key.offset: 2276,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2269,
+    key.offset: 2278,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2276,
+    key.offset: 2285,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2298,
+    key.offset: 2307,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2321,
+    key.offset: 2330,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2332,
+    key.offset: 2341,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2337,
+    key.offset: 2346,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2357,
+    key.offset: 2366,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2359,
+    key.offset: 2368,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2366,
+    key.offset: 2375,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2388,
+    key.offset: 2397,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2409,
+    key.offset: 2418,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2419,
+    key.offset: 2428,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2444,
+    key.offset: 2453,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2455,
+    key.offset: 2464,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2460,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 2469,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 2478,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2471,
+    key.offset: 2480,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2479,
+    key.offset: 2488,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 2501,
+    key.offset: 2510,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2511,
+    key.offset: 2520,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2534,
+    key.offset: 2543,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2545,
+    key.offset: 2554,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2554,
+    key.offset: 2563,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2559,
+    key.offset: 2568,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2566,
+    key.offset: 2575,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2568,
+    key.offset: 2577,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2579,
+    key.offset: 2588,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2602,
+    key.offset: 2611,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 2612,
+    key.offset: 2621,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2618,
+    key.offset: 2627,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2637,
+    key.offset: 2646,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2661,
+    key.offset: 2670,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2684,
+    key.offset: 2693,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2695,
+    key.offset: 2704,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2704,
+    key.offset: 2713,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2709,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2716,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
     key.offset: 2718,
     key.length: 6
   },
   {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 2725,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 2727,
+    key.length: 6
+  },
+  {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2726,
+    key.offset: 2735,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2748,
+    key.offset: 2757,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2772,
+    key.offset: 2781,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2795,
+    key.offset: 2804,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2806,
+    key.offset: 2815,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2815,
+    key.offset: 2824,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2820,
+    key.offset: 2829,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2827,
+    key.offset: 2836,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2832,
+    key.offset: 2841,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2843,
+    key.offset: 2852,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2865,
+    key.offset: 2874,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2887,
+    key.offset: 2896,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2897,
+    key.offset: 2906,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2922,
+    key.offset: 2931,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2933,
+    key.offset: 2942,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2945,
+    key.offset: 2954,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2956,
+    key.offset: 2965,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2965,
+    key.offset: 2974,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2970,
+    key.offset: 2979,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 2980,
+    key.offset: 2989,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 2982,
+    key.offset: 2991,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 2989,
+    key.offset: 2998,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3013,
+    key.offset: 3022,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3024,
+    key.offset: 3033,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3033,
+    key.offset: 3042,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3038,
+    key.offset: 3047,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3055,
+    key.offset: 3064,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3057,
+    key.offset: 3066,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3064,
+    key.offset: 3073,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3088,
+    key.offset: 3097,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3099,
+    key.offset: 3108,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3108,
+    key.offset: 3117,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3113,
+    key.offset: 3122,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3137,
+    key.offset: 3146,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3139,
+    key.offset: 3148,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
-    key.offset: 3146,
+    key.offset: 3155,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3167,
+    key.offset: 3177,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3174,
+    key.offset: 3184,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3192,
+    key.offset: 3202,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3204,
+    key.offset: 3214,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3209,
+    key.offset: 3219,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3211,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 3214,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
     key.offset: 3221,
     key.length: 1
   },
   {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 3224,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3231,
+    key.length: 1
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3223,
+    key.offset: 3233,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3226,
+    key.offset: 3236,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3239,
+    key.offset: 3249,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3243,
+    key.offset: 3253,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3246,
+    key.offset: 3256,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3257,
+    key.offset: 3267,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3261,
+    key.offset: 3271,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3264,
+    key.offset: 3274,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3273,
+    key.offset: 3284,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3283,
+    key.offset: 3294,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UnsafeMutablePointer",
     key.usr: "s:Sp",
-    key.offset: 3303,
+    key.offset: 3314,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooStruct1",
     key.usr: "c:@S@FooStruct1",
-    key.offset: 3324,
+    key.offset: 3335,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3336,
+    key.offset: 3348,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3343,
+    key.offset: 3355,
     key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3361,
-    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2257,21 +2323,9 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3378,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3380,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 3383,
-    key.length: 5
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3385,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
@@ -2285,484 +2339,491 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 3395,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3402,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3404,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3395,
+    key.offset: 3407,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3408,
+    key.offset: 3420,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3412,
+    key.offset: 3424,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3415,
+    key.offset: 3427,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3426,
+    key.offset: 3438,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3430,
+    key.offset: 3442,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3433,
+    key.offset: 3445,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3442,
+    key.offset: 3455,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3452,
+    key.offset: 3465,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooStruct2",
     key.usr: "c:@S@FooStruct2",
-    key.offset: 3472,
+    key.offset: 3485,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3483,
+    key.offset: 3497,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3490,
+    key.offset: 3504,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3515,
+    key.offset: 3529,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3527,
+    key.offset: 3541,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3532,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3534,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 3537,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3544,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
     key.offset: 3546,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Double",
-    key.usr: "s:Sd",
-    key.offset: 3549,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3562,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3566,
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3548,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3569,
+    key.offset: 3551,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3580,
-    key.length: 3
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 3558,
+    key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3584,
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 3560,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3587,
+    key.offset: 3563,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3596,
+    key.offset: 3576,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3580,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 3583,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3594,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3598,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Double",
+    key.usr: "s:Sd",
+    key.offset: 3601,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3611,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3606,
+    key.offset: 3621,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3620,
+    key.offset: 3635,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3626,
+    key.offset: 3642,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3630,
+    key.offset: 3646,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3641,
+    key.offset: 3657,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3647,
+    key.offset: 3664,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3652,
+    key.offset: 3669,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3661,
+    key.offset: 3678,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3663,
+    key.offset: 3680,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3666,
+    key.offset: 3683,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3676,
+    key.offset: 3693,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3682,
+    key.offset: 3700,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3687,
+    key.offset: 3705,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3710,
+    key.offset: 3728,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3712,
+    key.offset: 3730,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3715,
+    key.offset: 3733,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3725,
+    key.offset: 3743,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3731,
+    key.offset: 3750,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3736,
+    key.offset: 3755,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3745,
+    key.offset: 3764,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3747,
+    key.offset: 3766,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3750,
+    key.offset: 3769,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3757,
+    key.offset: 3776,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3759,
+    key.offset: 3778,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 3762,
+    key.offset: 3781,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3769,
+    key.offset: 3788,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3771,
+    key.offset: 3790,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Double",
     key.usr: "s:Sd",
-    key.offset: 3774,
+    key.offset: 3793,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3782,
+    key.offset: 3801,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3784,
+    key.offset: 3803,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UnsafeMutablePointer",
     key.usr: "s:Sp",
-    key.offset: 3787,
+    key.offset: 3806,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3808,
+    key.offset: 3827,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3820,
+    key.offset: 3839,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3826,
+    key.offset: 3846,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3831,
+    key.offset: 3851,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3848,
+    key.offset: 3868,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3850,
+    key.offset: 3870,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 3857,
+    key.offset: 3877,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3867,
+    key.offset: 3887,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3876,
+    key.offset: 3897,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3881,
+    key.offset: 3902,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 3908,
+    key.offset: 3929,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 3910,
+    key.offset: 3931,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 3918,
+    key.offset: 3939,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 3928,
+    key.offset: 3949,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3937,
+    key.offset: 3959,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3942,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.ref.enum,
-    key.name: "Never",
-    key.usr: "s:s5NeverO",
     key.offset: 3964,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3970,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3975,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "Never",
     key.usr: "s:s5NeverO",
-    key.offset: 3997,
+    key.offset: 3986,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4003,
+    key.offset: 3993,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4008,
+    key.offset: 3998,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.ref.enum,
+    key.name: "Never",
+    key.usr: "s:s5NeverO",
+    key.offset: 4020,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4027,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4032,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4030,
+    key.offset: 4055,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4035,
+    key.offset: 4060,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4057,
+    key.offset: 4083,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4062,
-    key.length: 19
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4084,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4089,
+    key.offset: 4088,
     key.length: 19
   },
   {
@@ -2777,114 +2838,102 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4138,
+    key.offset: 4139,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4143,
+    key.offset: 4144,
+    key.length: 19
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4167,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4172,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4176,
+    key.offset: 4205,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4178,
+    key.offset: 4207,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4181,
+    key.offset: 4210,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4191,
+    key.offset: 4220,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4197,
+    key.offset: 4227,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4206,
+    key.offset: 4236,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4229,
+    key.offset: 4259,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4234,
+    key.offset: 4264,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4254,
+    key.offset: 4284,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4259,
+    key.offset: 4289,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4300,
+    key.offset: 4330,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4305,
+    key.offset: 4335,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4346,
+    key.offset: 4376,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4353,
+    key.offset: 4383,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4358,
+    key.offset: 4388,
     key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4383,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4387,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 4401,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4409,
-    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2892,25 +2941,25 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4424,
-    key.length: 3
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4428,
+    key.offset: 4417,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4442,
+    key.offset: 4431,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4450,
+    key.offset: 4439,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4443,
     key.length: 3
   },
   {
@@ -2919,525 +2968,520 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4465,
-    key.length: 3
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4469,
+    key.offset: 4458,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 4483,
+    key.offset: 4472,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4491,
+    key.offset: 4480,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4484,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4495,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4499,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 4513,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4521,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4530,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4508,
+    key.offset: 4539,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "FooProtocolBase",
     key.usr: "c:objc(pl)FooProtocolBase",
-    key.offset: 4529,
+    key.offset: 4560,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4549,
+    key.offset: 4581,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4555,
+    key.offset: 4587,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4575,
+    key.offset: 4607,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4580,
+    key.offset: 4612,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4608,
+    key.offset: 4640,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4613,
+    key.offset: 4645,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4634,
+    key.offset: 4666,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4636,
+    key.offset: 4668,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4646,
+    key.offset: 4678,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 4655,
+    key.offset: 4687,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4674,
+    key.offset: 4706,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4687,
+    key.offset: 4719,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4699,
+    key.offset: 4731,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 4705,
+    key.offset: 4737,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 4711,
+    key.offset: 4743,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Float",
     key.usr: "s:Sf",
-    key.offset: 4714,
+    key.offset: 4746,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4726,
+    key.offset: 4758,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4731,
+    key.offset: 4763,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4768,
+    key.offset: 4800,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4774,
+    key.offset: 4806,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4779,
+    key.offset: 4811,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4804,
+    key.offset: 4836,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4809,
+    key.offset: 4841,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4829,
+    key.offset: 4861,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4839,
+    key.offset: 4871,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4844,
+    key.offset: 4876,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4864,
+    key.offset: 4896,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4874,
+    key.offset: 4906,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4879,
+    key.offset: 4911,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4900,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4910,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4915,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4935,
+    key.offset: 4932,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4942,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4947,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4967,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4975,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4948,
+    key.offset: 4981,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 4966,
+    key.offset: 4999,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "FooProtocolDerived",
     key.usr: "c:objc(pl)FooProtocolDerived",
-    key.offset: 4980,
+    key.offset: 5013,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5006,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5010,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 5024,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5035,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5039,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5043,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5053,
+    key.offset: 5057,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5064,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5068,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5072,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5082,
+    key.offset: 5086,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5090,
+    key.offset: 5097,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5101,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 5115,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5123,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5101,
+    key.offset: 5134,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5106,
+    key.offset: 5139,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5130,
+    key.offset: 5163,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5135,
+    key.offset: 5168,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5152,
+    key.offset: 5185,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5154,
+    key.offset: 5187,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5157,
+    key.offset: 5190,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5169,
+    key.offset: 5202,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5174,
+    key.offset: 5207,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5191,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5193,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 5196,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 5203,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 5209,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 5212,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5224,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 5226,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 5229,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 5236,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 5242,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 5245,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5257,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5229,
+    key.offset: 5262,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5266,
+    key.offset: 5299,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5272,
+    key.offset: 5305,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5277,
+    key.offset: 5310,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5295,
+    key.offset: 5329,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5305,
+    key.offset: 5339,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5321,
+    key.offset: 5355,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5327,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5331,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int32",
-    key.usr: "s:s5Int32V",
-    key.offset: 5344,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5352,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5358,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 5362,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5366,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5375,
+    key.offset: 5379,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5383,
+    key.offset: 5387,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5389,
+    key.offset: 5394,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5393,
+    key.offset: 5398,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5406,
+    key.offset: 5411,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5414,
+    key.offset: 5419,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5420,
+    key.offset: 5426,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5424,
+    key.offset: 5430,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int32",
+    key.usr: "s:s5Int32V",
+    key.offset: 5443,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5451,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5458,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5462,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 5437,
+    key.offset: 5475,
     key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5446,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5452,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5456,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "UInt64",
-    key.usr: "s:s6UInt64V",
-    key.offset: 5469,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5478,
-    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -3445,16 +3489,21 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5491,
+    key.length: 3
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5488,
+    key.offset: 5495,
     key.length: 11
   },
   {
-    key.kind: source.lang.swift.ref.typealias,
-    key.name: "typedef_int_t",
-    key.usr: "c:Foo.h@T@typedef_int_t",
-    key.offset: 5501,
-    key.length: 13
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "UInt64",
+    key.usr: "s:s6UInt64V",
+    key.offset: 5508,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -3463,1189 +3512,1211 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5523,
+    key.offset: 5524,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5527,
+    key.offset: 5528,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.typealias,
     key.name: "typedef_int_t",
     key.usr: "c:Foo.h@T@typedef_int_t",
-    key.offset: 5540,
+    key.offset: 5541,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5556,
+    key.offset: 5557,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5562,
+    key.offset: 5564,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5566,
+    key.offset: 5568,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.typealias,
+    key.name: "typedef_int_t",
+    key.usr: "c:Foo.h@T@typedef_int_t",
+    key.offset: 5581,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5597,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5604,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5608,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.typealias,
     key.name: "CChar",
     key.usr: "s:s5CChara",
-    key.offset: 5579,
+    key.offset: 5621,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5587,
+    key.offset: 5629,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5593,
+    key.offset: 5636,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5597,
+    key.offset: 5640,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5610,
+    key.offset: 5653,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5618,
+    key.offset: 5661,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5624,
+    key.offset: 5668,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5628,
+    key.offset: 5672,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int16",
     key.usr: "s:s5Int16V",
-    key.offset: 5642,
+    key.offset: 5686,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5650,
+    key.offset: 5694,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5656,
+    key.offset: 5701,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5660,
+    key.offset: 5705,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 5674,
+    key.offset: 5719,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5680,
+    key.offset: 5725,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5686,
+    key.offset: 5732,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5690,
+    key.offset: 5736,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5704,
+    key.offset: 5750,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5712,
+    key.offset: 5758,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5718,
+    key.offset: 5765,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5722,
+    key.offset: 5769,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5737,
+    key.offset: 5784,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5745,
+    key.offset: 5792,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5751,
+    key.offset: 5799,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5755,
+    key.offset: 5803,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt64",
     key.usr: "s:s6UInt64V",
-    key.offset: 5775,
+    key.offset: 5823,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5784,
+    key.offset: 5832,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5790,
+    key.offset: 5839,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5794,
+    key.offset: 5843,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 5812,
+    key.offset: 5861,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5821,
+    key.offset: 5870,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5827,
+    key.offset: 5877,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5831,
+    key.offset: 5881,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5850,
+    key.offset: 5900,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5858,
+    key.offset: 5908,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5864,
+    key.offset: 5915,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5868,
+    key.offset: 5919,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 5887,
+    key.offset: 5938,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5895,
+    key.offset: 5946,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5901,
+    key.offset: 5953,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5906,
+    key.offset: 5958,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5925,
+    key.offset: 5978,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5930,
+    key.offset: 5983,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5954,
+    key.offset: 6008,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5961,
+    key.offset: 6015,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5984,
+    key.offset: 6038,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5996,
+    key.offset: 6050,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6001,
+    key.offset: 6055,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6003,
+    key.offset: 6057,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6006,
+    key.offset: 6060,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6018,
+    key.offset: 6072,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6022,
+    key.offset: 6076,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6025,
+    key.offset: 6079,
     key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6033,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
-    key.name: "FooClassBase",
-    key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6043,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6063,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6068,
-    key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 6088,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6095,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6105,
+    key.offset: 6098,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6125,
+    key.offset: 6118,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6130,
+    key.offset: 6123,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6150,
+    key.offset: 6143,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6160,
+    key.offset: 6151,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.name: "FooClassBase",
+    key.usr: "c:objc(cs)FooClassBase",
+    key.offset: 6161,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6181,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6165,
+    key.offset: 6186,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6206,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6216,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6221,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6186,
+    key.offset: 6242,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6193,
+    key.offset: 6250,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6203,
+    key.offset: 6260,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6223,
+    key.offset: 6280,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6228,
+    key.offset: 6285,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6248,
+    key.offset: 6305,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6255,
+    key.offset: 6313,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6264,
+    key.offset: 6322,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6282,
+    key.offset: 6341,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6288,
+    key.offset: 6347,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "_InternalProt",
     key.usr: "c:objc(pl)_InternalProt",
-    key.offset: 6312,
+    key.offset: 6371,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6330,
+    key.offset: 6390,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6336,
+    key.offset: 6396,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6364,
+    key.offset: 6424,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6384,
+    key.offset: 6444,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6400,
+    key.offset: 6460,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6404,
+    key.offset: 6464,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6416,
+    key.offset: 6476,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6432,
+    key.offset: 6492,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6448,
+    key.offset: 6508,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6452,
+    key.offset: 6512,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6470,
+    key.offset: 6530,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6486,
+    key.offset: 6546,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6490,
+    key.offset: 6550,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6502,
+    key.offset: 6562,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6512,
+    key.offset: 6572,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6516,
+    key.offset: 6576,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6527,
+    key.offset: 6587,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6537,
+    key.offset: 6597,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6541,
+    key.offset: 6601,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6551,
+    key.offset: 6611,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6561,
+    key.offset: 6621,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6566,
+    key.offset: 6626,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6570,
+    key.offset: 6630,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6579,
+    key.offset: 6639,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6595,
+    key.offset: 6655,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6599,
+    key.offset: 6659,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6607,
+    key.offset: 6667,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6615,
+    key.offset: 6676,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6619,
+    key.offset: 6680,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6631,
+    key.offset: 6693,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6637,
+    key.offset: 6699,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 6661,
+    key.offset: 6723,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6681,
+    key.offset: 6743,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6693,
+    key.offset: 6755,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 6699,
+    key.offset: 6761,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 6703,
+    key.offset: 6765,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 6706,
+    key.offset: 6768,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6718,
+    key.offset: 6780,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6723,
+    key.offset: 6785,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6742,
+    key.offset: 6804,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6747,
+    key.offset: 6809,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6771,
+    key.offset: 6833,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6776,
+    key.offset: 6838,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6794,
+    key.offset: 6856,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6799,
+    key.offset: 6861,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6829,
+    key.offset: 6891,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6834,
+    key.offset: 6896,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6864,
+    key.offset: 6926,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6869,
+    key.offset: 6931,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6898,
+    key.offset: 6960,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6903,
+    key.offset: 6965,
     key.length: 23
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6934,
+    key.offset: 6996,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6939,
+    key.offset: 7001,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6972,
+    key.offset: 7034,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6977,
+    key.offset: 7039,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7010,
+    key.offset: 7072,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7015,
+    key.offset: 7077,
     key.length: 24
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7047,
+    key.offset: 7109,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7052,
+    key.offset: 7114,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7083,
+    key.offset: 7146,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7089,
+    key.offset: 7152,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7103,
+    key.offset: 7167,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7108,
+    key.offset: 7172,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7125,
+    key.offset: 7189,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7127,
+    key.offset: 7191,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 7130,
+    key.offset: 7194,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7142,
+    key.offset: 7207,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7147,
+    key.offset: 7212,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 7171,
+    key.offset: 7236,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7182,
+    key.offset: 7247,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7187,
+    key.offset: 7252,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 7203,
+    key.offset: 7268,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7210,
+    key.offset: 7275,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7215,
+    key.offset: 7280,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 7228,
+    key.offset: 7293,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7235,
+    key.offset: 7300,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7246,
+    key.offset: 7311,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7250,
+    key.offset: 7315,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 7261,
+    key.offset: 7326,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7267,
+    key.offset: 7332,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7278,
+    key.offset: 7343,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7289,
+    key.offset: 7354,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7294,
+    key.offset: 7359,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7299,
+    key.offset: 7364,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7304,
+    key.offset: 7369,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7312,
+    key.offset: 7377,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Hasher",
     key.usr: "s:s6HasherV",
-    key.offset: 7318,
+    key.offset: 7383,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7331,
+    key.offset: 7396,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7338,
+    key.offset: 7403,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 7343,
+    key.offset: 7408,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7347,
+    key.offset: 7412,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7349,
+    key.offset: 7414,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "ABAuthorizationStatus",
     key.usr: "c:@E@ABAuthorizationStatus",
-    key.offset: 7354,
+    key.offset: 7419,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7377,
+    key.offset: 7442,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7379,
+    key.offset: 7444,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "ABAuthorizationStatus",
     key.usr: "c:@E@ABAuthorizationStatus",
-    key.offset: 7384,
+    key.offset: 7449,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 7410,
+    key.offset: 7475,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7417,
+    key.offset: 7483,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7422,
+    key.offset: 7488,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7434,
+    key.offset: 7500,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7436,
+    key.offset: 7502,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 7439,
+    key.offset: 7505,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int32",
     key.usr: "s:s5Int32V",
-    key.offset: 7449,
+    key.offset: 7515,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7455,
+    key.offset: 7522,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7462,
+    key.offset: 7529,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 7476,
+    key.offset: 7543,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "RawRepresentable",
     key.usr: "s:SY",
-    key.offset: 7487,
+    key.offset: 7554,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7511,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7516,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7518,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "UInt32",
-    key.usr: "s:s6UInt32V",
-    key.offset: 7528,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7541,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7546,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7555,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "UInt32",
-    key.usr: "s:s6UInt32V",
-    key.offset: 7565,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 7578,
-    key.length: 3
+    key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7582,
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 7583,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 7585,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 7592,
+    key.offset: 7595,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7604,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7611,
+    key.offset: 7608,
     key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 7616,
-    key.length: 2
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7620,
-    key.length: 1
+    key.offset: 7613,
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
     key.offset: 7622,
-    key.length: 3
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.name: "FooSubEnum1",
-    key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7627,
-    key.length: 11
+    key.name: "UInt32",
+    key.usr: "s:s6UInt32V",
+    key.offset: 7632,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 7645,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7649,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "UInt32",
+    key.usr: "s:s6UInt32V",
+    key.offset: 7659,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 7671,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 7678,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 7683,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 7640,
+    key.offset: 7687,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 7642,
+    key.offset: 7689,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7647,
+    key.offset: 7694,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 7707,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 7709,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "FooSubEnum1",
+    key.usr: "c:@E@FooSubEnum1",
+    key.offset: 7714,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 7663,
+    key.offset: 7730,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7670,
+    key.offset: 7738,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7674,
+    key.offset: 7742,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7688,
+    key.offset: 7756,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7702,
+    key.offset: 7770,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7708,
+    key.offset: 7777,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7712,
+    key.offset: 7781,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7726,
+    key.offset: 7795,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7740,
+    key.offset: 7809,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7746,
+    key.offset: 7816,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7750,
+    key.offset: 7820,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 7777,
+    key.offset: 7847,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7783,
+    key.offset: 7853,
     key.length: 3
   }
 ]
@@ -4746,7 +4817,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooEnum1X",
     key.usr: "c:@E@FooEnum1@FooEnum1X",
     key.doc.full_as_xml: "<Variable file=Foo.h line=\"18\" column=\"3\"><Name>FooEnum1X</Name><USR>c:@E@FooEnum1@FooEnum1X</USR><Declaration>var FooEnum1X: FooEnum1 { get }</Declaration><Abstract><Para> Aaa.  FooEnum1X.  Bbb.</Para></Abstract></Variable>",
-    key.offset: 242,
+    key.offset: 243,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooEnum1X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooEnum1\">FooEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -4754,7 +4825,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooEnum2",
     key.usr: "c:@E@FooEnum2",
-    key.offset: 274,
+    key.offset: 276,
     key.length: 205,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooEnum2</decl.name> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol>, <ref.protocol usr=\"s:SY\">RawRepresentable</ref.protocol></decl.struct>",
     key.conforms: [
@@ -4774,7 +4845,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
         key.usr: "s:So8FooEnum2VyABs6UInt32Vcfc",
-        key.offset: 327,
+        key.offset: 329,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -4782,7 +4853,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rawValue",
-            key.offset: 344,
+            key.offset: 346,
             key.length: 6
           }
         ]
@@ -4791,7 +4862,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:So8FooEnum2V8rawValueABs6UInt32V_tcfc",
-        key.offset: 357,
+        key.offset: 359,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -4799,7 +4870,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 381,
+            key.offset: 383,
             key.length: 6
           }
         ]
@@ -4808,7 +4879,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
         key.usr: "s:So8FooEnum2V8rawValues6UInt32Vvp",
-        key.offset: 394,
+        key.offset: 396,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -4818,7 +4889,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooEnum2",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooEnum2</USR><Declaration>static func != (lhs: FooEnum2, rhs: FooEnum2) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 420,
+        key.offset: 422,
         key.length: 57,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooEnum2\">FooEnum2</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooEnum2\">FooEnum2</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -4826,14 +4897,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 443,
+            key.offset: 445,
             key.length: 8
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 460,
+            key.offset: 462,
             key.length: 8
           }
         ]
@@ -4844,7 +4915,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooEnum2X",
     key.usr: "c:@E@FooEnum2@FooEnum2X",
-    key.offset: 480,
+    key.offset: 483,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooEnum2X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooEnum2\">FooEnum2</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -4852,7 +4923,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooEnum2Y",
     key.usr: "c:@E@FooEnum2@FooEnum2Y",
-    key.offset: 512,
+    key.offset: 516,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooEnum2Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooEnum2\">FooEnum2</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -4860,7 +4931,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooEnum3",
     key.usr: "c:@E@FooEnum3",
-    key.offset: 544,
+    key.offset: 549,
     key.length: 205,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooEnum3</decl.name> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol>, <ref.protocol usr=\"s:SY\">RawRepresentable</ref.protocol></decl.struct>",
     key.conforms: [
@@ -4880,7 +4951,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
         key.usr: "s:So8FooEnum3VyABs6UInt32Vcfc",
-        key.offset: 597,
+        key.offset: 602,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -4888,7 +4959,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rawValue",
-            key.offset: 614,
+            key.offset: 619,
             key.length: 6
           }
         ]
@@ -4897,7 +4968,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:So8FooEnum3V8rawValueABs6UInt32V_tcfc",
-        key.offset: 627,
+        key.offset: 632,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -4905,7 +4976,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 651,
+            key.offset: 656,
             key.length: 6
           }
         ]
@@ -4914,7 +4985,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
         key.usr: "s:So8FooEnum3V8rawValues6UInt32Vvp",
-        key.offset: 664,
+        key.offset: 669,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -4924,7 +4995,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooEnum3",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooEnum3</USR><Declaration>static func != (lhs: FooEnum3, rhs: FooEnum3) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 690,
+        key.offset: 695,
         key.length: 57,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooEnum3\">FooEnum3</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooEnum3\">FooEnum3</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -4932,14 +5003,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 713,
+            key.offset: 718,
             key.length: 8
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 730,
+            key.offset: 735,
             key.length: 8
           }
         ]
@@ -4950,7 +5021,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooEnum3X",
     key.usr: "c:@E@FooEnum3@FooEnum3X",
-    key.offset: 750,
+    key.offset: 756,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooEnum3X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooEnum3\">FooEnum3</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -4958,7 +5029,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooEnum3Y",
     key.usr: "c:@E@FooEnum3@FooEnum3Y",
-    key.offset: 782,
+    key.offset: 789,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooEnum3Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooEnum3\">FooEnum3</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -4967,7 +5038,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooComparisonResult",
     key.usr: "c:@E@FooComparisonResult",
     key.doc.full_as_xml: "<Enum line=\"1\" column=\"1\"><Name>FooComparisonResult</Name><USR>c:@E@FooComparisonResult</USR><Declaration>enum FooComparisonResult : Int</Declaration><Abstract><Para> Aaa.  FooComparisonResult.  Bbb.</Para></Abstract></Enum>",
-    key.offset: 814,
+    key.offset: 822,
     key.length: 305,
     key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>FooComparisonResult</decl.name> : <ref.struct usr=\"s:Si\">Int</ref.struct></decl.enum>",
     key.inherits: [
@@ -4982,7 +5053,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "orderedAscending",
         key.usr: "c:@E@FooComparisonResult@FooOrderedAscending",
-        key.offset: 852,
+        key.offset: 860,
         key.length: 26,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>orderedAscending</decl.name> = <syntaxtype.number>-1</syntaxtype.number></decl.enumelement>"
       },
@@ -4990,7 +5061,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "orderedSame",
         key.usr: "c:@E@FooComparisonResult@FooOrderedSame",
-        key.offset: 884,
+        key.offset: 892,
         key.length: 20,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>orderedSame</decl.name> = <syntaxtype.number>0</syntaxtype.number></decl.enumelement>"
       },
@@ -4998,7 +5069,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "orderedDescending",
         key.usr: "c:@E@FooComparisonResult@FooOrderedDescending",
-        key.offset: 910,
+        key.offset: 918,
         key.length: 26,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>orderedDescending</decl.name> = <syntaxtype.number>1</syntaxtype.number></decl.enumelement>"
       },
@@ -5007,7 +5078,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hashValue",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@FooComparisonResult",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp",
-        key.offset: 942,
+        key.offset: 950,
         key.length: 37,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>hashValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -5016,7 +5087,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hash(into:)",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@FooComparisonResult",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF",
-        key.offset: 985,
+        key.offset: 993,
         key.length: 47,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>hash</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>into</decl.var.parameter.argument_label> <decl.var.parameter.name>hasher</decl.var.parameter.name>: <syntaxtype.keyword>inout</syntaxtype.keyword> <decl.var.parameter.type><ref.struct usr=\"s:s6HasherV\">Hasher</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -5024,7 +5095,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "into",
             key.name: "hasher",
-            key.offset: 1025,
+            key.offset: 1033,
             key.length: 6
           }
         ]
@@ -5035,7 +5106,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooComparisonResult",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooComparisonResult</USR><Declaration>static func != (lhs: FooComparisonResult, rhs: FooComparisonResult) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 1038,
+        key.offset: 1046,
         key.length: 79,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"c:@E@FooComparisonResult\">FooComparisonResult</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"c:@E@FooComparisonResult\">FooComparisonResult</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -5043,14 +5114,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 1061,
+            key.offset: 1069,
             key.length: 19
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 1089,
+            key.offset: 1097,
             key.length: 19
           }
         ]
@@ -5062,7 +5133,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooRuncingOptions",
     key.usr: "c:@E@FooRuncingOptions",
     key.doc.full_as_xml: "<Enum line=\"1\" column=\"1\"><Name>FooRuncingOptions</Name><USR>c:@E@FooRuncingOptions</USR><Declaration>struct FooRuncingOptions : OptionSet</Declaration><Abstract><Para> Aaa.  FooRuncingOptions.  Bbb.</Para></Abstract></Enum>",
-    key.offset: 1120,
+    key.offset: 1129,
     key.length: 336,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooRuncingOptions</decl.name> : <ref.protocol usr=\"s:s9OptionSetP\">OptionSet</ref.protocol></decl.struct>",
     key.conforms: [
@@ -5077,7 +5148,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:So17FooRuncingOptionsV8rawValueABSi_tcfc",
-        key.offset: 1164,
+        key.offset: 1173,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -5085,7 +5156,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 1188,
+            key.offset: 1197,
             key.length: 3
           }
         ]
@@ -5094,7 +5165,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.static,
         key.name: "enableMince",
         key.usr: "c:@E@FooRuncingOptions@FooRuncingEnableMince",
-        key.offset: 1198,
+        key.offset: 1207,
         key.length: 49,
         key.fully_annotated_decl: "<decl.var.static><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>enableMince</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.static>"
       },
@@ -5102,7 +5173,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.static,
         key.name: "enableQuince",
         key.usr: "c:@E@FooRuncingOptions@FooRuncingEnableQuince",
-        key.offset: 1253,
+        key.offset: 1262,
         key.length: 50,
         key.fully_annotated_decl: "<decl.var.static><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>enableQuince</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.static>"
       },
@@ -5112,7 +5183,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>static func != (lhs: FooRuncingOptions, rhs: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 1309,
+        key.offset: 1318,
         key.length: 75,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -5120,14 +5191,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 1332,
+            key.offset: 1341,
             key.length: 17
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 1358,
+            key.offset: 1367,
             key.length: 17
           }
         ]
@@ -5138,7 +5209,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPs7ElementQz012ArrayLiteralC0RtzrlE05arrayE0xAFd_tcfc::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPs7ElementQz012ArrayLiteralC0RtzrlE05arrayE0xAFd_tcfc",
         key.doc.full_as_xml: "<Function><Name>init(arrayLiteral:)</Name><USR>s:s10SetAlgebraPs7ElementQz012ArrayLiteralC0RtzrlE05arrayE0xAFd_tcfc::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable init(arrayLiteral: FooRuncingOptions...)</Declaration><CommentParts><Abstract><Para>Creates a set containing the elements of the given array literal.</Para></Abstract><Parameters><Parameter><Name>arrayLiteral</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A list of elements of the new set.</Para></Discussion></Parameter></Parameters><Discussion><Para>Do not call this initializer directly. It is used by the compiler when you use an array literal. Instead, create a new set using an array literal as its value by enclosing a comma-separated list of values in square brackets. You can use an array literal anywhere a set is expected by the type context.</Para><Para>Here, a set of strings is created from an array literal holding only strings:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let ingredients: Set = [\"cocoa beans\", \"sugar\", \"cocoa butter\", \"salt\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[if ingredients.isSuperset(of: [\"sugar\", \"salt\"]) {]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"Whatever it is, it's bound to be delicious!\")]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"Whatever it is, it's bound to be delicious!\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 1390,
+        key.offset: 1399,
         key.length: 64,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>arrayLiteral</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>...</decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -5146,7 +5217,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "arrayLiteral",
             key.name: "arrayLiteral",
-            key.offset: 1433,
+            key.offset: 1442,
             key.length: 20
           }
         ]
@@ -5156,7 +5227,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.extension.struct,
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>extension FooRuncingOptions</Declaration><CommentParts><Abstract><Para><codeVoice>SetAlgebra</codeVoice> requirements for which default implementations are supplied.</Para></Abstract><Discussion><Note><Para>A type conforming to <codeVoice>SetAlgebra</codeVoice> can implement any of these initializers or methods, and those implementations will be used in lieu of these defaults.</Para></Note></Discussion></CommentParts></Other>",
-    key.offset: 1458,
+    key.offset: 1467,
     key.length: 667,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>",
     key.extends: {
@@ -5184,7 +5255,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
           }
         ],
         key.doc.full_as_xml: "<Function><Name>init(_:)</Name><USR>s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable init&lt;S&gt;(_ sequence: S) where S : Sequence, FooRuncingOptions == S.Element</Declaration><CommentParts><Abstract><Para>Creates a new set from a finite sequence of items.</Para></Abstract><Parameters><Parameter><Name>sequence</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The elements to use as members of the new set.</Para></Discussion></Parameter></Parameters><Discussion><Para>Use this initializer to create a new set from an existing sequence, like an array or a range:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let validIndices = Set(0..<7).subtracting([2, 4, 5])]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(validIndices)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"[6, 0, 1, 3]\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 1493,
+        key.offset: 1502,
         key.length: 84,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>init</syntaxtype.keyword>&lt;<ref.generic_type_param usr=\"s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp\">S</ref.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>sequence</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp\">S</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement><ref.generic_type_param usr=\"s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp\">S</ref.generic_type_param> : <ref.protocol usr=\"s:ST\">Sequence</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct> == <ref.generic_type_param usr=\"s:s10SetAlgebraPsEyxqd__ncSTRd__7ElementQyd__ACRtzlufc1SL_qd__mfp\">S</ref.generic_type_param>.<ref.associatedtype usr=\"s:ST7ElementQa\">Element</ref.associatedtype></decl.generic_type_requirement></decl.function.constructor>",
         key.entities: [
@@ -5192,7 +5263,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "sequence",
-            key.offset: 1524,
+            key.offset: 1533,
             key.length: 1
           }
         ]
@@ -5203,7 +5274,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE8subtractyyxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE8subtractyyxF",
         key.doc.full_as_xml: "<Function><Name>subtract(_:)</Name><USR>s:s10SetAlgebraPsE8subtractyyxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable mutating func subtract(_ other: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Removes the elements of the given set from this set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><Discussion><Para>In the following example, the elements of the <codeVoice>employees</codeVoice> set that are also members of the <codeVoice>neighbors</codeVoice> set are removed. In particular, the names <codeVoice>&quot;Bethany&quot;</codeVoice> and <codeVoice>&quot;Eric&quot;</codeVoice> are removed from <codeVoice>employees</codeVoice>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let neighbors: Set = [\"Bethany\", \"Eric\", \"Forlani\", \"Greta\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[employees.subtract(neighbors)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"[\"Diana\", \"Chris\", \"Alicia\"]\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 1583,
+        key.offset: 1592,
         key.length: 61,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>subtract</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -5211,7 +5282,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 1626,
+            key.offset: 1635,
             key.length: 17
           }
         ]
@@ -5222,7 +5293,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE8isSubset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE8isSubset2ofSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isSubset(of:)</Name><USR>s:s10SetAlgebraPsE8isSubset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isSubset(of other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether the set is a subset of another set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set is a subset of <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>Set <emphasis>A</emphasis> is a subset of another set <emphasis>B</emphasis> if every member of <emphasis>A</emphasis> is also a member of <emphasis>B</emphasis>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let attendees: Set = [\"Alicia\", \"Bethany\", \"Diana\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(attendees.isSubset(of: employees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 1650,
+        key.offset: 1659,
         key.length: 61,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isSubset</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>of</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5230,7 +5301,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "of",
             key.name: "other",
-            key.offset: 1685,
+            key.offset: 1694,
             key.length: 17
           }
         ]
@@ -5241,7 +5312,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE10isSuperset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE10isSuperset2ofSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isSuperset(of:)</Name><USR>s:s10SetAlgebraPsE10isSuperset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isSuperset(of other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether the set is a superset of the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set is a superset of <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>Set <emphasis>A</emphasis> is a superset of another set <emphasis>B</emphasis> if every member of <emphasis>B</emphasis> is also a member of <emphasis>A</emphasis>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let attendees: Set = [\"Alicia\", \"Bethany\", \"Diana\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees.isSuperset(of: attendees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 1717,
+        key.offset: 1726,
         key.length: 63,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isSuperset</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>of</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5249,7 +5320,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "of",
             key.name: "other",
-            key.offset: 1754,
+            key.offset: 1763,
             key.length: 17
           }
         ]
@@ -5260,7 +5331,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE10isDisjoint4withSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE10isDisjoint4withSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isDisjoint(with:)</Name><USR>s:s10SetAlgebraPsE10isDisjoint4withSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isDisjoint(with other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether the set has no members in common with the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set has no elements in common with <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>In the following example, the <codeVoice>employees</codeVoice> set is disjoint with the <codeVoice>visitors</codeVoice> set because no name appears in both sets.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let visitors: Set = [\"Marcia\", \"Nathaniel\", \"Olivia\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees.isDisjoint(with: visitors))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 1786,
+        key.offset: 1795,
         key.length: 65,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isDisjoint</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>with</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5268,7 +5339,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "with",
             key.name: "other",
-            key.offset: 1825,
+            key.offset: 1834,
             key.length: 17
           }
         ]
@@ -5279,7 +5350,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE11subtractingyxxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE11subtractingyxxF",
         key.doc.full_as_xml: "<Function><Name>subtracting(_:)</Name><USR>s:s10SetAlgebraPsE11subtractingyxxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func subtracting(_ other: FooRuncingOptions) -&gt; FooRuncingOptions</Declaration><CommentParts><Abstract><Para>Returns a new set containing the elements of this set that do not occur in the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A new set.</Para></ResultDiscussion><Discussion><Para>In the following example, the <codeVoice>nonNeighbors</codeVoice> set is made up of the elements of the <codeVoice>employees</codeVoice> set that are not elements of <codeVoice>neighbors</codeVoice>:</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let neighbors: Set = [\"Bethany\", \"Eric\", \"Forlani\", \"Greta\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let nonNeighbors = employees.subtracting(neighbors)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(nonNeighbors)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"[\"Diana\", \"Chris\", \"Alicia\"]\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 1857,
+        key.offset: 1866,
         key.length: 76,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>subtracting</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5287,7 +5358,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 1894,
+            key.offset: 1903,
             key.length: 17
           }
         ]
@@ -5298,7 +5369,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE7isEmptySbvp::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE7isEmptySbvp",
         key.doc.full_as_xml: "<Other><Name>isEmpty</Name><USR>s:s10SetAlgebraPsE7isEmptySbvp::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable var isEmpty: Bool { get }</Declaration><CommentParts><Abstract><Para>A Boolean value that indicates whether the set has no elements.</Para></Abstract></CommentParts></Other>",
-        key.offset: 1939,
+        key.offset: 1948,
         key.length: 36,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>isEmpty</decl.name>: <decl.var.type><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -5308,7 +5379,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE16isStrictSuperset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE16isStrictSuperset2ofSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isStrictSuperset(of:)</Name><USR>s:s10SetAlgebraPsE16isStrictSuperset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isStrictSuperset(of other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether this set is a strict superset of the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set is a strict superset of <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>Set <emphasis>A</emphasis> is a strict superset of another set <emphasis>B</emphasis> if every member of <emphasis>B</emphasis> is also a member of <emphasis>A</emphasis> and <emphasis>A</emphasis> contains at least one element that is <emphasis>not</emphasis> a member of <emphasis>B</emphasis>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let attendees: Set = [\"Alicia\", \"Bethany\", \"Diana\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees.isStrictSuperset(of: attendees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// A set is never a strict superset of itself:]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(employees.isStrictSuperset(of: employees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"false\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 1981,
+        key.offset: 1990,
         key.length: 69,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isStrictSuperset</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>of</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5316,7 +5387,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "of",
             key.name: "other",
-            key.offset: 2024,
+            key.offset: 2033,
             key.length: 17
           }
         ]
@@ -5327,7 +5398,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s10SetAlgebraPsE14isStrictSubset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s10SetAlgebraPsE14isStrictSubset2ofSbx_tF",
         key.doc.full_as_xml: "<Function><Name>isStrictSubset(of:)</Name><USR>s:s10SetAlgebraPsE14isStrictSubset2ofSbx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func isStrictSubset(of other: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether this set is a strict subset of the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A set of the same type as the current set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the set is a strict subset of <codeVoice>other</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>Set <emphasis>A</emphasis> is a strict subset of another set <emphasis>B</emphasis> if every member of <emphasis>A</emphasis> is also a member of <emphasis>B</emphasis> and <emphasis>B</emphasis> contains at least one element that is not a member of <emphasis>A</emphasis>.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let employees: Set = [\"Alicia\", \"Bethany\", \"Chris\", \"Diana\", \"Eric\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let attendees: Set = [\"Alicia\", \"Bethany\", \"Diana\"]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(attendees.isStrictSubset(of: employees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// A set is never a strict subset of itself:]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(attendees.isStrictSubset(of: attendees))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"false\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2056,
+        key.offset: 2065,
         key.length: 67,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>isStrictSubset</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>of</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5335,7 +5406,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "of",
             key.name: "other",
-            key.offset: 2097,
+            key.offset: 2106,
             key.length: 17
           }
         ]
@@ -5345,7 +5416,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.extension.struct,
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>extension FooRuncingOptions</Declaration><CommentParts><Abstract><Para><codeVoice>OptionSet</codeVoice> requirements for which default implementations are supplied.</Para></Abstract><Discussion><Note><Para>A type conforming to <codeVoice>OptionSet</codeVoice> can implement any of these initializers or methods, and those implementations will be used in lieu of these defaults.</Para></Note></Discussion></CommentParts></Other>",
-    key.offset: 2127,
+    key.offset: 2136,
     key.length: 280,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>",
     key.extends: {
@@ -5360,7 +5431,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPsE5unionyxxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPsE5unionyxxF",
         key.doc.full_as_xml: "<Function><Name>union(_:)</Name><USR>s:s9OptionSetPsE5unionyxxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func union(_ other: FooRuncingOptions) -&gt; FooRuncingOptions</Declaration><CommentParts><Abstract><Para>Returns a new option set of the elements contained in this set, in the given set, or in both.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A new option set made up of the elements contained in this set, in <codeVoice>other</codeVoice>, or in both.</Para></ResultDiscussion><Discussion><Para>This example uses the <codeVoice>union(_:)</codeVoice> method to add two more shipping options to the default set.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let defaultShipping = ShippingOptions.standard]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let memberShipping = defaultShipping.union([.secondDay, .priority])]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(memberShipping.contains(.priority))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2162,
+        key.offset: 2171,
         key.length: 70,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>union</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5368,7 +5439,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 2193,
+            key.offset: 2202,
             key.length: 17
           }
         ]
@@ -5379,7 +5450,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPsE12intersectionyxxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPsE12intersectionyxxF",
         key.doc.full_as_xml: "<Function><Name>intersection(_:)</Name><USR>s:s9OptionSetPsE12intersectionyxxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func intersection(_ other: FooRuncingOptions) -&gt; FooRuncingOptions</Declaration><CommentParts><Abstract><Para>Returns a new option set with only the elements contained in both this set and the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A new option set with only the elements contained in both this set and <codeVoice>other</codeVoice>.</Para></ResultDiscussion><Discussion><Para>This example uses the <codeVoice>intersection(_:)</codeVoice> method to limit the available shipping options to what can be used with a PO Box destination.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[// Can only ship standard or priority to PO Boxes]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let poboxShipping: ShippingOptions = [.standard, .priority]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let memberShipping: ShippingOptions =]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[        [.standard, .priority, .secondDay]]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let availableOptions = memberShipping.intersection(poboxShipping)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(availableOptions.contains(.priority))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(availableOptions.contains(.secondDay))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"false\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2238,
+        key.offset: 2247,
         key.length: 77,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>intersection</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5387,7 +5458,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 2276,
+            key.offset: 2285,
             key.length: 17
           }
         ]
@@ -5398,7 +5469,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPsE19symmetricDifferenceyxxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPsE19symmetricDifferenceyxxF",
         key.doc.full_as_xml: "<Function><Name>symmetricDifference(_:)</Name><USR>s:s9OptionSetPsE19symmetricDifferenceyxxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func symmetricDifference(_ other: FooRuncingOptions) -&gt; FooRuncingOptions</Declaration><CommentParts><Abstract><Para>Returns a new option set with the elements contained in this set or in the given set, but not in both.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>A new option set with only the elements contained in either this set or <codeVoice>other</codeVoice>, but not in both.</Para></ResultDiscussion></CommentParts></Function>",
-        key.offset: 2321,
+        key.offset: 2330,
         key.length: 84,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>symmetricDifference</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5406,7 +5477,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 2366,
+            key.offset: 2375,
             key.length: 17
           }
         ]
@@ -5416,7 +5487,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.extension.struct,
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>extension FooRuncingOptions</Declaration><CommentParts><Abstract><Para><codeVoice>OptionSet</codeVoice> requirements for which default implementations are supplied when <codeVoice>Element == Self</codeVoice>, which is the default.</Para></Abstract><Discussion><Note><Para>A type conforming to <codeVoice>OptionSet</codeVoice> can implement any of these initializers or methods, and those implementations will be used in lieu of these defaults.</Para></Note></Discussion></CommentParts></Other>",
-    key.offset: 2409,
+    key.offset: 2418,
     key.length: 476,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>",
     key.extends: {
@@ -5431,7 +5502,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPs7ElementQzRszrlE8containsySbxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPs7ElementQzRszrlE8containsySbxF",
         key.doc.full_as_xml: "<Function><Name>contains(_:)</Name><USR>s:s9OptionSetPs7ElementQzRszrlE8containsySbxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable func contains(_ member: FooRuncingOptions) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value that indicates whether a given element is a member of the option set.</Para></Abstract><Parameters><Parameter><Name>member</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The element to look for in the option set.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>true</codeVoice> if the option set contains <codeVoice>member</codeVoice>; otherwise, <codeVoice>false</codeVoice>.</Para></ResultDiscussion><Discussion><Para>This example uses the <codeVoice>contains(_:)</codeVoice> method to check whether next-day shipping is in the <codeVoice>availableOptions</codeVoice> instance.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let availableOptions = ShippingOptions.express]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[if availableOptions.contains(.nextDay) {]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[    print(\"Next day shipping available\")]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"Next day shipping available\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2444,
+        key.offset: 2453,
         key.length: 61,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>contains</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>member</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5439,7 +5510,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "member",
-            key.offset: 2479,
+            key.offset: 2488,
             key.length: 17
           }
         ]
@@ -5450,7 +5521,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPs7ElementQzRszrlE6insertySb8inserted_x17memberAfterInserttxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPs7ElementQzRszrlE6insertySb8inserted_x17memberAfterInserttxF",
         key.doc.full_as_xml: "<Function><Name>insert(_:)</Name><USR>s:s9OptionSetPs7ElementQzRszrlE6insertySb8inserted_x17memberAfterInserttxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@discardableResult\n@inlinable mutating func insert(_ newMember: FooRuncingOptions) -&gt; (inserted: Bool, memberAfterInsert: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Adds the given element to the option set if it is not already a member.</Para></Abstract><Parameters><Parameter><Name>newMember</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The element to insert.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para><codeVoice>(true, newMember)</codeVoice> if <codeVoice>newMember</codeVoice> was not contained in <codeVoice>self</codeVoice>. Otherwise, returns <codeVoice>(false, oldMember)</codeVoice>, where <codeVoice>oldMember</codeVoice> is the member of the set equal to <codeVoice>newMember</codeVoice>.</Para></ResultDiscussion><Discussion><Para>In the following example, the <codeVoice>.secondDay</codeVoice> shipping option is added to the <codeVoice>freeOptions</codeVoice> option set if <codeVoice>purchasePrice</codeVoice> is greater than 50.0. For the <codeVoice>ShippingOptions</codeVoice> declaration, see the <codeVoice>OptionSet</codeVoice> protocol discussion.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let purchasePrice = 87.55]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[var freeOptions: ShippingOptions = [.standard, .priority]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[if purchasePrice > 50 {]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[    freeOptions.insert(.secondDay)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[}]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(freeOptions.contains(.secondDay))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2511,
+        key.offset: 2520,
         key.length: 144,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>insert</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>newMember</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><tuple>(<tuple.element><tuple.element.argument_label>inserted</tuple.element.argument_label>: <tuple.element.type><ref.struct usr=\"s:Sb\">Bool</ref.struct></tuple.element.type></tuple.element>, <tuple.element><tuple.element.argument_label>memberAfterInsert</tuple.element.argument_label>: <tuple.element.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></tuple.element.type></tuple.element>)</tuple></decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5458,7 +5529,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "newMember",
-            key.offset: 2579,
+            key.offset: 2588,
             key.length: 17
           }
         ]
@@ -5469,7 +5540,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPs7ElementQzRszrlE6removeyxSgxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPs7ElementQzRszrlE6removeyxSgxF",
         key.doc.full_as_xml: "<Function><Name>remove(_:)</Name><USR>s:s9OptionSetPs7ElementQzRszrlE6removeyxSgxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@discardableResult\n@inlinable mutating func remove(_ member: FooRuncingOptions) -&gt; FooRuncingOptions?</Declaration><CommentParts><Abstract><Para>Removes the given element and all elements subsumed by it.</Para></Abstract><Parameters><Parameter><Name>member</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>The element of the set to remove.</Para></Discussion></Parameter></Parameters><ResultDiscussion><Para>The intersection of <codeVoice>[member]</codeVoice> and the set, if the intersection was nonempty; otherwise, <codeVoice>nil</codeVoice>.</Para></ResultDiscussion><Discussion><Para>In the following example, the <codeVoice>.priority</codeVoice> shipping option is removed from the <codeVoice>options</codeVoice> option set. Attempting to remove the same shipping option a second time results in <codeVoice>nil</codeVoice>, because <codeVoice>options</codeVoice> no longer contains <codeVoice>.priority</codeVoice> as a member.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var options: ShippingOptions = [.secondDay, .priority]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let priorityOption = options.remove(.priority)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(priorityOption == .priority)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(options.remove(.priority))]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"nil\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing><Para>In the next example, the <codeVoice>.express</codeVoice> element is passed to <codeVoice>remove(_:)</codeVoice>. Although <codeVoice>.express</codeVoice> is not a member of <codeVoice>options</codeVoice>, <codeVoice>.express</codeVoice> subsumes the remaining <codeVoice>.secondDay</codeVoice> element of the option set. Therefore, <codeVoice>options</codeVoice> is emptied and the intersection between <codeVoice>.express</codeVoice> and <codeVoice>options</codeVoice> is returned.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[let expressOption = options.remove(.express)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(expressOption == .express)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"false\"]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(expressOption == .secondDay)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2661,
+        key.offset: 2670,
         key.length: 105,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>remove</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>member</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>?</decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5477,7 +5548,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "member",
-            key.offset: 2726,
+            key.offset: 2735,
             key.length: 17
           }
         ]
@@ -5488,7 +5559,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPs7ElementQzRszrlE6update4withxSgx_tF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPs7ElementQzRszrlE6update4withxSgx_tF",
         key.doc.full_as_xml: "<Function><Name>update(with:)</Name><USR>s:s9OptionSetPs7ElementQzRszrlE6update4withxSgx_tF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@discardableResult\n@inlinable mutating func update(with newMember: FooRuncingOptions) -&gt; FooRuncingOptions?</Declaration><CommentParts><Abstract><Para>Inserts the given element into the set.</Para></Abstract><ResultDiscussion><Para>The intersection of <codeVoice>[newMember]</codeVoice> and the set if the intersection was nonempty; otherwise, <codeVoice>nil</codeVoice>.</Para></ResultDiscussion><Discussion><Para>If <codeVoice>newMember</codeVoice> is not contained in the set but subsumes current members of the set, the subsumed members are returned.</Para><CodeListing language=\"swift\"><zCodeLineNumbered><![CDATA[var options: ShippingOptions = [.secondDay, .priority]]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[let replaced = options.update(with: .express)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[print(replaced == .secondDay)]]></zCodeLineNumbered><zCodeLineNumbered><![CDATA[// Prints \"true\"]]></zCodeLineNumbered><zCodeLineNumbered></zCodeLineNumbered></CodeListing></Discussion></CommentParts></Function>",
-        key.offset: 2772,
+        key.offset: 2781,
         key.length: 111,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@discardableResult</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>update</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>with</decl.var.parameter.argument_label> <decl.var.parameter.name>newMember</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>?</decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -5496,7 +5567,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "with",
             key.name: "newMember",
-            key.offset: 2843,
+            key.offset: 2852,
             key.length: 17
           }
         ]
@@ -5506,7 +5577,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.extension.struct,
     key.doc.full_as_xml: "<Other><Name></Name><Declaration>extension FooRuncingOptions</Declaration><CommentParts><Abstract><Para><codeVoice>OptionSet</codeVoice> requirements for which default implementations are supplied when <codeVoice>RawValue</codeVoice> conforms to <codeVoice>FixedWidthInteger</codeVoice>, which is the usual case.  Each distinct bit of an option set’s <codeVoice>.rawValue</codeVoice> corresponds to a disjoint value of the <codeVoice>OptionSet</codeVoice>.</Para></Abstract><Discussion><Note><Para>A type conforming to <codeVoice>OptionSet</codeVoice> can implement any of these initializers or methods, and those implementations will be used in lieu of these defaults.</Para></Note><List-Bullet><Item><Para><codeVoice>union</codeVoice> is implemented as a bitwise “or” (<codeVoice>|</codeVoice>) of <codeVoice>rawValue</codeVoice>s</Para></Item><Item><Para><codeVoice>intersection</codeVoice> is implemented as a bitwise “and” (<codeVoice>&amp;</codeVoice>) of <codeVoice>rawValue</codeVoice>s</Para></Item><Item><Para><codeVoice>symmetricDifference</codeVoice> is implemented as a bitwise “exclusive or” (<codeVoice>^</codeVoice>) of <codeVoice>rawValue</codeVoice>s</Para></Item></List-Bullet></Discussion></CommentParts></Other>",
-    key.offset: 2887,
+    key.offset: 2896,
     key.length: 279,
     key.fully_annotated_decl: "<syntaxtype.keyword>extension</syntaxtype.keyword> <ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct>",
     key.extends: {
@@ -5521,7 +5592,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlExycfc::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlExycfc",
         key.doc.full_as_xml: "<Function><Name>init()</Name><USR>s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlExycfc::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable init()</Declaration><CommentParts><Abstract><Para>Creates an empty option set.</Para></Abstract><Discussion><Para>This initializer creates an option set with a raw value of zero.</Para></Discussion></CommentParts></Function>",
-        key.offset: 2922,
+        key.offset: 2931,
         key.length: 17,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -5531,7 +5602,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE9formUnionyyxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE9formUnionyyxF",
         key.doc.full_as_xml: "<Function><Name>formUnion(_:)</Name><USR>s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE9formUnionyyxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable mutating func formUnion(_ other: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Inserts the elements of another set into this option set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><Discussion><Para>This method is implemented as a <codeVoice>|</codeVoice> (bitwise OR) operation on the two sets’ raw values.</Para></Discussion></CommentParts></Function>",
-        key.offset: 2945,
+        key.offset: 2954,
         key.length: 62,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>formUnion</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -5539,7 +5610,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 2989,
+            key.offset: 2998,
             key.length: 17
           }
         ]
@@ -5550,7 +5621,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE16formIntersectionyyxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE16formIntersectionyyxF",
         key.doc.full_as_xml: "<Function><Name>formIntersection(_:)</Name><USR>s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE16formIntersectionyyxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable mutating func formIntersection(_ other: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Removes all elements of this option set that are not also present in the given set.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><Discussion><Para>This method is implemented as a <codeVoice>&amp;</codeVoice> (bitwise AND) operation on the two sets’ raw values.</Para></Discussion></CommentParts></Function>",
-        key.offset: 3013,
+        key.offset: 3022,
         key.length: 69,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>formIntersection</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -5558,7 +5629,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 3064,
+            key.offset: 3073,
             key.length: 17
           }
         ]
@@ -5569,7 +5640,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE23formSymmetricDifferenceyyxF::SYNTHESIZED::c:@E@FooRuncingOptions",
         key.original_usr: "s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE23formSymmetricDifferenceyyxF",
         key.doc.full_as_xml: "<Function><Name>formSymmetricDifference(_:)</Name><USR>s:s9OptionSetPss17FixedWidthInteger8RawValueRpzrlE23formSymmetricDifferenceyyxF::SYNTHESIZED::c:@E@FooRuncingOptions</USR><Declaration>@inlinable mutating func formSymmetricDifference(_ other: FooRuncingOptions)</Declaration><CommentParts><Abstract><Para>Replaces this set with a new set containing all elements contained in either this set or the given set, but not in both.</Para></Abstract><Parameters><Parameter><Name>other</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>An option set.</Para></Discussion></Parameter></Parameters><Discussion><Para>This method is implemented as a <codeVoice>^</codeVoice> (bitwise XOR) operation on the two sets’ raw values.</Para></Discussion></CommentParts></Function>",
-        key.offset: 3088,
+        key.offset: 3097,
         key.length: 76,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>mutating</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>formSymmetricDifference</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>other</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooRuncingOptions\">FooRuncingOptions</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -5577,7 +5648,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "other",
-            key.offset: 3146,
+            key.offset: 3155,
             key.length: 17
           }
         ]
@@ -5588,7 +5659,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooStruct1",
     key.usr: "c:@S@FooStruct1",
-    key.offset: 3167,
+    key.offset: 3177,
     key.length: 105,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooStruct1</decl.name></decl.struct>",
     key.entities: [
@@ -5596,7 +5667,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So10FooStruct1VABycfc",
-        key.offset: 3192,
+        key.offset: 3202,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -5604,7 +5675,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
         key.usr: "s:So10FooStruct1V1x1yABs5Int32V_Sdtcfc",
-        key.offset: 3204,
+        key.offset: 3214,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -5612,14 +5683,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 3214,
+            key.offset: 3224,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "y",
             key.name: "y",
-            key.offset: 3226,
+            key.offset: 3236,
             key.length: 6
           }
         ]
@@ -5628,7 +5699,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@S@FooStruct1@FI@x",
-        key.offset: 3239,
+        key.offset: 3249,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -5636,7 +5707,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "y",
         key.usr: "c:@S@FooStruct1@FI@y",
-        key.offset: 3257,
+        key.offset: 3267,
         key.length: 13,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
       }
@@ -5646,7 +5717,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.typealias,
     key.name: "FooStruct1Pointer",
     key.usr: "c:Foo.h@T@FooStruct1Pointer",
-    key.offset: 3273,
+    key.offset: 3284,
     key.length: 62,
     key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>FooStruct1Pointer</decl.name> = <ref.struct usr=\"s:Sp\">UnsafeMutablePointer</ref.struct>&lt;<ref.struct usr=\"c:@S@FooStruct1\">FooStruct1</ref.struct>&gt;</decl.typealias>",
     key.conforms: [
@@ -5661,7 +5732,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooStruct2",
     key.usr: "c:@S@FooStruct2",
-    key.offset: 3336,
+    key.offset: 3348,
     key.length: 105,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooStruct2</decl.name></decl.struct>",
     key.entities: [
@@ -5669,7 +5740,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So10FooStruct2VABycfc",
-        key.offset: 3361,
+        key.offset: 3373,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -5677,7 +5748,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
         key.usr: "s:So10FooStruct2V1x1yABs5Int32V_Sdtcfc",
-        key.offset: 3373,
+        key.offset: 3385,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -5685,14 +5756,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 3383,
+            key.offset: 3395,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "y",
             key.name: "y",
-            key.offset: 3395,
+            key.offset: 3407,
             key.length: 6
           }
         ]
@@ -5701,7 +5772,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@S@FooStruct2@FI@x",
-        key.offset: 3408,
+        key.offset: 3420,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -5709,7 +5780,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "y",
         key.usr: "c:@S@FooStruct2@FI@y",
-        key.offset: 3426,
+        key.offset: 3438,
         key.length: 13,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
       }
@@ -5719,7 +5790,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.typealias,
     key.name: "FooStructTypedef1",
     key.usr: "c:Foo.h@T@FooStructTypedef1",
-    key.offset: 3442,
+    key.offset: 3455,
     key.length: 40,
     key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>FooStructTypedef1</decl.name> = <ref.struct usr=\"c:@S@FooStruct2\">FooStruct2</ref.struct></decl.typealias>"
   },
@@ -5727,7 +5798,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooStructTypedef2",
     key.usr: "c:@SA@FooStructTypedef2",
-    key.offset: 3483,
+    key.offset: 3497,
     key.length: 112,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooStructTypedef2</decl.name></decl.struct>",
     key.entities: [
@@ -5735,7 +5806,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So17FooStructTypedef2aABycfc",
-        key.offset: 3515,
+        key.offset: 3529,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -5743,7 +5814,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:y:)",
         key.usr: "s:So17FooStructTypedef2a1x1yABs5Int32V_Sdtcfc",
-        key.offset: 3527,
+        key.offset: 3541,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -5751,14 +5822,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 3537,
+            key.offset: 3551,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "y",
             key.name: "y",
-            key.offset: 3549,
+            key.offset: 3563,
             key.length: 6
           }
         ]
@@ -5767,7 +5838,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@SA@FooStructTypedef2@FI@x",
-        key.offset: 3562,
+        key.offset: 3576,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -5775,7 +5846,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "y",
         key.usr: "c:@SA@FooStructTypedef2@FI@y",
-        key.offset: 3580,
+        key.offset: 3594,
         key.length: 13,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>y</decl.name>: <decl.var.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.type></decl.var.instance>"
       }
@@ -5786,7 +5857,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooTypedef1",
     key.usr: "c:Foo.h@T@FooTypedef1",
     key.doc.full_as_xml: "<Typedef file=Foo.h line=\"60\" column=\"13\"><Name>FooTypedef1</Name><USR>c:Foo.h@T@FooTypedef1</USR><Declaration>typealias FooTypedef1 = Int32</Declaration><Abstract><Para> Aaa.  FooTypedef1.  Bbb.</Para></Abstract></Typedef>",
-    key.offset: 3596,
+    key.offset: 3611,
     key.length: 29,
     key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>FooTypedef1</decl.name> = <ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.typealias>",
     key.conforms: [
@@ -5812,7 +5883,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooIntVar",
     key.usr: "c:@fooIntVar",
     key.doc.full_as_xml: "<Variable file=Foo.h line=\"63\" column=\"12\"><Name>fooIntVar</Name><USR>c:@fooIntVar</USR><Declaration>var fooIntVar: Int32</Declaration><Abstract><Para> Aaa.  fooIntVar.  Bbb.</Para></Abstract></Variable>",
-    key.offset: 3626,
+    key.offset: 3642,
     key.length: 20,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooIntVar</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.global>"
   },
@@ -5821,7 +5892,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFunc1(_:)",
     key.usr: "c:@F@fooFunc1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"66\" column=\"5\"><Name>fooFunc1</Name><USR>c:@F@fooFunc1</USR><Declaration>func fooFunc1(_ a: Int32) -&gt; Int32</Declaration><Abstract><Para> Aaa.  fooFunc1.  Bbb.</Para></Abstract></Function>",
-    key.offset: 3647,
+    key.offset: 3664,
     key.length: 34,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -5829,7 +5900,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 3666,
+        key.offset: 3683,
         key.length: 5
       }
     ]
@@ -5838,14 +5909,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFunc1AnonymousParam(_:)",
     key.usr: "c:@F@fooFunc1AnonymousParam",
-    key.offset: 3682,
+    key.offset: 3700,
     key.length: 48,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc1AnonymousParam</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
-        key.offset: 3715,
+        key.offset: 3733,
         key.length: 5
       }
     ]
@@ -5854,7 +5925,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFunc3(_:_:_:_:)",
     key.usr: "c:@F@fooFunc3",
-    key.offset: 3731,
+    key.offset: 3750,
     key.length: 94,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFunc3</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>c</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sd\">Double</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>d</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sp\">UnsafeMutablePointer</ref.struct>&lt;<ref.struct usr=\"s:s5Int32V\">Int32</ref.struct>&gt;!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -5862,28 +5933,28 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 3750,
+        key.offset: 3769,
         key.length: 5
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "b",
-        key.offset: 3762,
+        key.offset: 3781,
         key.length: 5
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "c",
-        key.offset: 3774,
+        key.offset: 3793,
         key.length: 6
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "d",
-        key.offset: 3787,
+        key.offset: 3806,
         key.length: 28
       }
     ]
@@ -5892,7 +5963,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncWithBlock(_:)",
     key.usr: "c:@F@fooFuncWithBlock",
-    key.offset: 3826,
+    key.offset: 3846,
     key.length: 49,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithBlock</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>blk</decl.var.parameter.name>: <decl.var.parameter.type>((<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -5900,7 +5971,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "blk",
-        key.offset: 3855,
+        key.offset: 3875,
         key.length: 19
       }
     ]
@@ -5909,7 +5980,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncWithFunctionPointer(_:)",
     key.usr: "c:@F@fooFuncWithFunctionPointer",
-    key.offset: 3876,
+    key.offset: 3897,
     key.length: 60,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithFunctionPointer</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>fptr</decl.var.parameter.name>: <decl.var.parameter.type>((<decl.var.parameter><decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype>)!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
@@ -5917,7 +5988,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "fptr",
-        key.offset: 3916,
+        key.offset: 3937,
         key.length: 19
       }
     ]
@@ -5926,7 +5997,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncNoreturn1()",
     key.usr: "c:@F@fooFuncNoreturn1",
-    key.offset: 3937,
+    key.offset: 3959,
     key.length: 32,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncNoreturn1</decl.name>() -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never</ref.enum></decl.function.returntype></decl.function.free>"
   },
@@ -5934,7 +6005,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooFuncNoreturn2()",
     key.usr: "c:@F@fooFuncNoreturn2",
-    key.offset: 3970,
+    key.offset: 3993,
     key.length: 32,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncNoreturn2</decl.name>() -&gt; <decl.function.returntype><ref.enum usr=\"s:s5NeverO\">Never</ref.enum></decl.function.returntype></decl.function.free>"
   },
@@ -5943,7 +6014,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment1()",
     key.usr: "c:@F@fooFuncWithComment1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"89\" column=\"6\"><Name>fooFuncWithComment1</Name><USR>c:@F@fooFuncWithComment1</USR><Declaration>func fooFuncWithComment1()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment1.  Bbb. Ccc.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4003,
+    key.offset: 4027,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment1</decl.name>()</decl.function.free>"
   },
@@ -5952,7 +6023,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment2()",
     key.usr: "c:@F@fooFuncWithComment2",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"94\" column=\"6\"><Name>fooFuncWithComment2</Name><USR>c:@F@fooFuncWithComment2</USR><Declaration>func fooFuncWithComment2()</Declaration><Abstract><Para>  Aaa.  fooFuncWithComment2.  Bbb.</Para></Abstract></Function>",
-    key.offset: 4030,
+    key.offset: 4055,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment2</decl.name>()</decl.function.free>"
   },
@@ -5961,7 +6032,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment3()",
     key.usr: "c:@F@fooFuncWithComment3",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"102\" column=\"6\"><Name>fooFuncWithComment3</Name><USR>c:@F@fooFuncWithComment3</USR><Declaration>func fooFuncWithComment3()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment3.  Bbb.</Para></Abstract><Discussion><Para> Ccc.</Para></Discussion></Function>",
-    key.offset: 4057,
+    key.offset: 4083,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment3</decl.name>()</decl.function.free>"
   },
@@ -5970,7 +6041,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment4()",
     key.usr: "c:@F@fooFuncWithComment4",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"108\" column=\"6\"><Name>fooFuncWithComment4</Name><USR>c:@F@fooFuncWithComment4</USR><Declaration>func fooFuncWithComment4()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment4.  Bbb.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4084,
+    key.offset: 4111,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment4</decl.name>()</decl.function.free>"
   },
@@ -5979,7 +6050,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "fooFuncWithComment5()",
     key.usr: "c:@F@fooFuncWithComment5",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"114\" column=\"6\"><Name>fooFuncWithComment5</Name><USR>c:@F@fooFuncWithComment5</USR><Declaration>func fooFuncWithComment5()</Declaration><Abstract><Para> Aaa.  fooFuncWithComment5.  Bbb. Ccc.</Para></Abstract><Discussion><Para> Ddd.</Para></Discussion></Function>",
-    key.offset: 4111,
+    key.offset: 4139,
     key.length: 26,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooFuncWithComment5</decl.name>()</decl.function.free>"
   },
@@ -5988,7 +6059,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
     key.usr: "c:@F@redeclaredInMultipleModulesFunc1",
     key.doc.full_as_xml: "<Function file=Foo.h line=\"118\" column=\"5\"><Name>redeclaredInMultipleModulesFunc1</Name><USR>c:@F@redeclaredInMultipleModulesFunc1</USR><Declaration>func redeclaredInMultipleModulesFunc1(_ a: Int32) -&gt; Int32</Declaration><Abstract><Para> Aaa.  redeclaredInMultipleModulesFunc1.  Bbb.</Para></Abstract></Function>",
-    key.offset: 4138,
+    key.offset: 4167,
     key.length: 58,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>redeclaredInMultipleModulesFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -5996,7 +6067,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 4181,
+        key.offset: 4210,
         key.length: 5
       }
     ]
@@ -6006,7 +6077,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooProtocolBase",
     key.usr: "c:objc(pl)FooProtocolBase",
     key.doc.full_as_xml: "<Other file=Foo.h line=\"121\" column=\"11\"><Name>FooProtocolBase</Name><USR>c:objc(pl)FooProtocolBase</USR><Declaration>protocol FooProtocolBase</Declaration><Abstract><Para> Aaa.  FooProtocolBase.  Bbb.</Para></Abstract></Other>",
-    key.offset: 4197,
+    key.offset: 4227,
     key.length: 301,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>FooProtocolBase</decl.name></decl.protocol>",
     key.entities: [
@@ -6015,7 +6086,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFunc()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFunc",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"125\" column=\"1\"><Name>fooProtoFunc</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFunc</USR><Declaration>func fooProtoFunc()</Declaration><Abstract><Para> Aaa.  fooProtoFunc.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4229,
+        key.offset: 4259,
         key.length: 19,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFunc</decl.name>()</decl.function.method.instance>"
       },
@@ -6024,7 +6095,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFuncWithExtraIndentation1()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation1",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"129\" column=\"3\"><Name>fooProtoFuncWithExtraIndentation1</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation1</USR><Declaration>func fooProtoFuncWithExtraIndentation1()</Declaration><Abstract><Para> Aaa.  fooProtoFuncWithExtraIndentation1.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4254,
+        key.offset: 4284,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFuncWithExtraIndentation1</decl.name>()</decl.function.method.instance>"
       },
@@ -6033,7 +6104,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "fooProtoFuncWithExtraIndentation2()",
         key.usr: "c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation2",
         key.doc.full_as_xml: "<Function isInstanceMethod=\"1\" file=Foo.h line=\"135\" column=\"3\"><Name>fooProtoFuncWithExtraIndentation2</Name><USR>c:objc(pl)FooProtocolBase(im)fooProtoFuncWithExtraIndentation2</USR><Declaration>func fooProtoFuncWithExtraIndentation2()</Declaration><Abstract><Para> Aaa.  fooProtoFuncWithExtraIndentation2.  Bbb. Ccc.</Para></Abstract></Function>",
-        key.offset: 4300,
+        key.offset: 4330,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoFuncWithExtraIndentation2</decl.name>()</decl.function.method.instance>"
       },
@@ -6041,7 +6112,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.static,
         key.name: "fooProtoClassFunc()",
         key.usr: "c:objc(pl)FooProtocolBase(cm)fooProtoClassFunc",
-        key.offset: 4346,
+        key.offset: 4376,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.method.static><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooProtoClassFunc</decl.name>()</decl.function.method.static>"
       },
@@ -6049,7 +6120,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty1",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty1",
-        key.offset: 4383,
+        key.offset: 4413,
         key.length: 35,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty1</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6057,7 +6128,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty2",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty2",
-        key.offset: 4424,
+        key.offset: 4454,
         key.length: 35,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty2</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6065,7 +6136,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty3",
         key.usr: "c:objc(pl)FooProtocolBase(py)fooProperty3",
-        key.offset: 4465,
+        key.offset: 4495,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty3</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -6075,7 +6146,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.protocol,
     key.name: "FooProtocolDerived",
     key.usr: "c:objc(pl)FooProtocolDerived",
-    key.offset: 4499,
+    key.offset: 4530,
     key.length: 49,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>FooProtocolDerived</decl.name> : <ref.protocol usr=\"c:objc(pl)FooProtocolBase\">FooProtocolBase</ref.protocol></decl.protocol>",
     key.conforms: [
@@ -6090,7 +6161,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooClassBase",
     key.usr: "c:objc(cs)FooClassBase",
-    key.offset: 4549,
+    key.offset: 4581,
     key.length: 392,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassBase</decl.name></decl.class>",
     key.entities: [
@@ -6098,7 +6169,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFunc0()",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFunc0",
-        key.offset: 4575,
+        key.offset: 4607,
         key.length: 27,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc0</decl.name>()</decl.function.method.instance>"
       },
@@ -6106,7 +6177,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFunc1(_:)",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFunc1:",
-        key.offset: 4608,
+        key.offset: 4640,
         key.length: 60,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>anObject</decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>!</decl.function.returntype></decl.function.method.instance>",
         key.entities: [
@@ -6114,7 +6185,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "anObject",
-            key.offset: 4646,
+            key.offset: 4678,
             key.length: 4
           }
         ]
@@ -6123,7 +6194,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "c:objc(cs)FooClassBase(im)init",
-        key.offset: 4674,
+        key.offset: 4706,
         key.length: 7,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>!()</decl.function.constructor>"
       },
@@ -6131,7 +6202,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(float:)",
         key.usr: "c:objc(cs)FooClassBase(im)initWithFloat:",
-        key.offset: 4687,
+        key.offset: 4719,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>float</decl.var.parameter.argument_label> <decl.var.parameter.name>f</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6139,7 +6210,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "float",
             key.name: "f",
-            key.offset: 4714,
+            key.offset: 4746,
             key.length: 5
           }
         ]
@@ -6148,7 +6219,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFuncOverridden()",
         key.usr: "c:objc(cs)FooClassBase(im)fooBaseInstanceFuncOverridden",
-        key.offset: 4726,
+        key.offset: 4758,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFuncOverridden</decl.name>()</decl.function.method.instance>"
       },
@@ -6156,7 +6227,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "fooBaseClassFunc0()",
         key.usr: "c:objc(cs)FooClassBase(cm)fooBaseClassFunc0",
-        key.offset: 4768,
+        key.offset: 4800,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseClassFunc0</decl.name>()</decl.function.method.class>"
       },
@@ -6164,7 +6235,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 4804,
+        key.offset: 4836,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6172,7 +6243,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 4839,
+        key.offset: 4871,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6180,7 +6251,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 4874,
+        key.offset: 4906,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6188,7 +6259,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 4910,
+        key.offset: 4942,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6199,7 +6270,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.name: "FooClassDerived",
     key.usr: "c:objc(cs)FooClassDerived",
     key.doc.full_as_xml: "<Other file=Foo.h line=\"158\" column=\"12\"><Name>FooClassDerived</Name><USR>c:objc(cs)FooClassDerived</USR><Declaration>class FooClassDerived : FooClassBase, FooProtocolDerived</Declaration><Abstract><Para> Aaa.  FooClassDerived.  Bbb.</Para></Abstract></Other>",
-    key.offset: 4942,
+    key.offset: 4975,
     key.length: 352,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassDerived</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class>, <ref.protocol usr=\"c:objc(pl)FooProtocolDerived\">FooProtocolDerived</ref.protocol></decl.class>",
     key.inherits: [
@@ -6221,7 +6292,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty1",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty1",
-        key.offset: 5006,
+        key.offset: 5039,
         key.length: 23,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty1</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6229,7 +6300,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty2",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty2",
-        key.offset: 5035,
+        key.offset: 5068,
         key.length: 23,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty2</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6237,7 +6308,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "fooProperty3",
         key.usr: "c:objc(cs)FooClassDerived(py)fooProperty3",
-        key.offset: 5064,
+        key.offset: 5097,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>fooProperty3</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6245,7 +6316,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc0()",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc0",
-        key.offset: 5101,
+        key.offset: 5134,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc0</decl.name>()</decl.function.method.instance>"
       },
@@ -6253,7 +6324,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc1(_:)",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc1:",
-        key.offset: 5130,
+        key.offset: 5163,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -6261,7 +6332,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 5157,
+            key.offset: 5190,
             key.length: 5
           }
         ]
@@ -6270,7 +6341,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooInstanceFunc2(_:withB:)",
         key.usr: "c:objc(cs)FooClassDerived(im)fooInstanceFunc2:withB:",
-        key.offset: 5169,
+        key.offset: 5202,
         key.length: 49,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooInstanceFunc2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>withB</decl.var.parameter.argument_label> <decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -6278,14 +6349,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "a",
-            key.offset: 5196,
+            key.offset: 5229,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "withB",
             key.name: "b",
-            key.offset: 5212,
+            key.offset: 5245,
             key.length: 5
           }
         ]
@@ -6294,7 +6365,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "fooBaseInstanceFuncOverridden()",
         key.usr: "c:objc(cs)FooClassDerived(im)fooBaseInstanceFuncOverridden",
-        key.offset: 5224,
+        key.offset: 5257,
         key.length: 36,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooBaseInstanceFuncOverridden</decl.name>()</decl.function.method.instance>",
         key.inherits: [
@@ -6309,7 +6380,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "fooClassFunc0()",
         key.usr: "c:objc(cs)FooClassDerived(cm)fooClassFunc0",
-        key.offset: 5266,
+        key.offset: 5299,
         key.length: 26,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooClassFunc0</decl.name>()</decl.function.method.class>"
       }
@@ -6319,7 +6390,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.typealias,
     key.name: "typedef_int_t",
     key.usr: "c:Foo.h@T@typedef_int_t",
-    key.offset: 5295,
+    key.offset: 5329,
     key.length: 31,
     key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>typedef_int_t</decl.name> = <ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.typealias>",
     key.conforms: [
@@ -6344,7 +6415,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_1",
     key.usr: "c:Foo.h@3836@macro@FOO_MACRO_1",
-    key.offset: 5327,
+    key.offset: 5362,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_1</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6352,7 +6423,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_2",
     key.usr: "c:Foo.h@3858@macro@FOO_MACRO_2",
-    key.offset: 5358,
+    key.offset: 5394,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_2</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6360,7 +6431,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_3",
     key.usr: "c:Foo.h@3880@macro@FOO_MACRO_3",
-    key.offset: 5389,
+    key.offset: 5426,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_3</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6368,7 +6439,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_4",
     key.usr: "c:Foo.h@3944@macro@FOO_MACRO_4",
-    key.offset: 5420,
+    key.offset: 5458,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_4</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6376,7 +6447,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_5",
     key.usr: "c:Foo.h@3976@macro@FOO_MACRO_5",
-    key.offset: 5452,
+    key.offset: 5491,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_5</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt64V\">UInt64</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6384,7 +6455,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_6",
     key.usr: "c:Foo.h@4018@macro@FOO_MACRO_6",
-    key.offset: 5484,
+    key.offset: 5524,
     key.length: 38,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_6</decl.name>: <decl.var.type><ref.typealias usr=\"c:Foo.h@T@typedef_int_t\">typedef_int_t</ref.typealias></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6392,7 +6463,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_7",
     key.usr: "c:Foo.h@4059@macro@FOO_MACRO_7",
-    key.offset: 5523,
+    key.offset: 5564,
     key.length: 38,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_7</decl.name>: <decl.var.type><ref.typealias usr=\"c:Foo.h@T@typedef_int_t\">typedef_int_t</ref.typealias></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6400,7 +6471,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_8",
     key.usr: "c:Foo.h@4100@macro@FOO_MACRO_8",
-    key.offset: 5562,
+    key.offset: 5604,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_8</decl.name>: <decl.var.type><ref.typealias usr=\"s:s5CChara\">CChar</ref.typealias></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6408,7 +6479,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_9",
     key.usr: "c:Foo.h@4131@macro@FOO_MACRO_9",
-    key.offset: 5593,
+    key.offset: 5636,
     key.length: 30,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_9</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6416,7 +6487,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_10",
     key.usr: "c:Foo.h@4161@macro@FOO_MACRO_10",
-    key.offset: 5624,
+    key.offset: 5668,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_10</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int16V\">Int16</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6424,7 +6495,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_11",
     key.usr: "c:Foo.h@4195@macro@FOO_MACRO_11",
-    key.offset: 5656,
+    key.offset: 5701,
     key.length: 29,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_11</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6432,7 +6503,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_OR",
     key.usr: "c:Foo.h@4228@macro@FOO_MACRO_OR",
-    key.offset: 5686,
+    key.offset: 5732,
     key.length: 31,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_OR</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6440,7 +6511,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_AND",
     key.usr: "c:Foo.h@4277@macro@FOO_MACRO_AND",
-    key.offset: 5718,
+    key.offset: 5765,
     key.length: 32,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_AND</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6448,7 +6519,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_BITWIDTH",
     key.usr: "c:Foo.h@4327@macro@FOO_MACRO_BITWIDTH",
-    key.offset: 5751,
+    key.offset: 5799,
     key.length: 38,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_BITWIDTH</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt64V\">UInt64</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6456,7 +6527,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_SIGNED",
     key.usr: "c:Foo.h@4382@macro@FOO_MACRO_SIGNED",
-    key.offset: 5790,
+    key.offset: 5839,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_SIGNED</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6464,7 +6535,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_REDEF_1",
     key.usr: "c:Foo.h@4593@macro@FOO_MACRO_REDEF_1",
-    key.offset: 5827,
+    key.offset: 5877,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_REDEF_1</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6472,7 +6543,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_MACRO_REDEF_2",
     key.usr: "c:Foo.h@4650@macro@FOO_MACRO_REDEF_2",
-    key.offset: 5864,
+    key.offset: 5915,
     key.length: 36,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_MACRO_REDEF_2</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
@@ -6480,7 +6551,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "theLastDeclInFoo()",
     key.usr: "c:@F@theLastDeclInFoo",
-    key.offset: 5901,
+    key.offset: 5953,
     key.length: 23,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>theLastDeclInFoo</decl.name>()</decl.function.free>"
   },
@@ -6488,7 +6559,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "_internalTopLevelFunc()",
     key.usr: "c:@F@_internalTopLevelFunc",
-    key.offset: 5925,
+    key.offset: 5978,
     key.length: 28,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalTopLevelFunc</decl.name>()</decl.function.free>"
   },
@@ -6496,7 +6567,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "_InternalStruct",
     key.usr: "c:@S@_InternalStruct",
-    key.offset: 5954,
+    key.offset: 6008,
     key.length: 78,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>_InternalStruct</decl.name></decl.struct>",
     key.entities: [
@@ -6504,7 +6575,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
         key.usr: "s:So15_InternalStructVABycfc",
-        key.offset: 5984,
+        key.offset: 6038,
         key.length: 6,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
       },
@@ -6512,7 +6583,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(x:)",
         key.usr: "s:So15_InternalStructV1xABs5Int32V_tcfc",
-        key.offset: 5996,
+        key.offset: 6050,
         key.length: 16,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6520,7 +6591,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "x",
             key.name: "x",
-            key.offset: 6006,
+            key.offset: 6060,
             key.length: 5
           }
         ]
@@ -6529,7 +6600,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
         key.usr: "c:@S@_InternalStruct@FI@x",
-        key.offset: 6018,
+        key.offset: 6072,
         key.length: 12,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type></decl.var.instance>"
       }
@@ -6537,7 +6608,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 6033,
+    key.offset: 6088,
     key.length: 61,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
     key.extends: {
@@ -6550,7 +6621,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth1()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth1",
-        key.offset: 6063,
+        key.offset: 6118,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth1</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6558,7 +6629,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 6095,
+    key.offset: 6151,
     key.length: 97,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
     key.extends: {
@@ -6571,7 +6642,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth2()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth2",
-        key.offset: 6125,
+        key.offset: 6181,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth2</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       },
@@ -6579,7 +6650,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "nonInternalMeth()",
         key.usr: "c:objc(cs)FooClassBase(im)nonInternalMeth",
-        key.offset: 6160,
+        key.offset: 6216,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>nonInternalMeth</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6587,7 +6658,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 6193,
+    key.offset: 6250,
     key.length: 61,
     key.fully_annotated_decl: "<decl.extension.class><syntaxtype.keyword>extension</syntaxtype.keyword> <decl.name><ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.name></decl.extension.class>",
     key.extends: {
@@ -6600,7 +6671,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "_internalMeth3()",
         key.usr: "c:objc(cs)FooClassBase(im)_internalMeth3",
-        key.offset: 6223,
+        key.offset: 6280,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>_internalMeth3</decl.name>() -&gt; <decl.function.returntype><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.function.returntype></decl.function.method.instance>"
       }
@@ -6610,7 +6681,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.protocol,
     key.name: "_InternalProt",
     key.usr: "c:objc(pl)_InternalProt",
-    key.offset: 6255,
+    key.offset: 6313,
     key.length: 26,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>_InternalProt</decl.name></decl.protocol>"
   },
@@ -6618,7 +6689,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "ClassWithInternalProt",
     key.usr: "c:objc(cs)ClassWithInternalProt",
-    key.offset: 6282,
+    key.offset: 6341,
     key.length: 47,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>ClassWithInternalProt</decl.name> : <ref.protocol usr=\"c:objc(pl)_InternalProt\">_InternalProt</ref.protocol></decl.class>",
     key.conforms: [
@@ -6633,7 +6704,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooClassPropertyOwnership",
     key.usr: "c:objc(cs)FooClassPropertyOwnership",
-    key.offset: 6330,
+    key.offset: 6390,
     key.length: 284,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooClassPropertyOwnership</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.class>",
     key.inherits: [
@@ -6648,7 +6719,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "assignable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)assignable",
-        key.offset: 6384,
+        key.offset: 6444,
         key.length: 42,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>assignable</decl.name>: <decl.var.type>AnyObject!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6656,7 +6727,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "unsafeAssignable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)unsafeAssignable",
-        key.offset: 6432,
+        key.offset: 6492,
         key.length: 48,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>unowned(unsafe)</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>unsafeAssignable</decl.name>: <decl.var.type>AnyObject!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6664,7 +6735,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "retainable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)retainable",
-        key.offset: 6486,
+        key.offset: 6546,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>retainable</decl.name>: <decl.var.type><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6672,7 +6743,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "strongRef",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)strongRef",
-        key.offset: 6512,
+        key.offset: 6572,
         key.length: 19,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>strongRef</decl.name>: <decl.var.type><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6680,7 +6751,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "copyable",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)copyable",
-        key.offset: 6537,
+        key.offset: 6597,
         key.length: 18,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>copyable</decl.name>: <decl.var.type><syntaxtype.keyword>Any</syntaxtype.keyword>!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6688,7 +6759,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "weakRef",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)weakRef",
-        key.offset: 6561,
+        key.offset: 6621,
         key.length: 28,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>weak</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>weakRef</decl.name>: <decl.var.type>AnyObject!</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -6696,7 +6767,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "scalar",
         key.usr: "c:objc(cs)FooClassPropertyOwnership(py)scalar",
-        key.offset: 6595,
+        key.offset: 6655,
         key.length: 17,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>scalar</decl.name>: <decl.var.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -6706,7 +6777,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FOO_NIL",
     key.usr: "c:Foo.h@5439@macro@FOO_NIL",
-    key.offset: 6615,
+    key.offset: 6676,
     key.length: 15,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FOO_NIL</decl.name>: <decl.var.type><tuple>()</tuple></decl.var.type></decl.var.global>",
     key.attributes: [
@@ -6722,7 +6793,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooUnavailableMembers",
     key.usr: "c:objc(cs)FooUnavailableMembers",
-    key.offset: 6631,
+    key.offset: 6693,
     key.length: 451,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooUnavailableMembers</decl.name> : <ref.class usr=\"c:objc(cs)FooClassBase\">FooClassBase</ref.class></decl.class>",
     key.inherits: [
@@ -6737,7 +6808,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(int:)",
         key.usr: "c:objc(cs)FooUnavailableMembers(cm)unavailableMembersWithInt:",
-        key.offset: 6681,
+        key.offset: 6743,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>convenience</syntaxtype.keyword> <syntaxtype.keyword>init</syntaxtype.keyword>!(<decl.var.parameter><decl.var.parameter.argument_label>int</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -6745,7 +6816,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "int",
             key.name: "i",
-            key.offset: 6706,
+            key.offset: 6768,
             key.length: 5
           }
         ]
@@ -6754,7 +6825,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "unavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)unavailable",
-        key.offset: 6718,
+        key.offset: 6780,
         key.length: 18,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>unavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6770,7 +6841,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "swiftUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)swiftUnavailable",
-        key.offset: 6742,
+        key.offset: 6804,
         key.length: 23,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>swiftUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6785,7 +6856,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "deprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)deprecated",
-        key.offset: 6771,
+        key.offset: 6833,
         key.length: 17,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>deprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6801,7 +6872,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroduced()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroduced",
-        key.offset: 6794,
+        key.offset: 6856,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroduced</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6816,7 +6887,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecated()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecated",
-        key.offset: 6829,
+        key.offset: 6891,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecated</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6835,7 +6906,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoleted()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoleted",
-        key.offset: 6864,
+        key.offset: 6926,
         key.length: 28,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoleted</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6851,7 +6922,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailable()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailable",
-        key.offset: 6898,
+        key.offset: 6960,
         key.length: 30,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailable</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6867,7 +6938,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityIntroducedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityIntroducedMsg",
-        key.offset: 6934,
+        key.offset: 6996,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityIntroducedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6883,7 +6954,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityDeprecatedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityDeprecatedMsg",
-        key.offset: 6972,
+        key.offset: 7034,
         key.length: 32,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityDeprecatedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6902,7 +6973,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityObsoletedMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityObsoletedMsg",
-        key.offset: 7010,
+        key.offset: 7072,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityObsoletedMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6919,7 +6990,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "availabilityUnavailableMsg()",
         key.usr: "c:objc(cs)FooUnavailableMembers(im)availabilityUnavailableMsg",
-        key.offset: 7047,
+        key.offset: 7109,
         key.length: 33,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>availabilityUnavailableMsg</decl.name>()</decl.function.method.instance>",
         key.attributes: [
@@ -6938,7 +7009,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.class,
     key.name: "FooCFType",
     key.usr: "c:Foo.h@T@FooCFTypeRef",
-    key.offset: 7083,
+    key.offset: 7146,
     key.length: 19,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>FooCFType</decl.name></decl.class>"
   },
@@ -6946,14 +7017,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "FooCFTypeRelease(_:)",
     key.usr: "c:@F@FooCFTypeRelease",
-    key.offset: 7103,
+    key.offset: 7167,
     key.length: 38,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>FooCFTypeRelease</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"c:Foo.h@T@FooCFTypeRef\">FooCFType</ref.class>!</decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
-        key.offset: 7130,
+        key.offset: 7194,
         key.length: 10
       }
     ],
@@ -6970,7 +7041,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.enum,
     key.name: "ABAuthorizationStatus",
     key.usr: "c:@E@ABAuthorizationStatus",
-    key.offset: 7142,
+    key.offset: 7207,
     key.length: 274,
     key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>ABAuthorizationStatus</decl.name> : <ref.struct usr=\"s:Si\">Int</ref.struct></decl.enum>",
     key.inherits: [
@@ -6985,7 +7056,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "notDetermined",
         key.usr: "c:@E@ABAuthorizationStatus@kABAuthorizationStatusNotDetermined",
-        key.offset: 7182,
+        key.offset: 7247,
         key.length: 22,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>notDetermined</decl.name> = <syntaxtype.number>0</syntaxtype.number></decl.enumelement>",
         key.attributes: [
@@ -7000,7 +7071,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "restricted",
         key.usr: "c:@E@ABAuthorizationStatus@kABAuthorizationStatusRestricted",
-        key.offset: 7210,
+        key.offset: 7275,
         key.length: 19,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>restricted</decl.name> = <syntaxtype.number>1</syntaxtype.number></decl.enumelement>",
         key.attributes: [
@@ -7016,7 +7087,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hashValue",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp::SYNTHESIZED::c:@E@ABAuthorizationStatus",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE04hashB0Sivp",
-        key.offset: 7235,
+        key.offset: 7300,
         key.length: 37,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>hashValue</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -7025,7 +7096,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.name: "hash(into:)",
         key.usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF::SYNTHESIZED::c:@E@ABAuthorizationStatus",
         key.original_usr: "s:SYsSHRzSH8RawValueSYRpzrlE4hash4intoys6HasherVz_tF",
-        key.offset: 7278,
+        key.offset: 7343,
         key.length: 47,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@inlinable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>hash</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>into</decl.var.parameter.argument_label> <decl.var.parameter.name>hasher</decl.var.parameter.name>: <syntaxtype.keyword>inout</syntaxtype.keyword> <decl.var.parameter.type><ref.struct usr=\"s:s6HasherV\">Hasher</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
@@ -7033,7 +7104,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "into",
             key.name: "hasher",
-            key.offset: 7318,
+            key.offset: 7383,
             key.length: 6
           }
         ]
@@ -7044,7 +7115,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@ABAuthorizationStatus",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@ABAuthorizationStatus</USR><Declaration>static func != (lhs: ABAuthorizationStatus, rhs: ABAuthorizationStatus) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 7331,
+        key.offset: 7396,
         key.length: 83,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"c:@E@ABAuthorizationStatus\">ABAuthorizationStatus</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"c:@E@ABAuthorizationStatus\">ABAuthorizationStatus</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -7052,14 +7123,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 7354,
+            key.offset: 7419,
             key.length: 21
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 7384,
+            key.offset: 7449,
             key.length: 21
           }
         ]
@@ -7078,7 +7149,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fooSubFunc1(_:)",
     key.usr: "c:@F@fooSubFunc1",
-    key.offset: 7417,
+    key.offset: 7483,
     key.length: 37,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fooSubFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:s5Int32V\">Int32</ref.struct></decl.function.returntype></decl.function.free>",
     key.entities: [
@@ -7086,7 +7157,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "_",
         key.name: "a",
-        key.offset: 7439,
+        key.offset: 7505,
         key.length: 5
       }
     ],
@@ -7096,7 +7167,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 7455,
+    key.offset: 7522,
     key.length: 214,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooSubEnum1</decl.name> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol>, <ref.protocol usr=\"s:SY\">RawRepresentable</ref.protocol></decl.struct>",
     key.conforms: [
@@ -7116,7 +7187,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
         key.usr: "s:So11FooSubEnum1VyABs6UInt32Vcfc",
-        key.offset: 7511,
+        key.offset: 7578,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -7124,7 +7195,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rawValue",
-            key.offset: 7528,
+            key.offset: 7595,
             key.length: 6
           }
         ]
@@ -7133,7 +7204,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:So11FooSubEnum1V8rawValueABs6UInt32V_tcfc",
-        key.offset: 7541,
+        key.offset: 7608,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -7141,7 +7212,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 7565,
+            key.offset: 7632,
             key.length: 6
           }
         ]
@@ -7150,7 +7221,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
         key.usr: "s:So11FooSubEnum1V8rawValues6UInt32Vvp",
-        key.offset: 7578,
+        key.offset: 7645,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -7160,7 +7231,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooSubEnum1",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooSubEnum1</USR><Declaration>static func != (lhs: FooSubEnum1, rhs: FooSubEnum1) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 7604,
+        key.offset: 7671,
         key.length: 63,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -7168,14 +7239,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 7627,
+            key.offset: 7694,
             key.length: 11
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 7647,
+            key.offset: 7714,
             key.length: 11
           }
         ]
@@ -7187,7 +7258,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1X",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1X",
-    key.offset: 7670,
+    key.offset: 7738,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"
@@ -7196,7 +7267,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1Y",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1Y",
-    key.offset: 7708,
+    key.offset: 7777,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"
@@ -7205,7 +7276,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubUnnamedEnumeratorA1",
     key.usr: "c:@Ea@FooSubUnnamedEnumeratorA1@FooSubUnnamedEnumeratorA1",
-    key.offset: 7746,
+    key.offset: 7816,
     key.length: 42,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubUnnamedEnumeratorA1</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"

--- a/test/SourceKit/DocSupport/doc_clang_module.swift.sub.response
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift.sub.response
@@ -1,6 +1,7 @@
 import FooHelper
 
 func fooSubFunc1(_ a: Int32) -> Int32
+
 struct FooSubEnum1 : Equatable, RawRepresentable {
 
     init(_ rawValue: UInt32)
@@ -11,9 +12,13 @@ struct FooSubEnum1 : Equatable, RawRepresentable {
 
     static func != (_ lhs: FooSubEnum1, _ rhs: FooSubEnum1) -> Bool
 }
+
 var FooSubEnum1X: FooSubEnum1 { get }
+
 var FooSubEnum1Y: FooSubEnum1 { get }
+
 var FooSubUnnamedEnumeratorA1: Int { get }
+
 
 [
   {
@@ -62,209 +67,209 @@ var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 56,
+    key.offset: 57,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 63,
+    key.offset: 64,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Equatable",
     key.usr: "s:SQ",
-    key.offset: 77,
+    key.offset: 78,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "RawRepresentable",
     key.usr: "s:SY",
-    key.offset: 88,
+    key.offset: 89,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 112,
+    key.offset: 113,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 117,
+    key.offset: 118,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 119,
+    key.offset: 120,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 129,
+    key.offset: 130,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 142,
+    key.offset: 143,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 147,
+    key.offset: 148,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 156,
+    key.offset: 157,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 166,
+    key.offset: 167,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 179,
+    key.offset: 180,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 183,
+    key.offset: 184,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "UInt32",
     key.usr: "s:s6UInt32V",
-    key.offset: 193,
+    key.offset: 194,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 205,
+    key.offset: 206,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 212,
+    key.offset: 213,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 217,
+    key.offset: 218,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 221,
+    key.offset: 222,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 223,
+    key.offset: 224,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 228,
+    key.offset: 229,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 241,
+    key.offset: 242,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 243,
+    key.offset: 244,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 248,
+    key.offset: 249,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 264,
+    key.offset: 265,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 271,
+    key.offset: 273,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 275,
+    key.offset: 277,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 289,
+    key.offset: 291,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 303,
+    key.offset: 305,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 309,
+    key.offset: 312,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 313,
+    key.offset: 316,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 327,
+    key.offset: 330,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 341,
+    key.offset: 344,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 347,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 351,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 355,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 378,
+    key.offset: 382,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 384,
+    key.offset: 388,
     key.length: 3
   }
 ]
@@ -291,7 +296,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.name: "FooSubEnum1",
     key.usr: "c:@E@FooSubEnum1",
-    key.offset: 56,
+    key.offset: 57,
     key.length: 214,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>FooSubEnum1</decl.name> : <ref.protocol usr=\"s:SQ\">Equatable</ref.protocol>, <ref.protocol usr=\"s:SY\">RawRepresentable</ref.protocol></decl.struct>",
     key.conforms: [
@@ -311,7 +316,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(_:)",
         key.usr: "s:So11FooSubEnum1VyABs6UInt32Vcfc",
-        key.offset: 112,
+        key.offset: 113,
         key.length: 24,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>rawValue</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -319,7 +324,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rawValue",
-            key.offset: 129,
+            key.offset: 130,
             key.length: 6
           }
         ]
@@ -328,7 +333,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init(rawValue:)",
         key.usr: "s:So11FooSubEnum1V8rawValueABs6UInt32V_tcfc",
-        key.offset: 142,
+        key.offset: 143,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>rawValue</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.constructor>",
         key.entities: [
@@ -336,7 +341,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "rawValue",
             key.name: "rawValue",
-            key.offset: 166,
+            key.offset: 167,
             key.length: 6
           }
         ]
@@ -345,7 +350,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "rawValue",
         key.usr: "s:So11FooSubEnum1V8rawValues6UInt32Vvp",
-        key.offset: 179,
+        key.offset: 180,
         key.length: 20,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>rawValue</decl.name>: <decl.var.type><ref.struct usr=\"s:s6UInt32V\">UInt32</ref.struct></decl.var.type></decl.var.instance>"
       },
@@ -355,7 +360,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
         key.usr: "s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooSubEnum1",
         key.original_usr: "s:SQsE2neoiySbx_xtFZ",
         key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:SQsE2neoiySbx_xtFZ::SYNTHESIZED::c:@E@FooSubEnum1</USR><Declaration>static func != (lhs: FooSubEnum1, rhs: FooSubEnum1) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 205,
+        key.offset: 206,
         key.length: 63,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -363,14 +368,14 @@ var FooSubUnnamedEnumeratorA1: Int { get }
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 228,
+            key.offset: 229,
             key.length: 11
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 248,
+            key.offset: 249,
             key.length: 11
           }
         ]
@@ -382,7 +387,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1X",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1X",
-    key.offset: 271,
+    key.offset: 273,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1X</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"
@@ -391,7 +396,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubEnum1Y",
     key.usr: "c:@E@FooSubEnum1@FooSubEnum1Y",
-    key.offset: 309,
+    key.offset: 312,
     key.length: 37,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubEnum1Y</decl.name>: <decl.var.type><ref.struct usr=\"c:@E@FooSubEnum1\">FooSubEnum1</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"
@@ -400,7 +405,7 @@ var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.name: "FooSubUnnamedEnumeratorA1",
     key.usr: "c:@Ea@FooSubUnnamedEnumeratorA1@FooSubUnnamedEnumeratorA1",
-    key.offset: 347,
+    key.offset: 351,
     key.length: 42,
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>FooSubUnnamedEnumeratorA1</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>",
     key.modulename: "Foo.FooSub"

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.ClangFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.ClangFramework.response
@@ -1,6 +1,7 @@
 
 func fromClangFramework()
 
+
 // MARK: - BystandingLibrary Additions
 
 import SwiftOnoneSupport
@@ -22,37 +23,37 @@ func fromClangFrameworkCrossImport()
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 28,
+    key.offset: 29,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 31,
+    key.offset: 32,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 68,
+    key.offset: 69,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 75,
+    key.offset: 76,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 94,
+    key.offset: 95,
     key.length: 68
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 162,
+    key.offset: 163,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 167,
+    key.offset: 168,
     key.length: 29
   }
 ]
@@ -69,7 +70,7 @@ func fromClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromClangFrameworkCrossImport()",
     key.usr: "s:33_ClangFramework_BystandingLibrary04fromaB11CrossImportyyF",
-    key.offset: 162,
+    key.offset: 163,
     key.length: 36,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromClangFrameworkCrossImport</decl.name>()</decl.function.free>",
     key.required_bystanders: [

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.OverlaidClangFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.OverlaidClangFramework.response
@@ -1,11 +1,11 @@
 import SwiftOnoneSupport
 
 func fromOverlaidClangFramework()
+
 func fromOverlaidClangFrameworkOverlay()
 
 
 // MARK: - BystandingLibrary Additions
-
 
 // Available when BystandingLibrary is imported with OverlaidClangFramework
 func fromOverlaidClangFrameworkCrossImport()
@@ -34,22 +34,22 @@ func fromOverlaidClangFrameworkCrossImport()
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 60,
+    key.offset: 61,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 65,
+    key.offset: 66,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 103,
+    key.offset: 104,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 106,
+    key.offset: 107,
     key.length: 35
   },
   {
@@ -81,7 +81,7 @@ func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromOverlaidClangFrameworkOverlay()",
     key.usr: "s:22OverlaidClangFramework04fromabC7OverlayyyF",
-    key.offset: 60,
+    key.offset: 61,
     key.length: 40,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromOverlaidClangFrameworkOverlay</decl.name>()</decl.function.free>"
   },

--- a/test/SourceKit/DocSupport/doc_cross_import_common.swift.SwiftFramework.response
+++ b/test/SourceKit/DocSupport/doc_cross_import_common.swift.SwiftFramework.response
@@ -5,7 +5,6 @@ func fromSwiftFramework()
 
 // MARK: - BystandingLibrary Additions
 
-
 // Available when BystandingLibrary is imported with SwiftFramework
 func fromSwiftFrameworkCrossImport()
 
@@ -43,17 +42,17 @@ func fromSwiftFrameworkCrossImport()
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 95,
+    key.offset: 94,
     key.length: 68
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 163,
+    key.offset: 162,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 168,
+    key.offset: 167,
     key.length: 29
   }
 ]
@@ -70,7 +69,7 @@ func fromSwiftFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.name: "fromSwiftFrameworkCrossImport()",
     key.usr: "s:33_SwiftFramework_BystandingLibrary04fromaB11CrossImportyyF",
-    key.offset: 163,
+    key.offset: 162,
     key.length: 36,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>fromSwiftFrameworkCrossImport</decl.name>()</decl.function.free>",
     key.required_bystanders: [

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -31,7 +31,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=204:67 | %FileCheck -check-prefix=CHECK1 %s
+// RUN:      == -req=cursor -pos=176:67 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooClassBase' inside the list of base classes, see 'gen_clang_module.swift.response'
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
@@ -47,7 +47,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=231:20 | %FileCheck -check-prefix=CHECK2 %s
+// RUN:      == -req=cursor -pos=196:20 | %FileCheck -check-prefix=CHECK2 %s
 // The cursor points inside the interface, see 'gen_clang_module.swift.response'
 
 // CHECK2: source.lang.swift.decl.function.method.instance ({{.*}}Foo.framework/Headers/Foo.h:170:10-170:27)
@@ -61,7 +61,7 @@ var x: FooClassBase
 // RUN:      == -req=find-usr -usr "c:objc(cs)FooClassDerived(im)fooInstanceFunc0" | %FileCheck -check-prefix=CHECK-USR %s
 // The returned line:col points inside the interface, see 'gen_clang_module.swift.response'
 
-// CHECK-USR: (231:15-231:33)
+// CHECK-USR: (196:15-196:33)
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -31,7 +31,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=176:67 | %FileCheck -check-prefix=CHECK1 %s
+// RUN:      == -req=cursor -pos=191:67 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooClassBase' inside the list of base classes, see 'gen_clang_module.swift.response'
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
@@ -47,7 +47,7 @@ var x: FooClassBase
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN:      == -req=cursor -pos=196:20 | %FileCheck -check-prefix=CHECK2 %s
+// RUN:      == -req=cursor -pos=211:20 | %FileCheck -check-prefix=CHECK2 %s
 // The cursor points inside the interface, see 'gen_clang_module.swift.response'
 
 // CHECK2: source.lang.swift.decl.function.method.instance ({{.*}}Foo.framework/Headers/Foo.h:170:10-170:27)
@@ -61,7 +61,7 @@ var x: FooClassBase
 // RUN:      == -req=find-usr -usr "c:objc(cs)FooClassDerived(im)fooInstanceFunc0" | %FileCheck -check-prefix=CHECK-USR %s
 // The returned line:col points inside the interface, see 'gen_clang_module.swift.response'
 
-// CHECK-USR: (196:15-196:33)
+// CHECK-USR: (211:15-211:33)
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import  -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
 // RUN:         -target %target-triple %clang-importer-sdk-nosource -I %t \

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
@@ -2,37 +2,49 @@ import Foundation
 
 open class Foo : NSObject {
 }
+
 open class GlobalToMember_Class_Container : NSObject {
 }
+
 public typealias GlobalToMember_Class_Payload = GlobalToMember_Class_Container.Payload
+
 extension GlobalToMember_Class_Container {
 
     open class Payload : NSObject {
     }
 }
+
 open class MemberToGlobal_Class_Container : NSObject {
 }
+
 open class MemberToGlobal_Class_Payload : NSObject {
 }
+
 extension MemberToGlobal_Class_Container {
 
     public typealias Payload = MemberToGlobal_Class_Payload
 }
+
 open class MemberToMember_Class_Swift3 : NSObject {
 }
+
 open class MemberToMember_Class_Swift4 : NSObject {
 }
+
 extension MemberToMember_Class_Swift3 {
 
     public typealias PayloadFor3 = MemberToMember_Class_Swift4.PayloadFor4
 }
+
 extension MemberToMember_Class_Swift4 {
 
     open class PayloadFor4 : NSObject {
     }
 }
+
 open class MemberToMember_SameContainer_Class_Container : NSObject {
 }
+
 extension MemberToMember_SameContainer_Class_Container {
 
     public typealias PayloadFor3 = MemberToMember_SameContainer_Class_Container.PayloadFor4
@@ -40,65 +52,86 @@ extension MemberToMember_SameContainer_Class_Container {
     open class PayloadFor4 : NSObject {
     }
 }
+
 open class MemberToMember_SameName_Class_Swift3 : NSObject {
 }
+
 open class MemberToMember_SameName_Class_Swift4 : NSObject {
 }
+
 extension MemberToMember_SameName_Class_Swift3 {
 
     public typealias Payload = MemberToMember_SameName_Class_Swift4.Payload
 }
+
 extension MemberToMember_SameName_Class_Swift4 {
 
     open class Payload : NSObject {
     }
 }
+
 open class GlobalToMember_Typedef_Container : NSObject {
 }
+
 public typealias GlobalToMember_Typedef_Payload = GlobalToMember_Typedef_Container.Payload
+
 extension GlobalToMember_Typedef_Container {
 
     public typealias Payload = Foo
 }
+
 open class MemberToGlobal_Typedef_Container : NSObject {
 }
+
 public typealias MemberToGlobal_Typedef_Payload = Foo
+
 extension MemberToGlobal_Typedef_Container {
 
     public typealias Payload = MemberToGlobal_Typedef_Payload
 }
+
 open class MemberToMember_Typedef_Swift3 : NSObject {
 }
+
 open class MemberToMember_Typedef_Swift4 : NSObject {
 }
+
 extension MemberToMember_Typedef_Swift3 {
 
     public typealias PayloadFor3 = MemberToMember_Typedef_Swift4.PayloadFor4
 }
+
 extension MemberToMember_Typedef_Swift4 {
 
     public typealias PayloadFor4 = Foo
 }
+
 open class MemberToMember_SameContainer_Typedef_Container : NSObject {
 }
+
 extension MemberToMember_SameContainer_Typedef_Container {
 
     public typealias PayloadFor3 = MemberToMember_SameContainer_Typedef_Container.PayloadFor4
 
     public typealias PayloadFor4 = Foo
 }
+
 open class MemberToMember_SameName_Typedef_Swift3 : NSObject {
 }
+
 open class MemberToMember_SameName_Typedef_Swift4 : NSObject {
 }
+
 extension MemberToMember_SameName_Typedef_Swift3 {
 
     public typealias Payload = MemberToMember_SameName_Typedef_Swift4.Payload
 }
+
 extension MemberToMember_SameName_Typedef_Swift4 {
 
     public typealias Payload = Foo
 }
+
 
 [
   {
@@ -133,862 +166,862 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 49,
+    key.offset: 50,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 54,
+    key.offset: 55,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 60,
+    key.offset: 61,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 93,
+    key.offset: 94,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 106,
+    key.offset: 108,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 113,
+    key.offset: 115,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 123,
+    key.offset: 125,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 154,
+    key.offset: 156,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 185,
+    key.offset: 187,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 193,
+    key.offset: 196,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 203,
+    key.offset: 206,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 241,
+    key.offset: 244,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 246,
+    key.offset: 249,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 252,
+    key.offset: 255,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 262,
+    key.offset: 265,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 281,
+    key.offset: 285,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 286,
+    key.offset: 290,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 292,
+    key.offset: 296,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 325,
+    key.offset: 329,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 338,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 343,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 348,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 349,
+    key.offset: 354,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 380,
+    key.offset: 385,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 393,
+    key.offset: 399,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 403,
+    key.offset: 409,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 441,
+    key.offset: 447,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 448,
+    key.offset: 454,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 458,
+    key.offset: 464,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 468,
+    key.offset: 474,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 499,
+    key.offset: 506,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 504,
+    key.offset: 511,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 510,
+    key.offset: 517,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 540,
+    key.offset: 547,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 553,
+    key.offset: 561,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 558,
+    key.offset: 566,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 564,
+    key.offset: 572,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 594,
+    key.offset: 602,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 607,
+    key.offset: 616,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 617,
+    key.offset: 626,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 652,
+    key.offset: 661,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 659,
+    key.offset: 668,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 669,
+    key.offset: 678,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 683,
+    key.offset: 692,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 711,
+    key.offset: 720,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 725,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 735,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 745,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 770,
+    key.offset: 780,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 775,
+    key.offset: 785,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 781,
+    key.offset: 791,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 795,
+    key.offset: 805,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 814,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 819,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 825,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 830,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 836,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 872,
+    key.offset: 883,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 885,
+    key.offset: 897,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 895,
+    key.offset: 907,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 947,
+    key.offset: 959,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 954,
+    key.offset: 966,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 964,
+    key.offset: 976,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 978,
+    key.offset: 990,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1023,
+    key.offset: 1035,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1040,
+    key.offset: 1052,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1045,
+    key.offset: 1057,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1051,
+    key.offset: 1063,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1065,
+    key.offset: 1077,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1084,
+    key.offset: 1097,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1089,
+    key.offset: 1102,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1095,
+    key.offset: 1108,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1134,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 1147,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1161,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1152,
+    key.offset: 1166,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1158,
+    key.offset: 1172,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1197,
+    key.offset: 1211,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1210,
+    key.offset: 1225,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1220,
+    key.offset: 1235,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1264,
+    key.offset: 1279,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1271,
+    key.offset: 1286,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1281,
+    key.offset: 1296,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1291,
+    key.offset: 1306,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1328,
+    key.offset: 1343,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1338,
+    key.offset: 1354,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1348,
+    key.offset: 1364,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1392,
+    key.offset: 1408,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1397,
+    key.offset: 1413,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1403,
+    key.offset: 1419,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1413,
+    key.offset: 1429,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1432,
+    key.offset: 1449,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1437,
+    key.offset: 1454,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1443,
+    key.offset: 1460,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1478,
+    key.offset: 1495,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1491,
+    key.offset: 1509,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1498,
+    key.offset: 1516,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1508,
+    key.offset: 1526,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1541,
+    key.offset: 1559,
     key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1574,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1582,
-    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1592,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1601,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1611,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1632,
+    key.offset: 1651,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1639,
+    key.offset: 1658,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1649,
+    key.offset: 1668,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1659,
+    key.offset: 1678,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1665,
+    key.offset: 1685,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1670,
+    key.offset: 1690,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1676,
+    key.offset: 1696,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1711,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1724,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1731,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1745,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1752,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1741,
+    key.offset: 1762,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1774,
+    key.offset: 1795,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1778,
+    key.offset: 1800,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1788,
+    key.offset: 1810,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1828,
+    key.offset: 1850,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1835,
+    key.offset: 1857,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1845,
+    key.offset: 1867,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1855,
+    key.offset: 1877,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1888,
+    key.offset: 1911,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1893,
+    key.offset: 1916,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1899,
+    key.offset: 1922,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1931,
+    key.offset: 1954,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1944,
+    key.offset: 1968,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1949,
+    key.offset: 1973,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1955,
+    key.offset: 1979,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1987,
+    key.offset: 2011,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2000,
+    key.offset: 2025,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2010,
+    key.offset: 2035,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2047,
+    key.offset: 2072,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2054,
+    key.offset: 2079,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2064,
+    key.offset: 2089,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2078,
+    key.offset: 2103,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2108,
+    key.offset: 2133,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2122,
+    key.offset: 2148,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2132,
+    key.offset: 2158,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2169,
+    key.offset: 2195,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2176,
+    key.offset: 2202,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2186,
+    key.offset: 2212,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2200,
+    key.offset: 2226,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2206,
+    key.offset: 2233,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2211,
+    key.offset: 2238,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2217,
+    key.offset: 2244,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2266,
+    key.offset: 2293,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2279,
+    key.offset: 2307,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2289,
+    key.offset: 2317,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2343,
+    key.offset: 2371,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2350,
+    key.offset: 2378,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2360,
+    key.offset: 2388,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2374,
+    key.offset: 2402,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2421,
+    key.offset: 2449,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2438,
+    key.offset: 2466,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2445,
+    key.offset: 2473,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2455,
+    key.offset: 2483,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2469,
+    key.offset: 2497,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2475,
+    key.offset: 2504,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2480,
+    key.offset: 2509,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2486,
+    key.offset: 2515,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2527,
+    key.offset: 2556,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2540,
+    key.offset: 2570,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2545,
+    key.offset: 2575,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2551,
+    key.offset: 2581,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2592,
+    key.offset: 2622,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2605,
+    key.offset: 2636,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2615,
+    key.offset: 2646,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2661,
+    key.offset: 2692,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2668,
+    key.offset: 2699,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2678,
+    key.offset: 2709,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2688,
+    key.offset: 2719,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2727,
+    key.offset: 2758,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2737,
+    key.offset: 2769,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2747,
+    key.offset: 2779,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2793,
+    key.offset: 2825,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2800,
+    key.offset: 2832,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2810,
+    key.offset: 2842,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2820,
+    key.offset: 2852,
     key.length: 3
   }
 ]
@@ -1007,301 +1040,301 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 93,
+    key.offset: 94,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 154,
+    key.offset: 156,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 185,
+    key.offset: 187,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 203,
+    key.offset: 206,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 262,
+    key.offset: 265,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 325,
+    key.offset: 329,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 380,
+    key.offset: 385,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 403,
+    key.offset: 409,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 468,
+    key.offset: 474,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 540,
+    key.offset: 547,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 594,
+    key.offset: 602,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 617,
+    key.offset: 626,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 683,
+    key.offset: 692,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 711,
+    key.offset: 720,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 735,
+    key.offset: 745,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 795,
+    key.offset: 805,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 872,
+    key.offset: 883,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 895,
+    key.offset: 907,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 978,
+    key.offset: 990,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1023,
+    key.offset: 1035,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1065,
+    key.offset: 1077,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1134,
+    key.offset: 1147,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1197,
+    key.offset: 1211,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1220,
+    key.offset: 1235,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1291,
+    key.offset: 1306,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1328,
+    key.offset: 1343,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1348,
+    key.offset: 1364,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1413,
+    key.offset: 1429,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1478,
+    key.offset: 1495,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1541,
+    key.offset: 1559,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 1574,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
     key.offset: 1592,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1611,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1659,
+    key.offset: 1678,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1711,
+    key.offset: 1731,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1774,
+    key.offset: 1795,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1788,
+    key.offset: 1810,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 1855,
+    key.offset: 1877,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1931,
+    key.offset: 1954,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1987,
+    key.offset: 2011,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2010,
+    key.offset: 2035,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2078,
+    key.offset: 2103,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2108,
+    key.offset: 2133,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2132,
+    key.offset: 2158,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2200,
+    key.offset: 2226,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2266,
+    key.offset: 2293,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2289,
+    key.offset: 2317,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2374,
+    key.offset: 2402,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2421,
+    key.offset: 2449,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2469,
+    key.offset: 2497,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2527,
+    key.offset: 2556,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2592,
+    key.offset: 2622,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2615,
+    key.offset: 2646,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2688,
+    key.offset: 2719,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2727,
+    key.offset: 2758,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2747,
+    key.offset: 2779,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2820,
+    key.offset: 2852,
     key.length: 3
   }
 ]
@@ -1340,11 +1373,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 54,
+    key.offset: 55,
     key.length: 51,
-    key.nameoffset: 60,
+    key.nameoffset: 61,
     key.namelength: 30,
-    key.bodyoffset: 103,
+    key.bodyoffset: 104,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1353,7 +1386,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 49,
+        key.offset: 50,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1361,7 +1394,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 93,
+        key.offset: 94,
         key.length: 8
       }
     ]
@@ -1370,13 +1403,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "GlobalToMember_Class_Payload",
-    key.offset: 113,
+    key.offset: 115,
     key.length: 79,
-    key.nameoffset: 123,
+    key.nameoffset: 125,
     key.namelength: 28,
     key.attributes: [
       {
-        key.offset: 106,
+        key.offset: 108,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1385,22 +1418,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 193,
+    key.offset: 196,
     key.length: 87,
-    key.nameoffset: 203,
+    key.nameoffset: 206,
     key.namelength: 30,
-    key.bodyoffset: 235,
+    key.bodyoffset: 238,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 246,
+        key.offset: 249,
         key.length: 32,
-        key.nameoffset: 252,
+        key.nameoffset: 255,
         key.namelength: 7,
-        key.bodyoffset: 272,
+        key.bodyoffset: 275,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1409,7 +1442,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 241,
+            key.offset: 244,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1417,7 +1450,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 262,
+            key.offset: 265,
             key.length: 8
           }
         ]
@@ -1428,11 +1461,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 286,
+    key.offset: 290,
     key.length: 51,
-    key.nameoffset: 292,
+    key.nameoffset: 296,
     key.namelength: 30,
-    key.bodyoffset: 335,
+    key.bodyoffset: 339,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1441,7 +1474,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 281,
+        key.offset: 285,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1449,7 +1482,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 325,
+        key.offset: 329,
         key.length: 8
       }
     ]
@@ -1458,11 +1491,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Payload",
-    key.offset: 343,
+    key.offset: 348,
     key.length: 49,
-    key.nameoffset: 349,
+    key.nameoffset: 354,
     key.namelength: 28,
-    key.bodyoffset: 390,
+    key.bodyoffset: 395,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1471,7 +1504,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 338,
+        key.offset: 343,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1479,7 +1512,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 380,
+        key.offset: 385,
         key.length: 8
       }
     ]
@@ -1487,24 +1520,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 393,
+    key.offset: 399,
     key.length: 105,
-    key.nameoffset: 403,
+    key.nameoffset: 409,
     key.namelength: 30,
-    key.bodyoffset: 435,
+    key.bodyoffset: 441,
     key.bodylength: 62,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 448,
+        key.offset: 454,
         key.length: 48,
-        key.nameoffset: 458,
+        key.nameoffset: 464,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 441,
+            key.offset: 447,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1516,11 +1549,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 504,
+    key.offset: 511,
     key.length: 48,
-    key.nameoffset: 510,
+    key.nameoffset: 517,
     key.namelength: 27,
-    key.bodyoffset: 550,
+    key.bodyoffset: 557,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1529,7 +1562,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 499,
+        key.offset: 506,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1537,7 +1570,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 540,
+        key.offset: 547,
         key.length: 8
       }
     ]
@@ -1546,11 +1579,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 558,
+    key.offset: 566,
     key.length: 48,
-    key.nameoffset: 564,
+    key.nameoffset: 572,
     key.namelength: 27,
-    key.bodyoffset: 604,
+    key.bodyoffset: 612,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1559,7 +1592,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 553,
+        key.offset: 561,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1567,7 +1600,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 594,
+        key.offset: 602,
         key.length: 8
       }
     ]
@@ -1575,24 +1608,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 607,
+    key.offset: 616,
     key.length: 117,
-    key.nameoffset: 617,
+    key.nameoffset: 626,
     key.namelength: 27,
-    key.bodyoffset: 646,
+    key.bodyoffset: 655,
     key.bodylength: 77,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 659,
+        key.offset: 668,
         key.length: 63,
-        key.nameoffset: 669,
+        key.nameoffset: 678,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 652,
+            key.offset: 661,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1603,22 +1636,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 725,
+    key.offset: 735,
     key.length: 88,
-    key.nameoffset: 735,
+    key.nameoffset: 745,
     key.namelength: 27,
-    key.bodyoffset: 764,
+    key.bodyoffset: 774,
     key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 775,
+        key.offset: 785,
         key.length: 36,
-        key.nameoffset: 781,
+        key.nameoffset: 791,
         key.namelength: 11,
-        key.bodyoffset: 805,
+        key.bodyoffset: 815,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1627,7 +1660,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 770,
+            key.offset: 780,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1635,7 +1668,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 795,
+            key.offset: 805,
             key.length: 8
           }
         ]
@@ -1646,11 +1679,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 819,
+    key.offset: 830,
     key.length: 65,
-    key.nameoffset: 825,
+    key.nameoffset: 836,
     key.namelength: 44,
-    key.bodyoffset: 882,
+    key.bodyoffset: 893,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1659,7 +1692,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 814,
+        key.offset: 825,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1667,7 +1700,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 872,
+        key.offset: 883,
         key.length: 8
       }
     ]
@@ -1675,24 +1708,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 885,
+    key.offset: 897,
     key.length: 198,
-    key.nameoffset: 895,
+    key.nameoffset: 907,
     key.namelength: 44,
-    key.bodyoffset: 941,
+    key.bodyoffset: 953,
     key.bodylength: 141,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 954,
+        key.offset: 966,
         key.length: 80,
-        key.nameoffset: 964,
+        key.nameoffset: 976,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 947,
+            key.offset: 959,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1702,11 +1735,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 1045,
+        key.offset: 1057,
         key.length: 36,
-        key.nameoffset: 1051,
+        key.nameoffset: 1063,
         key.namelength: 11,
-        key.bodyoffset: 1075,
+        key.bodyoffset: 1087,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1715,7 +1748,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1040,
+            key.offset: 1052,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1723,7 +1756,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1065,
+            key.offset: 1077,
             key.length: 8
           }
         ]
@@ -1734,11 +1767,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift3",
-    key.offset: 1089,
+    key.offset: 1102,
     key.length: 57,
-    key.nameoffset: 1095,
+    key.nameoffset: 1108,
     key.namelength: 36,
-    key.bodyoffset: 1144,
+    key.bodyoffset: 1157,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1747,7 +1780,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1084,
+        key.offset: 1097,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1755,7 +1788,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1134,
+        key.offset: 1147,
         key.length: 8
       }
     ]
@@ -1764,11 +1797,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1152,
+    key.offset: 1166,
     key.length: 57,
-    key.nameoffset: 1158,
+    key.nameoffset: 1172,
     key.namelength: 36,
-    key.bodyoffset: 1207,
+    key.bodyoffset: 1221,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1777,7 +1810,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1147,
+        key.offset: 1161,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1785,7 +1818,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1197,
+        key.offset: 1211,
         key.length: 8
       }
     ]
@@ -1793,24 +1826,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Class_Swift3",
-    key.offset: 1210,
+    key.offset: 1225,
     key.length: 127,
-    key.nameoffset: 1220,
+    key.nameoffset: 1235,
     key.namelength: 36,
-    key.bodyoffset: 1258,
+    key.bodyoffset: 1273,
     key.bodylength: 78,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1271,
+        key.offset: 1286,
         key.length: 64,
-        key.nameoffset: 1281,
+        key.nameoffset: 1296,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1264,
+            key.offset: 1279,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1821,22 +1854,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1338,
+    key.offset: 1354,
     key.length: 93,
-    key.nameoffset: 1348,
+    key.nameoffset: 1364,
     key.namelength: 36,
-    key.bodyoffset: 1386,
+    key.bodyoffset: 1402,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 1397,
+        key.offset: 1413,
         key.length: 32,
-        key.nameoffset: 1403,
+        key.nameoffset: 1419,
         key.namelength: 7,
-        key.bodyoffset: 1423,
+        key.bodyoffset: 1439,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1845,7 +1878,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1392,
+            key.offset: 1408,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1853,7 +1886,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1413,
+            key.offset: 1429,
             key.length: 8
           }
         ]
@@ -1864,11 +1897,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 1437,
+    key.offset: 1454,
     key.length: 53,
-    key.nameoffset: 1443,
+    key.nameoffset: 1460,
     key.namelength: 32,
-    key.bodyoffset: 1488,
+    key.bodyoffset: 1505,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1877,7 +1910,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1432,
+        key.offset: 1449,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1885,7 +1918,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1478,
+        key.offset: 1495,
         key.length: 8
       }
     ]
@@ -1894,13 +1927,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "GlobalToMember_Typedef_Payload",
-    key.offset: 1498,
+    key.offset: 1516,
     key.length: 83,
-    key.nameoffset: 1508,
+    key.nameoffset: 1526,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 1491,
+        key.offset: 1509,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1909,24 +1942,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 1582,
+    key.offset: 1601,
     key.length: 82,
-    key.nameoffset: 1592,
+    key.nameoffset: 1611,
     key.namelength: 32,
-    key.bodyoffset: 1626,
+    key.bodyoffset: 1645,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1639,
+        key.offset: 1658,
         key.length: 23,
-        key.nameoffset: 1649,
+        key.nameoffset: 1668,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1632,
+            key.offset: 1651,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1938,11 +1971,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 1670,
+    key.offset: 1690,
     key.length: 53,
-    key.nameoffset: 1676,
+    key.nameoffset: 1696,
     key.namelength: 32,
-    key.bodyoffset: 1721,
+    key.bodyoffset: 1741,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1951,7 +1984,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1665,
+        key.offset: 1685,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1959,7 +1992,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1711,
+        key.offset: 1731,
         key.length: 8
       }
     ]
@@ -1968,13 +2001,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MemberToGlobal_Typedef_Payload",
-    key.offset: 1731,
+    key.offset: 1752,
     key.length: 46,
-    key.nameoffset: 1741,
+    key.nameoffset: 1762,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 1724,
+        key.offset: 1745,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1983,24 +2016,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 1778,
+    key.offset: 1800,
     key.length: 109,
-    key.nameoffset: 1788,
+    key.nameoffset: 1810,
     key.namelength: 32,
-    key.bodyoffset: 1822,
+    key.bodyoffset: 1844,
     key.bodylength: 64,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1835,
+        key.offset: 1857,
         key.length: 50,
-        key.nameoffset: 1845,
+        key.nameoffset: 1867,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1828,
+            key.offset: 1850,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2012,11 +2045,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 1893,
+    key.offset: 1916,
     key.length: 50,
-    key.nameoffset: 1899,
+    key.nameoffset: 1922,
     key.namelength: 29,
-    key.bodyoffset: 1941,
+    key.bodyoffset: 1964,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2025,7 +2058,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1888,
+        key.offset: 1911,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2033,7 +2066,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1931,
+        key.offset: 1954,
         key.length: 8
       }
     ]
@@ -2042,11 +2075,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 1949,
+    key.offset: 1973,
     key.length: 50,
-    key.nameoffset: 1955,
+    key.nameoffset: 1979,
     key.namelength: 29,
-    key.bodyoffset: 1997,
+    key.bodyoffset: 2021,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2055,7 +2088,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1944,
+        key.offset: 1968,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2063,7 +2096,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1987,
+        key.offset: 2011,
         key.length: 8
       }
     ]
@@ -2071,24 +2104,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 2000,
+    key.offset: 2025,
     key.length: 121,
-    key.nameoffset: 2010,
+    key.nameoffset: 2035,
     key.namelength: 29,
-    key.bodyoffset: 2041,
+    key.bodyoffset: 2066,
     key.bodylength: 79,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 2054,
+        key.offset: 2079,
         key.length: 65,
-        key.nameoffset: 2064,
+        key.nameoffset: 2089,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2047,
+            key.offset: 2072,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2099,24 +2132,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 2122,
+    key.offset: 2148,
     key.length: 83,
-    key.nameoffset: 2132,
+    key.nameoffset: 2158,
     key.namelength: 29,
-    key.bodyoffset: 2163,
+    key.bodyoffset: 2189,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 2176,
+        key.offset: 2202,
         key.length: 27,
-        key.nameoffset: 2186,
+        key.nameoffset: 2212,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2169,
+            key.offset: 2195,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2128,11 +2161,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 2211,
+    key.offset: 2238,
     key.length: 67,
-    key.nameoffset: 2217,
+    key.nameoffset: 2244,
     key.namelength: 46,
-    key.bodyoffset: 2276,
+    key.bodyoffset: 2303,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2141,7 +2174,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2206,
+        key.offset: 2233,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2149,7 +2182,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2266,
+        key.offset: 2293,
         key.length: 8
       }
     ]
@@ -2157,24 +2190,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 2279,
+    key.offset: 2307,
     key.length: 195,
-    key.nameoffset: 2289,
+    key.nameoffset: 2317,
     key.namelength: 46,
-    key.bodyoffset: 2337,
+    key.bodyoffset: 2365,
     key.bodylength: 136,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 2350,
+        key.offset: 2378,
         key.length: 82,
-        key.nameoffset: 2360,
+        key.nameoffset: 2388,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2343,
+            key.offset: 2371,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2184,13 +2217,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 2445,
+        key.offset: 2473,
         key.length: 27,
-        key.nameoffset: 2455,
+        key.nameoffset: 2483,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2438,
+            key.offset: 2466,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2202,11 +2235,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 2480,
+    key.offset: 2509,
     key.length: 59,
-    key.nameoffset: 2486,
+    key.nameoffset: 2515,
     key.namelength: 38,
-    key.bodyoffset: 2537,
+    key.bodyoffset: 2566,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2215,7 +2248,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2475,
+        key.offset: 2504,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2223,7 +2256,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2527,
+        key.offset: 2556,
         key.length: 8
       }
     ]
@@ -2232,11 +2265,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 2545,
+    key.offset: 2575,
     key.length: 59,
-    key.nameoffset: 2551,
+    key.nameoffset: 2581,
     key.namelength: 38,
-    key.bodyoffset: 2602,
+    key.bodyoffset: 2632,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2245,7 +2278,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2540,
+        key.offset: 2570,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2253,7 +2286,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2592,
+        key.offset: 2622,
         key.length: 8
       }
     ]
@@ -2261,24 +2294,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 2605,
+    key.offset: 2636,
     key.length: 131,
-    key.nameoffset: 2615,
+    key.nameoffset: 2646,
     key.namelength: 38,
-    key.bodyoffset: 2655,
+    key.bodyoffset: 2686,
     key.bodylength: 80,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2668,
+        key.offset: 2699,
         key.length: 66,
-        key.nameoffset: 2678,
+        key.nameoffset: 2709,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2661,
+            key.offset: 2692,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2289,24 +2322,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 2737,
+    key.offset: 2769,
     key.length: 88,
-    key.nameoffset: 2747,
+    key.nameoffset: 2779,
     key.namelength: 38,
-    key.bodyoffset: 2787,
+    key.bodyoffset: 2819,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2800,
+        key.offset: 2832,
         key.length: 23,
-        key.nameoffset: 2810,
+        key.nameoffset: 2842,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2793,
+            key.offset: 2825,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
@@ -1,14 +1,7 @@
 import Foundation
 
-
 open class Foo : NSObject {
 }
-// ===-------------------------------------------------------------------------
-// class Payload
-// ===-------------------------------------------------------------------------
-
-// 3: Payload
-// 4: Namespace.Payload
 open class GlobalToMember_Class_Container : NSObject {
 }
 public typealias GlobalToMember_Class_Payload = GlobalToMember_Class_Container.Payload
@@ -17,9 +10,6 @@ extension GlobalToMember_Class_Container {
     open class Payload : NSObject {
     }
 }
-
-// 3: Namespace.Payload
-// 4: Payload
 open class MemberToGlobal_Class_Container : NSObject {
 }
 open class MemberToGlobal_Class_Payload : NSObject {
@@ -28,9 +18,6 @@ extension MemberToGlobal_Class_Container {
 
     public typealias Payload = MemberToGlobal_Class_Payload
 }
-
-// 3: Namespace_Swift3.PayloadFor3
-// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Class_Swift3 : NSObject {
 }
 open class MemberToMember_Class_Swift4 : NSObject {
@@ -44,9 +31,6 @@ extension MemberToMember_Class_Swift4 {
     open class PayloadFor4 : NSObject {
     }
 }
-
-// 3: Namespace.PayloadFor3
-// 4: Namespace.PayloadFor4
 open class MemberToMember_SameContainer_Class_Container : NSObject {
 }
 extension MemberToMember_SameContainer_Class_Container {
@@ -56,9 +40,6 @@ extension MemberToMember_SameContainer_Class_Container {
     open class PayloadFor4 : NSObject {
     }
 }
-
-// 3: Namespace_Swift3.Payload
-// 4: Namespace_Swift4.Payload
 open class MemberToMember_SameName_Class_Swift3 : NSObject {
 }
 open class MemberToMember_SameName_Class_Swift4 : NSObject {
@@ -72,13 +53,6 @@ extension MemberToMember_SameName_Class_Swift4 {
     open class Payload : NSObject {
     }
 }
-
-// ===-------------------------------------------------------------------------
-// typealias Payload
-// ===-------------------------------------------------------------------------
-
-// 3: Payload
-// 4: Namespace.Payload
 open class GlobalToMember_Typedef_Container : NSObject {
 }
 public typealias GlobalToMember_Typedef_Payload = GlobalToMember_Typedef_Container.Payload
@@ -86,9 +60,6 @@ extension GlobalToMember_Typedef_Container {
 
     public typealias Payload = Foo
 }
-
-// 3: Namespace.Payload
-// 4: Payload
 open class MemberToGlobal_Typedef_Container : NSObject {
 }
 public typealias MemberToGlobal_Typedef_Payload = Foo
@@ -96,9 +67,6 @@ extension MemberToGlobal_Typedef_Container {
 
     public typealias Payload = MemberToGlobal_Typedef_Payload
 }
-
-// 3: Namespace_Swift3.PayloadFor3
-// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_Typedef_Swift4 : NSObject {
@@ -111,9 +79,6 @@ extension MemberToMember_Typedef_Swift4 {
 
     public typealias PayloadFor4 = Foo
 }
-
-// 3: Namespace.PayloadFor3
-// 4: Namespace.PayloadFor4
 open class MemberToMember_SameContainer_Typedef_Container : NSObject {
 }
 extension MemberToMember_SameContainer_Typedef_Container {
@@ -122,9 +87,6 @@ extension MemberToMember_SameContainer_Typedef_Container {
 
     public typealias PayloadFor4 = Foo
 }
-
-// 3: Namespace_Swift3.Payload
-// 4: Namespace_Swift4.Payload
 open class MemberToMember_SameName_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_SameName_Typedef_Swift4 : NSObject {
@@ -151,363 +113,423 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 20,
+    key.offset: 19,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 25,
+    key.offset: 24,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 30,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 37,
+    key.offset: 36,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 50,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 130,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 147,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 228,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 242,
-    key.length: 24
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 266,
+    key.offset: 49,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 271,
+    key.offset: 54,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 277,
+    key.offset: 60,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 310,
+    key.offset: 93,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 323,
+    key.offset: 106,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 330,
+    key.offset: 113,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 340,
+    key.offset: 123,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 371,
+    key.offset: 154,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 402,
+    key.offset: 185,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 410,
+    key.offset: 193,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 420,
+    key.offset: 203,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 241,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 246,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 252,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 262,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 281,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 286,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 292,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 325,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 338,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 343,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 349,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 380,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 393,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 403,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 441,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 448,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 458,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 463,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 469,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 479,
-    key.length: 8
+    key.offset: 468,
+    key.length: 28
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 499,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 523,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 537,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 542,
+    key.offset: 504,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 548,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 581,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 594,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 599,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 605,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 636,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 649,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 659,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 697,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 704,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 714,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 724,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 756,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 791,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 826,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 831,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 837,
+    key.offset: 510,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 867,
+    key.offset: 540,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 880,
+    key.offset: 553,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 558,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 564,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 594,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 607,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 617,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 652,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 659,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 669,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 683,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 711,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 725,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 735,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 770,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 775,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 781,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 795,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 814,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 819,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 825,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 872,
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 885,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 891,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 921,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 934,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 944,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 979,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 986,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 996,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1010,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1038,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1052,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1062,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1097,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1102,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1108,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1122,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1142,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1170,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1198,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1203,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1209,
-    key.length: 44
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1256,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1269,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1279,
+    key.offset: 895,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1331,
+    key.offset: 947,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 954,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 964,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 978,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1023,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1040,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1045,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1051,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1065,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1084,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1089,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1095,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1134,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1147,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1152,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1158,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1197,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1210,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1220,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1264,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1271,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1281,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1291,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1328,
+    key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -515,648 +537,458 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.length: 9
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1348,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1362,
-    key.length: 44
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1407,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1424,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1429,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1435,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1449,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1469,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1500,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1531,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1536,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1542,
     key.length: 36
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1581,
-    key.length: 8
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1594,
+    key.offset: 1392,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1599,
+    key.offset: 1397,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1605,
-    key.length: 36
+    key.offset: 1403,
+    key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1644,
+    key.offset: 1413,
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1432,
+    key.length: 4
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1657,
+    key.offset: 1437,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1443,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1478,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1491,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1498,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1508,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1541,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1574,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1582,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1667,
-    key.length: 36
+    key.offset: 1592,
+    key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1632,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1639,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1649,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1659,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1665,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1670,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1676,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1711,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1724,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1718,
+    key.offset: 1731,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1728,
-    key.length: 7
+    key.offset: 1741,
+    key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1738,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1775,
-    key.length: 7
+    key.offset: 1774,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1785,
+    key.offset: 1778,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1795,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1839,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1844,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1850,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1860,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1880,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1960,
-    key.length: 21
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1981,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2062,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2076,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2100,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2105,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2111,
+    key.offset: 1788,
     key.length: 32
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2146,
-    key.length: 8
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2159,
+    key.offset: 1828,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2166,
+    key.offset: 1835,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1845,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1855,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1888,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1893,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1899,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1931,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1944,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1949,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1955,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1987,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2000,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2010,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2047,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2054,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2064,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2078,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2108,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2122,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2132,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2169,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 2176,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2209,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2242,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2250,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2260,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2300,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2307,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2317,
-    key.length: 7
+    key.offset: 2186,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2327,
+    key.offset: 2200,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2334,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2358,
-    key.length: 14
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2372,
+    key.offset: 2206,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2377,
+    key.offset: 2211,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2383,
-    key.length: 32
+    key.offset: 2217,
+    key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2418,
+    key.offset: 2266,
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2279,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2289,
+    key.length: 46
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2431,
+    key.offset: 2343,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2350,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2360,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2374,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2421,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 2438,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2448,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2481,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2485,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2495,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2535,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2542,
+    key.offset: 2445,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2552,
-    key.length: 7
+    key.offset: 2455,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2562,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2596,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2631,
-    key.length: 35
+    key.offset: 2469,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2666,
+    key.offset: 2475,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2671,
+    key.offset: 2480,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2677,
-    key.length: 29
+    key.offset: 2486,
+    key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2709,
+    key.offset: 2527,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2722,
+    key.offset: 2540,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2545,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2551,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2592,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2605,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2615,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2661,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2668,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2678,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2688,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 2727,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2733,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2765,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2778,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2788,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2825,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2832,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2842,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2856,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2886,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2900,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2910,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2947,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2954,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2964,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2978,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2985,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 3013,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3041,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3046,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3052,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3101,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3114,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3124,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3178,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3185,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3195,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3209,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3256,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3273,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3280,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3290,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3304,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 3311,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 3342,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3373,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3378,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3384,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3425,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3438,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3443,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3449,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3490,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3503,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3513,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3559,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3566,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3576,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3586,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3625,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3635,
+    key.offset: 2737,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3645,
+    key.offset: 2747,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3691,
+    key.offset: 2793,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3698,
+    key.offset: 2800,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3708,
+    key.offset: 2810,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3718,
+    key.offset: 2820,
     key.length: 3
   }
 ]
@@ -1169,307 +1001,307 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 37,
+    key.offset: 36,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 310,
+    key.offset: 93,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 371,
+    key.offset: 154,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 402,
+    key.offset: 185,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 420,
+    key.offset: 203,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 479,
+    key.offset: 262,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 581,
+    key.offset: 325,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 636,
+    key.offset: 380,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 659,
+    key.offset: 403,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 724,
+    key.offset: 468,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 867,
+    key.offset: 540,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 921,
+    key.offset: 594,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 944,
+    key.offset: 617,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1010,
+    key.offset: 683,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1038,
+    key.offset: 711,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1062,
+    key.offset: 735,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1122,
+    key.offset: 795,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1256,
+    key.offset: 872,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1279,
+    key.offset: 895,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1362,
+    key.offset: 978,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1407,
+    key.offset: 1023,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1449,
+    key.offset: 1065,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1581,
+    key.offset: 1134,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1644,
+    key.offset: 1197,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1667,
+    key.offset: 1220,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1738,
+    key.offset: 1291,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1775,
+    key.offset: 1328,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1795,
+    key.offset: 1348,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1860,
+    key.offset: 1413,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2146,
+    key.offset: 1478,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2209,
+    key.offset: 1541,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2242,
+    key.offset: 1574,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2260,
+    key.offset: 1592,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2327,
+    key.offset: 1659,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2418,
+    key.offset: 1711,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2481,
+    key.offset: 1774,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2495,
+    key.offset: 1788,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2562,
+    key.offset: 1855,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2709,
+    key.offset: 1931,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2765,
+    key.offset: 1987,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2788,
+    key.offset: 2010,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2856,
+    key.offset: 2078,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2886,
+    key.offset: 2108,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2910,
+    key.offset: 2132,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2978,
+    key.offset: 2200,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3101,
+    key.offset: 2266,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3124,
+    key.offset: 2289,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3209,
+    key.offset: 2374,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 3256,
+    key.offset: 2421,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3304,
+    key.offset: 2469,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3425,
+    key.offset: 2527,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3490,
+    key.offset: 2592,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3513,
+    key.offset: 2615,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3586,
+    key.offset: 2688,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 3625,
+    key.offset: 2727,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3645,
+    key.offset: 2747,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3718,
+    key.offset: 2820,
     key.length: 3
   }
 ]
@@ -1478,11 +1310,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "Foo",
-    key.offset: 25,
+    key.offset: 24,
     key.length: 24,
-    key.nameoffset: 31,
+    key.nameoffset: 30,
     key.namelength: 3,
-    key.bodyoffset: 47,
+    key.bodyoffset: 46,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1491,7 +1323,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 20,
+        key.offset: 19,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1499,7 +1331,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 37,
+        key.offset: 36,
         key.length: 8
       }
     ]
@@ -1508,11 +1340,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 271,
+    key.offset: 54,
     key.length: 51,
-    key.nameoffset: 277,
+    key.nameoffset: 60,
     key.namelength: 30,
-    key.bodyoffset: 320,
+    key.bodyoffset: 103,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1521,7 +1353,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 266,
+        key.offset: 49,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1529,7 +1361,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 310,
+        key.offset: 93,
         key.length: 8
       }
     ]
@@ -1538,13 +1370,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "GlobalToMember_Class_Payload",
-    key.offset: 330,
+    key.offset: 113,
     key.length: 79,
-    key.nameoffset: 340,
+    key.nameoffset: 123,
     key.namelength: 28,
     key.attributes: [
       {
-        key.offset: 323,
+        key.offset: 106,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1553,22 +1385,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 410,
+    key.offset: 193,
     key.length: 87,
-    key.nameoffset: 420,
+    key.nameoffset: 203,
     key.namelength: 30,
-    key.bodyoffset: 452,
+    key.bodyoffset: 235,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 463,
+        key.offset: 246,
         key.length: 32,
-        key.nameoffset: 469,
+        key.nameoffset: 252,
         key.namelength: 7,
-        key.bodyoffset: 489,
+        key.bodyoffset: 272,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1577,7 +1409,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 458,
+            key.offset: 241,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1585,7 +1417,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 479,
+            key.offset: 262,
             key.length: 8
           }
         ]
@@ -1596,11 +1428,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 542,
+    key.offset: 286,
     key.length: 51,
-    key.nameoffset: 548,
+    key.nameoffset: 292,
     key.namelength: 30,
-    key.bodyoffset: 591,
+    key.bodyoffset: 335,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1609,7 +1441,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 537,
+        key.offset: 281,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1617,7 +1449,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 581,
+        key.offset: 325,
         key.length: 8
       }
     ]
@@ -1626,11 +1458,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Payload",
-    key.offset: 599,
+    key.offset: 343,
     key.length: 49,
-    key.nameoffset: 605,
+    key.nameoffset: 349,
     key.namelength: 28,
-    key.bodyoffset: 646,
+    key.bodyoffset: 390,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1639,7 +1471,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 594,
+        key.offset: 338,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1647,7 +1479,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 636,
+        key.offset: 380,
         key.length: 8
       }
     ]
@@ -1655,24 +1487,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 649,
+    key.offset: 393,
     key.length: 105,
-    key.nameoffset: 659,
+    key.nameoffset: 403,
     key.namelength: 30,
-    key.bodyoffset: 691,
+    key.bodyoffset: 435,
     key.bodylength: 62,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 704,
+        key.offset: 448,
         key.length: 48,
-        key.nameoffset: 714,
+        key.nameoffset: 458,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 697,
+            key.offset: 441,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1684,11 +1516,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 831,
+    key.offset: 504,
     key.length: 48,
-    key.nameoffset: 837,
+    key.nameoffset: 510,
     key.namelength: 27,
-    key.bodyoffset: 877,
+    key.bodyoffset: 550,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1697,7 +1529,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 826,
+        key.offset: 499,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1705,7 +1537,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 867,
+        key.offset: 540,
         key.length: 8
       }
     ]
@@ -1714,11 +1546,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 885,
+    key.offset: 558,
     key.length: 48,
-    key.nameoffset: 891,
+    key.nameoffset: 564,
     key.namelength: 27,
-    key.bodyoffset: 931,
+    key.bodyoffset: 604,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1727,7 +1559,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 880,
+        key.offset: 553,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1735,7 +1567,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 921,
+        key.offset: 594,
         key.length: 8
       }
     ]
@@ -1743,24 +1575,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 934,
+    key.offset: 607,
     key.length: 117,
-    key.nameoffset: 944,
+    key.nameoffset: 617,
     key.namelength: 27,
-    key.bodyoffset: 973,
+    key.bodyoffset: 646,
     key.bodylength: 77,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 986,
+        key.offset: 659,
         key.length: 63,
-        key.nameoffset: 996,
+        key.nameoffset: 669,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 979,
+            key.offset: 652,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1771,22 +1603,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 1052,
+    key.offset: 725,
     key.length: 88,
-    key.nameoffset: 1062,
+    key.nameoffset: 735,
     key.namelength: 27,
-    key.bodyoffset: 1091,
+    key.bodyoffset: 764,
     key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 1102,
+        key.offset: 775,
         key.length: 36,
-        key.nameoffset: 1108,
+        key.nameoffset: 781,
         key.namelength: 11,
-        key.bodyoffset: 1132,
+        key.bodyoffset: 805,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1795,7 +1627,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1097,
+            key.offset: 770,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1803,7 +1635,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1122,
+            key.offset: 795,
             key.length: 8
           }
         ]
@@ -1814,11 +1646,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 1203,
+    key.offset: 819,
     key.length: 65,
-    key.nameoffset: 1209,
+    key.nameoffset: 825,
     key.namelength: 44,
-    key.bodyoffset: 1266,
+    key.bodyoffset: 882,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1827,7 +1659,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1198,
+        key.offset: 814,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1835,7 +1667,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1256,
+        key.offset: 872,
         key.length: 8
       }
     ]
@@ -1843,24 +1675,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 1269,
+    key.offset: 885,
     key.length: 198,
-    key.nameoffset: 1279,
+    key.nameoffset: 895,
     key.namelength: 44,
-    key.bodyoffset: 1325,
+    key.bodyoffset: 941,
     key.bodylength: 141,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 1338,
+        key.offset: 954,
         key.length: 80,
-        key.nameoffset: 1348,
+        key.nameoffset: 964,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 1331,
+            key.offset: 947,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1870,11 +1702,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 1429,
+        key.offset: 1045,
         key.length: 36,
-        key.nameoffset: 1435,
+        key.nameoffset: 1051,
         key.namelength: 11,
-        key.bodyoffset: 1459,
+        key.bodyoffset: 1075,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1883,7 +1715,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1424,
+            key.offset: 1040,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1891,7 +1723,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1449,
+            key.offset: 1065,
             key.length: 8
           }
         ]
@@ -1902,11 +1734,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift3",
-    key.offset: 1536,
+    key.offset: 1089,
     key.length: 57,
-    key.nameoffset: 1542,
+    key.nameoffset: 1095,
     key.namelength: 36,
-    key.bodyoffset: 1591,
+    key.bodyoffset: 1144,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1915,7 +1747,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1531,
+        key.offset: 1084,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1923,7 +1755,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1581,
+        key.offset: 1134,
         key.length: 8
       }
     ]
@@ -1932,11 +1764,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1599,
+    key.offset: 1152,
     key.length: 57,
-    key.nameoffset: 1605,
+    key.nameoffset: 1158,
     key.namelength: 36,
-    key.bodyoffset: 1654,
+    key.bodyoffset: 1207,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1945,7 +1777,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1594,
+        key.offset: 1147,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1953,7 +1785,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1644,
+        key.offset: 1197,
         key.length: 8
       }
     ]
@@ -1961,24 +1793,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Class_Swift3",
-    key.offset: 1657,
+    key.offset: 1210,
     key.length: 127,
-    key.nameoffset: 1667,
+    key.nameoffset: 1220,
     key.namelength: 36,
-    key.bodyoffset: 1705,
+    key.bodyoffset: 1258,
     key.bodylength: 78,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1718,
+        key.offset: 1271,
         key.length: 64,
-        key.nameoffset: 1728,
+        key.nameoffset: 1281,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1711,
+            key.offset: 1264,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1989,22 +1821,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1785,
+    key.offset: 1338,
     key.length: 93,
-    key.nameoffset: 1795,
+    key.nameoffset: 1348,
     key.namelength: 36,
-    key.bodyoffset: 1833,
+    key.bodyoffset: 1386,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 1844,
+        key.offset: 1397,
         key.length: 32,
-        key.nameoffset: 1850,
+        key.nameoffset: 1403,
         key.namelength: 7,
-        key.bodyoffset: 1870,
+        key.bodyoffset: 1423,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -2013,7 +1845,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1839,
+            key.offset: 1392,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -2021,7 +1853,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1860,
+            key.offset: 1413,
             key.length: 8
           }
         ]
@@ -2032,11 +1864,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 2105,
+    key.offset: 1437,
     key.length: 53,
-    key.nameoffset: 2111,
+    key.nameoffset: 1443,
     key.namelength: 32,
-    key.bodyoffset: 2156,
+    key.bodyoffset: 1488,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2045,7 +1877,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2100,
+        key.offset: 1432,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2053,7 +1885,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2146,
+        key.offset: 1478,
         key.length: 8
       }
     ]
@@ -2062,13 +1894,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "GlobalToMember_Typedef_Payload",
-    key.offset: 2166,
+    key.offset: 1498,
     key.length: 83,
-    key.nameoffset: 2176,
+    key.nameoffset: 1508,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 2159,
+        key.offset: 1491,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -2077,24 +1909,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 2250,
+    key.offset: 1582,
     key.length: 82,
-    key.nameoffset: 2260,
+    key.nameoffset: 1592,
     key.namelength: 32,
-    key.bodyoffset: 2294,
+    key.bodyoffset: 1626,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2307,
+        key.offset: 1639,
         key.length: 23,
-        key.nameoffset: 2317,
+        key.nameoffset: 1649,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2300,
+            key.offset: 1632,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2106,11 +1938,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 2377,
+    key.offset: 1670,
     key.length: 53,
-    key.nameoffset: 2383,
+    key.nameoffset: 1676,
     key.namelength: 32,
-    key.bodyoffset: 2428,
+    key.bodyoffset: 1721,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2119,7 +1951,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2372,
+        key.offset: 1665,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2127,7 +1959,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2418,
+        key.offset: 1711,
         key.length: 8
       }
     ]
@@ -2136,13 +1968,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MemberToGlobal_Typedef_Payload",
-    key.offset: 2438,
+    key.offset: 1731,
     key.length: 46,
-    key.nameoffset: 2448,
+    key.nameoffset: 1741,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 2431,
+        key.offset: 1724,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -2151,24 +1983,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 2485,
+    key.offset: 1778,
     key.length: 109,
-    key.nameoffset: 2495,
+    key.nameoffset: 1788,
     key.namelength: 32,
-    key.bodyoffset: 2529,
+    key.bodyoffset: 1822,
     key.bodylength: 64,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2542,
+        key.offset: 1835,
         key.length: 50,
-        key.nameoffset: 2552,
+        key.nameoffset: 1845,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2535,
+            key.offset: 1828,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2180,11 +2012,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 2671,
+    key.offset: 1893,
     key.length: 50,
-    key.nameoffset: 2677,
+    key.nameoffset: 1899,
     key.namelength: 29,
-    key.bodyoffset: 2719,
+    key.bodyoffset: 1941,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2193,7 +2025,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2666,
+        key.offset: 1888,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2201,7 +2033,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2709,
+        key.offset: 1931,
         key.length: 8
       }
     ]
@@ -2210,11 +2042,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 2727,
+    key.offset: 1949,
     key.length: 50,
-    key.nameoffset: 2733,
+    key.nameoffset: 1955,
     key.namelength: 29,
-    key.bodyoffset: 2775,
+    key.bodyoffset: 1997,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2223,7 +2055,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2722,
+        key.offset: 1944,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2231,7 +2063,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2765,
+        key.offset: 1987,
         key.length: 8
       }
     ]
@@ -2239,24 +2071,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 2778,
+    key.offset: 2000,
     key.length: 121,
-    key.nameoffset: 2788,
+    key.nameoffset: 2010,
     key.namelength: 29,
-    key.bodyoffset: 2819,
+    key.bodyoffset: 2041,
     key.bodylength: 79,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 2832,
+        key.offset: 2054,
         key.length: 65,
-        key.nameoffset: 2842,
+        key.nameoffset: 2064,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2825,
+            key.offset: 2047,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2267,24 +2099,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 2900,
+    key.offset: 2122,
     key.length: 83,
-    key.nameoffset: 2910,
+    key.nameoffset: 2132,
     key.namelength: 29,
-    key.bodyoffset: 2941,
+    key.bodyoffset: 2163,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 2954,
+        key.offset: 2176,
         key.length: 27,
-        key.nameoffset: 2964,
+        key.nameoffset: 2186,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2947,
+            key.offset: 2169,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2296,11 +2128,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 3046,
+    key.offset: 2211,
     key.length: 67,
-    key.nameoffset: 3052,
+    key.nameoffset: 2217,
     key.namelength: 46,
-    key.bodyoffset: 3111,
+    key.bodyoffset: 2276,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2309,7 +2141,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 3041,
+        key.offset: 2206,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2317,7 +2149,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3101,
+        key.offset: 2266,
         key.length: 8
       }
     ]
@@ -2325,24 +2157,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 3114,
+    key.offset: 2279,
     key.length: 195,
-    key.nameoffset: 3124,
+    key.nameoffset: 2289,
     key.namelength: 46,
-    key.bodyoffset: 3172,
+    key.bodyoffset: 2337,
     key.bodylength: 136,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 3185,
+        key.offset: 2350,
         key.length: 82,
-        key.nameoffset: 3195,
+        key.nameoffset: 2360,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 3178,
+            key.offset: 2343,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2352,13 +2184,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 3280,
+        key.offset: 2445,
         key.length: 27,
-        key.nameoffset: 3290,
+        key.nameoffset: 2455,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 3273,
+            key.offset: 2438,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2370,11 +2202,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 3378,
+    key.offset: 2480,
     key.length: 59,
-    key.nameoffset: 3384,
+    key.nameoffset: 2486,
     key.namelength: 38,
-    key.bodyoffset: 3435,
+    key.bodyoffset: 2537,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2383,7 +2215,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 3373,
+        key.offset: 2475,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2391,7 +2223,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3425,
+        key.offset: 2527,
         key.length: 8
       }
     ]
@@ -2400,11 +2232,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 3443,
+    key.offset: 2545,
     key.length: 59,
-    key.nameoffset: 3449,
+    key.nameoffset: 2551,
     key.namelength: 38,
-    key.bodyoffset: 3500,
+    key.bodyoffset: 2602,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2413,7 +2245,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 3438,
+        key.offset: 2540,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2421,7 +2253,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3490,
+        key.offset: 2592,
         key.length: 8
       }
     ]
@@ -2429,24 +2261,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 3503,
+    key.offset: 2605,
     key.length: 131,
-    key.nameoffset: 3513,
+    key.nameoffset: 2615,
     key.namelength: 38,
-    key.bodyoffset: 3553,
+    key.bodyoffset: 2655,
     key.bodylength: 80,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 3566,
+        key.offset: 2668,
         key.length: 66,
-        key.nameoffset: 3576,
+        key.nameoffset: 2678,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3559,
+            key.offset: 2661,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2457,24 +2289,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 3635,
+    key.offset: 2737,
     key.length: 88,
-    key.nameoffset: 3645,
+    key.nameoffset: 2747,
     key.namelength: 38,
-    key.bodyoffset: 3685,
+    key.bodyoffset: 2787,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 3698,
+        key.offset: 2800,
         key.length: 23,
-        key.nameoffset: 3708,
+        key.nameoffset: 2810,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3691,
+            key.offset: 2793,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
@@ -2,73 +2,98 @@ import Foundation
 
 open class Foo : NSObject {
 }
+
 open class GlobalToMember_Class_Container : NSObject {
 }
+
 extension GlobalToMember_Class_Container {
 
     open class Payload : NSObject {
     }
 }
+
 open class MemberToGlobal_Class_Container : NSObject {
 }
+
 open class MemberToGlobal_Class_Payload : NSObject {
 }
+
 open class MemberToMember_Class_Swift3 : NSObject {
 }
+
 open class MemberToMember_Class_Swift4 : NSObject {
 }
+
 extension MemberToMember_Class_Swift4 {
 
     open class PayloadFor4 : NSObject {
     }
 }
+
 open class MemberToMember_SameContainer_Class_Container : NSObject {
 }
+
 extension MemberToMember_SameContainer_Class_Container {
 
     open class PayloadFor4 : NSObject {
     }
 }
+
 open class MemberToMember_SameName_Class_Swift3 : NSObject {
 }
+
 open class MemberToMember_SameName_Class_Swift4 : NSObject {
 }
+
 extension MemberToMember_SameName_Class_Swift4 {
 
     open class Payload : NSObject {
     }
 }
+
 open class GlobalToMember_Typedef_Container : NSObject {
 }
+
 extension GlobalToMember_Typedef_Container {
 
     public typealias Payload = Foo
 }
+
 open class MemberToGlobal_Typedef_Container : NSObject {
 }
+
 public typealias MemberToGlobal_Typedef_Payload = Foo
+
 open class MemberToMember_Typedef_Swift3 : NSObject {
 }
+
 open class MemberToMember_Typedef_Swift4 : NSObject {
 }
+
 extension MemberToMember_Typedef_Swift4 {
 
     public typealias PayloadFor4 = Foo
 }
+
 open class MemberToMember_SameContainer_Typedef_Container : NSObject {
 }
+
 extension MemberToMember_SameContainer_Typedef_Container {
 
     public typealias PayloadFor4 = Foo
 }
+
 open class MemberToMember_SameName_Typedef_Swift3 : NSObject {
 }
+
 open class MemberToMember_SameName_Typedef_Swift4 : NSObject {
 }
+
 extension MemberToMember_SameName_Typedef_Swift4 {
 
     public typealias Payload = Foo
 }
+
 
 [
   {
@@ -103,562 +128,562 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 49,
+    key.offset: 50,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 54,
+    key.offset: 55,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 60,
+    key.offset: 61,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 93,
+    key.offset: 94,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 106,
+    key.offset: 108,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 116,
+    key.offset: 118,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 154,
+    key.offset: 156,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 159,
+    key.offset: 161,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 165,
+    key.offset: 167,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 175,
+    key.offset: 177,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 194,
+    key.offset: 197,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 199,
+    key.offset: 202,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 205,
+    key.offset: 208,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 238,
+    key.offset: 241,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 251,
+    key.offset: 255,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 256,
+    key.offset: 260,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 262,
+    key.offset: 266,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 293,
+    key.offset: 297,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 306,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 311,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 317,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 347,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 360,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 365,
+    key.offset: 316,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 322,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 352,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 366,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 371,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 377,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 401,
+    key.offset: 407,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 414,
+    key.offset: 421,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 424,
+    key.offset: 431,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 459,
+    key.offset: 466,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 464,
+    key.offset: 471,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 470,
+    key.offset: 477,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 484,
+    key.offset: 491,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 503,
+    key.offset: 511,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 508,
+    key.offset: 516,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 514,
+    key.offset: 522,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 561,
+    key.offset: 569,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 574,
+    key.offset: 583,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 584,
+    key.offset: 593,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 636,
+    key.offset: 645,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 641,
+    key.offset: 650,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 647,
+    key.offset: 656,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 661,
+    key.offset: 670,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 680,
+    key.offset: 690,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 685,
+    key.offset: 695,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 691,
+    key.offset: 701,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 730,
+    key.offset: 740,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 743,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 748,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 754,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 793,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 806,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 816,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 860,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 865,
+    key.offset: 759,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 871,
+    key.offset: 765,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 804,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 818,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 828,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 872,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 877,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 883,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 881,
+    key.offset: 893,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 900,
+    key.offset: 913,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 905,
+    key.offset: 918,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 911,
+    key.offset: 924,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 946,
+    key.offset: 959,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 959,
+    key.offset: 973,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 969,
+    key.offset: 983,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1009,
+    key.offset: 1023,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1016,
+    key.offset: 1030,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1026,
+    key.offset: 1040,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1036,
+    key.offset: 1050,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1042,
+    key.offset: 1057,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1047,
+    key.offset: 1062,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1053,
+    key.offset: 1068,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1088,
+    key.offset: 1103,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1101,
+    key.offset: 1117,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1108,
+    key.offset: 1124,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1118,
+    key.offset: 1134,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1151,
+    key.offset: 1167,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1155,
+    key.offset: 1172,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1160,
+    key.offset: 1177,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1166,
+    key.offset: 1183,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1198,
+    key.offset: 1215,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1211,
+    key.offset: 1229,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1216,
+    key.offset: 1234,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1222,
+    key.offset: 1240,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1254,
+    key.offset: 1272,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1267,
+    key.offset: 1286,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1277,
+    key.offset: 1296,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1314,
+    key.offset: 1333,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1321,
+    key.offset: 1340,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1331,
+    key.offset: 1350,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1345,
+    key.offset: 1364,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1351,
+    key.offset: 1371,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1356,
+    key.offset: 1376,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1362,
+    key.offset: 1382,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1411,
+    key.offset: 1431,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1424,
+    key.offset: 1445,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1434,
+    key.offset: 1455,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1488,
+    key.offset: 1509,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1495,
+    key.offset: 1516,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1505,
+    key.offset: 1526,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1519,
+    key.offset: 1540,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1525,
+    key.offset: 1547,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1530,
+    key.offset: 1552,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1536,
+    key.offset: 1558,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1577,
+    key.offset: 1599,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1590,
+    key.offset: 1613,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1595,
+    key.offset: 1618,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1601,
+    key.offset: 1624,
     key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1642,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1655,
-    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1665,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1679,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1689,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1711,
+    key.offset: 1735,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1718,
+    key.offset: 1742,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1728,
+    key.offset: 1752,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1738,
+    key.offset: 1762,
     key.length: 3
   }
 ]
@@ -677,181 +702,181 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 93,
+    key.offset: 94,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 116,
+    key.offset: 118,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 175,
+    key.offset: 177,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 238,
+    key.offset: 241,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 293,
+    key.offset: 297,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 347,
+    key.offset: 352,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 401,
+    key.offset: 407,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 424,
+    key.offset: 431,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 484,
+    key.offset: 491,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 561,
+    key.offset: 569,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 584,
+    key.offset: 593,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 661,
+    key.offset: 670,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 730,
+    key.offset: 740,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 793,
+    key.offset: 804,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 816,
+    key.offset: 828,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 881,
+    key.offset: 893,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 946,
+    key.offset: 959,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 969,
+    key.offset: 983,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1036,
+    key.offset: 1050,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1088,
+    key.offset: 1103,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1151,
+    key.offset: 1167,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1198,
+    key.offset: 1215,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1254,
+    key.offset: 1272,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1277,
+    key.offset: 1296,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1345,
+    key.offset: 1364,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1411,
+    key.offset: 1431,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1434,
+    key.offset: 1455,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1519,
+    key.offset: 1540,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1577,
-    key.length: 8,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
-    key.offset: 1642,
+    key.offset: 1599,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.offset: 1665,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1689,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1738,
+    key.offset: 1762,
     key.length: 3
   }
 ]
@@ -890,11 +915,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 54,
+    key.offset: 55,
     key.length: 51,
-    key.nameoffset: 60,
+    key.nameoffset: 61,
     key.namelength: 30,
-    key.bodyoffset: 103,
+    key.bodyoffset: 104,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -903,7 +928,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 49,
+        key.offset: 50,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -911,7 +936,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 93,
+        key.offset: 94,
         key.length: 8
       }
     ]
@@ -919,22 +944,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 106,
+    key.offset: 108,
     key.length: 87,
-    key.nameoffset: 116,
+    key.nameoffset: 118,
     key.namelength: 30,
-    key.bodyoffset: 148,
+    key.bodyoffset: 150,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 159,
+        key.offset: 161,
         key.length: 32,
-        key.nameoffset: 165,
+        key.nameoffset: 167,
         key.namelength: 7,
-        key.bodyoffset: 185,
+        key.bodyoffset: 187,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -943,7 +968,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 154,
+            key.offset: 156,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -951,7 +976,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 175,
+            key.offset: 177,
             key.length: 8
           }
         ]
@@ -962,11 +987,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 199,
+    key.offset: 202,
     key.length: 51,
-    key.nameoffset: 205,
+    key.nameoffset: 208,
     key.namelength: 30,
-    key.bodyoffset: 248,
+    key.bodyoffset: 251,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -975,7 +1000,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 194,
+        key.offset: 197,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -983,7 +1008,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 238,
+        key.offset: 241,
         key.length: 8
       }
     ]
@@ -992,11 +1017,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Payload",
-    key.offset: 256,
+    key.offset: 260,
     key.length: 49,
-    key.nameoffset: 262,
+    key.nameoffset: 266,
     key.namelength: 28,
-    key.bodyoffset: 303,
+    key.bodyoffset: 307,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1005,7 +1030,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 251,
+        key.offset: 255,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1013,7 +1038,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 293,
+        key.offset: 297,
         key.length: 8
       }
     ]
@@ -1022,11 +1047,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 311,
+    key.offset: 316,
     key.length: 48,
-    key.nameoffset: 317,
+    key.nameoffset: 322,
     key.namelength: 27,
-    key.bodyoffset: 357,
+    key.bodyoffset: 362,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1035,7 +1060,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 306,
+        key.offset: 311,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1043,7 +1068,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 347,
+        key.offset: 352,
         key.length: 8
       }
     ]
@@ -1052,11 +1077,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 365,
+    key.offset: 371,
     key.length: 48,
-    key.nameoffset: 371,
+    key.nameoffset: 377,
     key.namelength: 27,
-    key.bodyoffset: 411,
+    key.bodyoffset: 417,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1065,7 +1090,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 360,
+        key.offset: 366,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1073,7 +1098,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 401,
+        key.offset: 407,
         key.length: 8
       }
     ]
@@ -1081,22 +1106,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 414,
+    key.offset: 421,
     key.length: 88,
-    key.nameoffset: 424,
+    key.nameoffset: 431,
     key.namelength: 27,
-    key.bodyoffset: 453,
+    key.bodyoffset: 460,
     key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 464,
+        key.offset: 471,
         key.length: 36,
-        key.nameoffset: 470,
+        key.nameoffset: 477,
         key.namelength: 11,
-        key.bodyoffset: 494,
+        key.bodyoffset: 501,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1105,7 +1130,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 459,
+            key.offset: 466,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1113,7 +1138,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 484,
+            key.offset: 491,
             key.length: 8
           }
         ]
@@ -1124,11 +1149,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 508,
+    key.offset: 516,
     key.length: 65,
-    key.nameoffset: 514,
+    key.nameoffset: 522,
     key.namelength: 44,
-    key.bodyoffset: 571,
+    key.bodyoffset: 579,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1137,7 +1162,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 503,
+        key.offset: 511,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1145,7 +1170,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 561,
+        key.offset: 569,
         key.length: 8
       }
     ]
@@ -1153,22 +1178,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 574,
+    key.offset: 583,
     key.length: 105,
-    key.nameoffset: 584,
+    key.nameoffset: 593,
     key.namelength: 44,
-    key.bodyoffset: 630,
+    key.bodyoffset: 639,
     key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 641,
+        key.offset: 650,
         key.length: 36,
-        key.nameoffset: 647,
+        key.nameoffset: 656,
         key.namelength: 11,
-        key.bodyoffset: 671,
+        key.bodyoffset: 680,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1177,7 +1202,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 636,
+            key.offset: 645,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1185,7 +1210,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 661,
+            key.offset: 670,
             key.length: 8
           }
         ]
@@ -1196,11 +1221,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift3",
-    key.offset: 685,
+    key.offset: 695,
     key.length: 57,
-    key.nameoffset: 691,
+    key.nameoffset: 701,
     key.namelength: 36,
-    key.bodyoffset: 740,
+    key.bodyoffset: 750,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1209,7 +1234,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 680,
+        key.offset: 690,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1217,7 +1242,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 730,
+        key.offset: 740,
         key.length: 8
       }
     ]
@@ -1226,11 +1251,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 748,
+    key.offset: 759,
     key.length: 57,
-    key.nameoffset: 754,
+    key.nameoffset: 765,
     key.namelength: 36,
-    key.bodyoffset: 803,
+    key.bodyoffset: 814,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1239,7 +1264,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 743,
+        key.offset: 754,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1247,7 +1272,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 793,
+        key.offset: 804,
         key.length: 8
       }
     ]
@@ -1255,22 +1280,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 806,
+    key.offset: 818,
     key.length: 93,
-    key.nameoffset: 816,
+    key.nameoffset: 828,
     key.namelength: 36,
-    key.bodyoffset: 854,
+    key.bodyoffset: 866,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 865,
+        key.offset: 877,
         key.length: 32,
-        key.nameoffset: 871,
+        key.nameoffset: 883,
         key.namelength: 7,
-        key.bodyoffset: 891,
+        key.bodyoffset: 903,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1279,7 +1304,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 860,
+            key.offset: 872,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1287,7 +1312,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 881,
+            key.offset: 893,
             key.length: 8
           }
         ]
@@ -1298,11 +1323,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 905,
+    key.offset: 918,
     key.length: 53,
-    key.nameoffset: 911,
+    key.nameoffset: 924,
     key.namelength: 32,
-    key.bodyoffset: 956,
+    key.bodyoffset: 969,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1311,7 +1336,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 900,
+        key.offset: 913,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1319,7 +1344,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 946,
+        key.offset: 959,
         key.length: 8
       }
     ]
@@ -1327,24 +1352,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 959,
+    key.offset: 973,
     key.length: 82,
-    key.nameoffset: 969,
+    key.nameoffset: 983,
     key.namelength: 32,
-    key.bodyoffset: 1003,
+    key.bodyoffset: 1017,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1016,
+        key.offset: 1030,
         key.length: 23,
-        key.nameoffset: 1026,
+        key.nameoffset: 1040,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1009,
+            key.offset: 1023,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1356,11 +1381,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 1047,
+    key.offset: 1062,
     key.length: 53,
-    key.nameoffset: 1053,
+    key.nameoffset: 1068,
     key.namelength: 32,
-    key.bodyoffset: 1098,
+    key.bodyoffset: 1113,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1369,7 +1394,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1042,
+        key.offset: 1057,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1377,7 +1402,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1088,
+        key.offset: 1103,
         key.length: 8
       }
     ]
@@ -1386,13 +1411,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MemberToGlobal_Typedef_Payload",
-    key.offset: 1108,
+    key.offset: 1124,
     key.length: 46,
-    key.nameoffset: 1118,
+    key.nameoffset: 1134,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 1101,
+        key.offset: 1117,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1402,11 +1427,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 1160,
+    key.offset: 1177,
     key.length: 50,
-    key.nameoffset: 1166,
+    key.nameoffset: 1183,
     key.namelength: 29,
-    key.bodyoffset: 1208,
+    key.bodyoffset: 1225,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1415,7 +1440,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1155,
+        key.offset: 1172,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1423,7 +1448,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1198,
+        key.offset: 1215,
         key.length: 8
       }
     ]
@@ -1432,11 +1457,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 1216,
+    key.offset: 1234,
     key.length: 50,
-    key.nameoffset: 1222,
+    key.nameoffset: 1240,
     key.namelength: 29,
-    key.bodyoffset: 1264,
+    key.bodyoffset: 1282,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1445,7 +1470,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1211,
+        key.offset: 1229,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1453,7 +1478,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1254,
+        key.offset: 1272,
         key.length: 8
       }
     ]
@@ -1461,24 +1486,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 1267,
+    key.offset: 1286,
     key.length: 83,
-    key.nameoffset: 1277,
+    key.nameoffset: 1296,
     key.namelength: 29,
-    key.bodyoffset: 1308,
+    key.bodyoffset: 1327,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 1321,
+        key.offset: 1340,
         key.length: 27,
-        key.nameoffset: 1331,
+        key.nameoffset: 1350,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 1314,
+            key.offset: 1333,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1490,11 +1515,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 1356,
+    key.offset: 1376,
     key.length: 67,
-    key.nameoffset: 1362,
+    key.nameoffset: 1382,
     key.namelength: 46,
-    key.bodyoffset: 1421,
+    key.bodyoffset: 1441,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1503,7 +1528,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1351,
+        key.offset: 1371,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1511,7 +1536,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1411,
+        key.offset: 1431,
         key.length: 8
       }
     ]
@@ -1519,24 +1544,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 1424,
+    key.offset: 1445,
     key.length: 100,
-    key.nameoffset: 1434,
+    key.nameoffset: 1455,
     key.namelength: 46,
-    key.bodyoffset: 1482,
+    key.bodyoffset: 1503,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 1495,
+        key.offset: 1516,
         key.length: 27,
-        key.nameoffset: 1505,
+        key.nameoffset: 1526,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 1488,
+            key.offset: 1509,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1548,11 +1573,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 1530,
+    key.offset: 1552,
     key.length: 59,
-    key.nameoffset: 1536,
+    key.nameoffset: 1558,
     key.namelength: 38,
-    key.bodyoffset: 1587,
+    key.bodyoffset: 1609,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1561,7 +1586,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1525,
+        key.offset: 1547,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1569,7 +1594,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1577,
+        key.offset: 1599,
         key.length: 8
       }
     ]
@@ -1578,11 +1603,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 1595,
+    key.offset: 1618,
     key.length: 59,
-    key.nameoffset: 1601,
+    key.nameoffset: 1624,
     key.namelength: 38,
-    key.bodyoffset: 1652,
+    key.bodyoffset: 1675,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1591,7 +1616,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1590,
+        key.offset: 1613,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1599,7 +1624,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1642,
+        key.offset: 1665,
         key.length: 8
       }
     ]
@@ -1607,24 +1632,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 1655,
+    key.offset: 1679,
     key.length: 88,
-    key.nameoffset: 1665,
+    key.nameoffset: 1689,
     key.namelength: 38,
-    key.bodyoffset: 1705,
+    key.bodyoffset: 1729,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1718,
+        key.offset: 1742,
         key.length: 23,
-        key.nameoffset: 1728,
+        key.nameoffset: 1752,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1711,
+            key.offset: 1735,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
@@ -1,14 +1,7 @@
 import Foundation
 
-
 open class Foo : NSObject {
 }
-// ===-------------------------------------------------------------------------
-// class Payload
-// ===-------------------------------------------------------------------------
-
-// 3: Payload
-// 4: Namespace.Payload
 open class GlobalToMember_Class_Container : NSObject {
 }
 extension GlobalToMember_Class_Container {
@@ -16,16 +9,10 @@ extension GlobalToMember_Class_Container {
     open class Payload : NSObject {
     }
 }
-
-// 3: Namespace.Payload
-// 4: Payload
 open class MemberToGlobal_Class_Container : NSObject {
 }
 open class MemberToGlobal_Class_Payload : NSObject {
 }
-
-// 3: Namespace_Swift3.PayloadFor3
-// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Class_Swift3 : NSObject {
 }
 open class MemberToMember_Class_Swift4 : NSObject {
@@ -35,9 +22,6 @@ extension MemberToMember_Class_Swift4 {
     open class PayloadFor4 : NSObject {
     }
 }
-
-// 3: Namespace.PayloadFor3
-// 4: Namespace.PayloadFor4
 open class MemberToMember_SameContainer_Class_Container : NSObject {
 }
 extension MemberToMember_SameContainer_Class_Container {
@@ -45,9 +29,6 @@ extension MemberToMember_SameContainer_Class_Container {
     open class PayloadFor4 : NSObject {
     }
 }
-
-// 3: Namespace_Swift3.Payload
-// 4: Namespace_Swift4.Payload
 open class MemberToMember_SameName_Class_Swift3 : NSObject {
 }
 open class MemberToMember_SameName_Class_Swift4 : NSObject {
@@ -57,28 +38,15 @@ extension MemberToMember_SameName_Class_Swift4 {
     open class Payload : NSObject {
     }
 }
-
-// ===-------------------------------------------------------------------------
-// typealias Payload
-// ===-------------------------------------------------------------------------
-
-// 3: Payload
-// 4: Namespace.Payload
 open class GlobalToMember_Typedef_Container : NSObject {
 }
 extension GlobalToMember_Typedef_Container {
 
     public typealias Payload = Foo
 }
-
-// 3: Namespace.Payload
-// 4: Payload
 open class MemberToGlobal_Typedef_Container : NSObject {
 }
 public typealias MemberToGlobal_Typedef_Payload = Foo
-
-// 3: Namespace_Swift3.PayloadFor3
-// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_Typedef_Swift4 : NSObject {
@@ -87,18 +55,12 @@ extension MemberToMember_Typedef_Swift4 {
 
     public typealias PayloadFor4 = Foo
 }
-
-// 3: Namespace.PayloadFor3
-// 4: Namespace.PayloadFor4
 open class MemberToMember_SameContainer_Typedef_Container : NSObject {
 }
 extension MemberToMember_SameContainer_Typedef_Container {
 
     public typealias PayloadFor4 = Foo
 }
-
-// 3: Namespace_Swift3.Payload
-// 4: Namespace_Swift4.Payload
 open class MemberToMember_SameName_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_SameName_Typedef_Swift4 : NSObject {
@@ -121,712 +83,582 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 20,
+    key.offset: 19,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 25,
+    key.offset: 24,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 30,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 37,
+    key.offset: 36,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 50,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 130,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 147,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 228,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 242,
-    key.length: 24
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 266,
+    key.offset: 49,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 271,
+    key.offset: 54,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 277,
+    key.offset: 60,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 310,
+    key.offset: 93,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 323,
+    key.offset: 106,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 333,
+    key.offset: 116,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 154,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 159,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 165,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 175,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 194,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 199,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 205,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 238,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 251,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 256,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 262,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 293,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 306,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 311,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 317,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 347,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 360,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 365,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 371,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 401,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 414,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 424,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 459,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 376,
+    key.offset: 464,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 382,
+    key.offset: 470,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 484,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 503,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 508,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 514,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 561,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 574,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 584,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 636,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 641,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 647,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 661,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 680,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 685,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 691,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 730,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 743,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 748,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 754,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 793,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 806,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 816,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 860,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 865,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 871,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 392,
+    key.offset: 881,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 412,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 436,
-    key.length: 14
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 450,
+    key.offset: 900,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 455,
+    key.offset: 905,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 461,
+    key.offset: 911,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 946,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 959,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 969,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1009,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1016,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1026,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1036,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1042,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1047,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1053,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1088,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1101,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1108,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1118,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 494,
-    key.length: 8
+    key.offset: 1151,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 507,
+    key.offset: 1155,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 512,
+    key.offset: 1160,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 518,
-    key.length: 28
+    key.offset: 1166,
+    key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 549,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 563,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 598,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 633,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 638,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 644,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 674,
+    key.offset: 1198,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 687,
+    key.offset: 1211,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 692,
+    key.offset: 1216,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 698,
-    key.length: 27
+    key.offset: 1222,
+    key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 728,
+    key.offset: 1254,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 741,
+    key.offset: 1267,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 751,
-    key.length: 27
+    key.offset: 1277,
+    key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 786,
-    key.length: 4
+    key.offset: 1314,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 791,
-    key.length: 5
+    key.offset: 1321,
+    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 797,
+    key.offset: 1331,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 811,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 831,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 859,
-    key.length: 28
+    key.offset: 1345,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 887,
+    key.offset: 1351,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 892,
+    key.offset: 1356,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 898,
-    key.length: 44
+    key.offset: 1362,
+    key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 945,
+    key.offset: 1411,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 958,
+    key.offset: 1424,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 968,
-    key.length: 44
+    key.offset: 1434,
+    key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1020,
-    key.length: 4
+    key.offset: 1488,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1025,
-    key.length: 5
+    key.offset: 1495,
+    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1031,
+    key.offset: 1505,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1045,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1065,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1096,
-    key.length: 31
+    key.offset: 1519,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1127,
+    key.offset: 1525,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1132,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1138,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1177,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1190,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1195,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1201,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1240,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1253,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1263,
-    key.length: 36
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1307,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1312,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1318,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1328,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1348,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1428,
-    key.length: 21
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1449,
-    key.length: 80
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
     key.offset: 1530,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1544,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1568,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1573,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1579,
-    key.length: 32
+    key.offset: 1536,
+    key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1614,
+    key.offset: 1577,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1590,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1595,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1601,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1642,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1627,
+    key.offset: 1655,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1637,
-    key.length: 32
+    key.offset: 1665,
+    key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1677,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1684,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1694,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1704,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
     key.offset: 1711,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1735,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1749,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1754,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1760,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1795,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1808,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1815,
+    key.offset: 1718,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1825,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1858,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1863,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1898,
-    key.length: 35
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1933,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1938,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1944,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1976,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1989,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1994,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2000,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2032,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2045,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2055,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2092,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2099,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2109,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2123,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2130,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2158,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2186,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2191,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2197,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2246,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2259,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2269,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2323,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2330,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2340,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2354,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2361,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2392,
-    key.length: 31
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2423,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2428,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2434,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2475,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2488,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2493,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2499,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2540,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2553,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2563,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2609,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2616,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2626,
+    key.offset: 1728,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2636,
+    key.offset: 1738,
     key.length: 3
   }
 ]
@@ -839,187 +671,187 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 37,
+    key.offset: 36,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 310,
+    key.offset: 93,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 333,
+    key.offset: 116,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 392,
+    key.offset: 175,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 494,
+    key.offset: 238,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 549,
+    key.offset: 293,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 674,
+    key.offset: 347,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 728,
+    key.offset: 401,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 751,
+    key.offset: 424,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 811,
+    key.offset: 484,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 945,
+    key.offset: 561,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 968,
+    key.offset: 584,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1045,
+    key.offset: 661,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1177,
+    key.offset: 730,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1240,
+    key.offset: 793,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1263,
+    key.offset: 816,
     key.length: 36
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1328,
+    key.offset: 881,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1614,
+    key.offset: 946,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1637,
+    key.offset: 969,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1704,
+    key.offset: 1036,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1795,
+    key.offset: 1088,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1858,
+    key.offset: 1151,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1976,
+    key.offset: 1198,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2032,
+    key.offset: 1254,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2055,
+    key.offset: 1277,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2123,
+    key.offset: 1345,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2246,
+    key.offset: 1411,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2269,
+    key.offset: 1434,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2354,
+    key.offset: 1519,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2475,
+    key.offset: 1577,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2540,
+    key.offset: 1642,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2563,
+    key.offset: 1665,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2636,
+    key.offset: 1738,
     key.length: 3
   }
 ]
@@ -1028,11 +860,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "Foo",
-    key.offset: 25,
+    key.offset: 24,
     key.length: 24,
-    key.nameoffset: 31,
+    key.nameoffset: 30,
     key.namelength: 3,
-    key.bodyoffset: 47,
+    key.bodyoffset: 46,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1041,7 +873,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 20,
+        key.offset: 19,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1049,7 +881,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 37,
+        key.offset: 36,
         key.length: 8
       }
     ]
@@ -1058,11 +890,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 271,
+    key.offset: 54,
     key.length: 51,
-    key.nameoffset: 277,
+    key.nameoffset: 60,
     key.namelength: 30,
-    key.bodyoffset: 320,
+    key.bodyoffset: 103,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1071,7 +903,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 266,
+        key.offset: 49,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1079,7 +911,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 310,
+        key.offset: 93,
         key.length: 8
       }
     ]
@@ -1087,22 +919,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 323,
+    key.offset: 106,
     key.length: 87,
-    key.nameoffset: 333,
+    key.nameoffset: 116,
     key.namelength: 30,
-    key.bodyoffset: 365,
+    key.bodyoffset: 148,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 376,
+        key.offset: 159,
         key.length: 32,
-        key.nameoffset: 382,
+        key.nameoffset: 165,
         key.namelength: 7,
-        key.bodyoffset: 402,
+        key.bodyoffset: 185,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1111,7 +943,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 371,
+            key.offset: 154,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1119,7 +951,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 392,
+            key.offset: 175,
             key.length: 8
           }
         ]
@@ -1130,11 +962,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 455,
+    key.offset: 199,
     key.length: 51,
-    key.nameoffset: 461,
+    key.nameoffset: 205,
     key.namelength: 30,
-    key.bodyoffset: 504,
+    key.bodyoffset: 248,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1143,7 +975,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 450,
+        key.offset: 194,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1151,7 +983,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 494,
+        key.offset: 238,
         key.length: 8
       }
     ]
@@ -1160,11 +992,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Payload",
-    key.offset: 512,
+    key.offset: 256,
     key.length: 49,
-    key.nameoffset: 518,
+    key.nameoffset: 262,
     key.namelength: 28,
-    key.bodyoffset: 559,
+    key.bodyoffset: 303,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1173,7 +1005,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 507,
+        key.offset: 251,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1181,7 +1013,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 549,
+        key.offset: 293,
         key.length: 8
       }
     ]
@@ -1190,11 +1022,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 638,
+    key.offset: 311,
     key.length: 48,
-    key.nameoffset: 644,
+    key.nameoffset: 317,
     key.namelength: 27,
-    key.bodyoffset: 684,
+    key.bodyoffset: 357,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1203,7 +1035,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 633,
+        key.offset: 306,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1211,7 +1043,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 674,
+        key.offset: 347,
         key.length: 8
       }
     ]
@@ -1220,11 +1052,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 692,
+    key.offset: 365,
     key.length: 48,
-    key.nameoffset: 698,
+    key.nameoffset: 371,
     key.namelength: 27,
-    key.bodyoffset: 738,
+    key.bodyoffset: 411,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1233,7 +1065,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 687,
+        key.offset: 360,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1241,7 +1073,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 728,
+        key.offset: 401,
         key.length: 8
       }
     ]
@@ -1249,22 +1081,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 741,
+    key.offset: 414,
     key.length: 88,
-    key.nameoffset: 751,
+    key.nameoffset: 424,
     key.namelength: 27,
-    key.bodyoffset: 780,
+    key.bodyoffset: 453,
     key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 791,
+        key.offset: 464,
         key.length: 36,
-        key.nameoffset: 797,
+        key.nameoffset: 470,
         key.namelength: 11,
-        key.bodyoffset: 821,
+        key.bodyoffset: 494,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1273,7 +1105,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 786,
+            key.offset: 459,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1281,7 +1113,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 811,
+            key.offset: 484,
             key.length: 8
           }
         ]
@@ -1292,11 +1124,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 892,
+    key.offset: 508,
     key.length: 65,
-    key.nameoffset: 898,
+    key.nameoffset: 514,
     key.namelength: 44,
-    key.bodyoffset: 955,
+    key.bodyoffset: 571,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1305,7 +1137,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 887,
+        key.offset: 503,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1313,7 +1145,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 945,
+        key.offset: 561,
         key.length: 8
       }
     ]
@@ -1321,22 +1153,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Class_Container",
-    key.offset: 958,
+    key.offset: 574,
     key.length: 105,
-    key.nameoffset: 968,
+    key.nameoffset: 584,
     key.namelength: 44,
-    key.bodyoffset: 1014,
+    key.bodyoffset: 630,
     key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "PayloadFor4",
-        key.offset: 1025,
+        key.offset: 641,
         key.length: 36,
-        key.nameoffset: 1031,
+        key.nameoffset: 647,
         key.namelength: 11,
-        key.bodyoffset: 1055,
+        key.bodyoffset: 671,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1345,7 +1177,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1020,
+            key.offset: 636,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1353,7 +1185,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1045,
+            key.offset: 661,
             key.length: 8
           }
         ]
@@ -1364,11 +1196,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift3",
-    key.offset: 1132,
+    key.offset: 685,
     key.length: 57,
-    key.nameoffset: 1138,
+    key.nameoffset: 691,
     key.namelength: 36,
-    key.bodyoffset: 1187,
+    key.bodyoffset: 740,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1377,7 +1209,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1127,
+        key.offset: 680,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1385,7 +1217,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1177,
+        key.offset: 730,
         key.length: 8
       }
     ]
@@ -1394,11 +1226,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1195,
+    key.offset: 748,
     key.length: 57,
-    key.nameoffset: 1201,
+    key.nameoffset: 754,
     key.namelength: 36,
-    key.bodyoffset: 1250,
+    key.bodyoffset: 803,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1407,7 +1239,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1190,
+        key.offset: 743,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1415,7 +1247,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1240,
+        key.offset: 793,
         key.length: 8
       }
     ]
@@ -1423,22 +1255,22 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Class_Swift4",
-    key.offset: 1253,
+    key.offset: 806,
     key.length: 93,
-    key.nameoffset: 1263,
+    key.nameoffset: 816,
     key.namelength: 36,
-    key.bodyoffset: 1301,
+    key.bodyoffset: 854,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 1312,
+        key.offset: 865,
         key.length: 32,
-        key.nameoffset: 1318,
+        key.nameoffset: 871,
         key.namelength: 7,
-        key.bodyoffset: 1338,
+        key.bodyoffset: 891,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -1447,7 +1279,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 1307,
+            key.offset: 860,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -1455,7 +1287,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 1328,
+            key.offset: 881,
             key.length: 8
           }
         ]
@@ -1466,11 +1298,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 1573,
+    key.offset: 905,
     key.length: 53,
-    key.nameoffset: 1579,
+    key.nameoffset: 911,
     key.namelength: 32,
-    key.bodyoffset: 1624,
+    key.bodyoffset: 956,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1479,7 +1311,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1568,
+        key.offset: 900,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1487,7 +1319,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1614,
+        key.offset: 946,
         key.length: 8
       }
     ]
@@ -1495,24 +1327,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 1627,
+    key.offset: 959,
     key.length: 82,
-    key.nameoffset: 1637,
+    key.nameoffset: 969,
     key.namelength: 32,
-    key.bodyoffset: 1671,
+    key.bodyoffset: 1003,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1684,
+        key.offset: 1016,
         key.length: 23,
-        key.nameoffset: 1694,
+        key.nameoffset: 1026,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1677,
+            key.offset: 1009,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1524,11 +1356,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 1754,
+    key.offset: 1047,
     key.length: 53,
-    key.nameoffset: 1760,
+    key.nameoffset: 1053,
     key.namelength: 32,
-    key.bodyoffset: 1805,
+    key.bodyoffset: 1098,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1537,7 +1369,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1749,
+        key.offset: 1042,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1545,7 +1377,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1795,
+        key.offset: 1088,
         key.length: 8
       }
     ]
@@ -1554,13 +1386,13 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MemberToGlobal_Typedef_Payload",
-    key.offset: 1815,
+    key.offset: 1108,
     key.length: 46,
-    key.nameoffset: 1825,
+    key.nameoffset: 1118,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 1808,
+        key.offset: 1101,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1570,11 +1402,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 1938,
+    key.offset: 1160,
     key.length: 50,
-    key.nameoffset: 1944,
+    key.nameoffset: 1166,
     key.namelength: 29,
-    key.bodyoffset: 1986,
+    key.bodyoffset: 1208,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1583,7 +1415,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1933,
+        key.offset: 1155,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1591,7 +1423,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1976,
+        key.offset: 1198,
         key.length: 8
       }
     ]
@@ -1600,11 +1432,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 1994,
+    key.offset: 1216,
     key.length: 50,
-    key.nameoffset: 2000,
+    key.nameoffset: 1222,
     key.namelength: 29,
-    key.bodyoffset: 2042,
+    key.bodyoffset: 1264,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1613,7 +1445,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 1989,
+        key.offset: 1211,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1621,7 +1453,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2032,
+        key.offset: 1254,
         key.length: 8
       }
     ]
@@ -1629,24 +1461,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 2045,
+    key.offset: 1267,
     key.length: 83,
-    key.nameoffset: 2055,
+    key.nameoffset: 1277,
     key.namelength: 29,
-    key.bodyoffset: 2086,
+    key.bodyoffset: 1308,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 2099,
+        key.offset: 1321,
         key.length: 27,
-        key.nameoffset: 2109,
+        key.nameoffset: 1331,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2092,
+            key.offset: 1314,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1658,11 +1490,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 2191,
+    key.offset: 1356,
     key.length: 67,
-    key.nameoffset: 2197,
+    key.nameoffset: 1362,
     key.namelength: 46,
-    key.bodyoffset: 2256,
+    key.bodyoffset: 1421,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1671,7 +1503,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2186,
+        key.offset: 1351,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1679,7 +1511,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2246,
+        key.offset: 1411,
         key.length: 8
       }
     ]
@@ -1687,24 +1519,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 2259,
+    key.offset: 1424,
     key.length: 100,
-    key.nameoffset: 2269,
+    key.nameoffset: 1434,
     key.namelength: 46,
-    key.bodyoffset: 2317,
+    key.bodyoffset: 1482,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 2330,
+        key.offset: 1495,
         key.length: 27,
-        key.nameoffset: 2340,
+        key.nameoffset: 1505,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2323,
+            key.offset: 1488,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1716,11 +1548,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 2428,
+    key.offset: 1530,
     key.length: 59,
-    key.nameoffset: 2434,
+    key.nameoffset: 1536,
     key.namelength: 38,
-    key.bodyoffset: 2485,
+    key.bodyoffset: 1587,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1729,7 +1561,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2423,
+        key.offset: 1525,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1737,7 +1569,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2475,
+        key.offset: 1577,
         key.length: 8
       }
     ]
@@ -1746,11 +1578,11 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 2493,
+    key.offset: 1595,
     key.length: 59,
-    key.nameoffset: 2499,
+    key.nameoffset: 1601,
     key.namelength: 38,
-    key.bodyoffset: 2550,
+    key.bodyoffset: 1652,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1759,7 +1591,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 2488,
+        key.offset: 1590,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1767,7 +1599,7 @@ extension MemberToMember_SameName_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2540,
+        key.offset: 1642,
         key.length: 8
       }
     ]
@@ -1775,24 +1607,24 @@ extension MemberToMember_SameName_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 2553,
+    key.offset: 1655,
     key.length: 88,
-    key.nameoffset: 2563,
+    key.nameoffset: 1665,
     key.namelength: 38,
-    key.bodyoffset: 2603,
+    key.bodyoffset: 1705,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2616,
+        key.offset: 1718,
         key.length: 23,
-        key.nameoffset: 2626,
+        key.nameoffset: 1728,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2609,
+            key.offset: 1711,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.explicit.response
@@ -1,6 +1,7 @@
 
 public func fooHelperExplicitFrameworkFunc1(_ a: Int32) -> Int32
 
+
 [
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
@@ -1,9 +1,7 @@
 import FooHelper.FooHelperExplicit
 import FooHelper.FooHelperSub
 
-
 public func fooHelperFunc1(_ a: Int32) -> Int32
-
 public var FooHelperUnnamedEnumeratorA1: Int { get }
 public var FooHelperUnnamedEnumeratorA2: Int { get }
 
@@ -40,87 +38,87 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 67,
+    key.offset: 66,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 74,
+    key.offset: 73,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 79,
+    key.offset: 78,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 94,
+    key.offset: 93,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 96,
+    key.offset: 95,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 99,
+    key.offset: 98,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 109,
+    key.offset: 108,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 116,
+    key.offset: 114,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 123,
+    key.offset: 121,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 127,
+    key.offset: 125,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 157,
+    key.offset: 155,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 163,
+    key.offset: 161,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 169,
+    key.offset: 167,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 176,
+    key.offset: 174,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 180,
+    key.offset: 178,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 210,
+    key.offset: 208,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 216,
+    key.offset: 214,
     key.length: 3
   }
 ]
@@ -147,25 +145,25 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 99,
+    key.offset: 98,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 109,
+    key.offset: 108,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 157,
+    key.offset: 155,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 210,
+    key.offset: 208,
     key.length: 3,
     key.is_system: 1
   }
@@ -175,14 +173,14 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooHelperFunc1(_:)",
-    key.offset: 74,
+    key.offset: 73,
     key.length: 40,
     key.typename: "Int32",
-    key.nameoffset: 79,
+    key.nameoffset: 78,
     key.namelength: 26,
     key.attributes: [
       {
-        key.offset: 67,
+        key.offset: 66,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -191,7 +189,7 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 94,
+        key.offset: 93,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -201,16 +199,16 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooHelperUnnamedEnumeratorA1",
-    key.offset: 123,
+    key.offset: 121,
     key.length: 45,
     key.typename: "Int",
-    key.nameoffset: 127,
+    key.nameoffset: 125,
     key.namelength: 28,
-    key.bodyoffset: 162,
+    key.bodyoffset: 160,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 116,
+        key.offset: 114,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -220,16 +218,16 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooHelperUnnamedEnumeratorA2",
-    key.offset: 176,
+    key.offset: 174,
     key.length: 45,
     key.typename: "Int",
-    key.nameoffset: 180,
+    key.nameoffset: 178,
     key.namelength: 28,
-    key.bodyoffset: 215,
+    key.bodyoffset: 213,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 169,
+        key.offset: 167,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
@@ -2,8 +2,11 @@ import FooHelper.FooHelperExplicit
 import FooHelper.FooHelperSub
 
 public func fooHelperFunc1(_ a: Int32) -> Int32
+
 public var FooHelperUnnamedEnumeratorA1: Int { get }
+
 public var FooHelperUnnamedEnumeratorA2: Int { get }
+
 
 [
   {
@@ -73,52 +76,52 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 114,
+    key.offset: 115,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 121,
+    key.offset: 122,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 125,
+    key.offset: 126,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 155,
+    key.offset: 156,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 161,
+    key.offset: 162,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 167,
+    key.offset: 169,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 174,
+    key.offset: 176,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 178,
+    key.offset: 180,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 208,
+    key.offset: 210,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 214,
+    key.offset: 216,
     key.length: 3
   }
 ]
@@ -157,13 +160,13 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 155,
+    key.offset: 156,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 208,
+    key.offset: 210,
     key.length: 3,
     key.is_system: 1
   }
@@ -199,16 +202,16 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooHelperUnnamedEnumeratorA1",
-    key.offset: 121,
+    key.offset: 122,
     key.length: 45,
     key.typename: "Int",
-    key.nameoffset: 125,
+    key.nameoffset: 126,
     key.namelength: 28,
-    key.bodyoffset: 160,
+    key.bodyoffset: 161,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 114,
+        key.offset: 115,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -218,16 +221,16 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooHelperUnnamedEnumeratorA2",
-    key.offset: 174,
+    key.offset: 176,
     key.length: 45,
     key.typename: "Int",
-    key.nameoffset: 178,
+    key.nameoffset: 180,
     key.namelength: 28,
-    key.bodyoffset: 213,
+    key.bodyoffset: 215,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 167,
+        key.offset: 169,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -2,14 +2,6 @@ import Foo.FooSub
 import FooHelper
 import SwiftOnoneSupport
 
-/*  Foo.h
-  Copyright (c) 1815, Napoleon Bonaparte. All rights reserved.
-*/
-
-// Types.
-
-// and stuff.
-// Yo.
 
 /// Aaa.  FooEnum1.  Bbb.
 public struct FooEnum1 : Equatable, RawRepresentable {
@@ -23,7 +15,6 @@ public struct FooEnum1 : Equatable, RawRepresentable {
 
 /// Aaa.  FooEnum1X.  Bbb.
 public var FooEnum1X: FooEnum1 { get }
-
 public struct FooEnum2 : Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
@@ -48,11 +39,9 @@ public var FooEnum3Y: FooEnum3 { get }
 /// Aaa.  FooComparisonResult.  Bbb.
 public enum FooComparisonResult : Int {
 
-    
-    // This is ascending
     case orderedAscending = -1
 
-    case orderedSame = 0 // But this is the same.
+    case orderedSame = 0
 
     case orderedDescending = 1
 }
@@ -62,13 +51,10 @@ public struct FooRuncingOptions : OptionSet {
 
     public init(rawValue: Int)
 
-    
-    // This is mince.
     public static var enableMince: FooRuncingOptions { get }
 
-    public static var enableQuince: FooRuncingOptions { get } /* But this is quince */
+    public static var enableQuince: FooRuncingOptions { get }
 }
-
 public struct FooStruct1 {
 
     public init()
@@ -80,7 +66,6 @@ public struct FooStruct1 {
     public var y: Double
 }
 public typealias FooStruct1Pointer = UnsafeMutablePointer<FooStruct1>
-
 public struct FooStruct2 {
 
     public init()
@@ -92,7 +77,6 @@ public struct FooStruct2 {
     public var y: Double
 }
 public typealias FooStructTypedef1 = FooStruct2
-
 public struct FooStructTypedef2 {
 
     public init()
@@ -112,18 +96,10 @@ public var fooIntVar: Int32
 
 /// Aaa.  fooFunc1.  Bbb.
 public func fooFunc1(_ a: Int32) -> Int32
-
 public func fooFunc1AnonymousParam(_: Int32) -> Int32
 public func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
-
-/*
-  Very good
-  fooFuncWithBlock function.
-*/
 public func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
-
 public func fooFuncWithFunctionPointer(_ fptr: (@convention(c) (Float) -> Int32)!)
-
 public func fooFuncNoreturn1() -> Never
 public func fooFuncNoreturn2() -> Never
 
@@ -166,37 +142,33 @@ public func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32
 /// Aaa.  FooProtocolBase.  Bbb.
 public protocol FooProtocolBase {
 
-    
+
     /// Aaa.  fooProtoFunc.  Bbb.
     /// Ccc.
     func fooProtoFunc()
 
-    
+
     /// Aaa.  fooProtoFuncWithExtraIndentation1.  Bbb.
     /// Ccc.
     func fooProtoFuncWithExtraIndentation1()
 
-    
+
     /**
      * Aaa.  fooProtoFuncWithExtraIndentation2.  Bbb.
      * Ccc.
      */
     func fooProtoFuncWithExtraIndentation2()
 
-    
     static func fooProtoClassFunc()
 
-    
     var fooProperty1: Int32 { get set }
 
     var fooProperty2: Int32 { get set }
 
     var fooProperty3: Int32 { get }
 }
-
 public protocol FooProtocolDerived : FooProtocolBase {
 }
-
 open class FooClassBase {
 
     open func fooBaseInstanceFunc0()
@@ -209,44 +181,32 @@ open class FooClassBase {
 
     open func fooBaseInstanceFuncOverridden()
 
-    
     open class func fooBaseClassFunc0()
 }
 
 /// Aaa.  FooClassDerived.  Bbb.
 open class FooClassDerived : FooClassBase, FooProtocolDerived {
 
-    
     open var fooProperty1: Int32
 
     open var fooProperty2: Int32
 
     open var fooProperty3: Int32 { get }
 
-    
-    /* Blah..
-       for fooInstanceFunc0..
-       blah blah.
-    */
     open func fooInstanceFunc0()
 
     open func fooInstanceFunc1(_ a: Int32)
 
     open func fooInstanceFunc2(_ a: Int32, withB b: Int32)
 
-    
     open func fooBaseInstanceFuncOverridden()
 
-    
     open class func fooClassFunc0()
 }
-
 public typealias typedef_int_t = Int32
-
-/* FOO_MACRO_1 is the answer */
 public var FOO_MACRO_1: Int32 { get }
 public var FOO_MACRO_2: Int32 { get }
-public var FOO_MACRO_3: Int32 { get } // Don't use FOO_MACRO_3 on Saturdays.
+public var FOO_MACRO_3: Int32 { get }
 public var FOO_MACRO_4: UInt32 { get }
 public var FOO_MACRO_5: UInt64 { get }
 public var FOO_MACRO_6: typedef_int_t { get }
@@ -259,15 +219,10 @@ public var FOO_MACRO_OR: Int32 { get }
 public var FOO_MACRO_AND: Int32 { get }
 public var FOO_MACRO_BITWIDTH: UInt64 { get }
 public var FOO_MACRO_SIGNED: UInt32 { get }
-
 public var FOO_MACRO_REDEF_1: Int32 { get }
-
 public var FOO_MACRO_REDEF_2: Int32 { get }
-
 public func theLastDeclInFoo()
-
 public func _internalTopLevelFunc()
-
 public struct _InternalStruct {
 
     public init()
@@ -276,31 +231,24 @@ public struct _InternalStruct {
 
     public var x: Int32
 }
-
 extension FooClassBase {
 
     open func _internalMeth1() -> Any!
 }
-
-/* Extending FooClassBase with cool stuff */
 extension FooClassBase {
 
     open func _internalMeth2() -> Any!
 
     open func nonInternalMeth() -> Any!
 }
-
 extension FooClassBase {
 
     open func _internalMeth3() -> Any!
 }
-
 public protocol _InternalProt {
 }
-
 open class ClassWithInternalProt : _InternalProt {
 }
-
 open class FooClassPropertyOwnership : FooClassBase {
 
     unowned(unsafe) open var assignable: AnyObject!
@@ -317,34 +265,27 @@ open class FooClassPropertyOwnership : FooClassBase {
 
     open var scalar: Int32
 }
-
 open class FooUnavailableMembers : FooClassBase {
 
     public convenience init!(int i: Int32)
 
-    
     @available(*, deprecated, message: "x")
     open func deprecated()
 
-    
     @available(macOS 10.1, *)
     open func availabilityIntroduced()
 
-    
     @available(macOS, introduced: 10.1, message: "x")
     open func availabilityIntroducedMsg()
 }
-
 public class FooCFType {
 }
-
 @available(*, deprecated, message: "use CNAuthorizationStatus")
 public enum ABAuthorizationStatus : Int {
 
-    
-    case notDetermined = 0 // deprecated, use CNAuthorizationStatusNotDetermined
+    case notDetermined = 0
 
-    case restricted = 1 // deprecated, use CNAuthorizationStatusRestricted
+    case restricted = 1
 }
 public class FooOverlayClassBase {
 
@@ -394,584 +335,664 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 17
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 61,
-    key.length: 75
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 138,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 149,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 163,
-    key.length: 7
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 171,
+    key.offset: 62,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 197,
+    key.offset: 88,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 204,
+    key.offset: 95,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 211,
+    key.offset: 102,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 222,
+    key.offset: 113,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 233,
+    key.offset: 124,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 257,
+    key.offset: 148,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 264,
+    key.offset: 155,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 269,
+    key.offset: 160,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 271,
+    key.offset: 162,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 281,
+    key.offset: 172,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 294,
+    key.offset: 185,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 301,
+    key.offset: 192,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 306,
+    key.offset: 197,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 316,
+    key.offset: 207,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 329,
+    key.offset: 220,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 336,
+    key.offset: 227,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 340,
+    key.offset: 231,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 350,
+    key.offset: 241,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 360,
+    key.offset: 251,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 387,
+    key.offset: 278,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 394,
+    key.offset: 285,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 398,
+    key.offset: 289,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 409,
+    key.offset: 300,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 420,
+    key.offset: 311,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 427,
+    key.offset: 317,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 434,
+    key.offset: 324,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 441,
+    key.offset: 331,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 452,
+    key.offset: 342,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 463,
+    key.offset: 353,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 487,
+    key.offset: 377,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 494,
+    key.offset: 384,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 499,
+    key.offset: 389,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 391,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 401,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 414,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 421,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 426,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 436,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 449,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 456,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 460,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 470,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 479,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 486,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 490,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 501,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 511,
-    key.length: 6
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 512,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 524,
+    key.offset: 518,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 531,
+    key.offset: 525,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 529,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 540,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 551,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 557,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 564,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 571,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 582,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 593,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 617,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 624,
     key.length: 4
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 629,
+    key.length: 1
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 536,
+    key.offset: 631,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 546,
+    key.offset: 641,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 559,
+    key.offset: 654,
     key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 566,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 570,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 580,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 589,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 596,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 600,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 611,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 622,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 628,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 635,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 639,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 650,
-    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 661,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 667,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 674,
-    key.length: 6
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 681,
+    key.offset: 666,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 692,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 703,
-    key.length: 16
+    key.offset: 676,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 727,
+    key.offset: 689,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 734,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 739,
-    key.length: 1
+    key.offset: 696,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 700,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 710,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 719,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 726,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 730,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 741,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 751,
-    key.length: 6
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 752,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 764,
+    key.offset: 758,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 771,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 776,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 786,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 799,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 806,
+    key.offset: 765,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 810,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 820,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 829,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 836,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 840,
+    key.offset: 769,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 851,
+    key.offset: 780,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 862,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 868,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 875,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 879,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 890,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 901,
+    key.offset: 791,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 908,
+    key.offset: 798,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 945,
+    key.offset: 835,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 952,
+    key.offset: 842,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 957,
+    key.offset: 847,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 979,
+    key.offset: 869,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 995,
-    key.length: 21
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1020,
+    key.offset: 880,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1025,
+    key.offset: 885,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1044,
+    key.offset: 904,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1052,
+    key.offset: 912,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1057,
+    key.offset: 917,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1071,
+    key.offset: 931,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1073,
-    key.length: 25
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1103,
+    key.offset: 938,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1108,
+    key.offset: 943,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 1128,
+    key.offset: 963,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1133,
+    key.offset: 968,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1168,
+    key.offset: 1003,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1175,
+    key.offset: 1010,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1182,
+    key.offset: 1017,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1202,
+    key.offset: 1037,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1219,
+    key.offset: 1054,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1226,
+    key.offset: 1061,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1231,
+    key.offset: 1066,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1241,
+    key.offset: 1076,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1256,
-    key.length: 18
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1278,
+    key.offset: 1086,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1285,
+    key.offset: 1093,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1292,
+    key.offset: 1100,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1296,
+    key.offset: 1104,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1309,
+    key.offset: 1117,
     key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1137,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1148,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1155,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1162,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1166,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1180,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1200,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1208,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1215,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1222,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1240,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1247,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1259,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1266,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1271,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1274,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1281,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1284,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1297,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1304,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1308,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1311,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1322,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -979,204 +1000,219 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1340,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1347,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1354,
-    key.length: 3
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1358,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1372,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1392,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1398,
-    key.length: 24
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1426,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1433,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1440,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1458,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1465,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1477,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1484,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1489,
+    key.offset: 1333,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1492,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1499,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1502,
+    key.offset: 1336,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1515,
+    key.offset: 1345,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1522,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1526,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1529,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1540,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1547,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1551,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1554,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1563,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1570,
+    key.offset: 1352,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1580,
+    key.offset: 1362,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1600,
+    key.offset: 1382,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1621,
+    key.offset: 1403,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1634,
+    key.offset: 1415,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1641,
+    key.offset: 1422,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1648,
+    key.offset: 1429,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1666,
+    key.offset: 1447,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1673,
+    key.offset: 1454,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1685,
+    key.offset: 1466,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1692,
+    key.offset: 1473,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1697,
+    key.offset: 1478,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1700,
+    key.offset: 1481,
     key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1488,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1491,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1504,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1511,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1515,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1518,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1529,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1536,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1540,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1543,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1552,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1559,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1569,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1589,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1600,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1607,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1614,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1639,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1646,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1658,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1665,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1670,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1673,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1680,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1683,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1696,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1703,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
@@ -1186,137 +1222,112 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1710,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1723,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1730,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1734,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1737,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1748,
+    key.offset: 1721,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1755,
+    key.offset: 1728,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1759,
+    key.offset: 1732,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1762,
+    key.offset: 1735,
     key.length: 6
   },
   {
+    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.offset: 1745,
+    key.length: 29
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1771,
+    key.offset: 1774,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1778,
+    key.offset: 1781,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1788,
-    key.length: 17
+    key.offset: 1791,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1808,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1820,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1827,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1834,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1859,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1866,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1878,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1885,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1890,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1893,
+    key.offset: 1805,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1900,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1903,
-    key.length: 6
+    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.offset: 1812,
+    key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1916,
+    key.offset: 1839,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1923,
+    key.offset: 1846,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1927,
+    key.offset: 1850,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1861,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.doccomment,
+    key.offset: 1868,
+    key.length: 26
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1894,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1901,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1906,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1915,
     key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1917,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1920,
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
@@ -1325,103 +1336,148 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1941,
+    key.offset: 1936,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1948,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1952,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1955,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1965,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1994,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2001,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2011,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2025,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2032,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2059,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2066,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2070,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2081,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2088,
-    key.length: 26
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2114,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2121,
+    key.offset: 1943,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2126,
+    key.offset: 1948,
+    key.length: 22
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1971,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1974,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1984,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1990,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1997,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2002,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2135,
+    key.offset: 2011,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2137,
+    key.offset: 2013,
     key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2016,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2023,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2025,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2028,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2035,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2037,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2040,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2048,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2050,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2053,
+    key.length: 20
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2074,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2086,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2092,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2099,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2104,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2121,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2123,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2130,
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
@@ -1429,799 +1485,809 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2150,
-    key.length: 5
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2157,
+    key.offset: 2149,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2164,
+    key.offset: 2156,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2169,
-    key.length: 22
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2192,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2195,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2205,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2211,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2218,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2223,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2232,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2234,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2237,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2244,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2246,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2249,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2256,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2258,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2261,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2269,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2271,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2274,
-    key.length: 20
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2295,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2307,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2314,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2361,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2368,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2373,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2390,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2392,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2399,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2409,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2419,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2426,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2431,
+    key.offset: 2161,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2458,
+    key.offset: 2188,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2460,
+    key.offset: 2190,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2467,
+    key.offset: 2197,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2479,
+    key.offset: 2209,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2483,
+    key.offset: 2213,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2493,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2503,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2510,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2515,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2537,
+    key.offset: 2223,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2543,
+    key.offset: 2232,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2550,
+    key.offset: 2239,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2555,
+    key.offset: 2244,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2577,
+    key.offset: 2266,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2272,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2279,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2284,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2306,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2584,
+    key.offset: 2313,
     key.length: 62
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2647,
+    key.offset: 2376,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2654,
+    key.offset: 2383,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2659,
+    key.offset: 2388,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2682,
+    key.offset: 2411,
     key.length: 42
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2725,
+    key.offset: 2454,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2732,
+    key.offset: 2461,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2737,
+    key.offset: 2466,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2760,
+    key.offset: 2489,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2804,
+    key.offset: 2533,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2820,
+    key.offset: 2549,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2827,
+    key.offset: 2556,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2832,
+    key.offset: 2561,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2855,
+    key.offset: 2584,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2899,
+    key.offset: 2628,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2908,
+    key.offset: 2637,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2915,
+    key.offset: 2644,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2920,
+    key.offset: 2649,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2943,
+    key.offset: 2672,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2980,
+    key.offset: 2709,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2989,
+    key.offset: 2718,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2993,
+    key.offset: 2722,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3002,
+    key.offset: 2731,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3009,
+    key.offset: 2738,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3014,
+    key.offset: 2743,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3037,
+    key.offset: 2766,
     key.length: 50
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3087,
+    key.offset: 2816,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3094,
+    key.offset: 2823,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3099,
+    key.offset: 2828,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3132,
+    key.offset: 2861,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3134,
+    key.offset: 2863,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3137,
+    key.offset: 2866,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3147,
+    key.offset: 2876,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3154,
+    key.offset: 2883,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3187,
+    key.offset: 2916,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3194,
+    key.offset: 2923,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3203,
+    key.offset: 2932,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3231,
+    key.offset: 2956,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3265,
+    key.offset: 2990,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3278,
+    key.offset: 3003,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3283,
+    key.offset: 3008,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3308,
+    key.offset: 3029,
     key.length: 51
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3363,
+    key.offset: 3084,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3376,
+    key.offset: 3097,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3381,
+    key.offset: 3102,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3427,
+    key.offset: 3144,
     key.length: 77
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3509,
+    key.offset: 3226,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3514,
+    key.offset: 3231,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3560,
+    key.offset: 3272,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3567,
+    key.offset: 3279,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3572,
+    key.offset: 3284,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3602,
+    key.offset: 3309,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3606,
+    key.offset: 3313,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3620,
+    key.offset: 3327,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3628,
+    key.offset: 3335,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3632,
+    key.offset: 3339,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3643,
+    key.offset: 3350,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3647,
+    key.offset: 3354,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3661,
+    key.offset: 3368,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3669,
+    key.offset: 3376,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3673,
+    key.offset: 3380,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3684,
+    key.offset: 3391,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3688,
+    key.offset: 3395,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3702,
+    key.offset: 3409,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3710,
+    key.offset: 3417,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3719,
+    key.offset: 3425,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3726,
+    key.offset: 3432,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3735,
+    key.offset: 3441,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3756,
+    key.offset: 3462,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3777,
+    key.offset: 3482,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3782,
+    key.offset: 3487,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3788,
+    key.offset: 3493,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3808,
+    key.offset: 3513,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3813,
+    key.offset: 3518,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3818,
+    key.offset: 3523,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3846,
+    key.offset: 3551,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3851,
+    key.offset: 3556,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3856,
+    key.offset: 3561,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3877,
+    key.offset: 3582,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3879,
+    key.offset: 3584,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3889,
+    key.offset: 3594,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3898,
+    key.offset: 3603,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3917,
+    key.offset: 3622,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3924,
+    key.offset: 3629,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3937,
+    key.offset: 3642,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3944,
+    key.offset: 3649,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3956,
+    key.offset: 3661,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3962,
+    key.offset: 3667,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3968,
+    key.offset: 3673,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3971,
+    key.offset: 3676,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3983,
+    key.offset: 3688,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3988,
+    key.offset: 3693,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3993,
+    key.offset: 3698,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4035,
+    key.offset: 3735,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4040,
+    key.offset: 3740,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4046,
+    key.offset: 3746,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4051,
+    key.offset: 3751,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 4074,
+    key.offset: 3774,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4107,
+    key.offset: 3807,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4112,
+    key.offset: 3812,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4118,
+    key.offset: 3818,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4136,
+    key.offset: 3836,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4150,
+    key.offset: 3850,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4181,
+    key.offset: 3876,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4186,
+    key.offset: 3881,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4190,
+    key.offset: 3885,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4204,
+    key.offset: 3899,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4215,
+    key.offset: 3910,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4220,
+    key.offset: 3915,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4224,
+    key.offset: 3919,
     key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3933,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3944,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3949,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3953,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3967,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3975,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3986,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3991,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3996,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4020,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4025,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4030,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4047,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4049,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4052,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4064,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4069,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4074,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4091,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4093,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4096,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4103,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4109,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4112,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4124,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4129,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4134,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4171,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4176,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4182,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4187,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4205,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4212,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4222,
+    key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
@@ -2230,188 +2296,273 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4249,
-    key.length: 4
+    key.offset: 4244,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4254,
+    key.offset: 4251,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4258,
-    key.length: 12
+    key.offset: 4255,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4272,
+    key.offset: 4268,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4280,
+    key.offset: 4276,
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4296,
-    key.length: 64
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4365,
-    key.length: 4
+    key.offset: 4282,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4370,
-    key.length: 4
+    key.offset: 4289,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4375,
-    key.length: 16
+    key.offset: 4293,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4306,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4314,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4399,
-    key.length: 4
+    key.offset: 4320,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4327,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4331,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4344,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4352,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4358,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4365,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4369,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4382,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4391,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4397,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4404,
-    key.length: 4
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4409,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4426,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4428,
-    key.length: 1
+    key.offset: 4408,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4431,
-    key.length: 5
+    key.offset: 4421,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4430,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4436,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4443,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4448,
-    key.length: 4
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4453,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4470,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4472,
-    key.length: 1
+    key.offset: 4447,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4475,
-    key.length: 5
+    key.offset: 4460,
+    key.length: 13
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4476,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 4482,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4488,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4491,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4508,
-    key.length: 4
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4513,
-    key.length: 4
+    key.offset: 4489,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4518,
-    key.length: 29
+    key.offset: 4493,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4506,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4522,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4528,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4535,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4539,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4552,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4560,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4565,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4571,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4576,
-    key.length: 13
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4595,
+    key.offset: 4566,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4602,
-    key.length: 9
+    key.offset: 4573,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4612,
-    key.length: 13
+    key.offset: 4577,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4628,
+    key.offset: 4590,
     key.length: 5
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4635,
-    key.length: 31
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4598,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4667,
+    key.offset: 4604,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4611,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4615,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4629,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4637,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4643,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4650,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4654,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4668,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2419,1188 +2570,903 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4678,
-    key.length: 11
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4680,
+    key.length: 6
   },
   {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4687,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4691,
-    key.length: 5
+    key.length: 12
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4699,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 4705,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4712,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4716,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4729,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4737,
+    key.offset: 4713,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4743,
+    key.offset: 4719,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4750,
+    key.offset: 4726,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4754,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4767,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4775,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 4781,
-    key.length: 39
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4820,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4827,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4831,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4844,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4853,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4859,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4866,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4870,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4883,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4892,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4898,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4905,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4909,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4922,
-    key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4938,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4944,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4951,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4955,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4968,
-    key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4984,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4990,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4997,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5001,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5014,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5022,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5028,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5035,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5039,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5052,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5060,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5066,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5073,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5077,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5091,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5099,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5105,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5112,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5116,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5130,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5136,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5142,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5149,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5153,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5167,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5175,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5181,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5188,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5192,
+    key.offset: 4730,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5207,
+    key.offset: 4745,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5215,
+    key.offset: 4753,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5221,
+    key.offset: 4759,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5228,
+    key.offset: 4766,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5232,
+    key.offset: 4770,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5252,
+    key.offset: 4790,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5261,
+    key.offset: 4799,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5267,
+    key.offset: 4805,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5274,
+    key.offset: 4812,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5278,
+    key.offset: 4816,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5296,
+    key.offset: 4834,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5305,
+    key.offset: 4843,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5312,
+    key.offset: 4849,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4856,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4860,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4879,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4887,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4893,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4900,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4904,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4923,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4931,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4937,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4944,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4949,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4968,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4975,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4980,
+    key.length: 21
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5004,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5011,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5018,
+    key.length: 15
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5041,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5048,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5060,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5067,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5072,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5075,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5087,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5094,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5098,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5101,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5109,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5119,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5139,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5144,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5149,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5169,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5176,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5186,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5206,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5211,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5216,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5236,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5246,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5251,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5256,
+    key.length: 15
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5277,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5284,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5294,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5314,
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5319,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5323,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5342,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5350,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5357,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5364,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5368,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5387,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5395,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5402,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5409,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5414,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5434,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5441,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5446,
-    key.length: 21
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5471,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5478,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5485,
-    key.length: 15
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5508,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5515,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5527,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5534,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5539,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5542,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5554,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5561,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5565,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5568,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5577,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5587,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5607,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5612,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5617,
+    key.offset: 5324,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5637,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 5645,
-    key.length: 44
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5690,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5700,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5720,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5725,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5730,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5750,
+    key.offset: 5344,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5760,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5765,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5770,
-    key.length: 15
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5791,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5799,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5809,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5829,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5834,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5839,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5859,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5867,
+    key.offset: 5351,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5874,
+    key.offset: 5358,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5883,
+    key.offset: 5367,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5902,
+    key.offset: 5385,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5907,
+    key.offset: 5390,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5913,
+    key.offset: 5396,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5937,
+    key.offset: 5420,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5956,
+    key.offset: 5438,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5961,
+    key.offset: 5443,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5967,
+    key.offset: 5449,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5995,
+    key.offset: 5477,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6015,
+    key.offset: 5497,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6031,
+    key.offset: 5513,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6036,
+    key.offset: 5518,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6040,
+    key.offset: 5522,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6052,
+    key.offset: 5534,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6068,
+    key.offset: 5550,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6084,
+    key.offset: 5566,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6089,
+    key.offset: 5571,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6093,
+    key.offset: 5575,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5593,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5609,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5614,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5618,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5630,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5640,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5645,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5649,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5660,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5670,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5675,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5679,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5689,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5699,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5704,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5709,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5713,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5722,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5738,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5743,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5747,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5755,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5763,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5768,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5774,
+    key.length: 21
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5798,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5818,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5825,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5837,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5843,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5847,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5850,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5862,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 5873,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5876,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5888,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.string,
+    key.offset: 5897,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5906,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5911,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5916,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5934,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5945,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.number,
+    key.offset: 5951,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.operator,
+    key.offset: 5957,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5964,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5969,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5974,
+    key.length: 22
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6004,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6015,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6022,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.number,
+    key.offset: 6034,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6040,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.string,
+    key.offset: 6049,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6058,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6063,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6068,
+    key.length: 25
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6098,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6105,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 6111,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6127,
-    key.length: 4
+    key.offset: 6125,
+    key.length: 10
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6132,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.kind: source.lang.swift.syntaxtype.operator,
     key.offset: 6136,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6148,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6158,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6163,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6167,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6178,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6188,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6193,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6197,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6207,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6217,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6222,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6227,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6231,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6240,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6256,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6261,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6265,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6273,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6282,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6287,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6293,
-    key.length: 21
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6317,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6337,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6344,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6356,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6362,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6366,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6369,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6386,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 6397,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6400,
+    key.offset: 6139,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6412,
+    key.offset: 6151,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6421,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6430,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6435,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6440,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6463,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6474,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6480,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 6486,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6493,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6498,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6503,
-    key.length: 22
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6538,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6549,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6556,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6568,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6574,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6583,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6592,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6597,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6602,
-    key.length: 25
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6633,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6640,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6646,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6661,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 6672,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6675,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6687,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6696,
+    key.offset: 6160,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6725,
+    key.offset: 6189,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6732,
+    key.offset: 6196,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6737,
+    key.offset: 6201,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6761,
+    key.offset: 6225,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6777,
+    key.offset: 6236,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6782,
+    key.offset: 6241,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6798,
+    key.offset: 6257,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 6800,
-    key.length: 54
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6859,
+    key.offset: 6264,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6864,
+    key.offset: 6269,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6877,
+    key.offset: 6282,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 6879,
-    key.length: 51
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6932,
+    key.offset: 6286,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6939,
+    key.offset: 6293,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6945,
+    key.offset: 6299,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6972,
+    key.offset: 6326,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6979,
+    key.offset: 6333,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6984,
+    key.offset: 6338,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6991,
+    key.offset: 6345,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6998,
+    key.offset: 6352,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7004,
+    key.offset: 6358,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 7029,
+    key.offset: 6383,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 7033,
+    key.offset: 6387,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7060,
+    key.offset: 6414,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 7069,
+    key.offset: 6423,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 7076,
+    key.offset: 6430,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 7081,
+    key.offset: 6435,
     key.length: 1
   }
 ]
@@ -3628,221 +3494,251 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 222,
+    key.offset: 113,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 233,
+    key.offset: 124,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 281,
+    key.offset: 172,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 316,
+    key.offset: 207,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 350,
+    key.offset: 241,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 409,
+    key.offset: 300,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 452,
+    key.offset: 342,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 463,
+    key.offset: 353,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 511,
+    key.offset: 401,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 546,
+    key.offset: 436,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 580,
+    key.offset: 470,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 611,
+    key.offset: 501,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 650,
+    key.offset: 540,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 692,
+    key.offset: 582,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 703,
+    key.offset: 593,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 751,
+    key.offset: 641,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 786,
+    key.offset: 676,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 820,
+    key.offset: 710,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 851,
+    key.offset: 741,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 890,
+    key.offset: 780,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 979,
+    key.offset: 869,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 1202,
+    key.offset: 1037,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1241,
+    key.offset: 1076,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1309,
+    key.offset: 1117,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1372,
+    key.offset: 1180,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1492,
+    key.offset: 1274,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1502,
+    key.offset: 1284,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1529,
+    key.offset: 1311,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1554,
+    key.offset: 1336,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1600,
+    key.offset: 1382,
     key.length: 20,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1621,
+    key.offset: 1403,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1700,
+    key.offset: 1481,
     key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1491,
+    key.length: 6,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1518,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1543,
+    key.length: 6,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1589,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1673,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1683,
+    key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.offset: 1710,
-    key.length: 6,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 1737,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1762,
+    key.offset: 1735,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1808,
-    key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 1893,
+    key.offset: 1805,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1903,
-    key.length: 6,
+    key.offset: 1861,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1920,
+    key.length: 5,
     key.is_system: 1
   },
   {
@@ -3853,19 +3749,55 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1955,
-    key.length: 6,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2025,
+    key.offset: 1974,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2081,
+    key.offset: 1984,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2016,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2028,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2040,
+    key.length: 6,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2053,
+    key.length: 20,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2074,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2086,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2130,
     key.length: 5,
     key.is_system: 1
   },
@@ -3877,153 +3809,117 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2150,
+    key.offset: 2213,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2195,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2205,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2237,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2249,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2261,
-    key.length: 6,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2274,
-    key.length: 20,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2295,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2307,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2399,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2409,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2483,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2493,
+    key.offset: 2223,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2537,
+    key.offset: 2266,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2577,
+    key.offset: 2306,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3137,
+    key.offset: 2866,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3147,
+    key.offset: 2876,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3620,
+    key.offset: 3327,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3661,
+    key.offset: 3368,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3702,
+    key.offset: 3409,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3756,
+    key.offset: 3462,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3898,
+    key.offset: 3603,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3971,
+    key.offset: 3676,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 4136,
+    key.offset: 3836,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 4150,
+    key.offset: 3850,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4204,
+    key.offset: 3899,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 3933,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 3967,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 4052,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 4096,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 4112,
     key.length: 5,
     key.is_system: 1
   },
@@ -4035,202 +3931,172 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4272,
+    key.offset: 4268,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4431,
+    key.offset: 4306,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4475,
+    key.offset: 4344,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4491,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4628,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4691,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4729,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4767,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 4844,
+    key.offset: 4382,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4883,
+    key.offset: 4421,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4922,
+    key.offset: 4460,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4968,
+    key.offset: 4506,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 5014,
+    key.offset: 4552,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5052,
+    key.offset: 4590,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5091,
+    key.offset: 4629,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5130,
+    key.offset: 4668,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5167,
+    key.offset: 4705,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5207,
+    key.offset: 4745,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5252,
+    key.offset: 4790,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5296,
+    key.offset: 4834,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5342,
+    key.offset: 4879,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5387,
+    key.offset: 4923,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5542,
+    key.offset: 5075,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5568,
+    key.offset: 5101,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5587,
+    key.offset: 5119,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5700,
+    key.offset: 5186,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5809,
+    key.offset: 5294,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5937,
+    key.offset: 5420,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5995,
+    key.offset: 5477,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6273,
+    key.offset: 5755,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 6317,
+    key.offset: 5798,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6369,
+    key.offset: 5850,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6761,
+    key.offset: 6225,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 7029,
+    key.offset: 6383,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 7033,
+    key.offset: 6387,
     key.length: 19
   }
 ]
@@ -4239,13 +4105,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1",
-    key.offset: 204,
+    key.offset: 95,
     key.length: 154,
-    key.nameoffset: 211,
+    key.nameoffset: 102,
     key.namelength: 8,
-    key.bodyoffset: 251,
+    key.bodyoffset: 142,
     key.bodylength: 106,
-    key.docoffset: 171,
+    key.docoffset: 62,
     key.doclength: 26,
     key.inheritedtypes: [
       {
@@ -4257,7 +4123,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 197,
+        key.offset: 88,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4265,12 +4131,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 222,
+        key.offset: 113,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 233,
+        key.offset: 124,
         key.length: 16
       }
     ],
@@ -4279,13 +4145,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 264,
+        key.offset: 155,
         key.length: 24,
-        key.nameoffset: 264,
+        key.nameoffset: 155,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 257,
+            key.offset: 148,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4294,7 +4160,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 269,
+            key.offset: 160,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4304,13 +4170,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 301,
+        key.offset: 192,
         key.length: 22,
-        key.nameoffset: 301,
+        key.nameoffset: 192,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 294,
+            key.offset: 185,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4319,10 +4185,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 306,
+            key.offset: 197,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 306,
+            key.nameoffset: 197,
             key.namelength: 8
           }
         ]
@@ -4332,14 +4198,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 336,
+        key.offset: 227,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 340,
+        key.nameoffset: 231,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 329,
+            key.offset: 220,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4351,18 +4217,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1X",
-    key.offset: 394,
+    key.offset: 285,
     key.length: 31,
     key.typename: "FooEnum1",
-    key.nameoffset: 398,
+    key.nameoffset: 289,
     key.namelength: 9,
-    key.bodyoffset: 419,
+    key.bodyoffset: 310,
     key.bodylength: 5,
-    key.docoffset: 360,
+    key.docoffset: 251,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 387,
+        key.offset: 278,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4372,11 +4238,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2",
-    key.offset: 434,
+    key.offset: 324,
     key.length: 154,
-    key.nameoffset: 441,
+    key.nameoffset: 331,
     key.namelength: 8,
-    key.bodyoffset: 481,
+    key.bodyoffset: 371,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -4388,7 +4254,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 427,
+        key.offset: 317,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4396,12 +4262,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 452,
+        key.offset: 342,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 463,
+        key.offset: 353,
         key.length: 16
       }
     ],
@@ -4410,13 +4276,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 494,
+        key.offset: 384,
         key.length: 24,
-        key.nameoffset: 494,
+        key.nameoffset: 384,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 487,
+            key.offset: 377,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4425,7 +4291,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 499,
+            key.offset: 389,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4435,13 +4301,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 531,
+        key.offset: 421,
         key.length: 22,
-        key.nameoffset: 531,
+        key.nameoffset: 421,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 524,
+            key.offset: 414,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4450,10 +4316,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 536,
+            key.offset: 426,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 536,
+            key.nameoffset: 426,
             key.namelength: 8
           }
         ]
@@ -4463,14 +4329,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 566,
+        key.offset: 456,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 570,
+        key.nameoffset: 460,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 559,
+            key.offset: 449,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4482,16 +4348,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2X",
-    key.offset: 596,
+    key.offset: 486,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 600,
+    key.nameoffset: 490,
     key.namelength: 9,
-    key.bodyoffset: 621,
+    key.bodyoffset: 511,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 589,
+        key.offset: 479,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4501,16 +4367,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2Y",
-    key.offset: 635,
+    key.offset: 525,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 639,
+    key.nameoffset: 529,
     key.namelength: 9,
-    key.bodyoffset: 660,
+    key.bodyoffset: 550,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 628,
+        key.offset: 518,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4520,11 +4386,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3",
-    key.offset: 674,
+    key.offset: 564,
     key.length: 154,
-    key.nameoffset: 681,
+    key.nameoffset: 571,
     key.namelength: 8,
-    key.bodyoffset: 721,
+    key.bodyoffset: 611,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -4536,7 +4402,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 667,
+        key.offset: 557,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4544,12 +4410,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 692,
+        key.offset: 582,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 703,
+        key.offset: 593,
         key.length: 16
       }
     ],
@@ -4558,13 +4424,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 734,
+        key.offset: 624,
         key.length: 24,
-        key.nameoffset: 734,
+        key.nameoffset: 624,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 727,
+            key.offset: 617,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4573,7 +4439,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 739,
+            key.offset: 629,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4583,13 +4449,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 771,
+        key.offset: 661,
         key.length: 22,
-        key.nameoffset: 771,
+        key.nameoffset: 661,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 764,
+            key.offset: 654,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4598,10 +4464,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 776,
+            key.offset: 666,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 776,
+            key.nameoffset: 666,
             key.namelength: 8
           }
         ]
@@ -4611,14 +4477,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 806,
+        key.offset: 696,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 810,
+        key.nameoffset: 700,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 799,
+            key.offset: 689,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4630,16 +4496,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3X",
-    key.offset: 836,
+    key.offset: 726,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 840,
+    key.nameoffset: 730,
     key.namelength: 9,
-    key.bodyoffset: 861,
+    key.bodyoffset: 751,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 829,
+        key.offset: 719,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4649,16 +4515,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3Y",
-    key.offset: 875,
+    key.offset: 765,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 879,
+    key.nameoffset: 769,
     key.namelength: 9,
-    key.bodyoffset: 900,
+    key.bodyoffset: 790,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 868,
+        key.offset: 758,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4668,13 +4534,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooComparisonResult",
-    key.offset: 952,
-    key.length: 179,
-    key.nameoffset: 957,
+    key.offset: 842,
+    key.length: 124,
+    key.nameoffset: 847,
     key.namelength: 19,
-    key.bodyoffset: 984,
-    key.bodylength: 146,
-    key.docoffset: 908,
+    key.bodyoffset: 874,
+    key.bodylength: 91,
+    key.docoffset: 798,
     key.doclength: 37,
     key.inheritedtypes: [
       {
@@ -4683,7 +4549,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 945,
+        key.offset: 835,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4691,28 +4557,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 979,
+        key.offset: 869,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 1020,
+        key.offset: 880,
         key.length: 26,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedAscending",
-            key.offset: 1025,
+            key.offset: 885,
             key.length: 21,
-            key.nameoffset: 1025,
+            key.nameoffset: 885,
             key.namelength: 16,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 1044,
+                key.offset: 904,
                 key.length: 2
               }
             ]
@@ -4721,21 +4587,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 1052,
+        key.offset: 912,
         key.length: 20,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedSame",
-            key.offset: 1057,
+            key.offset: 917,
             key.length: 15,
-            key.nameoffset: 1057,
+            key.nameoffset: 917,
             key.namelength: 11,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 1071,
+                key.offset: 931,
                 key.length: 1
               }
             ]
@@ -4744,21 +4610,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 1103,
+        key.offset: 938,
         key.length: 26,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedDescending",
-            key.offset: 1108,
+            key.offset: 943,
             key.length: 21,
-            key.nameoffset: 1108,
+            key.nameoffset: 943,
             key.namelength: 17,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 1128,
+                key.offset: 963,
                 key.length: 1
               }
             ]
@@ -4771,13 +4637,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooRuncingOptions",
-    key.offset: 1175,
-    key.length: 249,
-    key.nameoffset: 1182,
+    key.offset: 1010,
+    key.length: 197,
+    key.nameoffset: 1017,
     key.namelength: 17,
-    key.bodyoffset: 1213,
-    key.bodylength: 210,
-    key.docoffset: 1133,
+    key.bodyoffset: 1048,
+    key.bodylength: 158,
+    key.docoffset: 968,
     key.doclength: 35,
     key.inheritedtypes: [
       {
@@ -4786,7 +4652,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 1168,
+        key.offset: 1003,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4794,7 +4660,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1202,
+        key.offset: 1037,
         key.length: 9
       }
     ],
@@ -4803,13 +4669,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 1226,
+        key.offset: 1061,
         key.length: 19,
-        key.nameoffset: 1226,
+        key.nameoffset: 1061,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 1219,
+            key.offset: 1054,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4818,10 +4684,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 1231,
+            key.offset: 1066,
             key.length: 13,
             key.typename: "Int",
-            key.nameoffset: 1231,
+            key.nameoffset: 1066,
             key.namelength: 8
           }
         ]
@@ -4830,16 +4696,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableMince",
-        key.offset: 1285,
+        key.offset: 1093,
         key.length: 49,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1296,
+        key.nameoffset: 1104,
         key.namelength: 11,
-        key.bodyoffset: 1328,
+        key.bodyoffset: 1136,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1278,
+            key.offset: 1086,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4849,16 +4715,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableQuince",
-        key.offset: 1347,
+        key.offset: 1155,
         key.length: 50,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1358,
+        key.nameoffset: 1166,
         key.namelength: 12,
-        key.bodyoffset: 1391,
+        key.bodyoffset: 1199,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1340,
+            key.offset: 1148,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4870,15 +4736,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1",
-    key.offset: 1433,
+    key.offset: 1215,
     key.length: 129,
-    key.nameoffset: 1440,
+    key.nameoffset: 1222,
     key.namelength: 10,
-    key.bodyoffset: 1452,
+    key.bodyoffset: 1234,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1426,
+        key.offset: 1208,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4888,13 +4754,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1465,
+        key.offset: 1247,
         key.length: 6,
-        key.nameoffset: 1465,
+        key.nameoffset: 1247,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1458,
+            key.offset: 1240,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4904,13 +4770,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1484,
+        key.offset: 1266,
         key.length: 25,
-        key.nameoffset: 1484,
+        key.nameoffset: 1266,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1477,
+            key.offset: 1259,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4919,19 +4785,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1489,
+            key.offset: 1271,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1489,
+            key.nameoffset: 1271,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1499,
+            key.offset: 1281,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1499,
+            key.nameoffset: 1281,
             key.namelength: 1
           }
         ]
@@ -4941,14 +4807,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1522,
+        key.offset: 1304,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1526,
+        key.nameoffset: 1308,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1515,
+            key.offset: 1297,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4959,14 +4825,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1547,
+        key.offset: 1329,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1551,
+        key.nameoffset: 1333,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1540,
+            key.offset: 1322,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4978,13 +4844,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1Pointer",
-    key.offset: 1570,
+    key.offset: 1352,
     key.length: 62,
-    key.nameoffset: 1580,
+    key.nameoffset: 1362,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1563,
+        key.offset: 1345,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4994,15 +4860,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct2",
-    key.offset: 1641,
+    key.offset: 1422,
     key.length: 129,
-    key.nameoffset: 1648,
+    key.nameoffset: 1429,
     key.namelength: 10,
-    key.bodyoffset: 1660,
+    key.bodyoffset: 1441,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1634,
+        key.offset: 1415,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5012,13 +4878,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1673,
+        key.offset: 1454,
         key.length: 6,
-        key.nameoffset: 1673,
+        key.nameoffset: 1454,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1666,
+            key.offset: 1447,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5028,13 +4894,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1692,
+        key.offset: 1473,
         key.length: 25,
-        key.nameoffset: 1692,
+        key.nameoffset: 1473,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1685,
+            key.offset: 1466,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5043,19 +4909,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1697,
+            key.offset: 1478,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1697,
+            key.nameoffset: 1478,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1707,
+            key.offset: 1488,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1707,
+            key.nameoffset: 1488,
             key.namelength: 1
           }
         ]
@@ -5065,14 +4931,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1730,
+        key.offset: 1511,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1734,
+        key.nameoffset: 1515,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1723,
+            key.offset: 1504,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5083,14 +4949,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1755,
+        key.offset: 1536,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1759,
+        key.nameoffset: 1540,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1748,
+            key.offset: 1529,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5102,13 +4968,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef1",
-    key.offset: 1778,
+    key.offset: 1559,
     key.length: 40,
-    key.nameoffset: 1788,
+    key.nameoffset: 1569,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1771,
+        key.offset: 1552,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5118,15 +4984,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef2",
-    key.offset: 1827,
+    key.offset: 1607,
     key.length: 136,
-    key.nameoffset: 1834,
+    key.nameoffset: 1614,
     key.namelength: 17,
-    key.bodyoffset: 1853,
+    key.bodyoffset: 1633,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1820,
+        key.offset: 1600,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5136,13 +5002,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1866,
+        key.offset: 1646,
         key.length: 6,
-        key.nameoffset: 1866,
+        key.nameoffset: 1646,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1859,
+            key.offset: 1639,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5152,13 +5018,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1885,
+        key.offset: 1665,
         key.length: 25,
-        key.nameoffset: 1885,
+        key.nameoffset: 1665,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1878,
+            key.offset: 1658,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5167,19 +5033,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1890,
+            key.offset: 1670,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1890,
+            key.nameoffset: 1670,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1900,
+            key.offset: 1680,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1900,
+            key.nameoffset: 1680,
             key.namelength: 1
           }
         ]
@@ -5189,14 +5055,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1923,
+        key.offset: 1703,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1927,
+        key.nameoffset: 1707,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1916,
+            key.offset: 1696,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5207,14 +5073,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1948,
+        key.offset: 1728,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1952,
+        key.nameoffset: 1732,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1941,
+            key.offset: 1721,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5226,15 +5092,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooTypedef1",
-    key.offset: 2001,
+    key.offset: 1781,
     key.length: 29,
-    key.nameoffset: 2011,
+    key.nameoffset: 1791,
     key.namelength: 11,
-    key.docoffset: 1965,
+    key.docoffset: 1745,
     key.doclength: 29,
     key.attributes: [
       {
-        key.offset: 1994,
+        key.offset: 1774,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5245,16 +5111,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "fooIntVar",
-    key.offset: 2066,
+    key.offset: 1846,
     key.length: 20,
     key.typename: "Int32",
-    key.nameoffset: 2070,
+    key.nameoffset: 1850,
     key.namelength: 9,
-    key.docoffset: 2032,
+    key.docoffset: 1812,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 2059,
+        key.offset: 1839,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5264,16 +5130,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1(_:)",
-    key.offset: 2121,
+    key.offset: 1901,
     key.length: 34,
     key.typename: "Int32",
-    key.nameoffset: 2126,
+    key.nameoffset: 1906,
     key.namelength: 20,
-    key.docoffset: 2088,
+    key.docoffset: 1868,
     key.doclength: 26,
     key.attributes: [
       {
-        key.offset: 2114,
+        key.offset: 1894,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5282,7 +5148,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2135,
+        key.offset: 1915,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -5292,14 +5158,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1AnonymousParam(_:)",
-    key.offset: 2164,
+    key.offset: 1943,
     key.length: 46,
     key.typename: "Int32",
-    key.nameoffset: 2169,
+    key.nameoffset: 1948,
     key.namelength: 32,
     key.attributes: [
       {
-        key.offset: 2157,
+        key.offset: 1936,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5307,7 +5173,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
-        key.offset: 2192,
+        key.offset: 1971,
         key.length: 8,
         key.typename: "Int32"
       }
@@ -5317,14 +5183,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc3(_:_:_:_:)",
-    key.offset: 2218,
+    key.offset: 1997,
     key.length: 94,
     key.typename: "Int32",
-    key.nameoffset: 2223,
+    key.nameoffset: 2002,
     key.namelength: 80,
     key.attributes: [
       {
-        key.offset: 2211,
+        key.offset: 1990,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5333,28 +5199,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2232,
+        key.offset: 2011,
         key.length: 10,
         key.typename: "Int32"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "b",
-        key.offset: 2244,
+        key.offset: 2023,
         key.length: 10,
         key.typename: "Float"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "c",
-        key.offset: 2256,
+        key.offset: 2035,
         key.length: 11,
         key.typename: "Double"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "d",
-        key.offset: 2269,
+        key.offset: 2048,
         key.length: 33,
         key.typename: "UnsafeMutablePointer<Int32>!"
       }
@@ -5364,13 +5230,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithBlock(_:)",
-    key.offset: 2368,
+    key.offset: 2099,
     key.length: 49,
-    key.nameoffset: 2373,
+    key.nameoffset: 2104,
     key.namelength: 44,
     key.attributes: [
       {
-        key.offset: 2361,
+        key.offset: 2092,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5379,7 +5245,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "blk",
-        key.offset: 2390,
+        key.offset: 2121,
         key.length: 26,
         key.typename: "((Float) -> Int32)!"
       }
@@ -5389,13 +5255,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithFunctionPointer(_:)",
-    key.offset: 2426,
+    key.offset: 2156,
     key.length: 75,
-    key.nameoffset: 2431,
+    key.nameoffset: 2161,
     key.namelength: 70,
     key.attributes: [
       {
-        key.offset: 2419,
+        key.offset: 2149,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5404,7 +5270,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "fptr",
-        key.offset: 2458,
+        key.offset: 2188,
         key.length: 42,
         key.typename: "(@convention(c) (Float) -> Int32)!"
       }
@@ -5414,14 +5280,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn1()",
-    key.offset: 2510,
+    key.offset: 2239,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2515,
+    key.nameoffset: 2244,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2503,
+        key.offset: 2232,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5431,14 +5297,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn2()",
-    key.offset: 2550,
+    key.offset: 2279,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2555,
+    key.nameoffset: 2284,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2543,
+        key.offset: 2272,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5448,15 +5314,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment1()",
-    key.offset: 2654,
+    key.offset: 2383,
     key.length: 26,
-    key.nameoffset: 2659,
+    key.nameoffset: 2388,
     key.namelength: 21,
-    key.docoffset: 2584,
+    key.docoffset: 2313,
     key.doclength: 62,
     key.attributes: [
       {
-        key.offset: 2647,
+        key.offset: 2376,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5466,15 +5332,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment2()",
-    key.offset: 2732,
+    key.offset: 2461,
     key.length: 26,
-    key.nameoffset: 2737,
+    key.nameoffset: 2466,
     key.namelength: 21,
-    key.docoffset: 2682,
+    key.docoffset: 2411,
     key.doclength: 42,
     key.attributes: [
       {
-        key.offset: 2725,
+        key.offset: 2454,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5484,15 +5350,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment3()",
-    key.offset: 2827,
+    key.offset: 2556,
     key.length: 26,
-    key.nameoffset: 2832,
+    key.nameoffset: 2561,
     key.namelength: 21,
-    key.docoffset: 2760,
+    key.docoffset: 2489,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 2820,
+        key.offset: 2549,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5502,15 +5368,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment4()",
-    key.offset: 2915,
+    key.offset: 2644,
     key.length: 26,
-    key.nameoffset: 2920,
+    key.nameoffset: 2649,
     key.namelength: 21,
-    key.docoffset: 2855,
+    key.docoffset: 2584,
     key.doclength: 53,
     key.attributes: [
       {
-        key.offset: 2908,
+        key.offset: 2637,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5520,15 +5386,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment5()",
-    key.offset: 3009,
+    key.offset: 2738,
     key.length: 26,
-    key.nameoffset: 3014,
+    key.nameoffset: 2743,
     key.namelength: 21,
-    key.docoffset: 2943,
+    key.docoffset: 2672,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 3002,
+        key.offset: 2731,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5538,16 +5404,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
-    key.offset: 3094,
+    key.offset: 2823,
     key.length: 58,
     key.typename: "Int32",
-    key.nameoffset: 3099,
+    key.nameoffset: 2828,
     key.namelength: 44,
-    key.docoffset: 3037,
+    key.docoffset: 2766,
     key.doclength: 50,
     key.attributes: [
       {
-        key.offset: 3087,
+        key.offset: 2816,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5556,7 +5422,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 3132,
+        key.offset: 2861,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -5566,17 +5432,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolBase",
-    key.offset: 3194,
-    key.length: 523,
-    key.nameoffset: 3203,
+    key.offset: 2923,
+    key.length: 501,
+    key.nameoffset: 2932,
     key.namelength: 15,
-    key.bodyoffset: 3220,
-    key.bodylength: 496,
-    key.docoffset: 3154,
+    key.bodyoffset: 2949,
+    key.bodylength: 474,
+    key.docoffset: 2883,
     key.doclength: 33,
     key.attributes: [
       {
-        key.offset: 3187,
+        key.offset: 2916,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5586,42 +5452,42 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFunc()",
-        key.offset: 3278,
+        key.offset: 3003,
         key.length: 19,
-        key.nameoffset: 3283,
+        key.nameoffset: 3008,
         key.namelength: 14,
-        key.docoffset: 3231,
+        key.docoffset: 2956,
         key.doclength: 43
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation1()",
-        key.offset: 3376,
+        key.offset: 3097,
         key.length: 40,
-        key.nameoffset: 3381,
+        key.nameoffset: 3102,
         key.namelength: 35,
-        key.docoffset: 3308,
+        key.docoffset: 3029,
         key.doclength: 64
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation2()",
-        key.offset: 3509,
+        key.offset: 3226,
         key.length: 40,
-        key.nameoffset: 3514,
+        key.nameoffset: 3231,
         key.namelength: 35,
-        key.docoffset: 3427,
+        key.docoffset: 3144,
         key.doclength: 77
       },
       {
         key.kind: source.lang.swift.decl.function.method.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoClassFunc()",
-        key.offset: 3560,
+        key.offset: 3272,
         key.length: 31,
-        key.nameoffset: 3572,
+        key.nameoffset: 3284,
         key.namelength: 19
       },
       {
@@ -5629,12 +5495,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty1",
-        key.offset: 3602,
+        key.offset: 3309,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3606,
+        key.nameoffset: 3313,
         key.namelength: 12,
-        key.bodyoffset: 3627,
+        key.bodyoffset: 3334,
         key.bodylength: 9
       },
       {
@@ -5642,24 +5508,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty2",
-        key.offset: 3643,
+        key.offset: 3350,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3647,
+        key.nameoffset: 3354,
         key.namelength: 12,
-        key.bodyoffset: 3668,
+        key.bodyoffset: 3375,
         key.bodylength: 9
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty3",
-        key.offset: 3684,
+        key.offset: 3391,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 3688,
+        key.nameoffset: 3395,
         key.namelength: 12,
-        key.bodyoffset: 3709,
+        key.bodyoffset: 3416,
         key.bodylength: 5
       }
     ]
@@ -5668,11 +5534,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolDerived",
-    key.offset: 3726,
+    key.offset: 3432,
     key.length: 49,
-    key.nameoffset: 3735,
+    key.nameoffset: 3441,
     key.namelength: 18,
-    key.bodyoffset: 3773,
+    key.bodyoffset: 3479,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -5681,7 +5547,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 3719,
+        key.offset: 3425,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5689,7 +5555,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3756,
+        key.offset: 3462,
         key.length: 15
       }
     ]
@@ -5698,15 +5564,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassBase",
-    key.offset: 3782,
-    key.length: 290,
-    key.nameoffset: 3788,
+    key.offset: 3487,
+    key.length: 285,
+    key.nameoffset: 3493,
     key.namelength: 12,
-    key.bodyoffset: 3802,
-    key.bodylength: 269,
+    key.bodyoffset: 3507,
+    key.bodylength: 264,
     key.attributes: [
       {
-        key.offset: 3777,
+        key.offset: 3482,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5716,13 +5582,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc0()",
-        key.offset: 3813,
+        key.offset: 3518,
         key.length: 27,
-        key.nameoffset: 3818,
+        key.nameoffset: 3523,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 3808,
+            key.offset: 3513,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5732,14 +5598,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc1(_:)",
-        key.offset: 3851,
+        key.offset: 3556,
         key.length: 60,
         key.typename: "FooClassBase!",
-        key.nameoffset: 3856,
+        key.nameoffset: 3561,
         key.namelength: 38,
         key.attributes: [
           {
-            key.offset: 3846,
+            key.offset: 3551,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5748,7 +5614,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "anObject",
-            key.offset: 3877,
+            key.offset: 3582,
             key.length: 16,
             key.typename: "Any!"
           }
@@ -5758,13 +5624,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 3924,
+        key.offset: 3629,
         key.length: 7,
-        key.nameoffset: 3924,
+        key.nameoffset: 3629,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3917,
+            key.offset: 3622,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5774,18 +5640,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(float:)",
-        key.offset: 3956,
+        key.offset: 3661,
         key.length: 21,
-        key.nameoffset: 3956,
+        key.nameoffset: 3661,
         key.namelength: 21,
         key.attributes: [
           {
-            key.offset: 3944,
+            key.offset: 3649,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 3937,
+            key.offset: 3642,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5794,10 +5660,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "f",
-            key.offset: 3962,
+            key.offset: 3667,
             key.length: 14,
             key.typename: "Float",
-            key.nameoffset: 3962,
+            key.nameoffset: 3667,
             key.namelength: 5
           }
         ]
@@ -5806,13 +5672,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 3988,
+        key.offset: 3693,
         key.length: 36,
-        key.nameoffset: 3993,
+        key.nameoffset: 3698,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 3983,
+            key.offset: 3688,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5822,13 +5688,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseClassFunc0()",
-        key.offset: 4040,
+        key.offset: 3740,
         key.length: 30,
-        key.nameoffset: 4051,
+        key.nameoffset: 3751,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 4035,
+            key.offset: 3735,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5840,13 +5706,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassDerived",
-    key.offset: 4112,
-    key.length: 481,
-    key.nameoffset: 4118,
+    key.offset: 3812,
+    key.length: 392,
+    key.nameoffset: 3818,
     key.namelength: 15,
-    key.bodyoffset: 4170,
-    key.bodylength: 422,
-    key.docoffset: 4074,
+    key.bodyoffset: 3870,
+    key.bodylength: 333,
+    key.docoffset: 3774,
     key.doclength: 33,
     key.inheritedtypes: [
       {
@@ -5858,7 +5724,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 4107,
+        key.offset: 3807,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5866,12 +5732,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4136,
+        key.offset: 3836,
         key.length: 12
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 4150,
+        key.offset: 3850,
         key.length: 18
       }
     ],
@@ -5881,14 +5747,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty1",
-        key.offset: 4186,
+        key.offset: 3881,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4190,
+        key.nameoffset: 3885,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 4181,
+            key.offset: 3876,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5899,14 +5765,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty2",
-        key.offset: 4220,
+        key.offset: 3915,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 4224,
+        key.nameoffset: 3919,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 4215,
+            key.offset: 3910,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5916,16 +5782,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty3",
-        key.offset: 4254,
+        key.offset: 3949,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 4258,
+        key.nameoffset: 3953,
         key.namelength: 12,
-        key.bodyoffset: 4279,
+        key.bodyoffset: 3974,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 4249,
+            key.offset: 3944,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5935,13 +5801,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc0()",
-        key.offset: 4370,
+        key.offset: 3991,
         key.length: 23,
-        key.nameoffset: 4375,
+        key.nameoffset: 3996,
         key.namelength: 18,
         key.attributes: [
           {
-            key.offset: 4365,
+            key.offset: 3986,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5951,13 +5817,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc1(_:)",
-        key.offset: 4404,
+        key.offset: 4025,
         key.length: 33,
-        key.nameoffset: 4409,
+        key.nameoffset: 4030,
         key.namelength: 28,
         key.attributes: [
           {
-            key.offset: 4399,
+            key.offset: 4020,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5966,7 +5832,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4426,
+            key.offset: 4047,
             key.length: 10,
             key.typename: "Int32"
           }
@@ -5976,13 +5842,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc2(_:withB:)",
-        key.offset: 4448,
+        key.offset: 4069,
         key.length: 49,
-        key.nameoffset: 4453,
+        key.nameoffset: 4074,
         key.namelength: 44,
         key.attributes: [
           {
-            key.offset: 4443,
+            key.offset: 4064,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5991,17 +5857,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4470,
+            key.offset: 4091,
             key.length: 10,
             key.typename: "Int32"
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "b",
-            key.offset: 4482,
+            key.offset: 4103,
             key.length: 14,
             key.typename: "Int32",
-            key.nameoffset: 4482,
+            key.nameoffset: 4103,
             key.namelength: 5
           }
         ]
@@ -6010,13 +5876,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 4513,
+        key.offset: 4129,
         key.length: 36,
-        key.nameoffset: 4518,
+        key.nameoffset: 4134,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 4508,
+            key.offset: 4124,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6026,13 +5892,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooClassFunc0()",
-        key.offset: 4565,
+        key.offset: 4176,
         key.length: 26,
-        key.nameoffset: 4576,
+        key.nameoffset: 4187,
         key.namelength: 15,
         key.attributes: [
           {
-            key.offset: 4560,
+            key.offset: 4171,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6044,13 +5910,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "typedef_int_t",
-    key.offset: 4602,
+    key.offset: 4212,
     key.length: 31,
-    key.nameoffset: 4612,
+    key.nameoffset: 4222,
     key.namelength: 13,
     key.attributes: [
       {
-        key.offset: 4595,
+        key.offset: 4205,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6060,16 +5926,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_1",
-    key.offset: 4674,
+    key.offset: 4251,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4678,
+    key.nameoffset: 4255,
     key.namelength: 11,
-    key.bodyoffset: 4698,
+    key.bodyoffset: 4275,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4667,
+        key.offset: 4244,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6079,16 +5945,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_2",
-    key.offset: 4712,
+    key.offset: 4289,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4716,
+    key.nameoffset: 4293,
     key.namelength: 11,
-    key.bodyoffset: 4736,
+    key.bodyoffset: 4313,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4705,
+        key.offset: 4282,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6098,16 +5964,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_3",
-    key.offset: 4750,
+    key.offset: 4327,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4754,
+    key.nameoffset: 4331,
     key.namelength: 11,
-    key.bodyoffset: 4774,
+    key.bodyoffset: 4351,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4743,
+        key.offset: 4320,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6117,16 +5983,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_4",
-    key.offset: 4827,
+    key.offset: 4365,
     key.length: 31,
     key.typename: "UInt32",
-    key.nameoffset: 4831,
+    key.nameoffset: 4369,
     key.namelength: 11,
-    key.bodyoffset: 4852,
+    key.bodyoffset: 4390,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4820,
+        key.offset: 4358,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6136,16 +6002,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_5",
-    key.offset: 4866,
+    key.offset: 4404,
     key.length: 31,
     key.typename: "UInt64",
-    key.nameoffset: 4870,
+    key.nameoffset: 4408,
     key.namelength: 11,
-    key.bodyoffset: 4891,
+    key.bodyoffset: 4429,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4859,
+        key.offset: 4397,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6155,16 +6021,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_6",
-    key.offset: 4905,
+    key.offset: 4443,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4909,
+    key.nameoffset: 4447,
     key.namelength: 11,
-    key.bodyoffset: 4937,
+    key.bodyoffset: 4475,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4898,
+        key.offset: 4436,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6174,16 +6040,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_7",
-    key.offset: 4951,
+    key.offset: 4489,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4955,
+    key.nameoffset: 4493,
     key.namelength: 11,
-    key.bodyoffset: 4983,
+    key.bodyoffset: 4521,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4944,
+        key.offset: 4482,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6193,16 +6059,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_8",
-    key.offset: 4997,
+    key.offset: 4535,
     key.length: 30,
     key.typename: "CChar",
-    key.nameoffset: 5001,
+    key.nameoffset: 4539,
     key.namelength: 11,
-    key.bodyoffset: 5021,
+    key.bodyoffset: 4559,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4990,
+        key.offset: 4528,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6212,16 +6078,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_9",
-    key.offset: 5035,
+    key.offset: 4573,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 5039,
+    key.nameoffset: 4577,
     key.namelength: 11,
-    key.bodyoffset: 5059,
+    key.bodyoffset: 4597,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5028,
+        key.offset: 4566,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6231,16 +6097,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_10",
-    key.offset: 5073,
+    key.offset: 4611,
     key.length: 31,
     key.typename: "Int16",
-    key.nameoffset: 5077,
+    key.nameoffset: 4615,
     key.namelength: 12,
-    key.bodyoffset: 5098,
+    key.bodyoffset: 4636,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5066,
+        key.offset: 4604,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6250,16 +6116,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_11",
-    key.offset: 5112,
+    key.offset: 4650,
     key.length: 29,
     key.typename: "Int",
-    key.nameoffset: 5116,
+    key.nameoffset: 4654,
     key.namelength: 12,
-    key.bodyoffset: 5135,
+    key.bodyoffset: 4673,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5105,
+        key.offset: 4643,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6269,16 +6135,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_OR",
-    key.offset: 5149,
+    key.offset: 4687,
     key.length: 31,
     key.typename: "Int32",
-    key.nameoffset: 5153,
+    key.nameoffset: 4691,
     key.namelength: 12,
-    key.bodyoffset: 5174,
+    key.bodyoffset: 4712,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5142,
+        key.offset: 4680,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6288,16 +6154,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_AND",
-    key.offset: 5188,
+    key.offset: 4726,
     key.length: 32,
     key.typename: "Int32",
-    key.nameoffset: 5192,
+    key.nameoffset: 4730,
     key.namelength: 13,
-    key.bodyoffset: 5214,
+    key.bodyoffset: 4752,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5181,
+        key.offset: 4719,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6307,16 +6173,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_BITWIDTH",
-    key.offset: 5228,
+    key.offset: 4766,
     key.length: 38,
     key.typename: "UInt64",
-    key.nameoffset: 5232,
+    key.nameoffset: 4770,
     key.namelength: 18,
-    key.bodyoffset: 5260,
+    key.bodyoffset: 4798,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5221,
+        key.offset: 4759,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6326,16 +6192,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_SIGNED",
-    key.offset: 5274,
+    key.offset: 4812,
     key.length: 36,
     key.typename: "UInt32",
-    key.nameoffset: 5278,
+    key.nameoffset: 4816,
     key.namelength: 16,
-    key.bodyoffset: 5304,
+    key.bodyoffset: 4842,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5267,
+        key.offset: 4805,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6345,16 +6211,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_1",
-    key.offset: 5319,
+    key.offset: 4856,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 5323,
+    key.nameoffset: 4860,
     key.namelength: 17,
-    key.bodyoffset: 5349,
+    key.bodyoffset: 4886,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5312,
+        key.offset: 4849,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6364,16 +6230,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_2",
-    key.offset: 5364,
+    key.offset: 4900,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 5368,
+    key.nameoffset: 4904,
     key.namelength: 17,
-    key.bodyoffset: 5394,
+    key.bodyoffset: 4930,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 5357,
+        key.offset: 4893,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6383,13 +6249,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "theLastDeclInFoo()",
-    key.offset: 5409,
+    key.offset: 4944,
     key.length: 23,
-    key.nameoffset: 5414,
+    key.nameoffset: 4949,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 5402,
+        key.offset: 4937,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6399,13 +6265,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_internalTopLevelFunc()",
-    key.offset: 5441,
+    key.offset: 4975,
     key.length: 28,
-    key.nameoffset: 5446,
+    key.nameoffset: 4980,
     key.namelength: 23,
     key.attributes: [
       {
-        key.offset: 5434,
+        key.offset: 4968,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6415,15 +6281,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalStruct",
-    key.offset: 5478,
+    key.offset: 5011,
     key.length: 97,
-    key.nameoffset: 5485,
+    key.nameoffset: 5018,
     key.namelength: 15,
-    key.bodyoffset: 5502,
+    key.bodyoffset: 5035,
     key.bodylength: 72,
     key.attributes: [
       {
-        key.offset: 5471,
+        key.offset: 5004,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6433,13 +6299,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 5515,
+        key.offset: 5048,
         key.length: 6,
-        key.nameoffset: 5515,
+        key.nameoffset: 5048,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 5508,
+            key.offset: 5041,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6449,13 +6315,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:)",
-        key.offset: 5534,
+        key.offset: 5067,
         key.length: 14,
-        key.nameoffset: 5534,
+        key.nameoffset: 5067,
         key.namelength: 14,
         key.attributes: [
           {
-            key.offset: 5527,
+            key.offset: 5060,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6464,10 +6330,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 5539,
+            key.offset: 5072,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 5539,
+            key.nameoffset: 5072,
             key.namelength: 1
           }
         ]
@@ -6477,14 +6343,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 5561,
+        key.offset: 5094,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 5565,
+        key.nameoffset: 5098,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 5554,
+            key.offset: 5087,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6495,25 +6361,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5577,
+    key.offset: 5109,
     key.length: 66,
-    key.nameoffset: 5587,
+    key.nameoffset: 5119,
     key.namelength: 12,
-    key.bodyoffset: 5601,
+    key.bodyoffset: 5133,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth1()",
-        key.offset: 5612,
+        key.offset: 5144,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5617,
+        key.nameoffset: 5149,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5607,
+            key.offset: 5139,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6524,25 +6390,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5690,
+    key.offset: 5176,
     key.length: 107,
-    key.nameoffset: 5700,
+    key.nameoffset: 5186,
     key.namelength: 12,
-    key.bodyoffset: 5714,
+    key.bodyoffset: 5200,
     key.bodylength: 82,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth2()",
-        key.offset: 5725,
+        key.offset: 5211,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5730,
+        key.nameoffset: 5216,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5720,
+            key.offset: 5206,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6552,14 +6418,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "nonInternalMeth()",
-        key.offset: 5765,
+        key.offset: 5251,
         key.length: 30,
         key.typename: "Any!",
-        key.nameoffset: 5770,
+        key.nameoffset: 5256,
         key.namelength: 17,
         key.attributes: [
           {
-            key.offset: 5760,
+            key.offset: 5246,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6570,25 +6436,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5799,
+    key.offset: 5284,
     key.length: 66,
-    key.nameoffset: 5809,
+    key.nameoffset: 5294,
     key.namelength: 12,
-    key.bodyoffset: 5823,
+    key.bodyoffset: 5308,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth3()",
-        key.offset: 5834,
+        key.offset: 5319,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5839,
+        key.nameoffset: 5324,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5829,
+            key.offset: 5314,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6600,15 +6466,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalProt",
-    key.offset: 5874,
+    key.offset: 5358,
     key.length: 26,
-    key.nameoffset: 5883,
+    key.nameoffset: 5367,
     key.namelength: 13,
-    key.bodyoffset: 5898,
+    key.bodyoffset: 5382,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 5867,
+        key.offset: 5351,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6618,11 +6484,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "ClassWithInternalProt",
-    key.offset: 5907,
+    key.offset: 5390,
     key.length: 47,
-    key.nameoffset: 5913,
+    key.nameoffset: 5396,
     key.namelength: 21,
-    key.bodyoffset: 5952,
+    key.bodyoffset: 5435,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -6631,7 +6497,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5902,
+        key.offset: 5385,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6639,7 +6505,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5937,
+        key.offset: 5420,
         key.length: 13
       }
     ]
@@ -6648,11 +6514,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassPropertyOwnership",
-    key.offset: 5961,
+    key.offset: 5443,
     key.length: 319,
-    key.nameoffset: 5967,
+    key.nameoffset: 5449,
     key.namelength: 25,
-    key.bodyoffset: 6009,
+    key.bodyoffset: 5491,
     key.bodylength: 270,
     key.inheritedtypes: [
       {
@@ -6661,7 +6527,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5956,
+        key.offset: 5438,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6669,7 +6535,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5995,
+        key.offset: 5477,
         key.length: 12
       }
     ],
@@ -6679,19 +6545,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "assignable",
-        key.offset: 6036,
+        key.offset: 5518,
         key.length: 26,
         key.typename: "AnyObject!",
-        key.nameoffset: 6040,
+        key.nameoffset: 5522,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 6031,
+            key.offset: 5513,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6015,
+            key.offset: 5497,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6702,19 +6568,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "unsafeAssignable",
-        key.offset: 6089,
+        key.offset: 5571,
         key.length: 32,
         key.typename: "AnyObject!",
-        key.nameoffset: 6093,
+        key.nameoffset: 5575,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 6084,
+            key.offset: 5566,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6068,
+            key.offset: 5550,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6725,14 +6591,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "retainable",
-        key.offset: 6132,
+        key.offset: 5614,
         key.length: 20,
         key.typename: "Any!",
-        key.nameoffset: 6136,
+        key.nameoffset: 5618,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 6127,
+            key.offset: 5609,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6743,14 +6609,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "strongRef",
-        key.offset: 6163,
+        key.offset: 5645,
         key.length: 19,
         key.typename: "Any!",
-        key.nameoffset: 6167,
+        key.nameoffset: 5649,
         key.namelength: 9,
         key.attributes: [
           {
-            key.offset: 6158,
+            key.offset: 5640,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6761,14 +6627,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "copyable",
-        key.offset: 6193,
+        key.offset: 5675,
         key.length: 18,
         key.typename: "Any!",
-        key.nameoffset: 6197,
+        key.nameoffset: 5679,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 6188,
+            key.offset: 5670,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6779,19 +6645,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "weakRef",
-        key.offset: 6227,
+        key.offset: 5709,
         key.length: 23,
         key.typename: "AnyObject!",
-        key.nameoffset: 6231,
+        key.nameoffset: 5713,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 6222,
+            key.offset: 5704,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6217,
+            key.offset: 5699,
             key.length: 4,
             key.attribute: source.decl.attribute.weak
           }
@@ -6802,14 +6668,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "scalar",
-        key.offset: 6261,
+        key.offset: 5743,
         key.length: 17,
         key.typename: "Int32",
-        key.nameoffset: 6265,
+        key.nameoffset: 5747,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 6256,
+            key.offset: 5738,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6821,12 +6687,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooUnavailableMembers",
-    key.offset: 6287,
-    key.length: 344,
-    key.nameoffset: 6293,
+    key.offset: 5768,
+    key.length: 329,
+    key.nameoffset: 5774,
     key.namelength: 21,
-    key.bodyoffset: 6331,
-    key.bodylength: 299,
+    key.bodyoffset: 5812,
+    key.bodylength: 284,
     key.inheritedtypes: [
       {
         key.name: "FooClassBase"
@@ -6834,7 +6700,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6282,
+        key.offset: 5763,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6842,7 +6708,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6317,
+        key.offset: 5798,
         key.length: 12
       }
     ],
@@ -6851,18 +6717,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(int:)",
-        key.offset: 6356,
+        key.offset: 5837,
         key.length: 19,
-        key.nameoffset: 6356,
+        key.nameoffset: 5837,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 6344,
+            key.offset: 5825,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 6337,
+            key.offset: 5818,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6871,10 +6737,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "i",
-            key.offset: 6362,
+            key.offset: 5843,
             key.length: 12,
             key.typename: "Int32",
-            key.nameoffset: 6362,
+            key.nameoffset: 5843,
             key.namelength: 3
           }
         ]
@@ -6883,18 +6749,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "deprecated()",
-        key.offset: 6435,
+        key.offset: 5911,
         key.length: 17,
-        key.nameoffset: 6440,
+        key.nameoffset: 5916,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 6430,
+            key.offset: 5906,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6386,
+            key.offset: 5862,
             key.length: 39,
             key.attribute: source.decl.attribute.available
           }
@@ -6904,18 +6770,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroduced()",
-        key.offset: 6498,
+        key.offset: 5969,
         key.length: 29,
-        key.nameoffset: 6503,
+        key.nameoffset: 5974,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 6493,
+            key.offset: 5964,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6463,
+            key.offset: 5934,
             key.length: 25,
             key.attribute: source.decl.attribute.available
           }
@@ -6925,18 +6791,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroducedMsg()",
-        key.offset: 6597,
+        key.offset: 6063,
         key.length: 32,
-        key.nameoffset: 6602,
+        key.nameoffset: 6068,
         key.namelength: 27,
         key.attributes: [
           {
-            key.offset: 6592,
+            key.offset: 6058,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6538,
+            key.offset: 6004,
             key.length: 49,
             key.attribute: source.decl.attribute.available
           }
@@ -6948,15 +6814,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooCFType",
-    key.offset: 6640,
+    key.offset: 6105,
     key.length: 19,
-    key.nameoffset: 6646,
+    key.nameoffset: 6111,
     key.namelength: 9,
-    key.bodyoffset: 6657,
+    key.bodyoffset: 6122,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 6633,
+        key.offset: 6098,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6966,12 +6832,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "ABAuthorizationStatus",
-    key.offset: 6732,
-    key.length: 199,
-    key.nameoffset: 6737,
+    key.offset: 6196,
+    key.length: 89,
+    key.nameoffset: 6201,
     key.namelength: 21,
-    key.bodyoffset: 6766,
-    key.bodylength: 164,
+    key.bodyoffset: 6230,
+    key.bodylength: 54,
     key.inheritedtypes: [
       {
         key.name: "Int"
@@ -6979,12 +6845,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6725,
+        key.offset: 6189,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       },
       {
-        key.offset: 6661,
+        key.offset: 6125,
         key.length: 63,
         key.attribute: source.decl.attribute.available
       }
@@ -6992,28 +6858,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6761,
+        key.offset: 6225,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6777,
+        key.offset: 6236,
         key.length: 22,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "notDetermined",
-            key.offset: 6782,
+            key.offset: 6241,
             key.length: 17,
-            key.nameoffset: 6782,
+            key.nameoffset: 6241,
             key.namelength: 13,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6798,
+                key.offset: 6257,
                 key.length: 1
               }
             ]
@@ -7022,21 +6888,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6859,
+        key.offset: 6264,
         key.length: 19,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "restricted",
-            key.offset: 6864,
+            key.offset: 6269,
             key.length: 14,
-            key.nameoffset: 6864,
+            key.nameoffset: 6269,
             key.namelength: 10,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6877,
+                key.offset: 6282,
                 key.length: 1
               }
             ]
@@ -7049,15 +6915,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassBase",
-    key.offset: 6939,
+    key.offset: 6293,
     key.length: 50,
-    key.nameoffset: 6945,
+    key.nameoffset: 6299,
     key.namelength: 19,
-    key.bodyoffset: 6966,
+    key.bodyoffset: 6320,
     key.bodylength: 22,
     key.attributes: [
       {
-        key.offset: 6932,
+        key.offset: 6286,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -7067,13 +6933,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6979,
+        key.offset: 6333,
         key.length: 8,
-        key.nameoffset: 6984,
+        key.nameoffset: 6338,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 6972,
+            key.offset: 6326,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -7085,11 +6951,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassDerived",
-    key.offset: 6998,
+    key.offset: 6352,
     key.length: 88,
-    key.nameoffset: 7004,
+    key.nameoffset: 6358,
     key.namelength: 22,
-    key.bodyoffset: 7054,
+    key.bodyoffset: 6408,
     key.bodylength: 31,
     key.inheritedtypes: [
       {
@@ -7098,7 +6964,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6991,
+        key.offset: 6345,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -7106,7 +6972,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 7029,
+        key.offset: 6383,
         key.length: 23
       }
     ],
@@ -7115,18 +6981,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 7076,
+        key.offset: 6430,
         key.length: 8,
-        key.nameoffset: 7081,
+        key.nameoffset: 6435,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 7069,
+            key.offset: 6423,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           },
           {
-            key.offset: 7060,
+            key.offset: 6414,
             key.length: 8,
             key.attribute: source.decl.attribute.override
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -2,7 +2,6 @@ import Foo.FooSub
 import FooHelper
 import SwiftOnoneSupport
 
-
 /// Aaa.  FooEnum1.  Bbb.
 public struct FooEnum1 : Equatable, RawRepresentable {
 
@@ -15,6 +14,7 @@ public struct FooEnum1 : Equatable, RawRepresentable {
 
 /// Aaa.  FooEnum1X.  Bbb.
 public var FooEnum1X: FooEnum1 { get }
+
 public struct FooEnum2 : Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
@@ -23,8 +23,11 @@ public struct FooEnum2 : Equatable, RawRepresentable {
 
     public var rawValue: UInt32
 }
+
 public var FooEnum2X: FooEnum2 { get }
+
 public var FooEnum2Y: FooEnum2 { get }
+
 public struct FooEnum3 : Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
@@ -33,7 +36,9 @@ public struct FooEnum3 : Equatable, RawRepresentable {
 
     public var rawValue: UInt32
 }
+
 public var FooEnum3X: FooEnum3 { get }
+
 public var FooEnum3Y: FooEnum3 { get }
 
 /// Aaa.  FooComparisonResult.  Bbb.
@@ -55,6 +60,7 @@ public struct FooRuncingOptions : OptionSet {
 
     public static var enableQuince: FooRuncingOptions { get }
 }
+
 public struct FooStruct1 {
 
     public init()
@@ -65,7 +71,9 @@ public struct FooStruct1 {
 
     public var y: Double
 }
+
 public typealias FooStruct1Pointer = UnsafeMutablePointer<FooStruct1>
+
 public struct FooStruct2 {
 
     public init()
@@ -76,7 +84,9 @@ public struct FooStruct2 {
 
     public var y: Double
 }
+
 public typealias FooStructTypedef1 = FooStruct2
+
 public struct FooStructTypedef2 {
 
     public init()
@@ -96,11 +106,17 @@ public var fooIntVar: Int32
 
 /// Aaa.  fooFunc1.  Bbb.
 public func fooFunc1(_ a: Int32) -> Int32
+
 public func fooFunc1AnonymousParam(_: Int32) -> Int32
+
 public func fooFunc3(_ a: Int32, _ b: Float, _ c: Double, _ d: UnsafeMutablePointer<Int32>!) -> Int32
+
 public func fooFuncWithBlock(_ blk: ((Float) -> Int32)!)
+
 public func fooFuncWithFunctionPointer(_ fptr: (@convention(c) (Float) -> Int32)!)
+
 public func fooFuncNoreturn1() -> Never
+
 public func fooFuncNoreturn2() -> Never
 
 /**
@@ -142,16 +158,13 @@ public func redeclaredInMultipleModulesFunc1(_ a: Int32) -> Int32
 /// Aaa.  FooProtocolBase.  Bbb.
 public protocol FooProtocolBase {
 
-
     /// Aaa.  fooProtoFunc.  Bbb.
     /// Ccc.
     func fooProtoFunc()
 
-
     /// Aaa.  fooProtoFuncWithExtraIndentation1.  Bbb.
     /// Ccc.
     func fooProtoFuncWithExtraIndentation1()
-
 
     /**
      * Aaa.  fooProtoFuncWithExtraIndentation2.  Bbb.
@@ -167,8 +180,10 @@ public protocol FooProtocolBase {
 
     var fooProperty3: Int32 { get }
 }
+
 public protocol FooProtocolDerived : FooProtocolBase {
 }
+
 open class FooClassBase {
 
     open func fooBaseInstanceFunc0()
@@ -203,26 +218,47 @@ open class FooClassDerived : FooClassBase, FooProtocolDerived {
 
     open class func fooClassFunc0()
 }
+
 public typealias typedef_int_t = Int32
+
 public var FOO_MACRO_1: Int32 { get }
+
 public var FOO_MACRO_2: Int32 { get }
+
 public var FOO_MACRO_3: Int32 { get }
+
 public var FOO_MACRO_4: UInt32 { get }
+
 public var FOO_MACRO_5: UInt64 { get }
+
 public var FOO_MACRO_6: typedef_int_t { get }
+
 public var FOO_MACRO_7: typedef_int_t { get }
+
 public var FOO_MACRO_8: CChar { get }
+
 public var FOO_MACRO_9: Int32 { get }
+
 public var FOO_MACRO_10: Int16 { get }
+
 public var FOO_MACRO_11: Int { get }
+
 public var FOO_MACRO_OR: Int32 { get }
+
 public var FOO_MACRO_AND: Int32 { get }
+
 public var FOO_MACRO_BITWIDTH: UInt64 { get }
+
 public var FOO_MACRO_SIGNED: UInt32 { get }
+
 public var FOO_MACRO_REDEF_1: Int32 { get }
+
 public var FOO_MACRO_REDEF_2: Int32 { get }
+
 public func theLastDeclInFoo()
+
 public func _internalTopLevelFunc()
+
 public struct _InternalStruct {
 
     public init()
@@ -231,24 +267,30 @@ public struct _InternalStruct {
 
     public var x: Int32
 }
+
 extension FooClassBase {
 
     open func _internalMeth1() -> Any!
 }
+
 extension FooClassBase {
 
     open func _internalMeth2() -> Any!
 
     open func nonInternalMeth() -> Any!
 }
+
 extension FooClassBase {
 
     open func _internalMeth3() -> Any!
 }
+
 public protocol _InternalProt {
 }
+
 open class ClassWithInternalProt : _InternalProt {
 }
+
 open class FooClassPropertyOwnership : FooClassBase {
 
     unowned(unsafe) open var assignable: AnyObject!
@@ -265,6 +307,7 @@ open class FooClassPropertyOwnership : FooClassBase {
 
     open var scalar: Int32
 }
+
 open class FooUnavailableMembers : FooClassBase {
 
     public convenience init!(int i: Int32)
@@ -278,8 +321,10 @@ open class FooUnavailableMembers : FooClassBase {
     @available(macOS, introduced: 10.1, message: "x")
     open func availabilityIntroducedMsg()
 }
+
 public class FooCFType {
 }
+
 @available(*, deprecated, message: "use CNAuthorizationStatus")
 public enum ABAuthorizationStatus : Int {
 
@@ -287,6 +332,7 @@ public enum ABAuthorizationStatus : Int {
 
     case restricted = 1
 }
+
 public class FooOverlayClassBase {
 
     public func f()
@@ -336,127 +382,127 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 62,
+    key.offset: 61,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 88,
+    key.offset: 87,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 95,
+    key.offset: 94,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 102,
+    key.offset: 101,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 113,
+    key.offset: 112,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 124,
+    key.offset: 123,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 148,
+    key.offset: 147,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 155,
+    key.offset: 154,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 160,
+    key.offset: 159,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 162,
+    key.offset: 161,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 172,
+    key.offset: 171,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 185,
+    key.offset: 184,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 192,
+    key.offset: 191,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 197,
+    key.offset: 196,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 207,
+    key.offset: 206,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 220,
+    key.offset: 219,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 227,
+    key.offset: 226,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 231,
+    key.offset: 230,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 241,
+    key.offset: 240,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 251,
+    key.offset: 250,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 278,
+    key.offset: 277,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 285,
+    key.offset: 284,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 289,
+    key.offset: 288,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 300,
+    key.offset: 299,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 311,
+    key.offset: 310,
     key.length: 3
   },
   {
@@ -551,648 +597,638 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 479,
+    key.offset: 480,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 486,
+    key.offset: 487,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 490,
+    key.offset: 491,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 501,
+    key.offset: 502,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 512,
+    key.offset: 513,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 518,
+    key.offset: 520,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 525,
+    key.offset: 527,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 529,
+    key.offset: 531,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 540,
+    key.offset: 542,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 551,
+    key.offset: 553,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 557,
+    key.offset: 560,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 564,
+    key.offset: 567,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 571,
+    key.offset: 574,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 582,
+    key.offset: 585,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 593,
+    key.offset: 596,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 617,
+    key.offset: 620,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 624,
+    key.offset: 627,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 629,
+    key.offset: 632,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 631,
+    key.offset: 634,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 641,
+    key.offset: 644,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 654,
+    key.offset: 657,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 661,
+    key.offset: 664,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 666,
+    key.offset: 669,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 676,
+    key.offset: 679,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 689,
+    key.offset: 692,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 696,
+    key.offset: 699,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 700,
+    key.offset: 703,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 710,
+    key.offset: 713,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 719,
+    key.offset: 723,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 726,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 730,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 741,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 752,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 758,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 765,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 769,
+    key.offset: 734,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 780,
+    key.offset: 745,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 791,
+    key.offset: 756,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 763,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 770,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 774,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 785,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 796,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 798,
+    key.offset: 803,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 835,
+    key.offset: 840,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 842,
+    key.offset: 847,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 847,
+    key.offset: 852,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 869,
+    key.offset: 874,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 880,
+    key.offset: 885,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 885,
+    key.offset: 890,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 904,
+    key.offset: 909,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 912,
+    key.offset: 917,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 917,
+    key.offset: 922,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 931,
+    key.offset: 936,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 938,
+    key.offset: 943,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 943,
+    key.offset: 948,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 963,
+    key.offset: 968,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 968,
+    key.offset: 973,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1003,
+    key.offset: 1008,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1010,
+    key.offset: 1015,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1017,
+    key.offset: 1022,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1037,
+    key.offset: 1042,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1054,
+    key.offset: 1059,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1061,
+    key.offset: 1066,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1066,
+    key.offset: 1071,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1076,
+    key.offset: 1081,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1086,
+    key.offset: 1091,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1093,
+    key.offset: 1098,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1100,
+    key.offset: 1105,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1104,
+    key.offset: 1109,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1117,
+    key.offset: 1122,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1137,
+    key.offset: 1142,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1148,
+    key.offset: 1153,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1155,
+    key.offset: 1160,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1162,
+    key.offset: 1167,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1166,
+    key.offset: 1171,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1180,
+    key.offset: 1185,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1200,
+    key.offset: 1205,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1208,
+    key.offset: 1214,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1215,
+    key.offset: 1221,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1222,
+    key.offset: 1228,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1240,
+    key.offset: 1246,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1247,
+    key.offset: 1253,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1259,
+    key.offset: 1265,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1266,
+    key.offset: 1272,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1271,
+    key.offset: 1277,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1274,
+    key.offset: 1280,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1281,
+    key.offset: 1287,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1284,
+    key.offset: 1290,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1297,
+    key.offset: 1303,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1304,
+    key.offset: 1310,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1308,
+    key.offset: 1314,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1311,
+    key.offset: 1317,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1322,
+    key.offset: 1328,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1329,
+    key.offset: 1335,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1333,
+    key.offset: 1339,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1336,
+    key.offset: 1342,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1345,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1352,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1359,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1362,
+    key.offset: 1369,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1382,
+    key.offset: 1389,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1403,
+    key.offset: 1410,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1415,
+    key.offset: 1423,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1422,
+    key.offset: 1430,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1429,
+    key.offset: 1437,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1447,
+    key.offset: 1455,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1454,
+    key.offset: 1462,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1466,
+    key.offset: 1474,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1473,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1478,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1481,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1486,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1489,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1488,
+    key.offset: 1496,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1491,
+    key.offset: 1499,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1504,
+    key.offset: 1512,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1511,
+    key.offset: 1519,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1515,
+    key.offset: 1523,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1518,
+    key.offset: 1526,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1529,
+    key.offset: 1537,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1536,
+    key.offset: 1544,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1540,
+    key.offset: 1548,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1543,
+    key.offset: 1551,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1552,
+    key.offset: 1561,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1559,
+    key.offset: 1568,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1569,
+    key.offset: 1578,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1589,
+    key.offset: 1598,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1600,
+    key.offset: 1610,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1607,
+    key.offset: 1617,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1614,
+    key.offset: 1624,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1639,
+    key.offset: 1649,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1646,
+    key.offset: 1656,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1658,
+    key.offset: 1668,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1665,
+    key.offset: 1675,
     key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1670,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1673,
-    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
@@ -1202,132 +1238,137 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 1683,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1696,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1703,
-    key.length: 3
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1707,
+    key.offset: 1690,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1710,
+    key.offset: 1693,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1706,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1713,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1717,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1720,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1721,
+    key.offset: 1731,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1728,
+    key.offset: 1738,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1732,
+    key.offset: 1742,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1735,
+    key.offset: 1745,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1745,
+    key.offset: 1755,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1774,
+    key.offset: 1784,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1781,
+    key.offset: 1791,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1791,
+    key.offset: 1801,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1805,
+    key.offset: 1815,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1812,
+    key.offset: 1822,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1839,
+    key.offset: 1849,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1846,
+    key.offset: 1856,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1850,
+    key.offset: 1860,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1861,
+    key.offset: 1871,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 1868,
+    key.offset: 1878,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1894,
+    key.offset: 1904,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1901,
+    key.offset: 1911,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1906,
+    key.offset: 1916,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1915,
+    key.offset: 1925,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1917,
+    key.offset: 1927,
     key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1920,
-    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
@@ -1335,64 +1376,54 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 5
   },
   {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1940,
+    key.length: 5
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1936,
+    key.offset: 1947,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1943,
+    key.offset: 1954,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1948,
+    key.offset: 1959,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1971,
+    key.offset: 1982,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1974,
+    key.offset: 1985,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1984,
+    key.offset: 1995,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1990,
+    key.offset: 2002,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1997,
+    key.offset: 2009,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2002,
+    key.offset: 2014,
     key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2011,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2013,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2016,
-    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -1422,27 +1453,37 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 2040,
-    key.length: 6
+    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2048,
+    key.offset: 2047,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2050,
+    key.offset: 2049,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2053,
-    key.length: 20
+    key.offset: 2052,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2060,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2062,
+    key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2074,
-    key.length: 5
+    key.offset: 2065,
+    key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
@@ -1450,1069 +1491,1059 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 5
   },
   {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2098,
+    key.length: 5
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2092,
+    key.offset: 2105,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2099,
+    key.offset: 2112,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2104,
+    key.offset: 2117,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2121,
+    key.offset: 2134,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2123,
+    key.offset: 2136,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2130,
+    key.offset: 2143,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2140,
+    key.offset: 2153,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2149,
+    key.offset: 2163,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2156,
+    key.offset: 2170,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2161,
+    key.offset: 2175,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2188,
+    key.offset: 2202,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2190,
+    key.offset: 2204,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2197,
+    key.offset: 2211,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2209,
+    key.offset: 2223,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2213,
+    key.offset: 2227,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2223,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2232,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2239,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2244,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2266,
+    key.offset: 2237,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2272,
+    key.offset: 2247,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2279,
+    key.offset: 2254,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2284,
+    key.offset: 2259,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2306,
+    key.offset: 2281,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2288,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2295,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2300,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2322,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2313,
+    key.offset: 2329,
     key.length: 62
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2376,
+    key.offset: 2392,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2383,
+    key.offset: 2399,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2388,
+    key.offset: 2404,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2411,
+    key.offset: 2427,
     key.length: 42
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2454,
+    key.offset: 2470,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2461,
+    key.offset: 2477,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2466,
+    key.offset: 2482,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2489,
+    key.offset: 2505,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2533,
+    key.offset: 2549,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2549,
+    key.offset: 2565,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2556,
+    key.offset: 2572,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2561,
+    key.offset: 2577,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2584,
+    key.offset: 2600,
     key.length: 43
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2628,
+    key.offset: 2644,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2637,
+    key.offset: 2653,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2644,
+    key.offset: 2660,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2649,
+    key.offset: 2665,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2672,
+    key.offset: 2688,
     key.length: 37
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2709,
+    key.offset: 2725,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2718,
+    key.offset: 2734,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2722,
+    key.offset: 2738,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2731,
+    key.offset: 2747,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2738,
+    key.offset: 2754,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2743,
+    key.offset: 2759,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2766,
+    key.offset: 2782,
     key.length: 50
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2816,
+    key.offset: 2832,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2823,
+    key.offset: 2839,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2828,
+    key.offset: 2844,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2861,
+    key.offset: 2877,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2863,
+    key.offset: 2879,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2866,
+    key.offset: 2882,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2876,
+    key.offset: 2892,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2883,
+    key.offset: 2899,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2916,
+    key.offset: 2932,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2923,
+    key.offset: 2939,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2932,
+    key.offset: 2948,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2956,
+    key.offset: 2971,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 2990,
+    key.offset: 3005,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3003,
+    key.offset: 3018,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3008,
+    key.offset: 3023,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3029,
+    key.offset: 3043,
     key.length: 51
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3084,
+    key.offset: 3098,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3097,
+    key.offset: 3111,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3102,
+    key.offset: 3116,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3144,
+    key.offset: 3157,
     key.length: 77
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3226,
+    key.offset: 3239,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3231,
+    key.offset: 3244,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3272,
+    key.offset: 3285,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3279,
+    key.offset: 3292,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3284,
+    key.offset: 3297,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3309,
+    key.offset: 3322,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3313,
+    key.offset: 3326,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3327,
+    key.offset: 3340,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3335,
+    key.offset: 3348,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3339,
+    key.offset: 3352,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3350,
+    key.offset: 3363,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3354,
+    key.offset: 3367,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3368,
+    key.offset: 3381,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3376,
+    key.offset: 3389,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3380,
+    key.offset: 3393,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3391,
+    key.offset: 3404,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3395,
+    key.offset: 3408,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3409,
+    key.offset: 3422,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3417,
+    key.offset: 3430,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3425,
+    key.offset: 3439,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3432,
+    key.offset: 3446,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3441,
+    key.offset: 3455,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3462,
+    key.offset: 3476,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3482,
+    key.offset: 3497,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3487,
+    key.offset: 3502,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3493,
+    key.offset: 3508,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3513,
+    key.offset: 3528,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3518,
+    key.offset: 3533,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3523,
+    key.offset: 3538,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3551,
+    key.offset: 3566,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3556,
+    key.offset: 3571,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3561,
+    key.offset: 3576,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3582,
+    key.offset: 3597,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3584,
+    key.offset: 3599,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3594,
+    key.offset: 3609,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3603,
+    key.offset: 3618,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3622,
+    key.offset: 3637,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3629,
+    key.offset: 3644,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3642,
+    key.offset: 3657,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3649,
+    key.offset: 3664,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3661,
+    key.offset: 3676,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3667,
+    key.offset: 3682,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3673,
+    key.offset: 3688,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3676,
+    key.offset: 3691,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3688,
+    key.offset: 3703,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3693,
+    key.offset: 3708,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3698,
+    key.offset: 3713,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3735,
+    key.offset: 3750,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3740,
+    key.offset: 3755,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3746,
+    key.offset: 3761,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3751,
+    key.offset: 3766,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 3774,
+    key.offset: 3789,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3807,
+    key.offset: 3822,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3812,
+    key.offset: 3827,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3818,
+    key.offset: 3833,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3836,
+    key.offset: 3851,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3850,
+    key.offset: 3865,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3876,
+    key.offset: 3891,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3881,
+    key.offset: 3896,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3885,
+    key.offset: 3900,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3899,
+    key.offset: 3914,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3910,
+    key.offset: 3925,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3915,
+    key.offset: 3930,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3919,
+    key.offset: 3934,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3933,
+    key.offset: 3948,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3944,
+    key.offset: 3959,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3949,
+    key.offset: 3964,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3953,
+    key.offset: 3968,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3967,
+    key.offset: 3982,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3975,
+    key.offset: 3990,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3986,
+    key.offset: 4001,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3991,
+    key.offset: 4006,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3996,
+    key.offset: 4011,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4020,
+    key.offset: 4035,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4025,
+    key.offset: 4040,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4030,
+    key.offset: 4045,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4047,
+    key.offset: 4062,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4049,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4052,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 4064,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4069,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4074,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4091,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4093,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4096,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4103,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4109,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4112,
+    key.offset: 4067,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4124,
+    key.offset: 4079,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4129,
+    key.offset: 4084,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4134,
+    key.offset: 4089,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4106,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4108,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4111,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4118,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4124,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4127,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4139,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4144,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4149,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4171,
+    key.offset: 4186,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4176,
+    key.offset: 4191,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4182,
+    key.offset: 4197,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4187,
+    key.offset: 4202,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4205,
+    key.offset: 4221,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4212,
+    key.offset: 4228,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4222,
-    key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 4238,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4254,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4244,
+    key.offset: 4261,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4251,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4255,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 4268,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4276,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4282,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4289,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4272,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4285,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 4293,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4300,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4307,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4311,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4306,
+    key.offset: 4324,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4314,
+    key.offset: 4332,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4320,
+    key.offset: 4339,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4327,
+    key.offset: 4346,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4331,
+    key.offset: 4350,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4344,
+    key.offset: 4363,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4352,
+    key.offset: 4371,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4358,
+    key.offset: 4378,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4365,
+    key.offset: 4385,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4369,
+    key.offset: 4389,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4382,
+    key.offset: 4402,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4391,
+    key.offset: 4411,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4397,
+    key.offset: 4418,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4404,
+    key.offset: 4425,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4408,
+    key.offset: 4429,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4421,
+    key.offset: 4442,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4430,
+    key.offset: 4451,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4436,
+    key.offset: 4458,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4443,
+    key.offset: 4465,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4447,
+    key.offset: 4469,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4460,
-    key.length: 13
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4476,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 4482,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4489,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4493,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4506,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4522,
+    key.offset: 4498,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4528,
+    key.offset: 4505,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4535,
+    key.offset: 4512,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4539,
+    key.offset: 4516,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4529,
+    key.length: 13
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4545,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 4552,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4560,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4566,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4573,
+    key.offset: 4559,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4577,
+    key.offset: 4563,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4590,
+    key.offset: 4576,
     key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4584,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4591,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2520,24 +2551,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4604,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4611,
-    key.length: 3
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4615,
-    key.length: 12
+    key.offset: 4602,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4629,
+    key.offset: 4615,
     key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4623,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4630,
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -2545,123 +2576,123 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4643,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4650,
-    key.length: 3
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4654,
+    key.offset: 4641,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4668,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4674,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4680,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4687,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4691,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4705,
+    key.offset: 4655,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4713,
+    key.offset: 4663,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4719,
+    key.offset: 4670,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4726,
+    key.offset: 4677,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4730,
+    key.offset: 4681,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4695,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4701,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4708,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4715,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4719,
+    key.length: 12
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4733,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4741,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4748,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4755,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4759,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4745,
+    key.offset: 4774,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4753,
+    key.offset: 4782,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4759,
+    key.offset: 4789,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4766,
+    key.offset: 4796,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4770,
+    key.offset: 4800,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4790,
+    key.offset: 4820,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4799,
+    key.offset: 4829,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4805,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4812,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4816,
-    key.length: 16
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4834,
+    key.offset: 4836,
     key.length: 6
   },
   {
@@ -2670,803 +2701,818 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.length: 3
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4849,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 4847,
+    key.length: 16
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4865,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4856,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4860,
-    key.length: 17
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4879,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4887,
+    key.offset: 4874,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4893,
+    key.offset: 4881,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4900,
+    key.offset: 4888,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4904,
+    key.offset: 4892,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 4923,
+    key.offset: 4911,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4931,
+    key.offset: 4919,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4926,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4933,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 4937,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 4956,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 4964,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 4971,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4944,
+    key.offset: 4978,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4949,
+    key.offset: 4983,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 4968,
+    key.offset: 5003,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 4975,
+    key.offset: 5010,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 4980,
+    key.offset: 5015,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5004,
+    key.offset: 5040,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5011,
+    key.offset: 5047,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5018,
+    key.offset: 5054,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5041,
+    key.offset: 5077,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5048,
+    key.offset: 5084,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5060,
+    key.offset: 5096,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5067,
+    key.offset: 5103,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5072,
+    key.offset: 5108,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5075,
+    key.offset: 5111,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5087,
+    key.offset: 5123,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5094,
+    key.offset: 5130,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5098,
+    key.offset: 5134,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5101,
+    key.offset: 5137,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5109,
+    key.offset: 5146,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5119,
+    key.offset: 5156,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5139,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5144,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5149,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5169,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5176,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5186,
-    key.length: 12
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5206,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5211,
+    key.offset: 5181,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5216,
+    key.offset: 5186,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5236,
+    key.offset: 5206,
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5214,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 5224,
+    key.length: 12
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5246,
+    key.offset: 5244,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5251,
+    key.offset: 5249,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5256,
+    key.offset: 5254,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5274,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5284,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5289,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5294,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5277,
+    key.offset: 5315,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5284,
+    key.offset: 5323,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5294,
+    key.offset: 5333,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5314,
+    key.offset: 5353,
     key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5319,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5324,
-    key.length: 14
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5344,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5351,
-    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 5358,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 5363,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5383,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 5391,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 5398,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5367,
+    key.offset: 5407,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5385,
+    key.offset: 5426,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5390,
+    key.offset: 5431,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5396,
+    key.offset: 5437,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5420,
+    key.offset: 5461,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5438,
+    key.offset: 5480,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5443,
+    key.offset: 5485,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5449,
+    key.offset: 5491,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5477,
+    key.offset: 5519,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5497,
+    key.offset: 5539,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5513,
+    key.offset: 5555,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5518,
+    key.offset: 5560,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5522,
+    key.offset: 5564,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5534,
+    key.offset: 5576,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5550,
+    key.offset: 5592,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5566,
+    key.offset: 5608,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5571,
+    key.offset: 5613,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5575,
+    key.offset: 5617,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5593,
+    key.offset: 5635,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5609,
+    key.offset: 5651,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5614,
+    key.offset: 5656,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5618,
+    key.offset: 5660,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5630,
+    key.offset: 5672,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5640,
+    key.offset: 5682,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5645,
+    key.offset: 5687,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5649,
+    key.offset: 5691,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5660,
+    key.offset: 5702,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5670,
+    key.offset: 5712,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5675,
+    key.offset: 5717,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5679,
+    key.offset: 5721,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5689,
+    key.offset: 5731,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5699,
+    key.offset: 5741,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5704,
+    key.offset: 5746,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5709,
+    key.offset: 5751,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5713,
+    key.offset: 5755,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5722,
+    key.offset: 5764,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5738,
+    key.offset: 5780,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5743,
+    key.offset: 5785,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5747,
+    key.offset: 5789,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5755,
+    key.offset: 5797,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5763,
+    key.offset: 5806,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5768,
+    key.offset: 5811,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5774,
+    key.offset: 5817,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5798,
+    key.offset: 5841,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5818,
+    key.offset: 5861,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5825,
+    key.offset: 5868,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5837,
+    key.offset: 5880,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5843,
+    key.offset: 5886,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5847,
+    key.offset: 5890,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 5850,
+    key.offset: 5893,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5862,
+    key.offset: 5905,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 5873,
+    key.offset: 5916,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5876,
+    key.offset: 5919,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5888,
+    key.offset: 5931,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 5897,
+    key.offset: 5940,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5906,
+    key.offset: 5949,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5911,
+    key.offset: 5954,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5916,
+    key.offset: 5959,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5934,
+    key.offset: 5977,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5945,
+    key.offset: 5988,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 5951,
+    key.offset: 5994,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 5957,
+    key.offset: 6000,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 5964,
+    key.offset: 6007,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 5969,
+    key.offset: 6012,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 5974,
+    key.offset: 6017,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6004,
+    key.offset: 6047,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6015,
+    key.offset: 6058,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6022,
+    key.offset: 6065,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6034,
+    key.offset: 6077,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6040,
+    key.offset: 6083,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6049,
+    key.offset: 6092,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6058,
+    key.offset: 6101,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6063,
+    key.offset: 6106,
     key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6068,
-    key.length: 25
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6098,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6105,
-    key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 6111,
+    key.length: 25
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 6142,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 6149,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 6155,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6125,
+    key.offset: 6170,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.operator,
-    key.offset: 6136,
+    key.offset: 6181,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6139,
+    key.offset: 6184,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6151,
+    key.offset: 6196,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.string,
-    key.offset: 6160,
+    key.offset: 6205,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6189,
+    key.offset: 6234,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6196,
+    key.offset: 6241,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6201,
+    key.offset: 6246,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6225,
+    key.offset: 6270,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6236,
+    key.offset: 6281,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6241,
+    key.offset: 6286,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6257,
+    key.offset: 6302,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6264,
+    key.offset: 6309,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6269,
+    key.offset: 6314,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 6282,
+    key.offset: 6327,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6286,
+    key.offset: 6332,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6293,
+    key.offset: 6339,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6299,
+    key.offset: 6345,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6326,
+    key.offset: 6372,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6333,
+    key.offset: 6379,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6338,
+    key.offset: 6384,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6345,
+    key.offset: 6391,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6352,
+    key.offset: 6398,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6358,
+    key.offset: 6404,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6383,
+    key.offset: 6429,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 6387,
+    key.offset: 6433,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6414,
+    key.offset: 6460,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 6423,
+    key.offset: 6469,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 6430,
+    key.offset: 6476,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 6435,
+    key.offset: 6481,
     key.length: 1
   }
 ]
@@ -3494,37 +3540,37 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 113,
+    key.offset: 112,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 124,
+    key.offset: 123,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 172,
+    key.offset: 171,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 207,
+    key.offset: 206,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 241,
+    key.offset: 240,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 300,
+    key.offset: 299,
     key.length: 8
   },
   {
@@ -3559,185 +3605,179 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 501,
+    key.offset: 502,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 540,
+    key.offset: 542,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 582,
+    key.offset: 585,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 593,
+    key.offset: 596,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 641,
+    key.offset: 644,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 676,
+    key.offset: 679,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 710,
+    key.offset: 713,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 741,
+    key.offset: 745,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 780,
+    key.offset: 785,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 869,
+    key.offset: 874,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 1037,
+    key.offset: 1042,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1076,
+    key.offset: 1081,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1117,
+    key.offset: 1122,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1180,
+    key.offset: 1185,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1274,
+    key.offset: 1280,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1284,
+    key.offset: 1290,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1311,
+    key.offset: 1317,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1336,
+    key.offset: 1342,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1382,
+    key.offset: 1389,
     key.length: 20,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1403,
+    key.offset: 1410,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1481,
+    key.offset: 1489,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1491,
+    key.offset: 1499,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1518,
+    key.offset: 1526,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1543,
+    key.offset: 1551,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1589,
+    key.offset: 1598,
     key.length: 10
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 1673,
-    key.length: 5,
-    key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.offset: 1683,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 1693,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1710,
+    key.offset: 1720,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1735,
+    key.offset: 1745,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1805,
+    key.offset: 1815,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1861,
-    key.length: 5,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 1920,
+    key.offset: 1871,
     key.length: 5,
     key.is_system: 1
   },
@@ -3749,19 +3789,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1974,
+    key.offset: 1940,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 1984,
+    key.offset: 1985,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2016,
+    key.offset: 1995,
     key.length: 5,
     key.is_system: 1
   },
@@ -3774,19 +3814,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.ref.struct,
     key.offset: 2040,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2052,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2053,
+    key.offset: 2065,
     key.length: 20,
-    key.is_system: 1
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.offset: 2074,
-    key.length: 5,
     key.is_system: 1
   },
   {
@@ -3797,306 +3837,312 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2130,
+    key.offset: 2098,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2140,
+    key.offset: 2143,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2213,
+    key.offset: 2153,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2223,
+    key.offset: 2227,
+    key.length: 5,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.offset: 2237,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2266,
+    key.offset: 2281,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 2306,
+    key.offset: 2322,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2866,
+    key.offset: 2882,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 2876,
+    key.offset: 2892,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3327,
+    key.offset: 3340,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3368,
+    key.offset: 3381,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3409,
+    key.offset: 3422,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3462,
+    key.offset: 3476,
     key.length: 15
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3603,
+    key.offset: 3618,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3676,
+    key.offset: 3691,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3836,
+    key.offset: 3851,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 3850,
+    key.offset: 3865,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3899,
+    key.offset: 3914,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3933,
+    key.offset: 3948,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 3967,
+    key.offset: 3982,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4052,
+    key.offset: 4067,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4096,
+    key.offset: 4111,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4112,
+    key.offset: 4127,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4238,
+    key.offset: 4254,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4268,
+    key.offset: 4285,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4306,
+    key.offset: 4324,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4344,
+    key.offset: 4363,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4382,
+    key.offset: 4402,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4421,
+    key.offset: 4442,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4460,
+    key.offset: 4482,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4506,
+    key.offset: 4529,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 4552,
+    key.offset: 4576,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4590,
+    key.offset: 4615,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4629,
+    key.offset: 4655,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4668,
+    key.offset: 4695,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4705,
+    key.offset: 4733,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4745,
+    key.offset: 4774,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4790,
+    key.offset: 4820,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4834,
+    key.offset: 4865,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4879,
+    key.offset: 4911,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 4923,
+    key.offset: 4956,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5075,
+    key.offset: 5111,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5101,
+    key.offset: 5137,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5119,
+    key.offset: 5156,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5186,
+    key.offset: 5224,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5294,
+    key.offset: 5333,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 5420,
+    key.offset: 5461,
     key.length: 13
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5477,
+    key.offset: 5519,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5755,
+    key.offset: 5797,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 5798,
+    key.offset: 5841,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 5850,
+    key.offset: 5893,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 6225,
+    key.offset: 6270,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 6383,
+    key.offset: 6429,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 6387,
+    key.offset: 6433,
     key.length: 19
   }
 ]
@@ -4105,13 +4151,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1",
-    key.offset: 95,
+    key.offset: 94,
     key.length: 154,
-    key.nameoffset: 102,
+    key.nameoffset: 101,
     key.namelength: 8,
-    key.bodyoffset: 142,
+    key.bodyoffset: 141,
     key.bodylength: 106,
-    key.docoffset: 62,
+    key.docoffset: 61,
     key.doclength: 26,
     key.inheritedtypes: [
       {
@@ -4123,7 +4169,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 88,
+        key.offset: 87,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4131,12 +4177,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 113,
+        key.offset: 112,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 124,
+        key.offset: 123,
         key.length: 16
       }
     ],
@@ -4145,13 +4191,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 155,
+        key.offset: 154,
         key.length: 24,
-        key.nameoffset: 155,
+        key.nameoffset: 154,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 148,
+            key.offset: 147,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4160,7 +4206,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 160,
+            key.offset: 159,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4170,13 +4216,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 192,
+        key.offset: 191,
         key.length: 22,
-        key.nameoffset: 192,
+        key.nameoffset: 191,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 185,
+            key.offset: 184,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4185,10 +4231,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 197,
+            key.offset: 196,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 197,
+            key.nameoffset: 196,
             key.namelength: 8
           }
         ]
@@ -4198,14 +4244,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 227,
+        key.offset: 226,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 231,
+        key.nameoffset: 230,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 220,
+            key.offset: 219,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4217,18 +4263,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1X",
-    key.offset: 285,
+    key.offset: 284,
     key.length: 31,
     key.typename: "FooEnum1",
-    key.nameoffset: 289,
+    key.nameoffset: 288,
     key.namelength: 9,
-    key.bodyoffset: 310,
+    key.bodyoffset: 309,
     key.bodylength: 5,
-    key.docoffset: 251,
+    key.docoffset: 250,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 278,
+        key.offset: 277,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4348,16 +4394,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2X",
-    key.offset: 486,
+    key.offset: 487,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 490,
+    key.nameoffset: 491,
     key.namelength: 9,
-    key.bodyoffset: 511,
+    key.bodyoffset: 512,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 479,
+        key.offset: 480,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4367,16 +4413,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2Y",
-    key.offset: 525,
+    key.offset: 527,
     key.length: 31,
     key.typename: "FooEnum2",
-    key.nameoffset: 529,
+    key.nameoffset: 531,
     key.namelength: 9,
-    key.bodyoffset: 550,
+    key.bodyoffset: 552,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 518,
+        key.offset: 520,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4386,11 +4432,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3",
-    key.offset: 564,
+    key.offset: 567,
     key.length: 154,
-    key.nameoffset: 571,
+    key.nameoffset: 574,
     key.namelength: 8,
-    key.bodyoffset: 611,
+    key.bodyoffset: 614,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -4402,7 +4448,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 557,
+        key.offset: 560,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4410,12 +4456,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 582,
+        key.offset: 585,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 593,
+        key.offset: 596,
         key.length: 16
       }
     ],
@@ -4424,13 +4470,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 624,
+        key.offset: 627,
         key.length: 24,
-        key.nameoffset: 624,
+        key.nameoffset: 627,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 617,
+            key.offset: 620,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4439,7 +4485,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 629,
+            key.offset: 632,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -4449,13 +4495,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 661,
+        key.offset: 664,
         key.length: 22,
-        key.nameoffset: 661,
+        key.nameoffset: 664,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 654,
+            key.offset: 657,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4464,10 +4510,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 666,
+            key.offset: 669,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 666,
+            key.nameoffset: 669,
             key.namelength: 8
           }
         ]
@@ -4477,14 +4523,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 696,
+        key.offset: 699,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 700,
+        key.nameoffset: 703,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 689,
+            key.offset: 692,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4496,16 +4542,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3X",
-    key.offset: 726,
+    key.offset: 730,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 730,
+    key.nameoffset: 734,
     key.namelength: 9,
-    key.bodyoffset: 751,
+    key.bodyoffset: 755,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 719,
+        key.offset: 723,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4515,16 +4561,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3Y",
-    key.offset: 765,
+    key.offset: 770,
     key.length: 31,
     key.typename: "FooEnum3",
-    key.nameoffset: 769,
+    key.nameoffset: 774,
     key.namelength: 9,
-    key.bodyoffset: 790,
+    key.bodyoffset: 795,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 758,
+        key.offset: 763,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4534,13 +4580,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooComparisonResult",
-    key.offset: 842,
+    key.offset: 847,
     key.length: 124,
-    key.nameoffset: 847,
+    key.nameoffset: 852,
     key.namelength: 19,
-    key.bodyoffset: 874,
+    key.bodyoffset: 879,
     key.bodylength: 91,
-    key.docoffset: 798,
+    key.docoffset: 803,
     key.doclength: 37,
     key.inheritedtypes: [
       {
@@ -4549,7 +4595,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 835,
+        key.offset: 840,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4557,28 +4603,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 869,
+        key.offset: 874,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 880,
+        key.offset: 885,
         key.length: 26,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedAscending",
-            key.offset: 885,
+            key.offset: 890,
             key.length: 21,
-            key.nameoffset: 885,
+            key.nameoffset: 890,
             key.namelength: 16,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 904,
+                key.offset: 909,
                 key.length: 2
               }
             ]
@@ -4587,21 +4633,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 912,
+        key.offset: 917,
         key.length: 20,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedSame",
-            key.offset: 917,
+            key.offset: 922,
             key.length: 15,
-            key.nameoffset: 917,
+            key.nameoffset: 922,
             key.namelength: 11,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 931,
+                key.offset: 936,
                 key.length: 1
               }
             ]
@@ -4610,21 +4656,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 938,
+        key.offset: 943,
         key.length: 26,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "orderedDescending",
-            key.offset: 943,
+            key.offset: 948,
             key.length: 21,
-            key.nameoffset: 943,
+            key.nameoffset: 948,
             key.namelength: 17,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 963,
+                key.offset: 968,
                 key.length: 1
               }
             ]
@@ -4637,13 +4683,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooRuncingOptions",
-    key.offset: 1010,
+    key.offset: 1015,
     key.length: 197,
-    key.nameoffset: 1017,
+    key.nameoffset: 1022,
     key.namelength: 17,
-    key.bodyoffset: 1048,
+    key.bodyoffset: 1053,
     key.bodylength: 158,
-    key.docoffset: 968,
+    key.docoffset: 973,
     key.doclength: 35,
     key.inheritedtypes: [
       {
@@ -4652,7 +4698,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 1003,
+        key.offset: 1008,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4660,7 +4706,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1037,
+        key.offset: 1042,
         key.length: 9
       }
     ],
@@ -4669,13 +4715,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 1061,
+        key.offset: 1066,
         key.length: 19,
-        key.nameoffset: 1061,
+        key.nameoffset: 1066,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 1054,
+            key.offset: 1059,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4684,10 +4730,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 1066,
+            key.offset: 1071,
             key.length: 13,
             key.typename: "Int",
-            key.nameoffset: 1066,
+            key.nameoffset: 1071,
             key.namelength: 8
           }
         ]
@@ -4696,16 +4742,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableMince",
-        key.offset: 1093,
+        key.offset: 1098,
         key.length: 49,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1104,
+        key.nameoffset: 1109,
         key.namelength: 11,
-        key.bodyoffset: 1136,
+        key.bodyoffset: 1141,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1086,
+            key.offset: 1091,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4715,16 +4761,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "enableQuince",
-        key.offset: 1155,
+        key.offset: 1160,
         key.length: 50,
         key.typename: "FooRuncingOptions",
-        key.nameoffset: 1166,
+        key.nameoffset: 1171,
         key.namelength: 12,
-        key.bodyoffset: 1199,
+        key.bodyoffset: 1204,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 1148,
+            key.offset: 1153,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4736,15 +4782,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1",
-    key.offset: 1215,
+    key.offset: 1221,
     key.length: 129,
-    key.nameoffset: 1222,
+    key.nameoffset: 1228,
     key.namelength: 10,
-    key.bodyoffset: 1234,
+    key.bodyoffset: 1240,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1208,
+        key.offset: 1214,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4754,13 +4800,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1247,
+        key.offset: 1253,
         key.length: 6,
-        key.nameoffset: 1247,
+        key.nameoffset: 1253,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1240,
+            key.offset: 1246,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4770,13 +4816,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1266,
+        key.offset: 1272,
         key.length: 25,
-        key.nameoffset: 1266,
+        key.nameoffset: 1272,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1259,
+            key.offset: 1265,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4785,19 +4831,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1271,
+            key.offset: 1277,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1271,
+            key.nameoffset: 1277,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1281,
+            key.offset: 1287,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1281,
+            key.nameoffset: 1287,
             key.namelength: 1
           }
         ]
@@ -4807,14 +4853,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1304,
+        key.offset: 1310,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1308,
+        key.nameoffset: 1314,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1297,
+            key.offset: 1303,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4825,14 +4871,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1329,
+        key.offset: 1335,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1333,
+        key.nameoffset: 1339,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1322,
+            key.offset: 1328,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4844,13 +4890,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct1Pointer",
-    key.offset: 1352,
+    key.offset: 1359,
     key.length: 62,
-    key.nameoffset: 1362,
+    key.nameoffset: 1369,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1345,
+        key.offset: 1352,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4860,15 +4906,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStruct2",
-    key.offset: 1422,
+    key.offset: 1430,
     key.length: 129,
-    key.nameoffset: 1429,
+    key.nameoffset: 1437,
     key.namelength: 10,
-    key.bodyoffset: 1441,
+    key.bodyoffset: 1449,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1415,
+        key.offset: 1423,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4878,13 +4924,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1454,
+        key.offset: 1462,
         key.length: 6,
-        key.nameoffset: 1454,
+        key.nameoffset: 1462,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1447,
+            key.offset: 1455,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4894,13 +4940,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1473,
+        key.offset: 1481,
         key.length: 25,
-        key.nameoffset: 1473,
+        key.nameoffset: 1481,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1466,
+            key.offset: 1474,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4909,19 +4955,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1478,
+            key.offset: 1486,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1478,
+            key.nameoffset: 1486,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1488,
+            key.offset: 1496,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1488,
+            key.nameoffset: 1496,
             key.namelength: 1
           }
         ]
@@ -4931,14 +4977,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1511,
+        key.offset: 1519,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1515,
+        key.nameoffset: 1523,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1504,
+            key.offset: 1512,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4949,14 +4995,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1536,
+        key.offset: 1544,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1540,
+        key.nameoffset: 1548,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1529,
+            key.offset: 1537,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -4968,13 +5014,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef1",
-    key.offset: 1559,
+    key.offset: 1568,
     key.length: 40,
-    key.nameoffset: 1569,
+    key.nameoffset: 1578,
     key.namelength: 17,
     key.attributes: [
       {
-        key.offset: 1552,
+        key.offset: 1561,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -4984,15 +5030,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooStructTypedef2",
-    key.offset: 1607,
+    key.offset: 1617,
     key.length: 136,
-    key.nameoffset: 1614,
+    key.nameoffset: 1624,
     key.namelength: 17,
-    key.bodyoffset: 1633,
+    key.bodyoffset: 1643,
     key.bodylength: 109,
     key.attributes: [
       {
-        key.offset: 1600,
+        key.offset: 1610,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5002,13 +5048,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 1646,
+        key.offset: 1656,
         key.length: 6,
-        key.nameoffset: 1646,
+        key.nameoffset: 1656,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 1639,
+            key.offset: 1649,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5018,13 +5064,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:y:)",
-        key.offset: 1665,
+        key.offset: 1675,
         key.length: 25,
-        key.nameoffset: 1665,
+        key.nameoffset: 1675,
         key.namelength: 25,
         key.attributes: [
           {
-            key.offset: 1658,
+            key.offset: 1668,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5033,19 +5079,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 1670,
+            key.offset: 1680,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 1670,
+            key.nameoffset: 1680,
             key.namelength: 1
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "y",
-            key.offset: 1680,
+            key.offset: 1690,
             key.length: 9,
             key.typename: "Double",
-            key.nameoffset: 1680,
+            key.nameoffset: 1690,
             key.namelength: 1
           }
         ]
@@ -5055,14 +5101,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 1703,
+        key.offset: 1713,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 1707,
+        key.nameoffset: 1717,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1696,
+            key.offset: 1706,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5073,14 +5119,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "y",
-        key.offset: 1728,
+        key.offset: 1738,
         key.length: 13,
         key.typename: "Double",
-        key.nameoffset: 1732,
+        key.nameoffset: 1742,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 1721,
+            key.offset: 1731,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5092,15 +5138,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooTypedef1",
-    key.offset: 1781,
+    key.offset: 1791,
     key.length: 29,
-    key.nameoffset: 1791,
+    key.nameoffset: 1801,
     key.namelength: 11,
-    key.docoffset: 1745,
+    key.docoffset: 1755,
     key.doclength: 29,
     key.attributes: [
       {
-        key.offset: 1774,
+        key.offset: 1784,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5111,16 +5157,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.accessibility: source.lang.swift.accessibility.public,
     key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "fooIntVar",
-    key.offset: 1846,
+    key.offset: 1856,
     key.length: 20,
     key.typename: "Int32",
-    key.nameoffset: 1850,
+    key.nameoffset: 1860,
     key.namelength: 9,
-    key.docoffset: 1812,
+    key.docoffset: 1822,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 1839,
+        key.offset: 1849,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5130,16 +5176,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1(_:)",
-    key.offset: 1901,
+    key.offset: 1911,
     key.length: 34,
     key.typename: "Int32",
-    key.nameoffset: 1906,
+    key.nameoffset: 1916,
     key.namelength: 20,
-    key.docoffset: 1868,
+    key.docoffset: 1878,
     key.doclength: 26,
     key.attributes: [
       {
-        key.offset: 1894,
+        key.offset: 1904,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5148,7 +5194,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 1915,
+        key.offset: 1925,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -5158,14 +5204,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc1AnonymousParam(_:)",
-    key.offset: 1943,
+    key.offset: 1954,
     key.length: 46,
     key.typename: "Int32",
-    key.nameoffset: 1948,
+    key.nameoffset: 1959,
     key.namelength: 32,
     key.attributes: [
       {
-        key.offset: 1936,
+        key.offset: 1947,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5173,7 +5219,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.parameter,
-        key.offset: 1971,
+        key.offset: 1982,
         key.length: 8,
         key.typename: "Int32"
       }
@@ -5183,14 +5229,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFunc3(_:_:_:_:)",
-    key.offset: 1997,
+    key.offset: 2009,
     key.length: 94,
     key.typename: "Int32",
-    key.nameoffset: 2002,
+    key.nameoffset: 2014,
     key.namelength: 80,
     key.attributes: [
       {
-        key.offset: 1990,
+        key.offset: 2002,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5199,28 +5245,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2011,
+        key.offset: 2023,
         key.length: 10,
         key.typename: "Int32"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "b",
-        key.offset: 2023,
+        key.offset: 2035,
         key.length: 10,
         key.typename: "Float"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "c",
-        key.offset: 2035,
+        key.offset: 2047,
         key.length: 11,
         key.typename: "Double"
       },
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "d",
-        key.offset: 2048,
+        key.offset: 2060,
         key.length: 33,
         key.typename: "UnsafeMutablePointer<Int32>!"
       }
@@ -5230,13 +5276,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithBlock(_:)",
-    key.offset: 2099,
+    key.offset: 2112,
     key.length: 49,
-    key.nameoffset: 2104,
+    key.nameoffset: 2117,
     key.namelength: 44,
     key.attributes: [
       {
-        key.offset: 2092,
+        key.offset: 2105,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5245,7 +5291,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "blk",
-        key.offset: 2121,
+        key.offset: 2134,
         key.length: 26,
         key.typename: "((Float) -> Int32)!"
       }
@@ -5255,13 +5301,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithFunctionPointer(_:)",
-    key.offset: 2156,
+    key.offset: 2170,
     key.length: 75,
-    key.nameoffset: 2161,
+    key.nameoffset: 2175,
     key.namelength: 70,
     key.attributes: [
       {
-        key.offset: 2149,
+        key.offset: 2163,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5270,7 +5316,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "fptr",
-        key.offset: 2188,
+        key.offset: 2202,
         key.length: 42,
         key.typename: "(@convention(c) (Float) -> Int32)!"
       }
@@ -5280,14 +5326,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn1()",
-    key.offset: 2239,
+    key.offset: 2254,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2244,
+    key.nameoffset: 2259,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2232,
+        key.offset: 2247,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5297,14 +5343,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncNoreturn2()",
-    key.offset: 2279,
+    key.offset: 2295,
     key.length: 32,
     key.typename: "Never",
-    key.nameoffset: 2284,
+    key.nameoffset: 2300,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 2272,
+        key.offset: 2288,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5314,15 +5360,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment1()",
-    key.offset: 2383,
+    key.offset: 2399,
     key.length: 26,
-    key.nameoffset: 2388,
+    key.nameoffset: 2404,
     key.namelength: 21,
-    key.docoffset: 2313,
+    key.docoffset: 2329,
     key.doclength: 62,
     key.attributes: [
       {
-        key.offset: 2376,
+        key.offset: 2392,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5332,15 +5378,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment2()",
-    key.offset: 2461,
+    key.offset: 2477,
     key.length: 26,
-    key.nameoffset: 2466,
+    key.nameoffset: 2482,
     key.namelength: 21,
-    key.docoffset: 2411,
+    key.docoffset: 2427,
     key.doclength: 42,
     key.attributes: [
       {
-        key.offset: 2454,
+        key.offset: 2470,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5350,15 +5396,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment3()",
-    key.offset: 2556,
+    key.offset: 2572,
     key.length: 26,
-    key.nameoffset: 2561,
+    key.nameoffset: 2577,
     key.namelength: 21,
-    key.docoffset: 2489,
+    key.docoffset: 2505,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 2549,
+        key.offset: 2565,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5368,15 +5414,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment4()",
-    key.offset: 2644,
+    key.offset: 2660,
     key.length: 26,
-    key.nameoffset: 2649,
+    key.nameoffset: 2665,
     key.namelength: 21,
-    key.docoffset: 2584,
+    key.docoffset: 2600,
     key.doclength: 53,
     key.attributes: [
       {
-        key.offset: 2637,
+        key.offset: 2653,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5386,15 +5432,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooFuncWithComment5()",
-    key.offset: 2738,
+    key.offset: 2754,
     key.length: 26,
-    key.nameoffset: 2743,
+    key.nameoffset: 2759,
     key.namelength: 21,
-    key.docoffset: 2672,
+    key.docoffset: 2688,
     key.doclength: 59,
     key.attributes: [
       {
-        key.offset: 2731,
+        key.offset: 2747,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5404,16 +5450,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "redeclaredInMultipleModulesFunc1(_:)",
-    key.offset: 2823,
+    key.offset: 2839,
     key.length: 58,
     key.typename: "Int32",
-    key.nameoffset: 2828,
+    key.nameoffset: 2844,
     key.namelength: 44,
-    key.docoffset: 2766,
+    key.docoffset: 2782,
     key.doclength: 50,
     key.attributes: [
       {
-        key.offset: 2816,
+        key.offset: 2832,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5422,7 +5468,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 2861,
+        key.offset: 2877,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -5432,17 +5478,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolBase",
-    key.offset: 2923,
-    key.length: 501,
-    key.nameoffset: 2932,
+    key.offset: 2939,
+    key.length: 498,
+    key.nameoffset: 2948,
     key.namelength: 15,
-    key.bodyoffset: 2949,
-    key.bodylength: 474,
-    key.docoffset: 2883,
+    key.bodyoffset: 2965,
+    key.bodylength: 471,
+    key.docoffset: 2899,
     key.doclength: 33,
     key.attributes: [
       {
-        key.offset: 2916,
+        key.offset: 2932,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5452,42 +5498,42 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFunc()",
-        key.offset: 3003,
+        key.offset: 3018,
         key.length: 19,
-        key.nameoffset: 3008,
+        key.nameoffset: 3023,
         key.namelength: 14,
-        key.docoffset: 2956,
+        key.docoffset: 2971,
         key.doclength: 43
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation1()",
-        key.offset: 3097,
+        key.offset: 3111,
         key.length: 40,
-        key.nameoffset: 3102,
+        key.nameoffset: 3116,
         key.namelength: 35,
-        key.docoffset: 3029,
+        key.docoffset: 3043,
         key.doclength: 64
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoFuncWithExtraIndentation2()",
-        key.offset: 3226,
+        key.offset: 3239,
         key.length: 40,
-        key.nameoffset: 3231,
+        key.nameoffset: 3244,
         key.namelength: 35,
-        key.docoffset: 3144,
+        key.docoffset: 3157,
         key.doclength: 77
       },
       {
         key.kind: source.lang.swift.decl.function.method.static,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProtoClassFunc()",
-        key.offset: 3272,
+        key.offset: 3285,
         key.length: 31,
-        key.nameoffset: 3284,
+        key.nameoffset: 3297,
         key.namelength: 19
       },
       {
@@ -5495,12 +5541,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty1",
-        key.offset: 3309,
+        key.offset: 3322,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3313,
+        key.nameoffset: 3326,
         key.namelength: 12,
-        key.bodyoffset: 3334,
+        key.bodyoffset: 3347,
         key.bodylength: 9
       },
       {
@@ -5508,24 +5554,24 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty2",
-        key.offset: 3350,
+        key.offset: 3363,
         key.length: 35,
         key.typename: "Int32",
-        key.nameoffset: 3354,
+        key.nameoffset: 3367,
         key.namelength: 12,
-        key.bodyoffset: 3375,
+        key.bodyoffset: 3388,
         key.bodylength: 9
       },
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "fooProperty3",
-        key.offset: 3391,
+        key.offset: 3404,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 3395,
+        key.nameoffset: 3408,
         key.namelength: 12,
-        key.bodyoffset: 3416,
+        key.bodyoffset: 3429,
         key.bodylength: 5
       }
     ]
@@ -5534,11 +5580,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooProtocolDerived",
-    key.offset: 3432,
+    key.offset: 3446,
     key.length: 49,
-    key.nameoffset: 3441,
+    key.nameoffset: 3455,
     key.namelength: 18,
-    key.bodyoffset: 3479,
+    key.bodyoffset: 3493,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -5547,7 +5593,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 3425,
+        key.offset: 3439,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5555,7 +5601,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3462,
+        key.offset: 3476,
         key.length: 15
       }
     ]
@@ -5564,15 +5610,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassBase",
-    key.offset: 3487,
+    key.offset: 3502,
     key.length: 285,
-    key.nameoffset: 3493,
+    key.nameoffset: 3508,
     key.namelength: 12,
-    key.bodyoffset: 3507,
+    key.bodyoffset: 3522,
     key.bodylength: 264,
     key.attributes: [
       {
-        key.offset: 3482,
+        key.offset: 3497,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5582,13 +5628,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc0()",
-        key.offset: 3518,
+        key.offset: 3533,
         key.length: 27,
-        key.nameoffset: 3523,
+        key.nameoffset: 3538,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 3513,
+            key.offset: 3528,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5598,14 +5644,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFunc1(_:)",
-        key.offset: 3556,
+        key.offset: 3571,
         key.length: 60,
         key.typename: "FooClassBase!",
-        key.nameoffset: 3561,
+        key.nameoffset: 3576,
         key.namelength: 38,
         key.attributes: [
           {
-            key.offset: 3551,
+            key.offset: 3566,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5614,7 +5660,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "anObject",
-            key.offset: 3582,
+            key.offset: 3597,
             key.length: 16,
             key.typename: "Any!"
           }
@@ -5624,13 +5670,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 3629,
+        key.offset: 3644,
         key.length: 7,
-        key.nameoffset: 3629,
+        key.nameoffset: 3644,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3622,
+            key.offset: 3637,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5640,18 +5686,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(float:)",
-        key.offset: 3661,
+        key.offset: 3676,
         key.length: 21,
-        key.nameoffset: 3661,
+        key.nameoffset: 3676,
         key.namelength: 21,
         key.attributes: [
           {
-            key.offset: 3649,
+            key.offset: 3664,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 3642,
+            key.offset: 3657,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -5660,10 +5706,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "f",
-            key.offset: 3667,
+            key.offset: 3682,
             key.length: 14,
             key.typename: "Float",
-            key.nameoffset: 3667,
+            key.nameoffset: 3682,
             key.namelength: 5
           }
         ]
@@ -5672,13 +5718,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 3693,
+        key.offset: 3708,
         key.length: 36,
-        key.nameoffset: 3698,
+        key.nameoffset: 3713,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 3688,
+            key.offset: 3703,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5688,13 +5734,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseClassFunc0()",
-        key.offset: 3740,
+        key.offset: 3755,
         key.length: 30,
-        key.nameoffset: 3751,
+        key.nameoffset: 3766,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 3735,
+            key.offset: 3750,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5706,13 +5752,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassDerived",
-    key.offset: 3812,
+    key.offset: 3827,
     key.length: 392,
-    key.nameoffset: 3818,
+    key.nameoffset: 3833,
     key.namelength: 15,
-    key.bodyoffset: 3870,
+    key.bodyoffset: 3885,
     key.bodylength: 333,
-    key.docoffset: 3774,
+    key.docoffset: 3789,
     key.doclength: 33,
     key.inheritedtypes: [
       {
@@ -5724,7 +5770,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 3807,
+        key.offset: 3822,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -5732,12 +5778,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3836,
+        key.offset: 3851,
         key.length: 12
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3850,
+        key.offset: 3865,
         key.length: 18
       }
     ],
@@ -5747,14 +5793,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty1",
-        key.offset: 3881,
+        key.offset: 3896,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3885,
+        key.nameoffset: 3900,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 3876,
+            key.offset: 3891,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5765,14 +5811,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty2",
-        key.offset: 3915,
+        key.offset: 3930,
         key.length: 23,
         key.typename: "Int32",
-        key.nameoffset: 3919,
+        key.nameoffset: 3934,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 3910,
+            key.offset: 3925,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5782,16 +5828,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty3",
-        key.offset: 3949,
+        key.offset: 3964,
         key.length: 31,
         key.typename: "Int32",
-        key.nameoffset: 3953,
+        key.nameoffset: 3968,
         key.namelength: 12,
-        key.bodyoffset: 3974,
+        key.bodyoffset: 3989,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 3944,
+            key.offset: 3959,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5801,13 +5847,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc0()",
-        key.offset: 3991,
+        key.offset: 4006,
         key.length: 23,
-        key.nameoffset: 3996,
+        key.nameoffset: 4011,
         key.namelength: 18,
         key.attributes: [
           {
-            key.offset: 3986,
+            key.offset: 4001,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5817,13 +5863,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc1(_:)",
-        key.offset: 4025,
+        key.offset: 4040,
         key.length: 33,
-        key.nameoffset: 4030,
+        key.nameoffset: 4045,
         key.namelength: 28,
         key.attributes: [
           {
-            key.offset: 4020,
+            key.offset: 4035,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5832,7 +5878,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4047,
+            key.offset: 4062,
             key.length: 10,
             key.typename: "Int32"
           }
@@ -5842,13 +5888,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooInstanceFunc2(_:withB:)",
-        key.offset: 4069,
+        key.offset: 4084,
         key.length: 49,
-        key.nameoffset: 4074,
+        key.nameoffset: 4089,
         key.namelength: 44,
         key.attributes: [
           {
-            key.offset: 4064,
+            key.offset: 4079,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5857,17 +5903,17 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "a",
-            key.offset: 4091,
+            key.offset: 4106,
             key.length: 10,
             key.typename: "Int32"
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "b",
-            key.offset: 4103,
+            key.offset: 4118,
             key.length: 14,
             key.typename: "Int32",
-            key.nameoffset: 4103,
+            key.nameoffset: 4118,
             key.namelength: 5
           }
         ]
@@ -5876,13 +5922,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooBaseInstanceFuncOverridden()",
-        key.offset: 4129,
+        key.offset: 4144,
         key.length: 36,
-        key.nameoffset: 4134,
+        key.nameoffset: 4149,
         key.namelength: 31,
         key.attributes: [
           {
-            key.offset: 4124,
+            key.offset: 4139,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5892,13 +5938,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "fooClassFunc0()",
-        key.offset: 4176,
+        key.offset: 4191,
         key.length: 26,
-        key.nameoffset: 4187,
+        key.nameoffset: 4202,
         key.namelength: 15,
         key.attributes: [
           {
-            key.offset: 4171,
+            key.offset: 4186,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -5910,13 +5956,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "typedef_int_t",
-    key.offset: 4212,
+    key.offset: 4228,
     key.length: 31,
-    key.nameoffset: 4222,
+    key.nameoffset: 4238,
     key.namelength: 13,
     key.attributes: [
       {
-        key.offset: 4205,
+        key.offset: 4221,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5926,16 +5972,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_1",
-    key.offset: 4251,
+    key.offset: 4268,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4255,
+    key.nameoffset: 4272,
     key.namelength: 11,
-    key.bodyoffset: 4275,
+    key.bodyoffset: 4292,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4244,
+        key.offset: 4261,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5945,16 +5991,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_2",
-    key.offset: 4289,
+    key.offset: 4307,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4293,
+    key.nameoffset: 4311,
     key.namelength: 11,
-    key.bodyoffset: 4313,
+    key.bodyoffset: 4331,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4282,
+        key.offset: 4300,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5964,16 +6010,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_3",
-    key.offset: 4327,
+    key.offset: 4346,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4331,
+    key.nameoffset: 4350,
     key.namelength: 11,
-    key.bodyoffset: 4351,
+    key.bodyoffset: 4370,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4320,
+        key.offset: 4339,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -5983,16 +6029,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_4",
-    key.offset: 4365,
+    key.offset: 4385,
     key.length: 31,
     key.typename: "UInt32",
-    key.nameoffset: 4369,
+    key.nameoffset: 4389,
     key.namelength: 11,
-    key.bodyoffset: 4390,
+    key.bodyoffset: 4410,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4358,
+        key.offset: 4378,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6002,16 +6048,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_5",
-    key.offset: 4404,
+    key.offset: 4425,
     key.length: 31,
     key.typename: "UInt64",
-    key.nameoffset: 4408,
+    key.nameoffset: 4429,
     key.namelength: 11,
-    key.bodyoffset: 4429,
+    key.bodyoffset: 4450,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4397,
+        key.offset: 4418,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6021,16 +6067,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_6",
-    key.offset: 4443,
+    key.offset: 4465,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4447,
+    key.nameoffset: 4469,
     key.namelength: 11,
-    key.bodyoffset: 4475,
+    key.bodyoffset: 4497,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4436,
+        key.offset: 4458,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6040,16 +6086,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_7",
-    key.offset: 4489,
+    key.offset: 4512,
     key.length: 38,
     key.typename: "typedef_int_t",
-    key.nameoffset: 4493,
+    key.nameoffset: 4516,
     key.namelength: 11,
-    key.bodyoffset: 4521,
+    key.bodyoffset: 4544,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4482,
+        key.offset: 4505,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6059,16 +6105,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_8",
-    key.offset: 4535,
+    key.offset: 4559,
     key.length: 30,
     key.typename: "CChar",
-    key.nameoffset: 4539,
+    key.nameoffset: 4563,
     key.namelength: 11,
-    key.bodyoffset: 4559,
+    key.bodyoffset: 4583,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4528,
+        key.offset: 4552,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6078,16 +6124,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_9",
-    key.offset: 4573,
+    key.offset: 4598,
     key.length: 30,
     key.typename: "Int32",
-    key.nameoffset: 4577,
+    key.nameoffset: 4602,
     key.namelength: 11,
-    key.bodyoffset: 4597,
+    key.bodyoffset: 4622,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4566,
+        key.offset: 4591,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6097,16 +6143,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_10",
-    key.offset: 4611,
+    key.offset: 4637,
     key.length: 31,
     key.typename: "Int16",
-    key.nameoffset: 4615,
+    key.nameoffset: 4641,
     key.namelength: 12,
-    key.bodyoffset: 4636,
+    key.bodyoffset: 4662,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4604,
+        key.offset: 4630,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6116,16 +6162,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_11",
-    key.offset: 4650,
+    key.offset: 4677,
     key.length: 29,
     key.typename: "Int",
-    key.nameoffset: 4654,
+    key.nameoffset: 4681,
     key.namelength: 12,
-    key.bodyoffset: 4673,
+    key.bodyoffset: 4700,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4643,
+        key.offset: 4670,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6135,16 +6181,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_OR",
-    key.offset: 4687,
+    key.offset: 4715,
     key.length: 31,
     key.typename: "Int32",
-    key.nameoffset: 4691,
+    key.nameoffset: 4719,
     key.namelength: 12,
-    key.bodyoffset: 4712,
+    key.bodyoffset: 4740,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4680,
+        key.offset: 4708,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6154,16 +6200,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_AND",
-    key.offset: 4726,
+    key.offset: 4755,
     key.length: 32,
     key.typename: "Int32",
-    key.nameoffset: 4730,
+    key.nameoffset: 4759,
     key.namelength: 13,
-    key.bodyoffset: 4752,
+    key.bodyoffset: 4781,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4719,
+        key.offset: 4748,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6173,16 +6219,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_BITWIDTH",
-    key.offset: 4766,
+    key.offset: 4796,
     key.length: 38,
     key.typename: "UInt64",
-    key.nameoffset: 4770,
+    key.nameoffset: 4800,
     key.namelength: 18,
-    key.bodyoffset: 4798,
+    key.bodyoffset: 4828,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4759,
+        key.offset: 4789,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6192,16 +6238,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_SIGNED",
-    key.offset: 4812,
+    key.offset: 4843,
     key.length: 36,
     key.typename: "UInt32",
-    key.nameoffset: 4816,
+    key.nameoffset: 4847,
     key.namelength: 16,
-    key.bodyoffset: 4842,
+    key.bodyoffset: 4873,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4805,
+        key.offset: 4836,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6211,16 +6257,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_1",
-    key.offset: 4856,
+    key.offset: 4888,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 4860,
+    key.nameoffset: 4892,
     key.namelength: 17,
-    key.bodyoffset: 4886,
+    key.bodyoffset: 4918,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4849,
+        key.offset: 4881,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6230,16 +6276,16 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_2",
-    key.offset: 4900,
+    key.offset: 4933,
     key.length: 36,
     key.typename: "Int32",
-    key.nameoffset: 4904,
+    key.nameoffset: 4937,
     key.namelength: 17,
-    key.bodyoffset: 4930,
+    key.bodyoffset: 4963,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 4893,
+        key.offset: 4926,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6249,13 +6295,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "theLastDeclInFoo()",
-    key.offset: 4944,
+    key.offset: 4978,
     key.length: 23,
-    key.nameoffset: 4949,
+    key.nameoffset: 4983,
     key.namelength: 18,
     key.attributes: [
       {
-        key.offset: 4937,
+        key.offset: 4971,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6265,13 +6311,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_internalTopLevelFunc()",
-    key.offset: 4975,
+    key.offset: 5010,
     key.length: 28,
-    key.nameoffset: 4980,
+    key.nameoffset: 5015,
     key.namelength: 23,
     key.attributes: [
       {
-        key.offset: 4968,
+        key.offset: 5003,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6281,15 +6327,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalStruct",
-    key.offset: 5011,
+    key.offset: 5047,
     key.length: 97,
-    key.nameoffset: 5018,
+    key.nameoffset: 5054,
     key.namelength: 15,
-    key.bodyoffset: 5035,
+    key.bodyoffset: 5071,
     key.bodylength: 72,
     key.attributes: [
       {
-        key.offset: 5004,
+        key.offset: 5040,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6299,13 +6345,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 5048,
+        key.offset: 5084,
         key.length: 6,
-        key.nameoffset: 5048,
+        key.nameoffset: 5084,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 5041,
+            key.offset: 5077,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6315,13 +6361,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(x:)",
-        key.offset: 5067,
+        key.offset: 5103,
         key.length: 14,
-        key.nameoffset: 5067,
+        key.nameoffset: 5103,
         key.namelength: 14,
         key.attributes: [
           {
-            key.offset: 5060,
+            key.offset: 5096,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6330,10 +6376,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "x",
-            key.offset: 5072,
+            key.offset: 5108,
             key.length: 8,
             key.typename: "Int32",
-            key.nameoffset: 5072,
+            key.nameoffset: 5108,
             key.namelength: 1
           }
         ]
@@ -6343,14 +6389,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "x",
-        key.offset: 5094,
+        key.offset: 5130,
         key.length: 12,
         key.typename: "Int32",
-        key.nameoffset: 5098,
+        key.nameoffset: 5134,
         key.namelength: 1,
         key.attributes: [
           {
-            key.offset: 5087,
+            key.offset: 5123,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6361,25 +6407,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5109,
+    key.offset: 5146,
     key.length: 66,
-    key.nameoffset: 5119,
+    key.nameoffset: 5156,
     key.namelength: 12,
-    key.bodyoffset: 5133,
+    key.bodyoffset: 5170,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth1()",
-        key.offset: 5144,
+        key.offset: 5181,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5149,
+        key.nameoffset: 5186,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5139,
+            key.offset: 5176,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6390,25 +6436,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5176,
+    key.offset: 5214,
     key.length: 107,
-    key.nameoffset: 5186,
+    key.nameoffset: 5224,
     key.namelength: 12,
-    key.bodyoffset: 5200,
+    key.bodyoffset: 5238,
     key.bodylength: 82,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth2()",
-        key.offset: 5211,
+        key.offset: 5249,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5216,
+        key.nameoffset: 5254,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5206,
+            key.offset: 5244,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6418,14 +6464,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "nonInternalMeth()",
-        key.offset: 5251,
+        key.offset: 5289,
         key.length: 30,
         key.typename: "Any!",
-        key.nameoffset: 5256,
+        key.nameoffset: 5294,
         key.namelength: 17,
         key.attributes: [
           {
-            key.offset: 5246,
+            key.offset: 5284,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6436,25 +6482,25 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "FooClassBase",
-    key.offset: 5284,
+    key.offset: 5323,
     key.length: 66,
-    key.nameoffset: 5294,
+    key.nameoffset: 5333,
     key.namelength: 12,
-    key.bodyoffset: 5308,
+    key.bodyoffset: 5347,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "_internalMeth3()",
-        key.offset: 5319,
+        key.offset: 5358,
         key.length: 29,
         key.typename: "Any!",
-        key.nameoffset: 5324,
+        key.nameoffset: 5363,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5314,
+            key.offset: 5353,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6466,15 +6512,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "_InternalProt",
-    key.offset: 5358,
+    key.offset: 5398,
     key.length: 26,
-    key.nameoffset: 5367,
+    key.nameoffset: 5407,
     key.namelength: 13,
-    key.bodyoffset: 5382,
+    key.bodyoffset: 5422,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 5351,
+        key.offset: 5391,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6484,11 +6530,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "ClassWithInternalProt",
-    key.offset: 5390,
+    key.offset: 5431,
     key.length: 47,
-    key.nameoffset: 5396,
+    key.nameoffset: 5437,
     key.namelength: 21,
-    key.bodyoffset: 5435,
+    key.bodyoffset: 5476,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -6497,7 +6543,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5385,
+        key.offset: 5426,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6505,7 +6551,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5420,
+        key.offset: 5461,
         key.length: 13
       }
     ]
@@ -6514,11 +6560,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooClassPropertyOwnership",
-    key.offset: 5443,
+    key.offset: 5485,
     key.length: 319,
-    key.nameoffset: 5449,
+    key.nameoffset: 5491,
     key.namelength: 25,
-    key.bodyoffset: 5491,
+    key.bodyoffset: 5533,
     key.bodylength: 270,
     key.inheritedtypes: [
       {
@@ -6527,7 +6573,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5438,
+        key.offset: 5480,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6535,7 +6581,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5477,
+        key.offset: 5519,
         key.length: 12
       }
     ],
@@ -6545,19 +6591,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "assignable",
-        key.offset: 5518,
+        key.offset: 5560,
         key.length: 26,
         key.typename: "AnyObject!",
-        key.nameoffset: 5522,
+        key.nameoffset: 5564,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 5513,
+            key.offset: 5555,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 5497,
+            key.offset: 5539,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6568,19 +6614,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "unsafeAssignable",
-        key.offset: 5571,
+        key.offset: 5613,
         key.length: 32,
         key.typename: "AnyObject!",
-        key.nameoffset: 5575,
+        key.nameoffset: 5617,
         key.namelength: 16,
         key.attributes: [
           {
-            key.offset: 5566,
+            key.offset: 5608,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 5550,
+            key.offset: 5592,
             key.length: 15,
             key.attribute: source.decl.attribute.weak
           }
@@ -6591,14 +6637,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "retainable",
-        key.offset: 5614,
+        key.offset: 5656,
         key.length: 20,
         key.typename: "Any!",
-        key.nameoffset: 5618,
+        key.nameoffset: 5660,
         key.namelength: 10,
         key.attributes: [
           {
-            key.offset: 5609,
+            key.offset: 5651,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6609,14 +6655,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "strongRef",
-        key.offset: 5645,
+        key.offset: 5687,
         key.length: 19,
         key.typename: "Any!",
-        key.nameoffset: 5649,
+        key.nameoffset: 5691,
         key.namelength: 9,
         key.attributes: [
           {
-            key.offset: 5640,
+            key.offset: 5682,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6627,14 +6673,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "copyable",
-        key.offset: 5675,
+        key.offset: 5717,
         key.length: 18,
         key.typename: "Any!",
-        key.nameoffset: 5679,
+        key.nameoffset: 5721,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 5670,
+            key.offset: 5712,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6645,19 +6691,19 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "weakRef",
-        key.offset: 5709,
+        key.offset: 5751,
         key.length: 23,
         key.typename: "AnyObject!",
-        key.nameoffset: 5713,
+        key.nameoffset: 5755,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 5704,
+            key.offset: 5746,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 5699,
+            key.offset: 5741,
             key.length: 4,
             key.attribute: source.decl.attribute.weak
           }
@@ -6668,14 +6714,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.accessibility: source.lang.swift.accessibility.open,
         key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "scalar",
-        key.offset: 5743,
+        key.offset: 5785,
         key.length: 17,
         key.typename: "Int32",
-        key.nameoffset: 5747,
+        key.nameoffset: 5789,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 5738,
+            key.offset: 5780,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -6687,11 +6733,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "FooUnavailableMembers",
-    key.offset: 5768,
+    key.offset: 5811,
     key.length: 329,
-    key.nameoffset: 5774,
+    key.nameoffset: 5817,
     key.namelength: 21,
-    key.bodyoffset: 5812,
+    key.bodyoffset: 5855,
     key.bodylength: 284,
     key.inheritedtypes: [
       {
@@ -6700,7 +6746,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 5763,
+        key.offset: 5806,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -6708,7 +6754,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 5798,
+        key.offset: 5841,
         key.length: 12
       }
     ],
@@ -6717,18 +6763,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(int:)",
-        key.offset: 5837,
+        key.offset: 5880,
         key.length: 19,
-        key.nameoffset: 5837,
+        key.nameoffset: 5880,
         key.namelength: 19,
         key.attributes: [
           {
-            key.offset: 5825,
+            key.offset: 5868,
             key.length: 11,
             key.attribute: source.decl.attribute.convenience
           },
           {
-            key.offset: 5818,
+            key.offset: 5861,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6737,10 +6783,10 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "i",
-            key.offset: 5843,
+            key.offset: 5886,
             key.length: 12,
             key.typename: "Int32",
-            key.nameoffset: 5843,
+            key.nameoffset: 5886,
             key.namelength: 3
           }
         ]
@@ -6749,18 +6795,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "deprecated()",
-        key.offset: 5911,
+        key.offset: 5954,
         key.length: 17,
-        key.nameoffset: 5916,
+        key.nameoffset: 5959,
         key.namelength: 12,
         key.attributes: [
           {
-            key.offset: 5906,
+            key.offset: 5949,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 5862,
+            key.offset: 5905,
             key.length: 39,
             key.attribute: source.decl.attribute.available
           }
@@ -6770,18 +6816,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroduced()",
-        key.offset: 5969,
+        key.offset: 6012,
         key.length: 29,
-        key.nameoffset: 5974,
+        key.nameoffset: 6017,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 5964,
+            key.offset: 6007,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 5934,
+            key.offset: 5977,
             key.length: 25,
             key.attribute: source.decl.attribute.available
           }
@@ -6791,18 +6837,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "availabilityIntroducedMsg()",
-        key.offset: 6063,
+        key.offset: 6106,
         key.length: 32,
-        key.nameoffset: 6068,
+        key.nameoffset: 6111,
         key.namelength: 27,
         key.attributes: [
           {
-            key.offset: 6058,
+            key.offset: 6101,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           },
           {
-            key.offset: 6004,
+            key.offset: 6047,
             key.length: 49,
             key.attribute: source.decl.attribute.available
           }
@@ -6814,15 +6860,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooCFType",
-    key.offset: 6105,
+    key.offset: 6149,
     key.length: 19,
-    key.nameoffset: 6111,
+    key.nameoffset: 6155,
     key.namelength: 9,
-    key.bodyoffset: 6122,
+    key.bodyoffset: 6166,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 6098,
+        key.offset: 6142,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6832,11 +6878,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "ABAuthorizationStatus",
-    key.offset: 6196,
+    key.offset: 6241,
     key.length: 89,
-    key.nameoffset: 6201,
+    key.nameoffset: 6246,
     key.namelength: 21,
-    key.bodyoffset: 6230,
+    key.bodyoffset: 6275,
     key.bodylength: 54,
     key.inheritedtypes: [
       {
@@ -6845,12 +6891,12 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6189,
+        key.offset: 6234,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       },
       {
-        key.offset: 6125,
+        key.offset: 6170,
         key.length: 63,
         key.attribute: source.decl.attribute.available
       }
@@ -6858,28 +6904,28 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6225,
+        key.offset: 6270,
         key.length: 3
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6236,
+        key.offset: 6281,
         key.length: 22,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "notDetermined",
-            key.offset: 6241,
+            key.offset: 6286,
             key.length: 17,
-            key.nameoffset: 6241,
+            key.nameoffset: 6286,
             key.namelength: 13,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6257,
+                key.offset: 6302,
                 key.length: 1
               }
             ]
@@ -6888,21 +6934,21 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 6264,
+        key.offset: 6309,
         key.length: 19,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "restricted",
-            key.offset: 6269,
+            key.offset: 6314,
             key.length: 14,
-            key.nameoffset: 6269,
+            key.nameoffset: 6314,
             key.namelength: 10,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 6282,
+                key.offset: 6327,
                 key.length: 1
               }
             ]
@@ -6915,15 +6961,15 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassBase",
-    key.offset: 6293,
+    key.offset: 6339,
     key.length: 50,
-    key.nameoffset: 6299,
+    key.nameoffset: 6345,
     key.namelength: 19,
-    key.bodyoffset: 6320,
+    key.bodyoffset: 6366,
     key.bodylength: 22,
     key.attributes: [
       {
-        key.offset: 6286,
+        key.offset: 6332,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6933,13 +6979,13 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6333,
+        key.offset: 6379,
         key.length: 8,
-        key.nameoffset: 6338,
+        key.nameoffset: 6384,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 6326,
+            key.offset: 6372,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -6951,11 +6997,11 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassDerived",
-    key.offset: 6352,
+    key.offset: 6398,
     key.length: 88,
-    key.nameoffset: 6358,
+    key.nameoffset: 6404,
     key.namelength: 22,
-    key.bodyoffset: 6408,
+    key.bodyoffset: 6454,
     key.bodylength: 31,
     key.inheritedtypes: [
       {
@@ -6964,7 +7010,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     ],
     key.attributes: [
       {
-        key.offset: 6345,
+        key.offset: 6391,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -6972,7 +7018,7 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 6383,
+        key.offset: 6429,
         key.length: 23
       }
     ],
@@ -6981,18 +7027,18 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 6430,
+        key.offset: 6476,
         key.length: 8,
-        key.nameoffset: 6435,
+        key.nameoffset: 6481,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 6423,
+            key.offset: 6469,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           },
           {
-            key.offset: 6414,
+            key.offset: 6460,
             key.length: 8,
             key.attribute: source.decl.attribute.override
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -1,8 +1,6 @@
 import FooHelper
 
-
 public func fooSubFunc1(_ a: Int32) -> Int32
-
 public struct FooSubEnum1 : Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
@@ -13,7 +11,6 @@ public struct FooSubEnum1 : Equatable, RawRepresentable {
 }
 public var FooSubEnum1X: FooSubEnum1 { get }
 public var FooSubEnum1Y: FooSubEnum1 { get }
-
 public var FooSubUnnamedEnumeratorA1: Int { get }
 
 [
@@ -29,202 +26,202 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 19,
+    key.offset: 18,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 26,
+    key.offset: 25,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 31,
+    key.offset: 30,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 43,
+    key.offset: 42,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 45,
+    key.offset: 44,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 48,
+    key.offset: 47,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 58,
+    key.offset: 57,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 65,
+    key.offset: 63,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 72,
+    key.offset: 70,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 79,
+    key.offset: 77,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 93,
+    key.offset: 91,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 104,
+    key.offset: 102,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 128,
+    key.offset: 126,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 135,
+    key.offset: 133,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 140,
+    key.offset: 138,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 142,
+    key.offset: 140,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 152,
+    key.offset: 150,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 165,
+    key.offset: 163,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 172,
+    key.offset: 170,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 177,
+    key.offset: 175,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 187,
+    key.offset: 185,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 200,
+    key.offset: 198,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 207,
+    key.offset: 205,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 211,
+    key.offset: 209,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 221,
+    key.offset: 219,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 230,
+    key.offset: 228,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 237,
+    key.offset: 235,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 241,
+    key.offset: 239,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 255,
+    key.offset: 253,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 269,
+    key.offset: 267,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 275,
+    key.offset: 273,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 282,
+    key.offset: 280,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 286,
+    key.offset: 284,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 300,
+    key.offset: 298,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 314,
+    key.offset: 312,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 321,
+    key.offset: 318,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 328,
+    key.offset: 325,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 332,
+    key.offset: 329,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 359,
+    key.offset: 356,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 365,
+    key.offset: 362,
     key.length: 3
   }
 ]
@@ -236,59 +233,59 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 48,
+    key.offset: 47,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 58,
+    key.offset: 57,
     key.length: 5,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 93,
+    key.offset: 91,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 104,
+    key.offset: 102,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 152,
+    key.offset: 150,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 187,
+    key.offset: 185,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 221,
+    key.offset: 219,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 255,
+    key.offset: 253,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 300,
+    key.offset: 298,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 359,
+    key.offset: 356,
     key.length: 3,
     key.is_system: 1
   }
@@ -298,14 +295,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fooSubFunc1(_:)",
-    key.offset: 26,
+    key.offset: 25,
     key.length: 37,
     key.typename: "Int32",
-    key.nameoffset: 31,
+    key.nameoffset: 30,
     key.namelength: 23,
     key.attributes: [
       {
-        key.offset: 19,
+        key.offset: 18,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -314,7 +311,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
       {
         key.kind: source.lang.swift.decl.var.parameter,
         key.name: "a",
-        key.offset: 43,
+        key.offset: 42,
         key.length: 10,
         key.typename: "Int32"
       }
@@ -324,11 +321,11 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1",
-    key.offset: 72,
+    key.offset: 70,
     key.length: 157,
-    key.nameoffset: 79,
+    key.nameoffset: 77,
     key.namelength: 11,
-    key.bodyoffset: 122,
+    key.bodyoffset: 120,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -340,7 +337,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     ],
     key.attributes: [
       {
-        key.offset: 65,
+        key.offset: 63,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -348,12 +345,12 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 93,
+        key.offset: 91,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 104,
+        key.offset: 102,
         key.length: 16
       }
     ],
@@ -362,13 +359,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 135,
+        key.offset: 133,
         key.length: 24,
-        key.nameoffset: 135,
+        key.nameoffset: 133,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 128,
+            key.offset: 126,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -377,7 +374,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 140,
+            key.offset: 138,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -387,13 +384,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 172,
+        key.offset: 170,
         key.length: 22,
-        key.nameoffset: 172,
+        key.nameoffset: 170,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 165,
+            key.offset: 163,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -402,10 +399,10 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 177,
+            key.offset: 175,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 177,
+            key.nameoffset: 175,
             key.namelength: 8
           }
         ]
@@ -415,14 +412,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 207,
+        key.offset: 205,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 211,
+        key.nameoffset: 209,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 200,
+            key.offset: 198,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -434,16 +431,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1X",
-    key.offset: 237,
+    key.offset: 235,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 241,
+    key.nameoffset: 239,
     key.namelength: 12,
-    key.bodyoffset: 268,
+    key.bodyoffset: 266,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 230,
+        key.offset: 228,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -453,16 +450,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1Y",
-    key.offset: 282,
+    key.offset: 280,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 286,
+    key.nameoffset: 284,
     key.namelength: 12,
-    key.bodyoffset: 313,
+    key.bodyoffset: 311,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 275,
+        key.offset: 273,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -472,16 +469,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubUnnamedEnumeratorA1",
-    key.offset: 328,
+    key.offset: 325,
     key.length: 42,
     key.typename: "Int",
-    key.nameoffset: 332,
+    key.nameoffset: 329,
     key.namelength: 25,
-    key.bodyoffset: 364,
+    key.bodyoffset: 361,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 321,
+        key.offset: 318,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -1,6 +1,7 @@
 import FooHelper
 
 public func fooSubFunc1(_ a: Int32) -> Int32
+
 public struct FooSubEnum1 : Equatable, RawRepresentable {
 
     public init(_ rawValue: UInt32)
@@ -9,9 +10,13 @@ public struct FooSubEnum1 : Equatable, RawRepresentable {
 
     public var rawValue: UInt32
 }
+
 public var FooSubEnum1X: FooSubEnum1 { get }
+
 public var FooSubEnum1Y: FooSubEnum1 { get }
+
 public var FooSubUnnamedEnumeratorA1: Int { get }
+
 
 [
   {
@@ -61,167 +66,167 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 63,
+    key.offset: 64,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 70,
+    key.offset: 71,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 77,
+    key.offset: 78,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 91,
+    key.offset: 92,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 102,
+    key.offset: 103,
     key.length: 16
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 126,
+    key.offset: 127,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 133,
+    key.offset: 134,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 138,
+    key.offset: 139,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 140,
+    key.offset: 141,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 150,
+    key.offset: 151,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 163,
+    key.offset: 164,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 170,
+    key.offset: 171,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 175,
+    key.offset: 176,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 185,
+    key.offset: 186,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 198,
+    key.offset: 199,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 205,
+    key.offset: 206,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 209,
+    key.offset: 210,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 219,
+    key.offset: 220,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 228,
+    key.offset: 230,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 235,
+    key.offset: 237,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 239,
+    key.offset: 241,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 253,
+    key.offset: 255,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 267,
+    key.offset: 269,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 273,
+    key.offset: 276,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 280,
+    key.offset: 283,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 284,
+    key.offset: 287,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 298,
+    key.offset: 301,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 312,
+    key.offset: 315,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 318,
+    key.offset: 322,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 325,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 329,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 333,
     key.length: 25
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 356,
+    key.offset: 360,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 362,
+    key.offset: 366,
     key.length: 3
   }
 ]
@@ -245,47 +250,47 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 91,
+    key.offset: 92,
     key.length: 9,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.offset: 102,
+    key.offset: 103,
     key.length: 16,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 150,
+    key.offset: 151,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 185,
+    key.offset: 186,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 219,
+    key.offset: 220,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 253,
+    key.offset: 255,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 298,
+    key.offset: 301,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 356,
+    key.offset: 360,
     key.length: 3,
     key.is_system: 1
   }
@@ -321,11 +326,11 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1",
-    key.offset: 70,
+    key.offset: 71,
     key.length: 157,
-    key.nameoffset: 77,
+    key.nameoffset: 78,
     key.namelength: 11,
-    key.bodyoffset: 120,
+    key.bodyoffset: 121,
     key.bodylength: 106,
     key.inheritedtypes: [
       {
@@ -337,7 +342,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     ],
     key.attributes: [
       {
-        key.offset: 63,
+        key.offset: 64,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -345,12 +350,12 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 91,
+        key.offset: 92,
         key.length: 9
       },
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 102,
+        key.offset: 103,
         key.length: 16
       }
     ],
@@ -359,13 +364,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(_:)",
-        key.offset: 133,
+        key.offset: 134,
         key.length: 24,
-        key.nameoffset: 133,
+        key.nameoffset: 134,
         key.namelength: 24,
         key.attributes: [
           {
-            key.offset: 126,
+            key.offset: 127,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -374,7 +379,7 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 138,
+            key.offset: 139,
             key.length: 18,
             key.typename: "UInt32"
           }
@@ -384,13 +389,13 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(rawValue:)",
-        key.offset: 170,
+        key.offset: 171,
         key.length: 22,
-        key.nameoffset: 170,
+        key.nameoffset: 171,
         key.namelength: 22,
         key.attributes: [
           {
-            key.offset: 163,
+            key.offset: 164,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -399,10 +404,10 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "rawValue",
-            key.offset: 175,
+            key.offset: 176,
             key.length: 16,
             key.typename: "UInt32",
-            key.nameoffset: 175,
+            key.nameoffset: 176,
             key.namelength: 8
           }
         ]
@@ -412,14 +417,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "rawValue",
-        key.offset: 205,
+        key.offset: 206,
         key.length: 20,
         key.typename: "UInt32",
-        key.nameoffset: 209,
+        key.nameoffset: 210,
         key.namelength: 8,
         key.attributes: [
           {
-            key.offset: 198,
+            key.offset: 199,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -431,16 +436,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1X",
-    key.offset: 235,
+    key.offset: 237,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 239,
+    key.nameoffset: 241,
     key.namelength: 12,
-    key.bodyoffset: 266,
+    key.bodyoffset: 268,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 228,
+        key.offset: 230,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -450,16 +455,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1Y",
-    key.offset: 280,
+    key.offset: 283,
     key.length: 37,
     key.typename: "FooSubEnum1",
-    key.nameoffset: 284,
+    key.nameoffset: 287,
     key.namelength: 12,
-    key.bodyoffset: 311,
+    key.bodyoffset: 314,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 273,
+        key.offset: 276,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -469,16 +474,16 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubUnnamedEnumeratorA1",
-    key.offset: 325,
+    key.offset: 329,
     key.length: 42,
     key.typename: "Int",
-    key.nameoffset: 329,
+    key.nameoffset: 333,
     key.namelength: 25,
-    key.bodyoffset: 361,
+    key.bodyoffset: 365,
     key.bodylength: 5,
     key.attributes: [
       {
-        key.offset: 318,
+        key.offset: 322,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
@@ -4,10 +4,8 @@ public struct NUPixelSize {
 
     public init(width: Int, height: Int)
 
-
     /** Some clang-style comments */
     public var width: Int
-
 
     /**
      * Some clang-style comments
@@ -73,52 +71,52 @@ public struct NUPixelSize {
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 95,
+    key.offset: 94,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 132,
+    key.offset: 131,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 139,
+    key.offset: 138,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 143,
+    key.offset: 142,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 150,
+    key.offset: 149,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 160,
+    key.offset: 158,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 209,
+    key.offset: 207,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 216,
+    key.offset: 214,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 220,
+    key.offset: 218,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 228,
+    key.offset: 226,
     key.length: 3
   }
 ]
@@ -137,13 +135,13 @@ public struct NUPixelSize {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 150,
+    key.offset: 149,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 228,
+    key.offset: 226,
     key.length: 3,
     key.is_system: 1
   }
@@ -154,11 +152,11 @@ public struct NUPixelSize {
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "NUPixelSize",
     key.offset: 7,
-    key.length: 226,
+    key.length: 224,
     key.nameoffset: 14,
     key.namelength: 11,
     key.bodyoffset: 27,
-    key.bodylength: 205,
+    key.bodylength: 203,
     key.attributes: [
       {
         key.offset: 0,
@@ -224,16 +222,16 @@ public struct NUPixelSize {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "width",
-        key.offset: 139,
+        key.offset: 138,
         key.length: 14,
         key.typename: "Int",
-        key.nameoffset: 143,
+        key.nameoffset: 142,
         key.namelength: 5,
-        key.docoffset: 95,
+        key.docoffset: 94,
         key.doclength: 32,
         key.attributes: [
           {
-            key.offset: 132,
+            key.offset: 131,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -244,16 +242,16 @@ public struct NUPixelSize {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "height",
-        key.offset: 216,
+        key.offset: 214,
         key.length: 15,
         key.typename: "Int",
-        key.nameoffset: 220,
+        key.nameoffset: 218,
         key.namelength: 6,
-        key.docoffset: 160,
+        key.docoffset: 158,
         key.doclength: 44,
         key.attributes: [
           {
-            key.offset: 209,
+            key.offset: 207,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header2.response
@@ -1,12 +1,13 @@
-
 public struct NUPixelSize {
 
     public init()
 
     public init(width: Int, height: Int)
 
+
     /** Some clang-style comments */
     public var width: Int
+
 
     /**
      * Some clang-style comments
@@ -17,57 +18,57 @@ public struct NUPixelSize {
 [
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8,
+    key.offset: 7,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 15,
+    key.offset: 14,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 34,
+    key.offset: 33,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 41,
+    key.offset: 40,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 53,
+    key.offset: 52,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 60,
+    key.offset: 59,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 65,
+    key.offset: 64,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 72,
+    key.offset: 71,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 77,
+    key.offset: 76,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 85,
+    key.offset: 84,
     key.length: 3
   },
   {
@@ -97,40 +98,40 @@ public struct NUPixelSize {
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 159,
+    key.offset: 160,
     key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 208,
+    key.offset: 209,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 215,
+    key.offset: 216,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 219,
+    key.offset: 220,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 227,
+    key.offset: 228,
     key.length: 3
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 72,
+    key.offset: 71,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 85,
+    key.offset: 84,
     key.length: 3,
     key.is_system: 1
   },
@@ -142,7 +143,7 @@ public struct NUPixelSize {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 227,
+    key.offset: 228,
     key.length: 3,
     key.is_system: 1
   }
@@ -152,15 +153,15 @@ public struct NUPixelSize {
     key.kind: source.lang.swift.decl.struct,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "NUPixelSize",
-    key.offset: 8,
-    key.length: 224,
-    key.nameoffset: 15,
+    key.offset: 7,
+    key.length: 226,
+    key.nameoffset: 14,
     key.namelength: 11,
-    key.bodyoffset: 28,
-    key.bodylength: 203,
+    key.bodyoffset: 27,
+    key.bodylength: 205,
     key.attributes: [
       {
-        key.offset: 1,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -170,13 +171,13 @@ public struct NUPixelSize {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init()",
-        key.offset: 41,
+        key.offset: 40,
         key.length: 6,
-        key.nameoffset: 41,
+        key.nameoffset: 40,
         key.namelength: 6,
         key.attributes: [
           {
-            key.offset: 34,
+            key.offset: 33,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -186,13 +187,13 @@ public struct NUPixelSize {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "init(width:height:)",
-        key.offset: 60,
+        key.offset: 59,
         key.length: 29,
-        key.nameoffset: 60,
+        key.nameoffset: 59,
         key.namelength: 29,
         key.attributes: [
           {
-            key.offset: 53,
+            key.offset: 52,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -201,19 +202,19 @@ public struct NUPixelSize {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "width",
-            key.offset: 65,
+            key.offset: 64,
             key.length: 10,
             key.typename: "Int",
-            key.nameoffset: 65,
+            key.nameoffset: 64,
             key.namelength: 5
           },
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "height",
-            key.offset: 77,
+            key.offset: 76,
             key.length: 11,
             key.typename: "Int",
-            key.nameoffset: 77,
+            key.nameoffset: 76,
             key.namelength: 6
           }
         ]
@@ -243,16 +244,16 @@ public struct NUPixelSize {
         key.accessibility: source.lang.swift.accessibility.public,
         key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "height",
-        key.offset: 215,
+        key.offset: 216,
         key.length: 15,
         key.typename: "Int",
-        key.nameoffset: 219,
+        key.nameoffset: 220,
         key.namelength: 6,
-        key.docoffset: 159,
+        key.docoffset: 160,
         key.doclength: 44,
         key.attributes: [
           {
-            key.offset: 208,
+            key.offset: 209,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_header.swift.header3.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.header3.response
@@ -1,7 +1,5 @@
-
 public enum SKFuelKind : UInt32 {
 
-    
     case H2 = 0
 
     case CH4 = 1
@@ -18,151 +16,151 @@ extension SKFuelKind {
 [
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1,
+    key.offset: 0,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 8,
+    key.offset: 7,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 13,
+    key.offset: 12,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 26,
+    key.offset: 25,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 45,
+    key.offset: 39,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 50,
+    key.offset: 44,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 55,
+    key.offset: 49,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 62,
+    key.offset: 56,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 67,
+    key.offset: 61,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 73,
+    key.offset: 67,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 80,
+    key.offset: 74,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 85,
+    key.offset: 79,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.number,
-    key.offset: 94,
+    key.offset: 88,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 98,
+    key.offset: 92,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 108,
+    key.offset: 102,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 126,
+    key.offset: 120,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 133,
+    key.offset: 127,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 137,
+    key.offset: 131,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 150,
+    key.offset: 144,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 159,
+    key.offset: 153,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 170,
+    key.offset: 164,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 177,
+    key.offset: 171,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 181,
+    key.offset: 175,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 197,
+    key.offset: 191,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 206,
+    key.offset: 200,
     key.length: 3
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 26,
+    key.offset: 25,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.enum,
-    key.offset: 108,
+    key.offset: 102,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 150,
+    key.offset: 144,
     key.length: 6,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 197,
+    key.offset: 191,
     key.length: 6,
     key.is_system: 1
   }
@@ -172,12 +170,12 @@ extension SKFuelKind {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "SKFuelKind",
-    key.offset: 8,
-    key.length: 89,
-    key.nameoffset: 13,
+    key.offset: 7,
+    key.length: 84,
+    key.nameoffset: 12,
     key.namelength: 10,
-    key.bodyoffset: 34,
-    key.bodylength: 62,
+    key.bodyoffset: 33,
+    key.bodylength: 57,
     key.inheritedtypes: [
       {
         key.name: "UInt32"
@@ -185,7 +183,7 @@ extension SKFuelKind {
     ],
     key.attributes: [
       {
-        key.offset: 1,
+        key.offset: 0,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -193,28 +191,28 @@ extension SKFuelKind {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 26,
+        key.offset: 25,
         key.length: 6
       }
     ],
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 45,
+        key.offset: 39,
         key.length: 11,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "H2",
-            key.offset: 50,
+            key.offset: 44,
             key.length: 6,
-            key.nameoffset: 50,
+            key.nameoffset: 44,
             key.namelength: 2,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 55,
+                key.offset: 49,
                 key.length: 1
               }
             ]
@@ -223,21 +221,21 @@ extension SKFuelKind {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 62,
+        key.offset: 56,
         key.length: 12,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "CH4",
-            key.offset: 67,
+            key.offset: 61,
             key.length: 7,
-            key.nameoffset: 67,
+            key.nameoffset: 61,
             key.namelength: 3,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 73,
+                key.offset: 67,
                 key.length: 1
               }
             ]
@@ -246,21 +244,21 @@ extension SKFuelKind {
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 80,
+        key.offset: 74,
         key.length: 15,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.public,
             key.name: "C12H26",
-            key.offset: 85,
+            key.offset: 79,
             key.length: 10,
-            key.nameoffset: 85,
+            key.nameoffset: 79,
             key.namelength: 6,
             key.elements: [
               {
                 key.kind: source.lang.swift.structure.elem.init_expr,
-                key.offset: 94,
+                key.offset: 88,
                 key.length: 1
               }
             ]
@@ -272,27 +270,27 @@ extension SKFuelKind {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "SKFuelKind",
-    key.offset: 98,
+    key.offset: 92,
     key.length: 115,
-    key.nameoffset: 108,
+    key.nameoffset: 102,
     key.namelength: 10,
-    key.bodyoffset: 120,
+    key.bodyoffset: 114,
     key.bodylength: 92,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "isCryogenic",
-        key.offset: 133,
+        key.offset: 127,
         key.length: 31,
         key.typename: "UInt32",
-        key.nameoffset: 137,
+        key.nameoffset: 131,
         key.namelength: 11,
-        key.bodyoffset: 158,
+        key.bodyoffset: 152,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 126,
+            key.offset: 120,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -302,16 +300,16 @@ extension SKFuelKind {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "isNotCryogenic",
-        key.offset: 177,
+        key.offset: 171,
         key.length: 34,
         key.typename: "UInt32",
-        key.nameoffset: 181,
+        key.nameoffset: 175,
         key.namelength: 14,
-        key.bodyoffset: 205,
+        key.bodyoffset: 199,
         key.bodylength: 5,
         key.attributes: [
           {
-            key.offset: 170,
+            key.offset: 164,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_header.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.response
@@ -1,5 +1,4 @@
 public func doSomethingInHead(_ arg: Int32)
-
 open class BaseInHead {
 
     open func doIt(_ arg: Int32)
@@ -10,9 +9,6 @@ open class BaseInHead {
 /// Awesome name.
 open class SameName {
 }
-
-// random comment.
-
 public protocol SameNameProtocol {
 }
 
@@ -49,97 +45,92 @@ public protocol SameNameProtocol {
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 45,
+    key.offset: 44,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 50,
+    key.offset: 49,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 56,
+    key.offset: 55,
     key.length: 10
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 74,
+    key.offset: 73,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 79,
+    key.offset: 78,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 84,
+    key.offset: 83,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 89,
+    key.offset: 88,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 91,
+    key.offset: 90,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 96,
+    key.offset: 95,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 106,
+    key.offset: 105,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 124,
+    key.offset: 123,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 150,
+    key.offset: 149,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 168,
+    key.offset: 167,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 173,
+    key.offset: 172,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 179,
+    key.offset: 178,
     key.length: 8
   },
   {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 193,
-    key.length: 19
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 213,
+    key.offset: 191,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 220,
+    key.offset: 198,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 229,
+    key.offset: 207,
     key.length: 16
   }
 ]
@@ -152,7 +143,7 @@ public protocol SameNameProtocol {
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 96,
+    key.offset: 95,
     key.length: 5,
     key.is_system: 1
   }
@@ -187,15 +178,15 @@ public protocol SameNameProtocol {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "BaseInHead",
-    key.offset: 50,
+    key.offset: 49,
     key.length: 54,
-    key.nameoffset: 56,
+    key.nameoffset: 55,
     key.namelength: 10,
-    key.bodyoffset: 68,
+    key.bodyoffset: 67,
     key.bodylength: 35,
     key.attributes: [
       {
-        key.offset: 45,
+        key.offset: 44,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -205,13 +196,13 @@ public protocol SameNameProtocol {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "doIt(_:)",
-        key.offset: 79,
+        key.offset: 78,
         key.length: 23,
-        key.nameoffset: 84,
+        key.nameoffset: 83,
         key.namelength: 18,
         key.attributes: [
           {
-            key.offset: 74,
+            key.offset: 73,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -220,7 +211,7 @@ public protocol SameNameProtocol {
           {
             key.kind: source.lang.swift.decl.var.parameter,
             key.name: "arg",
-            key.offset: 89,
+            key.offset: 88,
             key.length: 12,
             key.typename: "Int32"
           }
@@ -232,17 +223,17 @@ public protocol SameNameProtocol {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "SameName",
-    key.offset: 173,
+    key.offset: 172,
     key.length: 18,
-    key.nameoffset: 179,
+    key.nameoffset: 178,
     key.namelength: 8,
-    key.bodyoffset: 189,
+    key.bodyoffset: 188,
     key.bodylength: 1,
-    key.docoffset: 106,
+    key.docoffset: 105,
     key.doclength: 62,
     key.attributes: [
       {
-        key.offset: 168,
+        key.offset: 167,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -252,15 +243,15 @@ public protocol SameNameProtocol {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "SameNameProtocol",
-    key.offset: 220,
+    key.offset: 198,
     key.length: 29,
-    key.nameoffset: 229,
+    key.nameoffset: 207,
     key.namelength: 16,
-    key.bodyoffset: 247,
+    key.bodyoffset: 225,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 213,
+        key.offset: 191,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_header.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_header.swift.response
@@ -3,7 +3,6 @@ open class BaseInHead {
 
     open func doIt(_ arg: Int32)
 }
-
 /// Awesome name.
 /// �������
 /// Awesome name.
@@ -90,47 +89,47 @@ public protocol SameNameProtocol {
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 105,
+    key.offset: 104,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 123,
+    key.offset: 122,
     key.length: 26
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 149,
+    key.offset: 148,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 167,
+    key.offset: 166,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 172,
+    key.offset: 171,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 178,
+    key.offset: 177,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 191,
+    key.offset: 190,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 198,
+    key.offset: 197,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 207,
+    key.offset: 206,
     key.length: 16
   }
 ]
@@ -223,17 +222,17 @@ public protocol SameNameProtocol {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "SameName",
-    key.offset: 172,
+    key.offset: 171,
     key.length: 18,
-    key.nameoffset: 178,
+    key.nameoffset: 177,
     key.namelength: 8,
-    key.bodyoffset: 188,
+    key.bodyoffset: 187,
     key.bodylength: 1,
-    key.docoffset: 105,
+    key.docoffset: 104,
     key.doclength: 62,
     key.attributes: [
       {
-        key.offset: 167,
+        key.offset: 166,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -243,15 +242,15 @@ public protocol SameNameProtocol {
     key.kind: source.lang.swift.decl.protocol,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "SameNameProtocol",
-    key.offset: 198,
+    key.offset: 197,
     key.length: 29,
-    key.nameoffset: 207,
+    key.nameoffset: 206,
     key.namelength: 16,
-    key.bodyoffset: 225,
+    key.bodyoffset: 224,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 191,
+        key.offset: 190,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift
@@ -12,7 +12,7 @@
 // Make sure cursor info within the generated interface of SwiftFramework on one of the
 // decls originally from a cross-import decls shows 'SwiftFramework' as the parent module.
 //
-// RUN: %sourcekitd-test -req=interface-gen-open -module SwiftFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=10:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %sourcekitd-test -req=interface-gen-open -module SwiftFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=9:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
 // RUN: %FileCheck --input-file %t.response --check-prefix=CHECKSWIFT %s
 //
 // CHECKSWIFT: key.name: "fromSwiftFrameworkCrossImport()"
@@ -27,7 +27,7 @@
 // Make sure cursor info within the generated interface of ClangFramework on one of the
 // decls originally from a cross-import decls shows 'ClangFramework' as the parent module.
 //
-// RUN: %sourcekitd-test -req=interface-gen-open -module ClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=9:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
+// RUN: %sourcekitd-test -req=interface-gen-open -module ClangFramework -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -module-cache-path %t/mcp == -req=cursor -print-raw-response -pos=10:13 -- -target %target-triple -I %t/include -I %t/lib/swift -F %t/Frameworks -Xfrontend -enable-cross-import-overlays > %t.response
 // RUN: %FileCheck --input-file %t.response --check-prefix=CHECKCLANG %s
 //
 // CHECKCLANG: key.name: "fromClangFrameworkCrossImport()"

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.ClangFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.ClangFramework.response
@@ -1,6 +1,7 @@
 
 public func fromClangFramework()
 
+
 // MARK: - BystandingLibrary Additions
 
 import SwiftOnoneSupport
@@ -27,49 +28,49 @@ public func fromClangFrameworkCrossImport()
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 35,
+    key.offset: 36,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 38,
+    key.offset: 39,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 75,
+    key.offset: 76,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 82,
+    key.offset: 83,
     key.length: 17
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 101,
+    key.offset: 102,
     key.length: 68
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 169,
+    key.offset: 170,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 176,
+    key.offset: 177,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 181,
+    key.offset: 182,
     key.length: 29
   }
 ]
 [
   {
     key.kind: source.lang.swift.ref.module,
-    key.offset: 82,
+    key.offset: 83,
     key.length: 17,
     key.is_system: 1
   }
@@ -95,13 +96,13 @@ public func fromClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromClangFrameworkCrossImport()",
-    key.offset: 176,
+    key.offset: 177,
     key.length: 36,
-    key.nameoffset: 181,
+    key.nameoffset: 182,
     key.namelength: 31,
     key.attributes: [
       {
-        key.offset: 169,
+        key.offset: 170,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.OverlaidClangFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.OverlaidClangFramework.response
@@ -1,11 +1,11 @@
 import SwiftOnoneSupport
 
 public func fromOverlaidClangFramework()
+
 public func fromOverlaidClangFrameworkOverlay()
 
 
 // MARK: - BystandingLibrary Additions
-
 
 // Available when BystandingLibrary is imported with OverlaidClangFramework
 public func fromOverlaidClangFrameworkCrossImport()
@@ -39,27 +39,27 @@ public func fromOverlaidClangFrameworkCrossImport()
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 67,
+    key.offset: 68,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 74,
+    key.offset: 75,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 79,
+    key.offset: 80,
     key.length: 33
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 117,
+    key.offset: 118,
     key.length: 39
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment.mark,
-    key.offset: 120,
+    key.offset: 121,
     key.length: 35
   },
   {
@@ -112,13 +112,13 @@ public func fromOverlaidClangFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromOverlaidClangFrameworkOverlay()",
-    key.offset: 74,
+    key.offset: 75,
     key.length: 40,
-    key.nameoffset: 79,
+    key.nameoffset: 80,
     key.namelength: 35,
     key.attributes: [
       {
-        key.offset: 67,
+        key.offset: 68,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.SwiftFramework.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_module_cross_import_common.swift.SwiftFramework.response
@@ -5,7 +5,6 @@ public func fromSwiftFramework()
 
 // MARK: - BystandingLibrary Additions
 
-
 // Available when BystandingLibrary is imported with SwiftFramework
 public func fromSwiftFrameworkCrossImport()
 
@@ -48,22 +47,22 @@ public func fromSwiftFrameworkCrossImport()
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 102,
+    key.offset: 101,
     key.length: 68
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 170,
+    key.offset: 169,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 177,
+    key.offset: 176,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 182,
+    key.offset: 181,
     key.length: 29
   }
 ]
@@ -96,13 +95,13 @@ public func fromSwiftFrameworkCrossImport()
     key.kind: source.lang.swift.decl.function.free,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "fromSwiftFrameworkCrossImport()",
-    key.offset: 177,
+    key.offset: 176,
     key.length: 36,
-    key.nameoffset: 182,
+    key.nameoffset: 181,
     key.namelength: 31,
     key.attributes: [
       {
-        key.offset: 170,
+        key.offset: 169,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -4747,7 +4747,7 @@ int main(int argc, char *argv[]) {
       ExitCode = doPrintModuleGroups(InitInvok, options::ModuleToPrint);
     else {
       if (options::NoEmptyLineBetweenMembers.getNumOccurrences() > 0)
-        PrintOpts.EmptyLineBetweenMembers = !options::NoEmptyLineBetweenMembers;
+        PrintOpts.EmptyLineBetweenDecls = !options::NoEmptyLineBetweenMembers;
       ExitCode = doPrintModules(
         InitInvok, options::ModuleToPrint, options::ModuleGroupToPrint,
         TraversalOptions, PrintOpts, options::AnnotatePrint,

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -699,12 +699,6 @@ SkipDocumentationComments("skip-print-doc-comments",
     llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
-PrintRegularComments("print-regular-comments",
-    llvm::cl::desc("Print regular comments from clang module headers"),
-    llvm::cl::cat(Category),
-    llvm::cl::init(false));
-
-static llvm::cl::opt<bool>
 PrintOriginalSourceText("print-original-source",
     llvm::cl::desc("print the original source text for applicable declarations"),
     llvm::cl::cat(Category),
@@ -4599,7 +4593,6 @@ int main(int argc, char *argv[]) {
     PrintOpts.PrintAccess = options::PrintAccess;
     PrintOpts.AccessFilter = options::AccessFilter;
     PrintOpts.PrintDocumentationComments = !options::SkipDocumentationComments;
-    PrintOpts.PrintRegularClangComments = options::PrintRegularComments;
     PrintOpts.SkipPrivateStdlibDecls = options::SkipPrivateStdlibDecls;
     PrintOpts.SkipUnsafeCXXMethods = options::SkipUnsafeCXXMethods;
     PrintOpts.SkipUnavailable = options::SkipUnavailable;


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/72420 https://github.com/apple/swift/pull/72553 into `release/6.0`

* **Explanation**: Generated interfaces for Clang modules used to try printing normal comments and whitespaces between decls extracted from the header text. That's was getting confusing mainly because of "import as member" which  reorders decls in the header files. So stop printing normal comments for Clang decls.
* **Scope**: Generated interface in SourceKit
* **Risk**: Low. Changes are simple. Nobody should rely on the comments/whitespaces in generated interfaces
* **Testing**: Updated regression test cases
* **Issues**: rdar://93731287
* **Reviewers**: Alex Hoppen (@ahoppen) Hamish Knight (@hamishknight)