### PR TITLE
Collection of rebranch changes required for the compiler to build

### DIFF
--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -147,7 +147,7 @@ public:
 
   /// Remove "on reconnect" callback.
   void removeOnReconnect(std::function<void(void)> *fn) {
-    llvm::erase_value(onReconnect, fn);
+    llvm::erase(onReconnect, fn);
   }
 
   llvm::sys::procid_t getPid() { return Process->process.Pid; }

--- a/include/swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h
+++ b/include/swift/Basic/ExponentialGrowthAppendingBinaryByteStream.h
@@ -23,6 +23,7 @@
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/BinaryByteStream.h"
+#include "llvm/Support/Endian.h"
 
 namespace swift {
 
@@ -34,13 +35,14 @@ class ExponentialGrowthAppendingBinaryByteStream
   SmallVector<uint8_t, 0> Data;
 
   /// Data in the stream is always encoded in little-endian byte order.
-  const llvm::support::endianness Endian = llvm::support::endianness::little;
+  const llvm::endianness Endian = llvm::endianness::little;
+
 public:
   ExponentialGrowthAppendingBinaryByteStream() = default;
 
   void reserve(size_t Size);
 
-  llvm::support::endianness getEndian() const override { return Endian; }
+  llvm::endianness getEndian() const override { return Endian; }
 
   llvm::Error readBytes(uint64_t Offset, uint64_t Size,
                         ArrayRef<uint8_t> &Buffer) override;

--- a/include/swift/Basic/STLExtras.h
+++ b/include/swift/Basic/STLExtras.h
@@ -259,7 +259,7 @@ public:
   }
 };
 
-/// An iterator that transforms the result of an underlying bidirectional
+/// An iterator that transforms the result of an underlying random access
 /// iterator with a given operation.
 ///
 /// Slightly different semantics from llvm::map_iterator, but we should
@@ -281,7 +281,7 @@ class TransformIterator {
   using OpTraits = function_traits<Operation>;
 
 public:
-  using iterator_category = std::bidirectional_iterator_tag;
+  using iterator_category = std::random_access_iterator_tag;
   using value_type = typename OpTraits::result_type;
   using reference = value_type;
   using pointer = void; // FIXME: Should provide a pointer proxy.
@@ -318,6 +318,17 @@ public:
     --*this;
     return old;
   }
+
+  int operator-(const TransformIterator &rhs) const {
+    return Current - rhs.Current;
+  }
+
+  TransformIterator &operator+=(int rhs) {
+    Current = Current + rhs;
+    return *this;
+  }
+
+  TransformIterator &operator-=(int rhs) { return operator+=(-rhs); }
 
   friend bool operator==(TransformIterator lhs, TransformIterator rhs) {
     return lhs.Current == rhs.Current;

--- a/include/swift/Basic/StableHasher.h
+++ b/include/swift/Basic/StableHasher.h
@@ -133,7 +133,7 @@ public:
       return setBufferLength(bufLen + N);
     }
 
-    constexpr auto endian = llvm::support::endianness::little;
+    constexpr auto endian = llvm::endianness::little;
     compress(llvm::support::endian::read<uint64_t>(byteBuffer, endian));
 
     // Now reseed the buffer with the remaining bytes.
@@ -146,7 +146,7 @@ public:
       typename T,
       typename std::enable_if<std::is_integral<T>::value>::type * = nullptr>
   void combine(T bits) {
-    constexpr auto endian = llvm::support::endianness::little;
+    constexpr auto endian = llvm::endianness::little;
     uint8_t buf[sizeof(T)] = {0};
     bits = llvm::support::endian::byte_swap<T>(bits, endian);
     std::memcpy(buf, &bits, sizeof(T));

--- a/include/swift/ClangImporter/SwiftAbstractBasicReader.h
+++ b/include/swift/ClangImporter/SwiftAbstractBasicReader.h
@@ -94,6 +94,11 @@ public:
     llvm::report_fatal_error("Read BTFTypeTagAttr that should never have been"
                              " serialized");
   }
+
+  template<typename T>
+  T *readDeclAs() {
+    return asImpl().template readDeclAs<T>();
+  }
 };
 
 }

--- a/include/swift/ClangImporter/SwiftAbstractBasicReader.h
+++ b/include/swift/ClangImporter/SwiftAbstractBasicReader.h
@@ -99,6 +99,11 @@ public:
   T *readDeclAs() {
     return asImpl().template readDeclAs<T>();
   }
+
+  clang::TypeCoupledDeclRefInfo readTypeCoupledDeclRefInfo() {
+    return clang::TypeCoupledDeclRefInfo(
+        asImpl().template readDeclAs<clang::ValueDecl>(), asImpl().readBool());
+  }
 };
 
 }

--- a/include/swift/ClangImporter/SwiftAbstractBasicWriter.h
+++ b/include/swift/ClangImporter/SwiftAbstractBasicWriter.h
@@ -99,6 +99,11 @@ public:
     // hit any of its attributes.
     llvm::report_fatal_error("Should never hit BTFTypeTagAttr serialization");
   }
+
+  void writeTypeCoupledDeclRefInfo(clang::TypeCoupledDeclRefInfo info) {
+    asImpl().writeDeclRef(info.getDecl());
+    asImpl().writeBool(info.isDeref());
+  }
 };
 
 }

--- a/include/swift/DependencyScan/ModuleDependencyScanner.h
+++ b/include/swift/DependencyScan/ModuleDependencyScanner.h
@@ -145,7 +145,7 @@ private:
   /// The available pool of workers for filesystem module search
   unsigned NumThreads;
   std::list<std::unique_ptr<ModuleDependencyScanningWorker>> Workers;
-  llvm::ThreadPool ScanningThreadPool;
+  llvm::StdThreadPool ScanningThreadPool;
   /// Protect worker access.
   std::mutex WorkersLock;
 };

--- a/include/swift/Localization/LocalizationFormat.h
+++ b/include/swift/Localization/LocalizationFormat.h
@@ -40,8 +40,6 @@ enum class DiagID : uint32_t;
 
 namespace diag {
 
-using namespace llvm::support;
-
 enum LocalizationProducerState : uint8_t {
   NotInitialized,
   Initialized,
@@ -77,14 +75,15 @@ public:
                                                         key_type_ref key,
                                                         data_type_ref data) {
     offset_type dataLength = static_cast<offset_type>(data.size());
-    endian::write<offset_type>(out, dataLength, little);
+    llvm::support::endian::write<offset_type>(out, dataLength,
+                                              llvm::endianness::little);
     // No need to write the key length; it's constant.
     return {sizeof(key_type), dataLength};
   }
 
   void EmitKey(llvm::raw_ostream &out, key_type_ref key, unsigned len) {
     assert(len == sizeof(key_type));
-    endian::write<key_type>(out, key, little);
+    llvm::support::endian::write<key_type>(out, key, llvm::endianness::little);
   }
 
   void EmitData(llvm::raw_ostream &out, key_type_ref key, data_type_ref data,
@@ -120,12 +119,15 @@ public:
   static std::pair<offset_type, offset_type>
   ReadKeyDataLength(const unsigned char *&data) {
     offset_type dataLength =
-        endian::readNext<offset_type, little, unaligned>(data);
+        llvm::support::endian::readNext<offset_type, llvm::endianness::little,
+                                        llvm::support::unaligned>(data);
     return {sizeof(uint32_t), dataLength};
   }
 
   internal_key_type ReadKey(const unsigned char *data, offset_type length) {
-    return endian::readNext<internal_key_type, little, unaligned>(data);
+    return llvm::support::endian::readNext<
+        internal_key_type, llvm::endianness::little, llvm::support::unaligned>(
+        data);
   }
 
   data_type ReadData(internal_key_type Key, const unsigned char *data,

--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -13,13 +13,9 @@
 #ifndef SWIFT_OPTION_OPTIONS_H
 #define SWIFT_OPTION_OPTIONS_H
 
-#include <memory>
+#include "llvm/Option/OptTable.h"
 
-namespace llvm {
-namespace opt {
-  class OptTable;
-}
-}
+#include <memory>
 
 namespace swift {
 namespace options {
@@ -49,9 +45,7 @@ namespace options {
 
   enum ID {
     OPT_INVALID = 0, // This is not an option ID.
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELPTEXT, METAVAR, VALUES)                                      \
-    OPT_##ID,
+#define OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__),
 #include "swift/Option/Options.inc"
     LastOption
 #undef OPTION

--- a/include/swift/SIL/LoopInfo.h
+++ b/include/swift/SIL/LoopInfo.h
@@ -24,13 +24,9 @@ namespace swift {
   class SILPassManager;
 }
 
-// Implementation in LoopInfoImpl.h
-#ifdef __GNUC__
-__extension__ extern template
-class llvm::LoopBase<swift::SILBasicBlock, swift::SILLoop>;
-__extension__ extern template
-class llvm::LoopInfoBase<swift::SILBasicBlock, swift::SILLoop>;
-#endif
+// Implementation in llvm/Support/GenericLoopInfoImpl.h
+extern template class llvm::LoopBase<swift::SILBasicBlock, swift::SILLoop>;
+extern template class llvm::LoopInfoBase<swift::SILBasicBlock, swift::SILLoop>;
 
 namespace swift {
 

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -94,6 +94,7 @@ template <> struct compute_node_options<::swift::SILInstruction> {
 
     static const bool enable_sentinel_tracking = false;
     static const bool is_sentinel_tracking_explicit = false;
+    static const bool has_iterator_bits = false;
     typedef void tag;
     typedef ilist_node_base<enable_sentinel_tracking> node_base_type;
     typedef SILInstructionListBase list_base_type;

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3026,7 +3026,7 @@ void ASTMangler::appendClangType(FnType *fn, llvm::raw_svector_ostream &out) {
       fn->getASTContext().getClangModuleLoader()->getClangASTContext();
   std::unique_ptr<clang::ItaniumMangleContext> mangler{
       clang::ItaniumMangleContext::create(clangCtx, clangCtx.getDiagnostics())};
-  mangler->mangleTypeName(clang::QualType(clangType, 0), scratchOS);
+  mangler->mangleCanonicalTypeName(clang::QualType(clangType, 0), scratchOS);
   out << scratchOS.str().size() << scratchOS.str();
 }
 

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -271,8 +271,8 @@ llvm::Error LoadedExecutablePlugin::sendMessage(llvm::StringRef message) const {
   size_t size = message.size();
 
   // Write header (message size).
-  uint64_t header = llvm::support::endian::byte_swap(
-      uint64_t(size), llvm::support::endianness::little);
+  uint64_t header = llvm::support::endian::byte_swap(uint64_t(size),
+                                                     llvm::endianness::little);
   writtenSize = Process->write(&header, sizeof(header));
   if (writtenSize != sizeof(header)) {
     setStale();
@@ -304,8 +304,8 @@ llvm::Expected<std::string> LoadedExecutablePlugin::waitForNextMessage() const {
                                    "failed to read plugin message header");
   }
 
-  size_t size = llvm::support::endian::read<uint64_t>(
-      &header, llvm::support::endianness::little);
+  size_t size =
+      llvm::support::endian::read<uint64_t>(&header, llvm::endianness::little);
 
   // Read message.
   std::string message;

--- a/lib/Basic/Platform.cpp
+++ b/lib/Basic/Platform.cpp
@@ -175,33 +175,32 @@ static StringRef getPlatformNameForDarwin(const DarwinPlatformKind platform) {
 
 StringRef swift::getPlatformNameForTriple(const llvm::Triple &triple) {
   switch (triple.getOS()) {
-  case llvm::Triple::ZOS:
-  case llvm::Triple::Ananas:
-  case llvm::Triple::CloudABI:
+  case llvm::Triple::AIX:
+  case llvm::Triple::AMDHSA:
+  case llvm::Triple::AMDPAL:
+  case llvm::Triple::BridgeOS:
+  case llvm::Triple::CUDA:
   case llvm::Triple::DragonFly:
   case llvm::Triple::DriverKit:
-  case llvm::Triple::XROS:
+  case llvm::Triple::ELFIAMCU:
   case llvm::Triple::Emscripten:
   case llvm::Triple::Fuchsia:
-  case llvm::Triple::KFreeBSD:
-  case llvm::Triple::Lv2:
-  case llvm::Triple::NetBSD:
-  case llvm::Triple::PS5:
-  case llvm::Triple::ShaderModel:
-  case llvm::Triple::Solaris:
-  case llvm::Triple::Minix:
-  case llvm::Triple::RTEMS:
-  case llvm::Triple::NaCl:
-  case llvm::Triple::AIX:
-  case llvm::Triple::CUDA:
-  case llvm::Triple::NVCL:
-  case llvm::Triple::AMDHSA:
-  case llvm::Triple::ELFIAMCU:
-  case llvm::Triple::Mesa3D:
-  case llvm::Triple::Contiki:
-  case llvm::Triple::AMDPAL:
   case llvm::Triple::HermitCore:
   case llvm::Triple::Hurd:
+  case llvm::Triple::KFreeBSD:
+  case llvm::Triple::Lv2:
+  case llvm::Triple::Mesa3D:
+  case llvm::Triple::NaCl:
+  case llvm::Triple::NetBSD:
+  case llvm::Triple::NVCL:
+  case llvm::Triple::PS5:
+  case llvm::Triple::RTEMS:
+  case llvm::Triple::Serenity:
+  case llvm::Triple::ShaderModel:
+  case llvm::Triple::Solaris:
+  case llvm::Triple::Vulkan:
+  case llvm::Triple::XROS:
+  case llvm::Triple::ZOS:
     return "";
   case llvm::Triple::Darwin:
   case llvm::Triple::MacOSX:

--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -776,7 +776,7 @@ OptionalTypeKind importer::getParamOptionality(const clang::ParmVarDecl *param,
   // Check for the 'static' annotation on C arrays.
   if (const auto *DT = dyn_cast<clang::DecayedType>(paramTy))
     if (const auto *AT = DT->getOriginalType()->getAsArrayTypeUnsafe())
-      if (AT->getSizeModifier() == clang::ArrayType::Static)
+      if (AT->getSizeModifier() == clang::ArraySizeModifier::Static)
         return OTK_None;
 
   // Default to implicitly unwrapped optionals.

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -264,8 +264,8 @@ instantiateTemplatedOperator(ClangImporter::Implementation &impl,
 
   clang::UnresolvedSet<1> ops;
   auto qualType = clang::QualType(classDecl->getTypeForDecl(), 0);
-  auto arg = new (clangCtx)
-      clang::CXXThisExpr(clang::SourceLocation(), qualType, false);
+  auto arg = clang::CXXThisExpr::Create(clangCtx, clang::SourceLocation(),
+                                        qualType, false);
   arg->setType(clang::QualType(classDecl->getTypeForDecl(), 0));
 
   clang::OverloadedOperatorKind opKind =

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5211,9 +5211,9 @@ static clang::CXXMethodDecl *synthesizeCxxBaseGetterAccessorMethod(
 
   // Returns the expression that accesses the base field from derived type.
   auto createFieldAccess = [&]() -> clang::Expr * {
-    auto *thisExpr = new (clangCtx)
-        clang::CXXThisExpr(clang::SourceLocation(), newMethod->getThisType(),
-                           /*IsImplicit=*/false);
+    auto *thisExpr = clang::CXXThisExpr::Create(
+        clangCtx, clang::SourceLocation(), newMethod->getThisType(),
+        /*IsImplicit=*/false);
     clang::QualType baseClassPtr = clangCtx.getRecordType(baseClass);
     baseClassPtr.addConst();
     baseClassPtr = clangCtx.getPointerType(baseClassPtr);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5588,12 +5588,6 @@ namespace {
       return nullptr;
     }
 
-    Decl *VisitClassScopeFunctionSpecializationDecl(
-                 const clang::ClassScopeFunctionSpecializationDecl *decl) {
-      // Note: templates are not imported.
-      return nullptr;
-    }
-
     Decl *VisitImportDecl(const clang::ImportDecl *decl) {
       // Transitive module imports are not handled at the declaration level.
       // Rather, they are understood from the module itself.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3742,7 +3742,7 @@ namespace {
               // this method would get sliced away, and an invocation would get
               // dispatched statically. This is fine because it matches the C++
               // behavior.
-              if (decl->isPure()) {
+              if (decl->isPureVirtual()) {
                 // If this is a pure virtual method, we won't have any
                 // implementation of it to invoke.
                 Impl.markUnavailable(

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3380,7 +3380,7 @@ namespace {
                    d->getName() == "cos" || d->getName() == "exit";
           return false;
         };
-        
+
         if (clang::Module *owningModule = decl->getOwningModule();
             owningModule && importer::isCxxStdModule(owningModule)) {
           if (isAlternativeCStdlibFunctionFromTextualHeader(decl)) {
@@ -3388,7 +3388,7 @@ namespace {
           }
 
           auto &sourceManager = Impl.getClangPreprocessor().getSourceManager();
-          if (const auto file = sourceManager.getFileEntryForID(
+          if (auto file = sourceManager.getFileEntryRefForID(
                   sourceManager.getFileID(decl->getLocation()))) {
             auto filename = file->getName();
             if ((file->getDir() == owningModule->Directory) &&

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -59,6 +59,7 @@
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Sema/Lookup.h"
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringExtras.h"

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4583,7 +4583,8 @@ namespace {
                                                : getOverridableAccessLevel(dc));
 
       // Optional methods in protocols.
-      if (decl->getImplementationControl() == clang::ObjCMethodDecl::Optional &&
+      if (decl->getImplementationControl() ==
+              clang::ObjCImplementationControl::Optional &&
           isa<ProtocolDecl>(dc))
         result->getAttrs().add(new (Impl.SwiftContext)
                                       OptionalAttr(/*implicit*/false));
@@ -5487,8 +5488,9 @@ namespace {
       if (decl->hasAttr<clang::IBOutletAttr>())
         result->getAttrs().add(
             new (Impl.SwiftContext) IBOutletAttr(/*IsImplicit=*/false));
-      if (decl->getPropertyImplementation() == clang::ObjCPropertyDecl::Optional
-          && isa<ProtocolDecl>(dc) &&
+      if (decl->getPropertyImplementation() ==
+              clang::ObjCPropertyDecl::Optional &&
+          isa<ProtocolDecl>(dc) &&
           !result->getAttrs().hasAttribute<OptionalAttr>())
         result->getAttrs().add(new (Impl.SwiftContext)
                                       OptionalAttr(/*implicit*/false));
@@ -7018,7 +7020,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
 
   // Find the counterpart.
   bool optionalMethods = (objcMethod->getImplementationControl() ==
-                          clang::ObjCMethodDecl::Optional);
+                          clang::ObjCImplementationControl::Optional);
 
   if (auto *counterpart = findCounterpart(counterpartSelector)) {
     const clang::ObjCMethodDecl *counterpartMethod = nullptr;
@@ -7032,7 +7034,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
       counterpartMethod = cast<clang::ObjCMethodDecl>(importedFrom);
       if (optionalMethods)
         optionalMethods = (counterpartMethod->getImplementationControl() ==
-                           clang::ObjCMethodDecl::Optional);
+                           clang::ObjCImplementationControl::Optional);
     }
 
     assert(!counterpart || !counterpart->isStatic());
@@ -8529,12 +8531,12 @@ ClangImporter::Implementation::importDeclImpl(const clang::NamedDecl *ClangDecl,
     if (auto clangProto
           = dyn_cast<clang::ObjCProtocolDecl>(ClangDecl->getDeclContext())) {
       if (auto method = dyn_cast<clang::ObjCMethodDecl>(ClangDecl)) {
-        if (method->getImplementationControl()
-              == clang::ObjCMethodDecl::Required)
+        if (method->getImplementationControl() ==
+            clang::ObjCImplementationControl::Required)
           hasMissingRequiredMember = true;
       } else if (auto prop = dyn_cast<clang::ObjCPropertyDecl>(ClangDecl)) {
-        if (prop->getPropertyImplementation()
-              == clang::ObjCPropertyDecl::Required)
+        if (prop->getPropertyImplementation() ==
+            clang::ObjCPropertyDecl::Required)
           hasMissingRequiredMember = true;
       }
 

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -108,11 +108,11 @@ void EnumInfo::classifyEnum(const clang::EnumDecl *decl,
 
   // If API notes have /removed/ a FlagEnum or EnumExtensibility attribute,
   // then we don't need to check the macros.
-  for (auto *attr : decl->specific_attrs<clang::SwiftVersionedAttr>()) {
+  for (auto *attr : decl->specific_attrs<clang::SwiftVersionedAdditionAttr>()) {
     if (!attr->getIsReplacedByActive())
       continue;
-    if (isa<clang::FlagEnumAttr>(attr->getAttrToAdd()) ||
-        isa<clang::EnumExtensibilityAttr>(attr->getAttrToAdd())) {
+    if (isa<clang::FlagEnumAttr>(attr->getAdditionalAttr()) ||
+        isa<clang::EnumExtensibilityAttr>(attr->getAdditionalAttr())) {
       kind = EnumKind::Unknown;
       return;
     }

--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -399,10 +399,9 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
 
   // Handle tokens starting with a type cast
   bool castTypeIsId = false;
-  if (numTokens > 3 &&
-      tokenI[0].is(clang::tok::l_paren) &&
+  if (numTokens > 3 && tokenI[0].is(clang::tok::l_paren) &&
       (tokenI[1].is(clang::tok::identifier) ||
-        impl.getClangSema().isSimpleTypeSpecifier(tokenI[1].getKind())) &&
+       tokenI[1].isSimpleTypeSpecifier(impl.getClangSema().getLangOpts())) &&
       tokenI[2].is(clang::tok::r_paren)) {
     if (!castType.isNull()) {
       // this is a nested cast

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -548,7 +548,7 @@ struct AnySwiftNameAttr {
   }
 };
 
-/// Aggregate struct for the common members of clang::SwiftVersionedAttr and
+/// Aggregate struct for the common members of clang::SwiftVersionedAdditionAttr and
 /// clang::SwiftVersionedRemovalAttr.
 ///
 /// For a SwiftVersionedRemovalAttr, the Attr member will be null.
@@ -671,8 +671,8 @@ findSwiftNameAttr(const clang::Decl *decl, ImportNameVersion version) {
     for (auto *attr : decl->attrs()) {
       VersionedSwiftNameInfo info;
 
-      if (auto *versionedAttr = dyn_cast<clang::SwiftVersionedAttr>(attr)) {
-        auto added = decodeAttr(versionedAttr->getAttrToAdd());
+      if (auto *versionedAttr = dyn_cast<clang::SwiftVersionedAdditionAttr>(attr)) {
+        auto added = decodeAttr(versionedAttr->getAdditionalAttr());
         if (!added)
           continue;
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1264,6 +1264,14 @@ namespace {
 
       return { importedType, ImportHint::ObjCPointer };
     }
+
+    ImportResult VisitPackIndexingType(const clang::PackIndexingType *type) {
+      return Type();
+    }
+
+    ImportResult VisitCountAttributedType(const clang::CountAttributedType *type) {
+      return Type();
+    }
   };
 } // end anonymous namespace
 

--- a/lib/ClangImporter/SwiftDeclSynthesizer.cpp
+++ b/lib/ClangImporter/SwiftDeclSynthesizer.cpp
@@ -2114,8 +2114,9 @@ clang::CXXMethodDecl *SwiftDeclSynthesizer::synthesizeCXXForwardingMethod(
   auto diagState = clangSema.DelayedDiagnostics.push(diagPool);
 
   // Construct the method's body.
-  clang::Expr *thisExpr = new (clangCtx) clang::CXXThisExpr(
-      clang::SourceLocation(), newMethod->getThisType(), /*IsImplicit=*/false);
+  clang::Expr *thisExpr = clang::CXXThisExpr::Create(
+      clangCtx, clang::SourceLocation(), newMethod->getThisType(),
+      /*IsImplicit=*/false);
   if (castThisToNonConstThis) {
     auto baseClassPtr =
         clangCtx.getPointerType(clangCtx.getRecordType(derivedClass));

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -731,7 +731,7 @@ namespace driver {
     /// Create \c NumberOfParallelCommands batches and assign each job to a
     /// batch either filling each partition in order or, if seeded with a
     /// nonzero value, pseudo-randomly (but deterministically and nearly-evenly).
-    void partitionIntoBatches(std::vector<const Job *> Batchable,
+    void partitionIntoBatches(const llvm::SmallVectorImpl<const Job *> &Batchable,
                               BatchPartition &Partition) {
       if (Comp.getShowJobLifecycle()) {
         llvm::outs() << "Found " << Batchable.size() << " batchable jobs\n";

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -249,7 +249,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   }
 
   inputArgs.AddAllArgs(arguments, options::OPT_I);
-  inputArgs.AddAllArgs(arguments, options::OPT_F, options::OPT_Fsystem);
+  inputArgs.addAllArgs(arguments, {options::OPT_F, options::OPT_Fsystem});
   inputArgs.AddAllArgs(arguments, options::OPT_vfsoverlay);
 
   inputArgs.AddLastArg(arguments, options::OPT_AssertConfig);
@@ -304,8 +304,8 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_profile_coverage_mapping);
-  inputArgs.AddAllArgs(arguments, options::OPT_warnings_as_errors,
-                       options::OPT_no_warnings_as_errors);
+  inputArgs.addAllArgs(arguments, {options::OPT_warnings_as_errors,
+                                   options::OPT_no_warnings_as_errors});
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_sanitize_recover_EQ);
   inputArgs.AddLastArg(arguments,
@@ -347,9 +347,9 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddAllArgs(arguments, options::OPT_D);
 
   // Pass on file paths that should be remapped in debug info.
-  inputArgs.AddAllArgs(arguments, options::OPT_debug_prefix_map,
-                                  options::OPT_coverage_prefix_map,
-                                  options::OPT_file_prefix_map);
+  inputArgs.addAllArgs(arguments, {options::OPT_debug_prefix_map,
+                                   options::OPT_coverage_prefix_map,
+                                   options::OPT_file_prefix_map});
 
   std::string globalRemapping = getGlobalDebugPathRemapping();
   if (!globalRemapping.empty()) {
@@ -1310,7 +1310,8 @@ ToolChain::constructInvocation(const REPLJobAction &job,
   addRuntimeLibraryFlags(context.OI, FrontendArgs);
 
   context.Args.AddLastArg(FrontendArgs, options::OPT_import_objc_header);
-  context.Args.AddAllArgs(FrontendArgs, options::OPT_framework, options::OPT_L);
+  context.Args.addAllArgs(FrontendArgs,
+                          {options::OPT_framework, options::OPT_L});
   ToolChain::addLinkedLibArgs(context.Args, FrontendArgs);
 
   if (!useLLDB) {

--- a/lib/DriverTool/swift_cache_tool_main.cpp
+++ b/lib/DriverTool/swift_cache_tool_main.cpp
@@ -56,9 +56,7 @@ struct OutputEntry {
 
 enum ID {
   OPT_INVALID = 0, // This is not an option ID.
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELPTEXT, METAVAR, VALUES)                                      \
-  OPT_##ID,
+#define OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__),
 #include "SwiftCacheToolOptions.inc"
   LastOption
 #undef OPTION
@@ -72,10 +70,7 @@ enum ID {
 #undef PREFIX
 
 static const OptTable::Info InfoTable[] = {
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELPTEXT, METAVAR, VALUES)                                      \
-  {PREFIX, NAME,  HELPTEXT,    METAVAR,     OPT_##ID,  Option::KIND##Class,    \
-   PARAM,  FLAGS, OPT_##GROUP, OPT_##ALIAS, ALIASARGS, VALUES},
+#define OPTION(...) LLVM_CONSTRUCT_OPT_INFO(__VA_ARGS__),
 #include "SwiftCacheToolOptions.inc"
 #undef OPTION
 };

--- a/lib/DriverTool/swift_llvm_opt_main.cpp
+++ b/lib/DriverTool/swift_llvm_opt_main.cpp
@@ -114,11 +114,11 @@ static llvm::cl::opt<std::string> PassPipeline(
 //                               Helper Methods
 //===----------------------------------------------------------------------===//
 
-static llvm::CodeGenOpt::Level GetCodeGenOptLevel(const SwiftLLVMOptOptions &options) {
+static llvm::CodeGenOptLevel GetCodeGenOptLevel(const SwiftLLVMOptOptions &options) {
   // TODO: Is this the right thing to do here?
   if (options.Optimized)
-    return llvm::CodeGenOpt::Default;
-  return llvm::CodeGenOpt::None;
+    return llvm::CodeGenOptLevel::Default;
+  return llvm::CodeGenOptLevel::None;
 }
 
 // Returns the TargetMachine instance or zero if no triple is provided.

--- a/lib/Frontend/CachedDiagnostics.cpp
+++ b/lib/Frontend/CachedDiagnostics.cpp
@@ -777,7 +777,7 @@ CachingDiagnosticsProcessor::CachingDiagnosticsProcessor(
     // Write the uncompressed size in the end.
     if (!Compression.empty()) {
       llvm::raw_svector_ostream BufOS((SmallVectorImpl<char> &)Compression);
-      llvm::support::endian::Writer Writer(BufOS, llvm::support::little);
+      llvm::support::endian::Writer Writer(BufOS, llvm::endianness::little);
       Writer.write(uint32_t(Output.size()));
     }
 
@@ -825,7 +825,7 @@ CachingDiagnosticsProcessor::replayCachedDiagnostics(llvm::StringRef Buffer) {
           std::make_error_code(std::errc::message_size));
 
     uint32_t UncompressedSize =
-        llvm::support::endian::read<uint32_t, llvm::support::little>(
+        llvm::support::endian::read<uint32_t, llvm::endianness::little>(
             Buffer.data() + Buffer.size() - sizeof(uint32_t));
 
     StringRef CompressedData = Buffer.drop_back(sizeof(uint32_t));

--- a/lib/Frontend/CompileJobCacheKey.cpp
+++ b/lib/Frontend/CompileJobCacheKey.cpp
@@ -94,7 +94,8 @@ swift::createCompileJobCacheKeyForOutput(llvm::cas::ObjectStore &CAS,
 
   // CacheKey is the index of the producting input + the base key.
   // Encode the unsigned value as little endian in the field.
-  llvm::support::endian::write<uint32_t>(OS, InputIndex, llvm::support::little);
+  llvm::support::endian::write<uint32_t>(OS, InputIndex,
+                                         llvm::endianness::little);
 
   return CAS.storeFromString({BaseKey}, OS.str());
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1263,9 +1263,9 @@ static bool printSwiftFeature(CompilerInstance &instance) {
     out << "}\n";
   };
   out << "  \"SupportedArguments\": [\n";
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELPTEXT, METAVAR, VALUES)                                      \
-  printSingleFrontendOpt(*table, swift::options::OPT_##ID, out);
+#define OPTION(...)                                                            \
+  printSingleFrontendOpt(*table,                                               \
+                         swift::options::LLVM_MAKE_OPT_ID(__VA_ARGS__), out);
 #include "swift/Option/Options.inc"
 #undef OPTION
   out << "    \"LastOption\"\n";

--- a/lib/IDE/CodeCompletionCache.cpp
+++ b/lib/IDE/CodeCompletionCache.cpp
@@ -304,8 +304,7 @@ static bool readCachedModule(llvm::MemoryBuffer *in,
 static void writeCachedModule(llvm::raw_ostream &out,
                               const CodeCompletionCache::Key &K,
                               CodeCompletionCache::Value &V) {
-  using namespace llvm::support;
-  endian::Writer LE(out, little);
+  llvm::support::endian::Writer LE(out, llvm::endianness::little);
 
   // HEADER
   // Metadata required for reading the completions.
@@ -321,7 +320,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
     llvm::raw_svector_ostream OSS(scratch);
     OSS << K.ModuleFilename << "\0";
     OSS << K.ModuleName << "\0";
-    endian::Writer OSSLE(OSS, little);
+    llvm::support::endian::Writer OSSLE(OSS, llvm::endianness::little);
     OSSLE.write(K.AccessPath.size());
     for (StringRef p : K.AccessPath)
       OSS << p << "\0";
@@ -340,7 +339,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
   llvm::raw_string_ostream results(results_);
   std::string chunks_;
   llvm::raw_string_ostream chunks(chunks_);
-  endian::Writer chunksLE(chunks, little);
+  llvm::support::endian::Writer chunksLE(chunks, llvm::endianness::little);
   std::string strings_;
   llvm::raw_string_ostream strings(strings_);
   llvm::StringMap<uint32_t> knownStrings;
@@ -356,7 +355,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
       return found->second;
     }
     auto size = strings.tell();
-    endian::Writer LE(strings, little);
+    llvm::support::endian::Writer LE(strings, llvm::endianness::little);
     LE.write(static_cast<uint32_t>(str.size()));
     strings << str;
     knownStrings[str] = size;
@@ -381,7 +380,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
     }
 
     auto size = types.tell();
-    endian::Writer LE(types, little);
+    llvm::support::endian::Writer LE(types, llvm::endianness::little);
     StringRef USR = type->getUSR();
     LE.write(static_cast<uint32_t>(USR.size()));
     types << USR;
@@ -414,7 +413,7 @@ static void writeCachedModule(llvm::raw_ostream &out,
 
   // RESULTS
   {
-    endian::Writer LE(results, little);
+    llvm::support::endian::Writer LE(results, llvm::endianness::little);
     for (const ContextFreeCodeCompletionResult *R : V.Results) {
       // FIXME: compress bitfield
       LE.write(static_cast<uint8_t>(R->getKind()));

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1025,6 +1025,10 @@ namespace {
         llvm_unreachable("ConstantMatrix type in ABI lowering?");
       }
 
+      case clang::Type::ArrayParameter:
+        llvm_unreachable("HLSL type in ABI lowering");
+
+
       case clang::Type::ConstantArray: {
         auto array = Ctx.getAsConstantArrayType(type);
         auto elt = Ctx.getCanonicalType(array->getElementType());

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1605,8 +1605,7 @@ namespace {
       std::optional<CanType> specializedGenericType;
       if ((specializedGenericType = getSpecializedGenericType()) && forMeta) {
         //     ClassMetadata *NonMetaClass;
-        b.addBitCast(IGM.getAddrOfTypeMetadata(*specializedGenericType),
-                     IGM.Int8PtrTy);
+        b.add(IGM.getAddrOfTypeMetadata(*specializedGenericType));
       } else {
         //     const uint8_t *IvarLayout;
         // GC/ARC layout.  TODO.

--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -42,7 +42,7 @@ using llvm::coverage::CovMapVersion;
 /// cannot pin our version, as it must remain in sync with the version Clang is
 /// using.
 /// Do not bump without at least filing a bug and pinging a coverage maintainer.
-static_assert(CovMapVersion::CurrentVersion == CovMapVersion::Version6,
+static_assert(CovMapVersion::CurrentVersion == CovMapVersion::Version7,
               "Coverage mapping emission needs updating");
 
 static std::string getInstrProfSection(IRGenModule &IGM,

--- a/lib/IRGen/GenDiffWitness.cpp
+++ b/lib/IRGen/GenDiffWitness.cpp
@@ -39,10 +39,8 @@ void IRGenModule::emitSILDifferentiabilityWitness(
          "Differentiability witness definition should have JVP");
   assert(dw->getVJP() &&
          "Differentiability witness definition should have VJP");
-  diffWitnessContents.addBitCast(
-      getAddrOfSILFunction(dw->getJVP(), NotForDefinition), Int8PtrTy);
-  diffWitnessContents.addBitCast(
-      getAddrOfSILFunction(dw->getVJP(), NotForDefinition), Int8PtrTy);
+  diffWitnessContents.add(getAddrOfSILFunction(dw->getJVP(), NotForDefinition));
+  diffWitnessContents.add(getAddrOfSILFunction(dw->getVJP(), NotForDefinition));
   getAddrOfDifferentiabilityWitness(
       dw, diffWitnessContents.finishAndCreateFuture());
 }

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -623,8 +623,9 @@ StackAddress IRGenFunction::emitDynamicAlloca(llvm::Type *eltTy,
   // executed more than once).
   bool isInEntryBlock = (Builder.GetInsertBlock() == &*CurFn->begin());
   if (!isInEntryBlock) {
-    stackRestorePoint =
-        Builder.CreateIntrinsicCall(llvm::Intrinsic::stacksave, {}, "spsave");
+    stackRestorePoint = Builder.CreateIntrinsicCall(
+        llvm::Intrinsic::stacksave,
+        {IGM.DataLayout.getAllocaPtrType(IGM.getLLVMContext())}, {}, "spsave");
   }
 
   // Emit the dynamic alloca.
@@ -664,7 +665,8 @@ void IRGenFunction::emitDeallocateDynamicAlloca(StackAddress address,
   auto savedSP = address.getExtraInfo();
   if (savedSP == nullptr)
     return;
-  Builder.CreateIntrinsicCall(llvm::Intrinsic::stackrestore, savedSP);
+  Builder.CreateIntrinsicCall(llvm::Intrinsic::stackrestore,
+                              {savedSP->getType()}, {savedSP});
 }
 
 /// Emit a call to do an 'initializeArrayWithCopy' operation.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1478,7 +1478,7 @@ public:
       if (isRelative)
         Table.addRelativeAddress(descriptor);
       else
-        Table.addBitCast(descriptor, IGM.Int8PtrTy);
+        Table.add(descriptor);
     }
 
     /// A base protocol is witnessed by a pointer to the conformance
@@ -1514,7 +1514,7 @@ public:
         Table.addRelativeAddress(baseWitness);
         return;
       } else if (baseWitness) {
-        Table.addBitCast(baseWitness, IGM.Int8PtrTy);
+        Table.add(baseWitness);
         return;
       }
 

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -651,8 +651,8 @@ bool swift::compileAndWriteLLVM(
     legacy::PassManager EmitPasses;
     CodeGenFileType FileType;
     FileType =
-        (opts.OutputKind == IRGenOutputKind::NativeAssembly ? CGFT_AssemblyFile
-                                                            : CGFT_ObjectFile);
+        (opts.OutputKind == IRGenOutputKind::NativeAssembly ? CodeGenFileType::AssemblyFile
+                                                            : CodeGenFileType::ObjectFile);
     EmitPasses.add(createTargetTransformInfoWrapperPass(
         targetMachine->getTargetIRAnalysis()));
 
@@ -850,9 +850,9 @@ static void setPointerAuthOptions(PointerAuthOptions &opts,
 
 std::unique_ptr<llvm::TargetMachine>
 swift::createTargetMachine(const IRGenOptions &Opts, ASTContext &Ctx) {
-  CodeGenOpt::Level OptLevel = Opts.shouldOptimize()
-                                   ? CodeGenOpt::Default // -Os
-                                   : CodeGenOpt::None;
+  CodeGenOptLevel OptLevel = Opts.shouldOptimize()
+                                   ? CodeGenOptLevel::Default // -Os
+                                   : CodeGenOptLevel::None;
 
   // Set up TargetOptions and create the target features string.
   TargetOptions TargetOpts;

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -326,7 +326,7 @@ void swift::performLLVMOptimizations(const IRGenOptions &Opts,
     options.Atomic = bool(Opts.Sanitizers & SanitizerKind::Thread);
     PB.registerPipelineStartEPCallback(
         [options](ModulePassManager &MPM, OptimizationLevel level) {
-          MPM.addPass(InstrProfiling(options, false));
+           MPM.addPass(InstrProfilingLoweringPass(options, false));
         });
   }
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3346,9 +3346,9 @@ struct DbgIntrinsicEmitter {
 
   ///
 
-  llvm::Instruction *insert(llvm::Value *Addr, llvm::DILocalVariable *VarInfo,
-                            llvm::DIExpression *Expr,
-                            const llvm::DILocation *DL) {
+  llvm::DbgInstPtr insert(llvm::Value *Addr, llvm::DILocalVariable *VarInfo,
+                          llvm::DIExpression *Expr,
+                          const llvm::DILocation *DL) {
     if (auto *Inst = InsertPt.dyn_cast<llvm::Instruction *>()) {
       return insert(Addr, VarInfo, Expr, DL, Inst);
     } else {
@@ -3357,10 +3357,10 @@ struct DbgIntrinsicEmitter {
     }
   }
 
-  llvm::Instruction *insert(llvm::Value *Addr, llvm::DILocalVariable *VarInfo,
-                            llvm::DIExpression *Expr,
-                            const llvm::DILocation *DL,
-                            llvm::Instruction *InsertBefore) {
+  llvm::DbgInstPtr insert(llvm::Value *Addr, llvm::DILocalVariable *VarInfo,
+                          llvm::DIExpression *Expr,
+                          const llvm::DILocation *DL,
+                          llvm::Instruction *InsertBefore) {
     if (ForceDbgDeclare == AddrDbgInstrKind::DbgDeclare)
       return DIBuilder.insertDeclare(Addr, VarInfo, Expr, DL, InsertBefore);
     Expr = llvm::DIExpression::append(Expr, llvm::dwarf::DW_OP_deref);
@@ -3368,10 +3368,10 @@ struct DbgIntrinsicEmitter {
                                             InsertBefore);
   }
 
-  llvm::Instruction *insert(llvm::Value *Addr, llvm::DILocalVariable *VarInfo,
-                            llvm::DIExpression *Expr,
-                            const llvm::DILocation *DL,
-                            llvm::BasicBlock *Block) {
+  llvm::DbgInstPtr insert(llvm::Value *Addr, llvm::DILocalVariable *VarInfo,
+                          llvm::DIExpression *Expr,
+                          const llvm::DILocation *DL,
+                          llvm::BasicBlock *Block) {
     if (ForceDbgDeclare == AddrDbgInstrKind::DbgDeclare)
       return DIBuilder.insertDeclare(Addr, VarInfo, Expr, DL, Block);
     Expr = llvm::DIExpression::append(Expr, llvm::dwarf::DW_OP_deref);

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -3394,7 +3394,7 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
 
   // An alloca may only be described by exactly one dbg.declare.
   if (isa<llvm::AllocaInst>(Storage) &&
-      !llvm::FindDbgDeclareUses(Storage).empty())
+      !llvm::findDbgDeclares(Storage).empty())
     return;
 
   // Fragment DIExpression cannot cover the whole variable

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -239,7 +239,7 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   Int32Ty = llvm::Type::getInt32Ty(getLLVMContext());
   Int32PtrTy = Int32Ty->getPointerTo();
   Int64Ty = llvm::Type::getInt64Ty(getLLVMContext());
-  Int8PtrTy = llvm::Type::getInt8PtrTy(getLLVMContext());
+  Int8PtrTy = PtrTy;
   Int8PtrPtrTy = Int8PtrTy->getPointerTo(0);
   SizeTy = DataLayout.getIntPtrType(getLLVMContext(), /*addrspace*/ 0);
 

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -695,7 +695,7 @@ public:
   bool ShouldUseSwiftError;
 
   llvm::Type *VoidTy;                  /// void (usually {})
-  llvm::Type *PtrTy;                   /// ptr
+  llvm::PointerType *PtrTy;            /// ptr
   llvm::IntegerType *Int1Ty;           /// i1
   llvm::IntegerType *Int8Ty;           /// i8
   llvm::IntegerType *Int16Ty;          /// i16

--- a/lib/Immediate/SwiftMaterializationUnit.cpp
+++ b/lib/Immediate/SwiftMaterializationUnit.cpp
@@ -157,7 +157,7 @@ SwiftJIT::CreateLLJIT(CompilerInstance &CI) {
                   .setOptions(std::move(TargetOpt))
                   .setCPU(std::move(CPU))
                   .addFeatures(Features)
-                  .setCodeGenOptLevel(llvm::CodeGenOpt::Default);
+                  .setCodeGenOptLevel(llvm::CodeGenOptLevel::Default);
   auto J = llvm::orc::LLJITBuilder()
                .setJITTargetMachineBuilder(std::move(JTMB))
                .create();

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -484,10 +484,13 @@ static void emitSymbolicInterfaceForClangModule(
     return;
   }
 
+  auto moduleRef = clangModule->getASTFile();
+  if (!moduleRef)
+    return;
+
   // Determine the output name for the symbolic interface file.
   clang::serialization::ModuleFile *ModFile =
-      clangCI.getASTReader()->getModuleManager().lookup(
-          clangModule->getASTFile());
+      clangCI.getASTReader()->getModuleManager().lookup(*moduleRef);
   assert(ModFile && "no module file loaded for module ?");
   SmallString<128> interfaceOutputPath = indexStorePath;
   appendSymbolicInterfaceToIndexStorePath(interfaceOutputPath);
@@ -636,7 +639,7 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
           modulePath = LFU->getSourceFilename();
         }
 
-        auto F = fileMgr.getFile(modulePath);
+        auto F = fileMgr.getFileRef(modulePath);
         if (!F)
           break;
 
@@ -855,17 +858,18 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
 
   IndexUnitWriter unitWriter(
       fileMgr, indexStorePath, "swift", swiftVersion, filename, moduleName,
-      /*MainFile=*/nullptr, isSystem, /*IsModuleUnit=*/true, isDebugCompilation,
+      /*MainFile=*/{}, isSystem, /*IsModuleUnit=*/true, isDebugCompilation,
       targetTriple, sysrootPath, clangRemapper, getModuleInfoFromOpaqueModule);
 
-  auto FE = fileMgr.getFile(filename);
-  for (auto &pair : records) {
-    std::string &recordFile = pair.first;
-    std::string &groupName = pair.second;
-    if (recordFile.empty())
-      continue;
-    clang::index::writer::OpaqueModule mod = &groupName;
-    unitWriter.addRecordFile(recordFile, *FE, isSystem, mod);
+  if (auto FE = fileMgr.getFileRef(filename)) {
+    for (auto &pair : records) {
+      std::string &recordFile = pair.first;
+      std::string &groupName = pair.second;
+      if (recordFile.empty())
+        continue;
+      clang::index::writer::OpaqueModule mod = &groupName;
+      unitWriter.addRecordFile(recordFile, *FE, isSystem, mod);
+    }
   }
 
   SmallVector<ImportedModule, 8> imports;
@@ -892,21 +896,25 @@ recordSourceFileUnit(SourceFile *primarySourceFile, StringRef indexUnitToken,
                      bool indexSystemModules, bool skipStdlib,
                      bool includeLocals, bool isDebugCompilation,
                      bool isExplicitModuleBuild, StringRef targetTriple,
-                     ArrayRef<const clang::FileEntry *> fileDependencies,
+                     ArrayRef<clang::FileEntryRef> fileDependencies,
                      const clang::CompilerInstance &clangCI,
                      const PathRemapper &pathRemapper,
                      DiagnosticEngine &diags) {
   auto &fileMgr = clangCI.getFileManager();
   auto *module = primarySourceFile->getParentModule();
   bool isSystem = module->isNonUserModule();
-  auto mainFile = fileMgr.getFile(primarySourceFile->getFilename());
   auto clangRemapper = pathRemapper.asClangPathRemapper();
+
+  auto mainFile = fileMgr.getFileRef(primarySourceFile->getFilename());
+  if (!mainFile)
+    return false;
+
   // FIXME: Get real values for the following.
   StringRef swiftVersion;
   StringRef sysrootPath = clangCI.getHeaderSearchOpts().Sysroot;
   IndexUnitWriter unitWriter(
       fileMgr, indexStorePath, "swift", swiftVersion, indexUnitToken,
-      module->getNameStr(), mainFile ? *mainFile : nullptr, isSystem,
+      module->getNameStr(), *mainFile, isSystem,
       /*isModuleUnit=*/false, isDebugCompilation, targetTriple, sysrootPath,
       clangRemapper, getModuleInfoFromOpaqueModule);
 
@@ -922,15 +930,16 @@ recordSourceFileUnit(SourceFile *primarySourceFile, StringRef indexUnitToken,
                         primarySourceFile);
 
   // File dependencies.
-  for (auto *F : fileDependencies)
+  for (auto F : fileDependencies)
     unitWriter.addFileDependency(F, /*FIXME:isSystem=*/false, /*Module=*/nullptr);
 
   recordSourceFile(primarySourceFile, indexStorePath, includeLocals, diags,
                    [&](StringRef recordFile, StringRef filename) {
-                     auto file = fileMgr.getFile(filename);
-                     unitWriter.addRecordFile(
-                         recordFile, file ? *file : nullptr,
-                         module->isNonUserModule(), /*Module=*/nullptr);
+                     if (auto file = fileMgr.getFileRef(filename)) {
+                       unitWriter.addRecordFile(
+                           recordFile, *file,
+                           module->isNonUserModule(), /*Module=*/nullptr);
+                     }
                    });
 
   std::string error;
@@ -988,24 +997,11 @@ bool index::indexAndRecord(SourceFile *primarySourceFile,
     return true;
   }
 
-  llvm::SetVector<const clang::FileEntry *> fileDependencies;
-  // FIXME: This is not desirable because:
-  // 1. It picks shim header files as file dependencies
-  // 2. Having all the other swift files of the module as file dependencies ends
-  //   up making all of them associated with all the other files as main files.
-  //   It's better to associate each swift file with the unit that recorded it
-  //   as the main one.
-  // Keeping the code in case we want to revisit.
-#if 0
-  auto *module = primarySourceFile->getParentModule();
-  collectFileDependencies(fileDependencies, dependencyTracker, module, fileMgr);
-#endif
-
   return recordSourceFileUnit(primarySourceFile, indexUnitToken,
                               indexStorePath, indexClangModules,
                               indexSystemModules, skipStdlib, includeLocals,
                               isDebugCompilation, isExplicitModuleBuild,
-                              targetTriple, fileDependencies.getArrayRef(),
+                              targetTriple, {},
                               clangCI, pathRemapper, diags);
 }
 
@@ -1032,19 +1028,6 @@ bool index::indexAndRecord(ModuleDecl *module,
     return true;
   }
 
-  // Add the current module's source files to the dependencies.
-  llvm::SetVector<const clang::FileEntry *> fileDependencies;
-  // FIXME: This is not desirable because:
-  // 1. It picks shim header files as file dependencies
-  // 2. Having all the other swift files of the module as file dependencies ends
-  //   up making all of them associated with all the other files as main files.
-  //   It's better to associate each swift file with the unit that recorded it
-  //   as the main one.
-  // Keeping the code in case we want to revisit.
-#if 0
-  collectFileDependencies(fileDependencies, dependencyTracker, module, fileMgr);
-#endif
-
   // Write a unit for each source file.
   unsigned unitIndex = 0;
   for (auto *F : module->getFiles()) {
@@ -1057,7 +1040,7 @@ bool index::indexAndRecord(ModuleDecl *module,
                                indexStorePath, indexClangModules,
                                indexSystemModules, skipStdlib, includeLocals,
                                isDebugCompilation, isExplicitModuleBuild,
-                               targetTriple, fileDependencies.getArrayRef(),
+                               targetTriple, {},
                                clangCI, pathRemapper, diags))
         return true;
       unitIndex += 1;

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -1078,6 +1078,7 @@ void SwiftMergeFunctions::mergeWithParams(const FunctionInfos &FInfos,
   Function *NewFunction = Function::Create(funcType,
                                            FirstF->getLinkage(),
                                            FirstF->getName() + "Tm");
+  NewFunction->setIsNewDbgInfoFormat(FirstF->IsNewDbgInfoFormat);
   NewFunction->copyAttributesFrom(FirstF);
   // NOTE: this function is not externally available, do ensure that we reset
   // the DLL storage

--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -31,31 +31,32 @@
 #include "swift/LLVMPasses/Passes.h"
 #include "clang/AST/StableHash.h"
 #include "clang/Basic/PointerAuthOptions.h"
-#include "llvm/Transforms/IPO.h"
-#include "llvm/Transforms/Utils/FunctionComparator.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/Statistic.h"
-#include "llvm/ADT/Hashing.h"
-#include "llvm/TargetParser/Triple.h"
 #include "llvm/IR/Attributes.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DataLayout.h"
+#include "llvm/IR/GlobalPtrAuthInfo.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InlineAsm.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/IR/StructuralHash.h"
 #include "llvm/IR/ValueHandle.h"
 #include "llvm/IR/ValueMap.h"
-#include "llvm/IR/GlobalPtrAuthInfo.h"
 #include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/Triple.h"
+#include "llvm/Transforms/IPO.h"
+#include "llvm/Transforms/Utils/FunctionComparator.h"
 #include <vector>
 
 using namespace llvm;
@@ -256,11 +257,12 @@ private:
     FunctionEntry *First;
 
     /// A very cheap hash, used to early exit if functions do not match.
-    FunctionComparator::FunctionHash Hash;
+    llvm::IRHash Hash;
+
   public:
     // Note the hash is recalculated potentially multiple times, but it is cheap.
     EquivalenceClass(FunctionEntry *First)
-      : First(First), Hash(FunctionComparator::functionHash(*First->F)) {
+        : First(First), Hash(llvm::StructuralHash(*First->F)) {
       assert(!First->Next);
     }
   };
@@ -710,21 +712,18 @@ bool SwiftMergeFunctions::runOnModule(Module &M) {
 
   // All functions in the module, ordered by hash. Functions with a unique
   // hash value are easily eliminated.
-  std::vector<std::pair<FunctionComparator::FunctionHash, Function *>>
-    HashedFuncs;
+  std::vector<std::pair<IRHash, Function *>> HashedFuncs;
 
   for (Function &Func : M) {
     if (isEligibleFunction(&Func)) {
-      HashedFuncs.push_back({FunctionComparator::functionHash(Func), &Func});
+      HashedFuncs.push_back({llvm::StructuralHash(Func), &Func});
     }
   }
 
   std::stable_sort(
       HashedFuncs.begin(), HashedFuncs.end(),
-      [](const std::pair<FunctionComparator::FunctionHash, Function *> &a,
-         const std::pair<FunctionComparator::FunctionHash, Function *> &b) {
-        return a.first < b.first;
-      });
+      [](const std::pair<IRHash, Function *> &a,
+         const std::pair<IRHash, Function *> &b) { return a.first < b.first; });
 
   std::vector<FunctionEntry> FuncEntryStorage;
   FuncEntryStorage.reserve(HashedFuncs.size());

--- a/lib/Localization/LocalizationFormat.cpp
+++ b/lib/Localization/LocalizationFormat.cpp
@@ -64,11 +64,11 @@ bool SerializedLocalizationWriter::emit(llvm::StringRef filePath) {
 
   offset_type offset;
   {
-    llvm::support::endian::write<offset_type>(OS, 0, llvm::support::little);
+    llvm::support::endian::write<offset_type>(OS, 0, llvm::endianness::little);
     offset = generator.Emit(OS);
   }
   OS.seek(0);
-  llvm::support::endian::write(OS, offset, llvm::support::little);
+  llvm::support::endian::write(OS, offset, llvm::endianness::little);
   OS.close();
 
   return OS.has_error();
@@ -116,7 +116,8 @@ SerializedLocalizationProducer::SerializedLocalizationProducer(
 bool SerializedLocalizationProducer::initializeImpl() {
   auto base =
       reinterpret_cast<const unsigned char *>(Buffer.get()->getBufferStart());
-  auto tableOffset = endian::read<offset_type>(base, little);
+  auto tableOffset =
+      llvm::support::endian::read<offset_type>(base, llvm::endianness::little);
   SerializedTable.reset(SerializedLocalizationTable::Create(
       base + tableOffset, base + sizeof(offset_type), base));
   return true;

--- a/lib/Option/Options.cpp
+++ b/lib/Option/Options.cpp
@@ -27,10 +27,7 @@ using namespace llvm::opt;
 #undef PREFIX
 
 static const llvm::opt::GenericOptTable::Info InfoTable[] = {
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELPTEXT, METAVAR, VALUES)                                      \
-  {PREFIX, NAME,  HELPTEXT,    METAVAR,     OPT_##ID,  Option::KIND##Class,    \
-   PARAM,  FLAGS, OPT_##GROUP, OPT_##ALIAS, ALIASARGS, VALUES},
+#define OPTION(...) LLVM_CONSTRUCT_OPT_INFO(__VA_ARGS__),
 #include "swift/Option/Options.inc"
 #undef OPTION
 };

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -13,12 +13,12 @@
 #define DEBUG_TYPE "deserialize"
 
 #include "DeserializeSIL.h"
-
 #include "BCReadingExtras.h"
 #include "DeserializationErrors.h"
 #include "ModuleFile.h"
 #include "SILFormat.h"
 #include "SILSerializationFunctionBuilder.h"
+#include "SerializationFormat.h"
 
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/GenericSignature.h"
@@ -143,14 +143,14 @@ public:
 
   internal_key_type ReadKey(const uint8_t *data, unsigned length) {
     assert(length == sizeof(uint32_t) && "Expect a single IdentifierID.");
-    IdentifierID keyID = endian::readNext<uint32_t, little, unaligned>(data);
+    IdentifierID keyID = readNext<uint32_t>(data);
     return MF.getIdentifierText(keyID);
   }
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
     assert(length == sizeof(uint32_t) && "Expect a single DeclID.");
-    data_type result = endian::readNext<uint32_t, little, unaligned>(data);
+    data_type result = readNext<uint32_t>(data);
     return result;
   }
 };

--- a/lib/Serialization/ModuleFileCoreTableInfo.h
+++ b/lib/Serialization/ModuleFileCoreTableInfo.h
@@ -13,8 +13,9 @@
 #ifndef SWIFT_SERIALIZATION_MODULEFILECORETABLEINFO_H
 #define SWIFT_SERIALIZATION_MODULEFILECORETABLEINFO_H
 
-#include "ModuleFileSharedCore.h"
 #include "DocFormat.h"
+#include "ModuleFileSharedCore.h"
+#include "SerializationFormat.h"
 #include "SourceInfoFormat.h"
 #include "swift/AST/RawComment.h"
 #include "llvm/Support/DJB.h"
@@ -51,16 +52,14 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned keyLength = readNext<uint16_t>(data);
+    unsigned dataLength = readNext<uint16_t>(data);
     return { keyLength, dataLength };
   }
 
   static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
     using namespace swift::serialization;
-    using namespace llvm::support;
-    uint8_t kind = endian::readNext<uint8_t, little, unaligned>(data);
+    uint8_t kind = readNext<uint8_t>(data);
     switch (kind) {
     case static_cast<uint8_t>(DeclNameKind::Normal): {
       StringRef str(reinterpret_cast<const char *>(data),
@@ -78,11 +77,10 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    using namespace llvm::support;
     data_type result;
     while (length > 0) {
       uint8_t kind = *data++;
-      DeclID offset = endian::readNext<uint32_t, little, unaligned>(data);
+      DeclID offset = readNext<uint32_t>(data);
       result.push_back({ kind, offset });
       length -= 5;
     }
@@ -114,9 +112,8 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned keyLength = readNext<uint16_t>(data);
+    unsigned dataLength = readNext<uint16_t>(data);
     return { keyLength, dataLength };
   }
 
@@ -126,14 +123,12 @@ public:
 
   data_type ReadData(internal_key_type key, const uint8_t *data,
                      unsigned length) {
-    using namespace llvm::support;
     data_type result;
     const uint8_t *limit = data + length;
     while (data < limit) {
-      DeclID offset = endian::readNext<uint32_t, little, unaligned>(data);
+      DeclID offset = readNext<uint32_t>(data);
 
-      int32_t nameIDOrLength =
-          endian::readNext<int32_t, little, unaligned>(data);
+      int32_t nameIDOrLength = readNext<int32_t>(data);
       StringRef moduleNameOrMangledBase;
       if (nameIDOrLength < 0) {
         StringRef moduleName = Core.getModuleNameFromID(-nameIDOrLength);
@@ -180,8 +175,7 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned keyLength = readNext<uint16_t>(data);
     return { keyLength, sizeof(uint32_t) };
   }
 
@@ -191,8 +185,7 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    using namespace llvm::support;
-    return endian::readNext<uint32_t, little, unaligned>(data);
+    return readNext<uint32_t>(data);
   }
 };
 
@@ -217,9 +210,8 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned keyLength = readNext<uint16_t>(data);
+    unsigned dataLength = readNext<uint16_t>(data);
     return { keyLength, dataLength };
   }
 
@@ -229,11 +221,10 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    using namespace llvm::support;
     data_type result;
     while (length > 0) {
-      DeclID parentID = endian::readNext<uint32_t, little, unaligned>(data);
-      DeclID childID = endian::readNext<uint32_t, little, unaligned>(data);
+      DeclID parentID = readNext<uint32_t>(data);
+      DeclID childID = readNext<uint32_t>(data);
       result.push_back({ parentID, childID });
       length -= sizeof(uint32_t) * 2;
     }
@@ -277,15 +268,13 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned keyLength = readNext<uint16_t>(data);
     return { keyLength, sizeof(uint32_t) };
   }
 
   static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
     using namespace swift::serialization;
-    using namespace llvm::support;
-    uint8_t kind = endian::readNext<uint8_t, little, unaligned>(data);
+    uint8_t kind = readNext<uint8_t>(data);
     switch (kind) {
     case static_cast<uint8_t>(DeclNameKind::Normal): {
       StringRef str(reinterpret_cast<const char *>(data),
@@ -305,9 +294,8 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    using namespace llvm::support;
     assert(length == sizeof(uint32_t));
-    return endian::readNext<uint32_t, little, unaligned>(data);
+    return readNext<uint32_t>(data);
   }
 };
 
@@ -338,22 +326,19 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned dataLength = readNext<uint16_t>(data);
     return { sizeof(uint32_t), dataLength };
   }
 
   static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    using namespace llvm::support;
-    return endian::readNext<uint32_t, little, unaligned>(data);
+    return readNext<uint32_t>(data);
   }
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    using namespace llvm::support;
     data_type result;
     while (length > 0) {
-      DeclID declID = endian::readNext<uint32_t, little, unaligned>(data);
+      DeclID declID = readNext<uint32_t>(data);
       result.push_back(declID);
       length -= sizeof(uint32_t);
     }
@@ -384,9 +369,8 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint32_t, little, unaligned>(data);
+    unsigned keyLength = readNext<uint16_t>(data);
+    unsigned dataLength = readNext<uint32_t>(data);
     return { keyLength, dataLength };
   }
 
@@ -396,13 +380,12 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    using namespace llvm::support;
     const constexpr auto recordSize = sizeof(uint32_t) + 1 + sizeof(uint32_t);
     data_type result;
     while (length > 0) {
-      unsigned ownerLen = endian::readNext<uint32_t, little, unaligned>(data);
+      unsigned ownerLen = readNext<uint32_t>(data);
       bool isInstanceMethod = *data++ != 0;
-      DeclID methodID = endian::readNext<uint32_t, little, unaligned>(data);
+      DeclID methodID = readNext<uint32_t>(data);
       std::string ownerName((const char *)data, ownerLen);
       result.push_back(
         std::make_tuple(std::move(ownerName), isInstanceMethod, methodID));
@@ -438,9 +421,8 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+    unsigned keyLength = readNext<uint16_t>(data);
+    unsigned dataLength = readNext<uint16_t>(data);
     return {keyLength, dataLength};
   }
 
@@ -450,12 +432,11 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    using namespace llvm::support;
     data_type result;
     const uint8_t *limit = data + length;
     while (data < limit) {
-      DeclID genSigId = endian::readNext<uint32_t, little, unaligned>(data);
-      int32_t nameLength = endian::readNext<int32_t, little, unaligned>(data);
+      DeclID genSigId = readNext<uint32_t>(data);
+      int32_t nameLength = readNext<int32_t>(data);
       std::string mangledName(reinterpret_cast<const char *>(data), nameLength);
       data += nameLength;
       result.push_back({std::string(mangledName), genSigId});
@@ -491,9 +472,8 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned keyLength = endian::readNext<uint32_t, little, unaligned>(data);
-    unsigned dataLength = endian::readNext<uint32_t, little, unaligned>(data);
+    unsigned keyLength = readNext<uint32_t>(data);
+    unsigned dataLength = readNext<uint32_t>(data);
     return { keyLength, dataLength };
   }
 
@@ -503,29 +483,27 @@ public:
 
   data_type ReadData(internal_key_type key, const uint8_t *data,
                      unsigned length) {
-    using namespace llvm::support;
     data_type result = std::make_unique<DeserializedCommentInfo>();
 
     {
-      unsigned BriefSize = endian::readNext<uint32_t, little, unaligned>(data);
+      unsigned BriefSize = readNext<uint32_t>(data);
       result->Info.Brief = StringRef(reinterpret_cast<const char *>(data), BriefSize);
       data += BriefSize;
     }
 
-    unsigned NumComments = endian::readNext<uint32_t, little, unaligned>(data);
+    unsigned NumComments = readNext<uint32_t>(data);
 
     for (unsigned i = 0; i != NumComments; ++i) {
-      unsigned StartColumn =
-          endian::readNext<uint32_t, little, unaligned>(data);
-      unsigned RawSize = endian::readNext<uint32_t, little, unaligned>(data);
+      unsigned StartColumn = readNext<uint32_t>(data);
+      unsigned RawSize = readNext<uint32_t>(data);
       auto RawText = StringRef(reinterpret_cast<const char *>(data), RawSize);
       data += RawSize;
 
       result->RawCommentStore.emplace_back(RawText, StartColumn);
     }
     result->Info.Raw = RawComment(result->RawCommentStore);
-    result->Info.Group = endian::readNext<uint32_t, little, unaligned>(data);
-    result->Info.SourceOrder = endian::readNext<uint32_t, little, unaligned>(data);
+    result->Info.Group = readNext<uint32_t>(data);
+    result->Info.SourceOrder = readNext<uint32_t>(data);
     return result;
   }
 };
@@ -550,8 +528,7 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
-    unsigned keyLength = endian::readNext<uint32_t, little, unaligned>(data);
+    unsigned keyLength = readNext<uint32_t>(data);
     unsigned dataLength = 4;
     return { keyLength, dataLength };
   }
@@ -560,10 +537,10 @@ public:
     return StringRef(reinterpret_cast<const char*>(data), length);
   }
 
-  data_type ReadData(internal_key_type key, const uint8_t *data, unsigned length) {
-    using namespace llvm::support;
+  data_type ReadData(internal_key_type key, const uint8_t *data,
+                     unsigned length) {
     assert(length == 4);
-    return endian::readNext<uint32_t, little, unaligned>(data);
+    return readNext<uint32_t>(data);
   }
 };
 
@@ -588,19 +565,16 @@ public:
   }
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
-    using namespace llvm::support;
     const unsigned dataLen = Fingerprint::DIGEST_LENGTH;
     return {sizeof(uint32_t), dataLen};
   }
 
   static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
-    using namespace llvm::support;
-    return endian::readNext<uint32_t, little, unaligned>(data);
+    return readNext<uint32_t>(data);
   }
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    using namespace llvm::support;
     auto str = llvm::StringRef{reinterpret_cast<const char *>(data),
                                Fingerprint::DIGEST_LENGTH};
     if (auto fp = Fingerprint::fromString(str))

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -14,6 +14,7 @@
 #include "BCReadingExtras.h"
 #include "DeserializationErrors.h"
 #include "ModuleFileCoreTableInfo.h"
+#include "SerializationFormat.h"
 #include "swift/Basic/LangOptions.h"
 #include "swift/Parse/ParseVersion.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
@@ -1001,9 +1002,9 @@ ModuleFileSharedCore::readGroupTable(ArrayRef<uint64_t> Fields,
                                      StringRef BlobData) const {
   auto pMap = std::make_unique<llvm::DenseMap<unsigned, StringRef>>();
   auto Data = reinterpret_cast<const uint8_t *>(BlobData.data());
-  unsigned GroupCount = endian::readNext<uint32_t, little, unaligned>(Data);
+  unsigned GroupCount = readNext<uint32_t>(Data);
   for (unsigned I = 0; I < GroupCount; ++I) {
-    auto RawSize = endian::readNext<uint32_t, little, unaligned>(Data);
+    auto RawSize = readNext<uint32_t>(Data);
     auto RawText = StringRef(reinterpret_cast<const char *>(Data), RawSize);
     Data += RawSize;
     (*pMap)[I] = RawText;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -146,14 +146,14 @@ namespace {
       uint32_t dataLength = (sizeof(uint32_t) + 1) * data.size();
       assert(dataLength == static_cast<uint16_t>(dataLength));
 
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint16_t>(keyLength);
       writer.write<uint16_t>(dataLength);
       return { keyLength, dataLength };
     }
 
     void EmitKey(raw_ostream &out, key_type_ref key, unsigned len) {
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       switch (key.getKind()) {
       case DeclBaseName::Kind::Normal:
         writer.write<uint8_t>(static_cast<uint8_t>(DeclNameKind::Normal));
@@ -174,7 +174,7 @@ namespace {
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       for (auto entry : data) {
         writer.write<uint8_t>(entry.first);
         writer.write<uint32_t>(entry.second);
@@ -230,7 +230,7 @@ namespace {
           dataLength += nameData;
       }
       assert(dataLength == static_cast<uint16_t>(dataLength));
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint16_t>(keyLength);
       writer.write<uint16_t>(dataLength);
       return { keyLength, dataLength };
@@ -243,7 +243,7 @@ namespace {
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       for (auto entry : data) {
         StringRef dataToWrite;
         writer.write<uint32_t>(entry.second);
@@ -273,7 +273,7 @@ namespace {
       uint32_t keyLength = key.size();
       assert(keyLength == static_cast<uint16_t>(keyLength));
       uint32_t dataLength = sizeof(uint32_t);
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint16_t>(keyLength);
       // No need to write the data length; it's constant.
       return { keyLength, dataLength };
@@ -286,7 +286,7 @@ namespace {
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint32_t>(data);
     }
   };
@@ -315,7 +315,7 @@ namespace {
       assert(keyLength == static_cast<uint16_t>(keyLength));
       uint32_t dataLength = (sizeof(uint32_t) * 2) * data.size();
       assert(dataLength == static_cast<uint16_t>(dataLength));
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint16_t>(keyLength);
       writer.write<uint16_t>(dataLength);
       return { keyLength, dataLength };
@@ -329,7 +329,7 @@ namespace {
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       for (auto entry : data) {
         writer.write<uint32_t>(entry.first);
         writer.write<uint32_t>(entry.second);
@@ -370,14 +370,14 @@ namespace {
       }
       assert(keyLength == static_cast<uint16_t>(keyLength));
       uint32_t dataLength = sizeof(uint32_t);
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint16_t>(keyLength);
       // No need to write dataLength, it's constant.
       return { keyLength, dataLength };
     }
 
     void EmitKey(raw_ostream &out, key_type_ref key, unsigned len) {
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       switch (key.getKind()) {
       case DeclBaseName::Kind::Normal:
         writer.write<uint8_t>(static_cast<uint8_t>(DeclNameKind::Normal));
@@ -398,7 +398,7 @@ namespace {
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
       static_assert(bitOffsetFitsIn32Bits(), "BitOffset too large");
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint32_t>(static_cast<uint32_t>(data));
     }
   };
@@ -423,7 +423,7 @@ namespace {
       // with the same DeclBaseName. Seems highly unlikely.
       assert((data.size() < (1 << 14)) && "Too many members");
       uint32_t dataLength = sizeof(uint32_t) * data.size(); // value DeclIDs
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       // No need to write the key length; it's constant.
       writer.write<uint16_t>(dataLength);
       return { sizeof(uint32_t), dataLength };
@@ -432,14 +432,14 @@ namespace {
     void EmitKey(raw_ostream &out, key_type_ref key, unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
       assert(len == sizeof(uint32_t));
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint32_t>(key);
     }
 
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       for (auto entry : data) {
         writer.write<uint32_t>(entry);
       }
@@ -463,7 +463,7 @@ namespace {
 
     std::pair<unsigned, unsigned>
     EmitKeyDataLength(raw_ostream &out, key_type_ref key, data_type_ref data) {
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       // No need to write the key or value length; they're both constant.
       const unsigned valueLen = Fingerprint::DIGEST_LENGTH;
       return {sizeof(uint32_t), valueLen};
@@ -472,7 +472,7 @@ namespace {
     void EmitKey(raw_ostream &out, key_type_ref key, unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
       assert(len == sizeof(uint32_t));
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint32_t>(key);
     }
 
@@ -480,7 +480,7 @@ namespace {
                   unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
       assert(len == Fingerprint::DIGEST_LENGTH);
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       out << data;
     }
   };
@@ -6196,7 +6196,7 @@ static void writeDeclTable(const index_block::DeclListLayout &DeclList,
 
     llvm::raw_svector_ostream blobStream(hashTableBlob);
     // Make sure that no bucket is at offset 0
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream);
   }
 
@@ -6222,7 +6222,7 @@ writeExtensionTable(const index_block::ExtensionTableLayout &ExtensionTable,
 
     llvm::raw_svector_ostream blobStream(hashTableBlob);
     // Make sure that no bucket is at offset 0
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream, info);
   }
 
@@ -6238,7 +6238,7 @@ static void writeLocalDeclTable(const index_block::DeclListLayout &DeclList,
   {
     llvm::raw_svector_ostream blobStream(hashTableBlob);
     // Make sure that no bucket is at offset 0
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream);
   }
 
@@ -6258,7 +6258,7 @@ writeNestedTypeDeclsTable(const index_block::NestedTypeDeclsLayout &declList,
 
     llvm::raw_svector_ostream blobStream(hashTableBlob);
     // Make sure that no bucket is at offset 0
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream);
   }
 
@@ -6283,7 +6283,7 @@ writeDeclMemberNamesTable(const index_block::DeclMemberNamesLayout &declNames,
 
     llvm::raw_svector_ostream blobStream(hashTableBlob);
     // Make sure that no bucket is at offset 0
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream);
   }
 
@@ -6303,7 +6303,7 @@ writeDeclMembersTable(const decl_member_tables_block::DeclMembersLayout &mems,
 
     llvm::raw_svector_ostream blobStream(hashTableBlob);
     // Make sure that no bucket is at offset 0
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream);
   }
 
@@ -6324,7 +6324,7 @@ writeDeclFingerprintsTable(const index_block::DeclFingerprintsLayout &fpl,
 
     llvm::raw_svector_ostream blobStream(hashTableBlob);
     // Make sure that no bucket is at offset 0
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream);
   }
 
@@ -6360,7 +6360,7 @@ namespace {
         dataLength += std::get<0>(entry).size();
       }
 
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint16_t>(keyLength);
       writer.write<uint32_t>(dataLength);
       return { keyLength, dataLength };
@@ -6377,7 +6377,7 @@ namespace {
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       for (const auto &entry : data) {
         writer.write<uint32_t>(std::get<0>(entry).size());
         writer.write<uint8_t>(std::get<1>(entry));
@@ -6410,7 +6410,7 @@ static void writeObjCMethodTable(const index_block::ObjCMethodTableLayout &out,
     }
 
     // Make sure that no bucket is at offset 0
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream);
   }
 
@@ -6443,7 +6443,7 @@ namespace {
       for (auto entry : data)
         dataLength += entry.first.size();
       assert(dataLength == static_cast<uint16_t>(dataLength));
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       writer.write<uint16_t>(keyLength);
       writer.write<uint16_t>(dataLength);
       return { keyLength, dataLength };
@@ -6456,7 +6456,7 @@ namespace {
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       for (auto &entry : data) {
         // Write `GenericSignatureID`.
         writer.write<uint32_t>(entry.second);
@@ -6481,7 +6481,7 @@ static void writeDerivativeFunctionConfigs(
     for (auto &entry : derivativeConfigs)
       generator.insert(entry.first.get(), entry.second);
     // Make sure that no bucket is at offset 0.
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream);
   }
   SmallVector<uint64_t, 8> scratch;

--- a/lib/Serialization/SerializationFormat.h
+++ b/lib/Serialization/SerializationFormat.h
@@ -1,0 +1,33 @@
+//===--- SerializationFormat.h - Serialization helpers ------ ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Various helper functions to deal with common serialization functionality.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SERIALIZATION_SERIALIZATIONFORMAT_H
+#define SWIFT_SERIALIZATION_SERIALIZATIONFORMAT_H
+
+#include "llvm/ADT/bit.h"
+#include "llvm/Support/Endian.h"
+
+namespace swift {
+
+template <typename value_type, typename CharT>
+[[nodiscard]] inline value_type readNext(const CharT *&memory) {
+  return llvm::support::endian::readNext<value_type, llvm::endianness::little, llvm::support::unaligned>(memory);
+}
+
+} // end namespace swift
+
+#endif

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -232,7 +232,7 @@ public:
 
     // Source order.
     dataLength += numLen;
-    endian::Writer writer(out, little);
+    endian::Writer writer(out, llvm::endianness::little);
     writer.write<uint32_t>(keyLength);
     writer.write<uint32_t>(dataLength);
     return { keyLength, dataLength };
@@ -244,7 +244,7 @@ public:
 
   void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                 unsigned len) {
-    endian::Writer writer(out, little);
+    endian::Writer writer(out, llvm::endianness::little);
     writer.write<uint32_t>(data.Brief.size());
     out << data.Brief;
     writer.write<uint32_t>(data.Raw.Comments.size());
@@ -300,7 +300,7 @@ static void writeGroupNames(const comment_block::GroupNamesLayout &GroupNames,
                             ArrayRef<StringRef> Names) {
   llvm::SmallString<32> Blob;
   llvm::raw_svector_ostream BlobStream(Blob);
-  endian::Writer Writer(BlobStream, little);
+  endian::Writer Writer(BlobStream, llvm::endianness::little);
   Writer.write<uint32_t>(Names.size());
   for (auto N : Names) {
     Writer.write<uint32_t>(N.size());
@@ -447,7 +447,7 @@ static void writeDeclCommentTable(
   {
     llvm::raw_svector_ostream blobStream(hashTableBlob);
     // Make sure that no bucket is at offset 0
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = Writer.generator.Emit(blobStream);
   }
 
@@ -519,7 +519,7 @@ public:
     const unsigned numLen = 4;
     uint32_t keyLength = key.size();
     uint32_t dataLength = numLen;
-    endian::Writer writer(out, little);
+    endian::Writer writer(out, llvm::endianness::little);
     writer.write<uint32_t>(keyLength);
     return { keyLength, dataLength };
   }
@@ -530,7 +530,7 @@ public:
 
   void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                 unsigned len) {
-    endian::Writer writer(out, little);
+    endian::Writer writer(out, llvm::endianness::little);
     writer.write<uint32_t>(data);
   }
 };
@@ -560,7 +560,7 @@ public:
     {
       llvm::raw_svector_ostream blobStream(hashTableBlob);
       // Make sure that no bucket is at offset 0
-      endian::write<uint32_t>(blobStream, 0, little);
+      endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
       tableOffset = generator.Emit(blobStream);
     }
     USRsList.emit(scratch, tableOffset, hashTableBlob);
@@ -637,7 +637,7 @@ public:
     }
 
     llvm::raw_svector_ostream OS(Buffer);
-    endian::Writer Writer(OS, little);
+    endian::Writer Writer(OS, llvm::endianness::little);
     Writer.write<uint32_t>(DocRanges.size());
     for (const auto &DocRange : DocRanges) {
       writeRawLoc(DocRange.first, Writer, Strings);
@@ -719,7 +719,7 @@ struct BasicDeclLocsTableWriter : public ASTWalker {
     llvm::sys::fs::make_absolute(AbsolutePath);
 
     llvm::raw_svector_ostream Out(Buffer);
-    endian::Writer Writer(Out, little);
+    endian::Writer Writer(Out, llvm::endianness::little);
     Writer.write<uint32_t>(FWriter.getTextOffset(AbsolutePath.str()));
     Writer.write<uint32_t>(
         DocWriter.getDocRangesOffset(D, llvm::ArrayRef(RawLocs->DocRanges)));
@@ -782,7 +782,7 @@ static void emitFileListRecord(llvm::BitstreamWriter &Out,
                            .count();
 
       llvm::raw_svector_ostream out(Buffer);
-      endian::Writer writer(out, little);
+      endian::Writer writer(out, llvm::endianness::little);
       // FilePath.
       writer.write<uint32_t>(fileID);
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -147,12 +147,12 @@ namespace {
 
     void EmitKey(raw_ostream &out, key_type_ref key, unsigned len) {
       uint32_t keyID = S.addUniquedStringRef(key);
-      endian::write<uint32_t>(out, keyID, little);
+      endian::write<uint32_t>(out, keyID, llvm::endianness::little);
     }
 
     void EmitData(raw_ostream &out, key_type_ref key, data_type_ref data,
                   unsigned len) {
-      endian::write<uint32_t>(out, data, little);
+      endian::write<uint32_t>(out, data, llvm::endianness::little);
     }
   };
 
@@ -2791,7 +2791,7 @@ static void writeIndexTable(Serializer &S,
 
     llvm::raw_svector_ostream blobStream(hashTableBlob);
     // Make sure that no bucket is at offset 0.
-    endian::write<uint32_t>(blobStream, 0, little);
+    endian::write<uint32_t>(blobStream, 0, llvm::endianness::little);
     tableOffset = generator.Emit(blobStream, tableInfo);
   }
   SmallVector<uint64_t, 8> scratch;

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -864,7 +864,7 @@ static void setLocationInfoForClangNode(ClangNode ClangNode,
   std::pair<clang::FileID, unsigned> Decomp =
       ClangSM.getDecomposedLoc(CharRange.getBegin());
   if (!Decomp.first.isInvalid()) {
-    if (auto FE = ClangSM.getFileEntryForID(Decomp.first)) {
+    if (auto FE = ClangSM.getFileEntryRefForID(Decomp.first)) {
       Location.Filename = FE->getName();
 
       std::pair<clang::FileID, unsigned> EndDecomp =

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -20,6 +20,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
+using namespace llvm::opt;
 using namespace sourcekitd_test;
 using llvm::StringRef;
 
@@ -28,9 +29,7 @@ namespace {
 // Create enum with OPT_xxx values for each option in Options.td.
 enum Opt {
   OPT_INVALID = 0,
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELP, META, VALUES)                                             \
-  OPT_##ID,
+#define OPTION(...) LLVM_MAKE_OPT_ID(__VA_ARGS__),
 #include "Options.inc"
   LastOption
 #undef OPTION
@@ -46,12 +45,7 @@ enum Opt {
 
 // Create table mapping all options defined in Options.td.
 static const llvm::opt::OptTable::Info InfoTable[] = {
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELPTEXT, METAVAR, VALUES)                                      \
-  {PREFIX,      NAME,      HELPTEXT,                                           \
-   METAVAR,     OPT_##ID,  llvm::opt::Option::KIND##Class,                     \
-   PARAM,       FLAGS,     OPT_##GROUP,                                        \
-   OPT_##ALIAS, ALIASARGS, VALUES},
+#define OPTION(...) LLVM_CONSTRUCT_OPT_INFO(__VA_ARGS__),
 #include "Options.inc"
 #undef OPTION
 };

--- a/tools/libMockPlugin/MockPlugin.cpp
+++ b/tools/libMockPlugin/MockPlugin.cpp
@@ -203,7 +203,7 @@ int TestRunner::run() {
 
     // Read request data.
     auto request_size = llvm::support::endian::byte_swap(
-        request_header, llvm::support::endianness::little);
+        request_header, llvm::endianness::little);
     llvm::SmallVector<char, 0> request_data;
     request_data.assign(request_size, 0);
     ioSize = fread(request_data.data(), request_size, 1, stdin);
@@ -240,8 +240,9 @@ int TestRunner::run() {
     llvm::SmallVector<char, 0> response_data;
     llvm::raw_svector_ostream(response_data) << response;
     auto response_size = response_data.size();
-    auto response_header = llvm::support::endian::byte_swap<
-        uint64_t, llvm::support::endianness::little>(response_size);
+    auto response_header =
+        llvm::support::endian::byte_swap<uint64_t, llvm::endianness::little>(
+            response_size);
     ioSize = fwrite(&response_header, sizeof(response_header), 1, stdout);
     if (!ioSize) {
       llvm::errs() << "failed to write response header\n";

--- a/tools/libSwiftScan/SwiftCaching.cpp
+++ b/tools/libSwiftScan/SwiftCaching.cpp
@@ -405,7 +405,7 @@ createCachedCompilation(SwiftScanCAS &CAS, const llvm::cas::CASID &ID,
   auto Input = KeyProxy->getData();
 
   unsigned Index =
-      llvm::support::endian::read<uint32_t, llvm::support::little,
+      llvm::support::endian::read<uint32_t, llvm::endianness::little,
                                   llvm::support::unaligned>(Input.data());
   {
     swift::cas::CompileJobResultSchema Schema(CAS.getCAS());

--- a/tools/libSwiftScan/libSwiftScan.cpp
+++ b/tools/libSwiftScan/libSwiftScan.cpp
@@ -617,9 +617,9 @@ swiftscan_string_set_t *
 swiftscan_compiler_supported_arguments_query() {
   std::unique_ptr<llvm::opt::OptTable> table = swift::createSwiftOptTable();
   std::vector<std::string> frontendFlags;
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELPTEXT, METAVAR, VALUES)                                      \
-  addFrontendFlagOption(*table, swift::options::OPT_##ID, frontendFlags);
+#define OPTION(...)                                                            \
+  addFrontendFlagOption(*table, swift::options::LLVM_MAKE_OPT_ID(__VA_ARGS__), \
+                        frontendFlags);
 #include "swift/Option/Options.inc"
 #undef OPTION
   return swift::c_string_utils::create_set(frontendFlags);

--- a/tools/swift-scan-test/swift-scan-test.cpp
+++ b/tools/swift-scan-test/swift-scan-test.cpp
@@ -221,7 +221,7 @@ int main(int argc, char *argv[]) {
   auto Args = createArgs(SwiftCommands, Saver);
 
   std::atomic<int> Ret = 0;
-  llvm::ThreadPool Pool(llvm::hardware_concurrency(Threads));
+  llvm::StdThreadPool Pool(llvm::hardware_concurrency(Threads));
   for (unsigned i = 0; i < Threads; ++i) {
     Pool.async([&]() {
       switch (Action) {

--- a/unittests/DependencyScan/Features.cpp
+++ b/unittests/DependencyScan/Features.cpp
@@ -45,9 +45,9 @@ TEST_F(ScanTest, TestHasArgumentQuery) {
     optionSet.insert(std::string(data, option.length));
   }
   swiftscan_string_set_dispose(supported_args_set);
-#define OPTION(PREFIX, NAME, ID, KIND, GROUP, ALIAS, ALIASARGS, FLAGS, PARAM,  \
-               HELPTEXT, METAVAR, VALUES)                                      \
-  testHasOption(*table, swift::options::OPT_##ID, optionSet);
+#define OPTION(...)                                                            \
+  testHasOption(*table, swift::options::LLVM_MAKE_OPT_ID(__VA_ARGS__),         \
+                optionSet);
 #include "swift/Option/Options.inc"
 #undef OPTION
 }


### PR DESCRIPTION
This set of changes enables the compiler to build, but currently asserts when building the stdlib while creating intrinsics and also when running LLVM's verifier pass.

Verifier failure:
```
Function debug format should match parent module
ptr @"$s6Darwin7FLT_MAXSfvgTm"
0
; ModuleID = '.../stdlib/swift-macosx-arm64/stdlib/public/ClangOverlays/IOS/arm64e/_Builtin_float.o'
1
```
ie. the module has `IsNewDbgInfoFormat` set but the function does not.

Intrinsic assertion:
```
Assertion failed: (Index < Length && "Invalid index!"), function operator[], file ArrayRef.h, line 257.
...
3.	While evaluating request IRGenRequest(IR Generation for module Synchronization)
4.	While emitting IR SIL function "@$s15Synchronization19AtomicLazyReferenceVfD".
 for 'deinit' (at .../swift/stdlib/public/Synchronization/AtomicLazyReference.swift:31:3)
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
...
5  libsystem_c.dylib        0x0000000183dc9a40 abort + 180
6  libsystem_c.dylib        0x0000000183dc8d30 err + 0
7  swift-frontend           0x00000001074b942c DecodeFixedType(llvm::ArrayRef<llvm::Intrinsic::IITDescriptor>&, llvm::ArrayRef<llvm::Type*>, llvm::LLVMContext&) (.cold.4) + 0
8  swift-frontend           0x0000000105ee1784 DecodeFixedType(llvm::ArrayRef<llvm::Intrinsic::IITDescriptor>&, llvm::ArrayRef<llvm::Type*>, llvm::LLVMContext&) + 744
9  swift-frontend           0x0000000105ee1340 llvm::Intrinsic::getType(llvm::LLVMContext&, unsigned int, llvm::ArrayRef<llvm::Type*>) + 116
10 swift-frontend           0x0000000105ee33c8 llvm::Intrinsic::getDeclaration(llvm::Module*, unsigned int, llvm::ArrayRef<llvm::Type*>) + 48
11 swift-frontend           0x000000010088b470 swift::irgen::IRBuilder::CreateIntrinsicCall(unsigned int, llvm::ArrayRef<llvm::Value*>, llvm::Twine const&) + 84
...
```
Possibly related to the above?