### PR TITLE
[6.0][TypeChecker] InferSendableFromCaptures: Infer @Sendable on adjusted types

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4371,7 +4371,7 @@ public:
   /// Wrapper over swift::adjustFunctionTypeForConcurrency that passes along
   /// the appropriate closure-type and opening extraction functions.
   FunctionType *adjustFunctionTypeForConcurrency(
-      FunctionType *fnType, ValueDecl *decl, DeclContext *dc,
+      FunctionType *fnType, Type baseType, ValueDecl *decl, DeclContext *dc,
       unsigned numApplies, bool isMainDispatchQueue,
       OpenedTypeMap &replacements, ConstraintLocatorBuilder locator);
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4370,8 +4370,8 @@ public:
 
   /// Wrapper over swift::adjustFunctionTypeForConcurrency that passes along
   /// the appropriate closure-type and opening extraction functions.
-  AnyFunctionType *adjustFunctionTypeForConcurrency(
-      AnyFunctionType *fnType, ValueDecl *decl, DeclContext *dc,
+  FunctionType *adjustFunctionTypeForConcurrency(
+      FunctionType *fnType, ValueDecl *decl, DeclContext *dc,
       unsigned numApplies, bool isMainDispatchQueue,
       OpenedTypeMap &replacements, ConstraintLocatorBuilder locator);
 

--- a/test/Concurrency/sendable_functions.swift
+++ b/test/Concurrency/sendable_functions.swift
@@ -46,19 +46,3 @@ extension S: Sendable where T: Sendable {
 
 @available(SwiftStdlib 5.1, *)
 @MainActor @Sendable func globalActorFuncAsync() async { }
-
-func test_initializer_ref() {
-  func test<T>(_: @Sendable (T, T) -> Array<T>) {
-  }
-
-  // Type of `initRef` should be @Sendable but due to implicitly injected autoclosure it isn't
-  let initRef = Array.init as (Int, Int) -> Array<Int>
-
-  // FIXME: incorrect non-Sendable diagnostic is produced due to `autoclosure` wrapping `Array.init`
-  test(initRef)
-  // expected-warning@-1 {{converting non-sendable function value to '@Sendable (Int, Int) -> Array<Int>' may introduce data races}}
-
-  // FIXME: Same here
-  test(Array.init as (Int, Int) -> Array<Int>)
-  // expected-warning@-1 {{converting non-sendable function value to '@Sendable (Int, Int) -> Array<Int>' may introduce data races}}
-}

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -255,3 +255,25 @@ func test_initializer_ref() {
   test(initRef) // Ok
   test(Array<Int>.init) // Ok
 }
+
+// rdar://119593407 - incorrect errors when partially applied member is accessed with InferSendableFromCaptures
+do {
+  @MainActor struct ErrorHandler {
+    static func log(_ error: Error) {}
+  }
+
+  @MainActor final class Manager {
+    static var shared: Manager!
+
+    func test(_: @escaping @MainActor (Error) -> Void) {
+    }
+  }
+
+  @MainActor class Test {
+    func schedule() {
+      Task {
+        Manager.shared.test(ErrorHandler.log) // Ok (access is wrapped in an autoclosure)
+      }
+    }
+  }
+}

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -244,3 +244,14 @@ do {
 
   let _: () -> Void = forward(Test.fn) // Ok
 }
+
+
+func test_initializer_ref() {
+  func test<T>(_: @Sendable (T, T) -> Array<T>) {
+  }
+
+  let initRef: @Sendable (Int, Int) -> Array<Int> = Array<Int>.init // Ok
+
+  test(initRef) // Ok
+  test(Array<Int>.init) // Ok
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/72527
---

- Explanation:

  Previously sendability was inferred directly on an (opened) interface type and 
  carried over to the "adjusted" type, this creates a problem for some partially 
  applied references to isolated members because they have to be wrapped in an 
  autoclosure that would attempt a conversion from i.e. `@Sendable` to `@MainActor`
  type and be diagnosed an a concurrency issue.

  Instead of doing that let's apply inference to the adjusted type, which maintains
  original behavior where (opened) interface type is adjusted via `FunctionConversionExpr`
  to a type with appropriate concurrency annotations.

- Scope: Partial applications with `InferSendableFromCaptures` feature enabled.

- Main Branch PRs: https://github.com/apple/swift/pull/72527

- Resolves: rdar://119593407

- Risk: Low

- Reviewed By: @hborla  

- Testing: Added test-cases to the test suite.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
