### PR TITLE
[6.0] Fix LifetimeDependenceDefUseWalker for address yields.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/AddressUtils.swift
@@ -127,7 +127,6 @@ extension AddressUseVisitor {
          is InitEnumDataAddrInst, is UncheckedTakeEnumDataAddrInst,
          is InitExistentialAddrInst, is OpenExistentialAddrInst,
          is ProjectBlockStorageInst, is UncheckedAddrCastInst,
-         is UnconditionalCheckedCastAddrInst,
          is MarkUninitializedInst, is DropDeinitInst,
          is CopyableToMoveOnlyWrapperAddrInst,
          is MoveOnlyWrapperToCopyableAddrInst,

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/LifetimeDependenceUtils.swift
@@ -1022,12 +1022,14 @@ extension LifetimeDependenceDefUseWalker {
       assert(!mdi.isUnresolved && !mdi.isNonEscaping,
              "should be handled as a dependence by AddressUseVisitor")
     }
-    if operand.instruction is ReturnInst, !operand.value.isEscapable {
-      return returnedDependence(result: operand)
+    if operand.instruction is YieldInst {
+      if operand.value.isEscapable {
+        return leafUse(of: operand)
+      } else {
+        return yieldedDependence(result: operand)
+      }
     }
-    if operand.instruction is YieldInst, !operand.value.isEscapable {
-      return yieldedDependence(result: operand)
-    }
+    // Escaping an address
     return escapingDependence(on: operand)
   }
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -1107,7 +1107,7 @@ final public class TuplePackElementAddrInst: SingleValueInstruction {
 
 final public class PackElementGetInst: SingleValueInstruction {}
 
-final public class PackElementSetInst: SingleValueInstruction {}
+final public class PackElementSetInst: Instruction {}
 
 final public class DifferentiableFunctionInst: SingleValueInstruction {}
 

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -529,9 +529,6 @@ final public class DeallocStackInst : Instruction, UnaryInstruction, Deallocatio
   }
 }
 
-final public class DeallocPackInst : Instruction, UnaryInstruction, Deallocation {}
-final public class DeallocPackMetadataInst : Instruction, Deallocation {}
-
 final public class DeallocStackRefInst : Instruction, UnaryInstruction, Deallocation {
   public var allocRef: AllocRefInstBase { operand.value as! AllocRefInstBase }
 }
@@ -702,12 +699,6 @@ class ValueMetatypeInst : SingleValueInstruction, UnaryInstruction {}
 
 final public
 class ExistentialMetatypeInst : SingleValueInstruction, UnaryInstruction {}
-
-final public class OpenPackElementInst : SingleValueInstruction {}
-final public class PackLengthInst : SingleValueInstruction {}
-final public class DynamicPackIndexInst : SingleValueInstruction {}
-final public class PackPackIndexInst : SingleValueInstruction {}
-final public class ScalarPackIndexInst : SingleValueInstruction {}
 
 final public class ObjCProtocolInst : SingleValueInstruction {}
 
@@ -1095,20 +1086,6 @@ final public class ObjectInst : SingleValueInstruction {
 final public class VectorInst : SingleValueInstruction {
 }
 
-final public class TuplePackExtractInst: SingleValueInstruction {
-  public var indexOperand: Operand { operands[0] }
-  public var tupleOperand: Operand { operands[1] }
-}
-
-final public class TuplePackElementAddrInst: SingleValueInstruction {
-  public var indexOperand: Operand { operands[0] }
-  public var tupleOperand: Operand { operands[1] }
-}
-
-final public class PackElementGetInst: SingleValueInstruction {}
-
-final public class PackElementSetInst: Instruction {}
-
 final public class DifferentiableFunctionInst: SingleValueInstruction {}
 
 final public class LinearFunctionInst: SingleValueInstruction {}
@@ -1141,9 +1118,6 @@ final public class AllocStackInst : SingleValueInstruction, Allocation, DebugVar
 final public class AllocVectorInst : SingleValueInstruction, Allocation, UnaryInstruction {
   public var capacity: Value { operand.value }
 }
-
-final public class AllocPackInst : SingleValueInstruction, Allocation {}
-final public class AllocPackMetadataInst : SingleValueInstruction, Allocation {}
 
 public class AllocRefInstBase : SingleValueInstruction, Allocation {
   final public var isObjC: Bool { bridged.AllocRefInstBase_isObjc() }
@@ -1362,6 +1336,36 @@ final public class DestructureStructInst : MultipleValueInstruction, UnaryInstru
 final public class DestructureTupleInst : MultipleValueInstruction, UnaryInstruction {
   public var `tuple`: Value { operand.value }
 }
+
+//===----------------------------------------------------------------------===//
+//                           parameter pack instructions
+//===----------------------------------------------------------------------===//
+
+final public class AllocPackInst : SingleValueInstruction, Allocation {}
+final public class AllocPackMetadataInst : SingleValueInstruction, Allocation {}
+
+final public class DeallocPackInst : Instruction, UnaryInstruction, Deallocation {}
+final public class DeallocPackMetadataInst : Instruction, Deallocation {}
+
+final public class OpenPackElementInst : SingleValueInstruction {}
+final public class PackLengthInst : SingleValueInstruction {}
+final public class DynamicPackIndexInst : SingleValueInstruction {}
+final public class PackPackIndexInst : SingleValueInstruction {}
+final public class ScalarPackIndexInst : SingleValueInstruction {}
+
+final public class TuplePackExtractInst: SingleValueInstruction {
+  public var indexOperand: Operand { operands[0] }
+  public var tupleOperand: Operand { operands[1] }
+}
+
+final public class TuplePackElementAddrInst: SingleValueInstruction {
+  public var indexOperand: Operand { operands[0] }
+  public var tupleOperand: Operand { operands[1] }
+}
+
+final public class PackElementGetInst: SingleValueInstruction {}
+
+final public class PackElementSetInst: Instruction {}
 
 //===----------------------------------------------------------------------===//
 //                            terminator instructions

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -432,7 +432,9 @@ final public class DebugStepInst : Instruction {}
 
 final public class SpecifyTestInst : Instruction {}
 
-final public class UnconditionalCheckedCastAddrInst : Instruction {
+final public class UnconditionalCheckedCastAddrInst : Instruction, SourceDestAddrInstruction {
+  public var isTakeOfSrc: Bool { true }
+  public var isInitializationOfDest: Bool { true }
   public override var mayTrap: Bool { true }
 }
 

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -556,6 +556,17 @@ struct ImmutableAddressUseVerifier {
     return false;
   }
 
+  /// Handle instructions that move a value from one address into another
+  /// address.
+  bool isConsumingOrMutatingMoveAddrUse(Operand *use) {
+    assert(use->getUser()->getNumOperands() == 2);
+    auto opIdx = use->getOperandNumber();
+    if (opIdx == CopyLikeInstruction::Dest)
+      return true;
+    assert(opIdx == CopyLikeInstruction::Src);
+    return false;
+  }
+
   bool isAddrCastToNonConsuming(SingleValueInstruction *i) {
     // Check if any of our uses are consuming. If none of them are consuming, we
     // are good to go.
@@ -679,6 +690,12 @@ struct ImmutableAddressUseVerifier {
         }
         return true;
       }
+      case SILInstructionKind::UnconditionalCheckedCastAddrInst:
+      case SILInstructionKind::UncheckedRefCastAddrInst:
+        if (isConsumingOrMutatingMoveAddrUse(use)) {
+          return true;
+        }
+        break;
       case SILInstructionKind::CheckedCastAddrBranchInst:
         switch (cast<CheckedCastAddrBranchInst>(inst)->getConsumptionKind()) {
         case CastConsumptionKind::BorrowAlways:

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -274,6 +274,44 @@ bb0(%0 : @guaranteed $C):
   return %99 : $()
 }
 
+// CHECK-LABEL: testInteriorUnconditionalAddrCast: interior-liveness with: %1
+// CHECK: Interior liveness: %1 = argument of bb0 : $D
+// CHECK-NEXT: bb0: LiveWithin
+// CHECK-NEXT: regular user:   [[FIELD:%.*]] = ref_element_addr %1 : $D, #D.object
+// CHECK-NEXT: regular user:   unconditional_checked_cast_addr C in [[FIELD]] : $*C to D in %0 : $*D
+// CHECK-NEXT: regular user:   copy_addr [take] %4 to [init] [[FIELD]] : $*C
+// CHECK-NEXT: regular user:   unchecked_ref_cast_addr  C in [[FIELD]] : $*C to D in %0 : $*D
+// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   unchecked_ref_cast_addr  C in [[FIELD]] : $*C to D in %0 : $*D
+// CHECK-NEXT: testInteriorUnconditionalAddrCast: interior-liveness with: %1
+
+// CHECK-LABEL: testInteriorUnconditionalAddrCast: interior_liveness_swift with: %1
+// CHECK: Interior liveness: %1 = argument of bb0 : $D
+// CHECK-NEXT: begin:      [[FIELD]] = ref_element_addr %1 : $D, #D.object
+// CHECK-NEXT: ends:       unchecked_ref_cast_addr  C in [[FIELD]] : $*C to D in %0 : $*D
+// CHECK-NEXT: exits:
+// CHECK-NEXT: interiors:  copy_addr [take] %4 to [init] [[FIELD]] : $*C
+// CHECK-NEXT:             unconditional_checked_cast_addr C in [[FIELD]] : $*C to D in %0 : $*D
+// CHECK-NEXT:             [[FIELD]] = ref_element_addr %1 : $D, #D.object
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   unchecked_ref_cast_addr  C in [[FIELD]] : $*C to D in %0 : $*D
+// CHECK-NEXT: testInteriorUnconditionalAddrCast: interior_liveness_swift with: %1
+sil [ossa] @testInteriorUnconditionalAddrCast : $@convention(thin) (@guaranteed D) -> @out D {
+bb0(%0 : $*D, %1 : @guaranteed $D):
+  specify_test "interior-liveness %1"
+  specify_test "interior_liveness_swift %1"
+  %c1 = ref_element_addr %1 : $D, #D.object
+  unconditional_checked_cast_addr C in %c1 : $*C to D in %0 : $*D
+  %c2 = unchecked_addr_cast %0 : $*D to $*C
+  copy_addr [take] %c2 to [init] %c1 : $*C
+  unchecked_ref_cast_addr C in %c1 : $*C to D in %0 : $*D
+  %99 = tuple()
+  return %99 : $()
+}
+
 // CHECK-LABEL: testInteriorReborrow: interior-liveness with: %borrow
 // CHECK: Complete liveness
 // CHECK-NEXT: Unenclosed phis {


### PR DESCRIPTION
Do not treat address yields as escapes.

--- CCC ---

Explanation: Fix LifetimeDependenceDefUseWalker for address yields.

Scope: Allows NonescapableTypes to be used with _modify accessors.

Radar/SR Issues: rdar://125752476 (UnsafeRawPointer property in non-escapable type doesn't compile)

Original PR: #72764

Risk: This fixes a latent bug in SIL utilities and verification. It reduces risk overall.

Testing: Unit tests added

Reviewer: TBD