### PR TITLE
fix GroupInfo.json: was invalid JSON

### DIFF
--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -151,7 +151,7 @@
     "Builtin.swift",
     "VarArgs.swift",
     "CTypes.swift",
-    "MemoryLayout.swift",
+    "MemoryLayout.swift"
   ],
   "KeyPaths": [
     "KeyPath.swift"


### PR DESCRIPTION
JSON doesn't allow trailing commas in lists/objects but this file had one.

before:

```
$ jq . stdlib/public/core/GroupInfo.json
parse error: Expected another array element at line 155, column 3
```

after: works