### PR TITLE
[6.0][Concurrency] Fix signature mismatch of _task_serialExecutor_checkIsolated

### DIFF
--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -96,7 +96,7 @@ void (*swift::swift_task_checkIsolated_hook)(
     swift_task_checkIsolated_original original) = nullptr;
 
 extern "C" SWIFT_CC(swift)
-    bool _task_serialExecutor_checkIsolated(
+    void _task_serialExecutor_checkIsolated(
         HeapObject *executor,
         const Metadata *selfType,
         const SerialExecutorWitnessTable *wtable);


### PR DESCRIPTION
* **Explanation**: `_task_serialExecutor_checkIsolated` was called with the wrong function signature.
* **Original PR**: https://github.com/apple/swift/pull/72734
* **Reviewer**: @ktoso 
* **Risk**: Low. The function is not a part of public ABI
* **Testing**: Tested as part of CI testing