### PR TITLE
Tests: fix typo to be CHECK-LABEL

### DIFF
--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -154,7 +154,7 @@ bb0:
 
 // CHECK-LABEL: sil [ossa] @test_beginborrow_parsing :
 // CHECK:   %1 = begin_borrow [pointer_escape] %0 : $Builtin.NativeObject
-// CHECK-LABE: } // end sil function 'test_beginborrow_parsing'
+// CHECK-LABEL: } // end sil function 'test_beginborrow_parsing'
 sil [ossa] @test_beginborrow_parsing : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = begin_borrow [pointer_escape] %0 : $Builtin.NativeObject

--- a/test/stmt/typed_throws_ast.swift
+++ b/test/stmt/typed_throws_ast.swift
@@ -41,7 +41,7 @@ func throwsAnything() throws {
 func doesNotThrow() { }
 
 func throwsNothing() {
-  // CHECK-LABE: func_decl{{.*}}"throwsNothing()"
+  // CHECK-LABEL: func_decl{{.*}}"throwsNothing()"
 
   // CHECK: force_try_expr{{.*}}thrown_error="Never"
   try! doesNotThrow()


### PR DESCRIPTION
I found `// CHECK-LABE:` typos that should be `// CHECK-LABEL:` in test files and corrected them.