### PR TITLE
Parser: Don't skip functions with a nested `typealias` or `actor` for LLDB

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5625,7 +5625,8 @@ static unsigned skipUntilMatchingRBrace(Parser &P,
       tok::pound_if, tok::pound_else, tok::pound_endif, tok::pound_elseif);
 
     HasNestedTypeDeclarations |= P.Tok.isAny(tok::kw_class, tok::kw_struct,
-                                             tok::kw_enum);
+                                             tok::kw_enum, tok::kw_typealias)
+                              || P.Tok.isContextualKeyword("actor");
 
     // HACK: Bail if we encounter what could potentially be a regex literal.
     // This is necessary as:

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5625,7 +5625,8 @@ static unsigned skipUntilMatchingRBrace(Parser &P,
       tok::pound_if, tok::pound_else, tok::pound_endif, tok::pound_elseif);
 
     HasNestedTypeDeclarations |= P.Tok.isAny(tok::kw_class, tok::kw_struct,
-                                             tok::kw_enum, tok::kw_typealias)
+                                             tok::kw_enum, tok::kw_typealias,
+                                             tok::kw_protocol)
                               || P.Tok.isContextualKeyword("actor");
 
     // HACK: Bail if we encounter what could potentially be a regex literal.

--- a/test/Frontend/skip-function-bodies.swift
+++ b/test/Frontend/skip-function-bodies.swift
@@ -217,6 +217,16 @@ public func funcPublicWithNestedTypeActor() {
 // CHECK-SIL-SKIP-NONINLINE-NOT: "funcPublicWithNestedTypeActor()"
 // CHECK-SIL-SKIP-WITHOUTTYPES: "funcPublicWithNestedTypeActor()"
 
+public func funcPublicWithNestedTypeProtocol() {
+  let INLINENOTYPECHECK_local = "funcPublicWithNestedTypeProtocol()"
+  _blackHole(INLINENOTYPECHECK_local)
+  protocol P {}
+}
+// CHECK-TEXTUAL-NOT: "funcPublicWithNestedTypeProtocol()"
+// CHECK-SIL-NO-SKIP: "funcPublicWithNestedTypeProtocol()"
+// CHECK-SIL-SKIP-NONINLINE-NOT: "funcPublicWithNestedTypeProtocol()"
+// CHECK-SIL-SKIP-WITHOUTTYPES: "funcPublicWithNestedTypeProtocol()"
+
 public func funcPublicWithNestedTypeStruct() {
   let INLINENOTYPECHECK_local = "funcPublicWithNestedTypeStruct()"
   _blackHole(INLINENOTYPECHECK_local)

--- a/test/Frontend/skip-function-bodies.swift
+++ b/test/Frontend/skip-function-bodies.swift
@@ -2,9 +2,9 @@
 
 // Check skipped function bodies are neither typechecked nor SILgen'd when the
 // -experimental-skip-*-function-bodies-* flags are specified.
-// RUN: %target-swift-frontend -emit-sil %s > %t/NoSkip.sil
+// RUN: %target-swift-frontend -emit-sil -target %target-swift-abi-5.10-triple %s > %t/NoSkip.sil
 // RUN: %target-swift-frontend -emit-sil -experimental-skip-non-inlinable-function-bodies -debug-forbid-typecheck-prefix NEVERTYPECHECK -debug-forbid-typecheck-prefix INLINENOTYPECHECK %s > %t/Skip.noninlinable.sil
-// RUN: %target-swift-frontend -emit-sil -experimental-skip-non-inlinable-function-bodies-without-types -debug-forbid-typecheck-prefix NEVERTYPECHECK %s > %t/Skip.withouttypes.sil
+// RUN: %target-swift-frontend -emit-sil -target %target-swift-abi-5.10-triple -experimental-skip-non-inlinable-function-bodies-without-types -debug-forbid-typecheck-prefix NEVERTYPECHECK %s > %t/Skip.withouttypes.sil
 
 // RUN: %FileCheck %s --check-prefixes CHECK,CHECK-SIL-NO-SKIP --input-file %t/NoSkip.sil
 // RUN: %FileCheck %s --check-prefixes CHECK,CHECK-SIL-SKIP-NONINLINE-OR-WITHOUTTYPES,CHECK-SIL-SKIP-NONINLINE --input-file %t/Skip.noninlinable.sil
@@ -14,16 +14,16 @@
 // RUN: %FileCheck %s --check-prefixes CHECK,CHECK-SIL-SKIP-ALL --input-file %t/Skip.all.sil
 
 // Emit module interfaces and check their contents, too.
-// RUN: %target-swift-emit-module-interface(%t/Skip.noninlinable.swiftinterface) %s -module-name Skip -experimental-skip-non-inlinable-function-bodies
+// RUN: %target-swift-emit-module-interface(%t/Skip.noninlinable.swiftinterface) %s -target %target-swift-abi-5.10-triple -module-name Skip -experimental-skip-non-inlinable-function-bodies
 // RUN: %target-swift-typecheck-module-from-interface(%t/Skip.noninlinable.swiftinterface) -module-name Skip
 // RUN: %FileCheck %s --check-prefixes CHECK,CHECK-TEXTUAL --input-file %t/Skip.noninlinable.swiftinterface
-// RUN: %target-swift-emit-module-interface(%t/Skip.all.swiftinterface) %s -module-name Skip -experimental-skip-all-function-bodies
+// RUN: %target-swift-emit-module-interface(%t/Skip.all.swiftinterface) %s -target %target-swift-abi-5.10-triple -module-name Skip -experimental-skip-all-function-bodies
 // RUN: %target-swift-typecheck-module-from-interface(%t/Skip.all.swiftinterface) -module-name Skip
 // RUN: %FileCheck %s --check-prefixes CHECK,CHECK-TEXTUAL --input-file %t/Skip.all.swiftinterface
 
 // Verify that the emitted interfaces match an interface emitted without any
 // body skipping flags.
-// RUN: %target-swift-emit-module-interface(%t/NoSkip.swiftinterface) %s  -module-name Skip
+// RUN: %target-swift-emit-module-interface(%t/NoSkip.swiftinterface) %s -target %target-swift-abi-5.10-triple -module-name Skip
 // RUN: %FileCheck %s --check-prefixes CHECK,CHECK-TEXTUAL --input-file %t/NoSkip.swiftinterface
 // RUN: diff -u %t/Skip.noninlinable.swiftinterface %t/NoSkip.swiftinterface
 // RUN: diff -u %t/Skip.all.swiftinterface %t/NoSkip.swiftinterface

--- a/test/Frontend/skip-function-bodies.swift
+++ b/test/Frontend/skip-function-bodies.swift
@@ -158,19 +158,20 @@ func funcPublicWithDefer() {
 // CHECK-SIL-SKIP-NONINLINE-OR-WITHOUTTYPES-NOT: "funcPublicWithDefer()"
 
 public func funcPublicWithNestedFuncAndTypealias() {
-  let NEVERTYPECHECK_outerLocal = "funcPublicWithNestedFuncAndTypealias()"
-  _blackHole(NEVERTYPECHECK_outerLocal)
+  let INLINENOTYPECHECK_outerLocal = "funcPublicWithNestedFuncAndTypealias()"
+  _blackHole(INLINENOTYPECHECK_outerLocal)
 
   typealias LocalType = Int
   func takesLocalType(_ x: LocalType) {
-    let NEVERTYPECHECK_innerLocal = "funcPublicWithNestedFuncAndTypealias()@takesLocalType(_:)"
-    _blackHole(NEVERTYPECHECK_innerLocal)
+    let INLINENOTYPECHECK_innerLocal = "funcPublicWithNestedFuncAndTypealias()@takesLocalType(_:)"
+    _blackHole(INLINENOTYPECHECK_innerLocal)
   }
   takesLocalType(0)
 }
 // CHECK-TEXTUAL-NOT: "funcPublicWithNestedFuncAndTypealias()"
 // CHECK-SIL-NO-SKIP: "funcPublicWithNestedFuncAndTypealias()"
-// CHECK-SIL-SKIP-NONINLINE-OR-WITHOUTTYPES-NOT: "funcPublicWithNestedFuncAndTypealias()"
+// CHECK-SIL-SKIP-WITHOUTTYPES: "funcPublicWithNestedFuncAndTypealias()"
+// CHECK-SIL-SKIP-NONINLINE-NOT: "funcPublicWithNestedFuncAndTypealias()"
 
 // CHECK-TEXTUAL-NOT: "funcPublicWithNestedFuncAndTypealias()@takesLocalType(_:)"
 // CHECK-SIL-NO-SKIP: "funcPublicWithNestedFuncAndTypealias()@takesLocalType(_:)"
@@ -195,6 +196,26 @@ public func funcPublicWithNestedTypeEnum() {
 // CHECK-SIL-NO-SKIP: "funcPublicWithNestedTypeEnum()"
 // CHECK-SIL-SKIP-NONINLINE-NOT: "funcPublicWithNestedTypeEnum()"
 // CHECK-SIL-SKIP-WITHOUTTYPES: "funcPublicWithNestedTypeEnum()"
+
+public func funcPublicWithNestedTypealias() {
+  let INLINENOTYPECHECK_local = "funcPublicWithNestedTypealias()"
+  _blackHole(INLINENOTYPECHECK_local)
+  typealias TA = Int
+}
+// CHECK-TEXTUAL-NOT: "funcPublicWithNestedTypealias()"
+// CHECK-SIL-NO-SKIP: "funcPublicWithNestedTypealias()"
+// CHECK-SIL-SKIP-NONINLINE-NOT: "funcPublicWithNestedTypealias()"
+// CHECK-SIL-SKIP-WITHOUTTYPES: "funcPublicWithNestedTypealias()"
+
+public func funcPublicWithNestedTypeActor() {
+  let INLINENOTYPECHECK_local = "funcPublicWithNestedTypeActor()"
+  _blackHole(INLINENOTYPECHECK_local)
+  actor A {}
+}
+// CHECK-TEXTUAL-NOT: "funcPublicWithNestedTypeActor()"
+// CHECK-SIL-NO-SKIP: "funcPublicWithNestedTypeActor()"
+// CHECK-SIL-SKIP-NONINLINE-NOT: "funcPublicWithNestedTypeActor()"
+// CHECK-SIL-SKIP-WITHOUTTYPES: "funcPublicWithNestedTypeActor()"
 
 public func funcPublicWithNestedTypeStruct() {
   let INLINENOTYPECHECK_local = "funcPublicWithNestedTypeStruct()"


### PR DESCRIPTION
The flag `-experimental-skip-non-inlinable-function-bodies-without-types` is used by the emit-module-separately phase to quickly extract the API of the target module to unblock building dependents. It is designed to preserve compatibility with LLDB by not skipping functions with nested types.

This logic relies on a simple heuristic to find nested type. It should detect nested tyealiases and actors declarations.

rdar://120928396