### PR TITLE
utils: Remove redundant if-statement in build.ps1

### DIFF
--- a/utils/build.ps1
+++ b/utils/build.ps1
@@ -1925,9 +1925,6 @@ try {
 
 if (-not $SkipBuild) {
   Fetch-Dependencies
-}
-
-if (-not $SkipBuild) {
   Invoke-BuildStep Build-CMark $HostArch
   Invoke-BuildStep Build-BuildTools $HostArch
   Invoke-BuildStep Build-Compilers $HostArch


### PR DESCRIPTION
Removes a redundant if-statement in utils/build.ps1