### PR TITLE
Enable failable initializers for noncopyable types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7743,8 +7743,6 @@ ERROR(noncopyable_enums_do_not_support_indirect,none,
       "noncopyable enum %0 cannot be marked indirect or have indirect cases yet", (Identifier))
 ERROR(noncopyable_cast,none,
       "noncopyable types cannot be conditionally cast", ())
-ERROR(noncopyable_failable_init,none,
-      "noncopyable types cannot have failable initializers yet", ())
 ERROR(noncopyable_objc_enum, none,
       "noncopyable enums cannot be marked '@objc'", ())
 ERROR(moveOnly_not_allowed_here,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5696,6 +5696,8 @@ ERROR(incorrect_optional_any,none,
 ERROR(existential_requires_any,none,
       "use of %select{protocol |}2%0 as a type must be written %1",
       (Type, Type, bool))
+ERROR(inverse_requires_any,none,
+      "constraint that suppresses conformance requires 'any'", ())
 
 ERROR(nonisolated_let,none,
       "'nonisolated' is meaningless on 'let' declarations because "

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1239,12 +1239,19 @@ public:
     // the following token is something that can introduce a type. Thankfully
     // none of these tokens overlap with the set of tokens that can follow an
     // identifier in a type production.
-    return (Tok.is(tok::identifier) &&
-            peekToken().isAny(tok::at_sign, tok::kw_inout, tok::l_paren,
-                              tok::identifier, tok::l_square, tok::kw_Any,
-                              tok::kw_Self, tok::kw__, tok::kw_var,
-                              tok::kw_let)) ||
-           isLifetimeDependenceToken();
+    if (Tok.is(tok::identifier)) {
+      auto next = peekToken();
+      if (next.isAny(tok::at_sign, tok::kw_inout, tok::l_paren,
+                     tok::identifier, tok::l_square, tok::kw_Any,
+                     tok::kw_Self, tok::kw__, tok::kw_var,
+                     tok::kw_let))
+        return true;
+
+      if (next.is(tok::oper_prefix) && next.getText() == "~")
+        return true;
+    }
+
+    return isLifetimeDependenceToken();
   }
 
   struct ParsedTypeAttributeList {

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -178,10 +178,10 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
       SpareBits.clear();
       IsFixedLayout = true;
       IsLoadable = true;
-      IsKnownTriviallyDestroyable = deinit;
-      IsKnownBitwiseTakable = IsBitwiseTakable;
-      IsKnownAlwaysFixedSize = IsFixedSize;
-      IsKnownCopyable = copyable;
+      IsKnownTriviallyDestroyable = deinit & builder.isTriviallyDestroyable();
+      IsKnownBitwiseTakable = builder.isBitwiseTakable();
+      IsKnownAlwaysFixedSize = builder.isAlwaysFixedSize();
+      IsKnownCopyable = copyable & builder.isCopyable();
       Ty = (typeToFill ? typeToFill : IGM.OpaqueTy);
     } else {
       MinimumAlign = builder.getAlignment();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -479,7 +479,8 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
 
   // 'any' followed by another identifier is an existential type.
   if (Tok.isContextualKeyword("any") &&
-      peekToken().is(tok::identifier) &&
+      (peekToken().is(tok::identifier) ||
+       peekToken().isContextualPunctuator("~")) &&
       !peekToken().isAtStartOfLine()) {
     ParserResult<TypeRepr> ty = parseType();
     auto *typeExpr = new (Context) TypeExpr(ty.get());

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -4035,16 +4035,6 @@ public:
       addDelayedFunction(CD);
     }
 
-    // a move-only / noncopyable type cannot have a failable initializer, since
-    // that would require the ability to wrap one inside an optional
-    if (CD->isFailable()) {
-      if (auto *nom = CD->getDeclContext()->getSelfNominalTypeDecl()) {
-        if (!nom->canBeCopyable()) {
-          CD->diagnose(diag::noncopyable_failable_init);
-        }
-      }
-    }
-
     checkDefaultArguments(CD->getParameters());
     checkVariadicParameters(CD->getParameters(), CD);
 

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -202,6 +202,9 @@ enum class TypeResolverContext : uint8_t {
 
   /// Whether this is a custom attribute.
   CustomAttr,
+
+  /// Whether this is the argument of an inverted constraint (~).
+  Inverted,
 };
 
 /// Options that determine how type resolution should work.
@@ -298,6 +301,7 @@ public:
     case Context::GenericParameterInherited:
     case Context::AssociatedTypeInherited:
     case Context::CustomAttr:
+    case Context::Inverted:
       return false;
     }
     llvm_unreachable("unhandled kind");
@@ -316,6 +320,7 @@ public:
     case Context::GenericRequirement:
     case Context::ExistentialConstraint:
     case Context::MetatypeBase:
+    case Context::Inverted:
       return false;
     case Context::None:
     case Context::ScalarGenericArgument:
@@ -353,6 +358,7 @@ public:
     case Context::PackElement:
     case Context::TupleElement:
     case Context::VariadicGenericArgument:
+    case Context::Inverted:
       return true;
     case Context::None:
     case Context::PatternBindingDecl:
@@ -425,6 +431,7 @@ public:
     case Context::ImmediateOptionalTypeArgument:
     case Context::AbstractFunctionDecl:
     case Context::CustomAttr:
+    case Context::Inverted:
       return false;
     }
   }

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -109,7 +109,7 @@ struct NeverCopyableDeinit<T: ~Copyable>: ~Copyable {
 }
 
 protocol Test: ~Copyable {
-  init?() // expected-error {{noncopyable types cannot have failable initializers yet}}
+  init?()
 }
 
 struct NoncopyableAndSendable: ~Copyable, Sendable {}

--- a/test/IRGen/existential_shape_metadata_noncopyable.swift
+++ b/test/IRGen/existential_shape_metadata_noncopyable.swift
@@ -11,6 +11,6 @@ public protocol QNC<A>: ~Copyable {
 public struct NCStruct: ~Copyable { }
 
 
-public func testNoncopyableConcrete() -> (Any & ~Copyable).Type {
+public func testNoncopyableConcrete() -> any  ~Copyable.Type {
   return (any QNC<NCStruct>).self
 }

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -373,3 +373,18 @@ public func testKlassEnumPairWithDeinit() {
         consumeKlassEnumPairWithDeinit(f)
     }
 }
+
+struct EmptyMoveOnlyWithDeinit: ~Copyable {
+  deinit {}
+}
+
+struct EnclosesEmptyMoveOnlyWithDeinit: ~Copyable {
+  var stored: EmptyMoveOnlyWithDeinit
+}
+
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits35testEnclosesEmptyMoveOnlyWithDeinityyF"()
+func testEnclosesEmptyMoveOnlyWithDeinit() {
+  // CHECK-NOT: ret
+  // CHECK: call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
+  _ = EnclosesEmptyMoveOnlyWithDeinit(stored: EmptyMoveOnlyWithDeinit())
+}

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -81,15 +81,18 @@ func ownership2(_ t: ~ borrowing Int) {} // expected-error {{cannot find type 'b
 
 func ownership3(_ t: consuming some ~Clone) {}
 
-func what(one: ~Copyable..., // expected-error {{type 'any Copyable' cannot be suppressed}}
+func what(one: ~Copyable..., // expected-error {{noncopyable type '~Copyable' cannot be used within a variadic type yet}}
           two: ~(Copyable...) // expected-error {{variadic parameter cannot appear outside of a function parameter list}}
-                              // expected-error@-1 {{type 'any Copyable' cannot be suppressed}}
+                              // expected-error@-1 {{parameter of noncopyable type '~Copyable' must specify ownership}}
+              // expected-note@-2{{add 'borrowing' for an immutable reference}}
+              // expected-note@-3{{add 'inout' for a mutable reference}}
+              // expected-note@-4{{add 'consuming' to take the value from the caller}}
           ) {}
 
 struct A { struct B { struct C {} } }
 
-typealias Z1 = (~Copyable).Type // FIXME: should be an error
-typealias Z1 = ~Copyable.Type // expected-error {{type 'any Copyable.Type' cannot be suppressed}}
+typealias Z0 = (~Copyable).Type // expected-error{{constraint that suppresses conformance requires 'any'}}{{17-17=any }}
+typealias Z1 = ~Copyable.Type // expected-error{{constraint that suppresses conformance requires 'any'}}{{16-16=any }}
 typealias Z2 = ~A.B.C // expected-error {{type 'A.B.C' cannot be suppressed}}
 typealias Z3 = ~A? // expected-error {{type 'A?' cannot be suppressed}}
 typealias Z4 = ~Rope<Int> // expected-error {{type 'Rope<Int>' cannot be suppressed}}
@@ -106,11 +109,22 @@ struct Bad: ~NotAProtocol {} // expected-error {{type 'NotAProtocol' cannot be s
 struct X<T: ~Copyable>: ~Copyable { }
 
 func typeInExpression() {
-  _ = [~Copyable]()  // expected-error{{type 'any Copyable' cannot be suppressed}}
+  _ = [~Copyable]()  // expected-error{{type '~Copyable' does not conform to protocol 'Copyable'}}
   _ = X<any ~Copyable>()
 
   _ = X<any ~Copyable & Foo>()
   _ = X<any Foo & ~Copyable>()
 
   _ = X<(borrowing any ~Copyable) -> Void>()
+
+  _ = ~Copyable.self // expected-error{{unary operator '~' cannot be applied to an operand of type '(any Copyable).Type'}}
+  _ = (~Copyable).self // expected-error{{constraint that suppresses conformance requires 'any'}}{{8-8=any }}
+  _ = (any ~Copyable).self
 }
+
+func param1(_ t: borrowing ~Copyable) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{28-28=any }}
+func param2(_ t: ~Copyable.Type) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{18-18=any }}
+func param3(_ t: borrowing any ~Copyable) {}
+func param4(_ t: any ~Copyable.Type) {}
+
+func param3(_ t: borrowing ExtraNoncopyProto & ~Copyable) {} // expected-error{{constraint that suppresses conformance requires 'any'}}{{28-28=any }}

--- a/test/SILGen/moveonly_failable_init.swift
+++ b/test/SILGen/moveonly_failable_init.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-emit-sil -module-name test %s | %FileCheck %s --enable-var-scope
+
+struct MoveWithDeinit: ~Copyable {
+  deinit { }
+}
+
+struct MyType: ~Copyable {
+  var handle: MoveWithDeinit
+
+  // CHECK-LABEL: sil hidden @$s4test6MyTypeV6handleACSgAA14MoveWithDeinitVSg_tcfC : $@convention(method) (@owned Optional<MoveWithDeinit>, @thin MyType.Type) -> @owned Optional<MyType>
+  // CHECK: bb0(%0 : $Optional<MoveWithDeinit>, %1 : $@thin MyType.Type):
+  init?(handle: consuming MoveWithDeinit?) {
+    // CHECK: switch_enum [[SUBJECT:%.*]] : $Optional<MoveWithDeinit>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
+    guard let handle = consume handle else {
+      // CHECK: bb1:
+      // CHECK: [[NONE:%.*]] = enum $Optional<MyType>, #Optional.none!enumelt
+      // CHECK: br bb3([[NONE]] : $Optional<MyType>)
+      return nil
+    }
+
+    // CHECK: bb2([[WRAPPED:%.*]] : $MoveWithDeinit):
+    // CHECK: br bb3
+    self.handle = handle
+  }
+}
+
+func test() -> MyType? {
+  return MyType(handle: MoveWithDeinit())
+}

--- a/test/Sema/moveonly_restrictions.swift
+++ b/test/Sema/moveonly_restrictions.swift
@@ -6,13 +6,13 @@ class CopyableKlass {}
 
 @_moveOnly
 class MoveOnlyKlass { // expected-note 6{{class 'MoveOnlyKlass' has '~Copyable' constraint preventing 'Copyable' conformance}}
-    init?() {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init?() {}
 }
 
 @_moveOnly
 struct MoveOnlyStruct { // expected-note {{struct 'MoveOnlyStruct' has '~Copyable' constraint preventing 'Copyable' conformance}}
-    init?(one: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
-    init!(two: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init?(one: Bool) {}
+    init!(two: Bool) {}
 }
 
 class C {
@@ -78,19 +78,19 @@ enum EMoveOnly {
     case lhs(CopyableKlass)
     case rhs(MoveOnlyKlass)
 
-    init?() {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init?() {}
 }
 
 extension EMoveOnly {
-    init!(three: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init!(three: Bool) {}
 }
 
 extension MoveOnlyKlass {
-    convenience init?(three: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    convenience init?(three: Bool) {}
 }
 
 extension MoveOnlyStruct {
-    init?(three: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init?(three: Bool) {}
 }
 
 func foo() {


### PR DESCRIPTION
Noncopyable types were prevented from having failable initializers because `Optional` itself didn't support noncopyable types. Now `Optional` does, so lift this restriction and add a test.

Also include a bug fix: an empty struct that is noncopyable can nonetheless have a `deinit`, so it is not trivially destructible. In such cases, embedded them in another empty struct means that the outer struct should also not be trivially destructible. Make it so.