### PR TITLE
[6.0] [DebugInfo] Salvage debug info for stores removed by DeadObject-Elim

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -771,6 +771,17 @@ class DeadObjectElimination : public SILFunctionTransform {
   DominanceInfo *domInfo = nullptr;
 
   void removeInstructions(ArrayRef<SILInstruction*> toRemove);
+  
+  /// Try to salvage the debug info for a dead instruction removed by
+  /// DeadObjectElimination.
+  ///
+  /// Dead stores will be replaced by a debug value for the object variable,
+  /// using a fragment expression. By walking from the store to the allocation,
+  /// we can know which member of the object is being assigned, and create
+  /// fragments for each member. Other instructions are not salvaged.
+  /// Currently only supports dead stack-allocated objects.
+  void salvageDebugInfo(SILInstruction *toBeRemoved);
+  std::optional<SILDebugVariable> buildDIExpression(SILInstruction *current);
 
   bool processAllocRef(AllocRefInstBase *ARI);
   bool processAllocStack(AllocStackInst *ASI);
@@ -831,6 +842,52 @@ DeadObjectElimination::removeInstructions(ArrayRef<SILInstruction*> toRemove) {
     // Now we know that I should not have any uses... erase it from its parent.
     deleter.forceDelete(I);
   }
+}
+
+void DeadObjectElimination::salvageDebugInfo(SILInstruction *toBeRemoved) {
+  auto *SI = dyn_cast<StoreInst>(toBeRemoved);
+  if (!SI)
+    return;
+
+  auto *parent = SI->getDest()->getDefiningInstruction();
+  auto varInfo = buildDIExpression(parent);
+  if (!varInfo)
+    return;
+
+  SILBuilderWithScope Builder(SI);
+  Builder.createDebugValue(SI->getLoc(), SI->getSrc(), *varInfo);
+}
+
+std::optional<SILDebugVariable>
+DeadObjectElimination::buildDIExpression(SILInstruction *current) {
+  if (!current)
+    return {};
+  if (auto dvci = dyn_cast<AllocStackInst>(current)) {
+    auto var = dvci->getVarInfo();
+    if (!var)
+      return {};
+    var->Type = dvci->getType();
+    return var;
+  }
+  if (auto *tupleAddr = dyn_cast<TupleElementAddrInst>(current)) {
+    auto *definer = tupleAddr->getOperand().getDefiningInstruction();
+    auto path = buildDIExpression(definer);
+    if (!path)
+      return {};
+    path->DIExpr.append(SILDebugInfoExpression::createTupleFragment(
+      tupleAddr->getTupleType(), tupleAddr->getFieldIndex()));
+    return path;
+  }
+  if (auto *structAddr = dyn_cast<StructElementAddrInst>(current)) {
+    auto *definer = structAddr->getOperand().getDefiningInstruction();
+    auto path = buildDIExpression(definer);
+    if (!path)
+      return {};
+    path->DIExpr.append(SILDebugInfoExpression::createFragment(
+      structAddr->getField()));
+    return path;
+  }
+  return {};
 }
 
 bool DeadObjectElimination::processAllocRef(AllocRefInstBase *ARI) {
@@ -957,6 +1014,8 @@ bool DeadObjectElimination::processAllocStack(AllocStackInst *ASI) {
     }
   }
 
+  for (auto *I : UsersToRemove)
+    salvageDebugInfo(I);
   // Remove the AllocRef and all of its users.
   removeInstructions(
     ArrayRef<SILInstruction*>(UsersToRemove.begin(), UsersToRemove.end()));

--- a/test/DebugInfo/dead-obj-elim.sil
+++ b/test/DebugInfo/dead-obj-elim.sil
@@ -1,0 +1,39 @@
+// RUN: %target-sil-opt -enable-sil-verify-all -deadobject-elim %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+struct MyObject {
+  var _storage: (UInt8, UInt8)
+}
+
+// CHECK-LABEL: sil @$myFunc
+sil @$myFunc : $@convention(thin) (UInt8) -> UInt8 {
+[global: ]
+bb0(%0 : $UInt8):
+  debug_value %0 : $UInt8, let, name "value", argno 1
+  // CHECK-NOT: alloc_stack
+  %2 = alloc_stack $MyObject, var, name "obj"
+  %24 = integer_literal $Builtin.Int8, 3
+  %25 = struct_extract %0 : $UInt8, #UInt8._value
+  %26 = integer_literal $Builtin.Int1, -1
+  %27 = builtin "uadd_with_overflow_Int8"(%25 : $Builtin.Int8, %24 : $Builtin.Int8, %26 : $Builtin.Int1) : $(Builtin.Int8, Builtin.Int1)
+  %28 = tuple_extract %27 : $(Builtin.Int8, Builtin.Int1), 0
+  %29 = tuple_extract %27 : $(Builtin.Int8, Builtin.Int1), 1
+  cond_fail %29 : $Builtin.Int1, "arithmetic overflow"
+  %31 = struct $UInt8 (%28 : $Builtin.Int8)
+  %34 = struct_element_addr %2 : $*MyObject, #MyObject._storage
+  %35 = tuple_element_addr %34 : $*(UInt8, UInt8), 0
+  %36 = tuple_element_addr %34 : $*(UInt8, UInt8), 1
+  // The store below should be replaced by a debug_value with the same operand as the store (%0)
+  // The fragment refers to the member being modified
+  // CHECK-NOT: store
+  // CHECK: debug_value %0 : $UInt8, var, name "obj", type $*MyObject, expr op_fragment:#MyObject._storage:op_tuple_fragment:$(UInt8, UInt8):1
+  store %0 to %36 : $*UInt8
+  // CHECK: debug_value %{{[0-9]}} : $UInt8, var, name "obj", type $*MyObject, expr op_fragment:#MyObject._storage:op_tuple_fragment:$(UInt8, UInt8):0
+  store %31 to %35 : $*UInt8
+  dealloc_stack %2 : $*MyObject
+  return %31 : $UInt8
+} // end sil function '$myFunc'


### PR DESCRIPTION
* **Explanation**:Debug info was lost by the Dead Object Elimination pass. This PR salvages the debug info for the eliminated object.
* **Scope**: Adds debug value instructions in the Dead Object Elimination pass
* **Original PR**: #72207
* **Risk**: Low, only debug instructions are added
* **Testing**: The SILVerifier check ensures all debug info is correct. A test has also been added for this.
* **Issue**: rdar://124283055
* **Reviewer**:  @adrian-prantl 
