### PR TITLE
SILCloner: allow builtin conformances

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -126,6 +126,17 @@ public:
                                     ProtocolDecl *conformedProtocol) const;
 };
 
+/// Functor class suitable for use as a \c LookupConformanceFn that provides
+/// only abstract conformances, or builtin conformances for invertible protocols
+/// for generic types. Asserts that the replacement
+/// type is an opaque generic type.
+class MakeAbstractOrBuiltinConformanceForGenericType {
+public:
+  ProtocolConformanceRef operator()(CanType dependentType,
+                                    Type conformingReplacementType,
+                                    ProtocolDecl *conformedProtocol) const;
+};
+
 /// Functor class suitable for use as a \c LookupConformanceFn that fetches
 /// conformances from a generic signature.
 class LookUpConformanceInSignature {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -196,7 +196,7 @@ public:
         // If we found a type containing a local archetype, substitute
         // open existentials throughout the substitution map.
         Subs = Subs.subst(QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-                          MakeAbstractConformanceForGenericType());
+                          MakeAbstractOrBuiltinConformanceForGenericType());
       }
     }
 
@@ -219,7 +219,7 @@ public:
     return Ty.subst(
       Builder.getModule(),
       QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-      MakeAbstractConformanceForGenericType(),
+      MakeAbstractOrBuiltinConformanceForGenericType(),
       CanGenericSignature());
   }
   SILType getOpType(SILType Ty) {
@@ -239,7 +239,7 @@ public:
 
     return ty.subst(
       QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-      MakeAbstractConformanceForGenericType()
+      MakeAbstractOrBuiltinConformanceForGenericType()
     )->getCanonicalType();
   }
 
@@ -352,7 +352,7 @@ public:
         conformance.subst(ty,
                           QueryTypeSubstitutionMapOrIdentity{
                                                         LocalArchetypeSubs},
-                          MakeAbstractConformanceForGenericType());
+                          MakeAbstractOrBuiltinConformanceForGenericType());
     }
 
     return asImpl().remapConformance(getASTTypeInClonedContext(ty),

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -230,6 +230,22 @@ operator()(CanType dependentType, Type conformingReplacementType,
   return Subs.lookupConformance(dependentType, conformedProtocol);
 }
 
+ProtocolConformanceRef MakeAbstractOrBuiltinConformanceForGenericType::
+operator()(CanType dependentType, Type conformingReplacementType,
+           ProtocolDecl *conformedProtocol) const {
+  // Workaround for rdar://125460667
+  if (conformedProtocol->getInvertibleProtocolKind()) {
+    auto &ctx = conformedProtocol->getASTContext();
+    return ProtocolConformanceRef(
+        ctx.getBuiltinConformance(conformingReplacementType, conformedProtocol,
+                                  BuiltinConformanceKind::Synthesized));
+  }
+
+  return MakeAbstractConformanceForGenericType()(dependentType,
+                                                 conformingReplacementType,
+                                                 conformedProtocol);
+}
+
 ProtocolConformanceRef MakeAbstractConformanceForGenericType::
 operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {


### PR DESCRIPTION
When cloning SIL, it's OK for conformances to Copyable or Escapable to be carried-over as a builtin conformance, rather than an abstract conformance.

This is a workaround for a bug introduced in
`6cd5468cceacc1d600c7dafdd4debc6740d1dfd6`.

resolves rdar://125460667