### PR TITLE
Add "_multithreaded" as valid `_runtime` argument

### DIFF
--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -111,6 +111,7 @@ static const SupportedConditionalValue SupportedConditionalCompilationPointerBit
 static const SupportedConditionalValue SupportedConditionalCompilationRuntimes[] = {
   "_ObjC",
   "_Native",
+  "_multithreaded",
 };
 
 static const SupportedConditionalValue SupportedConditionalCompilationTargetEnvironments[] = {
@@ -400,6 +401,16 @@ void LangOptions::setHasAtomicBitWidth(llvm::Triple triple) {
   }
 }
 
+static bool isMultiThreadedRuntime(llvm::Triple triple) {
+  if (triple.getOS() == llvm::Triple::WASI) {
+    return triple.getEnvironmentName() == "threads";
+  }
+  if (triple.getOSName() == "none") {
+    return false;
+  }
+  return true;
+}
+
 std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   clearAllPlatformConditionValues();
   clearAtomicBitWidths();
@@ -571,6 +582,11 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   if (tripleIsMacCatalystEnvironment(Target))
     addPlatformConditionValue(PlatformConditionKind::TargetEnvironment,
                               "macabi");
+
+  if (isMultiThreadedRuntime(Target)) {
+    addPlatformConditionValue(PlatformConditionKind::Runtime,
+                              "_multithreaded");
+  }
 
   // Set the "_hasHasAtomicBitWidth" platform condition.
   setHasAtomicBitWidth(triple);

--- a/test/Parse/ConditionalCompilation/noneOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/noneOSTarget.swift
@@ -1,0 +1,8 @@
+// RUN: %swift -typecheck %s -verify -target arm64-apple-none-macho -parse-stdlib
+// RUN: %swift-ide-test -test-input-complete -source-filename=%s -target arm64-apple-none-macho
+
+#if !_runtime(_multithreaded)
+  func underNoThreads() {
+    foo() // expected-error {{cannot find 'foo' in scope}}
+  }
+#endif

--- a/test/Parse/ConditionalCompilation/wasm32Target.swift
+++ b/test/Parse/ConditionalCompilation/wasm32Target.swift
@@ -8,3 +8,7 @@ var x = C()
 #endif
 #endif
 var y = x
+
+#if !_runtime(_multithreaded)
+  let z = xx // expected-error {{cannot find 'xx' in scope}}
+#endif

--- a/test/Parse/ConditionalCompilation/wasm32ThreadsTarget.swift
+++ b/test/Parse/ConditionalCompilation/wasm32ThreadsTarget.swift
@@ -1,0 +1,8 @@
+// RUN: %swift -typecheck %s -verify -target wasm32-unknown-wasip1-threads -parse-stdlib
+// RUN: %swift-ide-test -test-input-complete -source-filename=%s -target wasm32-unknown-wasip1-threads
+
+#if _runtime(_multithreaded)
+  func underThreads() {
+    foo() // expected-error {{cannot find 'foo' in scope}}
+  }
+#endif


### PR DESCRIPTION
This patch adds "threads" as a valid `targetEnvironment` argument and sets it when the target is `wasm32-unknown-wasi-threads`.
