### PR TITLE
NCGenerics: update `MakeAbstractConformanceForGenericType`

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -832,6 +832,15 @@ bool SubstitutionMap::isIdentity() const {
         continue;
     }
 
+    // Is it a builtin conformance to an invertible protocol?
+    if (conf.isConcrete()
+        && conf.getRequirement()->getInvertibleProtocolKind()) {
+      ProtocolConformance *concreteConf = conf.getConcrete();
+      RootProtocolConformance *rootConf = concreteConf->getRootConformance();
+      if (isa<BuiltinProtocolConformance>(rootConf))
+        continue;
+    }
+
     return false;
   }
 

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -251,6 +251,15 @@ operator()(CanType dependentType, Type conformingReplacementType,
         PackConformance::get(conformingPack, conformedProtocol, conformances));
   }
 
+  // All conformances for invertible protocols are builtin, so they're already
+  // abstract in a sense.
+  if (conformedProtocol->getInvertibleProtocolKind()) {
+    auto &ctx = conformedProtocol->getASTContext();
+    return ProtocolConformanceRef(
+        ctx.getBuiltinConformance(conformingReplacementType, conformedProtocol,
+                                  BuiltinConformanceKind::Synthesized));
+  }
+
   assert((conformingReplacementType->is<ErrorType>() ||
           conformingReplacementType->is<SubstitutableType>() ||
           conformingReplacementType->is<DependentMemberType>() ||


### PR DESCRIPTION
We should just return the builtin conformances for Copyable/Escapable, since those are the only kinds of unconditional conformances for these marker protocols.

resolves rdar://125460667