### PR TITLE
[stdlib][docs] Fix the SeeAlso documentation for `withDiscardingTaskGroup`

### DIFF
--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -66,7 +66,7 @@ import Swift
 /// For tasks that need to handle cancellation by throwing an error,
 /// use the `withThrowingDiscardingTaskGroup(returning:body:)` method instead.
 ///
-/// - SeeAlso: ``withThrowingDiscardingTaskGroup(returning:body:)
+/// - SeeAlso: ``withThrowingDiscardingTaskGroup(returning:body:)``
 @available(SwiftStdlib 5.9, *)
 @inlinable
 @_unsafeInheritExecutor


### PR DESCRIPTION
The SeeAlso documentation for `withDiscardingTaskGroup` is missing trailing backticks.