### PR TITLE
[DependencyScanning] Treat main source module as a Swift dependency node in cycle resolution graph

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1471,7 +1471,8 @@ static bool diagnoseCycle(const CompilerInstance &instance,
 
   auto kindIsSwiftDependency = [&](const ModuleDependencyID &ID) {
     return ID.Kind == swift::ModuleDependencyKind::SwiftInterface ||
-           ID.Kind == swift::ModuleDependencyKind::SwiftBinary;
+           ID.Kind == swift::ModuleDependencyKind::SwiftBinary ||
+           ID.Kind == swift::ModuleDependencyKind::SwiftSource;
   };
 
   auto emitModulePath = [&](const std::vector<ModuleDependencyID> path,


### PR DESCRIPTION
Otherwise Swift Overlay paths do not get printed for dependency cycles where the sink is the same module as the source module being built. 