### PR TITLE
[6.0] Allow @isolated(any) mismatches in witness matching.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3041,6 +3041,13 @@ matchFunctionThrowing(ConstraintSystem &cs,
   }
 }
 
+static bool isWitnessMatching(ConstraintLocatorBuilder locator) {
+  SmallVector<LocatorPathElt, 4> path;
+  (void) locator.getLocatorParts(path);
+  return (path.size() == 1 &&
+          path[0].is<LocatorPathElt::Witness>());
+}
+
 bool
 ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
                                           FunctionType *func2,
@@ -3054,8 +3061,11 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
   // function-conversion score to make sure this solution is worse than
   // an exact match.
   // FIXME: there may be a better way. see https://github.com/apple/swift/pull/62514
-  auto matchIfConversion = [&]() -> bool {
-    if (kind < ConstraintKind::Subtype)
+  auto matchIfConversion = [&](bool isErasure = false) -> bool {
+    // We generally require a conversion here, but allow some lassitude
+    // if we're doing witness-matching.
+    if (kind < ConstraintKind::Subtype &&
+        !(isErasure && isWitnessMatching(locator)))
       return false;
     increaseScore(SK_FunctionConversion, locator);
     return true;
@@ -3154,7 +3164,7 @@ ConstraintSystem::matchFunctionIsolations(FunctionType *func1,
     // isolation as a conversion.
     case FunctionTypeIsolation::Kind::NonIsolated:
     case FunctionTypeIsolation::Kind::GlobalActor:
-      return matchIfConversion();
+      return matchIfConversion(/*erasure*/ true);
 
     // Parameter isolation is value-dependent and can't be erased in the
     // abstract, though.  We need to be able to recover the isolation from

--- a/test/SILGen/isolated_any_conformance.swift
+++ b/test/SILGen/isolated_any_conformance.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature IsolatedAny %s -module-name test -swift-version 6 -disable-availability-checking | %FileCheck %s
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// rdar://125394096.  This was a source compatibility failure in which adding
+// @isolated(any) to TaskGroup.addTask caused problems with a project that
+// introduced a protocol for different task group types.
+
+struct A<T> {
+  func enqueue(operation: @escaping @isolated(any) () async -> T) {}
+}
+
+protocol Enqueuer {
+  associatedtype Result
+  func enqueue(operation: @escaping @Sendable () async -> Result)
+}
+
+extension A : Enqueuer {}
+
+// CHECK-LABEL: sil private [transparent] [thunk] [ossa] @$s4test1AVyxGAA8EnqueuerA2aEP7enqueue9operationy6ResultQzyYaYbc_tFTW :
+// CHECK:       bb0(%0 : @guaranteed $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0>, %1 : $*A<τ_0_0>):
+// CHECK-NEXT:  [[CONVERTED_FN:%.*]] = convert_function %0 : $@Sendable @async @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <τ_0_0> to $@Sendable @async @callee_guaranteed () -> @out τ_0_0
+// CHECK-NEXT:  [[ISOLATION:%.*]] = enum $Optional<any Actor>, #Optional.none
+// CHECK-NEXT:  [[FN_COPY:%.*]] = copy_value [[CONVERTED_FN]] : $@Sendable @async @callee_guaranteed () -> @out τ_0_0
+// CHECK-NEXT:  // function_ref
+// CHECK-NEXT:  [[THUNK:%.*]] = function_ref @$sxIeghHr_xIeAghHr_lTR
+// CHECK-NEXT:  partial_apply [callee_guaranteed] [isolated_any] [[THUNK]]<τ_0_0>([[ISOLATION]], [[FN_COPY]])

--- a/test/decl/protocol/conforms/isolated_any.swift
+++ b/test/decl/protocol/conforms/isolated_any.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature IsolatedAny -verify %s
+
+struct A<T> {
+  // expected-note @+1 {{candidate has non-matching type}}
+  func enqueue(operation: @escaping @Sendable () async -> T) {}
+}
+
+protocol AnnotatedEnqueuer {
+  associatedtype Result
+
+  // expected-note @+1 {{protocol requires function}}
+  func enqueue(operation: @escaping @isolated(any) () async -> Result)
+}
+
+// expected-error @+1 {{type 'A<T>' does not conform to protocol 'AnnotatedEnqueuer'}}
+extension A : AnnotatedEnqueuer {}


### PR DESCRIPTION
I'm not really convinced that this shouldn't be done by introducing a new kind of constraint rather than hacking in what are essentially conversions as "bind" constraints, but this is the most direct path for now

Explanation: Witness matching was not allowing a function that took an `@isolated(any)` parameter to witness a requirement that took a non-`@isolated(any)` parameter.  This caused a source break with a project that added a protocol for different `TaskGroup` types.
Scope: Fixes a source compatibility issue.  Should have no impact outside of witness matching or if `@isolated(any)` isn't involved.
Issue: rdar://125394096
Original PR: #72641
Risk: Low
Testing: Just regression testing
Reviewer: @xedin approved the original PR