### PR TITLE
Sema: Fix existential-metatype-to-Any conversion 

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -126,17 +126,6 @@ public:
                                     ProtocolDecl *conformedProtocol) const;
 };
 
-/// Functor class suitable for use as a \c LookupConformanceFn that provides
-/// only abstract conformances, or builtin conformances for invertible protocols
-/// for generic types. Asserts that the replacement
-/// type is an opaque generic type.
-class MakeAbstractOrBuiltinConformanceForGenericType {
-public:
-  ProtocolConformanceRef operator()(CanType dependentType,
-                                    Type conformingReplacementType,
-                                    ProtocolDecl *conformedProtocol) const;
-};
-
 /// Functor class suitable for use as a \c LookupConformanceFn that fetches
 /// conformances from a generic signature.
 class LookUpConformanceInSignature {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -196,7 +196,7 @@ public:
         // If we found a type containing a local archetype, substitute
         // open existentials throughout the substitution map.
         Subs = Subs.subst(QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-                          MakeAbstractOrBuiltinConformanceForGenericType());
+                          MakeAbstractConformanceForGenericType());
       }
     }
 
@@ -219,7 +219,7 @@ public:
     return Ty.subst(
       Builder.getModule(),
       QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-      MakeAbstractOrBuiltinConformanceForGenericType(),
+      MakeAbstractConformanceForGenericType(),
       CanGenericSignature());
   }
   SILType getOpType(SILType Ty) {
@@ -239,7 +239,7 @@ public:
 
     return ty.subst(
       QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-      MakeAbstractOrBuiltinConformanceForGenericType()
+      MakeAbstractConformanceForGenericType()
     )->getCanonicalType();
   }
 
@@ -352,7 +352,7 @@ public:
         conformance.subst(ty,
                           QueryTypeSubstitutionMapOrIdentity{
                                                         LocalArchetypeSubs},
-                          MakeAbstractOrBuiltinConformanceForGenericType());
+                          MakeAbstractConformanceForGenericType());
     }
 
     return asImpl().remapConformance(getASTTypeInClonedContext(ty),

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -230,22 +230,6 @@ operator()(CanType dependentType, Type conformingReplacementType,
   return Subs.lookupConformance(dependentType, conformedProtocol);
 }
 
-ProtocolConformanceRef MakeAbstractOrBuiltinConformanceForGenericType::
-operator()(CanType dependentType, Type conformingReplacementType,
-           ProtocolDecl *conformedProtocol) const {
-  // Workaround for rdar://125460667
-  if (conformedProtocol->getInvertibleProtocolKind()) {
-    auto &ctx = conformedProtocol->getASTContext();
-    return ProtocolConformanceRef(
-        ctx.getBuiltinConformance(conformingReplacementType, conformedProtocol,
-                                  BuiltinConformanceKind::Synthesized));
-  }
-
-  return MakeAbstractConformanceForGenericType()(dependentType,
-                                                 conformingReplacementType,
-                                                 conformedProtocol);
-}
-
 ProtocolConformanceRef MakeAbstractConformanceForGenericType::
 operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -853,9 +853,6 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     [&, concreteFormalType, F](SGFContext C) -> ManagedValue {
       auto concreteValue = F(SGFContext());
       assert(concreteFormalType->isBridgeableObjectType());
-      auto *M = SGM.M.getSwiftModule();
-      auto conformances = M->collectExistentialConformances(
-          concreteFormalType, anyObjectTy);
       return B.createInitExistentialRef(
           loc, SILType::getPrimitiveObjectType(anyObjectTy), concreteFormalType,
           concreteValue, conformances);
@@ -864,6 +861,12 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     if (this->F.getLoweredFunctionType()->isPseudogeneric()) {
       if (anyObjectTy && concreteFormalType->is<ArchetypeType>()) {
         concreteFormalType = anyObjectTy;
+
+        // The original conformances are no good because they have the wrong
+        // (pseudogeneric) subject type.
+        auto *M = SGM.M.getSwiftModule();
+        conformances = M->collectExistentialConformances(
+            concreteFormalType, anyObjectTy);
         F = eraseToAnyObject;
       }
     }

--- a/test/SILOptimizer/rdar125460667.swift
+++ b/test/SILOptimizer/rdar125460667.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+@_transparent func f(a: Any.Type) -> Any {
+  return a
+}
+
+func g(a: Any.Type) {
+  f(a: a)
+}


### PR DESCRIPTION
We were incorrectly unwrapping too many levels of metatype, and our ErasureExpr would end up with conformances for the instance type and not the metatype itself.

In the old universe, this was not a problem, but now Any has two protocol conformance members, so suddently this violated invariants.

I added a SILCloner test case that triggers the issue in the same way that it was originally observed, however subsequent commits in the PR add stronger assertions and with those assertions in place a bunch of tests failed already.

This was a regression, introduced in 6027bf46a6915aa976a30cf29ef37c74f74b09fd.

Fixes rdar://125460667.
