### PR TITLE
Fix name lookup in nested protocol inheritance clauses

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1087,7 +1087,8 @@ static DirectlyReferencedTypeDecls
 directReferencesForTypeRepr(Evaluator &evaluator, ASTContext &ctx,
                             TypeRepr *typeRepr, DeclContext *dc,
                             bool allowUsableFromInline,
-                            bool rhsOfSelfRequirement);
+                            bool rhsOfSelfRequirement,
+                            bool allowProtocolMembers);
 
 /// Retrieve the set of type declarations that are directly referenced from
 /// the given type.
@@ -1148,7 +1149,8 @@ SelfBounds SelfBoundsFromWhereClauseRequest::evaluate(
       rhsDecls = directReferencesForTypeRepr(evaluator, ctx, typeRepr,
                                              const_cast<DeclContext *>(dc),
                                              /*allowUsableFromInline=*/false,
-                                             /*rhsOfSelfRequirement=*/true);
+                                             /*rhsOfSelfRequirement=*/true,
+                                             /*allowProtocolMembers=*/true);
     }
 
     SmallVector<ModuleDecl *, 2> modulesFound;
@@ -1212,7 +1214,8 @@ TypeDeclsFromWhereClauseRequest::evaluate(Evaluator &evaluator,
   auto resolve = [&](TypeRepr *typeRepr) {
     auto decls = directReferencesForTypeRepr(evaluator, ctx, typeRepr, ext,
                                              /*allowUsableFromInline=*/false,
-                                             /*rhsOfSelfRequirement=*/false);
+                                             /*rhsOfSelfRequirement=*/false,
+                                             /*allowProtocolMembers=*/true);
     result.first.insert(result.first.end(),
                         decls.first.begin(),
                         decls.first.end());
@@ -2834,10 +2837,11 @@ directReferencesForUnqualifiedTypeLookup(DeclNameRef name,
                                          SourceLoc loc, DeclContext *dc,
                                          LookupOuterResults lookupOuter,
                                          bool allowUsableFromInline,
-                                         bool rhsOfSelfRequirement) {
-  UnqualifiedLookupOptions options =
-      UnqualifiedLookupFlags::TypeLookup |
-      UnqualifiedLookupFlags::AllowProtocolMembers;
+                                         bool rhsOfSelfRequirement,
+                                         bool allowProtocolMembers) {
+  UnqualifiedLookupOptions options = UnqualifiedLookupFlags::TypeLookup;
+  if (allowProtocolMembers)
+      options |= UnqualifiedLookupFlags::AllowProtocolMembers;
   if (lookupOuter == LookupOuterResults::Included)
     options |= UnqualifiedLookupFlags::IncludeOuterResults;
 
@@ -2951,11 +2955,12 @@ static DirectlyReferencedTypeDecls
 directReferencesForDeclRefTypeRepr(Evaluator &evaluator, ASTContext &ctx,
                                    DeclRefTypeRepr *repr, DeclContext *dc,
                                    bool allowUsableFromInline,
-                                   bool rhsOfSelfRequirement) {
+                                   bool rhsOfSelfRequirement,
+                                   bool allowProtocolMembers) {
   if (auto *qualIdentTR = dyn_cast<QualifiedIdentTypeRepr>(repr)) {
     auto result = directReferencesForTypeRepr(
         evaluator, ctx, qualIdentTR->getBase(), dc,
-        allowUsableFromInline, rhsOfSelfRequirement);
+        allowUsableFromInline, rhsOfSelfRequirement, allowProtocolMembers);
 
     // For a qualified identifier, perform qualified name lookup.
     result.first = directReferencesForQualifiedTypeLookup(
@@ -2968,14 +2973,15 @@ directReferencesForDeclRefTypeRepr(Evaluator &evaluator, ASTContext &ctx,
   // For an unqualified identifier, perform unqualified name lookup.
   return directReferencesForUnqualifiedTypeLookup(
       repr->getNameRef(), repr->getLoc(), dc, LookupOuterResults::Excluded,
-      allowUsableFromInline, rhsOfSelfRequirement);
+      allowUsableFromInline, rhsOfSelfRequirement, allowProtocolMembers);
 }
 
 static DirectlyReferencedTypeDecls
 directReferencesForTypeRepr(Evaluator &evaluator,
                             ASTContext &ctx, TypeRepr *typeRepr,
                             DeclContext *dc, bool allowUsableFromInline,
-                            bool rhsOfSelfRequirement) {
+                            bool rhsOfSelfRequirement,
+                            bool allowProtocolMembers) {
   DirectlyReferencedTypeDecls result;
 
   switch (typeRepr->getKind()) {
@@ -2988,7 +2994,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForTypeRepr(evaluator, ctx,
                                        attributed->getTypeRepr(), dc,
                                        allowUsableFromInline,
-                                       rhsOfSelfRequirement);
+                                       rhsOfSelfRequirement,
+                                       allowProtocolMembers);
   }
 
   case TypeReprKind::Composition: {
@@ -2997,7 +3004,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
       auto componentResult =
           directReferencesForTypeRepr(evaluator, ctx, component, dc,
                                       allowUsableFromInline,
-                                      rhsOfSelfRequirement);
+                                      rhsOfSelfRequirement,
+                                      allowProtocolMembers);
       result.first.insert(result.first.end(),
                           componentResult.first.begin(),
                           componentResult.first.end());
@@ -3013,7 +3021,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForDeclRefTypeRepr(evaluator, ctx,
                                               cast<DeclRefTypeRepr>(typeRepr),
                                               dc, allowUsableFromInline,
-                                              rhsOfSelfRequirement);
+                                              rhsOfSelfRequirement,
+                                              allowProtocolMembers);
 
   case TypeReprKind::Dictionary:
     result.first.push_back(ctx.getDictionaryDecl());
@@ -3025,7 +3034,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
       result = directReferencesForTypeRepr(evaluator, ctx,
                                            tupleRepr->getElementType(0), dc,
                                            allowUsableFromInline,
-                                           rhsOfSelfRequirement);
+                                           rhsOfSelfRequirement,
+                                           allowProtocolMembers);
     } else {
       result.first.push_back(ctx.getBuiltinTupleDecl());
     }
@@ -3037,7 +3047,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForTypeRepr(evaluator, ctx,
                                        packExpansionRepr->getElementType(), dc,
                                        allowUsableFromInline,
-                                       rhsOfSelfRequirement);
+                                       rhsOfSelfRequirement,
+                                       allowProtocolMembers);
   }
 
   case TypeReprKind::PackExpansion: {
@@ -3045,7 +3056,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForTypeRepr(evaluator, ctx,
                                        packExpansionRepr->getPatternType(), dc,
                                        allowUsableFromInline,
-                                       rhsOfSelfRequirement);
+                                       rhsOfSelfRequirement,
+                                       allowProtocolMembers);
   }
 
   case TypeReprKind::PackElement: {
@@ -3053,7 +3065,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     return directReferencesForTypeRepr(evaluator, ctx,
                                        packReferenceRepr->getPackType(), dc,
                                        allowUsableFromInline,
-                                       rhsOfSelfRequirement);
+                                       rhsOfSelfRequirement,
+                                       allowProtocolMembers);
   }
 
   case TypeReprKind::Inverse: {
@@ -3063,7 +3076,8 @@ directReferencesForTypeRepr(Evaluator &evaluator,
     auto innerResult = directReferencesForTypeRepr(evaluator, ctx,
                                                    inverseRepr->getConstraint(), dc,
                                                    allowUsableFromInline,
-                                                   rhsOfSelfRequirement);
+                                                   rhsOfSelfRequirement,
+                                                   allowProtocolMembers);
     if (innerResult.first.size() == 1) {
       if (auto *proto = dyn_cast<ProtocolDecl>(innerResult.first[0])) {
         if (auto ip = proto->getInvertibleProtocolKind()) {
@@ -3173,10 +3187,16 @@ DirectlyReferencedTypeDecls InheritedDeclsReferencedRequest::evaluate(
     else
       dc = (DeclContext *)decl.get<const ExtensionDecl *>();
 
+    // If looking at a protocol's inheritance list,
+    // do not look at protocol members to avoid circularity.
+    // Protocols cannot inherit from any protocol members anyway.
+    bool allowProtocolMembers = (dc->getSelfProtocolDecl() == nullptr);
+
     return directReferencesForTypeRepr(evaluator, dc->getASTContext(), typeRepr,
                                        const_cast<DeclContext *>(dc),
                                        /*allowUsableFromInline=*/false,
-                                       /*rhsOfSelfRequirement=*/false);
+                                       /*rhsOfSelfRequirement=*/false,
+                                       allowProtocolMembers);
   }
 
   // Fall back to semantic types.
@@ -3197,7 +3217,8 @@ DirectlyReferencedTypeDecls UnderlyingTypeDeclsReferencedRequest::evaluate(
     return directReferencesForTypeRepr(evaluator, typealias->getASTContext(),
                                        typeRepr, typealias,
                                        /*allowUsableFromInline=*/false,
-                                       /*rhsOfSelfRequirement=*/false);
+                                       /*rhsOfSelfRequirement=*/false,
+                                       /*allowProtocolMembers=*/true);
   }
 
   // Fall back to semantic types.
@@ -3356,7 +3377,8 @@ ExtendedNominalRequest::evaluate(Evaluator &evaluator,
   DirectlyReferencedTypeDecls referenced =
     directReferencesForTypeRepr(evaluator, ctx, typeRepr, ext->getParent(),
                                 ext->isInSpecializeExtensionContext(),
-                                /*rhsOfSelfRequirement=*/false);
+                                /*rhsOfSelfRequirement=*/false,
+                                /*allowProtocolMembers=*/true);
 
   // Resolve those type declarations to nominal type declarations.
   SmallVector<ModuleDecl *, 2> modulesFound;
@@ -3406,7 +3428,8 @@ bool TypeRepr::isProtocolOrProtocolComposition(DeclContext *dc) {
   auto &ctx = dc->getASTContext();
   auto references = directReferencesForTypeRepr(ctx.evaluator, ctx, this, dc,
                                                 /*allowUsableFromInline=*/false,
-                                                /*rhsOfSelfRequirement=*/false);
+                                                /*rhsOfSelfRequirement=*/false,
+                                                /*allowProtocolMembers=*/true);
   return declsAreProtocols(references.first);
 }
 
@@ -3441,7 +3464,8 @@ createTupleExtensionGenericParams(ASTContext &ctx,
                                 extendedTypeRepr,
                                 ext->getParent(),
                                 /*allowUsableFromInline=*/false,
-                                /*rhsOfSelfRequirement=*/false);
+                                /*rhsOfSelfRequirement=*/false,
+                                /*allowProtocolMembers=*/true);
   assert(referenced.second.empty() && "Implement me");
   if (referenced.first.size() != 1 || !isa<TypeAliasDecl>(referenced.first[0]))
     return nullptr;
@@ -3716,7 +3740,8 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
     decls = directReferencesForTypeRepr(
         evaluator, ctx, typeRepr, dc,
         /*allowUsableFromInline=*/false,
-        /*rhsOfSelfRequirement=*/false);
+        /*rhsOfSelfRequirement=*/false,
+        /*allowProtocolMembers=*/true);
   } else if (Type type = attr->getType()) {
     decls = directReferencesForType(type);
   }
@@ -3747,7 +3772,8 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
         decls = directReferencesForUnqualifiedTypeLookup(
             name, loc, dc, LookupOuterResults::Included,
             /*allowUsableFromInline=*/false,
-            /*rhsOfSelfRequirement=*/false);
+            /*rhsOfSelfRequirement=*/false,
+            /*allowProtocolMembers*/true);
         nominals = resolveTypeDeclsToNominal(evaluator, ctx, decls.first,
                                              ResolveToNominalOptions(),
                                              modulesFound, anyObject);
@@ -3982,7 +4008,8 @@ ProtocolDecl *ImplementsAttrProtocolRequest::evaluate(
   DirectlyReferencedTypeDecls referenced =
     directReferencesForTypeRepr(evaluator, ctx, typeRepr, dc,
                                 /*allowUsableFromInline=*/false,
-                                /*rhsOfSelfRequirement=*/false);
+                                /*rhsOfSelfRequirement=*/false,
+                                /*allowProtocolMembers=*/true);
 
   // Resolve those type declarations to nominal type declarations.
   SmallVector<ModuleDecl *, 2> modulesFound;

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -44,6 +44,46 @@ class OuterClass {
   protocol InnerProtocol : OuterClass { }
 }
 
+// Name lookup circularity tests.
+
+protocol SomeBaseProtocol {}
+
+struct ConformanceOnDecl: ConformanceOnDecl.P {
+    protocol P: SomeBaseProtocol {}
+}
+struct ConformanceOnDecl_2: ConformanceOnDecl_2.P {
+    protocol P where Self: SomeBaseProtocol {}
+}
+struct ConformanceOnDecl_3: Self.P {
+    protocol P: SomeBaseProtocol {}
+}
+struct ConformanceOnDecl_4: ConformanceOnDecl_4.Q {
+    protocol P: SomeBaseProtocol {}
+    protocol Q: P {}
+}
+
+
+struct ConformanceInExtension {
+    protocol P: SomeBaseProtocol {}
+}
+extension ConformanceInExtension: ConformanceInExtension.P {}
+
+struct ConformanceInExtension_2 {
+    protocol P where Self: SomeBaseProtocol {}
+}
+extension ConformanceInExtension_2: ConformanceInExtension_2.P {}
+
+struct ConformanceInExtension_3 {
+    protocol P: SomeBaseProtocol {}
+}
+extension ConformanceInExtension_3: Self.P {}
+
+struct ConformanceInExtension_4 {
+    protocol P: SomeBaseProtocol {}
+    protocol Q: P {}
+}
+extension ConformanceInExtension_4: ConformanceInExtension_4.Q {}
+
 // Protocols can be nested in actors.
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)


### PR DESCRIPTION
Currently, this fails to compile with a circular reference error:

```swift
protocol SomeBaseProtocol {}

struct ConformanceOnDecl: ConformanceOnDecl.P {
    protocol P: SomeBaseProtocol {}
}
```

Basically what happens is that `InheritedDeclsReferencedRequest` is executed for the nested protocol `P`, and tries to look up what `SomeBaseProtocol` is. 

This goes through to `ASTScope` lookup, which walks up to the `struct ConformanceOnDecl` context and calls `IterableTypeBodyPortion::lookupMembersOf`, which performs a _qualified_ lookup request within the `struct ConformanceOnDecl` DeclContext.

Qualified lookup then finds the protocol `P` again and calls `getSuperclassDecl` on it, which prompts another `InheritedDeclsReferencedRequest`, and we have a request cycle.

This doesn't happen for non-nested protocols because they live at the top level, so this whole thing where `ASTScope` walks up to their parent and then back down in to them again won't happen.

---

This patch turns off `AllowProtocolMembers` in `InheritedDeclsReferencedRequest` if the decl is a protocol, which causes qualified lookup to skip processing protocols it finds. There are no protocol members that are even valid in an inheritance list, so this should be fine. 

The generics book says:

> {UnqualifiedLookupFlags::AllowProtocolMembers}: if set, lookup finds members of protocols and protocol extensions. Generally should always be set, except to avoid request cycles in cases where it is known the result of the lookup cannot appear in a protocol or protocol extensions.

So I think un-setting this to avoid a cycle seems reasonable. Other flags such as `rhsOfSelfRequirement` seem like they exist to avoid similar cycles (although that particular flag _does_ support protocol members such as associated types, which we don't want here).