### PR TITLE
[6.0][SIL] Adjust `isTypeMetadataForLayoutAccessible()` to visit more lowered positions

### DIFF
--- a/test/IRGen/variadic_generic_captures.swift
+++ b/test/IRGen/variadic_generic_captures.swift
@@ -65,3 +65,8 @@ public func has_witness_table_pack2<each T: Sequence>(t: repeat each T) -> () ->
     where repeat (each T).Element: Sequence {
   return { _ = (repeat (each T).Element.Element).self }
 }
+
+// https://github.com/apple/swift/issues/71455
+func f<each T>(t: (repeat each T)) {
+  let tup = (repeat ((each T).self, each t))
+}


### PR DESCRIPTION
## Cherry-pick of #71376 

- **Explanation:** Fixes an issue where `isTypeMetadataForLayoutAccessible()` in SIL did not visit lowered positions for pack expansion types, resulting in compiler crashes.
- **Scope**: Additive change in SIL.
- **Issue:** #71455, #67645,  rdar://119267393
- **Original PR:** #71376 
- **Risk:** Very Low
- **Testing:** Added a test case to the test suite. 
- **Reviewer:** @xedin 