### PR TITLE
[IRGen] Add Builtin.addressOfRawLayout

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -1112,6 +1112,12 @@ BUILTIN_MISC_OPERATION_WITH_SILGEN(DistributedActorAsAnyActor, "distributedActor
 /// Returns a raw pointer to the address of the raw layout type. This address is
 /// only valid during a borrow access of the raw layout type or until the value
 /// is either moved or consumed.
+///
+/// Note: The purpose of this builtin is to get an opaque pointer to the address
+/// of the raw layout type. We explicitly do not want the optimizer looking into
+/// this pointer or address thereof to start assuming things about mutability or
+/// immutability. This builtin _must_ persist throughout all of SIL and must be
+/// lowered away at IRGen, no sooner.
 BUILTIN_MISC_OPERATION_WITH_SILGEN(AddressOfRawLayout, "addressOfRawLayout", "n", Special)
 
 /// Builtins for instrumentation added by sanitizers during SILGen.

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -1112,7 +1112,7 @@ BUILTIN_MISC_OPERATION_WITH_SILGEN(DistributedActorAsAnyActor, "distributedActor
 /// Returns a raw pointer to the address of the raw layout type. This address is
 /// only valid during a borrow access of the raw layout type or until the value
 /// is either moved or consumed.
-BUILTIN_SIL_OPERATION(AddressOfRawLayout, "addressOfRawLayout", Special)
+BUILTIN_MISC_OPERATION_WITH_SILGEN(AddressOfRawLayout, "addressOfRawLayout", "n", Special)
 
 /// Builtins for instrumentation added by sanitizers during SILGen.
 #ifndef BUILTIN_SANITIZER_OPERATION

--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -1107,6 +1107,13 @@ BUILTIN_MISC_OPERATION_WITH_SILGEN(InjectEnumTag, "injectEnumTag", "", Special)
 /// `any Actor` existential that refers to the local actor.
 BUILTIN_MISC_OPERATION_WITH_SILGEN(DistributedActorAsAnyActor, "distributedActorAsAnyActor", "n", Special)
 
+/// addressOfRawLayout: <T: ~Copyable>(_: borrowing T) -> Builtin.RawPointer
+///
+/// Returns a raw pointer to the address of the raw layout type. This address is
+/// only valid during a borrow access of the raw layout type or until the value
+/// is either moved or consumed.
+BUILTIN_SIL_OPERATION(AddressOfRawLayout, "addressOfRawLayout", Special)
+
 /// Builtins for instrumentation added by sanitizers during SILGen.
 #ifndef BUILTIN_SANITIZER_OPERATION
 #define BUILTIN_SANITIZER_OPERATION(Id, Name, Attrs) BUILTIN(Id, Name, Attrs)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -170,6 +170,7 @@ LANGUAGE_FEATURE(ExpressionMacroDefaultArguments, 422, "Expression macro as call
 LANGUAGE_FEATURE(BuiltinStoreRaw, 0, "Builtin.storeRaw")
 LANGUAGE_FEATURE(BuiltinCreateTask, 0, "Builtin.createTask and Builtin.createDiscardingTask")
 SUPPRESSIBLE_LANGUAGE_FEATURE(AssociatedTypeImplements, 0, "@_implements on associated types")
+LANGUAGE_FEATURE(BuiltinAddressOfRawLayout, 0, "Builtin.addressOfRawLayout")
 
 // Swift 6
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)

--- a/include/swift/SIL/AddressWalker.h
+++ b/include/swift/SIL/AddressWalker.h
@@ -276,6 +276,7 @@ TransitiveAddressWalker<Impl>::walk(SILValue projectedAddress) && {
         case BuiltinValueKind::ZeroInitializer:
         case BuiltinValueKind::GetEnumTag:
         case BuiltinValueKind::InjectEnumTag:
+        case BuiltinValueKind::AddressOfRawLayout:
           callVisitUse(op);
           continue;
         default:

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -2118,6 +2118,15 @@ static ValueDecl *getInjectEnumTag(ASTContext &ctx, Identifier id) {
   return builder.build(id);
 }
 
+static ValueDecl *getAddressOfRawLayout(ASTContext &ctx, Identifier id) {
+  BuiltinFunctionBuilder builder(ctx, /* genericParamCount */ 1);
+
+  builder.addParameter(makeGenericParam(), ParamSpecifier::Borrowing);
+  builder.setResult(makeConcrete(ctx.TheRawPointerType));
+
+  return builder.build(id);
+}
+
 /// An array of the overloaded builtin kinds.
 static const OverloadedBuiltinKind OverloadedBuiltinKinds[] = {
   OverloadedBuiltinKind::None,
@@ -3191,6 +3200,9 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
 
   case BuiltinValueKind::DistributedActorAsAnyActor:
     return getDistributedActorAsAnyActor(Context, Id);
+
+  case BuiltinValueKind::AddressOfRawLayout:
+    return getAddressOfRawLayout(Context, Id);
   }
 
   llvm_unreachable("bad builtin value!");

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -359,6 +359,7 @@ static bool usesFeatureExpressionMacroDefaultArguments(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(BuiltinStoreRaw)
+UNINTERESTING_FEATURE(BuiltinAddressOfRawLayout)
 
 // ----------------------------------------------------------------------------
 // MARK: - Upcoming Features

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1477,6 +1477,9 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     return;
   }
 
+  // LLVM must not see the address generated here as 'invariant' or immutable
+  // ever. A raw layout's address defies all formal access, so immutable looking
+  // uses may actually mutate the underlying value!
   if (Builtin.ID == BuiltinValueKind::AddressOfRawLayout) {
     auto addr = args.claimNext();
     auto value = IGF.Builder.CreateBitCast(addr, IGF.IGM.Int8PtrTy);

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1477,5 +1477,12 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     return;
   }
 
+  if (Builtin.ID == BuiltinValueKind::AddressOfRawLayout) {
+    auto addr = args.claimNext();
+    auto value = IGF.Builder.CreateBitCast(addr, IGF.IGM.Int8PtrTy);
+    out.add(value);
+    return;
+  }
+
   llvm_unreachable("IRGen unimplemented for this builtin!");
 }

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -892,6 +892,7 @@ BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, TargetOSVersionAtLeast)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, GetEnumTag)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, InjectEnumTag)
 BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, DistributedActorAsAnyActor)
+BUILTIN_OPERAND_OWNERSHIP(InstantaneousUse, AddressOfRawLayout)
 OperandOwnership OperandOwnershipBuiltinClassifier::visitCopy(BuiltinInst *bi,
                                                               StringRef) {
   if (bi->getFunction()->getConventions().useLoweredAddresses()) {

--- a/lib/SIL/IR/ValueOwnership.cpp
+++ b/lib/SIL/IR/ValueOwnership.cpp
@@ -620,6 +620,7 @@ CONSTANT_OWNERSHIP_BUILTIN(None, GetEnumTag)
 CONSTANT_OWNERSHIP_BUILTIN(None, InjectEnumTag)
 CONSTANT_OWNERSHIP_BUILTIN(Owned, DistributedActorAsAnyActor)
 CONSTANT_OWNERSHIP_BUILTIN(Guaranteed, ExtractFunctionIsolation) // unreachable
+CONSTANT_OWNERSHIP_BUILTIN(None, AddressOfRawLayout)
 
 #undef CONSTANT_OWNERSHIP_BUILTIN
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2667,6 +2667,7 @@ static void visitBuiltinAddress(BuiltinInst *builtin,
     // These builtins take a generic 'T' as their operand.
     case BuiltinValueKind::GetEnumTag:
     case BuiltinValueKind::InjectEnumTag:
+    case BuiltinValueKind::AddressOfRawLayout:
       visitor(&builtin->getAllOperands()[0]);
       return;
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -600,6 +600,12 @@ struct ImmutableAddressUseVerifier {
           if (builtinKind == BuiltinValueKind::GetEnumTag) {
             return false;
           }
+
+          // The optimizer cannot reason about a raw layout type's address due
+          // to it not respecting formal access scopes.
+          if (builtinKind == BuiltinValueKind::AddressOfRawLayout) {
+            return false;
+          }
         }
 
         // Otherwise this is a builtin that we are not expecting to see, so bail

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -2012,6 +2012,21 @@ static ManagedValue emitBuiltinDistributedActorAsAnyActor(
   return SGF.emitDistributedActorAsAnyActor(loc, subs, args[0]);
 }
 
+static ManagedValue emitBuiltinAddressOfRawLayout(SILGenFunction &SGF,
+                                                  SILLocation loc,
+                                                  SubstitutionMap subs,
+                                                  ArrayRef<ManagedValue> args,
+                                                  SGFContext C) {
+  auto &ctx = SGF.getASTContext();
+
+  auto bi = SGF.B.createBuiltin(
+    loc, ctx.getIdentifier(getBuiltinName(BuiltinValueKind::AddressOfRawLayout)),
+    SILType::getRawPointerType(ctx), subs,
+    { args[0].getValue() });
+
+  return ManagedValue::forObjectRValueWithoutOwnership(bi);
+}
+
 std::optional<SpecializedEmitter>
 SpecializedEmitter::forDecl(SILGenModule &SGM, SILDeclRef function) {
   // Only consider standalone declarations in the Builtin module.

--- a/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementReleaseSinking.cpp
@@ -159,6 +159,7 @@ static bool isBarrier(SILInstruction *inst) {
     case BuiltinValueKind::GetEnumTag:
     case BuiltinValueKind::InjectEnumTag:
     case BuiltinValueKind::ExtractFunctionIsolation:
+    case BuiltinValueKind::AddressOfRawLayout:
       return false;
 
     // Handle some rare builtins that may be sensitive to object lifetime

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -160,12 +160,12 @@ entry(%K: $*Keymaster):
     return undef : $()
 }
 
-// CHECK: define swiftcc ptr @get_cell_addr(ptr %"Cell<T>", ptr {{.*}} swiftself [[SELF:%.*]])
+// CHECK: define {{.*}}swiftcc ptr @get_cell_addr(ptr %"Cell<T>", ptr {{.*}} swiftself [[SELF:%.*]])
 // CHECK-NEXT:   entry:
 // CHECK-NEXT:     ret ptr [[SELF]]
 sil @get_cell_addr : $@convention(method) <T> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
 entry(%0 : $*Cell<T>):
-    %1 = raw_layout_address_to_pointer %0 : $*Cell<T> to $Builtin.RawPointer
+    %1 = builtin "addressOfRawLayout"(%0 : $*Cell<T>) : $Builtin.RawPointer
     %2 = struct $UnsafeMutablePointer<T> (%1 : $Builtin.RawPointer)
     return %2 : $UnsafeMutablePointer<T>
 }

--- a/test/IRGen/raw_layout.swift
+++ b/test/IRGen/raw_layout.swift
@@ -2,6 +2,7 @@
 // RUN: %{python} %utils/chex.py < %s > %t/raw_layout.sil
 // RUN: %target-swift-frontend -enable-experimental-feature RawLayout -emit-ir -disable-availability-checking %t/raw_layout.sil | %FileCheck %t/raw_layout.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
+import Builtin
 import Swift
 
 // CHECK-LABEL: @"$s{{[A-Za-z0-9_]*}}4LockVWV" = {{.*}} %swift.vwtable
@@ -142,6 +143,33 @@ struct BadBuffer: ~Copyable {
     let buffer: SmallVectorOf3<Int64?>
 }
 
+sil @use_lock : $@convention(thin) (@in_guaranteed Lock) -> () {
+entry(%L: $*Lock):
+    return undef : $()
+}
+
+sil @use_keymaster_locks : $@convention(thin) (@in_guaranteed Keymaster) -> () {
+entry(%K: $*Keymaster):
+    %f = function_ref @use_lock : $@convention(thin) (@in_guaranteed Lock) -> ()
+    %a = struct_element_addr %K : $*Keymaster, #Keymaster.lock1
+    apply %f(%a) : $@convention(thin) (@in_guaranteed Lock) -> ()
+    %b = struct_element_addr %K : $*Keymaster, #Keymaster.lock2
+    apply %f(%b) : $@convention(thin) (@in_guaranteed Lock) -> ()
+    %c = struct_element_addr %K : $*Keymaster, #Keymaster.lock2
+    apply %f(%c) : $@convention(thin) (@in_guaranteed Lock) -> ()
+    return undef : $()
+}
+
+// CHECK: define swiftcc ptr @get_cell_addr(ptr %"Cell<T>", ptr {{.*}} swiftself [[SELF:%.*]])
+// CHECK-NEXT:   entry:
+// CHECK-NEXT:     ret ptr [[SELF]]
+sil @get_cell_addr : $@convention(method) <T> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
+entry(%0 : $*Cell<T>):
+    %1 = raw_layout_address_to_pointer %0 : $*Cell<T> to $Builtin.RawPointer
+    %2 = struct $UnsafeMutablePointer<T> (%1 : $Builtin.RawPointer)
+    return %2 : $UnsafeMutablePointer<T>
+}
+
 // Dependent layout metadata initialization:
 
 // Cell<T>
@@ -165,20 +193,3 @@ struct BadBuffer: ~Copyable {
 
 // CHECK-LABEL: define {{.*}} swiftcc %swift.metadata_response @"$s{{[A-Za-z0-9_]*}}14SmallVectorBufVMr"(ptr %"SmallVectorBuf<T>", ptr {{.*}}, ptr {{.*}})
 // CHECK: call void @swift_initRawStructMetadata(ptr %"SmallVectorBuf<T>", {{i64|i32}} 0, ptr {{%.*}}, {{i64|i32}} 8)
-
-sil @use_lock : $@convention(thin) (@in_guaranteed Lock) -> () {
-entry(%L: $*Lock):
-    return undef : $()
-}
-
-sil @use_keymaster_locks : $@convention(thin) (@in_guaranteed Keymaster) -> () {
-entry(%K: $*Keymaster):
-    %f = function_ref @use_lock : $@convention(thin) (@in_guaranteed Lock) -> ()
-    %a = struct_element_addr %K : $*Keymaster, #Keymaster.lock1
-    apply %f(%a) : $@convention(thin) (@in_guaranteed Lock) -> ()
-    %b = struct_element_addr %K : $*Keymaster, #Keymaster.lock2
-    apply %f(%b) : $@convention(thin) (@in_guaranteed Lock) -> ()
-    %c = struct_element_addr %K : $*Keymaster, #Keymaster.lock2
-    apply %f(%c) : $@convention(thin) (@in_guaranteed Lock) -> ()
-    return undef : $()
-}

--- a/test/SILGen/raw_layout.swift
+++ b/test/SILGen/raw_layout.swift
@@ -1,10 +1,12 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-feature RawLayout %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-feature RawLayout -enable-builtin-module %s | %FileCheck %s
 
 // XFAIL: noncopyable_generics
 
 // CHECK: @_rawLayout(size: 4, alignment: 4) @_moveOnly struct Lock
 // CHECK: @_rawLayout(like: T) @_moveOnly struct Cell<T>
 // CHECK: @_rawLayout(likeArrayOf: T, count: 8) @_moveOnly struct SmallVectorBuf<T>
+
+import Builtin
 
 @_rawLayout(size: 4, alignment: 4)
 struct Lock: ~Copyable {
@@ -22,7 +24,18 @@ struct Lock: ~Copyable {
 }
 
 @_rawLayout(like: T)
-struct Cell<T>: ~Copyable {}
+struct Cell<T>: ~Copyable {
+    // CHECK-LABEL: sil {{.*}} @$s10raw_layout4CellV7addressSpyxGvg : $@convention(method) <T> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
+    // CHECK:         [[RAW_LAYOUT_ADDR:%.*]] = raw_layout_address_to_pointer {{%.*}} : $*Cell<T> to $Builtin.RawPointer
+    // CHECK-LABEL: } // end sil function '$s10raw_layout4CellV7addressSpyxGvg'
+    var address: UnsafeMutablePointer<T> {
+        .init(Builtin.addressOfRawLayout(self))
+    }
+
+    init(_ value: consuming T) {
+        address.initialize(to: value)
+    }
+}
 
 @_rawLayout(likeArrayOf: T, count: 8)
 struct SmallVectorBuf<T>: ~Copyable {}

--- a/test/SILGen/raw_layout.swift
+++ b/test/SILGen/raw_layout.swift
@@ -26,7 +26,7 @@ struct Lock: ~Copyable {
 @_rawLayout(like: T)
 struct Cell<T>: ~Copyable {
     // CHECK-LABEL: sil {{.*}} @$s10raw_layout4CellV7addressSpyxGvg : $@convention(method) <T> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
-    // CHECK:         [[RAW_LAYOUT_ADDR:%.*]] = raw_layout_address_to_pointer {{%.*}} : $*Cell<T> to $Builtin.RawPointer
+    // CHECK:         {{%.*}} = builtin "addressOfRawLayout"<Cell<T>>({{%.*}} : $*Cell<T>) : $Builtin.RawPointer
     // CHECK-LABEL: } // end sil function '$s10raw_layout4CellV7addressSpyxGvg'
     var address: UnsafeMutablePointer<T> {
         .init(Builtin.addressOfRawLayout(self))

--- a/test/SILOptimizer/stdlib/Cell.swift
+++ b/test/SILOptimizer/stdlib/Cell.swift
@@ -23,8 +23,6 @@ public struct Cell<T: ~Copyable>: ~Copyable {
   // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
   //                Calling 'UnsafeMutablePointer<T>.initialize(to:)'
   // CHECK:         {{%.*}} = apply {{%.*}}<T>([[VALUE]], [[POINTER]])
-  // CHECK-NEXT:    [[TUPLE:%.*]] = tuple ()
-  // CHECK-NEXT:    return [[TUPLE]] : $()
   // CHECK-LABEL: } // end sil function '$s4CellAAVAARiczrlEyAByxGxcfC'
   @_transparent
   public init(_ value: consuming T) {

--- a/test/SILOptimizer/stdlib/Cell.swift
+++ b/test/SILOptimizer/stdlib/Cell.swift
@@ -1,0 +1,38 @@
+// RUN: %target-swift-frontend -O -emit-sil -disable-availability-checking %s -enable-builtin-module -enable-experimental-feature RawLayout -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+
+import Builtin
+
+@frozen
+@_rawLayout(like: T)
+public struct Cell<T: ~Copyable>: ~Copyable {
+  // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARiczrlE7addressSpyxGvg : $@convention(method) <T where T : ~Copyable> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
+  // CHECK:       bb0([[SELF:%.*]] : $*Cell<T>):
+  // CHECK:         [[RAW_LAYOUT_ADDR:%.*]] = raw_layout_address_to_pointer [[SELF]] : $*Cell<T> to $Builtin.RawPointer
+  // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
+  // CHECK-NEXT:    return [[POINTER]] : $UnsafeMutablePointer<T>
+  // CHECK-LABEL: } // end sil function '$s4CellAAVAARiczrlE7addressSpyxGvg'
+  @_transparent
+  public var address: UnsafeMutablePointer<T> {
+    .init(Builtin.addressOfRawLayout(self))
+  }
+
+  // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARiczrlEyAByxGxcfC : $@convention(method) <T where T : ~Copyable> (@in T, @thin Cell<T>.Type) -> @out Cell<T> {
+  // CHECK:       bb0([[SELF:%.*]] : $*Cell<T>, [[VALUE:%.*]] : $*T, {{%.*}} : $@thin Cell<T>.Type):
+  // CHECK-NEXT:    {{%.*}} = builtin "zeroInitializer"<Cell<T>>([[SELF]] : $*Cell<T>) : $()
+  // CHECK-NEXT:    [[RAW_LAYOUT_ADDR:%.*]] = raw_layout_address_to_pointer [[SELF]] : $*Cell<T> to $Builtin.RawPointer
+  // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
+  //                Calling 'UnsafeMutablePointer<T>.initialize(to:)'
+  // CHECK:         {{%.*}} = apply {{%.*}}<T>([[VALUE]], [[POINTER]])
+  // CHECK-NEXT:    [[TUPLE:%.*]] = tuple ()
+  // CHECK-NEXT:    return [[TUPLE]] : $()
+  // CHECK-LABEL: } // end sil function '$s4CellAAVAARiczrlEyAByxGxcfC'
+  @_transparent
+  public init(_ value: consuming T) {
+    address.initialize(to: value)
+  }
+
+  @inlinable
+  deinit {
+    address.deinitialize(count: 1)
+  }
+}

--- a/test/SILOptimizer/stdlib/Cell.swift
+++ b/test/SILOptimizer/stdlib/Cell.swift
@@ -7,7 +7,7 @@ import Builtin
 public struct Cell<T: ~Copyable>: ~Copyable {
   // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARiczrlE7addressSpyxGvg : $@convention(method) <T where T : ~Copyable> (@in_guaranteed Cell<T>) -> UnsafeMutablePointer<T> {
   // CHECK:       bb0([[SELF:%.*]] : $*Cell<T>):
-  // CHECK:         [[RAW_LAYOUT_ADDR:%.*]] = raw_layout_address_to_pointer [[SELF]] : $*Cell<T> to $Builtin.RawPointer
+  // CHECK:         [[RAW_LAYOUT_ADDR:%.*]] = builtin "addressOfRawLayout"<Cell<T>>([[SELF]] : $*Cell<T>) : $Builtin.RawPointer
   // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
   // CHECK-NEXT:    return [[POINTER]] : $UnsafeMutablePointer<T>
   // CHECK-LABEL: } // end sil function '$s4CellAAVAARiczrlE7addressSpyxGvg'
@@ -17,9 +17,9 @@ public struct Cell<T: ~Copyable>: ~Copyable {
   }
 
   // CHECK-LABEL: sil {{.*}} @$s4CellAAVAARiczrlEyAByxGxcfC : $@convention(method) <T where T : ~Copyable> (@in T, @thin Cell<T>.Type) -> @out Cell<T> {
-  // CHECK:       bb0([[SELF:%.*]] : $*Cell<T>, [[VALUE:%.*]] : $*T, {{%.*}} : $@thin Cell<T>.Type):
-  // CHECK-NEXT:    {{%.*}} = builtin "zeroInitializer"<Cell<T>>([[SELF]] : $*Cell<T>) : $()
-  // CHECK-NEXT:    [[RAW_LAYOUT_ADDR:%.*]] = raw_layout_address_to_pointer [[SELF]] : $*Cell<T> to $Builtin.RawPointer
+  // CHECK:       bb0({{%.*}} : $*Cell<T>, [[VALUE:%.*]] : $*T, {{%.*}} : $@thin Cell<T>.Type):
+  // CHECK:         {{%.*}} = builtin "zeroInitializer"<Cell<T>>([[SELF:%.*]] : $*Cell<T>) : $()
+  // CHECK-NEXT:    [[RAW_LAYOUT_ADDR:%.*]] = builtin "addressOfRawLayout"<Cell<T>>([[SELF]] : $*Cell<T>) : $Builtin.RawPointer
   // CHECK-NEXT:    [[POINTER:%.*]] = struct $UnsafeMutablePointer<T> ([[RAW_LAYOUT_ADDR]] : $Builtin.RawPointer)
   //                Calling 'UnsafeMutablePointer<T>.initialize(to:)'
   // CHECK:         {{%.*}} = apply {{%.*}}<T>([[VALUE]], [[POINTER]])


### PR DESCRIPTION
This patch adds a distinct new instruction for converting the address of a raw layout to a `Builtin.RawPointer`. We want a distinction here because we want to keep raw layout operations opaque to the optimizer for the most part because it cannot reason about the formal access of raw layout (due to it having the ability vend mutable pointers to its storage in a borrowing context for example). This mostly works just like `address_to_pointer` except I haven't added this instruction to any optimizer pass or any instruction simplification to preserve it all the way to LLVM lowering.

In addition to the new instruction is a builtin that lowers directly to a call to this named `Builtin.addressOfRawLayout` with appropriate feature guards to ensure we don't have cond failures and such.