### PR TITLE
Test: clean-up `noncopyable_generics` lit usage

### DIFF
--- a/test/ModuleInterface/moveonly_interface_flag.swift
+++ b/test/ModuleInterface/moveonly_interface_flag.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %t
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 
-// XFAIL: noncopyable_generics
+
 
 // this test makes sure that decls containing a move-only type are guarded by the $MoveOnly feature flag
 

--- a/test/Parse/inverses_legacy.swift
+++ b/test/Parse/inverses_legacy.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// XFAIL: noncopyable_generics
+
 
 protocol Sando { func make() } // expected-note {{protocol requires function 'make()'}}
                                // expected-note@-1 {{type 'U' does not conform to inherited protocol 'Copyable'}}

--- a/test/Parse/inverses_legacy_ifdef.swift
+++ b/test/Parse/inverses_legacy_ifdef.swift
@@ -1,7 +1,7 @@
 // RUN: %swift-frontend -typecheck %s
 // RUN: %swift-frontend -typecheck %s -verify -DHAVE_NCGENERICS
 
-// XFAIL: noncopyable_generics
+
 
 /// This test checks that you can write ~Copyable in places that were illegal
 /// in Swift 5.9, as long as those illegal appearances are guarded within

--- a/test/SIL/Parser/array_roundtrip.swift
+++ b/test/SIL/Parser/array_roundtrip.swift
@@ -6,6 +6,7 @@
 
 // FIXME(NCG): This produces `cannot suppress conformances here` errors due to
 // all the new <τ_0_0 where τ_0_0 : ~Copyable> clauses
-// XFAIL: !noncopyable_generics
+// rdar://124657305 (@substituted generic signatures need to either include inverses or the Copyable/Escapable conformances)
+// XFAIL: *
 
 var W = [UInt32](repeating: 0, count: 16)

--- a/test/SILGen/raw_layout.swift
+++ b/test/SILGen/raw_layout.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature RawLayout -enable-builtin-module %s | %FileCheck %s
 
-// XFAIL: noncopyable_generics
+
 
 // CHECK: @_rawLayout(size: 4, alignment: 4) @_moveOnly struct Lock
 // CHECK: @_rawLayout(like: T) @_moveOnly struct Cell<T>

--- a/test/SILGen/variadic-generic-reabstract-tuple-result.swift
+++ b/test/SILGen/variadic-generic-reabstract-tuple-result.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
 
-// XFAIL: noncopyable_generics
+
 
 // rdar://110391963
 

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -6,9 +6,7 @@
 // RUN:     -enable-builtin-module                           \
 // RUN:     -debug-diagnostic-names
 
-// XFAIL: noncopyable_generics
-
-// REQUIRES: noncopyable_generics
+// XFAIL: *
 
 //==============================================================================
 //===========================DEPENDENCY-FREE TESTS=(BEGIN)===================={{

--- a/test/Sema/explicit_lifetime_dependence_specifiers2.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers2.swift
@@ -1,6 +1,5 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BitwiseCopyable
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
 // REQUIRES: nonescapable_types
 
 struct AnotherBufferView : ~Escapable, _BitwiseCopyable {

--- a/test/Serialization/AllowErrors/removed-decls.swift
+++ b/test/Serialization/AllowErrors/removed-decls.swift
@@ -4,7 +4,7 @@
 // RUN: mkdir -p %t/swiftmods %t/objcmods %t/objc
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// XFAIL: noncopyable_generics
+
 
 // Create a module A, then B that depends on A, replace A with an empty module,
 // and then try make a C that depends on B

--- a/test/Serialization/noncopyable_generics.swift
+++ b/test/Serialization/noncopyable_generics.swift
@@ -15,8 +15,6 @@
 // RUN:    -I %t -source-filename=%s                                           \
 // RUN:    | %FileCheck -check-prefix=CHECK-PRINT %s
 
-// REQUIRES: noncopyable_generics
-
 // CHECK-NOT: UnknownCode
 
 // CHECK-PRINT-DAG: protocol Generator<Value> {

--- a/test/api-digester/compare-dump-abi-parsable-interface.swift
+++ b/test/api-digester/compare-dump-abi-parsable-interface.swift
@@ -13,5 +13,5 @@
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
 // RUN: diff -u %t.expected %t.result.tmp
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/compare-dump-abi.swift
+++ b/test/api-digester/compare-dump-abi.swift
@@ -21,5 +21,5 @@
 // CHECK: cake_current/cake.swift:39:15: error: ABI breakage: struct C6 is now with @frozen
 // CHECK: cake_current/cake.swift:41:13: error: ABI breakage: enum IceKind is now without @frozen
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/compare-dump-parsable-interface.swift
+++ b/test/api-digester/compare-dump-parsable-interface.swift
@@ -13,5 +13,5 @@
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
 // RUN: diff -u %t.expected %t.result.tmp
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -32,5 +32,5 @@
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
 // RUN: diff -u %t.expected %t.result.tmp
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -20,4 +20,4 @@
 // when automatically evolving the standard library.
 // UNSUPPORTED: swift_evolve
 
-// XFAIL: noncopyable_generics
+

--- a/test/api-digester/internal-extension.swift
+++ b/test/api-digester/internal-extension.swift
@@ -1,6 +1,6 @@
 // REQUIRES: VENDOR=apple
 
-// XFAIL: noncopyable_generics
+
 
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -92,5 +92,5 @@ Func TaskLocal.withValueImpl(_:operation:file:line:) is a new API without @avail
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -66,4 +66,4 @@ Struct _RuntimeFunctionCounters is a new API without @available attribute
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
-// XFAIL: noncopyable_generics
+

--- a/test/api-digester/stability-stdlib-source.swift
+++ b/test/api-digester/stability-stdlib-source.swift
@@ -13,4 +13,3 @@
 // RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' | sort > %t.tmp/changes.txt.tmp
 // RUN: diff -u %t.tmp/stability-stdlib-source.swift.expected %t.tmp/changes.txt.tmp
 
-// XFAIL: noncopyable_generics

--- a/test/stdlib/Noncopyables/MemoryLayout.swift
+++ b/test/stdlib/Noncopyables/MemoryLayout.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
-// REQUIRES: executable_test, noncopyable_generics
+// REQUIRES: executable_test
 
 struct A: ~Copyable {
   let value: Int


### PR DESCRIPTION
There no longer is a lit feature called `noncopyable_generics`, it's just always on now.