### PR TITLE
[Demangler] Fix assertion failure.

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -3134,9 +3134,9 @@ NodePointer Demangler::demangleLifetimeDependenceKind(bool isSelfDependence) {
     return createNode(Node::Kind::SelfLifetimeDependence,
                       (Node::IndexType)kind);
   }
-  auto node = createNode(Node::Kind::ParamLifetimeDependence);
-  node->addChild(createNode(Node::Kind::Index, unsigned(kind)), *this);
-  node->addChild(popTypeAndGetChild(), *this);
+  auto node = createWithChildren(Node::Kind::ParamLifetimeDependence,
+                                 createNode(Node::Kind::Index, unsigned(kind)),
+                                 popTypeAndGetChild());
   return createType(node);
 }
 

--- a/test/Demangle/Inputs/objc-getclass.txt
+++ b/test/Demangle/Inputs/objc-getclass.txt
@@ -23,3 +23,6 @@ SlSIxip6/XXS*”PLEPÓd}}}}}}}
 
 # rdar://68449341
 ySfmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmf%mmmmmmmmmmmmmf%w
+
+# rdar://125350219
+8PDDoKcinYlistSi_natureNatur^natu`Dnat1


### PR DESCRIPTION
It's illegal to call `node->addChild()` with a `NULL` child argument; it's possible to construct unexpected `Node` trees by passing invalid manglings, and in this case that was causing `popTypeAndGetChild()` to fail (because the top node was not a `Type` node), which then meant that the call to `addChild` had a `NULL` child argument.

The simplest fix is to use `createWithChildren()` to do the node construction, because that function checks its arguments for `NULL`s.

rdar://125350219
