### PR TITLE
[concurrency] Diagnose synchronous sendable actor isolated functions that have their actor isolation type erased.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5836,6 +5836,15 @@ ERROR(async_named_decl_must_be_available_from_async,none,
 ERROR(async_unavailable_decl,none,
       "%kindbase0 is unavailable from asynchronous contexts%select{|; %1}1",
       (const ValueDecl *, StringRef))
+ERROR(actor_isolated_sync_closure_type_erased, none,
+      "synchronous %0 %kind1 cannot be passed as a %2",
+      (ActorIsolation, const ValueDecl *, Type))
+ERROR(actor_isolated_sync_closure_type_erased_no_decl, none,
+      "synchronous %0 cannot be passed as a %1",
+      (Type, Type))
+NOTE(actor_isolated_sync_closure_type_erased_note, none,
+     "Due to type erasure, the caller of the synchronous closure will not hop "
+     "to the closure's global actor before invoking it", ())
 
 //------------------------------------------------------------------------------
 // MARK: String Processing

--- a/test/Concurrency/type_erased_synchronous_sendable_closures.swift
+++ b/test/Concurrency/type_erased_synchronous_sendable_closures.swift
@@ -1,0 +1,81 @@
+// RUN: %target-swift-frontend  -disable-availability-checking -swift-version 6 -parse-as-library %s -emit-sil -o /dev/null -verify
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+public func takesClosure(_ closure: () -> Void) async {
+  closure()
+}
+
+@MainActor func mustRunOnMainActor() {
+  MainActor.assertIsolated()
+}
+
+@MainActor struct S {
+  func foo() {}
+}
+
+@MainActor class Test {
+  var s = S()
+  func foo() {}
+}
+
+@MainActor protocol P {
+  func foo()
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+@MainActor func testFunction() async {
+  await takesClosure(mustRunOnMainActor)
+  // expected-error @-1 {{synchronous main actor-isolated global function 'mustRunOnMainActor()' cannot be passed as a '() -> Void'}}
+  // expected-note @-2 {{Due to type erasure, the caller of the synchronous closure will not hop to the closure's global actor before invoking it}}
+}
+
+@MainActor func testConcreteInstanceMethod() async {
+  let x = Test()
+  let y = x.foo
+  await takesClosure(y)
+  // expected-error @-1 {{synchronous main actor-isolated let 'y' cannot be passed as a '() -> Void'}}
+  // expected-note @-2 {{Due to type erasure, the caller of the synchronous closure will not hop to the closure's global actor before invoking it}}
+
+  await takesClosure(x.foo)
+  // expected-error @-1 {{synchronous main actor-isolated instance method 'foo()' cannot be passed as a '() -> Void'}}
+  // expected-note @-2 {{Due to type erasure, the caller of the synchronous closure will not hop to the closure's global actor before invoking it}}
+
+  await takesClosure(x.s.foo)
+  // expected-error @-1 {{synchronous main actor-isolated instance method 'foo()' cannot be passed as a '() -> Void'}}
+  // expected-note @-2 {{Due to type erasure, the caller of the synchronous closure will not hop to the closure's global actor before invoking it}}
+}
+
+@MainActor func testGenericInstanceMethod<T: P>(_ t: T) async {
+  await takesClosure(t.foo)
+  // expected-error @-1 {{synchronous main actor-isolated instance method 'foo()' cannot be passed as a '() -> Void'}}
+  // expected-note @-2 {{Due to type erasure, the caller of the synchronous closure will not hop to the closure's global actor before invoking it}}
+  let y = t.foo
+  await takesClosure(y)
+  // expected-error @-1 {{synchronous main actor-isolated let 'y' cannot be passed as a '() -> Void'}}
+  // expected-note @-2 {{Due to type erasure, the caller of the synchronous closure will not hop to the closure's global actor before invoking it}}
+
+  let z = t
+  await takesClosure(z.foo)
+  // expected-error @-1 {{synchronous main actor-isolated instance method 'foo()' cannot be passed as a '() -> Void'}}
+  // expected-note @-2 {{Due to type erasure, the caller of the synchronous closure will not hop to the closure's global actor before invoking it}}
+}
+
+@MainActor func testWithCast() async {
+  let x = mustRunOnMainActor as Any
+  await takesClosure(x as! (@MainActor () -> ()))
+  // expected-error @-1 {{synchronous '@MainActor () -> ()' cannot be passed as a '() -> Void'}}
+  // expected-note @-2 {{Due to type erasure, the caller of the synchronous closure will not hop to the closure's global actor before invoking it}}
+  await takesClosure(x as! (@Sendable @MainActor () -> ()))
+  // expected-error @-1 {{synchronous '@MainActor @Sendable () -> ()' cannot be passed as a '() -> Void'}}
+  // expected-note @-2 {{Due to type erasure, the caller of the synchronous closure will not hop to the closure's global actor before invoking it}}
+  await takesClosure(x as! (@Sendable () -> ()))
+}


### PR DESCRIPTION
The problem that we are running into here is that:

1. actor isolated functions are considered sendable... so we cannot use region based isolation here.

2. But, structurally a synchronous actor isolated function can only be called from a context where we know that it is actor isolated so the caller can hop to the correct executor. Once the value is type erased and passed to a caller, we no longer have that information potentially creating races.

Since I can't use region isolation here, I created a type checker check instead.

rdar://118206647
