### PR TITLE
Parse inverse requirements like `~Copyable` in expression position.

### DIFF
--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -1567,6 +1567,15 @@ bool Parser::canParseType() {
     if (!canParseTypeIdentifier())
       return false;
     break;
+  case tok::oper_prefix:
+    if (Tok.getText() != "~") {
+      return false;
+    }
+
+    consumeToken();
+    if (!canParseTypeIdentifier())
+      return false;
+    break;
   case tok::kw_protocol:
     return canParseOldStyleProtocolComposition();
   case tok::l_paren: {

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1826,10 +1826,37 @@ VarDecl *PreCheckExpression::getImplicitSelfDeclForSuperContext(SourceLoc Loc) {
   return methodSelf;
 }
 
+/// Check whether this expression refers to the ~ operator.
+static bool isTildeOperator(Expr *expr) {
+  auto nameMatches = [&](DeclName name) {
+    return name.isOperator() && name.getBaseName().getIdentifier().is("~");
+  };
+
+  if (auto overload = dyn_cast<OverloadedDeclRefExpr>(expr)) {
+    return llvm::any_of(overload->getDecls(), [=](auto *decl) -> bool {
+      return nameMatches(decl->getName());
+    });
+  }
+
+  if (auto unresolved = dyn_cast<UnresolvedDeclRefExpr>(expr)) {
+    return nameMatches(unresolved->getName().getFullName());
+  }
+
+  if (auto declRef = dyn_cast<DeclRefExpr>(expr)) {
+    return nameMatches(declRef->getDecl()->getName());
+  }
+
+  return false;
+}
+
 /// Simplify expressions which are type sugar productions that got parsed
 /// as expressions due to the parser not knowing which identifiers are
 /// type names.
 TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
+  // If it's already a type expression, return it.
+  if (auto typeExpr = dyn_cast<TypeExpr>(E))
+    return typeExpr;
+
   // Fold member types.
   if (auto *UDE = dyn_cast<UnresolvedDotExpr>(E)) {
     return simplifyNestedTypeExpr(UDE);
@@ -2081,6 +2108,17 @@ TypeExpr *PreCheckExpression::simplifyTypeExpr(Expr *E) {
     return new (Ctx) TypeExpr(NewTypeRepr);
   }
   
+  // Fold '~P' into a composition type.
+  if (auto *unaryExpr = dyn_cast<PrefixUnaryExpr>(E)) {
+    if (isTildeOperator(unaryExpr->getFn())) {
+      if (auto operand = simplifyTypeExpr(unaryExpr->getOperand())) {
+        auto inverseTypeRepr = new (Ctx) InverseTypeRepr(
+            unaryExpr->getLoc(), operand->getTypeRepr());
+        return new (Ctx) TypeExpr(inverseTypeRepr);
+      }
+    }
+  }
+
   // Fold 'P & Q' into a composition type
   if (auto *binaryExpr = getCompositionExpr(E)) {
     // The protocols we are composing

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -102,3 +102,15 @@ typealias Z8 = ~Copyable & Hashable // expected-error {{composition cannot conta
 struct NotAProtocol {}
 
 struct Bad: ~NotAProtocol {} // expected-error {{type 'NotAProtocol' cannot be suppressed}}
+
+struct X<T: ~Copyable>: ~Copyable { }
+
+func typeInExpression() {
+  _ = [~Copyable]()  // expected-error{{type 'any Copyable' cannot be suppressed}}
+  _ = X<any ~Copyable>()
+
+  _ = X<any ~Copyable & Foo>()
+  _ = X<any Foo & ~Copyable>()
+
+  _ = X<(borrowing any ~Copyable) -> Void>()
+}


### PR DESCRIPTION
Implement parser and type-expression folding semantics for invertible protocols, so that one can write (e.g.) `[any ~Copyable]` as a type within expression context.

Fixes rdar://125201146.
