### PR TITLE
[6.0] Fix lifetime dependence in the presence of pointer escapes.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -85,6 +85,8 @@ private func extendAccessScopes(dependence: LifetimeDependence,
 
   _ = walker.walkDown(root: dependence.dependentValue)
 
+  log("Scope fixup for dependent uses:\n\(accessRange)")
+
   // Lifetime dependenent uses may not be dominated by the access. The dependent value may be used by a phi or stored
   // into a memory location. The access may be conditional relative to such uses. If any use was not dominated, then
   // `accessRange` will include the function entry.
@@ -219,6 +221,7 @@ private struct LifetimeDependenceScopeFixupWalker : LifetimeDependenceDefUseWalk
   }
 
   mutating func escapingDependence(on operand: Operand) -> WalkResult {
+    log(">>> Escaping dependence: \(operand)")
     _ = visitor(operand)
     // Make a best-effort attempt to extend the access scope regardless of escapes. It is possible that some mandatory
     // pass between scope fixup and diagnostics will make it possible for the LifetimeDependenceDefUseWalker to analyze

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -12,7 +12,7 @@
 
 import SIL
 
-private let verbose = true
+private let verbose = false
 
 private func log(_ message: @autoclosure () -> String) {
   if verbose {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -107,10 +107,10 @@ extension AddressUseVisitor {
       // A potentially escaping value depends on this address.
       return escapingAddressUse(of: operand)
 
-    case let pai as PartialApplyInst where pai.isOnStack:
+    case let pai as PartialApplyInst where !pai.mayEscape:
       return dependentAddressUse(of: operand, into: pai)
 
-    case let pai as PartialApplyInst where !pai.isOnStack:
+    case let pai as PartialApplyInst where pai.mayEscape:
       return escapingAddressUse(of: operand)
 
     case is ReturnInst, is ThrowInst, is YieldInst, is AddressToPointerInst:

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -502,7 +502,7 @@ extension AddressOwnershipLiveRange {
   ///
   /// For address values, use AccessBase.computeOwnershipRange.
   ///
-  /// FIXME: This should use computeLinearLiveness rather than computeInteriorLiveness as soon as lifetime completion
+  /// FIXME: This should use computeLinearLiveness rather than computeKnownLiveness as soon as lifetime completion
   /// runs immediately after SILGen.
   private static func computeValueLiveRange(of value: Value, _ context: FunctionPassContext)
     -> AddressOwnershipLiveRange? {
@@ -511,7 +511,7 @@ extension AddressOwnershipLiveRange {
       // This is unexpected for a value with derived addresses.
       return nil
     case .owned:
-      return .owned(value, computeInteriorLiveness(for: value, context))
+      return .owned(value, computeKnownLiveness(for: value, context))
     case .guaranteed:
       return .borrow(computeBorrowLiveRange(for: value, context))
     }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
@@ -169,7 +169,7 @@ enum BorrowingInstruction : CustomStringConvertible, Hashable {
       self = .storeBorrow(sbi)
     case let bai as BeginApplyInst:
       self = .beginApply(bai)
-    case let pai as PartialApplyInst where pai.isOnStack:
+    case let pai as PartialApplyInst where !pai.mayEscape:
       self = .partialApply(pai)
     case let mdi as MarkDependenceInst:
       self = .markDependence(mdi)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/BorrowUtils.swift
@@ -405,8 +405,9 @@ func gatherBorrowIntroducers(for value: Value,
 }
 
 /// Compute the live range for the borrow scopes of a guaranteed value. This returns a separate instruction range for
-/// each of the value's borrow introducers. Unioning those ranges would be incorrect. We typically want their
-/// intersection.
+/// each of the value's borrow introducers.
+///
+/// TODO: This should return a single multiply-defined instruction range.
 func computeBorrowLiveRange(for value: Value, _ context: FunctionPassContext)
   -> SingleInlineArray<(BeginBorrowValue, InstructionRange)> {
   assert(value.ownership == .guaranteed)
@@ -418,10 +419,10 @@ func computeBorrowLiveRange(for value: Value, _ context: FunctionPassContext)
   // If introducers is empty, then the dependence is on a trivial value, so
   // there is no ownership range.
   while let beginBorrow = introducers.pop() {
-    /// FIXME: Remove calls to computeInteriorLiveness as soon as lifetime completion runs immediately after
+    /// FIXME: Remove calls to computeKnownLiveness() as soon as lifetime completion runs immediately after
     /// SILGen. Instead, this should compute linear liveness for borrowed value by switching over BeginBorrowValue, just
     /// like LifetimeDependenc.Scope.computeRange().
-    ranges.push((beginBorrow, computeInteriorLiveness(for: beginBorrow.value, context)))
+    ranges.push((beginBorrow, computeKnownLiveness(for: beginBorrow.value, context)))
   }
   return ranges
 }

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
@@ -18,6 +18,14 @@
 
 import SIL
 
+private let verbose = false
+
+private func log(_ message: @autoclosure () -> String) {
+  if verbose {
+    print("### \(message())")
+  }
+}
+
 /// Return true if any use in `value`s forward-extend lifetime has
 /// .pointerEscape operand ownership.
 ///
@@ -370,6 +378,7 @@ struct NonEscapingClosureDefUseWalker {
       if operand.instruction.isIncidentalUse {
         return .continueWalk
       }
+      log(">>> Unexpected closure use \(operand)")
       // Escaping or unexpected closure use. Expected escaping uses include ReturnInst with a lifetime-dependent result.
       //
       // TODO: Check in the SIL verifier that all uses are expected.

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/ForwardingUtils.swift
@@ -355,7 +355,7 @@ struct NonEscapingClosureDefUseWalker {
   }
 
   mutating func walkDown(closure: PartialApplyInst) -> WalkResult {
-    assert(closure.isOnStack)
+    assert(!closure.mayEscape)
     return walkDownUses(of: closure, using: nil)
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -792,6 +792,8 @@ extension LifetimeDependenceUseDefWalker {
 ///   yieldedDependence(result: Operand) -> WalkResult
 /// Start walking:
 ///   walkDown(root: Value)
+///
+/// Note: this may visit values that are not dominated by `root` because of dependent phi operands.
 protocol LifetimeDependenceDefUseWalker : ForwardingDefUseWalker,
                                           OwnershipUseVisitor,
                                           AddressUseVisitor {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -530,13 +530,12 @@ extension LifetimeDependence {
       visitedValues.insert(value)
     }
 
-    // Visit the base value of a lifetime dependence. If the base is
-    // an address, the dependence scope is the enclosing access. The
-    // walker does not walk past an `mark_dependence [nonescaping]`
-    // that produces an address, because that will never occur inside
-    // of an access scope. An address type mark_dependence
-    // [nonescaping]` can only result from an indirect function result
-    // when opaque values are not enabled.
+    // Visit the base value of a lifetime dependence. If the base is an address, the dependence scope is the enclosing
+    // access. The walker does not walk past an `mark_dependence [nonescaping]` that produces an address, because that
+    // will never occur inside of an access scope. An address type mark_dependence [unresolved]` can only result from an
+    // indirect function result when opaque values are not enabled. Address type `mark_dependence [nonescaping]`
+    // instruction are also produced for captured arguments but ClosureLifetimeFixup, but those aren't considered to
+    // have a LifetimeDependence scope.
     mutating func introducer(_ value: Value, _ owner: Value?) -> WalkResult {
       let base = owner ?? value
       guard let scope = LifetimeDependence.Scope(base: base, context)
@@ -617,17 +616,13 @@ struct VariableIntroducerUseDefWalker : LifetimeDependenceUseDefWalker {
 
 /// Walk up the lifetime dependence chain.
 ///
-/// This finds the introducers of a dependence chain. which represent
-/// the value's "inherited" dependencies. This stops at phis; all
-/// introducers dominate. This stops at addresses in general, but if
-/// the value is loaded from a singly-initialized location, then it
-/// continues walking up the value stored by the initializer. This
+/// This finds the introducers of a dependence chain. which represent the value's "inherited" dependencies. This stops
+/// at phis, so all introducers dominate their dependencies. This stops at addresses in general, but if the value is
+/// loaded from a singly-initialized location, then it continues walking up the value stored by the initializer. This
 /// bypasses the copies to temporary memory locations emitted by SILGen.
 ///
-/// In this example, the dependence root is
-/// copied, borrowed, and forwarded before being used as the base
-/// operand of `mark_dependence`. The dependence "root" is the parent
-/// of the outer-most dependence scope.
+/// In this example, the dependence root is copied, borrowed, and forwarded before being used as the base operand of
+/// `mark_dependence`. The dependence "root" is the parent of the outer-most dependence scope.
 ///
 ///   %root = apply                  // lifetime dependence root
 ///   %copy = copy_value %root
@@ -635,14 +630,10 @@ struct VariableIntroducerUseDefWalker : LifetimeDependenceUseDefWalker {
 ///   %base = struct_extract %parent // lifetime dependence base value
 ///   %dependent = mark_dependence [nonescaping] %value on %base
 ///
-/// This extends the ForwardingUseDefWalker, which finds the
-/// forward-extended lifetime introducers. Certain forward-extended
-/// lifetime introducers can inherit a lifetime dependency from their
-/// operand: namely copies, moves, and borrows. These introducers are
-/// considered part of their operand's dependence scope because
-/// non-escapable values can be copied, moved, and
-/// borrowed. Nonetheless, all of their uses must remain within
-/// original dependence scope.
+/// This extends the ForwardingUseDefWalker, which finds the forward-extended lifetime introducers. Certain
+/// forward-extended lifetime introducers can inherit a lifetime dependency from their operand: namely copies, moves,
+/// and borrows. These introducers are considered part of their operand's dependence scope because non-escapable values
+/// can be copied, moved, and borrowed. Nonetheless, all of their uses must remain within original dependence scope.
 ///
 ///   # owned lifetime dependence
 ///   %parent = apply               // begin dependence scope -+
@@ -662,10 +653,9 @@ struct VariableIntroducerUseDefWalker : LifetimeDependenceUseDefWalker {
 ///   ...                                                      |
 ///   destroy_value %parent        // end dependence scope    -+
 ///
-/// All of the dependent uses including `end_borrow %5` and
-/// `destroy_value %4` must be before the end of the dependence scope:
-/// `destroy_value %parent`. In this case, the dependence parent is an
-/// owned value, so the scope is simply the value's OSSA lifetime.
+/// All of the dependent uses including `end_borrow %5` and `destroy_value %4` must be before the end of the dependence
+/// scope: `destroy_value %parent`. In this case, the dependence parent is an owned value, so the scope is simply the
+/// value's OSSA lifetime.
 ///
 /// Minimal requirements:
 ///   var context: Context
@@ -740,6 +730,7 @@ extension LifetimeDependenceUseDefWalker {
     if Phi(value) != nil {
       return introducer(value, owner)
     }
+    // ForwardingUseDefWalker will callback to introducer() when it finds no forwarding instruction.
     return walkUpDefault(forwarded: value, owner)
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -54,7 +54,7 @@
 
 import SIL
 
-private let verbose = true
+private let verbose = false
 
 private func log(_ message: @autoclosure () -> String) {
   if verbose {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -416,7 +416,7 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
 
   mutating func dependentAddressUse(of operand: Operand, into value: Value) -> WalkResult {
     // Find all uses of partial_apply [on_stack].
-    if let pai = value as? PartialApplyInst, pai.isOnStack {
+    if let pai = value as? PartialApplyInst, !pai.mayEscape {
       var walker = NonEscapingClosureDefUseWalker(context)
       defer { walker.deinitialize() }
       if walker.walkDown(closure: pai) == .abortWalk {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -25,7 +25,7 @@
 
 import SIL
 
-private let verbose = true
+private let verbose = false
 
 private func log(_ message: @autoclosure () -> String) {
   if verbose {
@@ -732,6 +732,7 @@ extension LocalVariableReachableAccess {
       forwardPropagateEffect(in: block, blockInfo: blockInfo, effect: currentEffect, blockList: &blockList,
                              accessStack: &accessStack)
     }
+    log("Local variable reachable uses: \(accessMap)\n\(accessStack)")
     return true
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -188,8 +188,8 @@ class LocalVariableAccessInfo: CustomStringConvertible {
   }
 
   var description: String {
-    return "\(access)" +
-      "\n    fully-assigned: \(_isFullyAssigned == nil ? "unknown" : String(describing: _isFullyAssigned!))"
+    return "full-assign: \(_isFullyAssigned == nil ? "unknown" : String(describing: _isFullyAssigned!)) "
+      + "\(access)"
   }
 }
 
@@ -200,7 +200,7 @@ class LocalVariableAccessInfo: CustomStringConvertible {
 /// map.
 ///
 /// TODO: In addition to isFullyAssigned, consider adding a lazily computed access path if any need arises.
-struct LocalVariableAccessMap: Collection, FormattedLikeArray {
+struct LocalVariableAccessMap: Collection, CustomStringConvertible {
   let context: Context
   let allocation: Value
 
@@ -279,6 +279,10 @@ struct LocalVariableAccessMap: Collection, FormattedLikeArray {
   subscript(_ accessIndex: Int) -> LocalVariableAccessInfo { accessList[accessIndex] }
 
   subscript(instruction: Instruction) -> LocalVariableAccessInfo? { accessMap[instruction] }
+
+  public var description: String {
+    "Access map:\n" + map({String(describing: $0)}).joined(separator: "\n")
+  }
 }
 
 /// Gather the accesses of a local allocation: alloc_box, alloc_stack, @in, @inout.
@@ -733,7 +737,8 @@ extension LocalVariableReachableAccess {
       forwardPropagateEffect(in: block, blockInfo: blockInfo, effect: currentEffect, blockList: &blockList,
                              accessStack: &accessStack)
     }
-    log("Local variable reachable uses: \(accessMap)\n\(accessStack)")
+    log("\(accessMap)")
+    log("Reachable access:\n\(accessStack.map({ String(describing: $0)}).joined(separator: "\n"))")
     return true
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LocalVariableUtils.swift
@@ -441,7 +441,8 @@ extension LocalVariableAccessWalker: AddressUseVisitor {
   }
 
   mutating func escapingAddressUse(of operand: Operand) -> WalkResult {
-    return .abortWalk
+    visit(LocalVariableAccess(.escape, operand))
+    return .continueWalk
   }
 
   mutating func unknownAddressUse(of operand: Operand) -> WalkResult {

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -388,7 +388,7 @@ extension OwnershipUseVisitor {
     -> WalkResult {
     switch operand.instruction {
     case let pai as PartialApplyInst:
-      assert(pai.isOnStack)
+      assert(!pai.mayEscape)
       return dependentUse(of: operand, into: pai)
     case let mdi as MarkDependenceInst:
       assert(operand == mdi.baseOperand && mdi.isNonEscaping)

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OwnershipLiveness.swift
@@ -23,6 +23,14 @@
 
 import SIL
 
+private let verbose = false
+
+private func log(_ message: @autoclosure () -> String) {
+  if verbose {
+    print("### \(message())")
+  }
+}
+
 /// Compute liveness and return a range, which the caller must deinitialize.
 ///
 /// `definingValue` must introduce an OSSA lifetime. It may be either
@@ -66,15 +74,13 @@ typealias InnerScopeHandler = (Value) -> WalkResult
 
 /// Compute liveness and return a range, which the caller must deinitialize.
 ///
-/// An OSSA lifetime begins with a single "defining" value, which must
-/// be owned, or must begin a borrow scope. A complete OSSA lifetime
-/// has a linear lifetime, meaning that it has a lifetime-ending use
-/// on all paths. Interior liveness computes liveness without assuming
-/// the lifetime is complete. To do this, it must find all "use
-/// points" and prove that the defining value is never propagated
-/// beyond those points. This is used to initially complete OSSA
-/// lifetimes and fix them after transformations that's don't preserve
-/// OSSA.
+/// An OSSA lifetime begins with a single "defining" value, which must be owned, or must begin a borrow scope. A
+/// complete OSSA lifetime has a linear lifetime, meaning that it has a lifetime-ending use on all paths. Interior
+/// liveness computes liveness without assuming the lifetime is complete. To do this, it must find all "use points" and
+/// prove that the defining value is never propagated beyond those points. This is used to initially complete OSSA
+/// lifetimes and fix them after transformations that's don't preserve OSSA.
+///
+/// The caller must check that `definingValue` has no pointer escape before calling this.
 ///
 /// Invariants:
 ///
@@ -83,39 +89,100 @@ typealias InnerScopeHandler = (Value) -> WalkResult
 /// - Liveness does not extend beyond lifetime-ending operations
 /// (a.k.a. affine lifetimes).
 ///
-/// - All inner scopes are complete. (Use `innerScopeHandler` to
-/// complete them or bail-out).
-func computeInteriorLiveness(for definingValue: Value,
-  _ context: FunctionPassContext,
-  innerScopeHandler: InnerScopeHandler? = nil) -> InstructionRange {
-
-  assert(definingValue.ownership == .owned
-    || BeginBorrowValue(definingValue) != nil,
-    "value must define an OSSA lifetime")
-
-  var range = InstructionRange(for: definingValue, context)
-
-  var visitor = InteriorUseWalker(definingValue: definingValue, context) {
-    range.insert($0.instruction)
-    return .continueWalk
-  }
-  defer { visitor.deinitialize() }
-  visitor.innerScopeHandler = innerScopeHandler
-  let success = visitor.visitUses()
-  switch visitor.pointerStatus {
-  case .nonEscaping:
+/// - All inner scopes are complete. (Use `innerScopeHandler` to complete them or bail-out).
+func computeInteriorLiveness(for definingValue: Value, _ context: FunctionPassContext,
+                             innerScopeHandler: InnerScopeHandler? = nil) -> InstructionRange {
+  let result = InteriorLivenessResult.compute(for: definingValue, ignoreEscape: false, context)
+  switch result.pointerStatus {
+  case .nonescaping:
     break
-  case let .escaping(operand):
+  case let .escaping(operands):
     fatalError("""
                  check findPointerEscape() before computing interior liveness.
-                 Pointer escape: \(operand.instruction)
+                 Pointer escape: \(operands[0].instruction)
                  """)
   case let .unknown(operand):
     fatalError("Unrecognized SIL address user \(operand.instruction)")
   }
-  assert(success == .continueWalk, "our visitor never fails")
-  assert(visitor.unenclosedPhis.isEmpty, "missing adjacent phis")
-  return range
+  return result.range
+}
+
+/// Compute known liveness and return a range, which the caller must deinitialize.
+///
+/// This computes a minimal liveness, ignoring pointer escaping uses.
+func computeKnownLiveness(for definingValue: Value, _ context: FunctionPassContext) -> InstructionRange {
+  return InteriorLivenessResult.compute(for: definingValue, ignoreEscape: true, context).range
+}
+
+/// If any interior pointer may escape, then record the first instance here. If 'ignoseEscape' is true, this
+/// immediately aborts the walk, so further instances are unavailable.
+///
+/// .escaping may either be a non-address operand with
+/// .pointerEscape ownership, or and address operand that escapes
+/// the address (address_to_pointer).
+///
+/// .unknown is an address operand whose user is unrecognized.
+enum InteriorPointerStatus: CustomDebugStringConvertible {
+  case nonescaping
+  case escaping(SingleInlineArray<Operand>)
+  case unknown(Operand)
+
+  mutating func setEscaping(operand: Operand) {
+    switch self {
+    case .nonescaping:
+      self = .escaping(SingleInlineArray(element: operand))
+    case let .escaping(oldOperands):
+      var newOperands = SingleInlineArray<Operand>()
+      newOperands.append(contentsOf: oldOperands)
+      newOperands.append(operand)
+      self = .escaping(newOperands)
+    case .unknown:
+      break
+    }
+  }
+
+  var debugDescription: String {
+    switch self {
+    case .nonescaping:
+      return "No pointer escape"
+    case let .escaping(operands):
+      return "Pointer escapes: " + operands.map({ "\($0)" }).joined(separator: "\n                 ")
+    case let .unknown(operand):
+      return "Unknown use: \(operand)"
+    }
+  }
+}
+
+struct InteriorLivenessResult: CustomDebugStringConvertible {
+  let success: WalkResult
+  let range: InstructionRange
+  let pointerStatus: InteriorPointerStatus
+
+  static func compute(for definingValue: Value, ignoreEscape: Bool = false,
+                      _ context: FunctionPassContext,
+                      innerScopeHandler: InnerScopeHandler? = nil) -> InteriorLivenessResult {
+
+    assert(definingValue.ownership == .owned || BeginBorrowValue(definingValue) != nil,
+           "value must define an OSSA lifetime")
+
+    var range = InstructionRange(for: definingValue, context)
+
+    var visitor = InteriorUseWalker(definingValue: definingValue, ignoreEscape: ignoreEscape, context) {
+      range.insert($0.instruction)
+      return .continueWalk
+    }
+    defer { visitor.deinitialize() }
+    visitor.innerScopeHandler = innerScopeHandler
+    let success = visitor.visitUses()
+    assert(visitor.unenclosedPhis.isEmpty, "missing adjacent phis")
+    let result = InteriorLivenessResult(success: success, range: range, pointerStatus: visitor.pointerStatus)
+    log("Interior liveness for: \(definingValue)\n\(result)")
+    return result
+  }
+
+  var debugDescription: String {
+    "\(success)\n\(range)\n\(pointerStatus)"
+  }
 }
 
 /// Classify ownership uses. This reduces operand ownership to a
@@ -455,6 +522,7 @@ struct InteriorUseWalker {
   var context: Context { functionContext }
 
   let definingValue: Value
+  let ignoreEscape: Bool
   let useVisitor: (Operand) -> WalkResult
 
   var innerScopeHandler: InnerScopeHandler? = nil
@@ -470,21 +538,7 @@ struct InteriorUseWalker {
 
   var function: Function { definingValue.parentFunction }
 
-  /// If any interior pointer may escape, then record the first instance
-  /// here. This immediately aborts the walk, so further instances are
-  /// unavailable.
-  ///
-  /// .escaping may either be a non-address operand with
-  /// .pointerEscape ownership, or and address operand that escapes
-  /// the address (address_to_pointer).
-  ///
-  /// .unknown is an address operand whose user is unrecognized.
-  enum InteriorPointerStatus {
-    case nonEscaping
-    case escaping(Operand)
-    case unknown(Operand)
-  }
-  var pointerStatus: InteriorPointerStatus = .nonEscaping
+  var pointerStatus: InteriorPointerStatus = .nonescaping
 
   private var visited: ValueSet
 
@@ -492,11 +546,12 @@ struct InteriorUseWalker {
     visited.deinitialize()
   }
 
-  init(definingValue: Value, _ context: FunctionPassContext,
+  init(definingValue: Value, ignoreEscape: Bool, _ context: FunctionPassContext,
     visitor: @escaping (Operand) -> WalkResult) {
     assert(!definingValue.type.isAddress, "address values have no ownership")
     self.functionContext = context
     self.definingValue = definingValue
+    self.ignoreEscape = ignoreEscape
     self.useVisitor = visitor
     self.visited = ValueSet(context)
   }
@@ -598,8 +653,8 @@ extension InteriorUseWalker: OwnershipUseVisitor {
     if useVisitor(operand) == .abortWalk {
       return .abortWalk
     }
-    pointerStatus = .escaping(operand)
-    return .abortWalk
+    pointerStatus.setEscaping(operand: operand)
+    return ignoreEscape ? .continueWalk : .abortWalk
   }
 
   // Call the innerScopeHandler before visiting the scope-ending uses.
@@ -695,8 +750,8 @@ extension InteriorUseWalker: AddressUseVisitor {
   }    
 
   mutating func escapingAddressUse(of operand: Operand) -> WalkResult {
-    pointerStatus = .escaping(operand)
-    return .abortWalk
+    pointerStatus.setEscaping(operand: operand)
+    return ignoreEscape ? .continueWalk : .abortWalk
   }
 
   mutating func unknownAddressUse(of operand: Operand) -> WalkResult {
@@ -894,7 +949,7 @@ let interiorLivenessTest = FunctionTest("interior_liveness_swift") {
   var range = InstructionRange(for: value, context)
   defer { range.deinitialize() }
 
-  var visitor = InteriorUseWalker(definingValue: value, context) {
+  var visitor = InteriorUseWalker(definingValue: value, ignoreEscape: true, context) {
     range.insert($0.instruction)
     return .continueWalk
   }
@@ -903,10 +958,12 @@ let interiorLivenessTest = FunctionTest("interior_liveness_swift") {
   let success = visitor.visitUses()
 
   switch visitor.pointerStatus {
-  case .nonEscaping:
+  case .nonescaping:
     break
-  case let .escaping(operand):
-    print("Pointer escape: \(operand.instruction)")
+  case let .escaping(operands):
+    for operand in operands {
+      print("Pointer escape: \(operand.instruction)")
+    }
   case let .unknown(operand):
     print("Unrecognized SIL address user \(operand.instruction)")
   }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1011,7 +1011,21 @@ class ClassifyBridgeObjectInst : SingleValueInstruction, UnaryInstruction {}
 
 final public class PartialApplyInst : SingleValueInstruction, ApplySite {
   public var numArguments: Int { bridged.PartialApplyInst_numArguments() }
+
+  /// WARNING: isOnStack incorrectly returns false for all closures prior to ClosureLifetimeFixup, even if they need to
+  /// be diagnosed as on-stack closures. Use has mayEscape instead.
   public var isOnStack: Bool { bridged.PartialApplyInst_isOnStack() }
+
+  public var mayEscape: Bool { !isOnStack && !hasNoescapeCapture }
+
+  /// True if this closure captures anything nonescaping.
+  public var hasNoescapeCapture: Bool {
+    if operandConventions.contains(.indirectInoutAliasable) {
+      return true
+    }
+    return arguments.contains { $0.type.containsNoEscapeFunction }
+  }
+
   public var unappliedArgumentCount: Int { bridged.PartialApply_getCalleeArgIndexOfFirstAppliedArg() }
 }
 

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -57,6 +57,7 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
   public var isFunction: Bool { bridged.isFunction() }
   public var isMetatype: Bool { bridged.isMetatype() }
   public var isNoEscapeFunction: Bool { bridged.isNoEscapeFunction() }
+  public var containsNoEscapeFunction: Bool { bridged.containsNoEscapeFunction() }
   public var isAsyncFunction: Bool { bridged.isAsyncFunction() }
 
   public var canBeClass: BridgedType.TraitResult { bridged.canBeClass() }

--- a/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
+++ b/SwiftCompilerSources/Sources/SIL/Utilities/SequenceUtilities.swift
@@ -154,7 +154,17 @@ public struct SingleInlineArray<Element>: RandomAccessCollection, FormattedLikeA
     }
   }
 
-  public mutating func push(_ element: Element) {
+  public mutating func append(_ element: __owned Element) {
+    push(element)
+  }
+
+  public mutating func append<S: Sequence>(contentsOf newElements: __owned S) where S.Element == Element {
+    for element in newElements {
+      push(element)
+    }
+  }
+
+  public mutating func push(_ element: __owned Element) {
     guard singleElement != nil else {
       singleElement = element
       return

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -346,6 +346,7 @@ struct BridgedType {
   BRIDGED_INLINE bool isFunction() const;
   BRIDGED_INLINE bool isMetatype() const;
   BRIDGED_INLINE bool isNoEscapeFunction() const;
+  BRIDGED_INLINE bool containsNoEscapeFunction() const;
   BRIDGED_INLINE bool isAsyncFunction() const;
   BRIDGED_INLINE bool isEmpty(BridgedFunction f) const;
   BRIDGED_INLINE TraitResult canBeClass() const;

--- a/include/swift/SIL/SILBridgingImpl.h
+++ b/include/swift/SIL/SILBridgingImpl.h
@@ -258,6 +258,10 @@ bool BridgedType::isNoEscapeFunction() const {
   return unbridged().isNoEscapeFunction();
 }
 
+bool BridgedType::containsNoEscapeFunction() const {
+  return unbridged().containsNoEscapeFunction();
+}
+
 bool BridgedType::isAsyncFunction() const {
   return unbridged().isAsyncFunction();
 }

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -534,6 +534,22 @@ public:
     return false;
   }
 
+  bool containsNoEscapeFunction() const {
+    auto ty = getASTType();
+    if (auto *fTy = ty->getAs<SILFunctionType>()) {
+      return fTy->isNoEscape();
+    }
+    // Look through box types to handle mutable 'var' bindings.
+    if (auto boxType = dyn_cast<SILBoxType>(ty)) {
+      for (auto field : boxType->getLayout()->getFields()) {
+        if (field.getLoweredType()->isNoEscape())
+          return true;
+      }
+    }
+    // Handle whatever AST types are known to hold functions. Namely tuples.
+    return ty->isNoEscape();
+  }
+
   bool isAsyncFunction() const {
     if (auto *fTy = getASTType()->getAs<SILFunctionType>()) {
       return fTy->isAsync();

--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -406,7 +406,7 @@ static SILValue insertMarkDependenceForCapturedArguments(PartialApplyInst *pai,
       if (m->hasGuaranteedInitialKind())
         continue;
     curr = b.createMarkDependence(pai->getLoc(), curr, arg.get(),
-                                  MarkDependenceKind::Escaping);
+                                  MarkDependenceKind::NonEscaping);
   }
 
   return curr;

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -260,7 +260,12 @@ bool swift::canDuplicateLoopInstruction(SILLoop *L, SILInstruction *I) {
       return false;
     }
   }
-
+  // Like partial_apply [onstack], mark_dependence [nonescaping] creates a
+  // borrow scope. We currently assume that a set of dominated scope-ending uses
+  // can be found.
+  if (auto *MD = dyn_cast<MarkDependenceInst>(I)) {
+    return !MD->isNonEscaping();
+  }
   // CodeGen can't build ssa for objc methods.
   if (auto *Method = dyn_cast<MethodInst>(I)) {
     if (Method->getMember().isForeign) {

--- a/test/SILOptimizer/closure-lifetime-fixup.sil
+++ b/test/SILOptimizer/closure-lifetime-fixup.sil
@@ -272,7 +272,7 @@ bb3:
 // CHECK:       [[SUCCESS_1]]
 // CHECK:         copy_addr [[INSTANCE]] to [init] [[STACK]] : $*Self, {{.*}} scope [[STACK_SCOPE:[0-9]+]]
 // CHECK:         [[CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [on_stack] undef<Self>([[STACK]])
-// CHECK:         [[DEPENDENCY:%[^,]+]] = mark_dependence [[CLOSURE]] {{.*}} on [[STACK]]
+// CHECK:         [[DEPENDENCY:%[^,]+]] = mark_dependence [nonescaping] [[CLOSURE]] {{.*}} on [[STACK]]
 // CHECK:         try_apply undef([[DEPENDENCY]]) {{.*}}, normal [[SUCCESS_2:bb[0-9]+]], error [[FAILURE_2:bb[0-9]+]]
 // CHECK:       [[SUCCESS_2]]
 // CHECK:         destroy_value [[DEPENDENCY]]

--- a/test/SILOptimizer/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence_closure.swift
@@ -1,0 +1,53 @@
+// RUN: %target-swift-frontend %s -emit-sil \
+// RUN:   -o /dev/null \
+// RUN:   -verify \
+// RUN:   -sil-verify-all \
+// RUN:   -module-name test \
+// RUN:   -disable-experimental-parser-round-trip \
+// RUN:   -enable-experimental-feature NonescapableTypes
+
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+
+struct NCInt: ~Copyable {
+  var value: Int
+
+  init(_ value: Int) { self.value = value }
+}
+
+@_nonescapable
+struct NEInt /*: ~Escapable*/ {
+  let value: Int
+
+  init(borrowed: borrowing NCInt) -> _borrow(borrowed) Self {
+    self.value = borrowed.value
+    return self
+  }
+}
+
+extension NCInt {
+  var neInt: NEInt {
+    borrowing get {
+      NEInt(borrowed: self)
+    }
+  }
+}
+
+func ncint_get_neint_mutable_local() {
+  var ncInt = NCInt(731)
+  do {
+    // Begin read access ncInt
+    var neInt = ncInt.neInt
+
+    // Capture neInt in a nonescapable closure.
+    assert(ncInt.value == neInt.value)
+    // End read access ncInt
+
+    // Begin read access ncInt
+    // Fully reassign neInt
+    neInt = ncInt.neInt
+    // Destroy neInt
+    // End read access ncInt
+  }
+  ncInt.value = 1
+}

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -73,7 +73,7 @@ func doit<T>(_ f: () -> T) -> T {
 // CHECK:         [[DUPLICATE_CLOSURE:%[^,]+]] = function_ref @$s19opaque_values_Onone10duplicate15valuex_xtx_tlFx_xtyXEfU_
 // CHECK:         copy_addr [[INSTANCE_ADDR_IN]] to [init] [[INSTANCE_ADDR]]
 // CHECK:         [[DUPLICATE_INSTANCE_CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [on_stack] [[DUPLICATE_CLOSURE]]<Value>([[INSTANCE_ADDR]])
-// CHECK:         [[DEPENDENDENCY:%[^,]+]] = mark_dependence [[DUPLICATE_INSTANCE_CLOSURE]] : $@noescape @callee_guaranteed () -> @out (Value, Value) on [[INSTANCE_ADDR]] : $*Value
+// CHECK:         [[DEPENDENDENCY:%[^,]+]] = mark_dependence [nonescaping] [[DUPLICATE_INSTANCE_CLOSURE]] : $@noescape @callee_guaranteed () -> @out (Value, Value) on [[INSTANCE_ADDR]] : $*Value
 // CHECK:         [[CONVERTED:%[^,]+]] = convert_function [[DEPENDENDENCY]]
 // CHECK:         apply {{%[^,]+}}<(Value, Value)>([[OUTPUT_TUPLE_ADDR]], [[CONVERTED]])
 // CHECK-LABEL: } // end sil function 'duplicate1'
@@ -97,7 +97,7 @@ func duplicate1<Value>(value: Value) -> (Value, Value) {
 // CHECK:         [[DUPLICATE_CLOSURE:%[^,]+]] = function_ref @$s19opaque_values_Onone10duplicate25valuex3one_x3twotx_tlFxAD_xAEtyXEfU_
 // CHECK:         copy_addr [[INSTANCE_ADDR_IN]] to [init] [[INSTANCE_ADDR]]
 // CHECK:         [[DUPLICATE_INSTANCE_CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [on_stack] [[DUPLICATE_CLOSURE]]<Value>([[INSTANCE_ADDR]])
-// CHECK:         [[DEPENDENDENCY:%[^,]+]] = mark_dependence [[DUPLICATE_INSTANCE_CLOSURE]] : $@noescape @callee_guaranteed () -> @out (one: Value, two: Value) on [[INSTANCE_ADDR]] : $*Value
+// CHECK:         [[DEPENDENDENCY:%[^,]+]] = mark_dependence [nonescaping] [[DUPLICATE_INSTANCE_CLOSURE]] : $@noescape @callee_guaranteed () -> @out (one: Value, two: Value) on [[INSTANCE_ADDR]] : $*Value
 // CHECK:         [[CONVERTED:%[^,]+]] = convert_function [[DEPENDENDENCY]]
 // CHECK:         apply {{%[^,]+}}<(one: Value, two: Value)>([[OUTPUT_TUPLE_ADDR]], [[CONVERTED]])
 // CHECK-LABEL: } // end sil function 'duplicate2'
@@ -133,7 +133,7 @@ func duplicate_with_int2<Value>(value: Value) -> ((Value, Value), Int) {
 // CHECK:         [[CLOSURE:%[^,]+]] = function_ref @$s19opaque_values_Onone19duplicate_with_int35valueSi_x_x_x_SitxttSitx_tlFSi_x_x_x_SitxttSityXEfU_
 // CHECK:         copy_addr [[INSTANCE_ADDR_IN]] to [init] [[INSTANCE_ADDR]]
 // CHECK:         [[INSTANCE_CLOSURE:%[^,]+]] = partial_apply [callee_guaranteed] [on_stack] [[CLOSURE]]<Value>([[INSTANCE_ADDR]])
-// CHECK:         [[DEPENDENCY:%[^,]+]] = mark_dependence [[INSTANCE_CLOSURE]]
+// CHECK:         [[DEPENDENCY:%[^,]+]] = mark_dependence [nonescaping] [[INSTANCE_CLOSURE]]
 // CHECK:         [[CONVERTED:%[^,]+]] = convert_function [[DEPENDENCY]]
 // CHECK:         apply {{%[^,]+}}<(Int, (Value, (Value, (Value, Int), Value)), Int)>({{%[^,]+}}, [[CONVERTED]])
 // CHECK-LABEL: } // end sil function 'duplicate_with_int3'

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -254,7 +254,6 @@ exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
 // CHECK-LABEL: testInteriorRefElementEscape: interior_liveness_swift with: %0
 // CHECK: Interior liveness: %0 = argument of bb0 : $C
 // CHECK-NEXT: Pointer escape:   %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
-// CHECK-NEXT: Incomplete liveness
 // CHECK-NEXT: begin:      %{{.*}} = unchecked_ref_cast %0 : $C to $D
 // CHECK-NEXT: ends:       %{{.*}} = address_to_pointer %{{.*}} : $*C to $Builtin.RawPointer
 // CHECK-NEXT: exits:    


### PR DESCRIPTION
--- CCC ---

Explanation: Fix lifetime dependence in the presence of pointer escapes.

Scope: This fixes common patterns exposed by generic ~Escapable types.

Radar/SR Issue: rdar://124564951 (Compiler crash when evaluating pointer escape in autoclosure; LifetimeDepenenceScopeFixup; Fatal error: check findPointerEscape() before computing interior liveness.)

Original PR: https://github.com/apple/swift/pull/72407

Risk: Changes the SIL representation of closure captures by adding a flag. This could expose bugs in downstream passes. This risk is mitigated in a subsequent PR: https://github.com/apple/swift/pull/72513

Testing: Unit tests added.

Reviewer: @meg-gupta 
