### PR TITLE
[Concurrency] Infer `@Sendable` for globally isolated function types and allow globally isolated closures to capture non-`Sendable` values.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3634,9 +3634,7 @@ public:
     return getExtInfo().isNoEscape();
   }
 
-  bool isSendable() const {
-    return getExtInfo().isSendable();
-  }
+  bool isSendable() const;
 
   bool isAsync() const { return getExtInfo().isAsync(); }
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3895,6 +3895,15 @@ Type AnyFunctionType::getThrownError() const {
   }
 }
 
+bool AnyFunctionType::isSendable() const {
+  auto &ctx = getASTContext();
+  if (ctx.LangOpts.hasFeature(Feature::GlobalActorIsolatedTypesUsability)) {
+    // Global-actor-isolated function types are implicitly Sendable.
+    return getExtInfo().isSendable() || getIsolation().isGlobalActor();
+  }
+  return getExtInfo().isSendable();
+}
+
 Type AnyFunctionType::getGlobalActor() const {
   switch (getKind()) {
   case TypeKind::Function:

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -559,7 +559,7 @@ extension MyActor {
 
 func testBadImplicitGlobalActorClosureCall() async {
   { @MainActor in  }() // expected-error{{expression is 'async' but is not marked with 'await'}}
-  // expected-note@-1{{calls function of type '@MainActor () -> ()' from outside of its actor context are implicitly asynchronous}}
+  // expected-note@-1{{calls function of type '@MainActor @Sendable () -> ()' from outside of its actor context are implicitly asynchronous}}
 }
 
 

--- a/test/Concurrency/global_actor_sendable_fn_type_inference.swift
+++ b/test/Concurrency/global_actor_sendable_fn_type_inference.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -disable-availability-checking -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature GlobalActorIsolatedTypesUsability
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+func inferSendableFunctionType() {
+  let closure: @MainActor () -> Void = {}
+
+  Task {
+    await closure() // okay
+  }
+}

--- a/test/Concurrency/global_actor_sendable_fn_type_inference.swift
+++ b/test/Concurrency/global_actor_sendable_fn_type_inference.swift
@@ -10,3 +10,12 @@ func inferSendableFunctionType() {
     await closure() // okay
   }
 }
+
+class NonSendable {}
+
+func allowNonSendableCaptures() {
+  let nonSendable = NonSendable()
+  let _: @MainActor () -> Void = {
+    let _ = nonSendable // okay
+  }
+}


### PR DESCRIPTION
- Globally isolated function types may never be called concurrently, so they are data-race safe. Thus, they should be implicitly `@Sendable`.

- For the same reason as above, globally isolated closures should be allowed to capture non-`Sendable` values.


This is the second part of the changes proposed by this [pitch](https://forums.swift.org/t/pitch-usability-of-global-actor-isolated-types/70799).

