### PR TITLE
[embedded] Use << instead of .dump() to fix build breakage with asserts off

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1973,7 +1973,7 @@ bool IRGenModule::finalize() {
   if (getSILModule().getOptions().StopOptimizationAfterSerialization) {
     // We're asked to emit an empty IR module, check that that's actually true
     if (Module.global_size() != 0 || Module.size() != 0) {
-      Module.dump();
+      llvm::errs() << Module;
       llvm::report_fatal_error("Module is not empty");
     }
   }


### PR DESCRIPTION
Build bot breakage here: https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/5109/

```
ld: Undefined symbols:
  llvm::Module::dump() const, referenced from:
      swift::irgen::IRGenModule::finalize() in libswiftIRGen.a[50](IRGenModule.cpp.o)
```

rdar://125662257
