### PR TITLE
🌸[6.0][SerialExecutor] SerialExecutor.checkIsolated() to check its own trac…

### DIFF
--- a/include/swift/ABI/Executor.h
+++ b/include/swift/ABI/Executor.h
@@ -155,8 +155,12 @@ public:
     return reinterpret_cast<DefaultActor*>(Identity);
   }
 
+  bool hasSerialExecutorWitnessTable() const {
+    return !isGeneric() && !isDefaultActor();
+  }
+
   const SerialExecutorWitnessTable *getSerialExecutorWitnessTable() const {
-    assert(!isGeneric() && !isDefaultActor());
+    assert(hasSerialExecutorWitnessTable());
     auto table = Implementation & WitnessTableMask;
     return reinterpret_cast<const SerialExecutorWitnessTable*>(table);
   }

--- a/include/swift/Runtime/Bincompat.h
+++ b/include/swift/Runtime/Bincompat.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2024 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -46,6 +46,38 @@ bool useLegacySwiftValueUnboxingInCasting();
 /// New semantics attempt to dispatch to Swift Hashable/Equatable conformances
 /// if present.
 bool useLegacySwiftObjCHashing();
+
+/// Legacy semantics allowed for the `swift_task_reportUnexpectedExecutor` to
+/// only log a warning. This changes in future releases and this function
+/// will fatal error always.
+///
+/// Similarly, the internal runtime function
+/// `swift_task_isCurrentExecutor(expected)` was previously allowed to return
+/// `false`. In future releases it will call into `checkIsolated`, and CRASH
+/// when previously it would have returned false.
+///
+/// Because some applications were running with "isolation warnings" and
+/// those call into the `isCurrentExecutor` API and expected warnings to be
+/// logged, but they ignored those warnings we cannot make them crashing,
+/// and must check if the app was built against a new.
+///
+/// Old behavior:
+/// - `swift_task_isCurrentExecutorImpl` cannot crash and does NOT invoke
+///     `SerialExecutor.checkIsolated`
+/// - `swift_task_isCurrentExecutorImpl` does not invoke `checkIsolated`
+/// - logging a warning on concurrency violation is allowed
+///
+/// New behavior:
+/// - always fatal error in `swift_task_reportUnexpectedExecutor`
+/// - `swift_task_isCurrentExecutorImpl` will crash when it would have returned
+///     false
+/// - `swift_task_isCurrentExecutorImpl` does invoke `checkIsolated` when other
+///     checks failed
+///
+/// This can be overridden by using `SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=1`
+/// or `SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=crash|nocrash`
+SWIFT_RUNTIME_STDLIB_SPI
+bool swift_bincompat_useLegacyNonCrashingExecutorChecks();
 
 } // namespace bincompat
 

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -715,6 +715,11 @@ void swift_task_enqueue(Job *job, SerialExecutorRef executor);
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueGlobal(Job *job);
 
+/// Invoke an executor's `checkIsolated` or otherwise equivalent API,
+/// that will crash if the current executor is NOT the passed executor.
+SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+void swift_task_checkIsolated(SerialExecutorRef executor);
+
 /// A count in nanoseconds.
 using JobDelay = unsigned long long;
 
@@ -729,6 +734,9 @@ void swift_task_enqueueGlobalWithDeadline(long long sec, long long nsec,
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_enqueueMainExecutor(Job *job);
 
+/// WARNING: This method is expected to CRASH when caller is not on the
+/// expected executor.
+///
 /// Return true if the caller is running in a Task on the passed Executor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 bool swift_task_isOnExecutor(
@@ -780,6 +788,12 @@ SWIFT_CC(swift) void (*swift_task_enqueueGlobalWithDeadline_hook)(
     long long tnsec,
     int clock, Job *job,
     swift_task_enqueueGlobalWithDeadline_original original);
+
+typedef SWIFT_CC(swift) void (*swift_task_checkIsolated_original)(SerialExecutorRef executor);
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) void (*swift_task_checkIsolated_hook)(
+    SerialExecutorRef executor, swift_task_checkIsolated_original original);
+
 
 typedef SWIFT_CC(swift) bool (*swift_task_isOnExecutor_original)(
     HeapObject *executor,

--- a/stdlib/public/Concurrency/CooperativeGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/CooperativeGlobalExecutor.inc
@@ -18,6 +18,7 @@
 ///   swift_task_enqueueGlobalImpl
 ///   swift_task_enqueueGlobalWithDelayImpl
 ///   swift_task_enqueueMainExecutorImpl
+///   swift_task_checkIsolatedImpl
 /// as well as any cooperative-executor-specific functions in the runtime.
 ///
 ///===------------------------------------------------------------------===///
@@ -134,6 +135,13 @@ static void insertDelayedJob(Job *newJob, JobDeadline deadline) {
   }
   JobQueueTraits::setNext(newJob, nullptr);
   *position = newJob;
+}
+
+SWIFT_CC(swift)
+static void swift_task_checkIsolatedImpl(SerialExecutorRef executor) {
+  _task_serialExecutor_checkIsolated(
+      executor.getIdentity(), swift_getObjectType(executor.getIdentity()),
+      executor.getSerialExecutorWitnessTable());
 }
 
 /// Insert a job into the cooperative global queue with a delay.

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -18,11 +18,13 @@
 ///   swift_task_enqueueGlobalImpl
 ///   swift_task_enqueueGlobalWithDelayImpl
 ///   swift_task_enqueueMainExecutorImpl
+///   swift_task_checkIsolated
 /// as well as any Dispatch-specific functions for the runtime.
 ///
 ///===------------------------------------------------------------------===///
 
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
+#include "swift/Runtime/HeapObject.h"
 #include <dispatch/dispatch.h>
 #if defined(_WIN32)
 #include <Windows.h>
@@ -233,7 +235,7 @@ static void swift_task_enqueueGlobalImpl(Job *job) {
 
 SWIFT_CC(swift)
 static void swift_task_enqueueGlobalWithDelayImpl(JobDelay delay,
-                                                  Job *job) {
+                                              Job *job) {
   assert(job && "no job provided");
 
   dispatch_function_t dispatchFunction = &__swift_run_job;
@@ -382,4 +384,57 @@ void swift::swift_task_enqueueOnDispatchQueue(Job *job,
   JobPriority priority = job->getPriority();
   auto queue = reinterpret_cast<dispatch_queue_t>(_queue);
   dispatchEnqueue(queue, job, (dispatch_qos_class_t)priority, queue);
+}
+
+/// Recognize if the SerialExecutor is specifically a `DispatchSerialQueue`
+/// by comparing witness tables and return it if true.
+static dispatch_queue_s *getAsDispatchSerialQueue(SerialExecutorRef executor) {
+  if (!executor.hasSerialExecutorWitnessTable()) {
+    return nullptr;
+  }
+
+  auto executorWitnessTable = reinterpret_cast<const WitnessTable *>(
+      executor.getSerialExecutorWitnessTable());
+  auto serialQueueWitnessTable = reinterpret_cast<const WitnessTable *>(
+      _swift_task_getDispatchQueueSerialExecutorWitnessTable());
+
+  if (swift_compareWitnessTables(executorWitnessTable,
+                                 serialQueueWitnessTable)) {
+    return reinterpret_cast<dispatch_queue_s *>(executor.getIdentity());
+  } else {
+    return nullptr;
+  }
+}
+
+/// If the executor is a `DispatchSerialQueue` we're able to invoke the
+/// dispatch's precondition API directly -- this is more efficient than going
+/// through the runtime call to end up calling the same API, and also allows us
+/// to perform this assertion on earlier platforms, where the `checkIsolated`
+/// requirement/witness was not shipping yet.
+SWIFT_CC(swift)
+static void swift_task_checkIsolatedImpl(SerialExecutorRef executor) {
+  // If it is the main executor, compare with the Main queue
+  if (executor.isMainExecutor()) {
+    dispatch_assert_queue(dispatch_get_main_queue());
+    return;
+  }
+
+  // if able to, use the checkIsolated implementation in Swift
+  if (executor.hasSerialExecutorWitnessTable()) {
+    _task_serialExecutor_checkIsolated(
+        executor.getIdentity(), swift_getObjectType(executor.getIdentity()),
+        executor.getSerialExecutorWitnessTable());
+    return;
+  }
+
+  if (auto queue = getAsDispatchSerialQueue(executor)) {
+    // if the executor was not SerialExecutor for some reason but we're able
+    // to get a queue from it anyway, use the assert directly on it.
+    dispatch_assert_queue(queue); // TODO(concurrency): could we report a better message here somehow?
+    return;
+  }
+
+  // otherwise, we have no way to check, so report an error
+  // TODO: can we swift_getTypeName(swift_getObjectType(executor.getIdentity()), false).data safely in the message here?
+  swift_Concurrency_fatalError(0, "Incorrect actor executor assumption");
 }

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -106,11 +106,12 @@ extension Actor {
       return
     }
 
+    // NOTE: This method will CRASH in new runtime versions,
+    // if it would have previously returned `false`.
+    // It will call through to SerialExecutor.checkIsolated` as a last resort.
     let expectationCheck = _taskIsCurrentExecutor(self.unownedExecutor.executor)
 
-    // TODO: offer information which executor we actually got
     precondition(expectationCheck,
-        // TODO: figure out a way to get the typed repr out of the unowned executor
         "Incorrect actor executor assumption; Expected '\(self.unownedExecutor)' executor. \(message())",
         file: file, line: line)
   }
@@ -247,8 +248,6 @@ extension Actor {
     }
 
     guard _taskIsCurrentExecutor(self.unownedExecutor.executor) else {
-      // TODO: offer information which executor we actually got
-      // TODO: figure out a way to get the typed repr out of the unowned executor
       let msg = "Incorrect actor executor assumption; Expected '\(self.unownedExecutor)' executor. \(message())"
       /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
       assertionFailure(msg, file: file, line: line) // short-cut so we get the exact same failure reporting semantics

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -90,6 +90,17 @@ SWIFT_CC(swift)
 void (*swift::swift_task_enqueueMainExecutor_hook)(
     Job *job, swift_task_enqueueMainExecutor_original original) = nullptr;
 
+SWIFT_CC(swift)
+void (*swift::swift_task_checkIsolated_hook)(
+    SerialExecutorRef executor,
+    swift_task_checkIsolated_original original) = nullptr;
+
+extern "C" SWIFT_CC(swift)
+    bool _task_serialExecutor_checkIsolated(
+        HeapObject *executor,
+        const Metadata *selfType,
+        const SerialExecutorWitnessTable *wtable);
+
 #if SWIFT_CONCURRENCY_COOPERATIVE_GLOBAL_EXECUTOR
 #include "CooperativeGlobalExecutor.inc"
 #elif SWIFT_CONCURRENCY_ENABLE_DISPATCH
@@ -132,6 +143,13 @@ void swift::swift_task_enqueueGlobalWithDeadline(
     swift_task_enqueueGlobalWithDeadlineImpl(sec, nsec, tsec, tnsec, clock, job);
 }
 
+void swift::swift_task_checkIsolated(SerialExecutorRef executor) {
+  if (swift_task_checkIsolated_hook)
+    swift_task_checkIsolated_hook(executor, swift_task_checkIsolatedImpl);
+  else
+    swift_task_checkIsolatedImpl(executor);
+}
+
 // Implemented in Swift because we need to obtain the user-defined flags on the executor ref.
 //
 // We could inline this with effort, though.
@@ -154,6 +172,12 @@ TaskExecutorRef _task_executor_getTaskExecutorRef(
     const SerialExecutorWitnessTable *wtable);
 #pragma clang diagnostic pop
 
+
+/// WARNING: This method is expected to CRASH in new runtimes, and cannot be
+/// used to implement "log warnings" mode. We would need a new entry point to
+/// implement a "only log warnings" actor isolation checking mode, and it would
+/// no be able handle more complex situations, as `SerialExecutor.checkIsolated`
+/// is able to (by calling into dispatchPrecondition on old runtimes).
 SWIFT_CC(swift)
 static bool swift_task_isOnExecutorImpl(HeapObject *executor,
                                         const Metadata *selfType,

--- a/stdlib/public/Concurrency/NonDispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/NonDispatchGlobalExecutor.inc
@@ -61,3 +61,10 @@ static void swift_task_enqueueMainExecutorImpl(Job *job) {
   swift_reportError(0, "operation unsupported without libdispatch: "
                        "swift_task_enqueueMainExecutor");
 }
+
+SWIFT_CC(swift)
+static void swift_task_checkIsolatedImpl(SerialExecutorRef executor) {
+  _task_serialExecutor_checkIsolated(
+      executor.getIdentity(), swift_getObjectType(executor.getIdentity()),
+      executor.getSerialExecutorWitnessTable());
+}

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -54,9 +54,7 @@ extension DistributedActor {
     let unownedExecutor = self.unownedExecutor
     let expectationCheck = _taskIsCurrentExecutor(unownedExecutor._executor)
 
-    // TODO: offer information which executor we actually got
     precondition(expectationCheck,
-        // TODO: figure out a way to get the typed repr out of the unowned executor
         "Incorrect actor executor assumption; Expected '\(self.unownedExecutor)' executor. \(message())",
         file: file, line: line)
   }
@@ -103,8 +101,6 @@ extension DistributedActor {
 
     let unownedExecutor = self.unownedExecutor
     guard _taskIsCurrentExecutor(unownedExecutor._executor) else {
-      // TODO: offer information which executor we actually got
-      // TODO: figure out a way to get the typed repr out of the unowned executor
       let msg = "Incorrect actor executor assumption; Expected '\(unownedExecutor)' executor. \(message())"
       /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
       assertionFailure(msg, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
@@ -187,6 +183,12 @@ extension DistributedActor {
   }
 }
 
+/// WARNING: This function will CRASH rather than return `false` in new runtimes
+///
+/// It eventually calls into `SerialExecutor.checkIsolated` which allows even
+/// for non Task code to assume isolation in certain situations, however this
+/// API cannot be made "return false", and instead will always crash if it
+/// were to return false.
 @available(SwiftStdlib 5.1, *)
 @usableFromInline
 @_silgen_name("swift_task_isCurrentExecutor")

--- a/stdlib/public/runtime/Bincompat.cpp
+++ b/stdlib/public/runtime/Bincompat.cpp
@@ -255,6 +255,17 @@ bool useLegacySwiftObjCHashing() {
 #endif
 }
 
+// FIXME(concurrency): Once the release is announced, adjust the logic detecting the SDKs
+bool swift_bincompat_useLegacyNonCrashingExecutorChecks() {
+#if BINARY_COMPATIBILITY_APPLE
+  return true; // For now, legacy behavior on Apple OSes
+#elif SWIFT_TARGET_OS_DARWIN
+  return true; // For now, use legacy behavior on open-source builds for Apple platforms
+#else
+  return false; // Always use the new behavior on non-Apple OSes
+#endif
+}
+
 } // namespace bincompat
 
 } // namespace runtime

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_dispatch.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor_checkIsolated_dispatch.swift
@@ -1,0 +1,149 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking %import-libdispatch -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN:  %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// REQUIRES: libdispatch
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+// FIXME(concurrency): rdar://119743909 fails in optimize tests.
+// UNSUPPORTED: swift_test_mode_optimize
+// UNSUPPORTED: swift_test_mode_optimize_size
+
+import StdlibUnittest
+import Dispatch
+
+// FIXME(concurrency): Dispatch should provide such implementation
+extension DispatchQueue { // which includes DispatchSerialQueue, when a platform has it
+  public func checkIsolated() {
+    dispatchPrecondition(condition: .onQueue(self))
+  }
+}
+
+
+/// We only do the executor dance because missing 'asUnownedSerialExecutor'
+/// on DispatchSerialQueue on some platforms, so we can't make this test
+/// reliably just use a queue as the executor directly.
+final class NaiveQueueExecutor: SerialExecutor {
+  let queue: DispatchQueue
+
+  init(queue: DispatchQueue) {
+    self.queue = queue
+  }
+
+  public func enqueue(_ unowned: UnownedJob) {
+    queue.sync {
+      unowned.runSynchronously(on: self.asUnownedSerialExecutor())
+    }
+  }
+
+  public func asUnownedSerialExecutor() -> UnownedSerialExecutor {
+    UnownedSerialExecutor(ordinary: self)
+  }
+
+  func checkIsolated() {
+    self.queue.checkIsolated()
+  }
+}
+
+actor ActorOnNaiveQueueExecutor {
+  let queue: DispatchQueue
+  let executor: NaiveQueueExecutor
+
+  init() {
+    self.queue = DispatchQueue(label: "MyQueue")
+    self.executor = NaiveQueueExecutor(queue: queue)
+  }
+
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    self.executor.asUnownedSerialExecutor()
+  }
+
+  nonisolated func checkPreconditionIsolated() async {
+    print("Before queue.sync {}")
+    self.queue.sync {
+      print("Before preconditionIsolated")
+      self.preconditionIsolated()
+      print("After preconditionIsolated")
+
+      print("Before dispatchPrecondition")
+      dispatchPrecondition(condition: .onQueue(self.queue))
+      print("After preconditionIsolated")
+    }
+  }
+}
+
+actor Other {
+  func checkUnexpected(actor: some Actor) {
+    actor.assumeIsolated { isolatedActor in
+      print("OK")
+    }
+  }
+}
+
+// FIXME(dispatch): DispatchSerialQueue conformance to SerialExecutor not available on all platforms yet
+//actor ActorOnQueue {
+//  let queue: DispatchSerialQueue
+//
+//  init() {
+//    self.queue = DispatchSerialQueue(label: "MyQueue")
+//  }
+//
+//  nonisolated var unownedExecutor: UnownedSerialExecutor {
+//    self.queue.asUnownedSerialExecutor()
+//  }
+//
+//  nonisolated func checkPreconditionIsolated() async {
+//    print("Before queue.sync {}")
+//    self.queue.sync {
+//      print("Before preconditionIsolated")
+//      self.queue.preconditionIsolated()
+//      print("After preconditionIsolated")
+//
+//      print("Before dispatchPrecondition")
+//      dispatchPrecondition(condition: .onQueue(self.queue))
+//      print("After preconditionIsolated")
+//    }
+//  }
+//}
+
+@main struct Main {
+  static func main() async {
+    let tests = TestSuite("AssertPreconditionActorExecutorCheckIsolated")
+
+    if #available(SwiftStdlib 6.0, *) {
+      let actorOnQueue = ActorOnNaiveQueueExecutor()
+
+      tests.test("\(ActorOnNaiveQueueExecutor.self): queue.sync { preconditionIsolated() } ") {
+        await actorOnQueue.checkPreconditionIsolated()
+      }
+
+      tests.test("\(Other.self): wrongly assume default actor on another actor's custom executor") {
+        expectCrashLater() // this will call into dispatch precondition, no message
+        let other = Other()
+        await other.checkUnexpected(actor: actorOnQueue)
+      }
+
+      tests.test("\(Other.self): correctly assume default actor on same default actor") {
+        let other = Other()
+        await other.checkUnexpected(actor: other)
+      }
+
+      // FIXME(dispatch): DispatchSerialQueue conformance to SerialExecutor not available on all platforms yet
+//      tests.test("\(ActorOnQueue.self): queue.sync { preconditionIsolated() } ") {
+//        await ActorOnQueue().checkPreconditionIsolated()
+//      }
+
+    }
+
+    await runAllTestsAsync()
+  }
+}

--- a/test/Concurrency/Runtime/data_race_detection_legacy_warning.swift
+++ b/test/Concurrency/Runtime/data_race_detection_legacy_warning.swift
@@ -1,0 +1,81 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %import-libdispatch -Xfrontend -disable-availability-checking -enable-actor-data-race-checks -parse-as-library %s -o %t/a.out -module-name main
+// RUN: %target-codesign %t/a.out
+
+// We specifically test for legacy behavior here, apps compiled against old SDKs
+// will be able to have this behavior, however new apps will not. We use the
+// overrides to test the logic for legacy code remains functional.
+//
+// RUN: env %env-SWIFT_UNEXPECTED_EXECUTOR_LOG_LEVEL=1 %env-SWIFT_IS_CURRENT_EXECUTOR_LEGACY_MODE_OVERRIDE=nocrash %target-run %t/a.out 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// rdar://76038845
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: single_threaded_concurrency
+
+import _Concurrency
+import Dispatch
+
+// For sleep
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+@MainActor func onMainActor() {
+  print("I'm on the main actor!")
+}
+
+func promiseMainThread(_ fn: @escaping @MainActor () -> Void) -> (() -> Void) {
+  typealias Fn = () -> Void
+  return unsafeBitCast(fn, to: Fn.self)
+}
+
+func launchTask(_ fn: @escaping () -> Void) {
+  if #available(macOS 10.10, iOS 8.0, watchOS 2.0, tvOS 8.0, *) {
+    DispatchQueue.global().async {
+      fn()
+    }
+  }
+}
+
+func launchFromMainThread() {
+  launchTask(promiseMainThread(onMainActor))
+}
+
+actor MyActor {
+  var counter = 0
+
+  func onMyActor() {
+    counter = counter + 1
+  }
+
+  func getTaskOnMyActor() -> (() -> Void) {
+    return {
+      self.onMyActor()
+    }
+  }
+}
+
+@main
+struct Runner {
+  static func main() async {
+    print("Launching a main-actor task")
+    // CHECK: warning: data race detected: @MainActor function at main/data_race_detection_legacy_warning.swift:30 was not called on the main thread
+    launchFromMainThread()
+    sleep(1)
+
+    let actor = MyActor()
+    let actorFn = await actor.getTaskOnMyActor()
+    print("Launching an actor-instance task")
+    // CHECK: warning: data race detected: actor-isolated function at main/data_race_detection_legacy_warning.swift:59 was not called on the same actor
+    launchTask(actorFn)
+
+    sleep(1)
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_availability.swift
@@ -29,7 +29,7 @@ import Distributed
       let system = LocalTestingDistributedActorSystem()
 
       tests.test("5.7 actor, no availability executor property => no custom executor") {
-        expectCrashLater(withMessage: "Fatal error: Incorrect actor executor assumption; Expected 'MainActor' executor.")
+        expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected MainActor executor")
         try! await FiveSevenActor_NothingExecutor(actorSystem: system).test(x: 42)
       }
 
@@ -38,7 +38,7 @@ import Distributed
       }
 
       tests.test("5.7 actor, 5.9 executor property => no custom executor") {
-        expectCrashLater(withMessage: "Fatal error: Incorrect actor executor assumption; Expected 'MainActor' executor.")
+        expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected MainActor executor")
         try! await FiveSevenActor_FiveNineExecutor(actorSystem: system).test(x: 42)
       }
 

--- a/test/Interpreter/preconcurrency_conformances.swift
+++ b/test/Interpreter/preconcurrency_conformances.swift
@@ -86,19 +86,19 @@ extension ActorTest : @preconcurrency P {
 //--- Crash1.swift
 import Types
 print(await runTest(Test.self))
-// CHECK: error: data race detected: @MainActor function at Types/Types.swift:16 was not called on the main thread
+// CHECK: Incorrect actor executor assumption; Expected MainActor executor
 
 //--- Crash2.swift
 import Types
 print(await runAccessors(Test.self))
-// CHECK: error: data race detected: @MainActor function at Types/Types.swift:15 was not called on the main thread
+// CHECK: Incorrect actor executor assumption; Expected MainActor executor
 
 //--- Crash3.swift
 import Types
 print(await runTest(ActorTest.self))
-// CHECK: error: data race detected: actor-isolated function at Types/Types.swift:33 was not called on the same actor
+// CHECK: Incorrect actor executor assumption
 
 //--- Crash4.swift
 import Types
 print(await runAccessors(ActorTest.self))
-// CHECK: error: data race detected: actor-isolated function at Types/Types.swift:30 was not called on the same actor
+// CHECK: Incorrect actor executor assumption

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -275,3 +275,13 @@ Added: _swift_task_pushTaskExecutorPreference
 Added: _$ss26withTaskExecutorPreference_9isolation9operationxSch_pSg_ScA_pSgYixyYaq_YKXEtYaq_YKs5ErrorR_r0_lF
 // async function pointer to Swift.withTaskExecutorPreference<A, B where B: Swift.Error>(_: Swift.TaskExecutor?, isolation: isolated Swift.Actor?, operation: () async throws(B) -> A) async throws(B) -> A
 Added: _$ss26withTaskExecutorPreference_9isolation9operationxSch_pSg_ScA_pSgYixyYaq_YKXEtYaq_YKs5ErrorR_r0_lFTu
+
+// === SerialExecutor.checkIsolated()
+Added: _swift_task_checkIsolated
+Added: _swift_task_checkIsolated_hook
+// (extension in Swift):Swift.SerialExecutor.checkIsolated() -> ()
+Added: _$sScfsE13checkIsolatedyyF
+// dispatch thunk of Swift.SerialExecutor.checkIsolated() -> ()
+Added: _$sScf13checkIsolatedyyFTj
+// method descriptor for Swift.SerialExecutor.checkIsolated() -> ()
+Added: _$sScf13checkIsolatedyyFTq

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -255,3 +255,6 @@ Added: __swift_exceptionPersonality
 Added: _swift_willThrowTypedImpl
 Added: __swift_willThrowTypedImpl
 Added: __swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstrumentsOnly
+
+// Runtime bincompat functions for Concurrency runtime to detect legacy mode
+Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks

--- a/test/abi/macOS/x86_64/concurrency.swift
+++ b/test/abi/macOS/x86_64/concurrency.swift
@@ -275,3 +275,13 @@ Added: _swift_task_pushTaskExecutorPreference
 Added: _$ss26withTaskExecutorPreference_9isolation9operationxSch_pSg_ScA_pSgYixyYaq_YKXEtYaq_YKs5ErrorR_r0_lF
 // async function pointer to Swift.withTaskExecutorPreference<A, B where B: Swift.Error>(_: Swift.TaskExecutor?, isolation: isolated Swift.Actor?, operation: () async throws(B) -> A) async throws(B) -> A
 Added: _$ss26withTaskExecutorPreference_9isolation9operationxSch_pSg_ScA_pSgYixyYaq_YKXEtYaq_YKs5ErrorR_r0_lFTu
+
+// === SerialExecutor.checkIsolated()
+Added: _swift_task_checkIsolated
+Added: _swift_task_checkIsolated_hook
+// (extension in Swift):Swift.SerialExecutor.checkIsolated() -> ()
+Added: _$sScfsE13checkIsolatedyyF
+// dispatch thunk of Swift.SerialExecutor.checkIsolated() -> ()
+Added: _$sScf13checkIsolatedyyFTj
+// method descriptor for Swift.SerialExecutor.checkIsolated() -> ()
+Added: _$sScf13checkIsolatedyyFTq

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -255,3 +255,6 @@ Added: __swift_exceptionPersonality
 Added: _swift_willThrowTypedImpl
 Added: __swift_willThrowTypedImpl
 Added: __swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstrumentsOnly
+
+// Runtime bincompat functions for Concurrency runtime to detect legacy mode
+Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -85,6 +85,13 @@ swift_task_enqueueGlobal_override(Job *job,
 }
 
 SWIFT_CC(swift)
+static void
+swift_task_checkIsolated_override(SerialExecutorRef executor,
+                                      swift_task_checkIsolated_original original) {
+  Ran = true;
+}
+
+SWIFT_CC(swift)
 static void swift_task_enqueueGlobalWithDelay_override(
     unsigned long long delay, Job *job,
     swift_task_enqueueGlobalWithDelay_original original) {
@@ -130,6 +137,8 @@ protected:
         swift_task_enqueueGlobalWithDelay_override;
     swift_task_enqueueMainExecutor_hook =
         swift_task_enqueueMainExecutor_override;
+    swift_task_checkIsolated_hook =
+        swift_task_checkIsolated_override;
 #ifdef RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST
     swift_task_asyncMainDrainQueue_hook =
         swift_task_asyncMainDrainQueue_override_fn;
@@ -180,6 +189,11 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_enqueueGlobal) {
 TEST_F(CompatibilityOverrideConcurrencyTest,
        test_swift_task_enqueueGlobalWithDelay) {
   swift_task_enqueueGlobalWithDelay(0, &fakeJob);
+}
+
+TEST_F(CompatibilityOverrideConcurrencyTest,
+       test_swift_task_checkIsolated) {
+  swift_task_checkIsolated(SerialExecutorRef::generic());
 }
 
 TEST_F(CompatibilityOverrideConcurrencyTest,


### PR DESCRIPTION
**Description:** This implements the proposal [SE-0424](https://github.com/apple/swift-evolution/blob/main/proposals/0424-custom-isolation-checking-for-serialexecutor.md?rgh-link-date=2024-01-26T05%3A04%3A58Z) In addition, we need to be more careful when upgrading the executor check to "default mode is crashing", and should only do so in the upcoming release.

This adds a runtime check that we'll replace with checking what version of the SDKs an app was linked against. If it is the release with Swift 6 (future), we'll make it crash by default, but by doing it dynamically like this -- old apps, linked against ols SDKs will be allowed to keep working, until they rebuild with a new SDK and get the new behavior.

**Risk:** Medium, this adds new semantics to how executor comparison works. Great care was taken to consider all cases though.
**Review by:** @hborla 
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift/pull/71172
**Radar:**  rdar://125107864 rdar://112637467