### PR TITLE
[region-isolation] Require T in assumeIsolated<T> to be Sendable.

### DIFF
--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -342,12 +342,10 @@ extension Actor {
   /// - Returns: the return value of the `operation`
   /// - Throws: rethrows the `Error` thrown by the operation if it threw
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
-  @backDeployed(before: SwiftStdlib 5.9)
-  #endif
+  @_alwaysEmitIntoClient
   @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
   @_unavailableInEmbedded
-  public nonisolated func assumeIsolated<T>(
+  public nonisolated func assumeIsolated<T : Sendable>(
       _ operation: (isolated Self) throws -> T,
       file: StaticString = #fileID, line: UInt = #line
   ) rethrows -> T {
@@ -372,6 +370,17 @@ extension Actor {
     #else
     fatalError("unsupported compiler")
     #endif
+  }
+
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  @_unavailableInEmbedded
+  @_silgen_name("$sScAsE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKlF")
+  internal nonisolated func __abi__assumeIsolated<T : Sendable>(
+      _ operation: (isolated Self) throws -> T,
+      _ file: StaticString, _ line: UInt
+  ) rethrows -> T {
+    try assumeIsolated(operation, file: file, line: line)
   }
 }
 

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -137,13 +137,12 @@ extension MainActor {
   /// - Returns: the return value of the `operation`
   /// - Throws: rethrows the `Error` thrown by the operation if it threw
   @available(SwiftStdlib 5.1, *)
-  @backDeployed(before: SwiftStdlib 5.9)
+  @_alwaysEmitIntoClient
   @_unavailableFromAsync(message: "await the call to the @MainActor closure directly")
-  public static func assumeIsolated<T>(
+  public static func assumeIsolated<T : Sendable>(
       _ operation: @MainActor () throws -> T,
       file: StaticString = #fileID, line: UInt = #line
   ) rethrows -> T {
-
     typealias YesActor = @MainActor () throws -> T
     typealias NoActor = () throws -> T
 
@@ -165,6 +164,16 @@ extension MainActor {
     #else
     fatalError("unsupported compiler")
     #endif
+  }
+
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  @_silgen_name("$sScM14assumeIsolated_4file4linexxyKScMYcXE_s12StaticStringVSutKlFZ")
+  internal static func __abi__assumeIsolated<T : Sendable>(
+      _ operation: @MainActor () throws -> T,
+      _ file: StaticString, _ line: UInt
+  ) rethrows -> T {
+    try assumeIsolated(operation, file: file, line: line)
   }
 }
 #endif

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -153,7 +153,8 @@ extension DistributedActor {
   /// - Throws: rethrows the `Error` thrown by the operation if it threw
   @available(SwiftStdlib 5.9, *)
   @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'distributed actor' instead")
-  public nonisolated func assumeIsolated<T>(
+  @_alwaysEmitIntoClient
+  public nonisolated func assumeIsolated<T : Sendable>(
       _ operation: (isolated Self) throws -> T,
       file: StaticString = #fileID, line: UInt = #line
   ) rethrows -> T {
@@ -180,6 +181,16 @@ extension DistributedActor {
     #else
     fatalError("unsupported compiler")
     #endif
+  }
+
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  @_silgen_name("$s11Distributed0A5ActorPAAE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKlF")
+  internal nonisolated func __abi__assumeIsolated<T : Sendable>(
+      _ operation: (isolated Self) throws -> T,
+      _ file: StaticString, _ line: UInt
+  ) rethrows -> T {
+    try assumeIsolated(operation, file: file, line: line)
   }
 }
 

--- a/test/Concurrency/assumeIsolated.swift
+++ b/test/Concurrency/assumeIsolated.swift
@@ -1,0 +1,30 @@
+// RUN: %target-build-swift -swift-version 5 %s -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -Xfrontend -verify
+
+class NonSendableKlass {} // expected-note 3{{class 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+
+@available(macOS 10.15, *)
+actor MyActor {
+  var x = NonSendableKlass()
+
+  nonisolated func doSomething() -> NonSendableKlass {
+    return self.assumeIsolated { isolatedSelf in // expected-warning {{type 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+      let x: NonSendableKlass = isolatedSelf.x
+      return x
+    }
+  }
+
+  nonisolated func doSomething2() -> NonSendableKlass {
+    let r: NonSendableKlass = assumeIsolated { isolatedSelf in // expected-warning {{type 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+      let x: NonSendableKlass = isolatedSelf.x
+      return x
+    }
+    return r
+  }
+}
+
+@available(macOS 10.15, *)
+nonisolated func mainActorAssumeIsolated() -> NonSendableKlass {
+  return MainActor.assumeIsolated { // expected-warning {{type 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+    NonSendableKlass()
+  }
+}

--- a/test/Concurrency/assumeIsolated.swift
+++ b/test/Concurrency/assumeIsolated.swift
@@ -1,5 +1,8 @@
 // RUN: %target-build-swift -swift-version 5 %s -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -Xfrontend -verify
 
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
 class NonSendableKlass {} // expected-note 3{{class 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
 
 @available(macOS 10.15, *)

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -41,7 +41,7 @@ func testSyncMember(obj: MyActor) -> Int {
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated({#(message): String#})[#Void#]; name=assertIsolated(:)
-// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> T##(isolated MyActor) throws -> T#})[' rethrows'][#T#]; name=assumeIsolated(:)
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> Sendable##(isolated MyActor) throws -> Sendable#})[' rethrows'][#Sendable#]; name=assumeIsolated(:)
 }
 
 func testSyncMember(obj: MyActor) async -> Int {
@@ -55,7 +55,7 @@ func testSyncMember(obj: MyActor) async -> Int {
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated({#(message): String#})[#Void#]; name=assertIsolated(:)
-// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> T##(isolated MyActor) throws -> T#})[' rethrows'][#T#]; name=assumeIsolated(:)
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> Sendable##(isolated MyActor) throws -> Sendable#})[' rethrows'][#Sendable#]; name=assumeIsolated(:)
 }
 
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
I had to change the APIs to always be always emit into client instead of back deployable since silgen_name seems to interfere with @backDeployment. So I switched the implementation so that it instead uses an always emit into client thunk with the in source function name and a usableFromInline function that has the silgen_name. This ensures that we still appropriately export the same symbol as we did before, so it is ABI stable.

This was approved as part of se-0414.

rdar://122030520
