### PR TITLE
[embedded] Build the macOS Embedded Stdlib with a recent deployment target

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -227,9 +227,9 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB)
       )
   elseif (SWIFT_HOST_VARIANT STREQUAL "macosx")
     set(EMBEDDED_STDLIB_TARGET_TRIPLES ${EMBEDDED_STDLIB_TARGET_TRIPLES}
-      "x86_64   x86_64-apple-macos        x86_64-apple-macos10.13"
-      "arm64    arm64-apple-macos         arm64-apple-macos10.13"
-      "arm64e   arm64e-apple-macos        arm64e-apple-macos10.13"
+      "x86_64   x86_64-apple-macos        x86_64-apple-macos14"
+      "arm64    arm64-apple-macos         arm64-apple-macos14"
+      "arm64e   arm64e-apple-macos        arm64e-apple-macos14"
       )
   endif()
 endif()

--- a/test/DebugInfo/embedded.swift
+++ b/test/DebugInfo/embedded.swift
@@ -1,7 +1,7 @@
 // Check that the "-enable-embedded-swift" is stored as a flag in the 
 // Compile Unit.
 
-// RUN: %target-swift-frontend -emit-ir -enable-experimental-feature Embedded -g %s -o - | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -emit-ir -enable-experimental-feature Embedded -g %s -o - | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test

--- a/test/IDE/complete_embedded_linux.swift
+++ b/test/IDE/complete_embedded_linux.swift
@@ -1,6 +1,6 @@
 // REQUIRES: asserts
 // REQUIRES: swift_in_compiler
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=linux-gnu
 // RUN: %batch-code-completion -enable-experimental-feature Embedded
 
 func test() {

--- a/test/IDE/complete_embedded_macos.swift
+++ b/test/IDE/complete_embedded_macos.swift
@@ -1,0 +1,15 @@
+// REQUIRES: asserts
+// REQUIRES: swift_in_compiler
+// REQUIRES: OS=macosx
+// RUN: %batch-code-completion -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded
+
+func test() {
+  #^GLOBAL^#
+// GLOBAL: Literal[Integer]/None:              0[#Int#];
+// GLOBAL: Literal[Boolean]/None:              true[#Bool#];
+// GLOBAL: Literal[Boolean]/None:              false[#Bool#];
+// GLOBAL: Literal[Nil]/None:                  nil;
+// GLOBAL: Literal[String]/None:               "{#(abc)#}"[#String#];
+// GLOBAL: Literal[Array]/None:                [{#(values)#}][#Array#];
+// GLOBAL: Literal[Dictionary]/None:           [{#(key)#}: {#(value)#}][#Dictionary#];
+}

--- a/test/SILOptimizer/devirt_deinits.swift
+++ b/test/SILOptimizer/devirt_deinits.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend  -primary-file %s -parse-as-library -sil-verify-all -Xllvm -enable-deinit-devirtualizer -module-name=test -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -primary-file %s -parse-as-library -sil-verify-all -Xllvm -enable-deinit-devirtualizer -module-name=test -emit-sil | %FileCheck %s
 
 // Also do an end-to-end test and check if the compiled executable works as expected.
 // RUN: %target-run-simple-swift(-Xllvm -enable-deinit-devirtualizer -parse-as-library) | %FileCheck -check-prefix CHECK-OUTPUT %s

--- a/test/SILOptimizer/devirt_deinits.swift
+++ b/test/SILOptimizer/devirt_deinits.swift
@@ -1,14 +1,14 @@
 // RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -primary-file %s -parse-as-library -sil-verify-all -Xllvm -enable-deinit-devirtualizer -module-name=test -emit-sil | %FileCheck %s
 
 // Also do an end-to-end test and check if the compiled executable works as expected.
-// RUN: %target-run-simple-swift(-Xllvm -enable-deinit-devirtualizer -parse-as-library) | %FileCheck -check-prefix CHECK-OUTPUT %s
+// RUN: %target-run-simple-swift(-target %target-cpu-apple-macos14 -Xllvm -enable-deinit-devirtualizer -parse-as-library) | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 // Check if it works in embedded mode.
-// RUN: %target-run-simple-swift(-enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck -check-prefix CHECK-OUTPUT %s
+// RUN: %target-run-simple-swift(-target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library -runtime-compatibility-version none -wmo -Xfrontend -disable-objc-interop) | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 // Run without the deinit-devirtualizer to verify that our CHECK-OUTPUT lines are correct.
 // TODO: currently disabled because of rdar://118449507
-// RUNx: %target-run-simple-swift(-Xllvm -sil-disable-pass=deinit-devirtualizer -parse-as-library) | %FileCheck -check-prefix CHECK-OUTPUT %s
+// RUNx: %target-run-simple-swift(-target %target-cpu-apple-macos14 -Xllvm -sil-disable-pass=deinit-devirtualizer -parse-as-library) | %FileCheck -check-prefix CHECK-OUTPUT %s
 
 
 // REQUIRES: swift_in_compiler

--- a/test/embedded/concurrency-actors.swift
+++ b/test/embedded/concurrency-actors.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/concurrency-async-let.swift
+++ b/test/embedded/concurrency-async-let.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/concurrency-builtins.swift
+++ b/test/embedded/concurrency-builtins.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -emit-irgen %s -enable-experimental-feature Embedded -enable-builtin-module | %FileCheck %s
+// RUN: %target-swift-frontend -emit-irgen %s -enable-experimental-feature Embedded -enable-builtin-module | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: optimized_stdlib

--- a/test/embedded/concurrency-simple.swift
+++ b/test/embedded/concurrency-simple.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
+// RUN: %target-swift-frontend -enable-experimental-feature Embedded -parse-as-library %s -c -o %t/a.o
 // RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out %swift_obj_root/lib/swift/embedded/%target-cpu-apple-macos/libswift_Concurrency.a -dead_strip
 // RUN: %target-run %t/a.out | %FileCheck %s

--- a/test/embedded/lit.local.cfg
+++ b/test/embedded/lit.local.cfg
@@ -1,0 +1,12 @@
+# Make a local copy of the substitutions.
+config.substitutions = list(config.substitutions)
+
+if config.target_sdk_name == 'macosx':
+  def do_fixup(key, value):
+    if isinstance(value, str):
+      value = value.replace("-apple-macosx10.13", "-apple-macos14")
+    elif isinstance(value, SubstituteCaptures):
+      value.substitution = value.substitution.replace("-apple-macosx10.13", "-apple-macos14")
+    return (key, value)
+
+  config.substitutions = [do_fixup(a, b) for (a, b) in config.substitutions]

--- a/test/embedded/opaque-return-types.swift
+++ b/test/embedded/opaque-return-types.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -target %target-cpu-apple-macos14 -enable-experimental-feature Embedded | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -enable-experimental-feature Embedded | %FileCheck %s
 
 // REQUIRES: swift_in_compiler
 // REQUIRES: VENDOR=apple


### PR DESCRIPTION
The macOS embedded stdlib, which is mostly used for testing (we run CI against it in ci.swift.org) and for experimentation/prototyping, is currently building with deployment target of macOS 10.13 (same as the regular stdlib). Given that the embedded stdlib is not meant for back-deploying to older OS's, let's bump it to 14 to simplify our testing story and allow embedded tests to take advantage of OS version gated features (this will enable us to test more Swift Concurrency).