### PR TITLE
[6.0] Frontend: Allow any experimental feature to be enabled when compiling a module

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -568,6 +568,7 @@ public:
   static bool doesActionGenerateIR(ActionType);
   static bool doesActionProduceOutput(ActionType);
   static bool doesActionProduceTextualOutput(ActionType);
+  static bool doesActionBuildModuleFromInterface(ActionType);
   static bool needsProperModuleName(ActionType);
   static file_types::ID formatForPrincipalOutputFileForAction(ActionType);
 };

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -227,8 +227,8 @@ bool ArgsToFrontendOptionsConverter::convert(
     Opts.RequestedAction = determineRequestedAction(Args);
   }
 
-  if (Opts.RequestedAction == FrontendOptions::ActionType::CompileModuleFromInterface ||
-      Opts.RequestedAction == FrontendOptions::ActionType::TypecheckModuleFromInterface) {
+  if (FrontendOptions::doesActionBuildModuleFromInterface(
+          Opts.RequestedAction)) {
     // The situations where we use this action, e.g. explicit module building and
     // generating prebuilt module cache, don't need synchronization. We should avoid
     // using lock files for them.
@@ -695,10 +695,8 @@ bool ArgsToFrontendOptionsConverter::
 
 bool ArgsToFrontendOptionsConverter::checkBuildFromInterfaceOnlyOptions()
     const {
-  if (Opts.RequestedAction !=
-          FrontendOptions::ActionType::CompileModuleFromInterface &&
-      Opts.RequestedAction !=
-          FrontendOptions::ActionType::TypecheckModuleFromInterface &&
+  if (!FrontendOptions::doesActionBuildModuleFromInterface(
+          Opts.RequestedAction) &&
       Opts.ExplicitInterfaceBuild) {
     Diags.diagnose(SourceLoc(),
                    diag::error_cannot_explicit_interface_build_in_mode);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -276,10 +276,8 @@ void CompilerInstance::recordPrimaryInputBuffer(unsigned BufID) {
 }
 
 bool CompilerInstance::setUpASTContextIfNeeded() {
-  if ((Invocation.getFrontendOptions().RequestedAction ==
-          FrontendOptions::ActionType::CompileModuleFromInterface ||
-      Invocation.getFrontendOptions().RequestedAction ==
-          FrontendOptions::ActionType::TypecheckModuleFromInterface) &&
+  if (FrontendOptions::doesActionBuildModuleFromInterface(
+          Invocation.getFrontendOptions().RequestedAction) &&
       !Invocation.getFrontendOptions().ExplicitInterfaceBuild) {
     // Compiling a module interface from source uses its own CompilerInstance
     // with options read from the input file. Don't bother setting up an

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -956,6 +956,47 @@ bool FrontendOptions::doesActionGenerateIR(ActionType action) {
   llvm_unreachable("unhandled action");
 }
 
+bool FrontendOptions::doesActionBuildModuleFromInterface(ActionType action) {
+  switch (action) {
+  case ActionType::CompileModuleFromInterface:
+  case ActionType::TypecheckModuleFromInterface:
+    return true;
+  case ActionType::NoneAction:
+  case ActionType::Parse:
+  case ActionType::DumpParse:
+  case ActionType::DumpInterfaceHash:
+  case ActionType::DumpAST:
+  case ActionType::PrintAST:
+  case ActionType::PrintASTDecl:
+  case ActionType::DumpScopeMaps:
+  case ActionType::DumpTypeRefinementContexts:
+  case ActionType::DumpTypeInfo:
+  case ActionType::Typecheck:
+  case ActionType::ResolveImports:
+  case ActionType::MergeModules:
+  case ActionType::EmitModuleOnly:
+  case ActionType::EmitPCH:
+  case ActionType::EmitSILGen:
+  case ActionType::EmitSIL:
+  case ActionType::EmitSIBGen:
+  case ActionType::EmitSIB:
+  case ActionType::EmitImportedModules:
+  case ActionType::EmitPCM:
+  case ActionType::DumpPCM:
+  case ActionType::ScanDependencies:
+  case ActionType::PrintVersion:
+  case ActionType::PrintFeature:
+  case ActionType::Immediate:
+  case ActionType::REPL:
+  case ActionType::EmitIRGen:
+  case ActionType::EmitIR:
+  case ActionType::EmitBC:
+  case ActionType::EmitAssembly:
+  case ActionType::EmitObject:
+    return false;
+  }
+  llvm_unreachable("unhandled action");
+}
 
 const PrimarySpecificPaths &
 FrontendOptions::getPrimarySpecificPathsForAtMostOnePrimary() const {

--- a/test/ModuleInterface/ExperimentalFeatures.swiftinterface
+++ b/test/ModuleInterface/ExperimentalFeatures.swiftinterface
@@ -1,0 +1,14 @@
+// swift-interface-format-version: 1.0
+// swift-module-flags: -module-name ExperimentalFeatures -enable-experimental-feature ParserRoundTrip
+
+// Building a module from this interface should always succeed, even though
+// ParserRoundTrip is an experimental feature that is not enabled in production
+// compilers.
+
+// RUN: %target-swift-frontend -compile-module-from-interface -module-name ExperimentalFeatures -o /dev/null %s -verify
+// RUN: %target-swift-frontend -typecheck-module-from-interface -module-name ExperimentalFeatures %s -verify
+
+import Swift
+extension Int {
+  public static var fortytwo: Int = 42
+}


### PR DESCRIPTION
- **Explanation:** When building a module from its interface, do not diagnose whether or not a feature is available in production compilers. This is important since older compilers may be expected to build .swiftinterfaces that were produced by newer compilers where the feature has been enabled by default.
- **Scope:** Relaxes diagnostics when parsing `-enable-experimental-feature` command line options. This is important to include in Swift 6 to prevent a class of condfail that has become common.
- **Issue/Radar:** rdar://125500318
- **Original PR:** https://github.com/apple/swift/pull/72632
- **Risk:** Low.
- **Testing:** Added a test to the compiler test suite.
- **Reviewer:** @xymus 