### PR TITLE
[6.0] 🍒 Disable tracing in xpcproxy

### DIFF
--- a/include/swift/Runtime/TracingCommon.h
+++ b/include/swift/Runtime/TracingCommon.h
@@ -33,7 +33,8 @@ static inline bool shouldEnableTracing() {
     return false;
   if (__progname && (strcmp(__progname, "logd") == 0 ||
                      strcmp(__progname, "diagnosticd") == 0 ||
-                     strcmp(__progname, "notifyd") == 0))
+                     strcmp(__progname, "notifyd") == 0) ||
+                     strcmp(__progname, "xpcproxy") == 0)
     return false;
   return true;
 }


### PR DESCRIPTION
**Description:** Add xpcproxy to the list of processes that handle tracing requests and therefore cannot themselves use tracing without deadlocking.

**Reviewed:** Ian Campbell

**Original PR:** #72591 

**Risk:** Low, just adds "xpcproxy" to an existing list of processes that will have tracing suppressed.

Resolves rdar://124996590