### PR TITLE
[6.0] Fix LifetimeDependenceDiagnostics to ignore closure captures

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -29,9 +29,6 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let lifetimeDependenceDiagnosticsPass = FunctionPass(
   name: "lifetime-dependence-diagnostics")
 { (function: Function, context: FunctionPassContext) in
-  if !context.options.hasFeature(.NonescapableTypes) {
-    return
-  }
   log(prefix: false, "\n--- Diagnosing lifetime dependence in \(function.name)")
   log("\(function)")
 

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceDiagnostics.swift
@@ -45,7 +45,7 @@ let lifetimeDependenceDiagnosticsPass = FunctionPass(
     }
   }
   for instruction in function.instructions {
-    if let markDep = instruction as? MarkDependenceInst {
+    if let markDep = instruction as? MarkDependenceInst, markDep.isUnresolved {
       if let lifetimeDep = LifetimeDependence(markDep, context) {
         analyze(dependence: lifetimeDep, context)
       }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceInsertion.swift
@@ -31,9 +31,6 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let lifetimeDependenceInsertionPass = FunctionPass(
   name: "lifetime-dependence-insertion")
 { (function: Function, context: FunctionPassContext) in
-  if !context.options.hasFeature(.NonescapableTypes) {
-    return
-  }
   log(prefix: false, "\n--- Inserting lifetime dependence markers in \(function.name)")
 
   for instruction in function.instructions {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/LifetimeDependenceScopeFixup.swift
@@ -31,9 +31,6 @@ private func log(prefix: Bool = true, _ message: @autoclosure () -> String) {
 let lifetimeDependenceScopeFixupPass = FunctionPass(
   name: "lifetime-dependence-scope-fixup")
 { (function: Function, context: FunctionPassContext) in
-  if !context.options.hasFeature(.NonescapableTypes) {
-    return
-  }
   log(prefix: false, "\n--- Scope fixup for lifetime dependence in \(function.name)")
 
   let localReachabilityCache = LocalVariableReachabilityCache()

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -1660,12 +1660,16 @@ bool DataflowState::process(
 
         {
           auto diag = diag::sil_movechecking_consuming_use_here;
-          diagnose(astContext, mvi->getLoc().getSourceLoc(), diag);
+          if (auto sourceLoc = mvi->getLoc().getSourceLoc()) {
+            diagnose(astContext, sourceLoc, diag);
+          }
         }
 
         {
           auto diag = diag::sil_movechecking_nonconsuming_use_here;
-          diagnose(astContext, iter->second->getLoc().getSourceLoc(), diag);
+          if (auto sourceLoc = iter->second->getLoc().getSourceLoc()) {
+            diagnose(astContext, sourceLoc, diag);
+          }
         }
 
         emittedSingleDiagnostic = true;
@@ -1690,13 +1694,17 @@ bool DataflowState::process(
 
           {
             auto diag = diag::sil_movechecking_consuming_use_here;
-            diagnose(astContext, mvi->getLoc().getSourceLoc(), diag);
+            if (auto sourceLoc = mvi->getLoc().getSourceLoc()) {
+              diagnose(astContext, sourceLoc, diag);
+            }
           }
 
           {
             auto diag = diag::sil_movechecking_nonconsuming_use_here;
             for (auto *user : iter->second->pairedUseInsts) {
-              diagnose(astContext, user->getLoc().getSourceLoc(), diag);
+              if (auto sourceLoc = user->getLoc().getSourceLoc()) {
+                diagnose(astContext, sourceLoc, diag);
+              }
             }
           }
 
@@ -2115,12 +2123,16 @@ bool ConsumeOperatorCopyableAddressesChecker::performSingleBasicBlockAnalysis(
     }
 
     auto diag = diag::sil_movechecking_consuming_use_here;
-    diagnose(astCtx, mvi->getLoc().getSourceLoc(), diag);
+    if (auto sourceLoc = mvi->getLoc().getSourceLoc()) {
+      diagnose(astCtx, sourceLoc, diag);
+    }
 
     {
       auto diag = diag::sil_movechecking_nonconsuming_use_here;
       for (auto *user : interestingClosureUsers) {
-        diagnose(astCtx, user->getLoc().getSourceLoc(), diag);
+        if (auto sourceLoc = user->getLoc().getSourceLoc()) {
+          diagnose(astCtx, sourceLoc, diag);
+        }
       }
     }
 
@@ -2157,12 +2169,16 @@ bool ConsumeOperatorCopyableAddressesChecker::performSingleBasicBlockAnalysis(
 
     {
       auto diag = diag::sil_movechecking_consuming_use_here;
-      diagnose(astCtx, mvi->getLoc().getSourceLoc(), diag);
+      if (auto sourceLoc = mvi->getLoc().getSourceLoc()) {
+        diagnose(astCtx, sourceLoc, diag);
+      }
     }
 
     {
       auto diag = diag::sil_movechecking_nonconsuming_use_here;
-      diagnose(astCtx, interestingUser->getLoc().getSourceLoc(), diag);
+      if (auto sourceLoc = interestingUser->getLoc().getSourceLoc()) {
+        diagnose(astCtx, sourceLoc, diag);
+      }
     }
 
     // We purposely continue to see if at least in simple cases, we can flag

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -252,8 +252,10 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
   diagnose(astContext, getSourceLocFromValue(borrowedValue),
            diag::sil_movechecking_value_used_after_consume,
            borrowedValueName);
-  diagnose(astContext, mvi->getLoc().getSourceLoc(),
-           diag::sil_movechecking_consuming_use_here);
+  if (auto sourceLoc = mvi->getLoc().getSourceLoc()) {
+    diagnose(astContext, sourceLoc,
+             diag::sil_movechecking_consuming_use_here);
+  }
 
   // Then we do a bit of work to figure out where /all/ of the later uses than
   // mvi are so we can emit notes to the user telling them this is a problem
@@ -283,8 +285,10 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
       case PrunedLiveness::NonLifetimeEndingUse:
       case PrunedLiveness::LifetimeEndingUse:
         LLVM_DEBUG(llvm::dbgs() << "Emitting note for in block use: " << inst);
-        diagnose(astContext, inst.getLoc().getSourceLoc(),
-                 diag::sil_movechecking_nonconsuming_use_here);
+        if (auto sourceLoc = inst.getLoc().getSourceLoc()) {
+          diagnose(astContext, sourceLoc,
+                   diag::sil_movechecking_nonconsuming_use_here);
+        }
         break;
       }
     }
@@ -342,8 +346,10 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
         case PrunedLiveness::LifetimeEndingUse:
           LLVM_DEBUG(llvm::dbgs()
                      << "(3) Emitting diagnostic for user: " << inst);
-          diagnose(astContext, inst.getLoc().getSourceLoc(),
-                   diag::sil_movechecking_nonconsuming_use_here);
+          if (auto sourceLoc = inst.getLoc().getSourceLoc()) {
+            diagnose(astContext, sourceLoc,
+                     diag::sil_movechecking_nonconsuming_use_here);
+          }
           break;
         }
       }
@@ -368,8 +374,10 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
       if (livenessInfo.nonLifetimeEndingUsesInLiveOut.contains(&inst)) {
         LLVM_DEBUG(llvm::dbgs()
                    << "(1) Emitting diagnostic for user: " << inst);
-        diagnose(astContext, inst.getLoc().getSourceLoc(),
-                 diag::sil_movechecking_nonconsuming_use_here);
+        if (auto sourceLoc = inst.getLoc().getSourceLoc()) {
+          diagnose(astContext, sourceLoc,
+                   diag::sil_movechecking_nonconsuming_use_here);
+        }
         continue;
       }
 
@@ -390,8 +398,10 @@ void ConsumeOperatorCopyableValuesChecker::emitDiagnosticForMove(
 
           LLVM_DEBUG(llvm::dbgs()
                      << "(2) Emitting diagnostic for user: " << inst);
-          diagnose(astContext, inst.getLoc().getSourceLoc(),
-                   diag::sil_movechecking_nonconsuming_use_here);
+          if (auto sourceLoc = inst.getLoc().getSourceLoc()) {
+            diagnose(astContext, sourceLoc,
+                     diag::sil_movechecking_nonconsuming_use_here);
+          }
         }
       }
     }

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -155,6 +155,8 @@ bool CheckerLivenessInfo::compute() {
             }
           }
         }
+        // FIXME: this ignores all other forms of Borrow ownership, such as
+        // partial_apply [onstack] and mark_dependence [nonescaping].
         break;
       }
       case OperandOwnership::GuaranteedForwarding:

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -60,7 +60,13 @@ static void diagnose(ASTContext &context, SILInstruction *inst, Diag<T...> diag,
   if (SilentlyEmitDiagnostics)
     return;
 
-  context.Diags.diagnose(loc.getSourceLoc(), diag, std::forward<U>(args)...);
+  auto sourceLoc = loc.getSourceLoc();
+  auto diagKind = context.Diags.declaredDiagnosticKindFor(diag.ID);
+  // Do not emit notes on invalid source locations.
+  if (!sourceLoc && diagKind == DiagnosticKind::Note) {
+    return;
+  }
+  context.Diags.diagnose(sourceLoc, diag, std::forward<U>(args)...);
 }
 
 template <typename... T, typename... U>

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -171,13 +171,6 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   // Check noImplicitCopy and move only types for objects and addresses.
   P.addMoveOnlyChecker();
 
-  // Check ~Escapable.
-  if (P.getOptions().EnableLifetimeDependenceDiagnostics) {
-    P.addLifetimeDependenceDiagnostics();
-  }
-  if (EnableDeinitDevirtualizer)
-    P.addDeinitDevirtualizer();
-
   // FIXME: rdar://122701694 (`consuming` keyword causes verification error on
   //        invalid SIL types)
   //
@@ -188,6 +181,19 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addConsumeOperatorCopyableAddressesChecker();
   // No uses after consume operator of copyable value.
   P.addConsumeOperatorCopyableValuesChecker();
+
+  // Check ~Escapable.
+  if (P.getOptions().EnableLifetimeDependenceDiagnostics) {
+    P.addLifetimeDependenceDiagnostics();
+  }
+
+  // Devirtualize deinits early if requested.
+  //
+  // FIXME: why is DeinitDevirtualizer in the middle of the mandatory pipeline,
+  // and what passes/compilation modes depend on it? This pass is never executed
+  // or tested without '-Xllvm enable-deinit-devirtualizer'.
+  if (EnableDeinitDevirtualizer)
+    P.addDeinitDevirtualizer();
 
   // As a temporary measure, we also eliminate move only for non-trivial types
   // until we can audit the later part of the pipeline. Eventually, this should

--- a/test/SILOptimizer/lifetime_dependence_borrow.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow.swift
@@ -3,6 +3,7 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
@@ -15,8 +16,7 @@ struct CN: ~Copyable {
 }
 
 // Some Bufferview-ish thing.
-@_nonescapable
-struct BV {
+struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
@@ -35,8 +35,7 @@ struct BV {
 }
 
 // Some MutableBufferview-ish thing.
-@_nonescapable
-struct MBV : ~Copyable {
+struct MBV : ~Escapable, ~Copyable {
   let p: UnsafeRawPointer
   let i: Int
   
@@ -53,8 +52,7 @@ struct MBV : ~Copyable {
 }
 
 // Nonescapable wrapper.
-@_nonescapable
-struct NEBV {
+struct NEBV : ~Escapable {
   var bv: BV
 
   init(_ bv: consuming BV) {

--- a/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_borrow_fail.swift
@@ -3,13 +3,13 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-@_nonescapable
-struct BV {
+struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
@@ -34,8 +34,7 @@ struct NC : ~Copyable {
   }
 }
 
-@_nonescapable
-struct NE {
+struct NE : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 

--- a/test/SILOptimizer/lifetime_dependence_closure.swift
+++ b/test/SILOptimizer/lifetime_dependence_closure.swift
@@ -4,6 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
 // RUN:   -disable-experimental-parser-round-trip \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
@@ -15,8 +16,7 @@ struct NCInt: ~Copyable {
   init(_ value: Int) { self.value = value }
 }
 
-@_nonescapable
-struct NEInt /*: ~Escapable*/ {
+struct NEInt : ~Escapable {
   let value: Int
 
   init(borrowed: borrowing NCInt) -> dependsOn(borrowed) Self {

--- a/test/SILOptimizer/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   2>&1 | %FileCheck %s
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-@_nonescapable
-struct BV {
+struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let c: Int
   @_unsafeNonescapableResult

--- a/test/SILOptimizer/lifetime_dependence_diagnostics.swift
+++ b/test/SILOptimizer/lifetime_dependence_diagnostics.swift
@@ -22,6 +22,12 @@ func bv_copy(_ bv: borrowing BV) -> dependsOn(bv) BV {
   copy bv
 }
 
+struct NCInt: ~Copyable {
+  var value: Int
+}
+
+func takeClosure(_: () -> ()) {}
+
 // No mark_dependence is needed for a inherited scope.
 //
 // CHECK-LABEL: sil hidden @$s4test14bv_borrow_copyyAA2BVVADYlsF : $@convention(thin) (@guaranteed BV) -> _scope(1) @owned BV {
@@ -44,4 +50,11 @@ func bv_borrow_copy(_ bv: borrowing BV) -> dependsOn(scoped bv) BV {
 // CHECK-LABEL: } // end sil function '$s4test010bv_borrow_C00B0AA2BVVAEYls_tF'
 func bv_borrow_borrow(bv: borrowing BV) -> dependsOn(scoped bv) BV {
   bv_borrow_copy(bv)
+}
+
+// This already has a mark_dependence [nonescaping] before diagnostics. If it triggers diagnostics again, it will fail
+// because lifetime dependence does not expect a dependence directly on an 'inout' address without any 'begin_access'
+// marker.
+func ncint_capture(ncInt: inout NCInt) {
+  takeClosure { _ = ncInt.value }
 }

--- a/test/SILOptimizer/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit.swift
@@ -3,13 +3,13 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-@_nonescapable
-struct BV {
+struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
@@ -26,8 +26,7 @@ struct BV {
   }
 }
 
-@_nonescapable
-struct NE {
+struct NE : ~Escapable {
   var bv: BV
 
   // Test lifetime inheritance through initialization.

--- a/test/SILOptimizer/lifetime_dependence_inherit.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit.swift
@@ -26,13 +26,26 @@ struct BV : ~Escapable {
   }
 }
 
-struct NE : ~Escapable {
+// Nonescapable wrapper.
+struct NEBV : ~Escapable {
   var bv: BV
 
   // Test lifetime inheritance through initialization.
   init(_ bv: consuming BV) -> dependsOn(bv) Self {
     self.bv = bv
-    return self
+  }
+
+  var view: BV {
+    _read {
+      yield bv
+    }
+    _modify {
+      yield &bv
+    }
+  }
+
+  func borrowedView() -> dependsOn(scoped self) BV {
+    bv
   }
 }
 
@@ -42,6 +55,26 @@ func bv_derive(bv: consuming BV) -> dependsOn(bv) BV {
 }
 
 // Test lifetime inheritance through stored properties.
-func ne_extract_member(ne: consuming NE) -> dependsOn(ne) BV {
-  return ne.bv
+func ne_extract_member(nebv: consuming NEBV) -> dependsOn(nebv) BV {
+  return nebv.bv
+}
+
+func ne_yield_member(nebv: consuming NEBV) -> dependsOn(nebv) BV {
+  return nebv.view
+}
+
+func bv_consume(_ x: consuming BV) {}
+
+// It is ok to consume the aggregate before the property.
+// The property's lifetime must exceed the aggregate's.
+func nebv_consume_member(nebv: consuming NEBV) {
+  let bv = nebv.bv
+  _ = consume nebv
+  bv_consume(bv)
+}
+
+func nebv_consume_after_yield(nebv: consuming NEBV) {
+  let view = nebv.view
+  _ = consume nebv
+  bv_consume(view)
 }

--- a/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_inherit_fail.swift
@@ -3,13 +3,13 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-@_nonescapable
-struct BV {
+struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 
@@ -26,8 +26,7 @@ struct BV {
   }
 }
 
-@_nonescapable
-struct NE {
+struct NE : ~Escapable {
   var bv: BV
 
   init(_ bv: consuming BV) -> dependsOn(bv) Self {

--- a/test/SILOptimizer/lifetime_dependence_insertion.swift
+++ b/test/SILOptimizer/lifetime_dependence_insertion.swift
@@ -2,14 +2,14 @@
 // RUN:   -Xllvm -sil-print-after=lifetime-dependence-insertion \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -o /dev/null 2>&1 | %FileCheck %s
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-@_nonescapable
-struct BV {
+struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 

--- a/test/SILOptimizer/lifetime_dependence_mutate.swift
+++ b/test/SILOptimizer/lifetime_dependence_mutate.swift
@@ -3,13 +3,13 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-@_nonescapable
-struct MBV : ~Copyable {
+struct MBV : ~Escapable, ~Copyable {
   let p: UnsafeMutableRawPointer
   let c: Int
 

--- a/test/SILOptimizer/lifetime_dependence_param.swift
+++ b/test/SILOptimizer/lifetime_dependence_param.swift
@@ -3,13 +3,13 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-@_nonescapable
-struct BV {
+struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let i: Int
 

--- a/test/SILOptimizer/lifetime_dependence_param_fail.swift
+++ b/test/SILOptimizer/lifetime_dependence_param_fail.swift
@@ -3,13 +3,13 @@
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
 
-@_nonescapable
-struct BV {
+struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let c: Int
 

--- a/test/SILOptimizer/lifetime_dependence_scope.swift
+++ b/test/SILOptimizer/lifetime_dependence_scope.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -sil-verify-all \
 // RUN:   -module-name test \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   2>&1 | %FileCheck %s
 
@@ -9,8 +10,7 @@
 
 // Test LifetimeDependenceScopeFixup.
 
-@_nonescapable
-struct BV {
+struct BV : ~Escapable {
   let p: UnsafeRawPointer
   let c: Int
 

--- a/test/SILOptimizer/lifetime_dependence_todo.swift
+++ b/test/SILOptimizer/lifetime_dependence_todo.swift
@@ -2,6 +2,7 @@
 // RUN:   -o /dev/null \
 // RUN:   -verify \
 // RUN:   -sil-verify-all \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
 // RUN:   -enable-experimental-feature NonescapableTypes
 
 // REQUIRES: asserts

--- a/test/SILOptimizer/lifetime_dependence_todo.swift
+++ b/test/SILOptimizer/lifetime_dependence_todo.swift
@@ -11,6 +11,65 @@
 // Future tests for LifetimeDependenceDiagnostics.
 // REQUIRES: disabled
 
+struct BV : ~Escapable {
+  let p: UnsafeRawPointer
+  let i: Int
+
+  @_unsafeNonescapableResult
+  init(_ p: UnsafeRawPointer, _ i: Int) {
+    self.p = p
+    self.i = i
+  }
+}
+
+// Nonescapable wrapper.
+struct NEBV : ~Escapable {
+  var bv: BV
+
+  // Test lifetime inheritance through initialization.
+  init(_ bv: consuming BV) {
+    self.bv = bv
+  }
+
+  var view: BV {
+    _read {
+      yield bv
+    }
+    _modify {
+      yield &bv
+    }
+  }
+
+  func borrowedView() -> dependsOn(scoped self) BV {
+    bv
+  }
+}
+
+// Noncopyable, Nonescapable wrapper.
+struct NCNEBV : ~Copyable, ~Escapable {
+  var bv: BV
+
+  // Test lifetime inheritance through initialization.
+  init(_ bv: consuming BV) {
+    self.bv = bv
+  }
+
+  var view: BV {
+    _read {
+      yield bv
+    }
+    _modify {
+      yield &bv
+    }
+  }
+
+  func borrowedView() -> dependsOn(scoped self) BV {
+    bv
+  }
+}
+
+func ncnebv_consume(_: consuming NCNEBV) {}
+func bv_consume(_: consuming BV) {}
 
 // =============================================================================
 // Diagnostics that should fail.
@@ -41,4 +100,31 @@ func bvcons_capture_escapelet(bv: consuming BV) -> ()->Int {
   let closure = { bv.c } // expected-error{{lifetime-dependent variable 'bv' escapes its scope}}
   // expected-note @-1 {{this use causes the lifetime-dependent value to escape}}
   return closure
+}
+
+// =============================================================================
+// Can't write lit tests because move-only diagnostics are broken.
+
+func nebv_consume(_: consuming NEBV) {}
+
+// FIXME: consume operator diagnostics does not report a line number for "used here"
+func nebv_consume_borrow(nebv: NEBV) {
+  let bv = nebv.borrowedView() // expected-note {{conflicting access is here}}
+  nebv_consume(nebv) // expected-error {{overlapping accesses to 'nebv', but deinitialization requires exclusive access}}
+  bv_consume(bv)
+}
+
+// FIXME: consume operator diagnostics does not report a line number for "used here"
+func nebv_consume_borrow(nebv: consuming NEBV) { // expected-error {{'nebv' used after consume}}
+  let bv = nebv.borrowedView() // expected-note {{conflicting access is here}}
+  _ = consume nebv // expected-error {{overlapping accesses to 'nebv', but modification requires exclusive access}}
+  // expected-note @-1{{consumed here}}
+  bv_consume(bv)
+}
+
+// FIXME: consume operator diagnostics does not report a line number for "used here"
+func ncnebv_consume_borrow(ncnebv: NCNEBV) {
+  let bv = ncnebv.borrowedView() // expected-note {{conflicting access is here}}
+  ncnebv_consume(ncnebv) // expected-error {{overlapping accesses to 'nebv', but deinitialization requires exclusive access}}
+  bv_consume(bv)
 }

--- a/test/SILOptimizer/lifetime_dependence_util.sil
+++ b/test/SILOptimizer/lifetime_dependence_util.sil
@@ -1,4 +1,6 @@
 // RUN: %target-sil-opt -test-runner %s \
+// RUN:     -module-name Swift \
+// RUN:     -enable-experimental-feature NoncopyableGenerics \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o /dev/null 2>&1 | %FileCheck %s
 
@@ -8,6 +10,8 @@
 sil_stage canonical
 
 import Builtin
+
+@_marker public protocol Escapable {}
 
 enum FakeOptional<T> {
 case none
@@ -36,15 +40,13 @@ sil_vtable D {
   #D.field!read: @d_field_read
 }
 
-@_nonescapable
-struct NE {
+struct NE : ~Escapable {
   var d: D
   @_unsafeNonescapableResult
   init() { }
 }
 
-@_nonescapable
-struct NEWrap {
+struct NEWrap : ~Escapable {
   var ne: NE
   @_unsafeNonescapableResult
   init() { }


### PR DESCRIPTION
Fix LifetimeDependenceDiagnostics to ignore closure captures

ClosureLifetimeFixup now emits mark_dependence [nonescaping]. Those should be
ignored by diagnostics. In the capture case, the dependence has already been
resolved, and may not match the SIL patterns that we expect for source-level
lifetime dependencies.

Fixes rdar://125375685 ([nonescapable] Fix lifetime-dependence diagnostics in the stdlib)x

This allows us to always-enable lifetime-depenence diagnostics.

This PR also includes obvious, harmless fixes to move-only diagnostics to allow adding
nonescapable unit tests.

Fix MoveOnlyDiagnostics, ConsumOperator...Checkers diagnostics

Emitting a note with an invalid source location is actively
harmful. It confuses users and tools, makes it impossible to write
unit tests. In this case, the note simply says "use here", so it's
completely free of information without the source location.

--- CCC ---

Explanation: Fix LifetimeDependenceDiagnostics to ignore closure captures

Scope: Allows NonescapableTypes to be enabled by default

Radar/SR Issue: rdar://125375685 ([nonescapable] Fix lifetime-dependence diagnostics in the stdlib)

Original PR: #72635

Risk: This bypasses new compiler functionality for code that does not require that functionality. It lowers risk.

Testing: Unit tests added

Reviewer: @meg-gupta
