### PR TITLE
Concurrency: Declare explicit Failure typealiases on AsyncSequence iterators

### DIFF
--- a/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncCompactMapSequence.swift
@@ -94,6 +94,10 @@ extension AsyncCompactMapSequence: AsyncSequence {
   public struct Iterator: AsyncIteratorProtocol {
     public typealias Element = ElementOfResult
 
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropFirstSequence.swift
@@ -81,6 +81,10 @@ extension AsyncDropFirstSequence: AsyncSequence {
 
   /// The iterator that produces elements of the drop-first sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
     

--- a/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncDropWhileSequence.swift
@@ -90,6 +90,10 @@ extension AsyncDropWhileSequence: AsyncSequence {
 
   /// The iterator that produces elements of the drop-while sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFilterSequence.swift
@@ -80,6 +80,10 @@ extension AsyncFilterSequence: AsyncSequence {
 
   /// The iterator that produces elements of the filter sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncFlatMapSequence.swift
@@ -197,6 +197,10 @@ extension AsyncFlatMapSequence: AsyncSequence {
 
   /// The iterator that produces elements of the flat map sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncMapSequence.swift
+++ b/stdlib/public/Concurrency/AsyncMapSequence.swift
@@ -90,6 +90,10 @@ extension AsyncMapSequence: AsyncSequence {
 
   /// The iterator that produces elements of the map sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixSequence.swift
@@ -81,6 +81,10 @@ extension AsyncPrefixSequence: AsyncSequence {
 
   /// The iterator that produces elements of the prefix sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var baseIterator: Base.AsyncIterator
 

--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -85,6 +85,10 @@ extension AsyncPrefixWhileSequence: AsyncSequence {
 
   /// The iterator that produces elements of the prefix-while sequence.
   public struct Iterator: AsyncIteratorProtocol {
+    // FIXME: Remove when $AssociatedTypeImplements is no longer needed
+    @available(SwiftStdlib 6.0, *)
+    public typealias Failure = Base.Failure
+
     @usableFromInline
     var predicateHasFailed = false
 


### PR DESCRIPTION
Associated type inference ought to take care of providing the `Failure` typealias for these `AsyncIteratorProtocol` types. However, the inferred typealias is printed with `@_implements` in the `.swiftinterface`, guarded with the `$AssociatedTypeImplements` language feature guard, which means older compilers cannot see the typealias and therefore think the conformance is incomplete. To make sure the `_Concurrency` module's interface is backward compatible, we must manually define these typealiases temporarily.

Part of rdar://125138945