### PR TITLE
[6.0] Fix condfails for TypedThrows, NoncopyableGenerics, and IsolatedAny

### DIFF
--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -483,12 +483,13 @@ BridgedAlignmentAttr_createParsed(BridgedASTContext cContext,
                                   BridgedSourceLoc cAtLoc,
                                   BridgedSourceRange cRange, size_t cValue);
 
-SWIFT_NAME("BridgedAllowFeatureSuppressionAttr.createParsed(_:atLoc:range:features:)")
+SWIFT_NAME("BridgedAllowFeatureSuppressionAttr.createParsed(_:atLoc:range:inverted:features:)")
 BridgedAllowFeatureSuppressionAttr
 BridgedAllowFeatureSuppressionAttr_createParsed(
                                   BridgedASTContext cContext,
                                   BridgedSourceLoc cAtLoc,
                                   BridgedSourceRange cRange,
+                                  bool inverted,
                                   BridgedArrayRef cFeatures);
 
 SWIFT_NAME("BridgedCDeclAttr.createParsed(_:atLoc:range:name:)")

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -192,9 +192,11 @@ protected:
       isUnsafe : 1
     );
 
-    SWIFT_INLINE_BITFIELD_FULL(AllowFeatureSuppressionAttr, DeclAttribute, 32,
+    SWIFT_INLINE_BITFIELD_FULL(AllowFeatureSuppressionAttr, DeclAttribute, 1+31,
       : NumPadBits,
-      NumFeatures : 32
+      Inverted : 1,
+
+      NumFeatures : 31
     );
   } Bits;
   // clang-format on
@@ -2628,13 +2630,16 @@ class AllowFeatureSuppressionAttr final
       private llvm::TrailingObjects<AllowFeatureSuppressionAttr, Identifier> {
   friend TrailingObjects;
 
-  /// Create an implicit @objc attribute with the given (optional) name.
-  AllowFeatureSuppressionAttr(SourceLoc atLoc, SourceRange range,
-                              bool implicit, ArrayRef<Identifier> features);
+  AllowFeatureSuppressionAttr(SourceLoc atLoc, SourceRange range, bool implicit,
+                              bool inverted, ArrayRef<Identifier> features);
+
 public:
   static AllowFeatureSuppressionAttr *create(ASTContext &ctx, SourceLoc atLoc,
                                              SourceRange range, bool implicit,
+                                             bool inverted,
                                              ArrayRef<Identifier> features);
+
+  bool getInverted() const { return Bits.AllowFeatureSuppressionAttr.Inverted; }
 
   ArrayRef<Identifier> getSuppressedFeatures() const {
     return {getTrailingObjects<Identifier>(),

--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -489,6 +489,7 @@ SIMPLE_DECL_ATTR(_noObjCBridging, NoObjCBridging,
 DECL_ATTR(_allowFeatureSuppression, AllowFeatureSuppression,
   OnAnyDecl | UserInaccessible | NotSerialized | ABIStableToAdd | APIStableToAdd | ABIStableToRemove | APIStableToRemove,
   157)
+DECL_ATTR_ALIAS(_disallowFeatureSuppression, AllowFeatureSuppression)
 SIMPLE_DECL_ATTR(_preInverseGenerics, PreInverseGenerics,
   OnAbstractFunction | OnSubscript | OnVar | OnExtension | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   158)

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -385,6 +385,9 @@ struct PrintOptions {
   /// Suppress Noncopyable generics.
   bool SuppressNoncopyableGenerics = false;
 
+  /// Suppress printing of `borrowing` and `consuming`.
+  bool SuppressNoncopyableOwnershipModifiers = false;
+
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {
       DeclAttrKind::Transparent, DeclAttrKind::Effects,

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -361,6 +361,9 @@ EXPERIMENTAL_FEATURE(ClosureIsolation, true)
 // Enable isolated(any) attribute on function types.
 CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedAny, true)
 
+// Alias for IsolatedAny
+EXPERIMENTAL_FEATURE(IsolatedAny2, true)
+
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -34,6 +34,11 @@
 // imply the existence of earlier features.  (This only needs to apply to
 // suppressible features.)
 //
+// Sometimes, certain declarations will conflict with existing declarations
+// when printed with a suppressible feature disabled. The attribute
+// @_disallowFeatureSuppression can be used to suppress feature suppression on
+// a particular declaration.
+//
 // If suppressing a feature in general is problematic, but it's okay to
 // suppress it for specific declarations, the feature can be made
 // conditionally suppressible.  Declarations opt in to suppression with

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -319,6 +319,9 @@ EXPERIMENTAL_FEATURE(Embedded, true)
 /// Enables noncopyable generics
 SUPPRESSIBLE_EXPERIMENTAL_FEATURE(NoncopyableGenerics, true)
 
+// Alias for NoncopyableGenerics
+EXPERIMENTAL_FEATURE(NoncopyableGenerics2, true)
+
 /// Allow destructuring stored `let` bindings in structs.
 EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1157,7 +1157,8 @@ public:
                                       std::optional<AccessLevel> &Visibility);
 
   ParserResult<AllowFeatureSuppressionAttr>
-  parseAllowFeatureSuppressionAttribute(SourceLoc atLoc, SourceLoc loc);
+  parseAllowFeatureSuppressionAttribute(bool inverted, SourceLoc atLoc,
+                                        SourceLoc loc);
 
   /// Parse the @attached or @freestanding attribute that specifies a macro
   /// role.

--- a/include/swift/Runtime/TracingCommon.h
+++ b/include/swift/Runtime/TracingCommon.h
@@ -33,8 +33,8 @@ static inline bool shouldEnableTracing() {
     return false;
   if (__progname && (strcmp(__progname, "logd") == 0 ||
                      strcmp(__progname, "diagnosticd") == 0 ||
-                     strcmp(__progname, "notifyd") == 0) ||
-                     strcmp(__progname, "xpcproxy") == 0)
+                     strcmp(__progname, "notifyd") == 0 ||
+                     strcmp(__progname, "xpcproxy") == 0))
     return false;
   return true;
 }

--- a/lib/AST/ASTBridging.cpp
+++ b/lib/AST/ASTBridging.cpp
@@ -433,12 +433,14 @@ BridgedAllowFeatureSuppressionAttr
 BridgedAllowFeatureSuppressionAttr_createParsed(BridgedASTContext cContext,
                                                 BridgedSourceLoc cAtLoc,
                                                 BridgedSourceRange cRange,
+                                                bool inverted,
                                                 BridgedArrayRef cFeatures) {
   SmallVector<Identifier> features;
   for (auto elem : cFeatures.unbridged<BridgedIdentifier>())
     features.push_back(elem.unbridged());
-  return AllowFeatureSuppressionAttr::create(cContext.unbridged(),
-      cAtLoc.unbridged(), cRange.unbridged(), /*implicit*/ false, features);
+  return AllowFeatureSuppressionAttr::create(
+      cContext.unbridged(), cAtLoc.unbridged(), cRange.unbridged(),
+      /*implicit*/ false, inverted, features);
 }
 
 BridgedCDeclAttr BridgedCDeclAttr_createParsed(BridgedASTContext cContext,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -506,6 +506,9 @@ static bool usesFeatureRawLayout(Decl *decl) {
 UNINTERESTING_FEATURE(Embedded)
 
 static bool usesFeatureNoncopyableGenerics(Decl *decl) {
+  if (decl->getAttrs().hasAttribute<PreInverseGenericsAttr>())
+    return true;
+
   if (auto *valueDecl = dyn_cast<ValueDecl>(decl)) {
     if (isa<StructDecl, EnumDecl, ClassDecl>(decl)) {
       auto *nominalDecl = cast<NominalTypeDecl>(valueDecl);

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -681,6 +681,8 @@ static bool usesFeatureIsolatedAny(Decl *decl) {
   });
 }
 
+UNINTERESTING_FEATURE(IsolatedAny2)
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -568,6 +568,8 @@ static bool usesFeatureNoncopyableGenerics(Decl *decl) {
   return !inverseReqs.empty();
 }
 
+UNINTERESTING_FEATURE(NoncopyableGenerics2)
+
 static bool usesFeatureStructLetDestructuring(Decl *decl) {
   auto sd = dyn_cast<StructDecl>(decl);
   if (!sd)

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -345,6 +345,16 @@ extension ASTGenVisitor {
       return nil
     }
 
+    let inverted: Bool
+    switch node.attributeName {
+    case "_allowFeatureSuppression":
+      inverted = false
+    case "_disallowFeatureSuppression":
+      inverted = true
+    default:
+      return nil
+    }
+
     let features = args.compactMap(in: self) { arg -> BridgedIdentifier? in
       guard arg.label == nil,
             let declNameExpr = arg.expression.as(DeclReferenceExprSyntax.self),
@@ -361,6 +371,7 @@ extension ASTGenVisitor {
       self.ctx,
       atLoc: self.generateSourceLoc(node.atSign),
       range: self.generateSourceRange(node),
+      inverted: inverted,
       features: features)
   }
 
@@ -388,7 +399,7 @@ extension ASTGenVisitor {
 
   func generateAvailableAttr(attribute node: AttributeSyntax) -> [BridgedAvailableAttr] {
     guard
-      // `@_OriginallyDefinedIn` has special argument list syntax.
+      // `@available` has special argument list syntax.
       let args = node.arguments?.as(AvailabilityArgumentListSyntax.self)
     else {
       // TODO: Diagnose.

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -883,6 +883,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 #else
       Opts.enableFeature(*feature);
 #endif
+
+      if (*feature == Feature::NoncopyableGenerics2)
+        Opts.enableFeature(Feature::NoncopyableGenerics);
     }
 
     // Hack: In order to support using availability macros in SPM packages, we

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -886,6 +886,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
       if (*feature == Feature::NoncopyableGenerics2)
         Opts.enableFeature(Feature::NoncopyableGenerics);
+
+      if (*feature == Feature::IsolatedAny2)
+        Opts.enableFeature(Feature::IsolatedAny);
     }
 
     // Hack: In order to support using availability macros in SPM packages, we

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2461,8 +2461,10 @@ Parser::parseDocumentationAttribute(SourceLoc atLoc, SourceLoc loc) {
 }
 
 ParserResult<AllowFeatureSuppressionAttr>
-Parser::parseAllowFeatureSuppressionAttribute(SourceLoc atLoc, SourceLoc loc) {
-  StringRef attrName = "_allowFeatureSuppression";
+Parser::parseAllowFeatureSuppressionAttribute(bool inverted, SourceLoc atLoc,
+                                              SourceLoc loc) {
+  StringRef attrName =
+      inverted ? "_disallowFeatureSuppression" : "_allowFeatureSuppression";
 
   SmallVector<Identifier, 4> features;
   SourceRange parensRange;
@@ -2479,9 +2481,9 @@ Parser::parseAllowFeatureSuppressionAttribute(SourceLoc atLoc, SourceLoc loc) {
     return status;
 
   auto range = SourceRange(loc, parensRange.End);
-  return makeParserResult(
-    AllowFeatureSuppressionAttr::create(Context, loc, range, /*implicit*/ false,
-                                        features));
+  return makeParserResult(AllowFeatureSuppressionAttr::create(
+      Context, loc, range, /*implicit*/ false, /*inverted*/ inverted,
+      features));
 }
 
 static std::optional<MacroIntroducedDeclNameKind>
@@ -3900,7 +3902,8 @@ ParserStatus Parser::parseNewDeclAttribute(DeclAttributes &Attributes,
     break;
   }
   case DeclAttrKind::AllowFeatureSuppression: {
-    auto Attr = parseAllowFeatureSuppressionAttribute(AtLoc, Loc);
+    auto inverted = (AttrName == "_disallowFeatureSuppression");
+    auto Attr = parseAllowFeatureSuppressionAttribute(inverted, AtLoc, Loc);
     Status |= Attr;
     if (Attr.isNonNull())
       Attributes.add(Attr.get());

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6034,22 +6034,6 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
         break;
       }
 
-      case decls_block::AllowFeatureSuppression_DECL_ATTR: {
-        bool isImplicit;
-        ArrayRef<uint64_t> featureIds;
-        serialization::decls_block::AllowFeatureSuppressionDeclAttrLayout
-                     ::readRecord(scratch, isImplicit, featureIds);
-
-        SmallVector<Identifier, 4> features;
-        for (auto id : featureIds)
-          features.push_back(MF.getIdentifier(id));
-
-        Attr = AllowFeatureSuppressionAttr::create(ctx, SourceLoc(),
-                                                   SourceRange(), isImplicit,
-                                                   features);
-        break;
-      }
-
       case decls_block::UnavailableFromAsync_DECL_ATTR: {
         bool isImplicit;
         serialization::decls_block::UnavailableFromAsyncDeclAttrLayout::

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -2138,12 +2138,6 @@ namespace decls_block {
     BCArray<IdentifierIDField> // name components
   >;
 
-  using AllowFeatureSuppressionDeclAttrLayout = BCRecordLayout<
-    AllowFeatureSuppression_DECL_ATTR,
-    BCFixed<1>,   // implicit flag
-    BCArray<IdentifierIDField>  // feature names
-  >;
-
   using SPIAccessControlDeclAttrLayout = BCRecordLayout<
     SPIAccessControl_DECL_ATTR,
     BCArray<IdentifierIDField>  // SPI names
@@ -2254,6 +2248,8 @@ namespace decls_block {
   using ClangImporterSynthesizedTypeDeclAttrLayout
     = BCRecordLayout<ClangImporterSynthesizedType_DECL_ATTR>;
   using PrivateImportDeclAttrLayout = BCRecordLayout<PrivateImport_DECL_ATTR>;
+  using AllowFeatureSuppressionDeclAttrLayout =
+      BCRecordLayout<AllowFeatureSuppression_DECL_ATTR>;
   using ProjectedValuePropertyDeclAttrLayout = BCRecordLayout<
       ProjectedValueProperty_DECL_ATTR,
       BCFixed<1>,        // isImplicit

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2717,6 +2717,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DeclAttrKind::RestatedObjCConformance:
     case DeclAttrKind::ClangImporterSynthesizedType:
     case DeclAttrKind::PrivateImport:
+    case DeclAttrKind::AllowFeatureSuppression:
       llvm_unreachable("cannot serialize attribute");
 
 #define SIMPLE_DECL_ATTR(_, CLASS, ...)                                        \
@@ -2766,20 +2767,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       CDeclDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord, abbrCode,
                                       theAttr->isImplicit(),
                                       theAttr->Name);
-      return;
-    }
-
-    case DeclAttrKind::AllowFeatureSuppression: {
-      auto *theAttr = cast<AllowFeatureSuppressionAttr>(DA);
-      auto abbrCode =
-        S.DeclTypeAbbrCodes[AllowFeatureSuppressionDeclAttrLayout::Code];
-
-      SmallVector<IdentifierID> ids;
-      for (auto id : theAttr->getSuppressedFeatures())
-        ids.push_back(S.addUniquedStringRef(id.str()));
-
-      AllowFeatureSuppressionDeclAttrLayout::emitRecord(
-          S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(), ids);
       return;
     }
 

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -612,7 +612,7 @@ function(_compile_swift_files
     list(APPEND swift_flags "-experimental-hermetic-seal-at-link")
   endif()
 
-  list(APPEND swift_flags "-enable-experimental-feature" "NoncopyableGenerics")
+  list(APPEND swift_flags "-enable-experimental-feature" "NoncopyableGenerics2")
 
   if(SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES)
     list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")

--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -94,6 +94,10 @@ extension AsyncCompactMapSequence: AsyncSequence {
   public struct Iterator: AsyncIteratorProtocol {
     public typealias Element = ElementOfResult
 
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -81,6 +81,10 @@ extension AsyncDropFirstSequence: AsyncSequence {
 
   /// The iterator that produces elements of the drop-first sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
     

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -90,6 +90,10 @@ extension AsyncDropWhileSequence: AsyncSequence {
 
   /// The iterator that produces elements of the drop-while sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -80,6 +80,10 @@ extension AsyncFilterSequence: AsyncSequence {
 
   /// The iterator that produces elements of the filter sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -197,6 +197,10 @@ extension AsyncFlatMapSequence: AsyncSequence {
 
   /// The iterator that produces elements of the flat map sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -90,6 +90,10 @@ extension AsyncMapSequence: AsyncSequence {
 
   /// The iterator that produces elements of the map sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -81,6 +81,10 @@ extension AsyncPrefixSequence: AsyncSequence {
 
   /// The iterator that produces elements of the prefix sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -85,6 +85,10 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
 
   /// The iterator that produces elements of the prefix-while sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var predicateHasFailed = false
 

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS
   "-enable-experimental-feature"
-  "IsolatedAny"
+  "IsolatedAny2"
 )
 
 list(APPEND SWIFT_RUNTIME_CONCURRENCY_C_FLAGS

--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -782,6 +782,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///     to set the child task's priority to the priority of the group.
   ///   - operation: The operation to execute as part of the task group.
   @_alwaysEmitIntoClient
+  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTask(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping @isolated(any) () async throws -> ChildTaskResult
@@ -823,6 +824,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   /// - Returns: `true` if the child task was added to the group;
   ///   otherwise `false`.
   @_alwaysEmitIntoClient
+  @_allowFeatureSuppression(IsolatedAny)
   public mutating func addTaskUnlessCancelled(
     priority: TaskPriority? = nil,
     operation: __owned @Sendable @escaping @isolated(any) () async throws -> ChildTaskResult

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -169,7 +169,7 @@ extension ${Self}: LosslessStringConvertible {
       self.init(Substring(text))
     } else {
       self = 0.0
-#if hasFeature(TypedThrows)
+#if $TypedThrows
       let success = _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
         text.withCString { chars -> Bool in
           switch chars[0] {
@@ -216,7 +216,7 @@ extension ${Self}: LosslessStringConvertible {
   @available(SwiftStdlib 5.3, *)
   public init?(_ text: Substring) {
     self = 0.0
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     let success = _withUnprotectedUnsafeMutablePointer(to: &self) { p -> Bool in
       text.withCString { chars -> Bool in
         switch chars[0] {

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -87,13 +87,14 @@ public func withUnsafeMutablePointer<
   try body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
 }
 
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss24withUnsafeMutablePointer2to_q_xz_q_SpyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_se0413_withUnsafeMutablePointer<T, Result>(
   to value: inout T,
   _ body: (UnsafeMutablePointer<T>) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   return try body(UnsafeMutablePointer<T>(Builtin.addressof(&value)))
 }
 
@@ -147,13 +148,14 @@ public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafePointer(to:_:) rethrows, expressed as "throws",
 /// which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss17withUnsafePointer2to_q_x_q_SPyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_withUnsafePointer<T, Result>(
   to value: T,
   _ body: (UnsafePointer<T>) throws -> Result
-) throws -> Result
+) rethrows -> Result
 {
   return try body(UnsafePointer<T>(Builtin.addressOfBorrow(value)))
 }
@@ -192,13 +194,14 @@ public func withUnsafePointer<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafePointer(to:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss17withUnsafePointer2to_q_xz_q_SPyxGKXEtKr0_lF")
 @usableFromInline
 internal func __abi_se0413_withUnsafePointer<T, Result>(
   to value: inout T,
   _ body: (UnsafePointer<T>) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   return try body(UnsafePointer<T>(Builtin.addressof(&value)))
 }
 

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -213,20 +213,22 @@ extension Optional where Wrapped: ~Copyable {
     }
   }
 
-#if hasFeature(BorrowingSwitch)
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient
   public borrowing func _borrowingMap<U: ~Copyable, E: Error>(
     _ transform: (borrowing Wrapped) throws(E) -> U
   ) throws(E) -> U? {
+    #if $NoncopyableGenerics
     switch self {
     case .some(_borrowing y):
       return .some(try transform(y))
     case .none:
       return .none
     }
+    #else
+    fatalError("unsupported compiler")
+    #endif
   }
-#endif
 }
 
 extension Optional {
@@ -263,6 +265,7 @@ extension Optional {
   }
 }
 
+@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Optional where Wrapped: ~Copyable {
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient
@@ -277,7 +280,6 @@ extension Optional where Wrapped: ~Copyable {
     }
   }
 
-#if hasFeature(BorrowingSwitch)
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient
   public func _borrowingFlatMap<U: ~Copyable, E: Error>(
@@ -290,7 +292,6 @@ extension Optional where Wrapped: ~Copyable {
       return .none
     }
   }
-#endif
 }
 
 extension Optional {
@@ -546,7 +547,6 @@ public struct _OptionalNilComparisonType: ExpressibleByNilLiteral {
   }
 }
 
-#if hasFeature(BorrowingSwitch)
 extension Optional where Wrapped: ~Copyable {
   /// Returns a Boolean value indicating whether an argument matches `nil`.
   ///
@@ -735,9 +735,6 @@ extension Optional where Wrapped: ~Copyable {
     }
   }
 }
-#else
-#error("FIXME(NCG): Fill this out.")
-#endif
 
 /// Performs a nil-coalescing operation, returning the wrapped value of an
 /// `Optional` instance or a default value.

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -158,7 +158,7 @@ public struct SystemRandomNumberGenerator: RandomNumberGenerator, Sendable {
   @inlinable
   public mutating func next() -> UInt64 {
     var random: UInt64 = 0
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     _withUnprotectedUnsafeMutablePointer(to: &random) {
       swift_stdlib_random($0, MemoryLayout<UInt64>.size)
     }

--- a/stdlib/public/core/Result.swift
+++ b/stdlib/public/core/Result.swift
@@ -61,6 +61,7 @@ extension Result {
   }
 }
 
+@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Result where Success: ~Copyable {
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient
@@ -75,7 +76,6 @@ extension Result where Success: ~Copyable {
     }
   }
 
-#if $BorrowingSwitch
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient
   public borrowing func _borrowingMap<NewSuccess: ~Copyable>(
@@ -88,7 +88,6 @@ extension Result where Success: ~Copyable {
       return .failure(failure)
     }
   }
-#endif
 }
 
 extension Result where Success: ~Copyable {
@@ -131,6 +130,7 @@ extension Result where Success: ~Copyable {
   }
 }
 
+@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Result {
   @_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
   @usableFromInline
@@ -186,6 +186,7 @@ extension Result {
   }
 }
 
+@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Result where Success: ~Copyable {
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient
@@ -200,7 +201,6 @@ extension Result where Success: ~Copyable {
     }
   }
 
-#if $BorrowingSwitch
   // FIXME(NCG): Make this public.
   @_alwaysEmitIntoClient
   public borrowing func _borrowingFlatMap<NewSuccess: ~Copyable>(
@@ -213,7 +213,6 @@ extension Result where Success: ~Copyable {
       return .failure(failure)
     }
   }
-#endif
 }
 
 extension Result {

--- a/stdlib/public/core/Runtime.swift
+++ b/stdlib/public/core/Runtime.swift
@@ -139,7 +139,7 @@ func _stdlib_atomicInitializeARCRef(
   let desiredPtr = unmanaged.toOpaque()
   let rawTarget = UnsafeMutableRawPointer(target).assumingMemoryBound(
     to: Optional<UnsafeRawPointer>.self)
-#if hasFeature(TypedThrows)
+#if $TypedThrows
   let wonRace = withUnsafeMutablePointer(to: &expected) {
     _stdlib_atomicCompareExchangeStrongPtr(
       object: rawTarget, expected: $0, desired: desiredPtr

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -223,7 +223,7 @@ extension _SmallString {
   ) rethrows -> Result {
     let count = self.count
     var raw = self.zeroTerminatedRawCodeUnits
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     return try Swift._withUnprotectedUnsafeBytes(of: &raw) {
       let rawPtr = $0.baseAddress._unsafelyUnwrappedUnchecked
       // Rebind the underlying (UInt64, UInt64) tuple to UInt8 for the

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -535,7 +535,7 @@ extension Unicode.Scalar {
 
     // The first code unit is in the least significant byte of codeUnits.
     codeUnits = codeUnits.littleEndian
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     return try Swift._withUnprotectedUnsafePointer(to: &codeUnits) {
       return try $0.withMemoryRebound(to: UInt8.self, capacity: 4) {
         return try body(UnsafeBufferPointer(start: $0, count: utf8Count))

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -456,6 +456,7 @@ extension Unsafe${Mutable}BufferPointer where Element: ~Copyable {
 
 }
 
+@_disallowFeatureSuppression(NoncopyableGenerics)
 extension Unsafe${Mutable}BufferPointer {
   /// Accesses the element at the specified position.
   ///

--- a/stdlib/public/core/UnsafePointer.swift
+++ b/stdlib/public/core/UnsafePointer.swift
@@ -286,6 +286,7 @@ extension UnsafePointer where Pointee: ~Copyable {
   }
 }
 
+@_disallowFeatureSuppression(NoncopyableGenerics)
 extension UnsafePointer {
   // This preserves the ABI of the original (pre-6.0) `pointee` property that
   // used to export a getter. The current one above would export a read
@@ -315,6 +316,7 @@ extension UnsafePointer where Pointee: ~Copyable {
   }
 }
 
+@_disallowFeatureSuppression(NoncopyableGenerics)
 extension UnsafePointer {
   // This preserves the ABI of the original (pre-6.0) subscript that used to
   // export a getter. The current one above would export a read accessor, if it
@@ -843,6 +845,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   }
 }
 
+@_disallowFeatureSuppression(NoncopyableGenerics)
 extension UnsafeMutablePointer {
   // This preserves the ABI of the original (pre-6.0) `pointee` property that
   // used to export a getter. The current one above would export a read
@@ -1300,6 +1303,7 @@ extension UnsafeMutablePointer where Pointee: ~Copyable {
   }
 }
 
+@_disallowFeatureSuppression(NoncopyableGenerics)
 extension UnsafeMutablePointer {
   // This preserves the ABI of the original (pre-6.0) subscript that used to
   // export a getter. The current one above would export a read accessor, if it

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -1230,13 +1230,14 @@ public func withUnsafeMutableBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafeMutableBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss22withUnsafeMutableBytes2of_q_xz_q_SwKXEtKr0_lF")
 @usableFromInline
 func __abi_se0413_withUnsafeMutableBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeMutableRawBufferPointer) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   return try withUnsafeMutablePointer(to: &value) {
     return try body(UnsafeMutableRawBufferPointer(
         start: $0, count: MemoryLayout<T>.size))
@@ -1297,13 +1298,14 @@ public func withUnsafeBytes<T: ~Copyable, E: Error, Result: ~Copyable>(
 
 /// ABI: Historical withUnsafeBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss15withUnsafeBytes2of_q_xz_q_SWKXEtKr0_lF")
 @usableFromInline
 func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: inout T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   return try withUnsafePointer(to: &value) {
     try body(UnsafeRawBufferPointer(start: $0, count: MemoryLayout<T>.size))
   }
@@ -1361,13 +1363,14 @@ public func withUnsafeBytes<
 
 /// ABI: Historical withUnsafeBytes(of:_:) rethrows,
 /// expressed as "throws", which is ABI-compatible with "rethrows".
-@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
+// FIXME(TypedThrows): Uncomment @_spi and revert rethrows
+//@_spi(SwiftStdlibLegacyABI) @available(swift, obsoleted: 1)
 @_silgen_name("$ss15withUnsafeBytes2of_q_x_q_SWKXEtKr0_lF")
 @usableFromInline
 func __abi_se0413_withUnsafeBytes<T, Result>(
   of value: T,
   _ body: (UnsafeRawBufferPointer) throws -> Result
-) throws -> Result {
+) rethrows -> Result {
   let addr = UnsafeRawPointer(Builtin.addressOfBorrow(value))
   let buffer = UnsafeRawBufferPointer(start: addr, count: MemoryLayout<T>.size)
   return try body(buffer)

--- a/stdlib/public/core/UnsafeRawPointer.swift
+++ b/stdlib/public/core/UnsafeRawPointer.swift
@@ -1501,7 +1501,7 @@ extension UnsafeMutableRawPointer {
       "storeBytes to misaligned raw pointer")
 
     var temp = value
-#if hasFeature(TypedThrows)
+#if $TypedThrows
     withUnsafeMutablePointer(to: &temp) { source in
       let rawSrc = UnsafeMutableRawPointer(source)._rawValue
       // FIXME: to be replaced by _memcpy when conversions are implemented.

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -215,7 +215,7 @@ public func _encodeBitsAsWords<T>(_ x: T) -> [Int] {
   _internalInvariant(!result.isEmpty)
   var tmp = x
   // FIXME: use UnsafeMutablePointer.assign(from:) instead of memcpy.
-#if hasFeature(TypedThrows)
+#if $TypedThrows
   _withUnprotectedUnsafeMutablePointer(to: &tmp) {
     _memcpy(dest: UnsafeMutablePointer(result._baseAddressIfContiguous!),
             src: $0,

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -13,9 +13,6 @@
 
 // REQUIRES: executable_test
 
-// FIXME(NCG): This test requires NoncopyableGenerics to be a "suppressible" compiler feature.
-// XFAIL: !noncopyable_generics
-
 //--- header.h
 
 #include <stdio.h>

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -5,9 +5,6 @@
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi)
 // RUN: %check-interop-cxx-header-in-clang(%t/Swift.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-private-field -Wno-unused-function -Wc++98-compat-extra-semi -DDEBUG=1)
 
-// FIXME(NCG): This test requires NoncopyableGenerics to be a "suppressible" compiler feature.
-// XFAIL: !noncopyable_generics
-
 // CHECK: namespace swift SWIFT_PRIVATE_ATTR SWIFT_SYMBOL_MODULE("swift") {
 
 // CHECK: template<class T_0_0>

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -106,3 +106,6 @@ extension Outer.InnerStruct {
 
 @_preInverseGenerics
 public func old_swap<T: ~Copyable>(_ a: inout T, _ b: inout T) {}
+
+@_preInverseGenerics
+public func borrowsNoncopyable<T: ~Copyable>(_ t: borrowing T) {}

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -109,3 +109,6 @@ public func old_swap<T: ~Copyable>(_ a: inout T, _ b: inout T) {}
 
 @_preInverseGenerics
 public func borrowsNoncopyable<T: ~Copyable>(_ t: borrowing T) {}
+
+@_disallowFeatureSuppression(NoncopyableGenerics)
+public func suppressesNoncopyableGenerics<T: ~Copyable>(_ t: borrowing T) {}

--- a/test/ModuleInterface/isolated_any_suppression.swift
+++ b/test/ModuleInterface/isolated_any_suppression.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -module-name isolated_any -emit-module -o %t/isolated_any.swiftmodule -emit-module-interface-path -  -enable-experimental-feature IsolatedAny %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -module-name isolated_any -emit-module -o %t/isolated_any.swiftmodule -emit-module-interface-path -  -enable-experimental-feature IsolatedAny2 %s | %FileCheck %s
 
 // CHECK:      #if compiler(>=5.3) && $IsolatedAny
 // CHECK-NEXT: {{^}}public func test1(fn: @isolated(any) @Sendable () -> ())

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -156,6 +156,11 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC-NEXT: public func borrowsNoncopyable<T>(_ t: T)
 // CHECK-MISC-NEXT: #endif
 
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: public func suppressesNoncopyableGenerics<T>(_ t: borrowing T) where T : ~Copyable
+// CHECK-MISC-NEXT: #endif
+
+
 import Swiftskell
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -144,7 +144,17 @@ import NoncopyableGenerics_Misc
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-MISC-NEXT: @_preInverseGenerics public func old_swap<T>(_ a: inout T, _ b: inout T) where T : ~Copyable
+// CHECK-MISC-NEXT: #else
+// CHECK-MISC-NOT: @_preInverseGenerics
+// CHECK-MISC-NEXT: public func old_swap<T>(_ a: inout T, _ b: inout T)
 // CHECK-MISC: #endif
+
+// CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
+// CHECK-MISC-NEXT: @_preInverseGenerics public func borrowsNoncopyable<T>(_ t: borrowing T) where T : ~Copyable
+// CHECK-MISC-NEXT: #else
+// CHECK-MISC-NOT: @_preInverseGenerics
+// CHECK-MISC-NEXT: public func borrowsNoncopyable<T>(_ t: T)
+// CHECK-MISC-NEXT: #endif
 
 import Swiftskell
 

--- a/test/ModuleInterface/retroactive-conformances.swift
+++ b/test/ModuleInterface/retroactive-conformances.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s
-// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
 // RUN: %FileCheck %s < %t.swiftinterface
 
 // CHECK: #if compiler(>=5.3) && $RetroactiveAttribute
@@ -19,4 +19,13 @@
 // CHECK: #endif
 extension Int: @retroactive Identifiable {
     public var id: Int { self }
+}
+
+// CHECK: #if compiler(>=5.3) && $RetroactiveAttribute
+// CHECK: extension Swift.String : @retroactive Swift.Identifiable {
+// CHECK-NOT: #else
+// CHECK: #endif
+@_disallowFeatureSuppression(RetroactiveAttribute)
+extension String: @retroactive Identifiable {
+    public var id: String { self }
 }

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -712,10 +712,17 @@ Func withExtendedLifetime(_:_:) has generic signature change from <T, Result> to
 Func withExtendedLifetime(_:_:) has mangled name changing from 'Swift.withExtendedLifetime<A, B>(A, () throws -> B) throws -> B' to 'Swift.withExtendedLifetime<A, B where A: ~Swift.Copyable, B: ~Swift.Copyable>(A, () throws -> B) throws -> B'
 Func withExtendedLifetime(_:_:) has parameter 0 changing from Default to Shared
 Func withExtendedLifetime(_:_:) is now with @_preInverseGenerics
-Func withUnsafeBytes(of:_:) has been removed
-Func withUnsafeMutableBytes(of:_:) has been removed
-Func withUnsafeMutablePointer(to:_:) has been removed
-Func withUnsafePointer(to:_:) has been removed
+Func withUnsafeBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeBytes(of:_:)
+Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeBytes(of:_:) has mangled name changing from 'Swift.withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeBytes<A, B>(of: inout A, _: (Swift.UnsafeRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeMutableBytes(of:_:) has been renamed to Func __abi_se0413_withUnsafeMutableBytes(of:_:)
+Func withUnsafeMutableBytes(of:_:) has mangled name changing from 'Swift.withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeMutableRawBufferPointer) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutableBytes<A, B>(of: inout A, _: (Swift.UnsafeMutableRawBufferPointer) throws -> B) throws -> B'
+Func withUnsafeMutablePointer(to:_:) has been renamed to Func __abi_se0413_withUnsafeMutablePointer(to:_:)
+Func withUnsafeMutablePointer(to:_:) has mangled name changing from 'Swift.withUnsafeMutablePointer<A, B>(to: inout A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafeMutablePointer<A, B>(to: inout A, _: (Swift.UnsafeMutablePointer<A>) throws -> B) throws -> B'
+Func withUnsafePointer(to:_:) has been renamed to Func __abi_se0413_withUnsafePointer(to:_:)
+Func withUnsafePointer(to:_:) has been renamed to Func __abi_withUnsafePointer(to:_:)
+Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_withUnsafePointer<A, B>(to: A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
+Func withUnsafePointer(to:_:) has mangled name changing from 'Swift.withUnsafePointer<A, B>(to: inout A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B' to 'Swift.__abi_se0413_withUnsafePointer<A, B>(to: inout A, _: (Swift.UnsafePointer<A>) throws -> B) throws -> B'
 Protocol _Pointer has generic signature change from <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable> to <Self : Swift.CustomDebugStringConvertible, Self : Swift.CustomReflectable, Self : Swift.Hashable, Self : Swift.Strideable, Self : Swift._BitwiseCopyable, Self.Pointee : ~Copyable>
 Struct ManagedBufferPointer has generic signature change from <Header, Element> to <Header, Element where Element : ~Copyable>
 Struct UnsafeBufferPointer has generic signature change from <Element> to <Element where Element : ~Copyable>


### PR DESCRIPTION
- **Explanation:** The `.swiftinterface` of the standard library must remain compatible with some older compilers. Recently, the introduction of code to the stdlib using several new compiler features (typed throws, non-copyable generics, and `@isolated(any)`) has broken backward compatibility. These changes repair the `Swift` and `_Concurrency` module `.swiftinterface`s so that specific older versions of the compiler can build them.
- **Scope:** Affects `.swiftinterface` printing for all modules. This must be fixed in Swift 6 to support important development workflows for users of the in-development toolchain.
- **Issue/Radar:**  rdar://125138945
- **Original PRs:** https://github.com/apple/swift/pull/72604, https://github.com/apple/swift/pull/72608, https://github.com/apple/swift/pull/72612, https://github.com/apple/swift/pull/72645
- **Risk:** Medium. The intent is to make the minimum changes necessary to support older compilers. However, this volume of changes cannot realistically be described as low risk. The main risk would be that these changes affect swiftinterface printing adversely for modules that are not the stdlib modules.
- **Testing:** Tested compatibility of the resulting stdlib `.swiftinterfaces` directly by compiling a simple program against them using the older compilers. 
- **Reviewer:** @DougGregor 