### PR TITLE
[AST] Fix best import kind when value decl is a typealias of an existential type

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1476,7 +1476,12 @@ ImportKind ImportDecl::getBestImportKind(const ValueDecl *VD) {
 
   case DeclKind::TypeAlias: {
     Type type = cast<TypeAliasDecl>(VD)->getDeclaredInterfaceType();
-    auto *nominal = type->getAnyNominal();
+    // FIXME: It's necessary to check for existentials because `getAnyNominal`
+    // looks through them.
+    auto canonical = type->getCanonicalType();
+    if (isa<ExistentialType>(canonical))
+      return ImportKind::Type;
+    auto *nominal = canonical->getAnyNominal();
     if (!nominal)
       return ImportKind::Type;
     return getBestImportKind(nominal);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -86,6 +86,8 @@ NominalTypeDecl *CanType::getAnyNominal() const {
 }
 
 GenericTypeDecl *CanType::getAnyGeneric() const {
+  // FIXME: Remove checking for existential types. `getAnyGeneric` should return
+  // the GenericTypeDecl the type is directly bound to.
   if (auto existential = dyn_cast<ExistentialType>(*this))
     return existential->getConstraintType()->getAnyGeneric();
   if (auto ppt = dyn_cast<ParameterizedProtocolType>(*this))

--- a/test/ImportResolution/Inputs/DeclsUsedWrongly.swift
+++ b/test/ImportResolution/Inputs/DeclsUsedWrongly.swift
@@ -7,3 +7,20 @@ public enum Choice {
 public typealias Callback = () -> Void
 
 public typealias Pair<T> = (T, T)
+
+public struct NamespaceStruct {
+
+    public protocol NestedProtocol {}
+
+    public typealias AnyNestedProtocol = any NestedProtocol
+}
+
+public typealias AnyNestedProtocol = NamespaceStruct.AnyNestedProtocol
+
+public typealias NestedProtocol = NamespaceStruct.NestedProtocol
+
+public protocol TopLevelProtocol {
+
+}
+
+public typealias AnyTopLevelProtocol = any TopLevelProtocol

--- a/test/ImportResolution/import-specific-fixits.swift
+++ b/test/ImportResolution/import-specific-fixits.swift
@@ -69,3 +69,10 @@ import typealias ambiguous.SomeStruct // expected-error{{ambiguous name 'SomeStr
 import class ambiguous.SomeStruct // expected-error{{ambiguous name 'SomeStruct' in module 'ambiguous'}}
 
 import func ambiguous.overloadedFunc // no-warning
+
+import protocol DeclsUsedWrongly.TopLevelProtocol  // no-warning
+import protocol DeclsUsedWrongly.AnyTopLevelProtocol // expected-error {{type alias 'AnyTopLevelProtocol' (aka 'any TopLevelProtocol') cannot be imported as 'protocol'}} {{8-16=typealias}}
+import typealias DeclsUsedWrongly.AnyTopLevelProtocol // no-warning
+import protocol DeclsUsedWrongly.NestedProtocol  // no-warning
+import typealias DeclsUsedWrongly.AnyNestedProtocol // no-warning
+import protocol DeclsUsedWrongly.AnyNestedProtocol // expected-error {{type alias 'AnyNestedProtocol' (aka 'any NamespaceStruct.NestedProtocol') cannot be imported as 'protocol'}} {{8-16=typealias}}


### PR DESCRIPTION
<!-- What's in this pull request? -->


<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #72724 .

Fixed behaviors:
```sh
/Users/lizhen/Projects/swift-projects/build/Ninja-DebugAssert/swift-macosx-arm64/bin/swift-frontend ./moduleB.swift -I . -L . -l./moduleA -typecheck
./moduleB.swift:3:17: error: type alias 'TypeAlias' (aka 'any Protocol') cannot be imported as 'protocol'
1 │
2 │ // Module B
3 │ import protocol ModuleA.TypeAlias 
  │                 ╰─ error: type alias 'TypeAlias' (aka 'any Protocol') cannot be imported as 'protocol'
4 │ import typealias ModuleA.TypeAlias

/Users/lizhen/Projects/swift-debug/./ModuleA.swift:3:18: note: 'TypeAlias' declared here
1 │ // Module A
2 │ public protocol Protocol {}
3 │ public typealias TypeAlias = any Protocol
  │                  ╰─ note: 'TypeAlias' declared here
4 │
```

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
