### PR TITLE
[ConstraintSystem] Order `VarDecl`s before other kinds of decls in disjunctions.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2365,6 +2365,18 @@ void DisjunctionChoiceProducer::partitionDisjunction(
       return true;
     }
 
+    // Order VarDecls before other kinds of declarations because they are
+    // effectively favored over functions when the two are in the same
+    // overload set. This disjunction order allows SK_UnappliedFunction
+    // to prune later overload choices that are functions when a solution
+    // has already been found with a property.
+    if (auto *decl = getOverloadChoiceDecl(constraint)) {
+      if (isa<VarDecl>(decl)) {
+        everythingElse.push_back(index);
+        return true;
+      }
+    }
+
     return false;
   });
 

--- a/validation-test/Sema/type_checker_perf/fast/property_vs_unapplied_func.swift
+++ b/validation-test/Sema/type_checker_perf/fast/property_vs_unapplied_func.swift
@@ -28,3 +28,17 @@ func rdar47742750(arr1: [Int], arr2: [Int]?) {
     assert(arr1.count == arr1.count + (arr2 == nil ? 0 : 1 + arr2!.count + arr2!.count + arr2!.count))
   }
 }
+
+func f(
+  a: String?,
+  b: String?,
+  c: Int,
+  d: String?,
+  e: String?
+) -> Int {
+  return (a?.unicodeScalars.count ?? 0) +
+  (b?.unicodeScalars.count ?? 0) +
+  c +
+  (d?.unicodeScalars.count ?? 0) +
+  (e?.unicodeScalars.count ?? 0)
+}

--- a/validation-test/Sema/type_checker_perf/fast/property_vs_unapplied_func.swift
+++ b/validation-test/Sema/type_checker_perf/fast/property_vs_unapplied_func.swift
@@ -16,12 +16,6 @@ struct DatabaseLog {
   }
 }
 
-extension Sequence {
-  public func count(
-    where predicate: (Element) throws -> Bool
-  ) rethrows -> Int { 0 }
-}
-
 
 func rdar47742750(arr1: [Int], arr2: [Int]?) {
   let _ = {


### PR DESCRIPTION
Order `VarDecl`s before other kinds of declarations because they are effectively favored over functions when the two are in the same overload set. This disjunction order allows `SK_UnappliedFunction` to prune later overload choices that are functions when a solution has already been found with a property, which enables solving code like this quickly:

```swift
func f(
  a: String?,
  b: String?,
  c: Int,
  d: String?,
  e: String?
) -> Int {
  return (a?.unicodeScalars.count ?? 0) +
  (b?.unicodeScalars.count ?? 0) +
  c +
  (d?.unicodeScalars.count ?? 0) +
  (e?.unicodeScalars.count ?? 0)
}
```

This resolves the source compatibility regression in penny-bot.

Resolves: rdar://125674969