### PR TITLE
stdlib: Make typed throws ABI placeholders properly `@usableFromInline`

### DIFF
--- a/include/swift/Runtime/TracingCommon.h
+++ b/include/swift/Runtime/TracingCommon.h
@@ -33,8 +33,8 @@ static inline bool shouldEnableTracing() {
     return false;
   if (__progname && (strcmp(__progname, "logd") == 0 ||
                      strcmp(__progname, "diagnosticd") == 0 ||
-                     strcmp(__progname, "notifyd") == 0) ||
-                     strcmp(__progname, "xpcproxy") == 0)
+                     strcmp(__progname, "notifyd") == 0 ||
+                     strcmp(__progname, "xpcproxy") == 0))
     return false;
   return true;
 }

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -169,7 +169,7 @@ extension ${Self}: LosslessStringConvertible {
       self.init(Substring(text))
     } else {
       self = 0.0
-#if hasFeature(TypedThrows)
+#if $TypedThrows
       let success = _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
         text.withCString { chars -> Bool in
           switch chars[0] {
@@ -216,7 +216,7 @@ extension ${Self}: LosslessStringConvertible {
   @available(SwiftStdlib 5.3, *)
   public init?(_ text: Substring) {
     self = 0.0
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     let success = _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
       text.withCString { chars -> Bool in
         switch chars[0] {

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -87,13 +87,14 @@ public func withUnsafeMutablePointer<
   try body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
 }
 
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss24withUnsafeMutablePointer2to_q_xz_q_SpyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_se0413_withUnsafeMutablePointer<T, Result>(
   to value: inout T,
   _ body: (UnsafeMutablePointer<T>) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   return try body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
 }
 
@@ -147,13 +148,14 @@ public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafePointer(to:_:) rethrows, expressed as "throws",
 /// which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss17withUnsafePointer2to_q_x_q_SPyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_withUnsafePointer<T, Result>(
   to value: T,
   _ body: (UnsafePointer<T>) throws -> Result
-) throws -> Result
+) rethrows -> Result
 {
   return try body(UnsafePointer<T>(Builtin.addressOfBorrow(value)))
 }
@@ -192,13 +194,14 @@ public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafePointer(to:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss17withUnsafePointer2to_q_xz_q_SPyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_se0413_withUnsafePointer<T, Result>(
   to value: inout T,
   _ body: (UnsafePointer<T>) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   return try body(UnsafePointer<T>(Builtin.addressof(&value)))
 }
 

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -158,7 +158,7 @@ public struct SystemRandomNumberGenerator: RandomNumberGenerator, Sendable {
   @inlinable
   public mutating func next() -> UInt64 {
     var random: UInt64 = 0
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     _withUnprotectedUnsafeMutablePointer(to: &random) {
       swift_stdlib_random($0, MemoryLayout<UInt64>.size)
     }

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -139,7 +139,7 @@ func _stdlib_atomicInitializeARCRef(
   let desiredPtr = unmanaged.toOpaque()
   let rawTarget = UnsafeMutableRawPointer(target).assumingMemoryBound(
     to: Optional<UnsafeRawPointer>.self)
-#if hasFeature(TypedThrows)
+#if $TypedThrows
   let wonRace = withUnsafeMutablePointer(to: &expected) {
     _stdlib_atomicCompareExchangeStrongPtr(
       object: rawTarget, expected: $0, desired: desiredPtr

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -223,7 +223,7 @@ extension _SmallString {
   ) rethrows -> Result {
     let count = self.count
     var raw = self.zeroTerminatedRawCodeUnits
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     return try Swift._withUnprotectedUnsafeBytes(of: &raw) {
       let rawPtr = $0.baseAddress._unsafelyUnwrappedUnchecked
       // Rebind the underlying (UInt64, UInt64) tuple to UInt8 for the

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -535,7 +535,7 @@ extension Unicode.Scalar {
 
     // The first code unit is in the least significant byte of codeUnits.
     codeUnits = codeUnits.littleEndian
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     return try Swift._withUnprotectedUnsafePointer(to: &codeUnits) {
       return try $0.withMemoryRebound(to: UInt8.self, capacity: 4) {
         return try body(UnsafeBufferPointer(start: $0, count: utf8Count))

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1230,13 +1230,14 @@ public func withUnsafeMutableBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafeMutableBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss22withUnsafeMutableBytes2of_q_xz_q_SwKXEtKr0_lF")
 @usableFromInline
 func __abi_se0413_withUnsafeMutableBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   return try withUnsafeMutablePointer(to: &value) {
     return try body(UnsafeMutableRawBufferPointer(
         start: $0, count: MemoryLayout<T>.size))
@@ -1297,13 +1298,14 @@ public func withUnsafeBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafeBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss15withUnsafeBytes2of_q_xz_q_SWKXEtKr0_lF")
 @usableFromInline
 func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   return try withUnsafePointer(to: &value) {
     try body(UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
   }
@@ -1361,13 +1363,14 @@ public func withUnsafeBytes<
 
 /// ABI: Historical withUnsafeBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss15withUnsafeBytes2of_q_x_q_SWKXEtKr0_lF")
 @usableFromInline
 func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   let addr = UnsafeRawPointer(Builtin.addressOfBorrow(value))
   let buffer = UnsafeRawBufferPointer(start: addr, count: MemoryLayout<T>.size)
   return try body(buffer)

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1501,7 +1501,7 @@ extension UnsafeMutableRawPointer {
       "storeBytes to misaligned raw pointer")
 
     var temp = value
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     withUnsafeMutablePointer(to: &temp) { source in
       let rawSrc = UnsafeMutableRawPointer(source)._rawValue
       // FIXME: to be replaced by _memcpy when conversions are implemented.

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -215,7 +215,7 @@ public func _encodeBitsAsWords<T>(_ x: T) -> [Int] {
   _internalInvariant(!result.isEmpty)
   var tmp = x
   // FIXME: use UnsafeMutablePointer.assign(from:) instead of memcpy.
-#if hasFeature(TypedThrows)
+#if $TypedThrows
   _withUnprotectedUnsafeMutablePointer(to: &tmp) {
     _memcpy(dest: UnsafeMutablePointer(result._baseAddressIfContiguous!),
             src: $0,

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -712,10 +712,17 @@ Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to
 Func withExtendedLifetime(_:_:) has mangled name changing from 'Swift.withExtendedLifetime<A, B>(A, () throws -> B) throws -> B' to 'Swift.withExtendedLifetime<A, B where A: ~Swift.Copyable, B: ~Swift.Copyable>(A, () throws -> B) throws -> B'
 Func withExtendedLifetime(_:_:) has parameter 0 changing from Default to Shared
 Func withExtendedLifetime(_:_:) is now with @_preInverseGenerics
-Func withUnsafeBytes(of:_:) has been removed
-Func withUnsafeMutableBytes(of:_:) has been removed
-Func withUnsafeMutablePointer(to:_:) has been removed
-Func withUnsafePointer(to:_:) has been removed
+Func withUnsafeBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeBytes(of:_:)
+Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeMutableBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeMutableBytes(of:_:)
+Func withUnsafeMutableBytes(of:_:) has mangled name changing from 'Swift.withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeMutableRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeMutableRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeMutablePointer(to:_:) has been renamed to Func __abi_se0413_withUnsafeMutablePointer(to:_:)
+Func withUnsafeMutablePointer(to:_:) has mangled name changing from 'Swift.withUnsafeMutablePointer<A, B>(to: inout A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutablePointer<A, B>(to: inout A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B'
+Func withUnsafePointer(to:_:) has been renamed to Func __abi_se0413_withUnsafePointer(to:_:)
+Func withUnsafePointer(to:_:) has been renamed to Func __abi_withUnsafePointer(to:_:)
+Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
+Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: inout A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafePointer<A, B>(to: inout A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
 Protocol _Pointer has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable> to <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable, Self : Swift._BitwiseCopyable, Self.Pointee : ~Copyable>
 Struct ManagedBufferPointer has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Struct UnsafeBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable>


### PR DESCRIPTION
Functions that are used in public `@inlinable` function bodies can't be marked `@_spi` nor can they be made obsolete. Also, they must retain `rethrows` so that use of these entry points from other `rethrows` functions is accepted.

Builds on https://github.com/apple/swift/pull/72365. Once we no longer have to support pre-`$TypedThrows` compilers, all of this can be reverted.

Part of rdar://125138945