### PR TITLE
Rename `StringRef::endswith` references to `StringRef::ends_with`

### DIFF
--- a/include/swift/AST/FineGrainedDependencies.h
+++ b/include/swift/AST/FineGrainedDependencies.h
@@ -989,7 +989,7 @@ private:
         includeExternals || n->getKey().getKind() != NodeKind::externalDepend;
     bool apiPredicate =
         includeAPINotes ||
-        !StringRef(n->getKey().humanReadableName()).endswith(".apinotes");
+        !StringRef(n->getKey().humanReadableName()).ends_with(".apinotes");
     return externalPredicate && apiPredicate;
   }
   bool includeGraphArc(const NodeT *def, const NodeT *use) const {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11782,7 +11782,7 @@ bool MacroDecl::isUniqueMacroName(StringRef name) {
     name = name.drop_back();
 
   // Check for fMu.
-  return name.endswith("fMu");
+  return name.ends_with("fMu");
 }
 
 bool MacroDecl::isUniqueMacroName(DeclBaseName name) {

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -46,7 +46,7 @@ std::optional<SourceFileDepGraph>
 SourceFileDepGraph::loadFromPath(StringRef path, const bool allowSwiftModule) {
   const bool treatAsModule =
       allowSwiftModule &&
-      path.endswith(file_types::getExtension(file_types::TY_SwiftModuleFile));
+      path.ends_with(file_types::getExtension(file_types::TY_SwiftModuleFile));
   auto bufferOrError = llvm::MemoryBuffer::getFile(path);
   if (!bufferOrError)
     return std::nullopt;

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -535,7 +535,7 @@ bool SwiftDependencyScanningService::setupCachingDependencyScanningService(
     std::error_code EC;
     for (auto F = FS.dir_begin(RuntimeLibPath, EC);
          !EC && F != llvm::vfs::directory_iterator(); F.increment(EC)) {
-      if (F->path().endswith(".yaml"))
+      if (F->path().ends_with(".yaml"))
         CommonDependencyFiles.emplace_back(F->path().str());
     }
   }

--- a/lib/Basic/EditorPlaceholder.cpp
+++ b/lib/Basic/EditorPlaceholder.cpp
@@ -39,7 +39,7 @@ using namespace swift;
 std::optional<EditorPlaceholderData>
 swift::parseEditorPlaceholder(llvm::StringRef PlaceholderText) {
   if (!PlaceholderText.starts_with("<#") ||
-      !PlaceholderText.endswith("#>"))
+      !PlaceholderText.ends_with("#>"))
     return std::nullopt;
 
   PlaceholderText = PlaceholderText.drop_front(2).drop_back(2);

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -580,7 +580,7 @@ std::string swift::getSDKBuildVersion(StringRef Path) {
 std::string swift::getSDKName(StringRef Path) {
   std::string Name = getPlistEntry(llvm::Twine(Path)+"/SDKSettings.plist",
                                    "CanonicalName");
-  if (Name.empty() && Path.endswith(".sdk")) {
+  if (Name.empty() && Path.ends_with(".sdk")) {
     Name = llvm::sys::path::filename(Path).drop_back(strlen(".sdk")).str();
   }
   return Name;

--- a/lib/Basic/PrettyStackTrace.cpp
+++ b/lib/Basic/PrettyStackTrace.cpp
@@ -30,7 +30,7 @@ void PrettyStackTraceStringAction::print(llvm::raw_ostream &out) const {
 void PrettyStackTraceFileContents::print(llvm::raw_ostream &out) const {
   out << "Contents of " << Buffer.getBufferIdentifier() << ":\n---\n"
       << Buffer.getBuffer();
-  if (!Buffer.getBuffer().endswith("\n"))
+  if (!Buffer.getBuffer().ends_with("\n"))
     out << '\n';
   out << "---\n";
 }

--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -69,7 +69,7 @@ PartOfSpeech swift::getPartOfSpeech(StringRef word) {
 #include "PartsOfSpeech.def"
 
   // Identify gerunds, which always end in "ing".
-  if (word.endswith("ing") && word.size() > 4) {
+  if (word.ends_with("ing") && word.size() > 4) {
     StringRef possibleVerb = word.drop_back(3);
 
     // If what remains is a verb, we have a gerund.
@@ -417,7 +417,7 @@ static std::optional<StringRef> skipTypeSuffix(StringRef typeName) {
   }
 
   // _t.
-  if (typeName.size() > 2 && typeName.endswith("_t")) {
+  if (typeName.size() > 2 && typeName.ends_with("_t")) {
     return typeName.drop_back(2);
   }
   return std::nullopt;
@@ -555,7 +555,7 @@ static StringRef omitNeedlessWordsFromPrefix(StringRef name,
     if (firstWord == "By") {
       StringRef nextWord = camel_case::getFirstWord(
                              newName.substr(firstWord.size()));
-      if (nextWord.endswith("ing")) {
+      if (nextWord.ends_with("ing")) {
         return newName.substr(firstWord.size());
       }
     }
@@ -1404,27 +1404,27 @@ bool swift::omitNeedlessWords(
 
 std::optional<StringRef>
 swift::stripWithCompletionHandlerSuffix(StringRef name) {
-  if (name.endswith("WithCompletionHandler")) {
+  if (name.ends_with("WithCompletionHandler")) {
     return name.drop_back(strlen("WithCompletionHandler"));
   }
 
-  if (name.endswith("WithCompletion")) {
+  if (name.ends_with("WithCompletion")) {
     return name.drop_back(strlen("WithCompletion"));
   }
 
-  if (name.endswith("WithCompletionBlock")) {
+  if (name.ends_with("WithCompletionBlock")) {
     return name.drop_back(strlen("WithCompletionBlock"));
   }
 
-  if (name.endswith("WithBlock")) {
+  if (name.ends_with("WithBlock")) {
     return name.drop_back(strlen("WithBlock"));
   }
 
-  if (name.endswith("WithReplyTo")) {
+  if (name.ends_with("WithReplyTo")) {
     return name.drop_back(strlen("WithReplyTo"));
   }
 
-  if (name.endswith("WithReply")) {
+  if (name.ends_with("WithReply")) {
     return name.drop_back(strlen("WithReply"));
   }
 

--- a/lib/ClangImporter/CFTypeInfo.cpp
+++ b/lib/ClangImporter/CFTypeInfo.cpp
@@ -102,7 +102,7 @@ StringRef importer::getCFTypeName(
   if (auto pointee = CFPointeeInfo::classifyTypedef(decl)) {
     auto name = decl->getName();
     if (pointee.isRecord() || pointee.isTypedef())
-      if (name.endswith(SWIFT_CFTYPE_SUFFIX))
+      if (name.ends_with(SWIFT_CFTYPE_SUFFIX))
         return name.drop_back(strlen(SWIFT_CFTYPE_SUFFIX));
 
     return name;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -458,7 +458,7 @@ static bool clangSupportsPragmaAttributeWithSwiftAttr() {
 
 static inline bool isPCHFilenameExtension(StringRef path) {
   return llvm::sys::path::extension(path)
-    .endswith(file_types::getExtension(file_types::TY_PCH));
+    .ends_with(file_types::getExtension(file_types::TY_PCH));
 }
 
 void importer::getNormalInvocationArguments(
@@ -7034,7 +7034,7 @@ bool ClangImporter::isUnsafeCXXMethod(const FuncDecl *func) {
   if (!func->hasName())
     return false;
   auto id = func->getBaseName().userFacingName();
-  return id.starts_with("__") && id.endswith("Unsafe");
+  return id.starts_with("__") && id.ends_with("Unsafe");
 }
 
 bool ClangImporter::isAnnotatedWith(const clang::CXXMethodDecl *method,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3392,8 +3392,8 @@ namespace {
                   sourceManager.getFileID(decl->getLocation()))) {
             auto filename = file->getName();
             if ((file->getDir() == owningModule->Directory) &&
-                (filename.endswith("cmath") || filename.endswith("math.h") ||
-                 filename.endswith("stdlib.h") || filename.endswith("cstdlib"))) {
+                (filename.ends_with("cmath") || filename.ends_with("math.h") ||
+                 filename.ends_with("stdlib.h") || filename.ends_with("cstdlib"))) {
               return nullptr;
             }
           }
@@ -8433,9 +8433,9 @@ void ClangImporter::Implementation::importAttributes(
   // such as CGColorRelease(CGColorRef).
   if (auto FD = dyn_cast<clang::FunctionDecl>(ClangDecl)) {
     if (FD->getNumParams() == 1 && FD->getDeclName().isIdentifier() &&
-         (FD->getName().endswith("Release") ||
-          FD->getName().endswith("Retain") ||
-          FD->getName().endswith("Autorelease")) &&
+         (FD->getName().ends_with("Release") ||
+          FD->getName().ends_with("Retain") ||
+          FD->getName().ends_with("Autorelease")) &&
         !FD->getAttr<clang::SwiftNameAttr>()) {
       if (auto t = FD->getParamDecl(0)->getType()->getAs<clang::TypedefType>()){
         if (isCFTypeDecl(t->getDecl())) {

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -219,7 +219,7 @@ StringRef importer::getCommonPluralPrefix(StringRef singular,
 
   // Is the plural string just "[singular]s"?
   plural = plural.drop_back();
-  if (plural.endswith(firstLeftoverWord))
+  if (plural.ends_with(firstLeftoverWord))
     return commonPrefixPlusWord;
 
   if (plural.empty() || plural.back() != 'e')
@@ -227,7 +227,7 @@ StringRef importer::getCommonPluralPrefix(StringRef singular,
 
   // Is the plural string "[singular]es"?
   plural = plural.drop_back();
-  if (plural.endswith(firstLeftoverWord))
+  if (plural.ends_with(firstLeftoverWord))
     return commonPrefixPlusWord;
 
   if (plural.empty() || !(plural.back() == 'i' && singular.back() == 'y'))
@@ -236,7 +236,7 @@ StringRef importer::getCommonPluralPrefix(StringRef singular,
   // Is the plural string "[prefix]ies" and the singular "[prefix]y"?
   plural = plural.drop_back();
   firstLeftoverWord = firstLeftoverWord.drop_back();
-  if (plural.endswith(firstLeftoverWord))
+  if (plural.ends_with(firstLeftoverWord))
     return commonPrefixPlusWord;
 
   return commonPrefix;

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -464,7 +464,7 @@ static StringRef stripLeadingK(StringRef name) {
 StringRef importer::stripNotification(StringRef name) {
   name = stripLeadingK(name);
   StringRef notification = "Notification";
-  if (name.size() <= notification.size() || !name.endswith(notification))
+  if (name.size() <= notification.size() || !name.ends_with(notification))
     return {};
   return name.drop_back(notification.size());
 }
@@ -1160,9 +1160,9 @@ NameImporter::considerErrorImport(const clang::ObjCMethodDecl *clangDecl,
     StringRef suffixToStrip;
     StringRef origBaseName = baseName;
     if (adjustName && index == 0 && paramNames[0].empty()) {
-      if (baseName.endswith(ErrorSuffix))
+      if (baseName.ends_with(ErrorSuffix))
         suffixToStrip = ErrorSuffix;
-      else if (baseName.endswith(AltErrorSuffix))
+      else if (baseName.ends_with(AltErrorSuffix))
         suffixToStrip = AltErrorSuffix;
 
       if (!suffixToStrip.empty()) {
@@ -1438,7 +1438,7 @@ bool NameImporter::hasErrorMethodNameCollision(
   auto &ctx = method->getASTContext();
   if (paramIndex == 0 && !suffixToStrip.empty()) {
     StringRef name = chunks[0]->getName();
-    assert(name.endswith(suffixToStrip));
+    assert(name.ends_with(suffixToStrip));
     name = name.drop_back(suffixToStrip.size());
     chunks[0] = &ctx.Idents.get(name);
   } else if (paramIndex != 0) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1821,7 +1821,7 @@ public:
   void setSinglePCHImport(std::optional<std::string> PCHFilename) {
     if (PCHFilename.has_value()) {
       assert(llvm::sys::path::extension(PCHFilename.value())
-                 .endswith(file_types::getExtension(file_types::TY_PCH)) &&
+                 .ends_with(file_types::getExtension(file_types::TY_PCH)) &&
              "Single PCH imported filename doesn't have .pch extension!");
     }
     SinglePCHImport = PCHFilename;

--- a/lib/Demangling/Context.cpp
+++ b/lib/Demangling/Context.cpp
@@ -96,14 +96,14 @@ static llvm::StringRef stripSuffix(llvm::StringRef Name) {
 
 // Removes a 'TQ<index>' or 'TY<index>' from \p Name.
 static llvm::StringRef stripAsyncContinuation(llvm::StringRef Name) {
-  if (!Name.endswith("_"))
+  if (!Name.ends_with("_"))
     return Name;
 
   StringRef Stripped = Name.drop_back();
   while (!Stripped.empty() && swift::Mangle::isDigit(Stripped.back()))
     Stripped = Stripped.drop_back();
 
-  if (Stripped.endswith("TQ") || Stripped.endswith("TY"))
+  if (Stripped.ends_with("TQ") || Stripped.ends_with("TY"))
     return Stripped.drop_back(2);
 
   return Name;
@@ -113,14 +113,14 @@ bool Context::isThunkSymbol(llvm::StringRef MangledName) {
   if (isMangledName(MangledName)) {
     MangledName = stripAsyncContinuation(stripSuffix(MangledName));
     // First do a quick check
-    if (MangledName.endswith("TA") ||  // partial application forwarder
-        MangledName.endswith("Ta") ||  // ObjC partial application forwarder
-        MangledName.endswith("To") ||  // swift-as-ObjC thunk
-        MangledName.endswith("TO") ||  // ObjC-as-swift thunk
-        MangledName.endswith("TR") ||  // reabstraction thunk helper function
-        MangledName.endswith("Tr") ||  // reabstraction thunk
-        MangledName.endswith("TW") ||  // protocol witness thunk
-        MangledName.endswith("fC")) {  // allocating constructor
+    if (MangledName.ends_with("TA") ||  // partial application forwarder
+        MangledName.ends_with("Ta") ||  // ObjC partial application forwarder
+        MangledName.ends_with("To") ||  // swift-as-ObjC thunk
+        MangledName.ends_with("TO") ||  // ObjC-as-swift thunk
+        MangledName.ends_with("TR") ||  // reabstraction thunk helper function
+        MangledName.ends_with("Tr") ||  // reabstraction thunk
+        MangledName.ends_with("TW") ||  // protocol witness thunk
+        MangledName.ends_with("fC")) {  // allocating constructor
 
       // To avoid false positives, we need to fully demangle the symbol.
       NodePointer Nd = D->demangleSymbol(MangledName);
@@ -171,12 +171,12 @@ std::string Context::getThunkTarget(llvm::StringRef MangledName) {
     MangledName = stripAsyncContinuation(MangledName);
 
     // The targets of those thunks not derivable from the mangling.
-    if (MangledName.endswith("TR") ||
-        MangledName.endswith("Tr") ||
-        MangledName.endswith("TW") )
+    if (MangledName.ends_with("TR") ||
+        MangledName.ends_with("Tr") ||
+        MangledName.ends_with("TW") )
       return std::string();
 
-    if (MangledName.endswith("fC")) {
+    if (MangledName.ends_with("fC")) {
       std::string target = MangledName.str();
       target[target.size() - 1] = 'c';
       return target;

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -157,7 +157,7 @@ static void addLinkRuntimeLibRPath(const ArgList &Args,
   // so we should make sure we add the rpaths last, after all user-specified
   // rpaths. This is currently true from this place, but we need to be
   // careful if this function is ever called before user's rpaths are emitted.
-  assert(DarwinLibName.endswith(".dylib") && "must be a dynamic library");
+  assert(DarwinLibName.ends_with(".dylib") && "must be a dynamic library");
 
   // Add @executable_path to rpath to support having the dylib copied with
   // the executable.
@@ -727,7 +727,7 @@ void toolchains::Darwin::addPlatformSpecificPluginFrontendArgs(
     llvm::sys::path::remove_filename(platformPath); // Developer
 
     StringRef platformName = llvm::sys::path::filename(platformPath);
-    if (platformName.endswith("Simulator.platform")){
+    if (platformName.ends_with("Simulator.platform")){
       StringRef devicePlatformName =
           platformName.drop_back(strlen("Simulator.platform"));
       llvm::sys::path::remove_filename(platformPath); // Platform

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -274,7 +274,7 @@ static void validateSearchPathArgs(DiagnosticEngine &diags,
                                    const ArgList &args) {
   for (const Arg *A : args.filtered(options::OPT_F, options::OPT_Fsystem)) {
     StringRef name = A->getValue();
-    if (name.endswith(".framework") || name.endswith(".framework/"))
+    if (name.ends_with(".framework") || name.ends_with(".framework/"))
       diags.diagnose(SourceLoc(),
                      diag::framework_search_path_includes_framework_extension,
                      name);
@@ -1830,7 +1830,7 @@ void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,
         if (auto *IA = dyn_cast<InputAction>(A)) {
           StringRef ObjectName = IA->getInputArg().getValue();
           if (Triple.getObjectFormat() == llvm::Triple::ELF &&
-              ObjectName.endswith(".so"))
+              ObjectName.ends_with(".so"))
             continue;
         }
         AutolinkExtractInputs.push_back(A);

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -294,7 +294,7 @@ class RemovedAddedNodeMatcher : public NodeMatcher, public MatchedNodeListener {
     if (((StringRef)LL).starts_with((llvm::Twine("ns") + RR).str()) ||
         ((StringRef)RR).starts_with((llvm::Twine("ns") + LL).str()))
       return true;
-    if (((StringRef)LL).endswith(RR) || ((StringRef)RR).endswith(LL))
+    if (((StringRef)LL).ends_with(RR) || ((StringRef)RR).ends_with(LL))
       return true;
     return false;
   }

--- a/lib/DriverTool/swift_cache_tool_main.cpp
+++ b/lib/DriverTool/swift_cache_tool_main.cpp
@@ -187,7 +187,7 @@ private:
     }
     // drop swift-frontend executable path and leading `-frontend` from
     // command-line.
-    if (StringRef(FrontendArgs[0]).endswith("swift-frontend"))
+    if (StringRef(FrontendArgs[0]).ends_with("swift-frontend"))
       FrontendArgs.erase(FrontendArgs.begin());
     if (StringRef(FrontendArgs[0]).equals("-frontend"))
       FrontendArgs.erase(FrontendArgs.begin());

--- a/lib/DriverTool/swift_parse_test_main.cpp
+++ b/lib/DriverTool/swift_parse_test_main.cpp
@@ -200,7 +200,7 @@ static void _loadSwiftFilesRecursively(
          I != E; I.increment(err)) {
       _loadSwiftFilesRecursively(I->path(), buffers);
     }
-  } else if (path.endswith(".swift")) {
+  } else if (path.ends_with(".swift")) {
     if (auto buffer = llvm::MemoryBuffer::getFile(path)) {
       buffers.push_back(std::move(*buffer));
     }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -115,7 +115,7 @@ getVersionedPrebuiltModulePath(std::optional<llvm::VersionTuple> sdkVer,
     llvm::sys::path::append(pathWithSDKVer, vs);
     if (llvm::sys::fs::exists(pathWithSDKVer)) {
       return pathWithSDKVer.str().str();
-    } else if (vs.endswith(".0")) {
+    } else if (vs.ends_with(".0")) {
       vs = vs.substr(0, vs.size() - 2);
     } else {
       return defaultPrebuiltPath.str();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -867,7 +867,7 @@ SourceFile *CompilerInstance::getIDEInspectionFile() const {
 
 static inline bool isPCHFilenameExtension(StringRef path) {
   return llvm::sys::path::extension(path)
-    .endswith(file_types::getExtension(file_types::TY_PCH));
+    .ends_with(file_types::getExtension(file_types::TY_PCH));
 }
 
 std::string CompilerInstance::getBridgingHeaderPath() const {

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -171,7 +171,7 @@ unsigned FrontendInputsAndOutputs::numberOfPrimaryInputsEndingWith(
     StringRef extension) const {
   unsigned n = 0;
   (void)forEachPrimaryInput([&](const InputFile &input) -> bool {
-    if (llvm::sys::path::extension(input.getFileName()).endswith(extension))
+    if (llvm::sys::path::extension(input.getFileName()).ends_with(extension))
       ++n;
     return false;
   });

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -685,8 +685,8 @@ class ModuleInterfaceLoaderImpl {
     if (!sdkPath.empty() &&
         hasPrefix(path::begin(interfacePath), path::end(interfacePath),
                   path::begin(sdkPath), path::end(sdkPath))) {
-      return !(StringRef(interfacePath).endswith(".private.swiftinterface") ||
-               StringRef(interfacePath).endswith(".package.swiftinterface"));
+      return !(StringRef(interfacePath).ends_with(".private.swiftinterface") ||
+               StringRef(interfacePath).ends_with(".package.swiftinterface"));
     }
     return false;
   }
@@ -734,8 +734,8 @@ class ModuleInterfaceLoaderImpl {
     if (sdkPath.empty() ||
         !hasPrefix(path::begin(interfacePath), path::end(interfacePath),
                    path::begin(sdkPath), path::end(sdkPath)) ||
-        StringRef(interfacePath).endswith(".private.swiftinterface") ||
-         StringRef(interfacePath).endswith(".package.swiftinterface"))
+        StringRef(interfacePath).ends_with(".private.swiftinterface") ||
+         StringRef(interfacePath).ends_with(".package.swiftinterface"))
       return std::nullopt;
 
     // If the module isn't target-specific, there's no fallback path.
@@ -1380,8 +1380,8 @@ ModuleInterfaceCheckerImpl::getCompiledModuleCandidatesForInterface(StringRef mo
 
   // When looking up the module for a private or package interface, strip
   // the '.private.' or '.package.'section of the base name
-  if (interfacePath.endswith(".private." + interfaceExt.str()) ||
-      interfacePath.endswith(".package." + interfaceExt.str())) {
+  if (interfacePath.ends_with(".private." + interfaceExt.str()) ||
+      interfacePath.ends_with(".package." + interfaceExt.str())) {
     auto newBaseName = llvm::sys::path::stem(llvm::sys::path::stem(interfacePath));
     modulePath = llvm::sys::path::parent_path(interfacePath);
     llvm::sys::path::append(modulePath, newBaseName + "." + newExt.str());

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -233,7 +233,7 @@ namespace serialized_diagnostics {
 /// Sanitize a filename for the purposes of the serialized diagnostics reader.
 static StringRef sanitizeFilename(
     StringRef filename, SmallString<32> &scratch) {
-  if (!filename.endswith("/") && !filename.endswith("\\"))
+  if (!filename.ends_with("/") && !filename.ends_with("\\"))
     return filename;
 
   scratch = filename;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -979,10 +979,10 @@ bool isNonDesirableImportedDefaultArg(const ParamDecl *param) {
   auto baseName = func->getBaseName().getIdentifier().str();
   switch (kind) {
   case DefaultArgumentKind::EmptyArray:
-    return (baseName.endswith("Options"));
+    return (baseName.ends_with("Options"));
   case DefaultArgumentKind::EmptyDictionary:
-    return (baseName.endswith("Options") || baseName.endswith("Attributes") ||
-            baseName.endswith("UserInfo"));
+    return (baseName.ends_with("Options") || baseName.ends_with("Attributes") ||
+            baseName.ends_with("UserInfo"));
   default:
     llvm_unreachable("unhandled DefaultArgumentKind");
   }

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1469,7 +1469,7 @@ bool ModelASTWalker::processComment(CharSourceRange Range) {
   if (NewLinePos != StringRef::npos) {
     Text = Text.substr(0, NewLinePos);
   }
-  if (Text.endswith("*/")) {
+  if (Text.ends_with("*/")) {
     Text = Text.drop_back(2);
   }
   Text = Text.rtrim();
@@ -1687,7 +1687,7 @@ bool ModelASTWalker::findFieldsInDocCommentBlock(SyntaxNode Node) {
 
   auto Text = OrigText.drop_front(3); // Drop "^/**" or "/*:"
 
-  if (!Text.endswith("*/"))
+  if (!Text.ends_with("*/"))
     return true;
 
   Text = Text.drop_back(2); // Drop "*/"

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -526,7 +526,7 @@ private:
 
     // Detect the main file.
     StringRef MainFileName = MainFile->getFilename();
-    if (MainFile && Filename.endswith(MainFileName)) {
+    if (MainFile && Filename.ends_with(MainFileName)) {
       SmallString<256> AbsThisFile, AbsMainFile;
       AbsThisFile = Filename;
       llvm::sys::fs::make_absolute(AbsThisFile);
@@ -578,7 +578,7 @@ private:
     } else {
       File = NormalizedFile;
       // Leave <compiler-generated> & friends as is, without directory.
-      if (!(File.starts_with("<") && File.endswith(">")))
+      if (!(File.starts_with("<") && File.ends_with(">")))
         Dir = CurDir;
       else
         Dir = llvm::sys::path::root_directory(CurDir);
@@ -2454,7 +2454,7 @@ IRGenDebugInfoImpl::IRGenDebugInfoImpl(const IRGenOptions &Opts,
   {
     auto B = llvm::sys::path::rbegin(Sysroot);
     auto E = llvm::sys::path::rend(Sysroot);
-    auto It = std::find_if(B, E, [](auto SDK) { return SDK.endswith(".sdk"); });
+    auto It = std::find_if(B, E, [](auto SDK) { return SDK.ends_with(".sdk"); });
     if (It != E)
       SDK = *It;
   }

--- a/lib/Immediate/SwiftMaterializationUnit.cpp
+++ b/lib/Immediate/SwiftMaterializationUnit.cpp
@@ -58,7 +58,7 @@ static std::string mangle(const StringRef Unmangled) {
 
 /// Whether a function name is mangled to be a lazy reexport
 static bool isMangled(const StringRef Symbol) {
-  return Symbol.endswith(ManglingSuffix);
+  return Symbol.ends_with(ManglingSuffix);
 }
 
 /// Demangle a lazy reexport

--- a/lib/Markup/LineList.cpp
+++ b/lib/Markup/LineList.cpp
@@ -96,9 +96,9 @@ LineList MarkupContext::getLineList(swift::RawComment RC) {
       unsigned CommentMarkerBytes = 2 + (C.isOrdinary() ? 0 : 1);
       StringRef Cleaned = C.RawText.drop_front(CommentMarkerBytes);
 
-      if (Cleaned.endswith("*/"))
+      if (Cleaned.ends_with("*/"))
         Cleaned = Cleaned.drop_back(2);
-      else if (Cleaned.endswith("/"))
+      else if (Cleaned.ends_with("/"))
         Cleaned = Cleaned.drop_back(1);
 
       swift::SourceLoc CleanedStartLoc =

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2979,7 +2979,7 @@ DeclAndTypePrinter::maybeGetOSObjectBaseName(const clang::NamedDecl *decl) {
       sourceMgr.getImmediateExpansionRange(loc).getBegin();
   clang::SourceLocation spellingLoc = sourceMgr.getSpellingLoc(expansionLoc);
 
-  if (!sourceMgr.getFilename(spellingLoc).endswith("/os/object.h"))
+  if (!sourceMgr.getFilename(spellingLoc).ends_with("/os/object.h"))
     return StringRef();
 
   return name;

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -290,7 +290,7 @@ public:
                     llvm::StringRef value = sa->getAttribute();
                     if ((value.starts_with("retain:") ||
                          value.starts_with("release:")) &&
-                        !value.endswith(":immortal"))
+                        !value.ends_with(":immortal"))
                       return true;
                   }
                   return false;

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -575,7 +575,7 @@ bool SILPassManager::isInstructionPassDisabled(StringRef instName) {
   StringRef prefix("simplify-");
   for (const std::string &namePattern : SILDisablePass) {
     StringRef pattern(namePattern);
-    if (pattern.starts_with(prefix) && pattern.endswith(instName) &&
+    if (pattern.starts_with(prefix) && pattern.ends_with(instName) &&
         pattern.size() == prefix.size() + instName.size()) {
       return true;
     }

--- a/lib/SILOptimizer/Utils/CFGOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/CFGOptUtils.cpp
@@ -534,9 +534,9 @@ static bool isTrapNoReturnFunction(ApplyInst *ai) {
       MANGLE_SYM(s18_fatalErrorMessageyys12StaticStringV_AcCSutF));
   auto *fn = ai->getReferencedFunctionOrNull();
 
-  // We use endswith here since if we specialize fatal error we will always
+  // We use ends_with here since if we specialize fatal error we will always
   // prepend the specialization records to fatalName.
-  if (!fn || !fn->getName().endswith(fatalName))
+  if (!fn || !fn->getName().ends_with(fatalName))
     return false;
 
   return true;

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -764,7 +764,7 @@ void UnboundImport::validateInterfaceWithPackageName(ModuleDecl *topLevelModule,
   ASTContext &ctx = topLevelModule->getASTContext();
   if (topLevelModule->inSamePackage(ctx.MainModule) &&
       topLevelModule->isBuiltFromInterface() &&
-      !topLevelModule->getModuleSourceFilename().endswith(".package.swiftinterface")) {
+      !topLevelModule->getModuleSourceFilename().ends_with(".package.swiftinterface")) {
       ctx.Diags.diagnose(import.module.getModulePath().front().Loc,
                          diag::in_package_module_not_compiled_from_source_or_package_interface,
                          topLevelModule->getBaseIdentifier(),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1271,7 +1271,7 @@ void AttributeChecker::visitSPIAccessControlAttr(SPIAccessControlAttr *attr) {
     if (importedModule) {
       auto path = importedModule->getModuleFilename();
       if (llvm::sys::path::extension(path) == ".swiftinterface" &&
-          !(path.endswith(".private.swiftinterface") || path.endswith(".package.swiftinterface"))) {
+          !(path.ends_with(".private.swiftinterface") || path.ends_with(".package.swiftinterface"))) {
         // If the module was built from the public swiftinterface, it can't
         // have any SPI.
         diagnose(attr->getLocation(),

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1147,7 +1147,7 @@ void Serializer::writeHeader() {
             // module defined in the framework.
             auto Next = std::next(Arg);
             if (Next != E &&
-                StringRef(*Next).endswith("unextended-module-overlay.yaml")) {
+                StringRef(*Next).ends_with("unextended-module-overlay.yaml")) {
               ++Arg;
               continue;
             }
@@ -1326,7 +1326,7 @@ void Serializer::writeInputBlock() {
     // that clients can consume it.
     if (Options.ExplicitModuleBuild &&
         llvm::sys::path::extension(importedHeaderPath)
-            .endswith(file_types::getExtension(file_types::TY_PCH)))
+            .ends_with(file_types::getExtension(file_types::TY_PCH)))
       importedHeaderPath = clangImporter->getClangInstance()
                                .getASTReader()
                                ->getModuleManager()

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1320,7 +1320,7 @@ bool swift::extractCompilerFlagsFromInterface(
       continue;
     auto spelling = ArgSaver.save(parse->getSpelling());
     auto &values = parse->getValues();
-    if (spelling.endswith("=")) {
+    if (spelling.ends_with("=")) {
       // Handle the case like -tbd-install_name=Foo. This should be rare because
       // most equal-separated arguments are alias to the separate form.
       assert(values.size() == 1);

--- a/stdlib/include/llvm/ADT/SmallString.h
+++ b/stdlib/include/llvm/ADT/SmallString.h
@@ -124,9 +124,9 @@ public:
     return str().starts_with(Prefix);
   }
 
-  /// endswith - Check if this string ends with the given \p Suffix.
-  bool endswith(StringRef Suffix) const {
-    return str().endswith(Suffix);
+  /// ends_with - Check if this string ends with the given \p Suffix.
+  bool ends_with(StringRef Suffix) const {
+    return str().ends_with(Suffix);
   }
 
   /// @}

--- a/stdlib/include/llvm/ADT/StringRef.h
+++ b/stdlib/include/llvm/ADT/StringRef.h
@@ -272,14 +272,14 @@ namespace llvm {
 
     /// Check if this string ends with the given \p Suffix.
     [[nodiscard]]
-    bool endswith(StringRef Suffix) const {
+    bool ends_with(StringRef Suffix) const {
       return Length >= Suffix.Length &&
         compareMemory(end() - Suffix.Length, Suffix.Data, Suffix.Length) == 0;
     }
 
     /// Check if this string ends with the given \p Suffix, ignoring case.
     [[nodiscard]]
-    bool endswith_insensitive(StringRef Suffix) const;
+    bool ends_with_insensitive(StringRef Suffix) const;
 
     /// @}
     /// @name String Searching
@@ -657,7 +657,7 @@ namespace llvm {
     /// Returns true if this StringRef has the given suffix and removes that
     /// suffix.
     bool consume_back(StringRef Suffix) {
-      if (!endswith(Suffix))
+      if (!ends_with(Suffix))
         return false;
 
       *this = drop_back(Suffix.size());
@@ -667,7 +667,7 @@ namespace llvm {
     /// Returns true if this StringRef has the given suffix, ignoring case,
     /// and removes that suffix.
     bool consume_back_insensitive(StringRef Suffix) {
-      if (!endswith_insensitive(Suffix))
+      if (!ends_with_insensitive(Suffix))
         return false;
 
       *this = drop_back(Suffix.size());

--- a/stdlib/include/llvm/ADT/StringSwitch.h
+++ b/stdlib/include/llvm/ADT/StringSwitch.h
@@ -73,7 +73,7 @@ public:
   }
 
   StringSwitch& EndsWith(StringLiteral S, T Value) {
-    if (!Result && Str.endswith(S)) {
+    if (!Result && Str.ends_with(S)) {
       Result = std::move(Value);
     }
     return *this;
@@ -146,7 +146,7 @@ public:
   }
 
   StringSwitch &EndsWithLower(StringLiteral S, T Value) {
-    if (!Result && Str.endswith_insensitive(S))
+    if (!Result && Str.ends_with_insensitive(S))
       Result = Value;
 
     return *this;

--- a/stdlib/public/LLVMSupport/StringRef.cpp
+++ b/stdlib/public/LLVMSupport/StringRef.cpp
@@ -44,7 +44,7 @@ bool StringRef::starts_with_insensitive(StringRef Prefix) const {
       ascii_strncasecmp(Data, Prefix.Data, Prefix.Length) == 0;
 }
 
-bool StringRef::endswith_insensitive(StringRef Suffix) const {
+bool StringRef::ends_with_insensitive(StringRef Suffix) const {
   return Length >= Suffix.Length &&
       ascii_strncasecmp(end() - Suffix.Length, Suffix.Data, Suffix.Length) == 0;
 }

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -249,7 +249,7 @@ bool BuiltinTypeInfo::readExtraInhabitantIndex(
   // Check if it's an integer first. The mangling of an integer type is
   // type ::= 'Bi' NATURAL '_'
   llvm::StringRef nameRef(Name);
-  if (nameRef.starts_with("Bi") && nameRef.endswith("_")) {
+  if (nameRef.starts_with("Bi") && nameRef.ends_with("_")) {
     // Drop the front "Bi" and "_" end, check that what we're left with is a
     // bool.
     llvm::StringRef naturalRef = nameRef.drop_front(2).drop_back();

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1357,7 +1357,7 @@ getClangDeclarationName(const clang::NamedDecl *ND, NameTranslatingInfo &Info) {
         Pieces.push_back(OrigSel.getIdentifierInfoForSlot(i));
       } else {
         StringRef T = Args[i];
-        Pieces.push_back(&Ctx.Idents.get(T.endswith(":") ? T.drop_back() : T));
+        Pieces.push_back(&Ctx.Idents.get(T.ends_with(":") ? T.drop_back() : T));
       }
     }
     return clang::DeclarationName(

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -341,7 +341,7 @@ static std::optional<sourcekitd_uid_t> getReqOptValueAsUID(StringRef Value) {
 
 static std::optional<sourcekitd_object_t>
 getReqOptValueAsArray(StringRef Value) {
-  if (!Value.starts_with("[") || !Value.endswith("]"))
+  if (!Value.starts_with("[") || !Value.ends_with("]"))
     return std::nullopt;
   SmallVector<StringRef, 4> Elements;
   Value.drop_front().drop_back().split(Elements, ';');

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1736,7 +1736,7 @@ static int doREPLCodeCompletion(const CompilerInvocation &InitInvok,
 
   StringRef BufferText = FileBuf->getBuffer();
   // Drop a single newline character from the buffer.
-  if (BufferText.endswith("\n"))
+  if (BufferText.ends_with("\n"))
     BufferText = BufferText.drop_back(1);
 
   CompilerInvocation Invocation(InitInvok);

--- a/tools/swift-scan-test/swift-scan-test.cpp
+++ b/tools/swift-scan-test/swift-scan-test.cpp
@@ -187,7 +187,7 @@ static int action_replay_result(swiftscan_cas_t cas, const char *key,
 
 static std::vector<const char *> createArgs(ArrayRef<std::string> Cmd,
                                             StringSaver &Saver) {
-  if (!Cmd.empty() && StringRef(Cmd.front()).endswith("swift-frontend"))
+  if (!Cmd.empty() && StringRef(Cmd.front()).ends_with("swift-frontend"))
     Cmd = Cmd.drop_front();
 
   std::vector<const char *> Args;


### PR DESCRIPTION
Missed this when doing the `startswith` renaming. `endswith` has also been deprecated upstream (and presumably soon to be removed).