### PR TITLE
[6.0] LargeTypesReg2Mem: Add a heuristic for C character arrays

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "loadable-address"
+#include "Explosion.h"
 #include "FixedTypeInfo.h"
 #include "IRGenMangler.h"
 #include "IRGenModule.h"
@@ -3431,6 +3432,29 @@ public:
     toDeleteBlockArg.push_back(std::make_pair(b, argIdx));
   }
 
+  bool isPotentiallyCArray(SILType ty) {
+    if (ty.isAddress() || ty.isClassOrClassMetatype()) {
+      return false;
+    }
+
+    auto canType = ty.getASTType();
+    if (canType->hasTypeParameter()) {
+      assert(genEnv && "Expected a GenericEnv");
+      canType = genEnv->mapTypeIntoContext(canType)->getCanonicalType();
+    }
+
+    if (canType.getAnyGeneric() || isa<TupleType>(canType)) {
+      assert(ty.isObject() &&
+             "Expected only two categories: address and object");
+      assert(!canType->hasTypeParameter());
+      const TypeInfo &TI = irgenModule->getTypeInfoForLowered(canType);
+      auto explosionSchema = TI.getSchema();
+      if (explosionSchema.size() > 15)
+        return true;
+    }
+    return false;
+  }
+
   bool isLargeLoadableType(SILType ty) {
     if (ty.isAddress() || ty.isClassOrClassMetatype()) {
       return false;
@@ -3448,7 +3472,11 @@ public:
       assert(!canType->hasTypeParameter());
       const TypeInfo &TI = irgenModule->getTypeInfoForLowered(canType);
       auto &nativeSchemaOrigParam = TI.nativeParameterValueSchema(*irgenModule);
-      return nativeSchemaOrigParam.size() > 15;
+      if (nativeSchemaOrigParam.size() > 15)
+        return true;
+      auto explosionSchema = TI.getSchema();
+      if (explosionSchema.size() > 15)
+        return true;
     }
     return false;
   }
@@ -3764,7 +3792,7 @@ protected:
       builder.createStore(bc->getLoc(), bc->getOperand(), opdAddr,
                           StoreOwnershipQualifier::Unqualified);
       assignment.mapValueToAddress(origValue, addr);
-
+      assignment.markForDeletion(bc);
       return;
     }
     auto opdAddr = assignment.getAddressForValue(bc->getOperand());
@@ -3926,7 +3954,9 @@ protected:
   }
 
   void visitDebugValueInst(DebugValueInst *dbg) {
-    if (!dbg->hasAddrVal() && overlapsWithOnStackDebugLoc(dbg->getOperand())) {
+    if (!dbg->hasAddrVal() &&
+        (assignment.isPotentiallyCArray(dbg->getOperand()->getType()) ||
+         overlapsWithOnStackDebugLoc(dbg->getOperand()))) {
       assignment.markForDeletion(dbg);
       return;
     }

--- a/test/IRGen/Inputs/large_union.h
+++ b/test/IRGen/Inputs/large_union.h
@@ -1,0 +1,13 @@
+#pragma once
+
+typedef union {
+  struct {
+    unsigned char a;
+    unsigned char arr[32];
+  } in;
+  struct {
+    int a;
+    unsigned char arr[32];
+    unsigned char b;
+  } out;
+} some_struct;

--- a/test/IRGen/large_union.swift
+++ b/test/IRGen/large_union.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend %s -Osize -Xllvm -sil-print-after=loadable-address -import-objc-header %S/Inputs/large_union.h -c -o %t/t.o 2>&1 | %FileCheck %s
+
+public func test1(_ s: some_struct) -> some_struct {
+  var copy = s
+  copy.out.a = 1
+  return copy
+}
+// CHECK: sil @$s1t5test1ySo11some_structaADF : $@convention(thin) (@in_guaranteed some_struct) -> @out some_struct {
+// CHECK-NOT: unchecked_trivial_bitcast
+// CHECK: unchecked_addr_cast {{.*}} : $*some_struct.__Unnamed_struct_out to $*some_struct
+// CHECK-NOT: unchecked_trivial_bitcast
+// CHECK: } // end sil function '$s1t5test1ySo11some_structaADF'
+
+// CHECK: sil @$s1t5test2yySo11some_structazF : $@convention(thin) (@inout some_struct) -> () {
+// CHECK-NOT: unchecked_trivial_bitcast
+// CHECK: unchecked_addr_cast {{.*}} : $*some_struct.__Unnamed_struct_out to $*some_struct
+// CHECK-NOT: unchecked_trivial_bitcast
+// CHECK: } // end sil function '$s1t5test2yySo11some_structazF'
+
+public func test2(_ s: inout some_struct) {
+  s.out.a = 1
+}


### PR DESCRIPTION
They can lower to a set of i64 registers we consider small but exploded to (manifested as SSA) registers they will cause significant code bloat.

rdar://125265576

Issue: Improve heuristic of large types handling
Risk: Low-Medium. Change to a heuristic
Testing: Tested as part of CI testing

Reviewer: @eeckstein

Cherry-pick from #72694

