### PR TITLE
[6.0🍒][NCGenerics] adjust infinite type substitution workaround

### DIFF
--- a/lib/AST/ProtocolConformanceRef.cpp
+++ b/lib/AST/ProtocolConformanceRef.cpp
@@ -118,13 +118,6 @@ ProtocolConformanceRef::subst(Type origType, InFlightSubstitution &IFS) const {
     return ProtocolConformanceRef::forInvalid();
   }
 
-  // If the type has been fully substituted and the requirement is for
-  // an invertible protocol, just do a module lookup. This avoids an infinite
-  // substitution issue by recognizing that these protocols are very simple
-  // (see rdar://119950540 for the general issue).
-  if (!substType->hasTypeParameter() && proto->getInvertibleProtocolKind())
-    return proto->getModuleContext()->lookupConformance(substType, proto);
-
   // Check the conformance map.
   // FIXME: Pack element level?
   return IFS.lookupConformance(origType->getCanonicalType(), substType, proto,


### PR DESCRIPTION
Explanation: Moves an existing workaround for infinite type substitution to a better place, to fix cases not already handled.
Scope: Small; fixes an infinite recursion in a complex test case.
Issue: rdar://124697829
Original PR: https://github.com/apple/swift/pull/72579
Risk: Low. This workaround was already known, but has moved to a better spot. It short-cuts substitution in cases where it's very simple, and returning a global conformance is what is suppose to be correct here.
Testing: Only local testing has been performed so far.
Reviewer: @slavapestov 
