### PR TITLE
[6.0][Preset] Disable verify dwarf for toolchain preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1301,6 +1301,8 @@ extra-cmake-options=
    -DCMAKE_C_FLAGS="-gline-tables-only"
    -DCMAKE_CXX_FLAGS="-gline-tables-only"
 
+dsymutil-args="--verify-dwarf=none"
+
 install-llvm
 install-swift
 install-lldb

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1301,7 +1301,7 @@ extra-cmake-options=
    -DCMAKE_C_FLAGS="-gline-tables-only"
    -DCMAKE_CXX_FLAGS="-gline-tables-only"
 
-dsymutil-args="--verify-dwarf=none"
+extra-dsymutil-args="--verify-dwarf=none"
 
 install-llvm
 install-swift


### PR DESCRIPTION
**Explanation**: The macOS toolchain bot has gotten slower due to dwarf verifier with assertion enabled.

extract symbols phase has increased by 260%: 

- macosx-x86_64-extractsymbols 832.14s (5.10) -> 2992.12s (main and release/6.0)
- macosx-arm64-extractsymbols 746.63s (5.10) -> 2728.38s (main and release/6.0)

**Issue**: rdar://124988302
**Original PR**: https://github.com/apple/swift/pull/72496
**Risk**: Low
**Testing**: Verify via building the toolchain on macOS
**Reviewer**: @edymtt 
