### PR TITLE
Fix typos in benchmark

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -13,7 +13,7 @@
 #
 # ===---------------------------------------------------------------------===//
 """
-Benchmark_Driver is a tool for running and analysing Swift Benchmarking Suite.
+Benchmark_Driver is a tool for running and analyzing Swift Benchmarking Suite.
 
 Example:
     $ Benchmark_Driver run

--- a/benchmark/scripts/compare_perf_tests.py
+++ b/benchmark/scripts/compare_perf_tests.py
@@ -564,7 +564,7 @@ class TestComparator(object):
     It determines which tests were `added`, `removed` and which can be
     compared. It then splits the `ResultComparison`s into 3 groups according to
     the `delta_threshold` by the change in performance: `increased`,
-    `descreased` and `unchanged`. Whole computation is performed during
+    `decreased` and `unchanged`. Whole computation is performed during
     initialization and results are provided as properties on this object.
 
     The lists of `added`, `removed` and `unchanged` tests are sorted


### PR DESCRIPTION
1. analysing -> analy `z` ing
2. de `s` creased -> decreased

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->