### PR TITLE
[build-toolchain] Add the ability to specify that a toolchain should only build macOS.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1371,6 +1371,14 @@ installable-package=%(installable_package)s
 [preset: mixin_osx_package,use_os_runtime]:
 darwin-toolchain-require-use-os-runtime=1
 
+[preset: mixin_osx_package,macos_only]:
+skip-build-ios
+skip-test-ios
+skip-build-tvos
+skip-test-tvos
+skip-build-watchos
+skip-test-watchos
+
 [preset: buildbot_osx_package]
 mixin-preset=
     mixin_osx_package_base
@@ -1389,6 +1397,11 @@ lldb-configure-tests=0
 mixin-preset=
     buildbot_osx_package
     mixin_osx_package,use_os_runtime
+
+[preset: buildbot_osx_package,macos_only]
+mixin-preset=
+    buildbot_osx_package
+    mixin_osx_package,macos_only
 
 [preset: buildbot_osx_package,no_assertions]
 mixin-preset=
@@ -1472,6 +1485,13 @@ skip-test-swiftdocc
 mixin-preset=
     buildbot_osx_package
     mixin_buildbot_osx_package,no_test
+
+# macOS package with out test
+[preset: buildbot_osx_package,no_test,macos_only]
+mixin-preset=
+    buildbot_osx_package
+    mixin_buildbot_osx_package,no_test
+    mixin_osx_package,macos_only
 
 # macOS package without test that when linked against uses the OS runtime
 # instead of the toolchain runtime.

--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -35,6 +35,9 @@ function usage() {
   echo "--preset-prefix"
   echo "Customize the preset invoked by prepending a prefix"
   echo ""
+  echo "--macos-only"
+  echo "On Darwin, only build for macOS instead of for all platforms"
+  echo ""
   echo "--use-os-runtime"
   echo "Require this toolchain to link against the OS runtime rather than the toolchains packaged runtime"
   echo ""
@@ -52,6 +55,7 @@ PRESET_FILE_FLAGS=
 PRESET_PREFIX=
 NO_TEST=",no_test"
 USE_OS_RUNTIME=
+MACOS_ONLY=
 
 case $(uname -s) in
   Darwin)
@@ -94,6 +98,9 @@ while [ $# -ne 0 ]; do
   ;;
     --use-os-runtime)
       USE_OS_RUNTIME=",use_os_runtime"
+  ;;
+    --macos-only)
+      MACOS_ONLY=",macos_only"
   ;;
   -h|--help)
     usage
@@ -145,7 +152,7 @@ SCCACHE_FLAG="${SCCACHE_FLAG}"
 
 ./utils/build-script ${DRY_RUN} ${DISTCC_FLAG} ${PRESET_FILE_FLAGS} \
         ${SCCACHE_FLAG} \
-        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_TEST}${USE_OS_RUNTIME}" \
+        --preset="${PRESET_PREFIX}${SWIFT_PACKAGE}${NO_TEST}${USE_OS_RUNTIME}${MACOS_ONLY}" \
         install_destdir="${SWIFT_INSTALL_DIR}" \
         installable_package="${SWIFT_INSTALLABLE_PACKAGE}" \
         install_toolchain_dir="${SWIFT_TOOLCHAIN_DIR}" \


### PR DESCRIPTION
This is useful when one only has to repro something on macOS, needs a toolchain, and wants to save some build time.
