### PR TITLE
[6.0] Sema: Signatures of decls in local contexts always inherit availability

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -682,6 +682,11 @@ private:
     if (isCurrentTRCContainedByDeploymentTarget())
       return false;
 
+    // A declaration inside of a local context always inherits the availability
+    // of the parent.
+    if (D->getDeclContext()->isLocalContext())
+      return false;
+
     // As a convenience, SPI decls and explicitly unavailable decls are
     // constrained to the deployment target. There's not much benefit to
     // checking these declarations at a lower availability version floor since

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -368,7 +368,7 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
 // using the minimum inlining target.
 //
 
-@inlinable public func inlinedUseNoAvailable( // expected-note 8 {{add @available attribute}}
+@inlinable public func inlinedUseNoAvailable( // expected-note 13 {{add @available attribute}}
   _: NoAvailable,
   _: BeforeInliningTarget,
   _: AtInliningTarget,
@@ -395,6 +395,28 @@ public func spiDeployedUseNoAvailable( // expected-note 3 {{add @available attri
   }
   if #available(macOS 11, *) {
     _ = AfterDeploymentTarget()
+  }
+
+  // Repeat everything with pattern binding decls instead of discard expressions.
+  defer {
+    let _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
+    let _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
+  }
+  let _ = NoAvailable()
+  let _ = BeforeInliningTarget()
+  let _ = AtInliningTarget()
+  let _ = BetweenTargets() // expected-error {{'BetweenTargets' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
+  let _ = AtDeploymentTarget() // expected-error {{'AtDeploymentTarget' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note {{add 'if #available'}}
+  let _ = AfterDeploymentTarget() // expected-error {{'AfterDeploymentTarget' is only available in macOS 11 or newer}} expected-note {{add 'if #available'}}
+
+  if #available(macOS 10.14.5, *) {
+    let _ = BetweenTargets()
+  }
+  if #available(macOS 10.15, *) {
+    let _ = AtDeploymentTarget()
+  }
+  if #available(macOS 11, *) {
+    let _ = AfterDeploymentTarget()
   }
 }
 


### PR DESCRIPTION
- **Explanation:** Declarations nested in inlinable function bodies, such as `var` declarations, should not introduce new `TypeRefinementContext` nodes that are restricted to the deployment target. This bug was preventing availability checking from noticing availability errors when the occurred in a `var` declaration inside of a fragile function body.
- **Scope:** Affects all Public SDK modules with inlinable functions containing `var` declarations. While this is not a regression, fixing this bug is important because it prevents SDK module owners from implementing back deployment bugs that could be caught by the availability checker.
- **Issue/Radar:** rdar://125564069
- **Original PR:** https://github.com/apple/swift/pull/72703
- **Risk:** Low. This may cause new diagnostics in existing code, but that existing code is most likely broken and needs to be fixed.
- **Testing:** Verified that the issue is fixed with the supplied reproducer and added a regression test.
- **Reviewer:** @artemcm @beccadax 
