### PR TITLE
Sema: Fix null dereference in `overApproximateAvailabilityAtLocation()`

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1375,9 +1375,11 @@ TypeChecker::overApproximateAvailabilityAtLocation(SourceLoc loc,
     if (rootTRC) {
       TypeRefinementContext *TRC =
           rootTRC->findMostRefinedSubContext(loc, Context);
-      OverApproximateContext.constrainWith(TRC->getAvailabilityInfo());
-      if (MostRefined) {
-        *MostRefined = TRC;
+      if (TRC) {
+        OverApproximateContext.constrainWith(TRC->getAvailabilityInfo());
+        if (MostRefined) {
+          *MostRefined = TRC;
+        }
       }
     }
   }


### PR DESCRIPTION
The `TypeRefinementContext::findMostRefinedSubContext()` method can return `nullptr` in some circumstances, which means that callers need to check the result before dereferencing it in order to avoid a crash. I haven't introduced a test case because I can only reproduce the circumstances under which `findMostRefinedSubContext()` returns `nullptr` with a specific project that is exercising a bug in Swift macros. The fix here is obvious enough hardening, though.

Resolves rdar://125054962
