### PR TITLE
TypeCheckType: Fix some bugs in the `any` syntax checker

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -184,6 +184,10 @@ public:
   /// opaque return type reprs.
   bool hasOpaque();
 
+  /// Returns a Boolean value indicating whether this written type is
+  /// parenthesized, that is, matches the following grammar: `'(' type ')'`.
+  bool isParenType() const;
+
   /// Retrieve the type repr without any parentheses around it.
   ///
   /// The use of this function must be restricted to contexts where

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -109,14 +109,18 @@ bool TypeRepr::hasOpaque() {
     findIf([](TypeRepr *ty) { return isa<OpaqueReturnTypeRepr>(ty); });
 }
 
+bool TypeRepr::isParenType() const {
+  auto *tuple = dyn_cast<TupleTypeRepr>(this);
+  return tuple && tuple->isParenType();
+}
+
 TypeRepr *TypeRepr::getWithoutParens() const {
-  auto *repr = const_cast<TypeRepr *>(this);
-  while (auto *tupleRepr = dyn_cast<TupleTypeRepr>(repr)) {
-    if (!tupleRepr->isParenType())
-      break;
-    repr = tupleRepr->getElementType(0);
+  auto *result = this;
+  while (result->isParenType()) {
+    result = cast<TupleTypeRepr>(result)->getElementType(0);
   }
-  return repr;
+
+  return const_cast<TypeRepr *>(result);
 }
 
 bool TypeRepr::isSimpleUnqualifiedIdentifier(Identifier identifier) const {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6085,14 +6085,14 @@ private:
       auto replacementIt = it;
 
       // Backtrack the stack and expand the replacement range to any parent
-      // `.Type` metatypes, skipping only parentheses.
+      // compositions or `.Type` metatypes, skipping only parentheses.
       do {
         --it;
         if ((*it)->isParenType()) {
           continue;
         }
 
-        if (isa<MetatypeTypeRepr>(*it)) {
+        if (isa<CompositionTypeRepr>(*it) || isa<MetatypeTypeRepr>(*it)) {
           replacementIt = it;
           continue;
         }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6057,7 +6057,9 @@ public:
   }
 
 private:
-  bool existentialNeedsParens(TypeRepr *parent) const {
+  /// Returns a Boolean value indicating whether the insertion of `any` before
+  /// a type representation with the given parent requires paretheses.
+  static bool anySyntaxNeedsParens(TypeRepr *parent) {
     switch (parent->getKind()) {
     case TypeReprKind::Optional:
     case TypeReprKind::Protocol:
@@ -6103,7 +6105,7 @@ private:
     bool needsParens = (exprCount != 0);
     if (reprStack.size() > 1) {
       auto parentIt = reprStack.end() - 2;
-      needsParens = existentialNeedsParens(*parentIt);
+      needsParens = anySyntaxNeedsParens(*parentIt);
 
       // Expand to include parenthesis before checking if the parent needs
       // to be replaced.
@@ -6115,7 +6117,7 @@ private:
       if ((*parentIt)->getKind() == TypeReprKind::Metatype) {
         replaceRepr = *parentIt;
         if (parentIt != reprStack.begin())
-          needsParens = existentialNeedsParens(*(parentIt - 1));
+          needsParens = anySyntaxNeedsParens(*(parentIt - 1));
       }
     }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -6037,6 +6037,7 @@ private:
   static bool anySyntaxNeedsParens(TypeRepr *parent) {
     switch (parent->getKind()) {
     case TypeReprKind::Optional:
+    case TypeReprKind::ImplicitlyUnwrappedOptional:
     case TypeReprKind::Protocol:
       return true;
     case TypeReprKind::Metatype:
@@ -6051,7 +6052,6 @@ private:
     case TypeReprKind::UnqualifiedIdent:
     case TypeReprKind::QualifiedIdent:
     case TypeReprKind::Dictionary:
-    case TypeReprKind::ImplicitlyUnwrappedOptional:
     case TypeReprKind::Inverse:
     case TypeReprKind::Tuple:
     case TypeReprKind::Fixed:

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -92,8 +92,6 @@ func what(one: ~Copyable..., // expected-error {{noncopyable type '~Copyable' ca
 
 struct A { struct B { struct C {} } }
 
-typealias Z0 = (~Copyable).Type // expected-error{{constraint that suppresses conformance requires 'any'}}{{17-17=any }}
-typealias Z1 = ~Copyable.Type // expected-error{{constraint that suppresses conformance requires 'any'}}{{16-16=any }}
 typealias Z2 = ~A.B.C // expected-error {{type 'A.B.C' cannot be suppressed}}
 typealias Z3 = ~A? // expected-error {{type 'A?' cannot be suppressed}}
 typealias Z4 = ~Rope<Int> // expected-error {{type 'Rope<Int>' cannot be suppressed}}
@@ -120,13 +118,8 @@ func typeInExpression() {
   _ = X<(borrowing any ~Copyable) -> Void>()
 
   _ = ~Copyable.self // expected-error{{unary operator '~' cannot be applied to an operand of type '(any Copyable).Type'}}
-  _ = (~Copyable).self // expected-error{{constraint that suppresses conformance requires 'any'}}{{8-8=any }}
   _ = (any ~Copyable).self
 }
 
-func param1(_ t: borrowing ~Copyable) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{28-28=any }}
-func param2(_ t: ~Copyable.Type) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{18-18=any }}
 func param3(_ t: borrowing any ~Copyable) {}
 func param4(_ t: any ~Copyable.Type) {}
-
-func param3(_ t: borrowing ExtraNoncopyProto & ~Copyable) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{28-28=any }}

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -103,9 +103,9 @@ struct DoesNotConform : Up {
 // Circular protocols
 
 protocol CircleMiddle : CircleStart { func circle_middle() }
-// expected-note@-1 2 {{protocol 'CircleMiddle' declared here}}
-protocol CircleStart : CircleEnd { func circle_start() } // expected-error 2 {{protocol 'CircleStart' refines itself}}
-protocol CircleEnd : CircleMiddle { func circle_end()} // expected-note 2 {{protocol 'CircleEnd' declared here}}
+// expected-note@-1 3 {{protocol 'CircleMiddle' declared here}}
+protocol CircleStart : CircleEnd { func circle_start() } // expected-error 3 {{protocol 'CircleStart' refines itself}}
+protocol CircleEnd : CircleMiddle { func circle_end()} // expected-note 3 {{protocol 'CircleEnd' declared here}}
 
 protocol CircleEntry : CircleTrivial { }
 protocol CircleTrivial : CircleTrivial { } // expected-error {{protocol 'CircleTrivial' refines itself}}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -419,6 +419,13 @@ func testAnyFixIt() {
   let _: (HasAssoc)?
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable)?
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
+  let _: HasAssoc!
+  // expected-error@+2 {{type '(any Copyable)?' cannot be suppressed}}
+  // expected-warning@+1 {{using '!' is not allowed here; treating this as '?' instead}}
+  let _: ~Copyable!
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
+  let _: (~Copyable)!
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=(any HasAssoc.Type)}}
   let _: HasAssoc.Type?
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=(any (~Copyable).Type)}}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -433,12 +433,16 @@ func testAnyFixIt() {
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
   let _: (borrowing ~Copyable) -> Void
   // https://github.com/apple/swift/issues/72588
-  // FIXME: No diagnostic.
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=any HasAssoc}}
   let _: any HasAssocGeneric<HasAssoc>
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{30-30=any }}
   let _: any HasAssocGeneric<~Copyable>
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{16-24=any HasAssoc}}
   let _: any G<HasAssoc>.HasAssoc_Alias
+  // FIXME: Generic argument not diagnosed.
   let _: any ~G<HasAssoc>.Copyable_Alias
   do {
+    // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{22-30=any HasAssoc}}
     func f(_: some G<HasAssoc>.HasAssoc_Alias) {}
   }
 
@@ -448,6 +452,7 @@ func testAnyFixIt() {
   // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
   // expected-error@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-40=any NonCopyableHasAssoc}}
   let _: (borrowing NonCopyableHasAssoc & ~Copyable) -> Void
+  let _: any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type // OK
 
   // Misplaced '?'.
 

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -451,13 +451,33 @@ func testAnyFixIt() {
     // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{22-30=any HasAssoc}}
     func f(_: some G<HasAssoc>.HasAssoc_Alias) {}
   }
+  // https://github.com/apple/swift/issues/65027
+  // expected-error@+2:10 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-29=any HasAssoc & HasAssoc}}
+  // expected-error@+1:21 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-29=any HasAssoc & HasAssoc}}
+  let _: HasAssoc & HasAssoc
+  // expected-error@+2:10 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1:22 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  let _: ~Copyable & ~Copyable
+  // expected-error@+3:10 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
+  // expected-error@+2:22 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
+  // expected-error@+1:33 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
+  let _: HasAssoc & (HasAssoc & HasAssoc)
+  // FIXME: Incorrect fix-its for nested composition.
+  // expected-error@+3:10 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+2:23 {{constraint that suppresses conformance requires 'any'}}{{23-23=any }}
+  // expected-error@+1:35 {{constraint that suppresses conformance requires 'any'}}{{23-23=any }}
+  let _: ~Copyable & (~Copyable & ~Copyable)
 
   // Misc. compound cases.
 
-  // FIXME: Incorrect fix-it for 'NonCopyableHasAssoc'.
   // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
-  // expected-error@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-40=any NonCopyableHasAssoc}}
+  // expected-error@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-52=any NonCopyableHasAssoc & ~Copyable}}
   let _: (borrowing NonCopyableHasAssoc & ~Copyable) -> Void
+  // FIXME: Incorrect fix-it.
+  // expected-error@+3:15 {{constraint that suppresses conformance requires 'any'}}{{15-15=any }}
+  // expected-error@+2:28 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
+  // expected-error@+1:51 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
+  let _: (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type?
   let _: any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type // OK
 
   // Misplaced '?'.

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -358,6 +358,8 @@ func testAnyFixIt() {
   let _: HasAssoc.Type
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
   let _: ~Copyable.Type
+  // expected-error@+1 {{type 'any Copyable.Type' cannot be suppressed}}
+  let _: ~(Copyable.Type)
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-25=any (HasAssoc).Type}}
   let _: (HasAssoc).Type
   // FIXME: Fix-it produces singleton, not existential, metatype type?
@@ -368,13 +370,18 @@ func testAnyFixIt() {
   // FIXME: Fix-it produces singleton, not existential, metatype type?
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{12-12=any }}
   let _: ((~Copyable)).Type
-  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-28=any HasAssoc.Type.Type}}
   let _: HasAssoc.Type.Type
   // expected-error@+1 {{type 'any Copyable.Type.Type' cannot be suppressed}}
   let _: ~Copyable.Type.Type
   // FIXME: Fix-it produces singleton, not existential, metatype type?
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
   let _: (~Copyable).Type.Type
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-30=any (HasAssoc.Type).Type}}
+  let _: (HasAssoc.Type).Type
+  // FIXME: Fix-it produces singleton, not existential, metatype type?
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable.Type).Type
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=(any HasAssoc)}}
   let _: HasAssoc.Protocol = HasAssoc.self
@@ -405,8 +412,7 @@ func testAnyFixIt() {
   // FIXME: Incorrect fix-it.
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
   let _: (~Copyable).Type.Protocol
-  // FIXME: Incorrect fix-it.
-  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-28=(any HasAssoc.Type.Type)}}
   let _: HasAssoc.Type.Type.Protocol
   // FIXME: Incorrect fix-it.
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -305,48 +305,48 @@ func testAnyFixIt() {
 
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=any HasAssoc}}
   let _: HasAssoc
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-19=any ~Copyable}}
   let _: ~Copyable
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
   let _: (HasAssoc)
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-21=any ~(Copyable)}}
   let _: ~(Copyable)
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{19-27=any HasAssoc}}
   let _: Optional<HasAssoc>
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{19-19=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{19-28=any ~Copyable}}
   let _: Optional<~Copyable>
   // FIXME: No fix-it + generic argument not diagnosed.
   // expected-error@+1 {{use of protocol 'HasAssocGeneric<any HasAssoc>' as a type must be written 'any HasAssocGeneric<any HasAssoc>'}}{{none}}
   let _: HasAssocGeneric<HasAssoc>
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{14-22=any HasAssoc}}
   let _: S.G<HasAssoc>
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{26-26=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{26-35=any ~Copyable}}
   let _: S.NonCopyable_G<~Copyable>
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   let _: G<HasAssoc>.S
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{24-24=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{24-33=any ~Copyable}}
   let _: NonCopyable_G<~Copyable>.S
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{24-32=any HasAssoc}}
   let _: G<HasAssoc>.G<HasAssoc>
-  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-24=any }}
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-49=any }}
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-33=any ~Copyable}}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-58=any ~Copyable}}
   let _: NonCopyable_G<~Copyable>.NonCopyable_G<~Copyable>
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{24-32=any HasAssoc}}
   let _: G<HasAssoc>.G<HasAssoc>.S
-  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-24=any }}
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-49=any }}
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-33=any ~Copyable}}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-58=any ~Copyable}}
   let _: NonCopyable_G<~Copyable>.NonCopyable_G<~Copyable>.S
   // expected-error@+1 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{10-26=any S.HasAssoc_Alias}}
   let _: S.HasAssoc_Alias
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-27=any ~S.Copyable_Alias}}
   let _: ~S.Copyable_Alias
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   // expected-error@+1 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{10-36=any G<HasAssoc>.HasAssoc_Alias}}
   let _: G<HasAssoc>.HasAssoc_Alias
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{13-21=any HasAssoc}}
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-37=any ~G<HasAssoc>.Copyable_Alias}}
   let _: ~G<HasAssoc>.Copyable_Alias
   // FIXME: No fix-it + generic argument not diagnosed.
   // expected-error@+1 {{use of 'HasAssocGeneric<any HasAssoc>' as a type must be written 'any HasAssocGeneric<any HasAssoc>}}{{none}}
@@ -356,31 +356,27 @@ func testAnyFixIt() {
   let _: HasAssoc.HasAssoc_Alias.Int_Alias
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
   let _: HasAssoc.Type
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-24=any ~Copyable.Type}}
   let _: ~Copyable.Type
   // expected-error@+1 {{type 'any Copyable.Type' cannot be suppressed}}
   let _: ~(Copyable.Type)
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-25=any (HasAssoc).Type}}
   let _: (HasAssoc).Type
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=any (~Copyable).Type}}
   let _: (~Copyable).Type
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-27=any ((HasAssoc)).Type}}
   let _: ((HasAssoc)).Type
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{12-12=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-28=any ((~Copyable)).Type}}
   let _: ((~Copyable)).Type
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-28=any HasAssoc.Type.Type}}
   let _: HasAssoc.Type.Type
   // expected-error@+1 {{type 'any Copyable.Type.Type' cannot be suppressed}}
   let _: ~Copyable.Type.Type
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-31=any (~Copyable).Type.Type}}
   let _: (~Copyable).Type.Type
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-30=any (HasAssoc.Type).Type}}
   let _: (HasAssoc.Type).Type
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-31=any (~Copyable.Type).Type}}
   let _: (~Copyable.Type).Type
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=(any HasAssoc)}}
@@ -390,12 +386,12 @@ func testAnyFixIt() {
   let _: (HasAssoc).Protocol = (HasAssoc).self
   // expected-error@+1 {{type '(any Copyable).Type' cannot be suppressed}}
   let _: ~Copyable.Protocol
-  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{34-34=any }}
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{34-43=any ~Copyable}}
   let _: (~Copyable).Protocol = (~Copyable).self
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc.Protocol.Type.Type
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable).Protocol.Type.Type
   do {
     let meta: S.Type
@@ -409,13 +405,11 @@ func testAnyFixIt() {
   let _: HasAssoc.Type.Protocol
   // expected-error@+1 {{type '(any Copyable.Type).Type' cannot be suppressed}}
   let _: ~Copyable.Type.Protocol
-  // FIXME: Incorrect fix-it.
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=(any (~Copyable).Type)}}
   let _: (~Copyable).Type.Protocol
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-28=(any HasAssoc.Type.Type)}}
   let _: HasAssoc.Type.Type.Protocol
-  // FIXME: Incorrect fix-it.
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-31=(any (~Copyable).Type.Type)}}
   let _: (~Copyable).Type.Type.Protocol
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc?
@@ -423,25 +417,24 @@ func testAnyFixIt() {
   let _: ~Copyable?
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
   let _: (HasAssoc)?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable)?
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=(any HasAssoc.Type)}}
   let _: HasAssoc.Type?
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=(any (~Copyable).Type)}}
   let _: (~Copyable).Type?
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc.Protocol?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable).Protocol?
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{21-29=any HasAssoc}}
   let _: (borrowing HasAssoc) -> Void
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{21-30=any ~Copyable}}
   let _: (borrowing ~Copyable) -> Void
   // https://github.com/apple/swift/issues/72588
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=any HasAssoc}}
   let _: any HasAssocGeneric<HasAssoc>
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{30-30=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{30-39=any ~Copyable}}
   let _: any HasAssocGeneric<~Copyable>
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{16-24=any HasAssoc}}
   let _: any G<HasAssoc>.HasAssoc_Alias
@@ -455,26 +448,24 @@ func testAnyFixIt() {
   // expected-error@+2:10 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-29=any HasAssoc & HasAssoc}}
   // expected-error@+1:21 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-29=any HasAssoc & HasAssoc}}
   let _: HasAssoc & HasAssoc
-  // expected-error@+2:10 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
-  // expected-error@+1:22 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+2:10 {{constraint that suppresses conformance requires 'any'}}{{10-31=any ~Copyable & ~Copyable}}
+  // expected-error@+1:22 {{constraint that suppresses conformance requires 'any'}}{{10-31=any ~Copyable & ~Copyable}}
   let _: ~Copyable & ~Copyable
   // expected-error@+3:10 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
   // expected-error@+2:22 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
   // expected-error@+1:33 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
   let _: HasAssoc & (HasAssoc & HasAssoc)
-  // FIXME: Incorrect fix-its for nested composition.
-  // expected-error@+3:10 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
-  // expected-error@+2:23 {{constraint that suppresses conformance requires 'any'}}{{23-23=any }}
-  // expected-error@+1:35 {{constraint that suppresses conformance requires 'any'}}{{23-23=any }}
+  // expected-error@+3:10 {{constraint that suppresses conformance requires 'any'}}{{10-45=any ~Copyable & (~Copyable & ~Copyable)}}
+  // expected-error@+2:23 {{constraint that suppresses conformance requires 'any'}}{{10-45=any ~Copyable & (~Copyable & ~Copyable)}}
+  // expected-error@+1:35 {{constraint that suppresses conformance requires 'any'}}{{10-45=any ~Copyable & (~Copyable & ~Copyable)}}
   let _: ~Copyable & (~Copyable & ~Copyable)
 
   // Misc. compound cases.
 
-  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{21-52=any NonCopyableHasAssoc & ~Copyable}}
   // expected-error@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-52=any NonCopyableHasAssoc & ~Copyable}}
   let _: (borrowing NonCopyableHasAssoc & ~Copyable) -> Void
-  // FIXME: Incorrect fix-it.
-  // expected-error@+3:15 {{constraint that suppresses conformance requires 'any'}}{{15-15=any }}
+  // expected-error@+3:15 {{constraint that suppresses conformance requires 'any'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
   // expected-error@+2:28 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
   // expected-error@+1:51 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
   let _: (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type?

--- a/test/type/explicit_existential.swift
+++ b/test/type/explicit_existential.swift
@@ -345,7 +345,7 @@ func testAnyFixIt() {
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   // expected-error@+1 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{10-36=any G<HasAssoc>.HasAssoc_Alias}}
   let _: G<HasAssoc>.HasAssoc_Alias
-  // FIXME: Generic argument not diagnosed.
+  // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{13-21=any HasAssoc}}
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
   let _: ~G<HasAssoc>.Copyable_Alias
   // FIXME: No fix-it + generic argument not diagnosed.
@@ -439,7 +439,7 @@ func testAnyFixIt() {
   let _: any HasAssocGeneric<~Copyable>
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{16-24=any HasAssoc}}
   let _: any G<HasAssoc>.HasAssoc_Alias
-  // FIXME: Generic argument not diagnosed.
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{17-25=any HasAssoc}}
   let _: any ~G<HasAssoc>.Copyable_Alias
   do {
     // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{22-30=any HasAssoc}}

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -483,13 +483,33 @@ func testAnyFixIt() {
     // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{22-30=any HasAssoc}}
     func f(_: some G<HasAssoc>.HasAssoc_Alias) {}
   }
+  // https://github.com/apple/swift/issues/65027
+  // expected-error@+2:10 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-29=any HasAssoc & HasAssoc}}
+  // expected-error@+1:21 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-29=any HasAssoc & HasAssoc}}
+  let _: HasAssoc & HasAssoc
+  // expected-error@+2:10 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1:22 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  let _: ~Copyable & ~Copyable
+  // expected-error@+3:10 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
+  // expected-error@+2:22 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
+  // expected-error@+1:33 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
+  let _: HasAssoc & (HasAssoc & HasAssoc)
+  // FIXME: Incorrect fix-its for nested composition.
+  // expected-error@+3:10 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+2:23 {{constraint that suppresses conformance requires 'any'}}{{23-23=any }}
+  // expected-error@+1:35 {{constraint that suppresses conformance requires 'any'}}{{23-23=any }}
+  let _: ~Copyable & (~Copyable & ~Copyable)
 
   // Misc. compound cases.
 
-  // FIXME: Incorrect fix-it for 'NonCopyableHasAssoc'.
   // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
-  // expected-error@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-40=any NonCopyableHasAssoc}}
+  // expected-error@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-52=any NonCopyableHasAssoc & ~Copyable}}
   let _: (borrowing NonCopyableHasAssoc & ~Copyable) -> Void
+  // FIXME: Incorrect fix-it.
+  // expected-error@+3:15 {{constraint that suppresses conformance requires 'any'}}{{15-15=any }}
+  // expected-error@+2:28 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
+  // expected-error@+1:51 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
+  let _: (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type?
   let _: any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type // OK
 
   // Misplaced '?'.

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -62,6 +62,9 @@ typealias T2 = any Pub & Bar
 protocol HasAssoc {
   associatedtype Assoc
   func foo()
+
+  typealias HasAssoc_Alias = HasAssoc
+  typealias Int_Alias = Int
 }
 
 do {
@@ -311,61 +314,185 @@ do {
   let _: Codable
 }
 
-func testAnyFixIt() {
-  struct ConformingType : HasAssoc {
-    typealias Assoc = Int
-    func foo() {}
+protocol HasAssocGeneric<Assoc> {
+  associatedtype Assoc
+}
 
-    func method() -> any HasAssoc {}
+protocol NonCopyableHasAssoc: ~Copyable {
+  associatedtype Assoc
+}
+
+func testAnyFixIt() {
+  struct S {
+    typealias HasAssoc_Alias = HasAssoc
+    typealias HasAssocGeneric_Alias = HasAssocGeneric
+    typealias Copyable_Alias = Copyable
+
+    typealias G<T> = Self
+    typealias NonCopyable_G<T: ~Copyable> = Self
+    typealias S = Self
   }
+  typealias G<T> = S
+  typealias NonCopyable_G<T: ~Copyable> = S
 
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=any HasAssoc}}
-  let _: HasAssoc = ConformingType()
+  let _: HasAssoc
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  let _: ~Copyable
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
+  let _: (HasAssoc)
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  let _: ~(Copyable)
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{19-27=any HasAssoc}}
-  let _: Optional<HasAssoc> = nil
+  let _: Optional<HasAssoc>
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{19-19=any }}
+  let _: Optional<~Copyable>
+  // FIXME: No fix-it + generic argument not diagnosed.
+  // expected-error@+1 {{use of protocol 'HasAssocGeneric<any HasAssoc>' as a type must be written 'any HasAssocGeneric<any HasAssoc>'}}{{none}}
+  let _: HasAssocGeneric<HasAssoc>
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{14-22=any HasAssoc}}
+  let _: S.G<HasAssoc>
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{26-26=any }}
+  let _: S.NonCopyable_G<~Copyable>
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
+  let _: G<HasAssoc>.S
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{24-24=any }}
+  let _: NonCopyable_G<~Copyable>.S
+  // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{24-32=any HasAssoc}}
+  let _: G<HasAssoc>.G<HasAssoc>
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-24=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-49=any }}
+  let _: NonCopyable_G<~Copyable>.NonCopyable_G<~Copyable>
+  // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{24-32=any HasAssoc}}
+  let _: G<HasAssoc>.G<HasAssoc>.S
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-24=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-49=any }}
+  let _: NonCopyable_G<~Copyable>.NonCopyable_G<~Copyable>.S
+  // expected-error@+1 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{10-26=any S.HasAssoc_Alias}}
+  let _: S.HasAssoc_Alias
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  let _: ~S.Copyable_Alias
+  // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
+  // expected-error@+1 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{10-36=any G<HasAssoc>.HasAssoc_Alias}}
+  let _: G<HasAssoc>.HasAssoc_Alias
+  // FIXME: Generic argument not diagnosed.
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  let _: ~G<HasAssoc>.Copyable_Alias
+  // FIXME: No fix-it + generic argument not diagnosed.
+  // expected-error@+1 {{use of 'HasAssocGeneric<any HasAssoc>' as a type must be written 'any HasAssocGeneric<any HasAssoc>}}{{none}}
+  let _: S.HasAssocGeneric_Alias<HasAssoc>
+  // FIXME: No diagnostic.
+  let _: HasAssoc.Int_Alias
+  let _: HasAssoc.HasAssoc_Alias.Int_Alias
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
-  let _: HasAssoc.Type = ConformingType.self
+  let _: HasAssoc.Type
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  let _: ~Copyable.Type
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-25=any (HasAssoc).Type}}
-  let _: (HasAssoc).Type = ConformingType.self
+  let _: (HasAssoc).Type
+  // FIXME: Fix-it produces singleton, not existential, metatype type?
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable).Type
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-27=any ((HasAssoc)).Type}}
-  let _: ((HasAssoc)).Type = ConformingType.self
+  let _: ((HasAssoc)).Type
+  // FIXME: Fix-it produces singleton, not existential, metatype type?
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{12-12=any }}
+  let _: ((~Copyable)).Type
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
+  let _: HasAssoc.Type.Type
+  // expected-error@+1 {{type 'any Copyable.Type.Type' cannot be suppressed}}
+  let _: ~Copyable.Type.Type
+  // FIXME: Fix-it produces singleton, not existential, metatype type?
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable).Type.Type
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=(any HasAssoc)}}
   let _: HasAssoc.Protocol = HasAssoc.self
+  // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{33-41=any HasAssoc}}
+  let _: (HasAssoc).Protocol = (HasAssoc).self
+  // expected-error@+1 {{type '(any Copyable).Type' cannot be suppressed}}
+  let _: ~Copyable.Protocol
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{34-34=any }}
+  let _: (~Copyable).Protocol = (~Copyable).self
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
+  let _: HasAssoc.Protocol.Type.Type
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable).Protocol.Type.Type
   do {
-    struct Wrapper {
-      typealias HasAssocAlias = HasAssoc
-    }
-    let wrapperMeta: Wrapper.Type
+    let meta: S.Type
     // FIXME: What is the correct fix-it for the initializer?
     //
-    // expected-error@+2:20 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{12-33=(any Wrapper.HasAssocAlias)}}
-    // expected-error@+1:57 {{use of 'Wrapper.HasAssocAlias' (aka 'HasAssoc') as a type must be written 'any Wrapper.HasAssocAlias' (aka 'any HasAssoc')}}{{57-70=(any HasAssocAlias)}}
-    let _: Wrapper.HasAssocAlias.Protocol = wrapperMeta.HasAssocAlias.self
+    // expected-error@+2:14 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{12-28=(any S.HasAssoc_Alias)}}
+    // expected-error@+1:45 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{45-59=(any HasAssoc_Alias)}}
+    let _: S.HasAssoc_Alias.Protocol = meta.HasAssoc_Alias.self
   }
-  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
-  let _: (HasAssoc).Protocol = (any HasAssoc).self
-  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
-  let _: HasAssoc? = ConformingType()
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=(any HasAssoc.Type)}}
-  let _: HasAssoc.Type? = ConformingType.self
+  let _: HasAssoc.Type.Protocol
+  // expected-error@+1 {{type '(any Copyable.Type).Type' cannot be suppressed}}
+  let _: ~Copyable.Type.Protocol
+  // FIXME: Incorrect fix-it.
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable).Type.Protocol
+  // FIXME: Incorrect fix-it.
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
+  let _: HasAssoc.Type.Type.Protocol
+  // FIXME: Incorrect fix-it.
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable).Type.Type.Protocol
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
-  let _: HasAssoc.Protocol? = (any HasAssoc).self
+  let _: HasAssoc?
+  // expected-error@+1 {{type '(any Copyable)?' cannot be suppressed}}
+  let _: ~Copyable?
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
+  let _: (HasAssoc)?
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable)?
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=(any HasAssoc.Type)}}
+  let _: HasAssoc.Type?
+  // FIXME: Fix-it produces singleton, not existential, metatype type?
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable).Type?
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
+  let _: HasAssoc.Protocol?
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable).Protocol?
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{21-29=any HasAssoc}}
+  let _: (borrowing HasAssoc) -> Void
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
+  let _: (borrowing ~Copyable) -> Void
+  // https://github.com/apple/swift/issues/72588
+  // FIXME: No diagnostic.
+  let _: any HasAssocGeneric<HasAssoc>
+  let _: any HasAssocGeneric<~Copyable>
+  let _: any G<HasAssoc>.HasAssoc_Alias
+  let _: any ~G<HasAssoc>.Copyable_Alias
+  do {
+    func f(_: some G<HasAssoc>.HasAssoc_Alias) {}
+  }
+
+  // Misc. compound cases.
+
+  // FIXME: Incorrect fix-it for 'NonCopyableHasAssoc'.
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
+  // expected-error@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-40=any NonCopyableHasAssoc}}
+  let _: (borrowing NonCopyableHasAssoc & ~Copyable) -> Void
+
+  // Misplaced '?'.
 
   // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc)?'}}{{10-23=(any HasAssoc)?}}
-  let _: any HasAssoc? = nil
+  let _: any HasAssoc?
+  // FIXME: Better recovery
+  // expected-error@+1 {{type '(any Copyable)?' cannot be suppressed}}
+  let _: any ~Copyable?
   // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc.Type)?'}}{{10-28=(any HasAssoc.Type)?}}
-  let _: any HasAssoc.Type? = nil
-
-  do {
-    struct Outer<T> {
-      struct Inner<U> {}
-    }
-
-    // expected-error@+2:18 {{must be written 'any HasAssoc'}}
-    // expected-error@+1:34 {{must be written 'any HasAssoc'}}
-    let _: Outer<HasAssoc>.Inner<HasAssoc>
-  }
+  let _: any HasAssoc.Type?
+  // FIXME: Better recovery
+  // expected-error@+1 {{type '(any Copyable.Type)?' cannot be suppressed}}
+  let _: any ~Copyable.Type?
 }
 
 func testNestedMetatype() {

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -337,48 +337,48 @@ func testAnyFixIt() {
 
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=any HasAssoc}}
   let _: HasAssoc
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-19=any ~Copyable}}
   let _: ~Copyable
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
   let _: (HasAssoc)
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-21=any ~(Copyable)}}
   let _: ~(Copyable)
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{19-27=any HasAssoc}}
   let _: Optional<HasAssoc>
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{19-19=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{19-28=any ~Copyable}}
   let _: Optional<~Copyable>
   // FIXME: No fix-it + generic argument not diagnosed.
   // expected-error@+1 {{use of protocol 'HasAssocGeneric<any HasAssoc>' as a type must be written 'any HasAssocGeneric<any HasAssoc>'}}{{none}}
   let _: HasAssocGeneric<HasAssoc>
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{14-22=any HasAssoc}}
   let _: S.G<HasAssoc>
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{26-26=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{26-35=any ~Copyable}}
   let _: S.NonCopyable_G<~Copyable>
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   let _: G<HasAssoc>.S
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{24-24=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{24-33=any ~Copyable}}
   let _: NonCopyable_G<~Copyable>.S
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{24-32=any HasAssoc}}
   let _: G<HasAssoc>.G<HasAssoc>
-  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-24=any }}
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-49=any }}
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-33=any ~Copyable}}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-58=any ~Copyable}}
   let _: NonCopyable_G<~Copyable>.NonCopyable_G<~Copyable>
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{24-32=any HasAssoc}}
   let _: G<HasAssoc>.G<HasAssoc>.S
-  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-24=any }}
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-49=any }}
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{24-33=any ~Copyable}}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{49-58=any ~Copyable}}
   let _: NonCopyable_G<~Copyable>.NonCopyable_G<~Copyable>.S
   // expected-error@+1 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{10-26=any S.HasAssoc_Alias}}
   let _: S.HasAssoc_Alias
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-27=any ~S.Copyable_Alias}}
   let _: ~S.Copyable_Alias
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   // expected-error@+1 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{10-36=any G<HasAssoc>.HasAssoc_Alias}}
   let _: G<HasAssoc>.HasAssoc_Alias
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{13-21=any HasAssoc}}
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-37=any ~G<HasAssoc>.Copyable_Alias}}
   let _: ~G<HasAssoc>.Copyable_Alias
   // FIXME: No fix-it + generic argument not diagnosed.
   // expected-error@+1 {{use of 'HasAssocGeneric<any HasAssoc>' as a type must be written 'any HasAssocGeneric<any HasAssoc>}}{{none}}
@@ -388,31 +388,27 @@ func testAnyFixIt() {
   let _: HasAssoc.HasAssoc_Alias.Int_Alias
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
   let _: HasAssoc.Type
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-24=any ~Copyable.Type}}
   let _: ~Copyable.Type
   // expected-error@+1 {{type 'any Copyable.Type' cannot be suppressed}}
   let _: ~(Copyable.Type)
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-25=any (HasAssoc).Type}}
   let _: (HasAssoc).Type
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=any (~Copyable).Type}}
   let _: (~Copyable).Type
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-27=any ((HasAssoc)).Type}}
   let _: ((HasAssoc)).Type
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{12-12=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-28=any ((~Copyable)).Type}}
   let _: ((~Copyable)).Type
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-28=any HasAssoc.Type.Type}}
   let _: HasAssoc.Type.Type
   // expected-error@+1 {{type 'any Copyable.Type.Type' cannot be suppressed}}
   let _: ~Copyable.Type.Type
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-31=any (~Copyable).Type.Type}}
   let _: (~Copyable).Type.Type
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-30=any (HasAssoc.Type).Type}}
   let _: (HasAssoc.Type).Type
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-31=any (~Copyable.Type).Type}}
   let _: (~Copyable.Type).Type
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=(any HasAssoc)}}
@@ -422,12 +418,12 @@ func testAnyFixIt() {
   let _: (HasAssoc).Protocol = (HasAssoc).self
   // expected-error@+1 {{type '(any Copyable).Type' cannot be suppressed}}
   let _: ~Copyable.Protocol
-  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{34-34=any }}
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{34-43=any ~Copyable}}
   let _: (~Copyable).Protocol = (~Copyable).self
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc.Protocol.Type.Type
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable).Protocol.Type.Type
   do {
     let meta: S.Type
@@ -441,13 +437,11 @@ func testAnyFixIt() {
   let _: HasAssoc.Type.Protocol
   // expected-error@+1 {{type '(any Copyable.Type).Type' cannot be suppressed}}
   let _: ~Copyable.Type.Protocol
-  // FIXME: Incorrect fix-it.
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=(any (~Copyable).Type)}}
   let _: (~Copyable).Type.Protocol
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-28=(any HasAssoc.Type.Type)}}
   let _: HasAssoc.Type.Type.Protocol
-  // FIXME: Incorrect fix-it.
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-31=(any (~Copyable).Type.Type)}}
   let _: (~Copyable).Type.Type.Protocol
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc?
@@ -455,25 +449,24 @@ func testAnyFixIt() {
   let _: ~Copyable?
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{11-19=any HasAssoc}}
   let _: (HasAssoc)?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable)?
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=(any HasAssoc.Type)}}
   let _: HasAssoc.Type?
-  // FIXME: Fix-it produces singleton, not existential, metatype type?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=(any (~Copyable).Type)}}
   let _: (~Copyable).Type?
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   let _: HasAssoc.Protocol?
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable).Protocol?
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{21-29=any HasAssoc}}
   let _: (borrowing HasAssoc) -> Void
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{21-30=any ~Copyable}}
   let _: (borrowing ~Copyable) -> Void
   // https://github.com/apple/swift/issues/72588
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=any HasAssoc}}
   let _: any HasAssocGeneric<HasAssoc>
-  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{30-30=any }}
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{30-39=any ~Copyable}}
   let _: any HasAssocGeneric<~Copyable>
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{16-24=any HasAssoc}}
   let _: any G<HasAssoc>.HasAssoc_Alias
@@ -487,26 +480,24 @@ func testAnyFixIt() {
   // expected-error@+2:10 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-29=any HasAssoc & HasAssoc}}
   // expected-error@+1:21 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-29=any HasAssoc & HasAssoc}}
   let _: HasAssoc & HasAssoc
-  // expected-error@+2:10 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
-  // expected-error@+1:22 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
+  // expected-error@+2:10 {{constraint that suppresses conformance requires 'any'}}{{10-31=any ~Copyable & ~Copyable}}
+  // expected-error@+1:22 {{constraint that suppresses conformance requires 'any'}}{{10-31=any ~Copyable & ~Copyable}}
   let _: ~Copyable & ~Copyable
   // expected-error@+3:10 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
   // expected-error@+2:22 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
   // expected-error@+1:33 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-42=any HasAssoc & (HasAssoc & HasAssoc)}}
   let _: HasAssoc & (HasAssoc & HasAssoc)
-  // FIXME: Incorrect fix-its for nested composition.
-  // expected-error@+3:10 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
-  // expected-error@+2:23 {{constraint that suppresses conformance requires 'any'}}{{23-23=any }}
-  // expected-error@+1:35 {{constraint that suppresses conformance requires 'any'}}{{23-23=any }}
+  // expected-error@+3:10 {{constraint that suppresses conformance requires 'any'}}{{10-45=any ~Copyable & (~Copyable & ~Copyable)}}
+  // expected-error@+2:23 {{constraint that suppresses conformance requires 'any'}}{{10-45=any ~Copyable & (~Copyable & ~Copyable)}}
+  // expected-error@+1:35 {{constraint that suppresses conformance requires 'any'}}{{10-45=any ~Copyable & (~Copyable & ~Copyable)}}
   let _: ~Copyable & (~Copyable & ~Copyable)
 
   // Misc. compound cases.
 
-  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
+  // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{21-52=any NonCopyableHasAssoc & ~Copyable}}
   // expected-error@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-52=any NonCopyableHasAssoc & ~Copyable}}
   let _: (borrowing NonCopyableHasAssoc & ~Copyable) -> Void
-  // FIXME: Incorrect fix-it.
-  // expected-error@+3:15 {{constraint that suppresses conformance requires 'any'}}{{15-15=any }}
+  // expected-error@+3:15 {{constraint that suppresses conformance requires 'any'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
   // expected-error@+2:28 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
   // expected-error@+1:51 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{10-88=(any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type)}}
   let _: (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type?

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -94,7 +94,7 @@ func testHasAssoc(_ x: Any, _: any HasAssoc) {
 
     func method() -> any HasAssoc {}
     func existentialArray() ->  [any HasAssoc] {}
-    func existentialcSequence() ->  any Sequence<HasAssoc> {}
+    func existentialcSequence() ->  any Sequence<any HasAssoc> {}
   }
 }
 
@@ -465,12 +465,16 @@ func testAnyFixIt() {
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
   let _: (borrowing ~Copyable) -> Void
   // https://github.com/apple/swift/issues/72588
-  // FIXME: No diagnostic.
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=any HasAssoc}}
   let _: any HasAssocGeneric<HasAssoc>
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{30-30=any }}
   let _: any HasAssocGeneric<~Copyable>
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{16-24=any HasAssoc}}
   let _: any G<HasAssoc>.HasAssoc_Alias
+  // FIXME: Generic argument not diagnosed.
   let _: any ~G<HasAssoc>.Copyable_Alias
   do {
+    // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{22-30=any HasAssoc}}
     func f(_: some G<HasAssoc>.HasAssoc_Alias) {}
   }
 
@@ -480,6 +484,7 @@ func testAnyFixIt() {
   // expected-error@+2 {{constraint that suppresses conformance requires 'any'}}{{21-21=any }}
   // expected-error@+1 {{use of protocol 'NonCopyableHasAssoc' as a type must be written 'any NonCopyableHasAssoc'}}{{21-40=any NonCopyableHasAssoc}}
   let _: (borrowing NonCopyableHasAssoc & ~Copyable) -> Void
+  let _: any (((((~Copyable) & NonCopyableHasAssoc) & NonCopyableHasAssoc).Type.Type)).Type // OK
 
   // Misplaced '?'.
 

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -390,6 +390,8 @@ func testAnyFixIt() {
   let _: HasAssoc.Type
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
   let _: ~Copyable.Type
+  // expected-error@+1 {{type 'any Copyable.Type' cannot be suppressed}}
+  let _: ~(Copyable.Type)
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-25=any (HasAssoc).Type}}
   let _: (HasAssoc).Type
   // FIXME: Fix-it produces singleton, not existential, metatype type?
@@ -400,13 +402,18 @@ func testAnyFixIt() {
   // FIXME: Fix-it produces singleton, not existential, metatype type?
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{12-12=any }}
   let _: ((~Copyable)).Type
-  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-28=any HasAssoc.Type.Type}}
   let _: HasAssoc.Type.Type
   // expected-error@+1 {{type 'any Copyable.Type.Type' cannot be suppressed}}
   let _: ~Copyable.Type.Type
   // FIXME: Fix-it produces singleton, not existential, metatype type?
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
   let _: (~Copyable).Type.Type
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-30=any (HasAssoc.Type).Type}}
+  let _: (HasAssoc.Type).Type
+  // FIXME: Fix-it produces singleton, not existential, metatype type?
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
+  let _: (~Copyable.Type).Type
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{30-38=(any HasAssoc)}}
   let _: HasAssoc.Protocol = HasAssoc.self
@@ -437,8 +444,7 @@ func testAnyFixIt() {
   // FIXME: Incorrect fix-it.
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}
   let _: (~Copyable).Type.Protocol
-  // FIXME: Incorrect fix-it.
-  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=any HasAssoc.Type}}
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-28=(any HasAssoc.Type.Type)}}
   let _: HasAssoc.Type.Type.Protocol
   // FIXME: Incorrect fix-it.
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-11=any }}

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -377,7 +377,7 @@ func testAnyFixIt() {
   // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{12-20=any HasAssoc}}
   // expected-error@+1 {{use of 'S.HasAssoc_Alias' (aka 'HasAssoc') as a type must be written 'any S.HasAssoc_Alias' (aka 'any HasAssoc')}}{{10-36=any G<HasAssoc>.HasAssoc_Alias}}
   let _: G<HasAssoc>.HasAssoc_Alias
-  // FIXME: Generic argument not diagnosed.
+  // expected-error@+2 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{13-21=any HasAssoc}}
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-10=any }}
   let _: ~G<HasAssoc>.Copyable_Alias
   // FIXME: No fix-it + generic argument not diagnosed.
@@ -471,7 +471,7 @@ func testAnyFixIt() {
   let _: any HasAssocGeneric<~Copyable>
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{16-24=any HasAssoc}}
   let _: any G<HasAssoc>.HasAssoc_Alias
-  // FIXME: Generic argument not diagnosed.
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{17-25=any HasAssoc}}
   let _: any ~G<HasAssoc>.Copyable_Alias
   do {
     // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{22-30=any HasAssoc}}

--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -451,6 +451,13 @@ func testAnyFixIt() {
   let _: (HasAssoc)?
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
   let _: (~Copyable)?
+  // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-18=(any HasAssoc)}}
+  let _: HasAssoc!
+  // expected-error@+2 {{type '(any Copyable)?' cannot be suppressed}}
+  // expected-warning@+1 {{using '!' is not allowed here; treating this as '?' instead}}
+  let _: ~Copyable!
+  // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{11-20=any ~Copyable}}
+  let _: (~Copyable)!
   // expected-error@+1 {{use of protocol 'HasAssoc' as a type must be written 'any HasAssoc'}}{{10-23=(any HasAssoc.Type)}}
   let _: HasAssoc.Type?
   // expected-error@+1 {{constraint that suppresses conformance requires 'any'}}{{10-26=(any (~Copyable).Type)}}


### PR DESCRIPTION
Resolves #65026, resolves #65027, resolves #72588.

Diff counts are mostly due to tests.