### PR TITLE
[diagnostics] Move the assert on warn/error later in the diagnostic pipeline so we do not error if an error/warning diagnostic is limited.

### DIFF
--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1126,10 +1126,6 @@ DiagnosticBehavior DiagnosticState::determineBehavior(const Diagnostic &diag) {
     anyErrorOccurred = true;
   }
 
-  assert((!AssertOnError || !anyErrorOccurred) && "We emitted an error?!");
-  assert((!AssertOnWarning || (lvl != DiagnosticBehavior::Warning)) &&
-         "We emitted a warning?!");
-
   previousBehavior = lvl;
   return lvl;
 }
@@ -1462,6 +1458,10 @@ void DiagnosticEngine::emitDiagnostic(const Diagnostic &diagnostic) {
   std::vector<Diagnostic> extendedChildNotes;
 
   if (auto info = diagnosticInfoForDiagnostic(diagnostic)) {
+    assert((!AssertOnError || info->Kind != DiagnosticKind::Error) && "We emitted an error?!");
+    assert((!AssertOnWarning || info->Kind != DiagnosticKind::Warning) &&
+           "We emitted a warning?!");
+
     // If the diagnostic location is within a buffer containing generated
     // source code, add child notes showing where the generation occurred.
     // We need to avoid doing this if this is itself a child note, as otherwise


### PR DESCRIPTION
Otherwise, the assert will trigger throughout Concurrency code since Concurrency relies on preconcurrency and friends which works via limiting diagnostics in preconcurrency code.
