### PR TITLE
[Demangle-to-AST] Match invertible-generics extensions with no signature

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1864,6 +1864,32 @@ public:
   /// the original nominal type context.
   bool isInSameDefiningModule() const;
 
+  /// Determine whether this extension is equivalent to one that requires at
+  /// at least some constraints to be written in the source.
+  ///
+  /// This result will differ from `isConstrainedExtension()` when any of
+  /// the generic parameters of the type are invertible, e.g.,
+  /// \code
+  /// struct X<T: ~Copyable>: ~Copyable { }
+  ///
+  /// // Implies `T: Copyable`. This extension `!isWrittenWithConstraints()`
+  /// // and `isConstrainedExtension()`.
+  /// extension X { }
+  ///
+  /// // This extension `isWrittenWithConstraints()`
+  /// // and `!isConstrainedExtension()`.
+  /// extension X where T: ~Copyable { }
+  ///
+  /// // Implies `T: Copyable`. This extension `isWrittenWithConstraints()`
+  /// // and `isConstrainedExtension()`.
+  /// extension X where T: P { }
+  ///
+  /// // This extension `isWrittenWithConstraints()`
+  /// // and `isConstrainedExtension()`.
+  /// extension X where T: Q, T: ~Copyable { }
+  /// \endcode
+  bool isWrittenWithConstraints() const;
+
   /// Returns the name of the category specified by the \c \@_objcImplementation
   /// attribute, or \c None if the name is invalid or
   /// \c isObjCImplementation() is false.

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1298,6 +1298,9 @@ ASTBuilder::findDeclContext(NodePointer node) {
         continue;
       }
 
+      if (!ext->isWrittenWithConstraints() && !genericSig)
+        return ext;
+
       auto extSig = ext->getGenericSignature().getCanonicalSignature();
       if (extSig == genericSig) {
         return ext;

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -62,6 +62,20 @@ extension XQ: Q where T: ~Copyable {
   struct A { }
 }
 
+protocol HasResult {
+  associatedtype Success
+}
+
+extension Result: HasResult {
+  func testMe() -> Success? {
+    var x: Result.Success? = nil
+    if case let .success(s) = self {
+      x = s
+    }
+    return x
+  }
+}
+
 // Class metadata
 
 @_fixed_layout


### PR DESCRIPTION
Introduce a predicate that determines when a given extension corresponds to what one would get by existing the nominal type without spelling out any constraints. This differs from the notion of a "constrained extension" when the nominal type suppresses conformances on any of its generic parameters, e.g.,

    struct X<T: ~Copyable> { ... }

    // doesn't spell out any constraints, but is constrained because it
    // implicitly adds T: ~Copyable.
    extension X { ... }

    // does spell out constraints, but is not constrained because the
    // generic signature matches that of X.
    extension X where T: ~Copyable { }

Use this predicate when demangling a name to metadata, because name mangling for extensions suppresses the generic signature for cases where one "doesn't spell out any constraints."

Fixes rdar://125515645, a source compatibility suite failure in swift-futures
