### PR TITLE
Ensure that we map the capture isolation into context 

### DIFF
--- a/lib/SILGen/SILGenConcurrency.cpp
+++ b/lib/SILGen/SILGenConcurrency.cpp
@@ -463,8 +463,8 @@ static ManagedValue emitLoadOfCaptureIsolation(SILGenFunction &SGF,
   auto &TC = SGF.SGM.Types;
   auto captureInfo = TC.getLoweredLocalCaptures(constant);
 
-  auto isolatedVarType =
-    isolatedCapture->getInterfaceType()->getCanonicalType();
+  auto isolatedVarType = SGF.F.mapTypeIntoContext(
+    isolatedCapture->getInterfaceType())->getCanonicalType();
 
   // Capture arguments are 1-1 with the lowered capture info.
   auto captures = captureInfo.getCaptures();

--- a/test/Distributed/distributed_actor_to_actor.swift
+++ b/test/Distributed/distributed_actor_to_actor.swift
@@ -9,6 +9,7 @@
 // rdar://123970272
 // UNSUPPORTED: CPU=arm64e
 
+import Swift
 import _Concurrency
 import Distributed
 
@@ -38,6 +39,25 @@ func getAnyActor(distributedActor: isolated some DistributedActor) -> any Actor 
 // CHECK-IR-NEXT: [[SELF_DA_REQ:%.*]] = getelementptr inbounds ptr, ptr [[CONDITIONAL_REQ_GEP]], i32 0
 // CHECK-IR-NEXT: store ptr %"some DistributedActor.DistributedActor", ptr [[SELF_DA_REQ]]
 // CHECK-IR-NEXT: call ptr @swift_getWitnessTable(ptr @"$sxScA11DistributedMc", ptr %"some DistributedActor", ptr [[CONDITIONAL_REQ_GEP]])
+
+distributed actor WorkerPool<Worker, ActorSystem: DistributedActorSystem>: AsyncSequence, AsyncIteratorProtocol {
+  var level: Int
+  public init(actorSystem system: ActorSystem) async throws {
+    self.actorSystem = system
+    self.level = 0
+
+    // CHECK-SIL: sil private @$s021distributed_actor_to_B010WorkerPoolC0B6SystemACyxq_Gq__tYaKcfcyyYaYbcfU_ : $@convention(thin) @Sendable @async <Worker, ActorSystem where ActorSystem : DistributedActorSystem> (@guaranteed Optional<any Actor>, @sil_isolated @guaranteed WorkerPool<Worker, ActorSystem>) -> @out
+    // CHECK-SIL: hop_to_executor {{%.*}} : $WorkerPool<Worker, ActorSystem>
+    _ = Task {
+      for await x in self {
+        print(x)
+      }
+    }
+  }
+
+  nonisolated func makeAsyncIterator() -> WorkerPool { self }
+  nonisolated func next() async -> Int? { nil }
+}
 
 // CHECK-SIL-LABEL: sil_witness_table shared <Self where Self : DistributedActor> T: Actor module Distributed {
 // CHECK-SIL-NEXT: method #Actor.unownedExecutor!getter: <Self where Self : Actor> (Self) -> () -> UnownedSerialExecutor : @$sxScA11DistributedScA15unownedExecutorScevgTW

--- a/test/decl/protocol/req/associated_type_typealias_implements.swift
+++ b/test/decl/protocol/req/associated_type_typealias_implements.swift
@@ -36,3 +36,33 @@ struct Y3: Q { // expected-error{{type 'Y3' does not conform to protocol 'Q'}}
   typealias T = XT
   // FIXME: More detail from diagnostic.
 }
+
+
+protocol A1 {
+  associatedtype T
+}
+protocol A2 {
+  associatedtype T
+}
+
+struct BothA1_and_A2: A1, A2 {
+  @_implements(A1, T)
+  typealias X = Int
+
+  @_implements(A2, T)
+  typealias Y = String
+}
+
+typealias A1_T<U: A1> = U.T
+typealias A2_T<U: A2> = U.T
+
+struct RequireSame<T, U> { }
+
+extension RequireSame where T == U {
+  init(same: Bool) { }
+}
+
+func testImplements() {
+  _ = RequireSame<A1_T<BothA1_and_A2>, Int>(same: true)
+  _ = RequireSame<A2_T<BothA1_and_A2>, String>(same: true)
+}


### PR DESCRIPTION
Failing to map the type of an isolation capture into context
caused assertions in type lowering. Fixes the build of the
swift-distributed-actors package.