### PR TITLE
Mark tests that require the new runtime for invertible protocols support

### DIFF
--- a/test/Interpreter/escapable_generics_casting.swift
+++ b/test/Interpreter/escapable_generics_casting.swift
@@ -3,6 +3,9 @@
 
 // REQUIRES: executable_test, asserts
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 protocol P {
   func speak()
 }

--- a/test/Interpreter/moveonly_generics.swift
+++ b/test/Interpreter/moveonly_generics.swift
@@ -4,6 +4,8 @@
 // REQUIRES: executable_test
 // REQUIRES: asserts
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 
 // Needed due to limitations of autoclosures and noncopyable types.
 func eagerAssert(_ b: Bool, _ line: Int = #line) {

--- a/test/Interpreter/moveonly_generics_casting.swift
+++ b/test/Interpreter/moveonly_generics_casting.swift
@@ -3,6 +3,9 @@
 
 // REQUIRES: executable_test
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 protocol P {
   func speak()
 }


### PR DESCRIPTION
Fixes rdar://125628899
