### PR TITLE
[silgen] Emit the location of the original function def if SILGen is erroring on a duplicate symbol definition.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -46,6 +46,9 @@ ERROR(bridging_objcbridgeable_broken,none,
 ERROR(sil_function_redefinition,none,
       "multiple definitions of symbol '%0'",
       (StringRef))
+NOTE(sil_function_redefinition_note,none,
+      "other definition here",
+      ())
 
 ERROR(invalid_sil_builtin,none,
       "INTERNAL ERROR: invalid use of builtin: %0",

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -813,6 +813,8 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
   if (!f->empty()) {
     diagnose(constant.getAsRegularLocation(), diag::sil_function_redefinition,
              f->getName());
+    if (f->hasLocation())
+      diagnose(f->getLocation(), diag::sil_function_redefinition_note);
     return;
   }
 

--- a/test/SILGen/diagnose_duplicate_functions.swift
+++ b/test/SILGen/diagnose_duplicate_functions.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-emit-silgen %s -o /dev/null -verify
 
 @_silgen_name("foo")
-func a(_ x: Int) -> Int {
+func a(_ x: Int) -> Int { // expected-note {{other definition here}}
   return x
 }
 
@@ -11,7 +11,7 @@ func b(_ x: Int) -> Int { // expected-error {{multiple definitions of symbol 'fo
 }
 
 @_cdecl("bar")
-func c(_ x: Int) -> Int {
+func c(_ x: Int) -> Int { // expected-note {{other definition here}}
   return x
 }
 


### PR DESCRIPTION
This diagnostic is useful around silgen_name where it validates that we do not have any weird collisions. Sadly, it just points where one of the conflicting elements is... with this patch, we also emit an error on the other function if we have a SILLocation.
