### PR TITLE
[region-isolation] Propagate global actor-ness of functions/closures.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -348,7 +348,7 @@ private:
   unsigned BlockListChangeIdx = 0;
 
   /// The isolation of this function.
-  std::optional<ActorIsolation> actorIsolation;
+  ActorIsolation actorIsolation = ActorIsolation::forUnspecified();
 
   /// The function's bare attribute. Bare means that the function is SIL-only
   /// and does not require debug info.
@@ -1374,9 +1374,7 @@ public:
     actorIsolation = newActorIsolation;
   }
 
-  std::optional<ActorIsolation> getActorIsolation() const {
-    return actorIsolation;
-  }
+  ActorIsolation getActorIsolation() const { return actorIsolation; }
 
   //===--------------------------------------------------------------------===//
   // Block List Access

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -208,6 +208,10 @@ public:
     return SILIsolationInfo();
   }
 
+  static SILIsolationInfo getGlobalActorIsolated(Type globalActorType) {
+    return getActorIsolated(ActorIsolation::forGlobalActor(globalActorType));
+  }
+
   static SILIsolationInfo getTaskIsolated(SILValue value) {
     return {Kind::Task, value};
   }

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -901,8 +901,8 @@ private:
       // our transferring operand. If so, we can squelch this.
       if (auto functionIsolation =
               transferringOp->getUser()->getFunction()->getActorIsolation()) {
-        if (functionIsolation->isActorIsolated() &&
-            SILIsolationInfo::getActorIsolated(*functionIsolation) ==
+        if (functionIsolation.isActorIsolated() &&
+            SILIsolationInfo::getActorIsolated(functionIsolation) ==
                 SILIsolationInfo::get(transferringOp->getUser()))
           return;
       }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -725,6 +725,13 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
         return IGM.getFunction(constant, NotForDefinition);
       });
 
+  // If we have global actor isolation for our constant, put the isolation onto
+  // the function.
+  if (auto isolation =
+          getActorIsolationOfContext(constant.getInnermostDeclContext())) {
+    F->setActorIsolation(isolation);
+  }
+
   assert(F && "SILFunction should have been defined");
 
   emittedFunctions[constant] = F;
@@ -1217,9 +1224,12 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
   if (F->getLoweredFunctionType()->isPolymorphic())
     F->setGenericEnvironment(Types.getConstantGenericEnvironment(constant));
 
-  // Set the actor isolation of the function to its innermost decl context.
-  F->setActorIsolation(
-      getActorIsolationOfContext(constant.getInnermostDeclContext()));
+  // If we have global actor isolation for our constant, put the isolation onto
+  // the function.
+  if (auto isolation =
+          getActorIsolationOfContext(constant.getInnermostDeclContext())) {
+    F->setActorIsolation(isolation);
+  }
 
   // Create a debug scope for the function using astNode as source location.
   F->setDebugScope(new (M) SILDebugScope(Loc, F));

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -91,7 +91,7 @@ SILIsolationInfo SILIsolationInfo::get(SILFunctionArgument *arg) {
   // should be marked as actor isolated.
   if (auto *self = arg->getFunction()->maybeGetSelfArgument()) {
     if (auto functionIsolation = arg->getFunction()->getActorIsolation()) {
-      if (functionIsolation->isActorIsolated()) {
+      if (functionIsolation.isActorIsolated()) {
         if (auto *nomDecl = self->getType().getNominalOrBoundGenericNominal()) {
           if (auto isolationInfo =
                   SILIsolationInfo::getActorIsolated(nomDecl)) {

--- a/test/Concurrency/Inputs/GlobalActorIsolatedFunction.swift
+++ b/test/Concurrency/Inputs/GlobalActorIsolatedFunction.swift
@@ -1,0 +1,2 @@
+
+@MainActor public func mainActorFunction() {}

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -39,9 +39,9 @@ class NotSendable {
   let ns = NotSendable(x: 0)
   MyActor.ns = ns
 
-  // expected-region-isolation-warning @+2 {{transferring 'ns' may cause a race}}
-  // expected-region-isolation-note @+1 {{transferring global actor 'MyActor'-isolated 'ns' to global actor 'YourActor'-isolated callee could cause races between global actor 'YourActor'-isolated and global actor 'MyActor'-isolated uses}}
   await { @YourActor in
+    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a race}}
+    // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
@@ -61,8 +61,9 @@ class NotSendable {
   let ns = NotSendable(x: 0)
   ns.stash()
 
-  // FIXME: Region isolation should diagnose this (https://github.com/apple/swift/issues/71533)
   await { @YourActor in
+    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a race}}
+    // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
@@ -81,8 +82,9 @@ class NotSendable {
 @MyActor func exhibitRace3() async {
   let ns = NotSendable()
 
-  // FIXME: Region isolation should diagnose this (https://github.com/apple/swift/issues/71533)
   await { @YourActor in
+    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a race}}
+    // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()

--- a/test/Concurrency/transfernonsendable_global_actor_serialization.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_serialization.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/GlobalActorIsolatedFunction.swiftmodule -module-name GlobalActorIsolatedFunction -strict-concurrency=complete %S/Inputs/GlobalActorIsolatedFunction.swift
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null -parse-as-library -I %t
+
+// README: This is testing that we properly serialize ActorIsolation on
+// SILFunctions. We do not print it yet on SILFunctions, but we can observe it
+// behaviorally.
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+import GlobalActorIsolatedFunction
+
+func useValueAsync<T>(_ t: T) async {}
+
+@MainActor func synchronousActorIsolatedFunctionError() async {
+  let erased: () -> Void = mainActorFunction
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}

--- a/test/Concurrency/transfernonsendable_global_actor_swift6.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_swift6.swift
@@ -1,0 +1,87 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null -parse-as-library
+
+// README: This is testing specific patterns around global actors that are
+// slightly different in between swift 5 and swift 6. The normal global actor
+// test is in swift 5, so any tests that work with swift 5 need to be there.
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+final class SendableKlass : Sendable {}
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+func transferToNonIsolated<T>(_ t: T) async {}
+@MainActor func transferToMainActor<T>(_ t: T) async {}
+@CustomActor func transferToCustomActor<T>(_ t: T) async {}
+func useValue<T>(_ t: T) {}
+func useValueAsync<T>(_ t: T) async {}
+@MainActor func useValueMainActor<T>(_ t: T) {}
+@MainActor func mainActorFunction() {}
+
+var booleanFlag: Bool { false }
+@MainActor var mainActorIsolatedGlobal = NonSendableKlass()
+@CustomActor var customActorIsolatedGlobal = NonSendableKlass()
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+@MainActor func synchronousActorIsolatedClosureError() async {
+  let closure = { @MainActor @Sendable in
+    MainActor.assertIsolated()
+  }
+
+  let erased: () -> Void = closure
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor func synchronousActorIsolatedFunctionError() async {
+  let erased: () -> Void = mainActorFunction
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
+  let erased: (T) -> Void = useValueMainActor
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor func synchronousActorIsolatedClassMethodError() async {
+  @MainActor class Test {
+    func foo() {}
+  }
+
+  let t = Test()
+  let erased: () -> Void = t.foo
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor func synchronousActorIsolatedFinalClassMethodError() async {
+  @MainActor final class Test {
+    func foo() {}
+  }
+
+  let t = Test()
+  let erased: () -> Void = t.foo
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}


### PR DESCRIPTION
I fixed a bunch of small issues around here that resulted in a bunch of radars
being fixed. Specifically:

1. I made it so that we treat function_refs that are from an actor isolated
function as actor isolated instead of sendable.

2. I made it so that autoclosures which return global actor isolated functions
are treated as producing a global actor isolated function.

3. I made it so that we properly handle SILGen code patterns produced by
Sendable GlobalActor isolated things.

rdar://125452372
rdar://121954871
rdar://121955895
rdar://122692698

