### PR TITLE
[cxx-interop] Use C++17 standard by default

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -541,7 +541,7 @@ void importer::getNormalInvocationArguments(
         *clang::LangStandard::getLangStandardForName(CLANG_DEFAULT_STD_CXX);
 #else
         clang::LangStandard::getLangStandardForKind(
-            clang::LangStandard::lang_gnucxx14);
+            clang::LangStandard::lang_gnucxx17);
 #endif
 
     const clang::LangStandard &stdc =

--- a/test/Interop/Cxx/class/method/msvc-abi-return-indirect-trivial-record.swift
+++ b/test/Interop/Cxx/class/method/msvc-abi-return-indirect-trivial-record.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-emit-irgen -I %t/Inputs -enable-experimental-cxx-interop  -Xcc -std=c++17 %t/test.swift -module-name Test | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-%target-cpu
+// RUN: %target-swift-emit-irgen -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift -module-name Test | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-%target-cpu
 
 // REQUIRES: OS=windows-msvc
 

--- a/test/Interop/Cxx/class/structured-bindings-get-method.swift
+++ b/test/Interop/Cxx/class/structured-bindings-get-method.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir -Xcc -std=c++17 | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir | %FileCheck %s
 
 import StructuredBindingsGetMethod
 

--- a/test/Interop/Cxx/reference/reference-silgen-cxx-objc-ctors+init.swift
+++ b/test/Interop/Cxx/reference/reference-silgen-cxx-objc-ctors+init.swift
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: %target-swift-emit-sil -I %S/Inputs -enable-experimental-cxx-interop -Xcc -std=c++17 -Ounchecked %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -I %S/Inputs -enable-experimental-cxx-interop -Ounchecked %s | %FileCheck %s
 
 import ConstRefCxxObjCCtorInitParameter
 

--- a/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
+++ b/test/Interop/Cxx/static/constexpr-static-member-var-errors.swift
@@ -1,7 +1,8 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=ConstexprStaticMemberVarErrors -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop 2>&1 | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ConstexprStaticMemberVarErrors -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -Xcc -std=c++14 2>&1 | %FileCheck %s
 
 // Check that we properly report the error and don't crash when importing an
 // invalid decl.
+// When using C++17, this C++ header doesn't trigger any Clang error. This is expected.
 
 // Windows doesn't fail at all here which seems ok (and probably should be the case for other platforms too).
 // XFAIL: OS=windows-msvc

--- a/test/Interop/Cxx/stdlib/avoid-import-cxx-math.swift
+++ b/test/Interop/Cxx/stdlib/avoid-import-cxx-math.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend %s -typecheck -verify -enable-experimental-cxx-interop -Xcc -std=c++17
-// RUN: %target-swift-frontend %s -typecheck -verify -cxx-interoperability-mode=swift-6 -Xcc -std=c++17
-// RUN: %target-swift-frontend %s -typecheck -verify -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17
+// RUN: %target-swift-frontend %s -typecheck -verify -enable-experimental-cxx-interop
+// RUN: %target-swift-frontend %s -typecheck -verify -cxx-interoperability-mode=swift-6
+// RUN: %target-swift-frontend %s -typecheck -verify -cxx-interoperability-mode=upcoming-swift
 
 // REQUIRES: OS=macosx || OS=linux-gnu
 

--- a/test/Interop/Cxx/stdlib/import-cxx-math-ambiguities.swift
+++ b/test/Interop/Cxx/stdlib/import-cxx-math-ambiguities.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend %s -typecheck -enable-experimental-cxx-interop -Xcc -std=c++17
-// RUN: %target-swift-frontend %s -typecheck -cxx-interoperability-mode=swift-6 -Xcc -std=c++17
-// RUN: %target-swift-frontend %s -typecheck -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17
+// RUN: %target-swift-frontend %s -typecheck -enable-experimental-cxx-interop
+// RUN: %target-swift-frontend %s -typecheck -cxx-interoperability-mode=swift-6
+// RUN: %target-swift-frontend %s -typecheck -cxx-interoperability-mode=upcoming-swift
 
 #if canImport(Foundation)
 // Foundation depends on C++ standard library

--- a/test/Interop/Cxx/stdlib/import-string-view-from-std.swift
+++ b/test/Interop/Cxx/stdlib/import-string-view-from-std.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
-// RUN: %target-swift-frontend %t/test.swift -c -enable-experimental-cxx-interop -Xcc -std=c++17 -Xcc -fmodules-cache-path=%t/cache -I %t/Inputs
+// RUN: %target-swift-frontend %t/test.swift -c -enable-experimental-cxx-interop -Xcc -fmodules-cache-path=%t/cache -I %t/Inputs
 // RUN: find %t/cache | %FileCheck %s
 
 // REQUIRES: OS=macosx || OS=linux-gnu

--- a/test/Interop/Cxx/stdlib/msvc-abi-use-vector-iterator.swift
+++ b/test/Interop/Cxx/stdlib/msvc-abi-use-vector-iterator.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 
 // REQUIRES: OS=windows-msvc
 // REQUIRES: executable_test

--- a/test/Interop/Cxx/stdlib/use-std-chrono.swift
+++ b/test/Interop/Cxx/stdlib/use-std-chrono.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 

--- a/test/Interop/Cxx/stdlib/use-std-function.swift
+++ b/test/Interop/Cxx/stdlib/use-std-function.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 

--- a/test/Interop/Cxx/stdlib/use-std-optional.swift
+++ b/test/Interop/Cxx/stdlib/use-std-optional.swift
@@ -1,5 +1,5 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=swift-6 -Xcc -std=c++17)
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=swift-6)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift)
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 //
 // REQUIRES: executable_test

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 

--- a/test/Interop/Cxx/stdlib/use-std-set.swift
+++ b/test/Interop/Cxx/stdlib/use-std-set.swift
@@ -1,6 +1,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -2,6 +2,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -D USE_CUSTOM_STRING_API)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6 -D SUPPORTS_DEFAULT_ARGUMENTS -D USE_CUSTOM_STRING_API)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D SUPPORTS_DEFAULT_ARGUMENTS -D USE_CUSTOM_STRING_API)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D SUPPORTS_DEFAULT_ARGUMENTS -D USE_CUSTOM_STRING_API -Xcc -std=c++14)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D SUPPORTS_DEFAULT_ARGUMENTS -D USE_CUSTOM_STRING_API -Xcc -std=c++17)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -D SUPPORTS_DEFAULT_ARGUMENTS -D USE_CUSTOM_STRING_API -Xcc -std=c++20)
 //

--- a/test/Interop/Cxx/stdlib/use-std-unique-ptr.swift
+++ b/test/Interop/Cxx/stdlib/use-std-unique-ptr.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=swift-6)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift)
+// RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++14)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++17)
 // RUN: %target-run-simple-swift(-I %S/Inputs -cxx-interoperability-mode=upcoming-swift -Xcc -std=c++20)
 //


### PR DESCRIPTION
Clang is using C++17 standard version by default since Clang 16.

Swift’s ClangImporter should do the same, to make sure that clients who run clang and then swiftc without explicit std version see consistent behavior.

rdar://125777068