### PR TITLE
[6.0 cherry-pick] [embedded] Add swift_isUniquelyReferenced_native into the embedded runtime

### DIFF
--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -146,6 +146,12 @@ func swift_initStackObject(metadata: UnsafeMutablePointer<ClassMetadata>, object
 public func swift_setDeallocating(object: Builtin.RawPointer) {
 }
 
+@_cdecl("swift_isUniquelyReferenced_native")
+public func swift_isUniquelyReferenced_native(object: Builtin.RawPointer) -> Bool {
+  if Int(Builtin.ptrtoint_Word(object)) == 0 { return false }
+  return swift_isUniquelyReferenced_nonNull_native(object: UnsafeMutablePointer<HeapObject>(object))
+}
+
 @_cdecl("swift_isUniquelyReferenced_nonNull_native")
 public func swift_isUniquelyReferenced_nonNull_native(object: Builtin.RawPointer) -> Bool {
   return swift_isUniquelyReferenced_nonNull_native(object: UnsafeMutablePointer<HeapObject>(object))

--- a/test/embedded/classes-optional.swift
+++ b/test/embedded/classes-optional.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -enable-experimental-feature Embedded -c -o %t/main.o
+// RUN: %target-clang %t/main.o -o %t/a.out -dead_strip
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+class Foo {
+    var foo: Foo?
+}
+
+do {
+  _ = Foo()
+  print("OK!")
+}
+// CHECK: OK!


### PR DESCRIPTION
* **Explanation**: Optional reference to the parent class causes a missing symbol at link: swift_isUniquelyReferenced_native, fix is trivial: Add swift_isUniquelyReferenced_native into the embedded runtime. https://github.com/apple/swift/pull/72563
* **Scope**: Embedded Swift only.
* **Risk**: Low, trivial change only applying to Embedded Swift.
* **Testing**: Added test case.
* **Issue**: rdar://125420193, https://github.com/apple/swift/issues/72559
* **Reviewer**:  @al45tair on https://github.com/apple/swift/pull/72563
