### PR TITLE
[6.0] Serialization: Harden recovery from broken deserialization context 

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3810,14 +3810,22 @@ public:
       AddAttribute(new (ctx) HasStorageAttr(/*isImplicit:*/true));
 
     if (opaqueReturnTypeID) {
+      auto opaqueReturnType = MF.getDeclChecked(opaqueReturnTypeID);
+      if (!opaqueReturnType)
+        return opaqueReturnType.takeError();
+
       ctx.evaluator.cacheOutput(
           OpaqueResultTypeRequest{var},
-          cast<OpaqueTypeDecl>(MF.getDecl(opaqueReturnTypeID)));
+          cast<OpaqueTypeDecl>(opaqueReturnType.get()));
     }
 
     // If this is a lazy property, record its backing storage.
     if (lazyStorageID) {
-      VarDecl *storage = cast<VarDecl>(MF.getDecl(lazyStorageID));
+      auto lazyStorageDecl = MF.getDeclChecked(lazyStorageID);
+      if (!lazyStorageDecl)
+        return lazyStorageDecl.takeError();
+
+      VarDecl *storage = cast<VarDecl>(lazyStorageDecl.get());
       ctx.evaluator.cacheOutput(
           LazyStoragePropertyRequest{var}, std::move(storage));
     }

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3469,7 +3469,10 @@ public:
       }
     }
 
-    auto DC = MF.getDeclContext(contextID);
+    auto DCOrError = MF.getDeclContextChecked(contextID);
+    if (!DCOrError)
+      return DCOrError.takeError();
+    auto DC = DCOrError.get();
     if (declOrOffset.isComplete())
       return declOrOffset;
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -873,7 +873,11 @@ ProtocolConformanceDeserializer::readInheritedProtocolConformance(
   InheritedProtocolConformanceLayout::readRecord(scratch, conformanceID,
                                                  conformingTypeID);
 
-  Type conformingType = MF.getType(conformingTypeID);
+  auto conformingTypeOrError =
+    MF.getTypeChecked(conformingTypeID);
+  if (!conformingTypeOrError)
+    return conformingTypeOrError.takeError();
+  Type conformingType = conformingTypeOrError.get();
 
   PrettyStackTraceType trace(ctx, "reading inherited conformance for",
                              conformingType);


### PR DESCRIPTION
Both SourceKit and LLDB deserialize swiftmodule files and trigger more issues than normal compilation. SourceKit supports swiftmodules with errors and may see more mismatching context, while LLDB force loading more dependencies which may be missing and leading to a different context. Fix a few issues encountered by these tools by passing up any error instead of crashing.

Scope: Affects the deserialization logic shared by the compiler, LLDB and SourceKit.
Issue: rdar://110026935&125188407
Original PR: #72561
Risk: Very low, this change will give a chance to the compiler to keep going where it currently crashes.
Testing: There are no new tests, the services used here are already widely tested.
Reviewer: @adrian-prantl 