### PR TITLE
Correct typo in swift_build_support product.py file when cross-building

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -370,7 +370,7 @@ class Product(object):
     def get_linux_sysroot(self, platform, arch):
         if not self.is_cross_compile_target('{}-{}'.format(platform, arch)):
             return None
-        sysroot_arch, abi = self.get_linux_target_components(arch)
+        sysroot_arch, _, abi = self.get_linux_target_components(arch)
         # $ARCH-$PLATFORM-$ABI
         # E.x.: aarch64-linux-gnu
         sysroot_dirname = '{}-{}-{}'.format(sysroot_arch, platform, abi)


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is a very simple fix for a small typo in `utils/swift_build_support/swift_build_support/products/product.py`. I noticed it when cross-compiling Swift for armhf. The error the script gives when running is as follows:

```
Traceback (most recent call last):
  File "/workspaces/swift-armv7/workspace/swift/./utils/build-script", line 800, in <module>
    exit_code = main()
  File "/workspaces/swift-armv7/workspace/swift/./utils/build-script", line 795, in main
    return main_normal()
  File "/workspaces/swift-armv7/workspace/swift/./utils/build-script", line 740, in main_normal
    invocation.execute()
  File "/workspaces/swift-armv7/workspace/swift/utils/swift_build_support/swift_build_support/build_script_invocation.py", line 734, in execute
    self._execute(pipeline, all_host_names)
  File "/workspaces/swift-armv7/workspace/swift/utils/swift_build_support/swift_build_support/build_script_invocation.py", line 794, in _execute
    self.execute_product_build_steps(product_class, host_target)
  File "/workspaces/swift-armv7/workspace/swift/utils/swift_build_support/swift_build_support/build_script_invocation.py", line 855, in execute_product_build_steps
    product.build(host_target)
  File "/workspaces/swift-armv7/workspace/swift/utils/swift_build_support/swift_build_support/products/llvm.py", line 212, in build
    toolchain_file = self.generate_linux_toolchain_file(platform, arch)
  File "/workspaces/swift-armv7/workspace/swift/utils/swift_build_support/swift_build_support/products/product.py", line 403, in generate_linux_toolchain_file
    maybe_sysroot = self.get_linux_sysroot(platform, arch)
  File "/workspaces/swift-armv7/workspace/swift/utils/swift_build_support/swift_build_support/products/product.py", line 373, in get_linux_sysroot
    sysroot_arch, abi = self.get_linux_target_components(arch)
ValueError: too many values to unpack (expected 2)
```

I checked the Swift main branch and other pull requests and did not see anyone addressing this yet, so I figured pull requesting this small typo fix would be useful. For now, on our cross-build we created a simple patch for this file to fix the error, but it would be good to include in Swift main for the next release.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
