### PR TITLE
[Concurrency] Fix signature mismatch of _task_serialExecutor_checkIsolated

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -96,7 +96,7 @@ void (*swift::swift_task_checkIsolated_hook)(
     swift_task_checkIsolated_original original) = nullptr;
 
 extern "C" SWIFT_CC(swift)
-    bool _task_serialExecutor_checkIsolated(
+    void _task_serialExecutor_checkIsolated(
         HeapObject *executor,
         const Metadata *selfType,
         const SerialExecutorWitnessTable *wtable);


### PR DESCRIPTION
`_task_serialExecutor_checkIsolated` is defined as returning nothing in `Executor.swift`, but it was used as returning a boolean in C++ side.