### PR TITLE
[Macros] Allow running exectuable macro plugins under Rosetta

### DIFF
--- a/lib/Basic/Sandbox.cpp
+++ b/lib/Basic/Sandbox.cpp
@@ -27,6 +27,11 @@ static StringRef sandboxProfile(llvm::BumpPtrAllocator &Alloc) {
   // Allow reading dylibs.
   contents += "(allow file-read* (regex #\"\\.dylib$\"))\n";
 
+  // Allow running under Rosetta.
+  contents +=
+      "(allow file-read* "
+      "(literal \"/Library/Apple/usr/libexec/oah/libRosettaRuntime\"))\n";
+
   // This is required to launch any processes (execve(2)).
   contents += "(allow process-exec*)\n";
 

--- a/test/Macros/macro_plugin_rosetta.swift
+++ b/test/Macros/macro_plugin_rosetta.swift
@@ -1,0 +1,52 @@
+// REQUIRES: swift_swift_parser
+// REQUIRES: CPU=arm64 && OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %clang -isysroot %host_sdk -target x86_64-apple-macosx10.13 -o %t/mock-plugin %t/plugin.cpp
+
+// RUN: env SWIFT_DUMP_PLUGIN_MESSAGING=1 %target-swift-frontend \
+// RUN:   -typecheck -verify \
+// RUN:   -swift-version 5 \
+// RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
+// RUN:   -module-name MyApp \
+// RUN:   %t/test.swift \
+// RUN:   > %t/macro-expansions.txt 2>&1
+
+// RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
+
+// CHECK: ->(plugin:[[#PID:]]) {"getCapability":{"capability":{"protocolVersion":[[#PROTOCOL_VERSION:]]}}}
+// CHECK: <-(plugin:[[#PID]]) {"getCapabilityResult":{"capability":{"protocolVersion":7}}}
+// CHECK: ->(plugin:[[#PID]]) {"expandFreestandingMacro":{{.*$}}
+// CHECK: <-(plugin:[[#PID]]) {"expandMacroResult":{"diagnostics":[],"expandedSource":"42"}}
+
+//--- test.swift
+@freestanding(expression) macro testInt() -> Int = #externalMacro(module: "TestPlugin", type: "TestIntMacro")
+
+func test() {
+  let _: Int =  #testInt
+}
+
+//--- plugin.cpp
+// dumb plugin just returnig expected responses.
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+
+void send_message(const char *str) {
+  uint64_t size = strlen(str);
+  fwrite(&size, sizeof(size), 1, stdout);
+  fwrite(str, size, 1, stdout);
+  fflush(stdout);
+}
+
+int main() {
+#define JSON(...) #__VA_ARGS__
+  send_message(JSON({"getCapabilityResult":{"capability":{"protocolVersion":7}}}));
+  send_message(JSON({"expandMacroResult":{"diagnostics":[],"expandedSource":"42"}}));
+  sleep(1);
+  return 0;
+}

--- a/test/Macros/macro_plugin_rosetta.swift
+++ b/test/Macros/macro_plugin_rosetta.swift
@@ -1,5 +1,6 @@
 // REQUIRES: swift_swift_parser
 // REQUIRES: CPU=arm64 && OS=macosx
+// REQUIRES: rosetta2_runtime
 
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1400,6 +1400,9 @@ if run_vendor == 'apple':
         if re.match('^(1[3-9]|[2-9])', sw_vers_vers):
             config.available_features.add('macos_min_version_13')
 
+        if os.path.exists('/Library/Apple/usr/libexec/oah/libRosettaRuntime'):
+            config.available_features.add('rosetta2_runtime')
+
     else:
         lit_config.fatal("Unknown Apple OS '" + run_os + "' " +
                          "(from " + config.variant_triple + ")")


### PR DESCRIPTION
Allow opening `/Library/Apple/usr/libexec/oah/libRosettaRuntime` in sandbox

rdar://110665062
