### PR TITLE
AST: Introduce `@_disallowFeatureSuppression` attribute

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -483,12 +483,13 @@ BridgedAlignmentAttr_createParsed(BridgedASTContext cContext,
                                   BridgedSourceLoc cAtLoc,
                                   BridgedSourceRange cRange, size_t cValue);
 
-SWIFT_NAME("BridgedAllowFeatureSuppressionAttr.createParsed(_:atLoc:range:features:)")
+SWIFT_NAME("BridgedAllowFeatureSuppressionAttr.createParsed(_:atLoc:range:inverted:features:)")
 BridgedAllowFeatureSuppressionAttr
 BridgedAllowFeatureSuppressionAttr_createParsed(
                                   BridgedASTContext cContext,
                                   BridgedSourceLoc cAtLoc,
                                   BridgedSourceRange cRange,
+                                  bool inverted,
                                   BridgedArrayRef cFeatures);
 
 SWIFT_NAME("BridgedCDeclAttr.createParsed(_:atLoc:range:name:)")

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -192,9 +192,11 @@ protected:
       isUnsafe : 1
     );
 
-    SWIFT_INLINE_BITFIELD_FULL(AllowFeatureSuppressionAttr, DeclAttribute, 32,
+    SWIFT_INLINE_BITFIELD_FULL(AllowFeatureSuppressionAttr, DeclAttribute, 1+31,
       : NumPadBits,
-      NumFeatures : 32
+      Inverted : 1,
+
+      NumFeatures : 31
     );
   } Bits;
   // clang-format on
@@ -2628,13 +2630,16 @@ class AllowFeatureSuppressionAttr final
       private llvm::TrailingObjects<AllowFeatureSuppressionAttr, Identifier> {
   friend TrailingObjects;
 
-  /// Create an implicit @objc attribute with the given (optional) name.
-  AllowFeatureSuppressionAttr(SourceLoc atLoc, SourceRange range,
-                              bool implicit, ArrayRef<Identifier> features);
+  AllowFeatureSuppressionAttr(SourceLoc atLoc, SourceRange range, bool implicit,
+                              bool inverted, ArrayRef<Identifier> features);
+
 public:
   static AllowFeatureSuppressionAttr *create(ASTContext &ctx, SourceLoc atLoc,
                                              SourceRange range, bool implicit,
+                                             bool inverted,
                                              ArrayRef<Identifier> features);
+
+  bool getInverted() const { return Bits.AllowFeatureSuppressionAttr.Inverted; }
 
   ArrayRef<Identifier> getSuppressedFeatures() const {
     return {getTrailingObjects<Identifier>(),

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -489,6 +489,7 @@ SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
 DECL_ATTR(_allowFeatureSuppression, AllowFeatureSuppression,
   OnAnyDecl | UserInaccessible | NotSerialized | ABIStableToAdd | APIStableToAdd | ABIStableToRemove | APIStableToRemove,
   157)
+DECL_ATTR_ALIAS(_disallowFeatureSuppression, AllowFeatureSuppression)
 SIMPLE_DECL_ATTR(_preInverseGenerics, PreInverseGenerics,
   OnAbstractFunction | OnSubscript | OnVar | OnExtension | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   158)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -34,6 +34,11 @@
 // imply the existence of earlier features.  (This only needs to apply to
 // suppressible features.)
 //
+// Sometimes, certain declarations will conflict with existing declarations
+// when printed with a suppressible feature disabled. The attribute
+// @_disallowFeatureSuppression can be used to suppress feature suppression on
+// a particular declaration.
+//
 // If suppressing a feature in general is problematic, but it's okay to
 // suppress it for specific declarations, the feature can be made
 // conditionally suppressible.  Declarations opt in to suppression with

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1157,7 +1157,8 @@ public:
                                       std::optional<AccessLevel> &Visibility);
 
   ParserResult<AllowFeatureSuppressionAttr>
-  parseAllowFeatureSuppressionAttribute(SourceLoc atLoc, SourceLoc loc);
+  parseAllowFeatureSuppressionAttribute(bool inverted, SourceLoc atLoc,
+                                        SourceLoc loc);
 
   /// Parse the @attached or @freestanding attribute that specifies a macro
   /// role.

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -433,12 +433,14 @@ BridgedAllowFeatureSuppressionAttr
 BridgedAllowFeatureSuppressionAttr_createParsed(BridgedASTContext cContext,
                                                 BridgedSourceLoc cAtLoc,
                                                 BridgedSourceRange cRange,
+                                                bool inverted,
                                                 BridgedArrayRef cFeatures) {
   SmallVector<Identifier> features;
   for (auto elem : cFeatures.unbridged<BridgedIdentifier>())
     features.push_back(elem.unbridged());
-  return AllowFeatureSuppressionAttr::create(cContext.unbridged(),
-      cAtLoc.unbridged(), cRange.unbridged(), /*implicit*/ false, features);
+  return AllowFeatureSuppressionAttr::create(
+      cContext.unbridged(), cAtLoc.unbridged(), cRange.unbridged(),
+      /*implicit*/ false, inverted, features);
 }
 
 BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -695,9 +695,14 @@ void FeatureSet::collectSuppressibleFeature(Feature feature,
                               operation == Insert);
 }
 
-static bool shouldSuppressFeature(StringRef featureName, Decl *decl) {
+static bool hasFeatureSuppressionAttribute(Decl *decl, StringRef featureName,
+                                           bool inverted) {
   auto attr = decl->getAttrs().getAttribute<AllowFeatureSuppressionAttr>();
-  if (!attr) return false;
+  if (!attr)
+    return false;
+
+  if (attr->getInverted() != inverted)
+    return false;
 
   for (auto suppressedFeature : attr->getSuppressedFeatures()) {
     if (suppressedFeature.is(featureName))
@@ -705,6 +710,14 @@ static bool shouldSuppressFeature(StringRef featureName, Decl *decl) {
   }
 
   return false;
+}
+
+static bool disallowFeatureSuppression(StringRef featureName, Decl *decl) {
+  return hasFeatureSuppressionAttribute(decl, featureName, true);
+}
+
+static bool allowFeatureSuppression(StringRef featureName, Decl *decl) {
+  return hasFeatureSuppressionAttribute(decl, featureName, false);
 }
 
 /// Go through all the features used by the given declaration and
@@ -716,11 +729,15 @@ void FeatureSet::collectFeaturesUsed(Decl *decl, InsertOrRemove operation) {
   if (usesFeature##FeatureName(decl))                                          \
     collectRequiredFeature(Feature::FeatureName, operation);
 #define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description)      \
-  if (usesFeature##FeatureName(decl))                                          \
-    collectSuppressibleFeature(Feature::FeatureName, operation);
+  if (usesFeature##FeatureName(decl)) {                                        \
+    if (disallowFeatureSuppression(#FeatureName, decl))                        \
+      collectRequiredFeature(Feature::FeatureName, operation);                 \
+    else                                                                       \
+      collectSuppressibleFeature(Feature::FeatureName, operation);             \
+  }
 #define CONDITIONALLY_SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description)      \
   if (usesFeature##FeatureName(decl)) {                                        \
-    if (shouldSuppressFeature(#FeatureName, decl))                             \
+    if (allowFeatureSuppression(#FeatureName, decl))                           \
       collectSuppressibleFeature(Feature::FeatureName, operation);             \
     else                                                                       \
       collectRequiredFeature(Feature::FeatureName, operation);                 \

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -345,6 +345,16 @@ extension ASTGenVisitor {
       return nil
     }
 
+    let inverted: Bool
+    switch node.attributeName {
+    case "_allowFeatureSuppression":
+      inverted = false
+    case "_disallowFeatureSuppression":
+      inverted = true
+    default:
+      return nil
+    }
+
     let features = args.compactMap(in: self) { arg -> BridgedIdentifier? in
       guard arg.label == nil,
             let declNameExpr = arg.expression.as(DeclReferenceExprSyntax.self),
@@ -361,6 +371,7 @@ extension ASTGenVisitor {
       self.ctx,
       atLoc: self.generateSourceLoc(node.atSign),
       range: self.generateSourceRange(node),
+      inverted: inverted,
       features: features)
   }
 
@@ -388,7 +399,7 @@ extension ASTGenVisitor {
 
   func generateAvailableAttr(attribute node: AttributeSyntax) -> [BridgedAvailableAttr] {
     guard
-      // `@_OriginallyDefinedIn` has special argument list syntax.
+      // `@available` has special argument list syntax.
       let args = node.arguments?.as(AvailabilityArgumentListSyntax.self)
     else {
       // TODO: Diagnose.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2461,8 +2461,10 @@ Parser::parseDocumentationAttribute(SourceLoc atLoc, SourceLoc loc) {
 }
 
 ParserResult<AllowFeatureSuppressionAttr>
-Parser::parseAllowFeatureSuppressionAttribute(SourceLoc atLoc, SourceLoc loc) {
-  StringRef attrName = "_allowFeatureSuppression";
+Parser::parseAllowFeatureSuppressionAttribute(bool inverted, SourceLoc atLoc,
+                                              SourceLoc loc) {
+  StringRef attrName =
+      inverted ? "_disallowFeatureSuppression" : "_allowFeatureSuppression";
 
   SmallVector<Identifier, 4> features;
   SourceRange parensRange;
@@ -2479,9 +2481,9 @@ Parser::parseAllowFeatureSuppressionAttribute(SourceLoc atLoc, SourceLoc loc) {
     return status;
 
   auto range = SourceRange(loc, parensRange.End);
-  return makeParserResult(
-    AllowFeatureSuppressionAttr::create(Context, loc, range, /*implicit*/ false,
-                                        features));
+  return makeParserResult(AllowFeatureSuppressionAttr::create(
+      Context, loc, range, /*implicit*/ false, /*inverted*/ inverted,
+      features));
 }
 
 static std::optional<MacroIntroducedDeclNameKind>
@@ -3900,7 +3902,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
   case DeclAttrKind::AllowFeatureSuppression: {
-    auto Attr = parseAllowFeatureSuppressionAttribute(AtLoc, Loc);
+    auto inverted = (AttrName == "_disallowFeatureSuppression");
+    auto Attr = parseAllowFeatureSuppressionAttribute(inverted, AtLoc, Loc);
     Status |= Attr;
     if (Attr.isNonNull())
       Attributes.add(Attr.get());

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6034,22 +6034,6 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
-      case decls_block::AllowFeatureSuppression_DECL_ATTR: {
-        bool isImplicit;
-        ArrayRef<uint64_t> featureIds;
-        serialization::decls_block::AllowFeatureSuppressionDeclAttrLayout
-                     ::readRecord(scratch, isImplicit, featureIds);
-
-        SmallVector<Identifier, 4> features;
-        for (auto id : featureIds)
-          features.push_back(MF.getIdentifier(id));
-
-        Attr = AllowFeatureSuppressionAttr::create(ctx, SourceLoc(),
-                                                   SourceRange(), isImplicit,
-                                                   features);
-        break;
-      }
-
       case decls_block::UnavailableFromAsync_DECL_ATTR: {
         bool isImplicit;
         serialization::decls_block::UnavailableFromAsyncDeclAttrLayout::

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2138,12 +2138,6 @@ namespace decls_block {
     BCArray<IdentifierIDField> // name components
   >;
 
-  using AllowFeatureSuppressionDeclAttrLayout = BCRecordLayout<
-    AllowFeatureSuppression_DECL_ATTR,
-    BCFixed<1>,   // implicit flag
-    BCArray<IdentifierIDField>  // feature names
-  >;
-
   using SPIAccessControlDeclAttrLayout = BCRecordLayout<
     SPIAccessControl_DECL_ATTR,
     BCArray<IdentifierIDField>  // SPI names
@@ -2254,6 +2248,8 @@ namespace decls_block {
   using ClangImporterSynthesizedTypeDeclAttrLayout
     = BCRecordLayout<ClangImporterSynthesizedType_DECL_ATTR>;
   using PrivateImportDeclAttrLayout = BCRecordLayout<PrivateImport_DECL_ATTR>;
+  using AllowFeatureSuppressionDeclAttrLayout =
+      BCRecordLayout<AllowFeatureSuppression_DECL_ATTR>;
   using ProjectedValuePropertyDeclAttrLayout = BCRecordLayout<
       ProjectedValueProperty_DECL_ATTR,
       BCFixed<1>,        // isImplicit

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2717,6 +2717,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DeclAttrKind::RestatedObjCConformance:
     case DeclAttrKind::ClangImporterSynthesizedType:
     case DeclAttrKind::PrivateImport:
+    case DeclAttrKind::AllowFeatureSuppression:
       llvm_unreachable("cannot serialize attribute");
 
 #define SIMPLE_DECL_ATTR(_, CLASS, ...)                                        \
@@ -2766,20 +2767,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       CDeclDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                       theAttr->isImplicit(),
                                       theAttr->Name);
-      return;
-    }
-
-    case DeclAttrKind::AllowFeatureSuppression: {
-      auto *theAttr = cast<AllowFeatureSuppressionAttr>(DA);
-      auto abbrCode =
-        S.DeclTypeAbbrCodes[AllowFeatureSuppressionDeclAttrLayout::Code];
-
-      SmallVector<IdentifierID> ids;
-      for (auto id : theAttr->getSuppressedFeatures())
-        ids.push_back(S.addUniquedStringRef(id.str()));
-
-      AllowFeatureSuppressionDeclAttrLayout::emitRecord(
-          S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(), ids);
       return;
     }
 

--- a/test/ModuleInterface/retroactive-conformances.swift
+++ b/test/ModuleInterface/retroactive-conformances.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
 // RUN: %FileCheck %s < %t.swiftinterface
 
 // CHECK: #if compiler(>=5.3) && $RetroactiveAttribute
@@ -19,4 +19,13 @@
 // CHECK: #endif
 extension Int: @retroactive Identifiable {
     public var id: Int { self }
+}
+
+// CHECK: #if compiler(>=5.3) && $RetroactiveAttribute
+// CHECK: extension Swift.String : @retroactive Swift.Identifiable {
+// CHECK-NOT: #else
+// CHECK: #endif
+@_disallowFeatureSuppression(RetroactiveAttribute)
+extension String: @retroactive Identifiable {
+    public var id: String { self }
 }


### PR DESCRIPTION
This attribute is the inverse of the existing `@_allowFeatureSuppression` attribute (introduced in https://github.com/apple/swift/pull/72008).
    
Part of rdar://125138945