### PR TITLE
6.0: [BitwiseCopyable] Loosen validation assertion.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3205,9 +3205,10 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
 
   if (!lowering.isTrivial() && conformance) {
     // A non-trivial type can have a conformance in a few cases:
-    // (1) contains a conforming archetype
+    // (1) containing or being a conforming archetype
     // (2) is resilient with minimal expansion
     // (3) containing or being ~Escapable
+    // (4) containing or being an opaque archetype
     bool hasNoConformingArchetypeNode = visitAggregateLeaves(
         origType, substType, forExpansion,
         /*isLeaf=*/
@@ -3255,6 +3256,11 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
           // An archetype may conform but be non-trivial (case (1)).
           if (origTy.isTypeParameter())
             return false;
+
+          // An opaque archetype may conform but be non-trivial (case (4)).
+          if (isa<OpaqueTypeArchetypeType>(ty)) {
+            return false;
+          }
 
           return true;
         });

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3203,7 +3203,8 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
     }
   }
 
-  if (!lowering.isTrivial() && conformance) {
+  if (!lowering.isTrivial() && conformance &&
+      !conformance.hasUnavailableConformance()) {
     // A non-trivial type can have a conformance in a few cases:
     // (1) containing or being a conforming archetype
     // (2) is resilient with minimal expansion

--- a/test/SILGen/bitwise_copyable.swift
+++ b/test/SILGen/bitwise_copyable.swift
@@ -51,3 +51,11 @@ func pass(_ e: E) { take(e) }
 func opacify() -> some _BitwiseCopyable {
     return Int()
 }
+
+struct NeverGoingToBeBitwiseCopyable {
+  var a: AnyObject
+}
+
+@available(*, unavailable)
+extension NeverGoingToBeBitwiseCopyable : _BitwiseCopyable {
+}

--- a/test/SILGen/bitwise_copyable.swift
+++ b/test/SILGen/bitwise_copyable.swift
@@ -47,3 +47,7 @@ public enum E : _BitwiseCopyable {
 func take<T : _BitwiseCopyable>(_ t: T) {}
 
 func pass(_ e: E) { take(e) }
+
+func opacify() -> some _BitwiseCopyable {
+    return Int()
+}


### PR DESCRIPTION
**Explanation**: Silence two wrong assertions during asserts-only BitwiseCopyable verification.
**Scope**: Affects asserts builds.
**Issue**: rdar://125443922
**Original PR**: https://github.com/apple/swift/pull/72600
**Risk**: Very low.
**Testing**: Added test cases that previously resulted in assertion failures.
**Reviewer**: Andrew Trick ( @atrick )

