### PR TITLE
[Concurrency] Don't allow erasing global actor isolation when the function value crosses an isolation boundary.

### DIFF
--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -468,6 +468,8 @@ actor Crystal {
   await asyncGlobalActorFunc()
 }
 
+func crossIsolationBoundary(_ closure: () -> Void) async {}
+
 @available(SwiftStdlib 5.1, *)
 func testGlobalActorClosures() {
   let _: Int = acceptAsyncClosure { @SomeGlobalActor in
@@ -480,6 +482,15 @@ func testGlobalActorClosures() {
   }
 
   acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning {{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
+
+  @MainActor func test() async {
+    let closure = { @MainActor @Sendable in
+      MainActor.assertIsolated()
+    }
+
+    await crossIsolationBoundary(closure)
+    // expected-warning@-1 {{converting function value of type '@MainActor @Sendable () -> ()' to '() -> Void' loses global actor 'MainActor'; this is an error in the Swift 6 language mode}}
+  }
 }
 
 @available(SwiftStdlib 5.1, *)


### PR DESCRIPTION
The actor isolation checker allows erasing global actor isolation in function conversions when the conversion happens in the same isolation domain and the destination type is not Sendable under the assumption that the function value will never cross an isolation boundary. This is an important rule, because it allows calling synchronous higher order function APIs with global actor isolated function values as long as you're calling from a global actor isolated context. However, the actor isolation checker was allowing the conversion in cases where the function value crosses an isolation boundary:

```swift
func crossIsolationBoundary(_ closure: () -> Void) async { closure() }

@MainActor func test() async {
  let closure = { @MainActor @Sendable in
    MainActor.assertIsolated()
  }

  await crossIsolationBoundary(closure)
}
```

This PR diagnoses the function conversion that loses actor isolation if the function conversion is an argument to a call that crosses an isolation boundary.

We still need to fix this case under region isolation:

```swift
func crossIsolationBoundary(_ closure: () -> Void) async { closure() }

@MainActor func test() async {
  let closure = { @MainActor @Sendable in
    MainActor.assertIsolated()
  }

  let erased: () -> Void = closure

  await crossIsolationBoundary(erased)
}
```

Currently, the above code is "fine" because the function conversion itself isn't crossing an isolation boundary, and from the perspective of region analysis, `erased` is in a disconnected region. I think the way to solve this is to merge `erased` to the main actor region due to the function conversion that erases main actor isolation.

Resolves: rdar://118206647