### PR TITLE
🌸 Fix class extension visibility bug

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6103,8 +6103,13 @@ ClangCategoryLookupRequest::evaluate(Evaluator &evaluator,
     llvm::TinyPtrVector<Decl *> results;
     results.push_back(const_cast<ClassDecl *>(CD));
 
+    auto importer =
+       static_cast<ClangImporter *>(CD->getASTContext().getClangModuleLoader());
+    ClangImporter::Implementation &impl = importer->Impl;
+
     for (auto clangExt : clangClass->known_extensions()) {
-      results.push_back(importCategory(clangExt));
+      if (impl.getClangSema().isVisible(clangExt))
+        results.push_back(importCategory(clangExt));
     }
 
     return results;

--- a/test/ClangImporter/Inputs/frameworks/Module.framework/Headers/Module.h
+++ b/test/ClangImporter/Inputs/frameworks/Module.framework/Headers/Module.h
@@ -8,6 +8,8 @@ const char *getModuleVersion(void);
 +alloc;
 @end
 
+@protocol ModuleProto @end
+
 #define MODULE_H_MACRO 1
 #__private_macro MODULE_H_MACRO
 

--- a/test/ClangImporter/Inputs/frameworks/Module.framework/Modules/module.private.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/Module.framework/Modules/module.private.modulemap
@@ -1,0 +1,4 @@
+framework module Module_Private {
+  umbrella "PrivateHeaders"
+  explicit module * { export * }
+}

--- a/test/ClangImporter/Inputs/frameworks/Module.framework/PrivateHeaders/Sub3.h
+++ b/test/ClangImporter/Inputs/frameworks/Module.framework/PrivateHeaders/Sub3.h
@@ -1,0 +1,5 @@
+#import <Module/Module.h>
+
+@interface Module () <ModuleProto>
+@property (readwrite) int extensionProperty;
+@end

--- a/test/ClangImporter/Inputs/frameworks/Module.framework/PrivateHeaders/Sub4.h
+++ b/test/ClangImporter/Inputs/frameworks/Module.framework/PrivateHeaders/Sub4.h
@@ -1,0 +1,1 @@
+#import <Module/Module.h>

--- a/test/ClangImporter/diags_from_module.swift
+++ b/test/ClangImporter/diags_from_module.swift
@@ -37,7 +37,7 @@ import Module
 // CHECK-PRIMARY: diags_from_module.swift:[[@LINE-4]]:8: error: could not build Objective-C module 'Module'
 
 // CHECK-WARN: Sub2.h:7:2: warning: here is some warning about something
-// CHECK-WARN: Module.h:20:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h'
+// CHECK-WARN: Module.h:22:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h'
 // FIXME: show [-Wincomplete-umbrella]
 
 // CHECK-NO-WARN-NOT: warning about something

--- a/test/ClangImporter/rdar123543707.swift
+++ b/test/ClangImporter/rdar123543707.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-typecheck-verify-swift -F %S/Inputs/frameworks -module-cache-path %t/mcp1
+
+// REQUIRES: objc_interop
+
+import Module
+import Module_Private.Sub4
+
+@_objcImplementation extension Module {
+  // expected-error@-1 {{'@_objcImplementation' cannot be used to implement root class 'Module'}}
+  // expected-warning@-2 {{extension for main class interface should provide implementation for class method 'version()'}}
+  // expected-warning@-3 {{extension for main class interface should provide implementation for class method 'alloc()'}}
+}
+
+extension Module: @retroactive ModuleProto {} // no-error


### PR DESCRIPTION
* **Explanation**: A previous change in `@_objcImplementation` handling did not correctly filter out class extensions based on their visibility. This could cause class extensions in un-imported submodules to be exposed to Swift, creating various issues with duplicate conformances, missing `override` keywords, etc.
* **Scope**: Code that imports Objective-C modules which contain private headers. Fixes a regression.
* **Issue**: rdar://123543707
* **Original PR**: https://github.com/apple/swift/pull/71938
* **Risk**: None. This fix has already been selectively cherry-picked and caused no problems.
* **Testing**: Unit tests have been added.
* **Reviewer**: @ian-twilightcoder 
