### PR TITLE
ClangImporter: handle `-target-cpu` for x86 targets

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -799,8 +799,19 @@ importer::addCommonInvocationArguments(
   }
 
   if (!importerOpts.TargetCPU.empty()) {
-    invocationArgStrs.push_back("-mcpu=" + importerOpts.TargetCPU);
-
+    switch (triple.getArch()) {
+    case llvm::Triple::x86:
+    case llvm::Triple::x86_64:
+      // `-mcpu` is deprecated and an alias for `-mtune`. We need to pass
+      // `-march` and `-mtune` to behave identically to the `apple-a\d+` cases
+      // below.
+      invocationArgStrs.push_back("-march=" + importerOpts.TargetCPU);
+      invocationArgStrs.push_back("-mtune=" + importerOpts.TargetCPU);
+      break;
+    default:
+      invocationArgStrs.push_back("-mcpu=" + importerOpts.TargetCPU);
+      break;
+    }
   } else if (triple.isOSDarwin()) {
     // Special case CPU based on known deployments:
     //   - arm64 deploys to apple-a7

--- a/test/Misc/target-cpu.swift
+++ b/test/Misc/target-cpu.swift
@@ -40,3 +40,6 @@
 // RUN: not %swift -typecheck -target s390x-unknown-linux-gnu -Xcc -### %s 2>&1 | %FileCheck -check-prefix=S390X_CPU %s
 // S390X_CPU: "-target-cpu" "z13"
 
+// RUN: not %swiftc -typecheck -target x86_64-unknown-windows-msvc -target-cpu haswell -Xcc -### %s 2>&1 | %FileCheck -check-prefix X86_64 %s
+// X86_64: "-target-cpu" "haswell"
+// X86_64: "-tune-cpu" "haswell"


### PR DESCRIPTION
`-mcpu` is a deprecated "alias" (unsupported) on x86 targets for `-mtune`. Unlike `-mcpu`, `-mtune` simply tunes the code for the CPU but does not prevent execution on other targets. In order to match the behaviour of `-mcpu` on ARM, we must use both `-march=` and `-mtune=`. Adjust this behaviour to allow tuning of code for non-Darwin targets.