### PR TITLE
[embedded] Add a flag to specify whether the module is leaf or library

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -585,6 +585,8 @@ ERROR(objc_with_embedded,none,
       "Objective-C interoperability cannot be enabled with embedded Swift.", ())
 ERROR(no_allocations_without_embedded,none,
       "-no-allocations is only applicable with embedded Swift.", ())
+ERROR(optimize_embedded_module_without_embedded,none,
+      "-optimize-embedded-module-as is only applicable with embedded Swift.", ())
 ERROR(no_swift_sources_with_embedded,none,
       "embedded swift cannot be enabled in a compiler built without Swift sources", ())
 

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -70,6 +70,12 @@ enum class CrossModuleOptimizationMode : uint8_t {
   Everything = 3,
 };
 
+enum class ModuleRoleOption : uint8_t {
+  Unknown = 0,
+  Library = 1,
+  Leaf = 2,
+};
+
 class SILModule;
 
 class SILOptions {
@@ -173,6 +179,11 @@ public:
   /// Whether to stop the optimization pipeline right before we lower ownership
   /// and go from OSSA to non-ownership SIL.
   bool StopOptimizationBeforeLoweringOwnership = false;
+
+  /// Whether this module is definitely a leaf module (cannot have other
+  /// modules depending on it), definitely a library module (will have
+  /// dependents), or we don't know.
+  ModuleRoleOption ModuleRole = ModuleRoleOption::Unknown;
 
   /// Do we always serialize SIL in OSSA form?
   ///

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1017,6 +1017,10 @@ def AssumeSingleThreaded : Flag<["-"], "assume-single-threaded">,
   HelpText<"Assume that code will be executed in a single-threaded "
            "environment">;
 
+def OptimizeEmbeddedModuleAs : Joined<["-"], "optimize-embedded-module-as=">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Specify whether the module is 'leaf' or 'library'">;
+
 // Debug info options
 
 def g_Group : OptionGroup<"<debug info options>">;


### PR DESCRIPTION
Add two new flags, restricted to only be available under Embedded Swift:
- `-optimize-embedded-module-as=leaf` -- this will allow more optimizations, specifically dead-code elimination and possibly removal of things that would normally be an ABI break (e.g. vtable entries) but if the module cannot have any clients, then it's not an ABI break
- `-optimize-embedded-module-as=library`
- plus the default state of "unknown"

This is just adding the flag, further work with enable the actual optimizations.
