### PR TITLE
[region-isolation] Begin upstreaming isolation history

### DIFF
--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -90,7 +90,8 @@ class BlockPartitionState {
 
   BlockPartitionState(SILBasicBlock *basicBlock,
                       PartitionOpTranslator &translator,
-                      TransferringOperandSetFactory &ptrSetFactory);
+                      TransferringOperandSetFactory &ptrSetFactory,
+                      IsolationHistory::Factory &isolationHistoryFactory);
 
 public:
   bool getLiveness() const { return isLive; }
@@ -393,6 +394,8 @@ class RegionAnalysisFunctionInfo {
   PartitionOpTranslator *translator;
 
   TransferringOperandSetFactory ptrSetFactory;
+
+  IsolationHistory::Factory isolationHistoryFactory;
 
   // We make this optional to prevent an issue that we have seen on windows when
   // capturing a field in a closure that is used to initialize a different

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1460,7 +1460,8 @@ public:
     auto functionArguments = function->getArguments();
     if (functionArguments.empty()) {
       LLVM_DEBUG(llvm::dbgs() << "    None.\n");
-      functionArgPartition = Partition::singleRegion({}, historyFactory.get());
+      functionArgPartition = Partition::singleRegion(SILLocation::invalid(), {},
+                                                     historyFactory.get());
       return;
     }
 
@@ -1489,8 +1490,8 @@ public:
       }
     }
 
-    functionArgPartition =
-        Partition::singleRegion(nonSendableJoinedIndices, historyFactory.get());
+    functionArgPartition = Partition::singleRegion(
+        SILLocation::invalid(), nonSendableJoinedIndices, historyFactory.get());
     for (Element elt : nonSendableSeparateIndices) {
       functionArgPartition->trackNewElement(elt);
     }

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -237,14 +237,31 @@ void PartitionOp::print(llvm::raw_ostream &os, bool extraSpace) const {
 //                              MARK: Partition
 //===----------------------------------------------------------------------===//
 
-Partition Partition::singleRegion(ArrayRef<Element> indices) {
-  Partition p;
+Partition Partition::singleRegion(ArrayRef<Element> indices,
+                                  IsolationHistory inputHistory) {
+  Partition p(inputHistory);
   if (!indices.empty()) {
-    Region min_index =
-        Region(*std::min_element(indices.begin(), indices.end()));
-    p.fresh_label = Region(min_index + 1);
+    // Lowest element is our region representative and the value that our
+    // region takes.
+    Element repElement = *std::min_element(indices.begin(), indices.end());
+    Region repElementRegion = Region(repElement);
+    p.fresh_label = Region(repElementRegion + 1);
+
+    // Place all of the operations until end of scope into one history
+    // sequence.
+    p.pushHistorySequenceBoundary();
+
+    // First create a region for repElement. We are going to merge all other
+    // regions into its region.
+    p.pushNewElementRegion(repElement);
+    llvm::SmallVector<Element, 32> nonRepElts;
     for (Element index : indices) {
-      p.elementToRegionMap.insert_or_assign(index, min_index);
+      p.elementToRegionMap.insert_or_assign(index, repElementRegion);
+      if (index != repElement) {
+        p.pushNewElementRegion(index);
+        nonRepElts.push_back(index);
+      }
+      p.pushMergeElementRegions(repElement, nonRepElts);
     }
   }
 
@@ -252,14 +269,19 @@ Partition Partition::singleRegion(ArrayRef<Element> indices) {
   return p;
 }
 
-Partition Partition::separateRegions(ArrayRef<Element> indices) {
-  Partition p;
+Partition Partition::separateRegions(ArrayRef<Element> indices,
+                                     IsolationHistory inputHistory) {
+  Partition p(inputHistory);
   if (indices.empty())
     return p;
+
+  // Place all operations in one history sequence.
+  p.pushHistorySequenceBoundary();
 
   auto maxIndex = Element(0);
   for (Element index : indices) {
     p.elementToRegionMap.insert_or_assign(index, Region(index));
+    p.pushNewElementRegion(index);
     maxIndex = Element(std::max(maxIndex, index));
   }
   p.fresh_label = Region(maxIndex + 1);
@@ -273,6 +295,7 @@ void Partition::markTransferred(Element val,
   // its new region as transferred.
   if (!isTrackingElement(val)) {
     elementToRegionMap.insert_or_assign(val, fresh_label);
+    pushNewElementRegion(val);
     regionToTransferredOpMap.insert({fresh_label, transferredOperandSet});
     fresh_label = Region(fresh_label + 1);
     canonical = false;
@@ -297,6 +320,7 @@ bool Partition::undoTransfer(Element val) {
   // First see if our val is tracked. If it is not tracked, insert it.
   if (!isTrackingElement(val)) {
     elementToRegionMap.insert_or_assign(val, fresh_label);
+    pushNewElementRegion(val);
     fresh_label = Region(fresh_label + 1);
     canonical = false;
     return true;
@@ -309,7 +333,7 @@ bool Partition::undoTransfer(Element val) {
   return regionToTransferredOpMap.erase(iter1->second);
 }
 
-void Partition::trackNewElement(Element newElt) {
+void Partition::trackNewElement(Element newElt, bool updateHistory) {
   SWIFT_DEFER { validateRegionToTransferredOpMapRegions(); };
 
   // First try to emplace newElt with fresh_label.
@@ -318,6 +342,11 @@ void Partition::trackNewElement(Element newElt) {
   // If we did insert, then we know that the value is completely new. We can
   // just update the fresh_label, set canonical to false, and return.
   if (iter.second) {
+    // Since the value is completely new, add a completely new history node to
+    // the history.
+    if (updateHistory)
+      pushNewElementRegion(newElt);
+
     // Increment the fresh label so it remains fresh.
     fresh_label = Region(fresh_label + 1);
     canonical = false;
@@ -337,11 +366,25 @@ void Partition::trackNewElement(Element newElt) {
   auto oldRegion = iter.first->second;
   iter.first->second = fresh_label;
 
-  if (llvm::none_of(elementToRegionMap, [&](std::pair<Element, Region> value) {
-        return value.second == oldRegion;
-      })) {
+  auto getValueFromOtherRegion = [&]() -> std::optional<Element> {
+    for (auto pair : elementToRegionMap) {
+      if (pair.second == oldRegion)
+        return pair.first;
+    }
+    return {};
+  };
+
+  if (auto matchingElt = getValueFromOtherRegion()) {
+    if (updateHistory)
+      pushRemoveElementFromRegion(*matchingElt, newElt);
+  } else {
     regionToTransferredOpMap.erase(oldRegion);
+    if (updateHistory)
+      pushRemoveLastElementFromRegion(newElt);
   }
+
+  if (updateHistory)
+    pushNewElementRegion(newElt);
 
   // Increment the fresh label so it remains fresh.
   fresh_label = Region(fresh_label + 1);
@@ -349,113 +392,200 @@ void Partition::trackNewElement(Element newElt) {
 }
 
 /// Assigns \p oldElt to the region associated with \p newElt.
-void Partition::assignElement(Element oldElt, Element newElt) {
+void Partition::assignElement(Element oldElt, Element newElt,
+                              bool updateHistory) {
+  // If the old/new elt at the same, just return.
+  if (oldElt == newElt)
+    return;
+
   SWIFT_DEFER { validateRegionToTransferredOpMapRegions(); };
 
   // First try to emplace oldElt with the newRegion.
   auto newRegion = elementToRegionMap.at(newElt);
   auto iter = elementToRegionMap.try_emplace(oldElt, newRegion);
 
-  // If we did an insert, then we know that the value is new and we can just
-  // set canonical to false and return.
+  // If we did an insert, then we know that oldElt was new to this
+  // partition. This means that we update our history for a completely new
+  // value in newElt's region. We also set canonical to false to ensure when
+  // ever we do a merge/etc, we renumber indices as appropriate.
   if (iter.second) {
+    if (updateHistory) {
+      pushNewElementRegion(oldElt);
+      pushMergeElementRegions(newElt, oldElt);
+    }
     canonical = false;
     return;
   }
 
-  // Otherwise, we did an assign. In such a case, we need to see if oldElt was
-  // the last element in oldRegion. If so, we need to erase the oldRegion from
-  // regionToTransferredOpMap.
+  // Otherwise, we did an assign.
   auto oldRegion = iter.first->second;
+
+  // First check if oldRegion and newRegion are the same. In such a case, just
+  // return.
+  if (oldRegion == newRegion)
+    return;
+
+  // Otherwise, we need to actually assign. In such a case, we need to see if
+  // oldElt was the last element in oldRegion. If so, we need to erase the
+  // oldRegion from regionToTransferredOpMap.
   iter.first->second = newRegion;
 
-  if (llvm::none_of(elementToRegionMap, [&](std::pair<Element, Region> value) {
-        return value.second == oldRegion;
-      })) {
+  auto getValueFromOtherRegion = [&]() -> std::optional<Element> {
+    for (auto pair : elementToRegionMap) {
+      if (pair.second == oldRegion)
+        return pair.first;
+    }
+    return {};
+  };
+
+  if (auto otherElt = getValueFromOtherRegion()) {
+    if (updateHistory)
+      pushRemoveElementFromRegion(*otherElt, oldElt);
+  } else {
     regionToTransferredOpMap.erase(oldRegion);
+    if (updateHistory)
+      pushRemoveLastElementFromRegion(oldElt);
+  }
+
+  if (updateHistory) {
+    pushNewElementRegion(oldElt);
+    pushMergeElementRegions(newElt, oldElt);
   }
 
   canonical = false;
 }
 
-Partition Partition::join(const Partition &fst, const Partition &snd) {
-  // First copy and canonicalize our inputs.
-  Partition fstReduced = fst;
-  Partition sndReduced = snd;
+Partition Partition::join(const Partition &fst, Partition &mutableSnd) {
+  // READ THIS! Remember, we cannot touch mutableSnd after this point. We just
+  // use it to canonicalize to avoid having to copy snd. After this point,
+  // please use the const reference snd to keep each other honest.
+  mutableSnd.canonicalize();
+  const auto &snd = mutableSnd;
 
-  fstReduced.canonicalize();
-  sndReduced.canonicalize();
+  // First copy fst into result and canonicalize the result.and canonicalize
+  // fst.
+  Partition result = fst;
+  result.canonicalize();
+
+  // Push a history join so when processing, we know the next element to
+  // process.
+  result.pushCFGHistoryJoin(snd.history);
 
   // For each (sndEltNumber, sndRegionNumber) in snd_reduced...
-  for (auto pair : sndReduced.elementToRegionMap) {
+  for (auto pair : snd.elementToRegionMap) {
     auto sndEltNumber = pair.first;
     auto sndRegionNumber = pair.second;
 
-    // Check if fstReduced has sndEltNumber within it...
-    if (fstReduced.elementToRegionMap.count(sndEltNumber)) {
-      // If we do, we just merge sndEltNumber into fstRegion.
-      auto mergedRegion =
-          fstReduced.merge(sndEltNumber, Element(sndRegionNumber));
-
-      // Then if sndRegionNumber is transferred in sndReduced, make sure
-      // mergedRegion is transferred in fstReduced.
-      auto sndIter = sndReduced.regionToTransferredOpMap.find(sndRegionNumber);
-      if (sndIter != sndReduced.regionToTransferredOpMap.end()) {
-        auto fstIter = fstReduced.regionToTransferredOpMap.try_emplace(
-            mergedRegion, sndIter->second);
-        if (!fstIter.second) {
-          fstIter.first->getSecond() =
-              fstIter.first->getSecond()->merge(sndIter->second);
-        }
-      }
-      continue;
-    }
-
-    // Then check if the representative element number for this element in snd
-    // is in fst. In that case, we know that we visited it before we visited
-    // this elt number (since we are processing in order) so what ever is
-    // mapped to that number in snd must be the correct number for this
-    // element as well since this number is guaranteed to be greater than our
-    // representative and the number mapped to our representative in fst must
-    // be <= our representative.
-    //
-    // In this case, we do not need to propagate transfer into fstRegion since
-    // we would have handled that already when we visited our earlier
-    // representative element number.
+    // Check if result has sndEltNumber already within it...
     {
-      auto iter = fstReduced.elementToRegionMap.find(Element(sndRegionNumber));
-      if (iter != fstReduced.elementToRegionMap.end()) {
-        fstReduced.elementToRegionMap.insert({sndEltNumber, iter->second});
-        // We want fresh_label to always be one element larger than our
-        // maximum element.
-        if (fstReduced.fresh_label <= Region(sndEltNumber))
-          fstReduced.fresh_label = Region(sndEltNumber + 1);
+      auto resultIter = result.elementToRegionMap.find(sndEltNumber);
+      if (result.elementToRegionMap.end() != resultIter) {
+        auto resultRegion = resultIter->second;
+
+        // If we do and Element(sndRegionNumber) isn't the same element as
+        // sndEltNumber, then we know that sndEltNumber isn't the
+        // representative element of its region in sndReduced. We need to
+        // ensure that in result, that representative and our current
+        // value are in the same region. If they are the same value, we can
+        // just reuse sndEltNumber's region in result for the transferring
+        // check.
+        if (sndEltNumber != Element(sndRegionNumber)) {
+          // NOTE: History is updated by Partition::merge(...).
+          resultRegion = result.merge(sndEltNumber, Element(sndRegionNumber));
+        }
+
+        // Then if sndRegionNumber is transferred in sndReduced, make sure
+        // mergedRegion is transferred in result.
+        auto sndIter = snd.regionToTransferredOpMap.find(sndRegionNumber);
+        if (sndIter != snd.regionToTransferredOpMap.end()) {
+          auto resultIter = result.regionToTransferredOpMap.try_emplace(
+              resultRegion, sndIter->second);
+          if (!resultIter.second) {
+            resultIter.first->getSecond() =
+                resultIter.first->getSecond()->merge(sndIter->second);
+          }
+        }
         continue;
       }
     }
 
-    // Otherwise, we have an element that is not in fst and its representative
-    // is not in fst. This means that we must be our representative in snd
-    // since we should have visited our representative earlier if we were not
-    // due to our traversal being in order. Thus just add this to fst_reduced.
+    // At this point, we know that sndEltNumber is not in result.
+    //
+    // Check if the representative element number
+    // (i.e. Element(sndRegionNumber)) for this element in snd is in result. In
+    // that case, we know that we visited the representative number before we
+    // visited this elt number (since we are processing in order) so what ever
+    // is mapped to that number in snd must be the correct region for this
+    // element as well since this number is guaranteed to be greater than our
+    // representative and the number mapped to our representative in result must
+    // be
+    // <= our representative.
+    //
+    // In this case, we do not need to propagate transfer into resultRegion
+    // since we would have handled that already when we visited our earlier
+    // representative element number.
+    {
+      auto iter = result.elementToRegionMap.find(Element(sndRegionNumber));
+      if (iter != result.elementToRegionMap.end()) {
+        result.elementToRegionMap.insert({sndEltNumber, iter->second});
+        result.pushMergeElementRegions(sndEltNumber, Element(sndRegionNumber));
+        // We want fresh_label to always be one element larger than our
+        // maximum element.
+        if (result.fresh_label <= Region(sndEltNumber))
+          result.fresh_label = Region(sndEltNumber + 1);
+        continue;
+      }
+    }
+
+    // Otherwise, we have an element that is not in result and its
+    // representative is not in result. This means that we must be our
+    // representative in snd since we should have visited our representative
+    // earlier if we were not due to our traversal being in order. Thus just add
+    // this to result.
     assert(sndEltNumber == Element(sndRegionNumber));
-    fstReduced.elementToRegionMap.insert({sndEltNumber, sndRegionNumber});
-    auto sndIter = sndReduced.regionToTransferredOpMap.find(sndRegionNumber);
-    if (sndIter != sndReduced.regionToTransferredOpMap.end()) {
-      auto fstIter = fstReduced.regionToTransferredOpMap.try_emplace(
+    result.elementToRegionMap.insert({sndEltNumber, sndRegionNumber});
+    result.pushNewElementRegion(sndEltNumber);
+    auto sndIter = snd.regionToTransferredOpMap.find(sndRegionNumber);
+    if (sndIter != snd.regionToTransferredOpMap.end()) {
+      auto fstIter = result.regionToTransferredOpMap.try_emplace(
           sndRegionNumber, sndIter->second);
       if (!fstIter.second)
         fstIter.first->getSecond() =
             fstIter.first->second->merge(sndIter->second);
     }
-    if (fstReduced.fresh_label <= sndRegionNumber)
-      fstReduced.fresh_label = Region(sndEltNumber + 1);
+    if (result.fresh_label <= sndRegionNumber)
+      result.fresh_label = Region(sndEltNumber + 1);
   }
 
-  assert(fstReduced.is_canonical_correct());
+  // We should have preserved canonicality during the computation above. It
+  // would be wasteful to need to canonicalize twice.
+  assert(result.is_canonical_correct());
 
-  // fst_reduced is now the join
-  return fstReduced;
+  // result is now the join.
+  return result;
+}
+
+bool Partition::popHistory(
+    SmallVectorImpl<IsolationHistory> &foundJoinedHistories) {
+  // We only allow for history rewinding if we are not tracking any
+  // transferring operands. This is because the history rewinding does not
+  // care about transferring. One can either construct a new Partition from
+  // the current Partition using Partition::removingTransferringInfo or clear
+  // the transferring information using Partition::clearTransferringInfo().
+  assert(regionToTransferredOpMap.empty() &&
+         "Can only rewind history if not tracking any transferring operands");
+
+  if (!history.getHead())
+    return false;
+
+  // Just put in a continue here to ensure that clang-format doesn't do weird
+  // things with the semicolon.
+  while (popHistoryOnce(foundJoinedHistories))
+    continue;
+
+  // Return if our history head is non-null so our user knows if there are more
+  // things to pop.
+  return history.getHead();
 }
 
 void Partition::print(llvm::raw_ostream &os) const {
@@ -553,6 +683,50 @@ void Partition::printVerbose(llvm::raw_ostream &os) const {
   }
 }
 
+void Partition::printHistory(llvm::raw_ostream &os) const {
+  llvm::dbgs() << "History Dump!\n";
+  const auto *head = history.head;
+
+  if (!head)
+    return;
+
+  do {
+    switch (head->getKind()) {
+    case IsolationHistory::Node::AddNewRegionForElement:
+      os << "AddNewRegionForElement: " << head->getFirstArgAsElement();
+      break;
+    case IsolationHistory::Node::RemoveLastElementFromRegion:
+      os << "RemoveLastElementFromRegion: " << head->getFirstArgAsElement();
+      break;
+    case IsolationHistory::Node::RemoveElementFromRegion: {
+      os << "RemoveElementFromRegion: " << head->getFirstArgAsElement();
+      auto extraArgs = head->getAdditionalElementArgs();
+      if (extraArgs.empty())
+        break;
+      llvm::interleave(extraArgs, os, ", ");
+      break;
+    }
+    case IsolationHistory::Node::MergeElementRegions: {
+      os << "MergeElementRegions: " << head->getFirstArgAsElement();
+      auto extraArgs = head->getAdditionalElementArgs();
+      if (extraArgs.empty())
+        break;
+      os << ", ";
+      llvm::interleave(extraArgs, os, ", ");
+      break;
+    }
+    case IsolationHistory::Node::CFGHistoryJoin:
+      os << "CFGHistoryJoin";
+      break;
+    case IsolationHistory::Node::SequenceBoundary:
+      os << "SequenceBoundary";
+      break;
+    }
+    os << "\n";
+
+  } while ((head = head->getParent()));
+}
+
 bool Partition::is_canonical_correct() const {
 #ifdef NDEBUG
   return true;
@@ -591,44 +765,45 @@ bool Partition::is_canonical_correct() const {
 #endif
 }
 
-Region Partition::merge(Element fst, Element snd) {
+Region Partition::merge(Element fst, Element snd, bool updateHistory) {
   assert(elementToRegionMap.count(fst) && elementToRegionMap.count(snd));
 
+  // Remember: fstRegion and sndRegion are actually elements in
+  // elementToRegionMap... they are just the representative of the region
+  // (which is the smallest element number).
   auto fstRegion = elementToRegionMap.at(fst);
   auto sndRegion = elementToRegionMap.at(snd);
 
+  // Our value reps are the same... we can return either. Just return fstRegion.
   if (fstRegion == sndRegion)
     return fstRegion;
 
-  // Maintain canonicality by renaming the greater-numbered region to the
-  // smaller region.
-  std::optional<Region> result;
-  if (fstRegion < sndRegion) {
-    result = fstRegion;
+  // To maintain canonicality, we require that fstRegion is always less than
+  // sndRegion. If we do not have that, swap first and second state.
+  if (fstRegion > sndRegion) {
+    std::swap(fst, snd);
+    std::swap(fstRegion, sndRegion);
+  }
 
-    // Rename snd to use first region.
-    horizontalUpdate(elementToRegionMap, snd, fstRegion);
-    auto iter = regionToTransferredOpMap.find(sndRegion);
-    if (iter != regionToTransferredOpMap.end()) {
-      auto operand = iter->second;
-      regionToTransferredOpMap.erase(iter);
-      regionToTransferredOpMap.try_emplace(fstRegion, operand);
-    }
-  } else {
-    result = sndRegion;
+  Region result = fstRegion;
 
-    horizontalUpdate(elementToRegionMap, fst, sndRegion);
-    auto iter = regionToTransferredOpMap.find(fstRegion);
-    if (iter != regionToTransferredOpMap.end()) {
-      auto operand = iter->second;
-      regionToTransferredOpMap.erase(iter);
-      regionToTransferredOpMap.try_emplace(sndRegion, operand);
-    }
+  // Rename snd and snd's entire region to fst's region.
+  SmallVector<Element, 32> mergedElements;
+  horizontalUpdate(snd, fstRegion, mergedElements);
+  auto iter = regionToTransferredOpMap.find(sndRegion);
+  if (iter != regionToTransferredOpMap.end()) {
+    auto operand = iter->second;
+    regionToTransferredOpMap.erase(iter);
+    regionToTransferredOpMap.try_emplace(fstRegion, operand);
   }
 
   assert(is_canonical_correct());
   assert(elementToRegionMap.at(fst) == elementToRegionMap.at(snd));
-  return *result;
+
+  // Now that we are correct/canonicalized, add the merge to our history.
+  if (updateHistory)
+    pushMergeElementRegions(fst, mergedElements);
+  return result;
 }
 
 void Partition::canonicalize() {
@@ -674,18 +849,165 @@ void Partition::canonicalize() {
   assert(is_canonical_correct());
 }
 
-void Partition::horizontalUpdate(std::map<Element, Region> &map, Element key,
-                                 Region val) {
-  if (!map.count(key)) {
-    map.insert({key, val});
+void Partition::horizontalUpdate(
+    Element targetElement, Region newRegion,
+    llvm::SmallVectorImpl<Element> &mergedElements) {
+  // It is on our caller to make sure a value is in elementToRegionMap.
+  Region oldRegion = elementToRegionMap.at(targetElement);
+
+  // If our old region is the same as our new region, we do not have anything
+  // to do.
+  if (oldRegion == newRegion)
+    return;
+
+  for (auto [element, region] : elementToRegionMap) {
+    if (region == oldRegion) {
+      elementToRegionMap.insert_or_assign(element, newRegion);
+      mergedElements.push_back(element);
+    }
+  }
+}
+
+bool Partition::popHistoryOnce(
+    SmallVectorImpl<IsolationHistory> &foundJoinedHistoryNodes) {
+  const auto *head = history.pop();
+  if (!head)
+    return false;
+
+  // When popping, we /always/ want to canonicalize.
+  canonicalize();
+
+  switch (head->getKind()) {
+  case IsolationHistory::Node::SequenceBoundary:
+    return false;
+
+  case IsolationHistory::Node::AddNewRegionForElement: {
+    // We added an element to its own region... so we should remove it and it
+    // should be the last element in the region.
+    auto iter = elementToRegionMap.find(head->getFirstArgAsElement());
+    assert(iter != elementToRegionMap.end());
+    Region oldRegion = iter->second;
+    regionToTransferredOpMap.erase(oldRegion);
+    elementToRegionMap.erase(iter);
+    assert(llvm::none_of(elementToRegionMap,
+                         [&](std::pair<Element, Region> pair) {
+                           return pair.second == oldRegion;
+                         }) &&
+           "Should have been last element?!");
+    return true;
+  }
+  case IsolationHistory::Node::RemoveLastElementFromRegion:
+    // We removed an element from a region and it was the last element. Just
+    // add new.
+    trackNewElement(head->getFirstArgAsElement(), false /*update history*/);
+    return true;
+  case IsolationHistory::Node::RemoveElementFromRegion:
+    // We removed an element from a specific region. So, we need to add it
+    // back.
+    assignElement(head->getFirstArgAsElement(),
+                  head->getAdditionalElementArgs()[1],
+                  false /*update history*/);
+    return true;
+
+  case IsolationHistory::Node::MergeElementRegions: {
+    // We merged two regions together. We need to remove all elements from the
+    // previous region into their own new region.
+    auto elementsToExtract = head->getAdditionalElementArgs();
+    assert(elementsToExtract.size());
+
+    removeElement(elementsToExtract[0]);
+    trackNewElement(elementsToExtract[0], false /*update history*/);
+
+    for (auto e : elementsToExtract.drop_front()) {
+      assert(head->getFirstArgAsElement() != e &&
+             "We assume that we are never removing all values when undoing "
+             "merging");
+      removeElement(e);
+      trackNewElement(e, false /*update history*/);
+      merge(e, elementsToExtract[0], false /*update history*/);
+    }
+
+    return true;
+  }
+  case IsolationHistory::Node::CFGHistoryJoin:
+    // When we have a CFG History Merge, we cannot simply pop. Instead, we need
+    // to signal to the user that they need to visit each history node in turn
+    // by returning it in the out parameter.
+    auto newHistory = IsolationHistory(history.factory);
+    newHistory.head = head->getFirstArgAsNode();
+    foundJoinedHistoryNodes.push_back(newHistory);
+    return true;
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                           MARK: IsolationHistory
+//===----------------------------------------------------------------------===//
+
+// Push onto the history list that \p value should be added into its own
+// independent region.
+IsolationHistory::Node *
+IsolationHistory::pushNewElementRegion(Element element) {
+  unsigned size = Node::totalSizeToAlloc<Element>(0);
+  void *mem = factory->allocator.Allocate(size, alignof(Node));
+  head = new (mem) Node(Node::AddNewRegionForElement, head, element);
+  return getHead();
+}
+
+IsolationHistory::Node *IsolationHistory::pushHistorySequenceBoundary() {
+  unsigned size = Node::totalSizeToAlloc<Element>(0);
+  void *mem = factory->allocator.Allocate(size, alignof(Node));
+  head = new (mem) Node(Node::SequenceBoundary, head);
+  return getHead();
+}
+
+// Push onto the history that \p value should be removed from any region that it
+// is apart of and placed within its own separate region.
+void IsolationHistory::pushRemoveLastElementFromRegion(Element element) {
+  unsigned size = Node::totalSizeToAlloc<Element>(0);
+  void *mem = factory->allocator.Allocate(size, alignof(Node));
+  head = new (mem) Node(Node::RemoveLastElementFromRegion, head, element);
+}
+
+void IsolationHistory::pushRemoveElementFromRegion(
+    Element otherElementInOldRegion, Element element) {
+  head = new (factory->allocator) Node(Node::RemoveElementFromRegion, head,
+                                       element, {otherElementInOldRegion});
+}
+
+void IsolationHistory::pushMergeElementRegions(Element elementToMergeInto,
+                                               ArrayRef<Element> eltsToMerge) {
+  assert(llvm::none_of(eltsToMerge,
+                       [&](Element elt) { return elt == elementToMergeInto; }));
+  unsigned size = Node::totalSizeToAlloc<Element>(eltsToMerge.size());
+  void *mem = factory->allocator.Allocate(size, alignof(Node));
+  head = new (mem)
+      Node(Node::MergeElementRegions, head, elementToMergeInto, eltsToMerge);
+}
+
+// Push that \p other should be merged into this region.
+void IsolationHistory::pushCFGHistoryJoin(Node *otherNode) {
+  if (!otherNode)
+    return;
+
+  // If we do not have any history, just take on the history of otherNode. We
+  // are going to merge our contents.
+  if (!head) {
+    head = otherNode;
     return;
   }
 
-  Region oldVal = map.at(key);
-  if (val == oldVal)
-    return;
+  // Otherwise, create a node that joins our true head and other node as a side
+  // path we can follow.
+  head = new (factory->allocator)
+      Node(Node(Node::CFGHistoryJoin, head, otherNode));
+}
 
-  for (auto [otherKey, otherVal] : map)
-    if (otherVal == oldVal)
-      map.insert_or_assign(otherKey, val);
+IsolationHistory::Node *IsolationHistory::pop() {
+  if (!head)
+    return nullptr;
+
+  auto *result = head;
+  head = head->parent;
+  return result;
 }

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -237,7 +237,7 @@ void PartitionOp::print(llvm::raw_ostream &os, bool extraSpace) const {
 //                              MARK: Partition
 //===----------------------------------------------------------------------===//
 
-Partition Partition::singleRegion(ArrayRef<Element> indices,
+Partition Partition::singleRegion(SILLocation loc, ArrayRef<Element> indices,
                                   IsolationHistory inputHistory) {
   Partition p(inputHistory);
   if (!indices.empty()) {
@@ -249,7 +249,7 @@ Partition Partition::singleRegion(ArrayRef<Element> indices,
 
     // Place all of the operations until end of scope into one history
     // sequence.
-    p.pushHistorySequenceBoundary();
+    p.pushHistorySequenceBoundary(loc);
 
     // First create a region for repElement. We are going to merge all other
     // regions into its region.
@@ -269,14 +269,14 @@ Partition Partition::singleRegion(ArrayRef<Element> indices,
   return p;
 }
 
-Partition Partition::separateRegions(ArrayRef<Element> indices,
+Partition Partition::separateRegions(SILLocation loc, ArrayRef<Element> indices,
                                      IsolationHistory inputHistory) {
   Partition p(inputHistory);
   if (indices.empty())
     return p;
 
   // Place all operations in one history sequence.
-  p.pushHistorySequenceBoundary();
+  p.pushHistorySequenceBoundary(loc);
 
   auto maxIndex = Element(0);
   for (Element index : indices) {
@@ -954,10 +954,11 @@ IsolationHistory::pushNewElementRegion(Element element) {
   return getHead();
 }
 
-IsolationHistory::Node *IsolationHistory::pushHistorySequenceBoundary() {
+IsolationHistory::Node *
+IsolationHistory::pushHistorySequenceBoundary(SILLocation loc) {
   unsigned size = Node::totalSizeToAlloc<Element>(0);
   void *mem = factory->allocator.Allocate(size, alignof(Node));
-  head = new (mem) Node(Node::SequenceBoundary, head);
+  head = new (mem) Node(Node::SequenceBoundary, head, loc);
   return getHead();
 }
 

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -75,12 +75,13 @@ SILInstruction *instSingletons[5] = {
 // p1 and p2, but also applied in its entirety to p3, then joining p1 and p2
 // yields p3.
 TEST(PartitionUtilsTest, TestMergeAndJoin) {
-  Partition p1;
-  Partition p2;
-  Partition p3;
-
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+
+  Partition p1(historyFactory.get());
+  Partition p2(historyFactory.get());
+  Partition p3(historyFactory.get());
 
   {
     MockedPartitionOpEvaluator eval(p1, factory);
@@ -193,10 +194,12 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
 TEST(PartitionUtilsTest, Join1) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
 
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
-  Partition p1 = Partition::separateRegions(llvm::ArrayRef(data1));
+  Partition p1 =
+      Partition::separateRegions(llvm::ArrayRef(data1), historyFactory.get());
 
   {
     MockedPartitionOpEvaluator eval(p1, factory);
@@ -208,7 +211,8 @@ TEST(PartitionUtilsTest, Join1) {
                 PartitionOp::Assign(Element(5), Element(2))});
   }
 
-  Partition p2 = Partition::separateRegions(llvm::ArrayRef(data1));
+  Partition p2 =
+      Partition::separateRegions(llvm::ArrayRef(data1), historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
@@ -232,10 +236,12 @@ TEST(PartitionUtilsTest, Join1) {
 TEST(PartitionUtilsTest, Join2) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
 
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
-  Partition p1 = Partition::separateRegions(llvm::ArrayRef(data1));
+  Partition p1 =
+      Partition::separateRegions(llvm::ArrayRef(data1), historyFactory.get());
 
   {
     MockedPartitionOpEvaluator eval(p1, factory);
@@ -249,7 +255,8 @@ TEST(PartitionUtilsTest, Join2) {
 
   Element data2[] = {Element(4), Element(5), Element(6),
                      Element(7), Element(8), Element(9)};
-  Partition p2 = Partition::separateRegions(llvm::ArrayRef(data2));
+  Partition p2 =
+      Partition::separateRegions(llvm::ArrayRef(data2), historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(4), Element(4)),
@@ -277,10 +284,12 @@ TEST(PartitionUtilsTest, Join2) {
 TEST(PartitionUtilsTest, Join2Reversed) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
 
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
-  Partition p1 = Partition::separateRegions(llvm::ArrayRef(data1));
+  Partition p1 =
+      Partition::separateRegions(llvm::ArrayRef(data1), historyFactory.get());
 
   {
     MockedPartitionOpEvaluator eval(p1, factory);
@@ -294,7 +303,8 @@ TEST(PartitionUtilsTest, Join2Reversed) {
 
   Element data2[] = {Element(4), Element(5), Element(6),
                      Element(7), Element(8), Element(9)};
-  Partition p2 = Partition::separateRegions(llvm::ArrayRef(data2));
+  Partition p2 =
+      Partition::separateRegions(llvm::ArrayRef(data2), historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(4), Element(4)),
@@ -322,6 +332,7 @@ TEST(PartitionUtilsTest, Join2Reversed) {
 TEST(PartitionUtilsTest, JoinLarge) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
 
   Element data1[] = {
       Element(0),  Element(1),  Element(2),  Element(3),  Element(4),
@@ -330,7 +341,8 @@ TEST(PartitionUtilsTest, JoinLarge) {
       Element(15), Element(16), Element(17), Element(18), Element(19),
       Element(20), Element(21), Element(22), Element(23), Element(24),
       Element(25), Element(26), Element(27), Element(28), Element(29)};
-  Partition p1 = Partition::separateRegions(llvm::ArrayRef(data1));
+  Partition p1 =
+      Partition::separateRegions(llvm::ArrayRef(data1), historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p1, factory);
     eval.apply({PartitionOp::Assign(Element(0), Element(29)),
@@ -372,7 +384,8 @@ TEST(PartitionUtilsTest, JoinLarge) {
       Element(30), Element(31), Element(32), Element(33), Element(34),
       Element(35), Element(36), Element(37), Element(38), Element(39),
       Element(40), Element(41), Element(42), Element(43), Element(44)};
-  Partition p2 = Partition::separateRegions(llvm::ArrayRef(data2));
+  Partition p2 =
+      Partition::separateRegions(llvm::ArrayRef(data2), historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::Assign(Element(15), Element(31)),
@@ -459,10 +472,11 @@ TEST(PartitionUtilsTest, JoinLarge) {
 TEST(PartitionUtilsTest, TestAssign) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
 
-  Partition p1;
-  Partition p2;
-  Partition p3;
+  Partition p1(historyFactory.get());
+  Partition p2(historyFactory.get());
+  Partition p3(historyFactory.get());
 
   MockedPartitionOpEvaluator evalP1(p1, factory);
   evalP1.apply({PartitionOp::AssignFresh(Element(0)),
@@ -578,8 +592,9 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
 TEST(PartitionUtilsTest, TestConsumeAndRequire) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
 
-  Partition p;
+  Partition p(historyFactory.get());
 
   {
     MockedPartitionOpEvaluator eval(p, factory);
@@ -674,8 +689,9 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
 TEST(PartitionUtilsTest, TestCopyConstructor) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
 
-  Partition p1;
+  Partition p1(historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p1, factory);
     eval.apply(PartitionOp::AssignFresh(Element(0)));
@@ -712,8 +728,9 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
 TEST(PartitionUtilsTest, TestUndoTransfer) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
 
-  Partition p;
+  Partition p(historyFactory.get());
   MockedPartitionOpEvaluatorWithFailureCallback eval(
       p, factory, [&](const PartitionOp &, unsigned, TransferringOperand *) {
         EXPECT_TRUE(false);
@@ -729,9 +746,10 @@ TEST(PartitionUtilsTest, TestUndoTransfer) {
 TEST(PartitionUtilsTest, TestLastEltInTransferredRegion) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
 
   // First make sure that we do this correctly with an assign fresh.
-  Partition p;
+  Partition p(historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p, factory);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
@@ -743,7 +761,7 @@ TEST(PartitionUtilsTest, TestLastEltInTransferredRegion) {
   p.validateRegionToTransferredOpMapRegions();
 
   // Now make sure that we do this correctly with assign.
-  Partition p2;
+  Partition p2(historyFactory.get());
   {
     MockedPartitionOpEvaluator eval(p2, factory);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
@@ -753,4 +771,204 @@ TEST(PartitionUtilsTest, TestLastEltInTransferredRegion) {
                 PartitionOp::Assign(Element(0), Element(2))});
   }
   p2.validateRegionToTransferredOpMapRegions();
+}
+
+TEST(PartitionUtilsTest, TestHistory_CreateVariable) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+  SmallVector<IsolationHistory, 8> joinedHistories;
+
+  // First make sure that we do this correctly with an assign fresh.
+  Partition p(historyFactory.get());
+  {
+    MockedPartitionOpEvaluator eval(p, factory);
+    eval.apply({PartitionOp::AssignFresh(Element(0)),
+                PartitionOp::AssignFresh(Element(1))});
+  }
+
+  Partition pSnapshot = p;
+
+  {
+    MockedPartitionOpEvaluator eval(p, factory);
+    eval.apply({PartitionOp::AssignFresh(Element(2))});
+  }
+
+  p.popHistory(joinedHistories);
+
+  EXPECT_TRUE(Partition::equals(p, pSnapshot));
+  EXPECT_TRUE(joinedHistories.empty());
+}
+
+TEST(PartitionUtilsTest, TestHistory_AssignRegion) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+  SmallVector<IsolationHistory, 8> joinedHistories;
+
+  // First make sure that we do this correctly with an assign fresh.
+  Partition p(historyFactory.get());
+  {
+    MockedPartitionOpEvaluator eval(p, factory);
+    eval.apply({PartitionOp::AssignFresh(Element(0)),
+                PartitionOp::AssignFresh(Element(1)),
+                PartitionOp::AssignFresh(Element(2))});
+  }
+
+  Partition pSnapshot = p;
+
+  {
+    MockedPartitionOpEvaluator eval(p, factory);
+    eval.apply({PartitionOp::Assign(Element(1), Element(2))});
+  }
+
+  Partition pSnapshot2 = p;
+  {
+    MockedPartitionOpEvaluator eval(p, factory);
+    eval.apply({PartitionOp::Assign(Element(0), Element(2))});
+  }
+
+  p.popHistory(joinedHistories);
+
+  EXPECT_TRUE(Partition::equals(p, pSnapshot2));
+  EXPECT_TRUE(joinedHistories.empty());
+
+  p.popHistory(joinedHistories);
+
+  EXPECT_TRUE(Partition::equals(p, pSnapshot));
+  EXPECT_TRUE(joinedHistories.empty());
+}
+
+TEST(PartitionUtilsTest, TestHistory_BuildNewRegionRepIsMergee) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+  SmallVector<IsolationHistory, 8> joinedHistories;
+
+  Partition p(historyFactory.get());
+  {
+    MockedPartitionOpEvaluator eval(p, factory);
+    eval.apply({PartitionOp::AssignFresh(Element(2)),
+                PartitionOp::AssignFresh(Element(3)),
+                PartitionOp::AssignFresh(Element(10)),
+                PartitionOp::AssignFresh(Element(0)),
+                PartitionOp::Assign(Element(3), Element(2)),
+                PartitionOp::Assign(Element(10), Element(2)),
+                PartitionOp::Merge(Element(2), Element(0))});
+  }
+
+  Partition pSnapshot = p;
+
+  {
+    MockedPartitionOpEvaluator eval(p, factory);
+    eval.apply({PartitionOp::Assign(Element(1), Element(2))});
+  }
+
+  Partition pSnapshot2 = p;
+  {
+    MockedPartitionOpEvaluator eval(p, factory);
+    eval.apply({PartitionOp::Assign(Element(0), Element(2))});
+  }
+
+  // Even though we pushed a new instruction, nothing changed in our region.
+  EXPECT_TRUE(Partition::equals(p, pSnapshot2));
+
+  // We pop but nothing changes since we did not need to change anything.
+  p.popHistory(joinedHistories);
+
+  EXPECT_TRUE(Partition::equals(p, pSnapshot2));
+  EXPECT_TRUE(joinedHistories.empty());
+
+  // We pop a last time to return to our original value.
+  p.popHistory(joinedHistories);
+
+  EXPECT_TRUE(Partition::equals(p, pSnapshot));
+  EXPECT_TRUE(joinedHistories.empty());
+}
+
+TEST(PartitionUtilsTest, TestHistory_ReturnFalseWhenNoneLeft) {
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+  SmallVector<IsolationHistory, 8> joinedHistories;
+
+  Partition p(historyFactory.get());
+
+  EXPECT_FALSE(p.popHistory(joinedHistories));
+  EXPECT_TRUE(joinedHistories.empty());
+
+  {
+    MockedPartitionOpEvaluator eval(p, factory);
+    eval.apply({PartitionOp::AssignFresh(Element(2)),
+                PartitionOp::AssignFresh(Element(3))});
+  }
+
+  EXPECT_TRUE(p.popHistory(joinedHistories));
+  EXPECT_TRUE(joinedHistories.empty());
+
+  EXPECT_FALSE(p.popHistory(joinedHistories));
+  EXPECT_TRUE(joinedHistories.empty());
+}
+
+TEST(PartitionUtilsTest, TestHistory_JoiningTwoEmpty) {
+  // Make sure that we do sane things when we join empty history.
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+  SmallVector<IsolationHistory, 8> joinedHistories;
+
+  Partition p1(historyFactory.get());
+  Partition p2(historyFactory.get());
+
+  auto result = Partition::join(p1, p2);
+  EXPECT_TRUE(result.begin() == result.end());
+  EXPECT_FALSE(result.hasHistory());
+}
+
+TEST(PartitionUtilsTest, TestHistory_JoiningNotEmptyAndEmpty) {
+  // Make sure that we do sane things when we join empty history.
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+  SmallVector<IsolationHistory, 8> joinedHistories;
+
+  Partition p1(historyFactory.get());
+  Partition p2(historyFactory.get());
+
+  {
+    MockedPartitionOpEvaluator eval(p1, factory);
+    eval.apply({PartitionOp::AssignFresh(Element(2))});
+  }
+
+  EXPECT_TRUE(p1.historySize() == 2);
+  EXPECT_TRUE(p2.historySize() == 0);
+  auto result = Partition::join(p1, p2);
+  EXPECT_TRUE(std::next(result.begin()) == result.end());
+  // Since p2 doesn't have any history, we do not actually perform any join and
+  // thus do not insert a CFGHistory change.
+  EXPECT_TRUE(result.historySize() == 2);
+}
+
+TEST(PartitionUtilsTest, TestHistory_JoiningEmptyAndNotEmpty) {
+  // Make sure that we do sane things when we join empty history.
+  llvm::BumpPtrAllocator allocator;
+  Partition::TransferringOperandSetFactory factory(allocator);
+  IsolationHistory::Factory historyFactory(allocator);
+  SmallVector<IsolationHistory, 8> joinedHistories;
+
+  Partition p1(historyFactory.get());
+  Partition p2(historyFactory.get());
+
+  {
+    MockedPartitionOpEvaluator eval(p1, factory);
+    eval.apply({PartitionOp::AssignFresh(Element(2))});
+  }
+
+  EXPECT_TRUE(p1.historySize() == 2);
+  EXPECT_TRUE(p2.historySize() == 0);
+  auto result = Partition::join(p1, p2);
+  EXPECT_TRUE(std::next(result.begin()) == result.end());
+  // Since p2 doesn't have any history, we do not actually perform any join and
+  // thus do not insert a CFGHistory change.
+  EXPECT_TRUE(result.historySize() == 2);
 }

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -53,6 +53,8 @@ struct MockedPartitionOpEvaluator final
   static SILLocation getLoc(SILInstruction *inst) {
     return SILLocation::invalid();
   }
+
+  static SILLocation getLoc(Operand *op) { return SILLocation::invalid(); }
 };
 
 } // namespace
@@ -87,6 +89,8 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
   static SILLocation getLoc(SILInstruction *inst) {
     return SILLocation::invalid();
   }
+
+  static SILLocation getLoc(Operand *op) { return SILLocation::invalid(); }
 };
 
 } // namespace


### PR DESCRIPTION
This PR begins to upstream my isolation history implementation. Isolation history is an immutable acyclic graph that includes the necessary information to undo the effect of an individual partition op being applied to a Partition. Thus by walking the graph we can reverse the partition history and then figure out when values are no longer part of the same region.