### PR TITLE
[6.0] [Demangle-to-AST] Match invertible-generics extensions with no signature

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1864,6 +1864,32 @@ public:
   /// the original nominal type context.
   bool isInSameDefiningModule() const;
 
+  /// Determine whether this extension is equivalent to one that requires at
+  /// at least some constraints to be written in the source.
+  ///
+  /// This result will differ from `isConstrainedExtension()` when any of
+  /// the generic parameters of the type are invertible, e.g.,
+  /// \code
+  /// struct X<T: ~Copyable>: ~Copyable { }
+  ///
+  /// // Implies `T: Copyable`. This extension `!isWrittenWithConstraints()`
+  /// // and `isConstrainedExtension()`.
+  /// extension X { }
+  ///
+  /// // This extension `isWrittenWithConstraints()`
+  /// // and `!isConstrainedExtension()`.
+  /// extension X where T: ~Copyable { }
+  ///
+  /// // Implies `T: Copyable`. This extension `isWrittenWithConstraints()`
+  /// // and `isConstrainedExtension()`.
+  /// extension X where T: P { }
+  ///
+  /// // This extension `isWrittenWithConstraints()`
+  /// // and `isConstrainedExtension()`.
+  /// extension X where T: Q, T: ~Copyable { }
+  /// \endcode
+  bool isWrittenWithConstraints() const;
+
   /// Returns the name of the category specified by the \c \@_objcImplementation
   /// attribute, or \c None if the name is invalid or
   /// \c isObjCImplementation() is false.

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -1298,6 +1298,9 @@ ASTBuilder::findDeclContext(NodePointer node) {
         continue;
       }
 
+      if (!ext->isWrittenWithConstraints() && !genericSig)
+        return ext;
+
       auto extSig = ext->getGenericSignature().getCanonicalSignature();
       if (extSig == genericSig) {
         return ext;

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -62,6 +62,20 @@ extension XQ: Q where T: ~Copyable {
   struct A { }
 }
 
+protocol HasResult {
+  associatedtype Success
+}
+
+extension Result: HasResult {
+  func testMe() -> Success? {
+    var x: Result.Success? = nil
+    if case let .success(s) = self {
+      x = s
+    }
+    return x
+  }
+}
+
 // Class metadata
 
 @_fixed_layout


### PR DESCRIPTION
Explanation: Correctly handle demangling extensions with no mangled generic signature to generic types with invertible constraints.
Issue: rdar://125515645
Original PR: https://github.com/apple/swift/pull/72644
Risk: Low. The change only has an impact on demangling to AST types when invertible protocols are involved.
Testing: New tests.
