### PR TITLE
[region-isolation] A few improvements + If a value is dynamically actor isolated, do not consider it transferred if the transfer statically was to that same actor isolation.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -987,7 +987,7 @@ NOTE(regionbasedisolation_named_stronglytransferred_binding, none,
       "%0 used after being passed as a transferring parameter; Later uses could race",
       (Identifier))
 NOTE(regionbasedisolation_named_isolated_closure_yields_race, none,
-      "%0 %1 is captured by %2 closure. %2 uses in closure may race against later %3 uses",
+      "%0 %1 is captured by a %2 closure. %2 uses in closure may race against later %3 uses",
       (StringRef, Identifier, ActorIsolation, ActorIsolation))
 
 // Misc Error.

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -347,6 +347,9 @@ private:
   /// block indices.
   unsigned BlockListChangeIdx = 0;
 
+  /// The isolation of this function.
+  std::optional<ActorIsolation> actorIsolation;
+
   /// The function's bare attribute. Bare means that the function is SIL-only
   /// and does not require debug info.
   unsigned Bare : 1;
@@ -1365,6 +1368,14 @@ public:
     }
 
     return false;
+  }
+
+  void setActorIsolation(ActorIsolation newActorIsolation) {
+    actorIsolation = newActorIsolation;
+  }
+
+  std::optional<ActorIsolation> getActorIsolation() const {
+    return actorIsolation;
   }
 
   //===--------------------------------------------------------------------===//

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -288,6 +288,13 @@ public:
   void print(llvm::raw_ostream &os) const {
     os << "TrackableValue. State: ";
     valueState.print(os);
+    os << "\n    Rep Value: ";
+    getRepresentative().print(os);
+  }
+
+  void printVerbose(llvm::raw_ostream &os) const {
+    os << "TrackableValue. State: ";
+    valueState.print(os);
     os << "\n    Rep Value: " << getRepresentative();
   }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1217,6 +1217,10 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
   if (F->getLoweredFunctionType()->isPolymorphic())
     F->setGenericEnvironment(Types.getConstantGenericEnvironment(constant));
 
+  // Set the actor isolation of the function to its innermost decl context.
+  F->setActorIsolation(
+      getActorIsolationOfContext(constant.getInnermostDeclContext()));
+
   // Create a debug scope for the function using astNode as source location.
   F->setDebugScope(new (M) SILDebugScope(Loc, F));
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3460,7 +3460,9 @@ void RegionAnalysisValueMap::print(llvm::raw_ostream &os) const {
   }
   std::sort(temp.begin(), temp.end());
   for (auto p : temp) {
-    os << "%%" << p.first << ": " << p.second;
+    os << "%%" << p.first << ": ";
+    auto value = getValueForId(Element(p.first));
+    value->print(os);
   }
 #endif
 }

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1470,6 +1470,7 @@ public:
     llvm::SmallVector<Element, 8> nonSendableJoinedIndices;
     llvm::SmallVector<Element, 8> nonSendableSeparateIndices;
     for (SILArgument *arg : functionArguments) {
+      // This will decide what the isolation region is.
       if (auto state = tryToTrackValue(arg)) {
         // If we can transfer our parameter, just add it to
         // nonSendableSeparateIndices.
@@ -1485,9 +1486,8 @@ public:
 
         // Otherwise, it is one of our merged parameters. Add it to the never
         // transfer list and to the region join list.
-        LLVM_DEBUG(llvm::dbgs() << "    %%" << state->getID() << ": " << *arg);
-        valueMap.mergeIsolationRegionInfo(
-            arg, SILIsolationInfo::getTaskIsolated(arg));
+        LLVM_DEBUG(llvm::dbgs() << "    %%" << state->getID() << ": ";
+                   state->print(llvm::dbgs()); llvm::dbgs() << *arg);
         nonSendableJoinedIndices.push_back(state->getID());
       }
     }

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -1023,8 +1023,13 @@ public:
 
   void emitFunctionArgumentClosure(SourceLoc loc, Type type,
                                    ApplyIsolationCrossing crossing) {
+    SmallString<64> descriptiveKindStr;
+    {
+      llvm::raw_svector_ostream os(descriptiveKindStr);
+      getIsolationRegionInfo().printForDiagnostics(os);
+    }
     diagnoseError(loc, diag::regionbasedisolation_arg_transferred,
-                  "task-isolated", type, crossing.getCalleeIsolation())
+                  descriptiveKindStr, type, crossing.getCalleeIsolation())
         .highlight(getOperand()->getUser()->getLoc().getSourceRange());
   }
 

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -15,7 +15,7 @@
 ////////////////////////
 
 /// Classes are always non-sendable, so this is non-sendable
-class NonSendableKlass { // expected-complete-note 36{{}}
+class NonSendableKlass { // expected-complete-note 38{{}}
   // expected-typechecker-only-note @-1 4{{}}
   // expected-tns-note @-2 2{{}}
   var field: NonSendableKlass? = nil
@@ -129,15 +129,43 @@ func closureInOut(_ a: Actor) async {
   // expected-tns-warning @-2 {{transferring 'ns0' may cause a race}}
   // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
-  // We only emit a warning on the first use we see, so make sure we do both
-  // klass and the closure.
   if await booleanFlag {
-    await a.useKlass(ns1) // expected-tns-note {{use here could race}}
+    // This is not an actual use since we are passing values to the same
+    // isolation domain.
+    await a.useKlass(ns1)
     // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
   } else {
     closure() // expected-tns-note {{use here could race}}
   }
 }
+
+func closureInOutDifferentActor(_ a: Actor, _ a2: Actor) async {
+  var contents = NonSendableKlass()
+  let ns0 = NonSendableKlass()
+  let ns1 = NonSendableKlass()
+
+  contents = ns0
+  contents = ns1
+
+  var closure = {}
+  closure = { useInOut(&contents) }
+
+  await a.useKlass(ns0)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  // expected-tns-warning @-2 {{transferring 'ns0' may cause a race}}
+  // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+
+  // We only emit a warning on the first use we see, so make sure we do both
+  // the print and the closure.
+  if await booleanFlag {
+    // This is an actual use since a2 is a different actor from a1
+    await a2.useKlass(ns1)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
+  } else {
+    closure() // expected-tns-note {{use here could race}}
+  }
+}
+
 
 func closureInOut2(_ a: Actor) async {
   var contents = NonSendableKlass()
@@ -1182,9 +1210,11 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
     // good... that is QoI though.
     await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
     // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-    // expected-tns-note @-2 {{use here could race}}
-    // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
-    test = StructFieldTests()
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
+
+    // This is treated as a use since test is in box form and is mutable. So we
+    // treat assignment as a merge.
+    test = StructFieldTests() // expected-tns-note {{use here could race}}
     cls = {
       useInOut(&test.varSendableNonTrivial)
     }
@@ -1215,7 +1245,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   }
 
   test.varSendableNonTrivial = SendableKlass()
-  useValue(test)
+  useValue(test) // expected-tns-note {{use here could race}}
 }
 
 func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
@@ -1387,7 +1417,7 @@ func controlFlowTest2() async {
     x = NonSendableKlass()
   }
 
-  useValue(x)
+  useValue(x) // expected-tns-note {{use here could race}}
 }
 
 ////////////////////////

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1502,6 +1502,7 @@ final actor FinalActorWithSetter {
 
 func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let _ = { @MainActor in
-    let _ = x // expected-tns-warning {{task-isolated value of type '() -> ()' transferred to main actor-isolated context}}
+    let _ = x // expected-tns-warning {{transferring 'x' may cause a race}}
+    // expected-tns-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -177,8 +177,11 @@ struct Clock {
   let ns = customActorIsolatedGlobal
 
   let _ = { @MainActor in
-    print(ns) // expected-tns-warning {{global actor 'CustomActor'-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
-    // expected-complete-warning @-1 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in an isolated closure}}
+    // TODO: The type checker seems to think that the isolation here is
+    // nonisolated instead of custom actor isolated.
+    print(ns) // expected-tns-warning {{transferring 'ns' may cause a race}}
+    // expected-tns-note @-1 {{global actor 'CustomActor'-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-complete-warning @-2 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in an isolated closure}}
   }
 
   useValue(ns)
@@ -189,7 +192,8 @@ struct Clock {
 
   // TODO: We should not consider this to be a transfer.
   let _ = { @MainActor in
-    print(ns) // expected-tns-warning {{main actor-isolated value of type 'NonSendableKlass' transferred to main actor-isolated context}}
+    print(ns) // expected-tns-warning {{transferring 'ns' may cause a race}}
+    // expected-tns-note @-1 {{main actor-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 
   useValue(ns)

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -190,10 +190,21 @@ struct Clock {
 @MainActor func testGlobalAndGlobalIsolatedPartialApplyMatch() {
   let ns = mainActorIsolatedGlobal
 
-  // TODO: We should not consider this to be a transfer.
+  // This is not a transfer since ns is already main actor isolated.
   let _ = { @MainActor in
-    print(ns) // expected-tns-warning {{transferring 'ns' may cause a race}}
-    // expected-tns-note @-1 {{main actor-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    print(ns)
+  }
+
+  useValue(ns)
+}
+
+@MainActor func testGlobalAndGlobalIsolatedPartialApplyMatch2() {
+  var ns = (NonSendableKlass(), NonSendableKlass())
+  ns.0 = mainActorIsolatedGlobal
+
+  // This is not a transfer since ns is already main actor isolated.
+  let _ = { @MainActor in
+    print(ns)
   }
 
   useValue(ns)

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -209,3 +209,15 @@ struct Clock {
 
   useValue(ns)
 }
+
+@MainActor func testGlobalAndDisconnected() {
+  let ns = NonSendableKlass()
+
+  let _ = { @MainActor in
+    print(ns)
+  }
+
+  // Since useValue is running in an actor isolated context, it is ok to use the
+  // transferred value 'ns' here.
+  useValue(ns)
+}

--- a/test/Concurrency/transfernonsendable_global_actor_transferring.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_transferring.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -enable-experimental-feature TransferringArgsAndResults -verify %s -o /dev/null -parse-as-library
+
+// README: Once we loosen the parser so that transferring is rejected in Sema
+// instead of the parser, move into the normal
+// transfernonsendable_global_actor.swift
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+
+extension Task where Failure == Never {
+  public static func fakeInit(
+    @_implicitSelfCapture operation: transferring @escaping () async -> Success
+  ) {}
+}
+
+func useValue<T>(_ t: T) {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+@MainActor func testGlobalFakeInit() {
+  let ns = NonSendableKlass()
+
+  // Will be resolved once @MainActor is @Sendable
+  Task.fakeInit { @MainActor in // expected-error {{main actor-isolated value of type '@MainActor () async -> ()' passed as a strongly transferred parameter}}
+    print(ns) // expected-error {{transferring 'ns' may cause a race}}
+    // expected-note @-1 {{disconnected 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+  }
+
+  useValue(ns) // expected-note {{use here could race}}
+}

--- a/test/Concurrency/transfernonsendable_global_actor_transferring.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_transferring.swift
@@ -27,9 +27,8 @@ func useValue<T>(_ t: T) {}
 
   // Will be resolved once @MainActor is @Sendable
   Task.fakeInit { @MainActor in // expected-error {{main actor-isolated value of type '@MainActor () async -> ()' passed as a strongly transferred parameter}}
-    print(ns) // expected-error {{transferring 'ns' may cause a race}}
-    // expected-note @-1 {{disconnected 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    print(ns)
   }
 
-  useValue(ns) // expected-note {{use here could race}}
+  useValue(ns)
 }

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -645,12 +645,14 @@ bb0:
 
   fix_lifetime %value : $SendableKlass
 
+  // This is not considered a bad use of the raw pointer since this is
+  // transferring to the same isolation domain.
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
-  // expected-note @-2 {{use here could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
   // expected-note @-1 {{use here could race}}
+  // expected-note @-2 {{use here could race}}  
 
   destroy_value %value : $SendableKlass
   %9999 = tuple ()
@@ -723,10 +725,10 @@ bb0:
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
-  // expected-note @-2 {{use here could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
   // expected-note @-1 {{use here could race}}
+  // expected-note @-2 {{use here could race}}
 
   destroy_value %value : $SendableKlass
   %9999 = tuple ()
@@ -802,10 +804,10 @@ bb0:
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferRawPointer(%rawPointer) : $@convention(thin) @async (Builtin.RawPointer) -> ()
   // expected-warning @-1 {{transferring value of non-Sendable type 'Builtin.RawPointer' from nonisolated context to global actor '<null>'-isolated context; later accesses could race}}
-  // expected-note @-2 {{use here could race}}
 
   fix_lifetime %rawPointer : $Builtin.RawPointer
   // expected-note @-1 {{use here could race}}
+  // expected-note @-2 {{use here could race}}
 
   end_borrow %valueB : $SendableKlass
   destroy_value %value : $SendableKlass
@@ -1238,7 +1240,8 @@ bb0:
   unchecked_ref_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{use here could race}}
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  %use = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply %use<NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   destroy_addr %b : $*NonSendableKlass
   dealloc_stack %b : $*NonSendableKlass
@@ -1264,7 +1267,8 @@ bb0:
   unconditional_checked_cast_addr NonSendableKlass in %a : $*NonSendableKlass to NonSendableKlass in %b : $*NonSendableKlass // expected-note {{use here could race}}
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+  %use = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply %use<NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   destroy_addr %b : $*NonSendableKlass
   dealloc_stack %b : $*NonSendableKlass
@@ -1290,7 +1294,8 @@ bb0:
   destroy_value %aValue : $NonSendableKlass
 
   apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
-  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %f<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
+    %use = function_ref @useIndirect : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  apply %use<@sil_unowned NonSendableKlass>(%b) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-note {{use here could race}}
 
   destroy_addr %b : $*@sil_unowned NonSendableKlass
   destroy_addr %a : $*NonSendableKlass

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -36,18 +36,19 @@ func doSomething(_ x: NonSendableKlass, _ y: NonSendableKlass) { }
 actor ProtectsNonSendable {
   var ns: NonSendableKlass = .init()
 
-  nonisolated func testParameter(_ ns: NonSendableKlass) async {
+  nonisolated func testParameter(_ nsArg: NonSendableKlass) async {
+    // TODO: This is wrong, we should get an error saying that nsArg is task
+    // isolated since this is nonisolated.
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = ns // expected-warning {{task-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+      isolatedSelf.ns = nsArg // expected-warning {{actor-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
     }
   }
 
-  // This should get the note since l is different from 'ns'.
-  nonisolated func testParameterMergedIntoLocal(_ ns: NonSendableKlass) async {
+  nonisolated func testParameterMergedIntoLocal(_ nsArg: NonSendableKlass) async {
     let l = NonSendableKlass()
-    doSomething(l, ns)
+    doSomething(l, nsArg)
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{task-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+      isolatedSelf.ns = l // expected-warning {{actor-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
     }
   }
 

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -41,7 +41,7 @@ actor ProtectsNonSendable {
     // isolated since this is nonisolated.
     self.assumeIsolated { isolatedSelf in
       isolatedSelf.ns = nsArg // expected-warning {{transferring 'nsArg' may cause a race}}
-      // expected-note @-1 {{actor-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 
@@ -50,7 +50,7 @@ actor ProtectsNonSendable {
     doSomething(l, nsArg)
     self.assumeIsolated { isolatedSelf in
       isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a race}}
-      // expected-note @-1 {{actor-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{task-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -40,7 +40,8 @@ actor ProtectsNonSendable {
     // TODO: This is wrong, we should get an error saying that nsArg is task
     // isolated since this is nonisolated.
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = nsArg // expected-warning {{actor-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+      isolatedSelf.ns = nsArg // expected-warning {{transferring 'nsArg' may cause a race}}
+      // expected-note @-1 {{actor-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 
@@ -48,7 +49,8 @@ actor ProtectsNonSendable {
     let l = NonSendableKlass()
     doSomething(l, nsArg)
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{actor-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+      isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a race}}
+      // expected-note @-1 {{actor-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
 
@@ -67,7 +69,7 @@ actor ProtectsNonSendable {
     // This is not safe since we use l later.
     self.assumeIsolated { isolatedSelf in
       isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a race}}
-      // expected-note @-1 {{disconnected 'l' is captured by actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
+      // expected-note @-1 {{disconnected 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
 
     useValue(l) // expected-note {{use here could race}}
@@ -85,7 +87,7 @@ func normalFunc_testLocal_2() {
   let x = NonSendableKlass()
   let _ = { @MainActor in
     useValue(x) // expected-warning {{transferring 'x' may cause a race}}
-    // expected-note @-1 {{disconnected 'x' is captured by main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{disconnected 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -50,14 +50,15 @@ func testIsolationCrossingDueToCapture() async {
   let x = NonSendableType()
   let _ = { @MainActor in
     print(x) // expected-error {{transferring 'x' may cause a race}}
-    // expected-note @-1 {{disconnected 'x' is captured by main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    // expected-note @-1 {{disconnected 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
 }
 
 func testIsolationCrossingDueToCaptureParameter(_ x: NonSendableType) async {
   let _ = { @MainActor in
-    print(x) // expected-error {{task-isolated value of type 'NonSendableType' transferred to main actor-isolated context; later accesses to value could race}}
+    print(x) // expected-error {{transferring 'x' may cause a race}}
+    // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x)
 }

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -47,6 +47,8 @@ struct MockedPartitionOpEvaluator final
   SILIsolationInfo getIsolationRegionInfo(Element elt) const {
     return SILIsolationInfo::getDisconnected();
   }
+
+  bool shouldTryToSquelchErrors() const { return false; }
 };
 
 } // namespace
@@ -566,6 +568,8 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
   SILIsolationInfo getIsolationRegionInfo(Element elt) const {
     return SILIsolationInfo::getDisconnected();
   }
+
+  bool shouldTryToSquelchErrors() const { return false; }
 };
 
 } // namespace


### PR DESCRIPTION
This PR contains a few different changes that build on each other to solve rdar://123474616 (the title problem of the radar). Specifically (ignoring a test fix change):

1. b19081daad11a3f05a45af61f52c8104845cce64. I have been meaning to make this change for some time. It just makes it easier to read the debug output to check if a specific value has the wrong isolation kind.
2. 5e58aa64a2c2fd7878c2ca93ac6ffdb9019cd663. While doing work for the main piece of work here, I noticed that when dealing with values captured in isolated closures, we were always saying that they are task isolated... which is wrong! Instead I needed to use the dynamic isolation information of the value at the transfer point provided by the dynamic isolation tracking infrastructure I added recently. rdar://125372336
3. d0d2f2d9b2155fa4655a30f05ad8862eb49f1978. After doing that, I realized that the previous diagnostic was a diagnostic that I missed when I was converting diagnostics to have named forms. In this commit I did that taking advantage again of the dynamic isolation information. rdar://125372790.
4. 8243b5cb74ca7f7ded9680d4250b1b30ac2e6964. This is the main meat of the PR. In this commit I make it so that if a value is actor isolated and is passed to a closure isolated to the same actor, we do not treat the passing to the closure as a transfer. We still have a require though. rdar://123474616.
5. e36aab63017d90d3b4221a0190cddd91f257b554. In this PR, I finish by making it so that we ignore use after transfer if we can prove that the use is actor isolated to the same actor as the place we transferred the value or if the use doesn't make any isolation assumptions but is running in a context that has the same actor isolation as the place we transfer the parameter, then we squelch the error.