### PR TITLE
[Concurrency] Perform Sendable checking on parameter and result types for async function conversions that change actor isolation.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5611,6 +5611,14 @@ ERROR(non_sendable_param_type,none,
       "in parameter of superclass method overridden by %3 %kind2|"
       "in parameter of %3 '@objc' %kind2}1 cannot cross actor boundary",
       (Type, unsigned, const ValueDecl *, ActorIsolation))
+ERROR(non_sendable_param_reference,none,
+      "non-sendable parameter type %0 in conversion from %1 function to "
+      "%2 function",
+      (Type, ActorIsolation, ActorIsolation))
+ERROR(non_sendable_result_reference,none,
+      "non-sendable result type %0 in conversion from %1 function to "
+      "%2 function",
+      (Type, ActorIsolation, ActorIsolation))
 ERROR(non_sendable_call_argument,none,
       "passing argument of non-sendable type %0 %select{into %2 context|"
       "outside of %2 context}1 may introduce data races",

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -404,3 +404,17 @@ extension GlobalType {
     rhs: GlobalType
   ) -> Bool { true }
 }
+
+// expected-complete-tns-note@+1 2 {{class 'NotSendable' does not conform to the 'Sendable' protocol}}
+class NotSendable {}
+
+func testUnsafeAsyncFunctionConversions(
+  f: @escaping @MainActor (NotSendable) async -> Void,
+  g: @escaping @MainActor () async -> NotSendable
+) {
+  // expected-complete-tns-warning@+1 {{non-sendable parameter type 'NotSendable' in conversion from main actor-isolated function to nonisolated function; this is an error in the Swift 6 language mode}}
+  let _: (NotSendable) async -> Void = f
+
+  // expected-complete-tns-warning@+1 {{non-sendable result type 'NotSendable' in conversion from main actor-isolated function to nonisolated function; this is an error in the Swift 6 language mode}}
+  let _: () async -> NotSendable = g
+}


### PR DESCRIPTION
Such conversions are unsafe because they allow sneaking non-Sendable types across isolation boundaries:

```swift
class NotSendable {}

func testUnsafeAsyncFunctionConversions(
  f: @escaping @MainActor (NotSendable) async -> Void,
  ns: NotSendable
) {
  let newF: (NotSendable) async -> Void = f
  await newF(ns) // non-Sendable state escapes to the main actor here!
}
```

This change isn't ready yet (just putting the PR up so I don't forget about it!) because it doesn't handle function conversions in the other direction - nonisolated functions converted to global actor isolated functions. However, the constraint system currently injects function conversions from nonisolated functions to global actor isolated functions for all calls to global actor isolated functions due to the way `adjustFunctionTypeForConcurrency` is called. I believe we need to split that function up into two steps - one that adds global actor isolation, and a separate one that strips annotations for `@preconcurrenty`. The first function type should be used as the original type and the stripped function type should be used as the adjusted type, eliminating the function conversion except in the cases where it's needed for `@preconcurrency`. Then, this code in the actor isolation checker can be applied to function conversations that add global actor isolation.