### PR TITLE
[BitwiseCopyable] Allow suppression via ~.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1628,17 +1628,29 @@ private:
   /// Whether there was an @preconcurrency attribute.
   bool IsPreconcurrency : 1;
 
+  /// Whether there was a ~ indicating suppression.
+  ///
+  /// This is true in cases like ~Copyable but not (P & ~Copyable).
+  bool IsSuppressed : 1;
+
 public:
   InheritedEntry(const TypeLoc &typeLoc);
 
   InheritedEntry(const TypeLoc &typeLoc, bool isUnchecked, bool isRetroactive,
-                 bool isPreconcurrency)
+                 bool isPreconcurrency, bool isSuppressed = false)
       : TypeLoc(typeLoc), IsUnchecked(isUnchecked),
-        IsRetroactive(isRetroactive), IsPreconcurrency(isPreconcurrency) {}
+        IsRetroactive(isRetroactive), IsPreconcurrency(isPreconcurrency),
+        IsSuppressed(isSuppressed) {}
 
   bool isUnchecked() const { return IsUnchecked; }
   bool isRetroactive() const { return IsRetroactive; }
   bool isPreconcurrency() const { return IsPreconcurrency; }
+  bool isSuppressed() const { return IsSuppressed; }
+
+  void setSuppressed() {
+    assert(!IsSuppressed && "setting suppressed again!?");
+    IsSuppressed = true;
+  }
 };
 
 /// A wrapper for the collection of inherited types for either a `TypeDecl` or
@@ -4435,6 +4447,8 @@ public:
   /// If you need a more precise answer, ask this Decl's corresponding
   /// Type if it `isEscapable` instead of using this.
   CanBeInvertible::Result canBeEscapable() const;
+
+  bool suppressesConformance(KnownProtocolKind kp) const;
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const Decl *D) {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7696,6 +7696,8 @@ ERROR(non_bitwise_copyable_type_indirect_enum_element,none,
       "enum with indirect case cannot conform to 'BitwiseCopyable'", ())
 NOTE(note_non_bitwise_copyable_type_indirect_enum_element,none,
      "indirect case is here", ())
+ERROR(non_bitwise_copyable_type_suppressed,none,
+      "cannot both conform to and suppress conformance to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_type_cxx_nontrivial,none,
       "non-trivial C++ type cannot conform to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_c_type_nontrivial,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7721,6 +7721,12 @@ NOTE(add_generic_parameter_non_bitwise_copyable_conformance,none,
 ERROR(bitwise_copyable_outside_module,none,
       "conformance to 'BitwiseCopyable' must occur in the same module as %kind0",
       (const ValueDecl *))
+ERROR(suppress_inferrable_protocol_extension,none,
+      "conformance to inferrable protocol %0 cannot be suppressed in an extension", (const ProtocolDecl *))
+ERROR(suppress_nonsuppressable_protocol,none,
+      "conformance to %0 cannot be suppressed", (const ProtocolDecl *))
+WARNING(suppress_already_suppressed_protocol,none,
+      "already suppressed conformance to %0", (const ProtocolDecl *))
 
 // -- older ones below --
 ERROR(noncopyable_parameter_requires_ownership, none,

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -150,7 +150,7 @@ PROTOCOL(FloatingPoint)
     INVERTIBLE_PROTOCOL_WITH_NAME(Name, #Name)
 #include "swift/ABI/InvertibleProtocols.def"
 
-PROTOCOL_(BitwiseCopyable)
+REPRESSIBLE_PROTOCOL_(BitwiseCopyable)
 
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "Array", false)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByBooleanLiteral, "BooleanLiteralType", true)

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -49,6 +49,16 @@
     PROTOCOL_WITH_NAME(Id, Name)
 #endif
 
+/// \def REPRESSIBLE_PROTOCOL_WITH_NAME(id, name)
+/// \param id the internal "enum name" of this protocol
+/// \param name a string literal with the external name of this protocol
+#ifndef REPRESSIBLE_PROTOCOL_WITH_NAME
+#define REPRESSIBLE_PROTOCOL_WITH_NAME(Id, Name) \
+    PROTOCOL_WITH_NAME(Id, Name)
+#endif
+
+#define REPRESSIBLE_PROTOCOL(name) REPRESSIBLE_PROTOCOL_WITH_NAME(name, #name)
+#define REPRESSIBLE_PROTOCOL_(name) REPRESSIBLE_PROTOCOL_WITH_NAME(name, "_" #name)
 
 #define PROTOCOL(name) PROTOCOL_WITH_NAME(name, #name)
 #define PROTOCOL_(name) PROTOCOL_WITH_NAME(name, "_" #name)
@@ -169,6 +179,9 @@ BUILTIN_EXPRESSIBLE_BY_LITERAL_PROTOCOL_(ExpressibleByBuiltinUnicodeScalarLitera
 #undef EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME
 #undef BUILTIN_EXPRESSIBLE_BY_LITERAL_PROTOCOL_
 #undef BUILTIN_EXPRESSIBLE_BY_LITERAL_PROTOCOL_WITH_NAME
+#undef REPRESSIBLE_PROTOCOL_WITH_NAME
+#undef REPRESSIBLE_PROTOCOL
+#undef REPRESSIBLE_PROTOCOL_
 #undef INVERTIBLE_PROTOCOL_WITH_NAME
 #undef PROTOCOL
 #undef PROTOCOL_

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -589,12 +589,16 @@ struct InheritedNominalEntry : Located<NominalTypeDecl *> {
   /// The location of the "preconcurrency" attribute if present.
   SourceLoc preconcurrencyLoc;
 
+  /// Whether this inherited entry was suppressed via "~".
+  bool isSuppressed;
+
   InheritedNominalEntry() { }
 
   InheritedNominalEntry(NominalTypeDecl *item, SourceLoc loc,
-                        SourceLoc uncheckedLoc, SourceLoc preconcurrencyLoc)
+                        SourceLoc uncheckedLoc, SourceLoc preconcurrencyLoc,
+                        bool isSuppressed)
       : Located(item, loc), uncheckedLoc(uncheckedLoc),
-        preconcurrencyLoc(preconcurrencyLoc) {}
+        preconcurrencyLoc(preconcurrencyLoc), isSuppressed(isSuppressed) {}
 };
 
 /// Retrieve the set of nominal type declarations that are directly

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -388,6 +388,9 @@ struct PrintOptions {
   /// Suppress printing of `borrowing` and `consuming`.
   bool SuppressNoncopyableOwnershipModifiers = false;
 
+  /// Suppress printing of '~Proto' for suppressible, non-invertible protocols.
+  bool SuppressConformanceSuppression = false;
+
   /// List of attribute kinds that should not be printed.
   std::vector<AnyAttrKind> ExcludeAttrList = {
       DeclAttrKind::Transparent, DeclAttrKind::Effects,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -16,23 +16,25 @@
 #ifndef SWIFT_TYPE_CHECK_REQUESTS_H
 #define SWIFT_TYPE_CHECK_REQUESTS_H
 
-#include "swift/AST/ActorIsolation.h"
-#include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/ASTTypeIDs.h"
+#include "swift/AST/ActorIsolation.h"
+#include "swift/AST/AnyFunctionRef.h"
 #include "swift/AST/CatchNode.h"
 #include "swift/AST/Effects.h"
+#include "swift/AST/Evaluator.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/GenericSignature.h"
-#include "swift/AST/Type.h"
-#include "swift/AST/Evaluator.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PluginRegistry.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SimpleRequest.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/Type.h"
 #include "swift/AST/TypeResolutionStage.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/Basic/TaggedUnion.h"
+#include "swift/Basic/TypeID.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/TinyPtrVector.h"
@@ -51,6 +53,7 @@ class DoCatchStmt;
 struct ExternalMacroDefinition;
 class ClosureExpr;
 class GenericParamList;
+class InverseTypeRepr;
 class LabeledStmt;
 class MacroDefinition;
 class PrecedenceGroupDecl;
@@ -78,13 +81,75 @@ void simple_display(
 
 void simple_display(llvm::raw_ostream &out, ASTContext *ctx);
 
+/// Emulates the following enum with associated values:
+/// enum InheritedTypeResult {
+///     case inherited(Type)
+///     case suppressed(Type, InverseTypeRepr *)
+///     case `default`
+/// }
+class InheritedTypeResult {
+  struct Inherited_ {
+    Type ty;
+  };
+  struct Suppressed_ {
+    // The type which is suppressed.  Not the result of inverting a protocol.
+    Type ty;
+    InverseTypeRepr *repr;
+  };
+  struct Default_ {};
+  using Payload = TaggedUnion<Inherited_, Suppressed_, Default_>;
+  Payload payload;
+  InheritedTypeResult(Payload payload) : payload(payload) {}
+
+public:
+  enum Kind { Inherited, Suppressed, Default };
+  static InheritedTypeResult forInherited(Type ty) { return {Inherited_{ty}}; }
+  static InheritedTypeResult forSuppressed(Type ty, InverseTypeRepr *repr) {
+    return {Suppressed_{ty, repr}};
+  }
+  static InheritedTypeResult forDefault() { return {Default_{}}; }
+  operator Kind() {
+    if (payload.isa<Inherited_>()) {
+      return Kind::Inherited;
+    } else if (payload.isa<Suppressed_>()) {
+      return Kind::Suppressed;
+    }
+    return Kind::Default;
+  }
+  explicit operator bool() { return !payload.isa<Default_>(); }
+  Type getInheritedTypeOrNull(ASTContext &ctx) {
+    switch (*this) {
+    case Inherited:
+      return getInheritedType();
+    case Suppressed: {
+      auto suppressed = getSuppressed();
+      auto kp = suppressed.first->getKnownProtocol();
+      if (!kp)
+        return Type();
+      auto ipk = getInvertibleProtocolKind(*kp);
+      if (!ipk)
+        return Type();
+      return ProtocolCompositionType::getInverseOf(ctx, *ipk);
+    }
+    case Default:
+      return Type();
+    }
+  }
+  Type getInheritedType() { return payload.get<Inherited_>().ty; }
+  std::pair<Type, InverseTypeRepr *> getSuppressed() {
+    auto &suppressed = payload.get<Suppressed_>();
+    return {suppressed.ty, suppressed.repr};
+  }
+};
+
 /// Request the type from the ith entry in the inheritance clause for the
 /// given declaration.
 class InheritedTypeRequest
     : public SimpleRequest<
           InheritedTypeRequest,
-          Type(llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *>,
-               unsigned, TypeResolutionStage),
+          InheritedTypeResult(
+              llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *>,
+              unsigned, TypeResolutionStage),
           RequestFlags::SeparatelyCached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -93,12 +158,13 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  Type
+  InheritedTypeResult
   evaluate(Evaluator &evaluator,
            llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
            unsigned index, TypeResolutionStage stage) const;
 
-  const TypeLoc &getTypeLoc() const;
+  const InheritedEntry &getInheritedEntry() const;
+  ASTContext &getASTContext() const;
 
 public:
   // Source location
@@ -106,8 +172,8 @@ public:
 
   // Caching
   bool isCached() const;
-  std::optional<Type> getCachedResult() const;
-  void cacheResult(Type value) const;
+  std::optional<InheritedTypeResult> getCachedResult() const;
+  void cacheResult(InheritedTypeResult value) const;
 };
 
 /// Request the superclass type for the given class.
@@ -4882,6 +4948,23 @@ private:
 
 public:
   // Caching.
+  bool isCached() const { return true; }
+};
+
+class SuppressesConformanceRequest
+    : public SimpleRequest<SuppressesConformanceRequest,
+                           bool(NominalTypeDecl *decl, KnownProtocolKind kp),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, NominalTypeDecl *decl,
+                KnownProtocolKind kp) const;
+
+public:
   bool isCached() const { return true; }
 };
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -568,3 +568,6 @@ SWIFT_REQUEST(TypeChecker, ImportDeclRequest,
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, LifetimeDependenceInfoRequest,
               LifetimeDependenceInfo(AbstractFunctionDecl *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SuppressesConformanceRequest,
+              bool(NominalTypeDecl *decl, KnownProtocolKind kp),
+              SeparatelyCached, NoLocationInfo)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -345,6 +345,9 @@ EXPERIMENTAL_FEATURE(ExtractConstantsFromMembers, false)
 /// Enable bitwise-copyable feature.
 EXPERIMENTAL_FEATURE(BitwiseCopyable, true)
 
+/// Enable the suppression of inferred, non-invertible, protocols via ~.
+SUPPRESSIBLE_EXPERIMENTAL_FEATURE(ConformanceSuppression, true)
+
 /// Enables the FixedArray data type.
 EXPERIMENTAL_FEATURE(FixedArrays, true)
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -163,6 +163,11 @@ public:
   // to ensure there's no parsing performance regression.
   bool EnabledNoncopyableGenerics;
 
+  bool canSuppressConformancesWithTilde() const {
+    return EnabledNoncopyableGenerics ||
+           Context.LangOpts.hasFeature(Feature::ConformanceSuppression);
+  }
+
   /// Whether we should delay parsing nominal type, extension, and function
   /// bodies.
   bool isDelayedParsingEnabled() const;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -130,6 +130,33 @@ void swift::simple_display(llvm::raw_ostream &out,
   out << getProtocolName(getKnownProtocolKind(value));
 }
 
+std::optional<RepressibleProtocolKind>
+swift::getRepressibleProtocolKind(KnownProtocolKind kp) {
+  switch (kp) {
+#define REPRESSIBLE_PROTOCOL_WITH_NAME(Id, Name)                               \
+  case KnownProtocolKind::Id:                                                  \
+    return RepressibleProtocolKind::Id;
+#include "swift/AST/KnownProtocols.def"
+  default:
+    return std::nullopt;
+  }
+}
+
+/// Returns the KnownProtocolKind corresponding to an RepressibleProtocolKind.
+KnownProtocolKind swift::getKnownProtocolKind(RepressibleProtocolKind ip) {
+  switch (ip) {
+#define REPRESSIBLE_PROTOCOL_WITH_NAME(Id, Name)                               \
+  case RepressibleProtocolKind::Id:                                            \
+    return KnownProtocolKind::Id;
+#include "swift/AST/KnownProtocols.def"
+  }
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                           const RepressibleProtocolKind &value) {
+  out << getProtocolName(getKnownProtocolKind(value));
+}
+
 // Metadata stores a 16-bit field for invertible protocols. Trigger a build
 // error when we assign the 15th bit so we can think about what to do.
 #define INVERTIBLE_PROTOCOL(Name, Bit) \

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -302,7 +302,14 @@ void ConformanceLookupTable::updateLookupTable(NominalTypeDecl *nominal,
           bool anyObject = false;
           for (const auto &found :
                   getDirectlyInheritedNominalTypeDecls(nominal, inverses, anyObject)) {
-            if (auto proto = dyn_cast<ProtocolDecl>(found.Item)) {
+            auto proto = dyn_cast<ProtocolDecl>(found.Item);
+            if (!proto)
+              continue;
+            auto kp = proto->getKnownProtocolKind();
+            assert(!found.isSuppressed ||
+                   kp.has_value() &&
+                       "suppressed conformance for non-known protocol!?");
+            if (!found.isSuppressed) {
               addProtocol(proto, found.Loc,
                           source.withUncheckedLoc(found.uncheckedLoc)
                                 .withPreconcurrencyLoc(found.preconcurrencyLoc));

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1678,7 +1678,8 @@ Type InheritedTypes::getResolvedType(unsigned i,
                         ? Decl.get<const ExtensionDecl *>()->getASTContext()
                         : Decl.get<const TypeDecl *>()->getASTContext();
   return evaluateOrDefault(ctx.evaluator, InheritedTypeRequest{Decl, i, stage},
-                           Type());
+                           InheritedTypeResult::forDefault())
+      .getInheritedTypeOrNull(getASTContext());
 }
 
 ExtensionDecl::ExtensionDecl(SourceLoc extensionLoc,
@@ -5372,6 +5373,13 @@ bool NominalTypeDecl::isAnyActor() const {
 bool NominalTypeDecl::isMainActor() const {
   return getName().is("MainActor") &&
          getParentModule()->getName() == getASTContext().Id_Concurrency;
+}
+
+bool NominalTypeDecl::suppressesConformance(KnownProtocolKind kp) const {
+  auto mutableThis = const_cast<NominalTypeDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           SuppressesConformanceRequest{mutableThis, kp},
+                           false);
 }
 
 GenericTypeDecl::GenericTypeDecl(DeclKind K, DeclContext *DC,

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -673,6 +673,42 @@ UNINTERESTING_FEATURE(BorrowingSwitch)
 
 UNINTERESTING_FEATURE(ClosureIsolation)
 
+static bool usesFeatureConformanceSuppression(Decl *decl) {
+  auto *nominal = dyn_cast<NominalTypeDecl>(decl);
+  if (!nominal)
+    return false;
+
+  auto inherited = InheritedTypes(nominal);
+  for (auto index : indices(inherited.getEntries())) {
+    // Ensure that InheritedTypeRequest has set the isSuppressed bit if
+    // appropriate.
+    auto resolvedTy = inherited.getResolvedType(index);
+    (void)resolvedTy;
+
+    auto entry = inherited.getEntry(index);
+
+    if (!entry.isSuppressed())
+      continue;
+
+    auto ty = entry.getType();
+
+    if (!ty)
+      continue;
+
+    auto kp = ty->getKnownProtocol();
+    if (!kp)
+      continue;
+
+    auto rpk = getRepressibleProtocolKind(*kp);
+    if (!rpk)
+      continue;
+
+    return true;
+  }
+
+  return false;
+}
+
 static bool usesFeatureIsolatedAny(Decl *decl) {
   return usesTypeMatching(decl, [](Type type) {
     if (auto fnType = type->getAs<AnyFunctionType>()) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6817,7 +6817,7 @@ ParserStatus Parser::parseInheritance(
       continue;
     }
 
-    if (!EnabledNoncopyableGenerics && Tok.isTilde()) {
+    if (!canSuppressConformancesWithTilde() && Tok.isTilde()) {
       ErrorTypeRepr *error = nullptr;
       if (parseTildeCopyable) {
         const auto &nextTok = peekToken(); // lookahead

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -312,7 +312,7 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
   // Wrap in an InverseTypeRepr if needed.
   if (tildeLoc) {
     TypeRepr *repr;
-    if (EnabledNoncopyableGenerics)
+    if (canSuppressConformancesWithTilde())
       repr = new (Context) InverseTypeRepr(tildeLoc, ty.get());
     else
       repr =

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3085,6 +3085,7 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
     // (7) being or containing a variadic generic type which doesn't conform
     //     unconditionally but does in this case
     // (8) being or containing the error type
+    // (9) explicitly suppressing conformance
     bool hasNoNonconformingNode = visitAggregateLeaves(
         origType, substType, forExpansion,
         /*isLeafAggregate=*/
@@ -3099,6 +3100,13 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
           // non-conformance; walk into the rest.
           if (!nominal)
             return false;
+
+          // A trivial type that suppresses conformance doesn't conform (case
+          // (9)).
+          if (nominal && nominal->suppressesConformance(
+                             KnownProtocolKind::BitwiseCopyable)) {
+            return true;
+          }
 
           // Nominals with fields that are generic may not conform
           // unconditionally (the only kind automatically derived currently)
@@ -3178,6 +3186,13 @@ void TypeConverter::verifyTrivialLowering(const TypeLowering &lowering,
                 << "of " << origType << "\n";
             assert(false);
             return true;
+          }
+
+          // A trivial type that suppresses conformance doesn't conform (case
+          // (9)).
+          if (nominal->suppressesConformance(
+                  KnownProtocolKind::BitwiseCopyable)) {
+            return false;
           }
 
           // A generic type may be trivial when instantiated with particular

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -229,6 +229,14 @@ void BitwiseCopyableStorageVisitor::emitNonconformingMemberTypeDiagnostic(
 static bool checkBitwiseCopyableInstanceStorage(NominalTypeDecl *nominal,
                                                 DeclContext *dc,
                                                 BitwiseCopyableCheck check) {
+  auto *conformanceDecl = dc->getAsDecl() ? dc->getAsDecl() : nominal;
+  if (nominal->suppressesConformance(KnownProtocolKind::BitwiseCopyable)) {
+    if (!isImplicit(check)) {
+      conformanceDecl->diagnose(diag::non_bitwise_copyable_type_suppressed);
+    }
+    return true;
+  }
+
   if (dc->mapTypeIntoContext(nominal->getDeclaredInterfaceType())
           ->isNoncopyable()) {
     // Already separately diagnosed when explicit.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -41,6 +41,7 @@
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/KnownProtocols.h"
 #include "swift/AST/MacroDefinition.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
@@ -87,6 +88,73 @@ static Type containsParameterizedProtocolType(Type inheritedTy) {
   return Type();
 }
 
+class CheckRepressions {
+  llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> declUnion;
+  ASTContext &ctx;
+
+  llvm::DenseSet<RepressibleProtocolKind> seen;
+
+public:
+  CheckRepressions(
+      llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> declUnion,
+      ASTContext &ctx)
+      : declUnion(declUnion), ctx(ctx) {}
+
+  template <typename... ArgTypes>
+  InFlightDiagnostic diagnoseInvalid(TypeRepr &repr, ArgTypes &&...Args) {
+    auto &diags = ctx.Diags;
+    repr.setInvalid();
+    return diags.diagnose(std::forward<ArgTypes>(Args)...);
+  }
+
+  /// Record the repressed kind indicated by the provided
+  /// InheritedTypeResult.Suppressed (i.e. \p ty and \p repr) if it is in fact
+  /// repressed or return the inverted type.
+  Type add(Type ty, InverseTypeRepr &repr,
+           llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl) {
+    if (!ty)
+      return Type();
+    assert(!ty->is<ExistentialMetatypeType>());
+    auto kp = ty->getKnownProtocol();
+    if (!kp) {
+      diagnoseInvalid(repr, repr.getLoc(), diag::inverse_type_not_invertible,
+                      ty);
+      return Type();
+    }
+    auto ipk = getInvertibleProtocolKind(*kp);
+    if (ipk) {
+      // Gate the '~Escapable' type behind a specific flag for now.
+      if (*ipk == InvertibleProtocolKind::Escapable &&
+          !ctx.LangOpts.hasFeature(Feature::NonescapableTypes)) {
+        diagnoseInvalid(repr, repr.getLoc(),
+                        diag::escapable_requires_feature_flag);
+        return ErrorType::get(ctx);
+      }
+
+      return ProtocolCompositionType::getInverseOf(ctx, *ipk);
+    }
+    auto rpk = getRepressibleProtocolKind(*kp);
+    if (!rpk) {
+      diagnoseInvalid(repr, repr.getLoc(),
+                      diag::suppress_nonsuppressable_protocol,
+                      ctx.getProtocol(*kp));
+      return Type();
+    }
+    if (auto *extension = dyn_cast<const ExtensionDecl *>(decl)) {
+      diagnoseInvalid(repr, extension,
+                      diag::suppress_inferrable_protocol_extension,
+                      ctx.getProtocol(*kp));
+      return Type();
+    }
+    if (!seen.insert(*rpk).second) {
+      diagnoseInvalid(repr, repr.getLoc(),
+                      diag::suppress_already_suppressed_protocol,
+                      ctx.getProtocol(getKnownProtocolKind(*rpk)));
+    }
+    return Type();
+  }
+};
+
 /// Check the inheritance clause of a type declaration or extension thereof.
 ///
 /// This routine performs detailed checking of the inheritance clause of the
@@ -126,6 +194,8 @@ static void checkInheritanceClause(
   ASTContext &ctx = decl->getASTContext();
   auto &diags = ctx.Diags;
 
+  CheckRepressions checkRepressions(declUnion, ctx);
+
   // Check all of the types listed in the inheritance clause.
   Type superclassTy;
   SourceRange superclassRange;
@@ -135,7 +205,26 @@ static void checkInheritanceClause(
 
     // Validate the type.
     InheritedTypeRequest request{declUnion, i, TypeResolutionStage::Interface};
-    Type inheritedTy = evaluateOrDefault(ctx.evaluator, request, Type());
+    auto result = evaluateOrDefault(ctx.evaluator, request,
+                                    InheritedTypeResult::forDefault());
+
+    Type inheritedTy;
+    switch (result) {
+    case InheritedTypeResult::Inherited:
+      inheritedTy = result.getInheritedType();
+      break;
+    case InheritedTypeResult::Suppressed: {
+      auto pair = result.getSuppressed();
+
+      auto inverted = checkRepressions.add(pair.first, *pair.second, declUnion);
+      if (!inverted)
+        continue;
+      inheritedTy = inverted;
+      break;
+    }
+    case InheritedTypeResult::Default:
+      continue;
+    }
 
     // If we couldn't resolve an the inherited type, or it contains an error,
     // ignore it.

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -26,7 +26,7 @@
 
 using namespace swift;
 
-Type InheritedTypeRequest::evaluate(
+InheritedTypeResult InheritedTypeRequest::evaluate(
     Evaluator &evaluator,
     llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> decl,
     unsigned index, TypeResolutionStage stage) const {
@@ -71,15 +71,26 @@ Type InheritedTypeRequest::evaluate(
     break;
   }
 
-  const TypeLoc &typeLoc = InheritedTypes(decl).getEntry(index);
+  const InheritedEntry &inheritedEntry = InheritedTypes(decl).getEntry(index);
 
   Type inheritedType;
-  if (typeLoc.getTypeRepr())
-    inheritedType = resolution->resolveType(typeLoc.getTypeRepr());
-  else
-    inheritedType = typeLoc.getType();
+  if (auto *typeRepr = inheritedEntry.getTypeRepr()) {
+    // Check for suppressed inferrable conformances.
+    if (auto itr = dyn_cast<InverseTypeRepr>(typeRepr)) {
+      Type inheritedTy = resolution->resolveType(itr->getConstraint());
+      return InheritedTypeResult::forSuppressed(inheritedTy, itr);
+    }
+    inheritedType = resolution->resolveType(typeRepr);
+  } else {
+    auto ty = inheritedEntry.getType();
+    if (inheritedEntry.isSuppressed()) {
+      return InheritedTypeResult::forSuppressed(ty, nullptr);
+    }
+    inheritedType = ty;
+  }
 
-  return inheritedType ? inheritedType : ErrorType::get(dc->getASTContext());
+  return InheritedTypeResult::forInherited(
+      inheritedType ? inheritedType : ErrorType::get(dc->getASTContext()));
 }
 
 Type
@@ -92,7 +103,8 @@ SuperclassTypeRequest::evaluate(Evaluator &evaluator,
   for (unsigned int idx : classDecl->getInherited().getIndices()) {
     auto result = evaluateOrDefault(evaluator,
                                     InheritedTypeRequest{classDecl, idx, stage},
-                                    Type());
+                                    InheritedTypeResult::forDefault())
+                      .getInheritedTypeOrNull(classDecl->getASTContext());
     if (!result)
       continue;
 
@@ -119,9 +131,12 @@ SuperclassTypeRequest::evaluate(Evaluator &evaluator,
 Type EnumRawTypeRequest::evaluate(Evaluator &evaluator,
                                   EnumDecl *enumDecl) const {
   for (unsigned int idx : enumDecl->getInherited().getIndices()) {
-    auto inheritedType = evaluateOrDefault(evaluator,
-        InheritedTypeRequest{enumDecl, idx, TypeResolutionStage::Interface},
-        Type());
+    auto inheritedType =
+        evaluateOrDefault(
+            evaluator,
+            InheritedTypeRequest{enumDecl, idx, TypeResolutionStage::Interface},
+            InheritedTypeResult::forDefault())
+            .getInheritedTypeOrNull(enumDecl->getASTContext());
     if (!inheritedType) continue;
 
     // Skip protocol conformances.
@@ -133,6 +148,30 @@ Type EnumRawTypeRequest::evaluate(Evaluator &evaluator,
 
   // No raw type.
   return Type();
+}
+
+bool SuppressesConformanceRequest::evaluate(Evaluator &evaluator,
+                                            NominalTypeDecl *nominal,
+                                            KnownProtocolKind kp) const {
+  auto inheritedTypes = InheritedTypes(nominal);
+  auto inheritedClause = inheritedTypes.getEntries();
+  for (unsigned i = 0, n = inheritedClause.size(); i != n; ++i) {
+    InheritedTypeRequest request{nominal, i, TypeResolutionStage::Interface};
+    auto result = evaluateOrDefault(evaluator, request,
+                                    InheritedTypeResult::forDefault());
+    if (result != InheritedTypeResult::Suppressed)
+      continue;
+    auto pair = result.getSuppressed();
+    auto ty = pair.first;
+    if (!ty)
+      continue;
+    auto other = ty->getKnownProtocol();
+    if (!other)
+      continue;
+    if (other == kp)
+      return true;
+  }
+  return false;
 }
 
 CustomAttr *

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 870; // borrowed-from instruction
+const uint16_t SWIFTMODULE_VERSION_MINOR = 871; // ~ for suppression
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3921,6 +3921,8 @@ public:
       typeRef = (typeRef << 1) | (inherited.isUnchecked() ? 0x01 : 0x00);
       // Encode "preconcurrency" in the low bit.
       typeRef = (typeRef << 1) | (inherited.isPreconcurrency() ? 0x01 : 0x00);
+      // Encode "suppressed" in the next bit.
+      typeRef = (typeRef << 1) | (inherited.isSuppressed() ? 0x01 : 0x00);
 
       result.push_back(typeRef);
     }

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -317,6 +317,7 @@ list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Freestand
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Extern")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BitwiseCopyable")
 list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "BorrowingSwitch")
+list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "ConformanceSuppression")
 
 if("${SWIFT_NATIVE_SWIFT_TOOLS_PATH}" STREQUAL "")
   set(swift_bin_dir "${CMAKE_BINARY_DIR}/bin")

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -19,8 +19,17 @@ internal func _swift_stdlib_getUnsafeArgvArgc(_: UnsafeMutablePointer<Int32>)
   -> UnsafeMutablePointer<UnsafeMutablePointer<Int8>?>
 
 /// Command-line arguments for the current process.
+#if $BitwiseCopyable && $ConformanceSuppression
 @frozen // namespace
-public enum CommandLine {}
+public enum CommandLine : ~_BitwiseCopyable {
+}
+#else
+@frozen // namespace
+public enum CommandLine {
+}
+@available(*, unavailable)
+extension CommandLine : _BitwiseCopyable {}
+#endif
 
 extension CommandLine {
   /// The backing static variable for argument count may come either from the
@@ -103,8 +112,5 @@ extension CommandLine {
     }
   }
 }
-
-@available(*, unavailable)
-extension CommandLine : _BitwiseCopyable {}
 
 #endif // SWIFT_STDLIB_HAS_COMMANDLINE

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -20,7 +20,9 @@ internal func _swift_stdlib_getUnsafeArgvArgc(_: UnsafeMutablePointer<Int32>)
 
 /// Command-line arguments for the current process.
 @frozen // namespace
-public enum CommandLine {
+public enum CommandLine {}
+
+extension CommandLine {
   /// The backing static variable for argument count may come either from the
   /// entry point or it may need to be computed e.g. if we're in the REPL.
   @usableFromInline

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -39,11 +39,15 @@
 ///     let pointPointer = UnsafeMutableRawPointer.allocate(
 ///             byteCount: count * MemoryLayout<Point>.stride,
 ///             alignment: MemoryLayout<Point>.alignment)
+#if $BitwiseCopyable && $ConformanceSuppression
+@frozen // namespace
+public enum MemoryLayout<T: ~Copyable>: ~_BitwiseCopyable, Copyable {}
+#else
 @frozen // namespace
 public enum MemoryLayout<T: ~Copyable>: Copyable {}
-
 @available(*, unavailable)
 extension MemoryLayout: _BitwiseCopyable {}
+#endif
 
 extension MemoryLayout where T: ~Copyable {
   /// The contiguous memory footprint of `T`, in bytes.

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -671,9 +671,11 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
 }
 
 /// A namespace for Unicode utilities.
+#if $BitwiseCopyable && $ConformanceSuppression
+@frozen
+public enum Unicode : ~_BitwiseCopyable {}
+#else
 @frozen
 public enum Unicode {}
-
-@available(*, unavailable)
-extension Unicode : _BitwiseCopyable {}
+#endif
 

--- a/test/ModuleInterface/invertible_constraints.swift
+++ b/test/ModuleInterface/invertible_constraints.swift
@@ -17,7 +17,7 @@ public protocol P: ~Copyable {
 }
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK: public struct X<T> : ~Copyable where T : ~Copyable {
+// CHECK: public struct X<T> : ~Swift.Copyable where T : ~Copyable {
 // CHECK: }
 // CHECK: #else
 // CHECK: public struct X<T> {
@@ -51,7 +51,7 @@ extension X where T: ~Copyable {
 }
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK: public enum Y<T> : ~Copyable where T : ~Copyable {
+// CHECK: public enum Y<T> : ~Swift.Copyable where T : ~Copyable {
 // CHECK:   case none
 // CHECK:   case some(T)
 // CHECK: }

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -80,13 +80,13 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC: public static func opaqueEscapable(_ s: some _NoEscapableP)
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: public struct ExplicitHello<T> : ~Copyable where T : ~Copyable {
+// CHECK-MISC-NEXT: public struct ExplicitHello<T> : ~Swift.Copyable where T : ~Copyable {
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-MISC-NEXT: extension {{.*}}.ExplicitHello : Swift.Copyable {
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: public struct Hello<T> : ~Copyable, ~Escapable where T : ~Copyable, T : ~Escapable {
+// CHECK-MISC-NEXT: public struct Hello<T> : ~Swift.Copyable, ~Swift.Escapable where T : ~Copyable, T : ~Escapable {
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-MISC-NEXT: extension NoncopyableGenerics_Misc.Hello : Swift.Escapable where T : ~Copyable {
@@ -119,12 +119,12 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC: public func checkAnyObject<Result>(_ t: Result) where Result : AnyObject
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: public struct Outer<A> : ~Copyable where A : ~Copyable {
+// CHECK-MISC-NEXT: public struct Outer<A> : ~Swift.Copyable where A : ~Copyable {
 // CHECK-MISC-NEXT:   public func innerFn<B>(_ b: borrowing B) where B : ~Copyable
-// CHECK-MISC:   public struct InnerStruct<C> : ~Copyable where C : ~Copyable {
+// CHECK-MISC:   public struct InnerStruct<C> : ~Swift.Copyable where C : ~Copyable {
 // CHECK-MISC-NEXT:     public func g<D>(_ d: borrowing D) where D : ~Copyable
-// CHECK-MISC:   public struct InnerVariation1<D> : ~Copyable, ~Escapable where D : ~Copyable
-// CHECK-MISC:   public struct InnerVariation2<D> : ~Copyable, ~Escapable where D : ~Escapable
+// CHECK-MISC:   public struct InnerVariation1<D> : ~Swift.Copyable, ~Swift.Escapable where D : ~Copyable
+// CHECK-MISC:   public struct InnerVariation2<D> : ~Swift.Copyable, ~Swift.Escapable where D : ~Escapable
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
 // CHECK-MISC-NEXT: extension {{.*}}.Outer : Swift.Copyable {
@@ -185,7 +185,7 @@ import Swiftskell
 // CHECK: #endif
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: public enum Either<Success, Failure> : ~Copyable where Failure : Swift.Error, Success : ~Copyable {
+// CHECK-NEXT: public enum Either<Success, Failure> : ~Swift.Copyable where Failure : Swift.Error, Success : ~Copyable {
 // CHECK: #endif
 
 /// This one is position dependent so we can ensure the associated type was printed correctly.
@@ -194,11 +194,11 @@ import Swiftskell
 // CHECK: #endif
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: public enum Pair<L, R> : ~Copyable where L : ~Copyable, R : ~Copyable {
+// CHECK-NEXT: public enum Pair<L, R> : ~Swift.Copyable where L : ~Copyable, R : ~Copyable {
 // CHECK: #endif
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-NEXT: public enum Maybe<Value> : ~Copyable where Value : ~Copyable {
+// CHECK-NEXT: public enum Maybe<Value> : ~Swift.Copyable where Value : ~Copyable {
 // CHECK: #endif
 
 // CHECK: #if compiler(>=5.3) && $NoncopyableGenerics

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -15,7 +15,7 @@ func more() {
   let _: ~AnyObject // expected-error {{type 'AnyObject' cannot be suppressed}}
 }
 
-struct S4: ~(Copyable & Equatable) {} // expected-error {{type 'Equatable' cannot be suppressed}}
+struct S4: ~(Copyable & Equatable) {} // expected-error {{conformance to 'Equatable' cannot be suppressed}}
 
 func blah<T>(_ t: borrowing T) where T: ~Copyable,
                                      T: ~Hashable {}  // expected-error@:41 {{type 'Hashable' cannot be suppressed}}

--- a/test/SILGen/bitwise_copyable.swift
+++ b/test/SILGen/bitwise_copyable.swift
@@ -1,8 +1,9 @@
-// RUN: %target-swift-frontend                           \
-// RUN:     %s                                           \
-// RUN:     -emit-silgen                                 \
-// RUN:     -disable-availability-checking               \
-// RUN:     -enable-experimental-feature BitwiseCopyable \
+// RUN: %target-swift-frontend                                  \
+// RUN:     %s                                                  \
+// RUN:     -emit-silgen                                        \
+// RUN:     -disable-availability-checking                      \
+// RUN:     -enable-experimental-feature ConformanceSuppression \
+// RUN:     -enable-experimental-feature BitwiseCopyable        \
 // RUN:     -enable-builtin-module
 
 // REQUIRES: asserts
@@ -59,3 +60,5 @@ struct NeverGoingToBeBitwiseCopyable {
 @available(*, unavailable)
 extension NeverGoingToBeBitwiseCopyable : _BitwiseCopyable {
 }
+
+struct AlsoNotBitwiseCopyable : ~_BitwiseCopyable {}

--- a/test/Sema/bitwise_copyable_2.swift
+++ b/test/Sema/bitwise_copyable_2.swift
@@ -1,7 +1,8 @@
-// RUN: %target-typecheck-verify-swift                       \
-// RUN:     -enable-experimental-feature NonescapableTypes   \
-// RUN:     -enable-experimental-feature BitwiseCopyable     \
-// RUN:     -enable-builtin-module                           \
+// RUN: %target-typecheck-verify-swift                          \
+// RUN:     -enable-experimental-feature NonescapableTypes      \
+// RUN:     -enable-experimental-feature ConformanceSuppression \
+// RUN:     -enable-experimental-feature BitwiseCopyable        \
+// RUN:     -enable-builtin-module                              \
 // RUN:     -debug-diagnostic-names
 
 // This test file only exists in order to test without noncopyable_generics and can be deleted once that is always enabled.
@@ -35,11 +36,14 @@ func take<T : _BitwiseCopyable>(_ t: T) {}
 func passInternalUsableStruct(_ s: InternalUsableStruct) { take(s) } // expected-error{{type_does_not_conform_decl_owner}}
                                                                      // expected-note@-8{{where_requirement_failure_one_subst}}
 
-func passMemoryLayout<T>(_ m: MemoryLayout<T>) { take(m) } // expected-error{{conformance_availability_unavailable}}
+func passMemoryLayout<T>(_ m: MemoryLayout<T>) { take(m) } // expected-error{{global function 'take' requires that 'MemoryLayout<T>' conform to '_BitwiseCopyable'}}
+                                                           // expected-note@-11{{where 'T' = 'MemoryLayout<T>'}}
 
-func passCommandLine(_ m: CommandLine) { take(m) } // expected-error{{conformance_availability_unavailable}}
+func passCommandLine(_ m: CommandLine) { take(m) } // expected-error{{global function 'take' requires that 'CommandLine' conform to '_BitwiseCopyable'}}
+                                                   // expected-note@-14{{where 'T' = 'CommandLine'}}
 
-func passUnicode(_ m: Unicode) { take(m) } // expected-error{{conformance_availability_unavailable}}
+func passUnicode(_ m: Unicode) { take(m) } // expected-error{{global function 'take' requires that 'Unicode' conform to '_BitwiseCopyable'}}
+                                           // expected-note@-17{{where 'T' = 'Unicode'}}
 
 import Builtin
 
@@ -62,3 +66,33 @@ enum E_Raw_String : String {
 }
 
 func passE_Raw_String(_ e: E_Raw_String) { take(e) }
+
+struct S_Suppressed : ~_BitwiseCopyable {
+  var i: Int
+}
+
+func passS_Suppressed(_ s: S_Suppressed) { take(s) } // expected-error{{global function 'take' requires that 'S_Suppressed' conform to '_BitwiseCopyable'}}
+                                                     // expected-note@-46{{where 'T' = 'S_Suppressed'}}
+
+struct S_Suppressed_Extension {}
+extension S_Suppressed_Extension : ~_BitwiseCopyable {} // expected-error{{conformance to inferrable protocol '_BitwiseCopyable' cannot be suppressed in an extension}}
+
+struct S_Explicit_Suppressed : _BitwiseCopyable, ~_BitwiseCopyable {} // expected-error{{cannot both conform to and suppress conformance to 'BitwiseCopyable'}}
+
+func passS_Explicit_Suppressed(_ s: S_Explicit_Suppressed) { take(s) }
+
+struct S_Suppressed_Explicit : ~_BitwiseCopyable, _BitwiseCopyable {} // expected-error{{cannot both conform to and suppress conformance to 'BitwiseCopyable'}}
+
+func passS_Explicit_Suppressed(_ s: S_Suppressed_Explicit) { take(s) }
+
+struct S_Suppressed_Twice : ~_BitwiseCopyable, ~_BitwiseCopyable {} // expected-warning{{already suppressed conformance to '_BitwiseCopyable'}}
+
+enum E : ~Equatable { // expected-error{{conformance to 'Equatable' cannot be suppressed}}
+  case i
+  case e
+  case io
+}
+
+enum E_Suppressed : ~_BitwiseCopyable {}
+
+extension E_Suppressed : _BitwiseCopyable {} // expected-error{{cannot both conform to and suppress conformance to 'BitwiseCopyable'}}


### PR DESCRIPTION
In addition to the existing language mechanism of `@available(*, unavailable)` on an extension.
