### PR TITLE
Disable tracing in xpcproxy

### DIFF
--- a/include/swift/Runtime/TracingCommon.h
+++ b/include/swift/Runtime/TracingCommon.h
@@ -33,7 +33,8 @@ static inline bool shouldEnableTracing() {
     return false;
   if (__progname && (strcmp(__progname, "logd") == 0 ||
                      strcmp(__progname, "diagnosticd") == 0 ||
-                     strcmp(__progname, "notifyd") == 0))
+                     strcmp(__progname, "notifyd") == 0) ||
+                     strcmp(__progname, "xpcproxy") == 0)
     return false;
   return true;
 }


### PR DESCRIPTION
Add xpcproxy to the list of processes that handle tracing requests and therefore cannot themselves use tracing without deadlocking.

rdar://124996590
