### PR TITLE
Record the last fatal error message for crash reporting on Windows

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -60,6 +60,13 @@ static inline const char *CRGetCrashLogMessage() {
 SWIFT_RUNTIME_ATTRIBUTE_ALWAYS_INLINE
 static inline void CRSetCrashLogMessage(const char *) {}
 
+#if defined(_WIN32)
+extern "C" {
+SWIFT_ATTRIBUTE_FOR_EXPORTS
+extern char* gLastFatalErrorMessage;
+}
+#endif // _WIN32
+
 #endif
 
 namespace swift {

--- a/stdlib/public/runtime/CrashReporter.cpp
+++ b/stdlib/public/runtime/CrashReporter.cpp
@@ -33,3 +33,10 @@ struct crashreporter_annotations_t gCRAnnotations __attribute__((
 }
 
 #endif
+
+#if defined(_WIN32)
+extern "C" {
+SWIFT_ATTRIBUTE_FOR_EXPORTS
+char* gLastFatalErrorMessage = nullptr;
+}
+#endif

--- a/test/Runtime/Inputs/setup-handler-win.swift
+++ b/test/Runtime/Inputs/setup-handler-win.swift
@@ -1,0 +1,25 @@
+import WinSDK
+
+func setupHandler() {
+    SetUnhandledExceptionFilter { exception_pointers in
+        guard let hSwiftCore = GetModuleHandleA("swiftCore.dll") else {
+            return EXCEPTION_EXECUTE_HANDLER
+        }
+        guard let ppLastFatalErrorMessage = unsafeBitCast(
+            GetProcAddress(hSwiftCore, "gLastFatalErrorMessage"),
+            to: Optional<UnsafeMutablePointer<Optional<UnsafeMutablePointer<UInt8>>>>.self) else {
+            return EXCEPTION_EXECUTE_HANDLER
+        }
+        guard let pLastFatalErrorMessage = ppLastFatalErrorMessage.pointee else {
+            return EXCEPTION_EXECUTE_HANDLER
+        }
+        let message = "Fatal error message: \(String(cString: pLastFatalErrorMessage))"
+        message.utf8CString.withUnsafeBufferPointer { buf in
+            let addr = buf.baseAddress!
+            let count = DWORD(buf.count)
+            let stderr = GetStdHandle(STD_ERROR_HANDLE)
+            WriteFile(stderr, addr, count, nil, nil)
+        }
+        return EXCEPTION_EXECUTE_HANDLER
+    }
+}

--- a/test/Runtime/fatal-error-message-win.swift
+++ b/test/Runtime/fatal-error-message-win.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s %S/Inputs/setup-handler-win.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: not %target-run %t/a.out 2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: OS=windows-msvc
+
+// CHECK: Fatal error message: a/fatal-error-message-win.swift:{{[0-9]+}}: Fatal error: Fatal crash!
+
+func crash() {
+    fatalError("Fatal crash!")
+}
+
+@main
+struct Test {
+    static func main() throws {
+        setupHandler()
+        crash()
+    }
+}

--- a/test/Runtime/fatal-try-error-message-win.swift
+++ b/test/Runtime/fatal-try-error-message-win.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s %S/Inputs/setup-handler-win.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: not %target-run %t/a.out 2>&1 | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: OS=windows-msvc
+
+// CHECK: Fatal error message: a/fatal-try-error-message-win.swift:{{[0-9]+}}: Fatal error: 'try!' expression unexpectedly raised an error: a.Errs.getMyDescription("Try crash!")
+
+enum Errs: Error {
+    case getMyDescription(String)
+}
+
+func throwings(_ i: Int) throws {
+    if i == 0 {
+        throw Errs.getMyDescription("Try crash!")
+    }
+}
+
+func crash() {
+    try! throwings(0)
+}
+
+@main
+struct Test {
+    static func main() throws {
+        setupHandler()
+        crash()
+    }
+}


### PR DESCRIPTION
AFAICT, `crashreporter` is specific to Darwin and currently it's not possible to record the fatal error message in a crash dump on Windows. Use a similar technique to make it available for Windows crash dump tools.
