### PR TITLE
🌸 Support objcImpl + implementationOnly

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -65,6 +65,8 @@ ExportContext::ExportContext(
 bool swift::isExported(const ValueDecl *VD) {
   if (VD->getAttrs().hasAttribute<ImplementationOnlyAttr>())
     return false;
+  if (VD->isObjCMemberImplementation())
+    return false;
 
   // Is this part of the module's API or ABI?
   AccessScope accessScope =

--- a/test/decl/ext/Inputs/objc_implementation_internal.h
+++ b/test/decl/ext/Inputs/objc_implementation_internal.h
@@ -1,0 +1,8 @@
+@import Foundation;
+
+@interface InternalObjCClass : NSObject
+
+- (void)methodFromHeader1:(int)param;
+
+@end
+

--- a/test/decl/ext/Inputs/objc_implementation_private.modulemap
+++ b/test/decl/ext/Inputs/objc_implementation_private.modulemap
@@ -2,3 +2,7 @@ module objc_implementation_private {
   header "objc_implementation.h"
   export *
 }
+module objc_implementation_internal {
+  header "objc_implementation_internal.h"
+  export *
+}

--- a/test/decl/ext/objc_implementation_impl_only.swift
+++ b/test/decl/ext/objc_implementation_impl_only.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift -Xcc -fmodule-map-file=%S/Inputs/objc_implementation_private.modulemap
+// REQUIRES: objc_interop
+
+@_implementationOnly import objc_implementation_internal
+
+@_objcImplementation extension InternalObjCClass {
+  @objc public func method(fromHeader1: CInt) {
+    // OK
+  }
+}


### PR DESCRIPTION
* **Explanation**: Modify the decl checker to understand that ObjC member implementations do not actually expose new API surface and can be used with, among other things, `@_implementationOnly` imports.
* **Scope**: Projects using `@_objcImplementation`; additive change.
* **Issue**: rdar://121229058
* **Original PR**: https://github.com/apple/swift/pull/71743
* **Risk**: Very low. This is an additive change to the interaction between two compiler-internal features.
* **Testing**: New unit tests have been added to the test suite.
* **Reviewer**: @xymus 
