### PR TITLE
Parse suppressed-conformance constraints in expressions and validate them

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5696,6 +5696,8 @@ ERROR(incorrect_optional_any,none,
 ERROR(existential_requires_any,none,
       "use of %select{protocol |}2%0 as a type must be written %1",
       (Type, Type, bool))
+ERROR(inverse_requires_any,none,
+      "constraint that suppresses conformance requires 'any'", ())
 
 ERROR(nonisolated_let,none,
       "'nonisolated' is meaningless on 'let' declarations because "

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1239,12 +1239,19 @@ public:
     // the following token is something that can introduce a type. Thankfully
     // none of these tokens overlap with the set of tokens that can follow an
     // identifier in a type production.
-    return (Tok.is(tok::identifier) &&
-            peekToken().isAny(tok::at_sign, tok::kw_inout, tok::l_paren,
-                              tok::identifier, tok::l_square, tok::kw_Any,
-                              tok::kw_Self, tok::kw__, tok::kw_var,
-                              tok::kw_let)) ||
-           isLifetimeDependenceToken();
+    if (Tok.is(tok::identifier)) {
+      auto next = peekToken();
+      if (next.isAny(tok::at_sign, tok::kw_inout, tok::l_paren,
+                     tok::identifier, tok::l_square, tok::kw_Any,
+                     tok::kw_Self, tok::kw__, tok::kw_var,
+                     tok::kw_let))
+        return true;
+
+      if (next.is(tok::oper_prefix) && next.getText() == "~")
+        return true;
+    }
+
+    return isLifetimeDependenceToken();
   }
 
   struct ParsedTypeAttributeList {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -479,7 +479,8 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 
   // 'any' followed by another identifier is an existential type.
   if (Tok.isContextualKeyword("any") &&
-      peekToken().is(tok::identifier) &&
+      (peekToken().is(tok::identifier) ||
+       peekToken().isContextualPunctuator("~")) &&
       !peekToken().isAtStartOfLine()) {
     ParserResult<TypeRepr> ty = parseType();
     auto *typeExpr = new (Context) TypeExpr(ty.get());

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -202,6 +202,9 @@ enum class TypeResolverContext : uint8_t {
 
   /// Whether this is a custom attribute.
   CustomAttr,
+
+  /// Whether this is the argument of an inverted constraint (~).
+  Inverted,
 };
 
 /// Options that determine how type resolution should work.
@@ -298,6 +301,7 @@ public:
     case Context::GenericParameterInherited:
     case Context::AssociatedTypeInherited:
     case Context::CustomAttr:
+    case Context::Inverted:
       return false;
     }
     llvm_unreachable("unhandled kind");
@@ -316,6 +320,7 @@ public:
     case Context::GenericRequirement:
     case Context::ExistentialConstraint:
     case Context::MetatypeBase:
+    case Context::Inverted:
       return false;
     case Context::None:
     case Context::ScalarGenericArgument:
@@ -353,6 +358,7 @@ public:
     case Context::PackElement:
     case Context::TupleElement:
     case Context::VariadicGenericArgument:
+    case Context::Inverted:
       return true;
     case Context::None:
     case Context::PatternBindingDecl:
@@ -425,6 +431,7 @@ public:
     case Context::ImmediateOptionalTypeArgument:
     case Context::AbstractFunctionDecl:
     case Context::CustomAttr:
+    case Context::Inverted:
       return false;
     }
   }

--- a/test/IRGen/existential_shape_metadata_noncopyable.swift
+++ b/test/IRGen/existential_shape_metadata_noncopyable.swift
@@ -11,6 +11,6 @@ public protocol QNC<A>: ~Copyable {
 public struct NCStruct: ~Copyable { }
 
 
-public func testNoncopyableConcrete() -> (Any & ~Copyable).Type {
+public func testNoncopyableConcrete() -> any  ~Copyable.Type {
   return (any QNC<NCStruct>).self
 }

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -81,15 +81,18 @@ func ownership2(_ t: ~ borrowing Int) {} // expected-error {{cannot find type 'b
 
 func ownership3(_ t: consuming some ~Clone) {}
 
-func what(one: ~Copyable..., // expected-error {{type 'any Copyable' cannot be suppressed}}
+func what(one: ~Copyable..., // expected-error {{noncopyable type '~Copyable' cannot be used within a variadic type yet}}
           two: ~(Copyable...) // expected-error {{variadic parameter cannot appear outside of a function parameter list}}
-                              // expected-error@-1 {{type 'any Copyable' cannot be suppressed}}
+                              // expected-error@-1 {{parameter of noncopyable type '~Copyable' must specify ownership}}
+              // expected-note@-2{{add 'borrowing' for an immutable reference}}
+              // expected-note@-3{{add 'inout' for a mutable reference}}
+              // expected-note@-4{{add 'consuming' to take the value from the caller}}
           ) {}
 
 struct A { struct B { struct C {} } }
 
-typealias Z1 = (~Copyable).Type // FIXME: should be an error
-typealias Z1 = ~Copyable.Type // expected-error {{type 'any Copyable.Type' cannot be suppressed}}
+typealias Z0 = (~Copyable).Type // expected-error{{constraint that suppresses conformance requires 'any'}}{{17-17=any }}
+typealias Z1 = ~Copyable.Type // expected-error{{constraint that suppresses conformance requires 'any'}}{{16-16=any }}
 typealias Z2 = ~A.B.C // expected-error {{type 'A.B.C' cannot be suppressed}}
 typealias Z3 = ~A? // expected-error {{type 'A?' cannot be suppressed}}
 typealias Z4 = ~Rope<Int> // expected-error {{type 'Rope<Int>' cannot be suppressed}}
@@ -106,11 +109,22 @@ struct Bad: ~NotAProtocol {} // expected-error {{type 'NotAProtocol' cannot be s
 struct X<T: ~Copyable>: ~Copyable { }
 
 func typeInExpression() {
-  _ = [~Copyable]()  // expected-error{{type 'any Copyable' cannot be suppressed}}
+  _ = [~Copyable]()  // expected-error{{type '~Copyable' does not conform to protocol 'Copyable'}}
   _ = X<any ~Copyable>()
 
   _ = X<any ~Copyable & Foo>()
   _ = X<any Foo & ~Copyable>()
 
   _ = X<(borrowing any ~Copyable) -> Void>()
+
+  _ = ~Copyable.self // expected-error{{unary operator '~' cannot be applied to an operand of type '(any Copyable).Type'}}
+  _ = (~Copyable).self // expected-error{{constraint that suppresses conformance requires 'any'}}{{8-8=any }}
+  _ = (any ~Copyable).self
 }
+
+func param1(_ t: borrowing ~Copyable) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{28-28=any }}
+func param2(_ t: ~Copyable.Type) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{18-18=any }}
+func param3(_ t: borrowing any ~Copyable) {}
+func param4(_ t: any ~Copyable.Type) {}
+
+func param3(_ t: borrowing ExtraNoncopyProto & ~Copyable) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{28-28=any }}


### PR DESCRIPTION
Ensure that we're properly parsing suppressed-conformance constraints in expression contents and in metatypes. This allows types like `any ~Copyable` in expression context as well as types like `any ~Copyable.Type`.

While we're here, ensure that existentials that involve suppressed-conformance constraints are spelled with `any`.

Fixes rdar://123728228.
