### PR TITLE
[embedded] Default Embedded Concurrency to SWIFT_THREADING_PACKAGE=none

### DIFF
--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -199,6 +199,8 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
   set(SWIFT_CONCURRENCY_USES_DISPATCH FALSE)
   set(SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY TRUE)
   set(SWIFT_STDLIB_CONCURRENCY_TRACING FALSE)
+  set(SWIFT_STDLIB_HAS_ENVIRON FALSE)
+  set(SWIFT_STDLIB_HAS_ASL FALSE)
 
   foreach(entry ${EMBEDDED_STDLIB_TARGET_TRIPLES})
     string(REGEX REPLACE "[ \t]+" ";" list "${entry}")
@@ -220,9 +222,15 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
       set(extra_swift_compile_flags -Xcc -D__MACH__ -Xcc -D__APPLE__ -Xcc -ffreestanding)
     endif()
     
+    set(SWIFT_SDK_embedded_THREADING_PACKAGE none)
     set(SWIFT_SDK_embedded_ARCH_${mod}_MODULE "${mod}")
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
+
+    if("${mod}" MATCHES "-macos$")
+      set(SWIFT_SDK_embedded_THREADING_PACKAGE darwin)
+    endif()
+
     add_swift_target_library_single(
       embedded-concurrency-${mod}
       swift_Concurrency

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -227,10 +227,6 @@ if(SWIFT_SHOULD_BUILD_EMBEDDED_STDLIB AND SWIFT_SHOULD_BUILD_EMBEDDED_CONCURRENC
     set(SWIFT_SDK_embedded_LIB_SUBDIR "embedded")
     set(SWIFT_SDK_embedded_ARCH_${mod}_TRIPLE "${triple}")
 
-    if("${mod}" MATCHES "-macos$")
-      set(SWIFT_SDK_embedded_THREADING_PACKAGE darwin)
-    endif()
-
     add_swift_target_library_single(
       embedded-concurrency-${mod}
       swift_Concurrency

--- a/test/embedded/dependencies-concurrency.swift
+++ b/test/embedded/dependencies-concurrency.swift
@@ -9,7 +9,6 @@
 // Fail if there is any entry in actual-dependencies.txt that's not in allowed-dependencies.txt
 // RUN: test -z "`comm -13 %t/allowed-dependencies.txt %t/actual-dependencies.txt`"
 
-// DEP: __ZNSt3__111this_thread9sleep_forERKNS_6chrono8durationIxNS_5ratioILl1ELl1000000000EEEEE
 // DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6appendEPKc
 // DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6appendEPKcm
 // DEP: __ZNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEE6insertEmPKc
@@ -20,12 +19,12 @@
 // DEP: __ZdlPv
 // DEP: __Znwm
 // DEP: ___assert_rtn
+// DEP: ___error
 // DEP: ___stack_chk_fail
 // DEP: ___stack_chk_guard
 // DEP: ___stderrp
 // DEP: __availability_version_check
 // DEP: _abort
-// DEP: _asl_log
 // DEP: _dispatch_once_f
 // DEP: _dlsym
 // DEP: _exit
@@ -37,15 +36,9 @@
 // DEP: _fseek
 // DEP: _ftell
 // DEP: _malloc
-// DEP: _memcpy
 // DEP: _memset_s
-// DEP: _os_unfair_lock_lock
-// DEP: _os_unfair_lock_unlock
+// DEP: _nanosleep
 // DEP: _posix_memalign
-// DEP: _pthread_equal
-// DEP: _pthread_getspecific
-// DEP: _pthread_self
-// DEP: _pthread_setspecific
 // DEP: _putchar
 // DEP: _rewind
 // DEP: _sscanf


### PR DESCRIPTION
The Concurrency runtime (including Embedded Concurrency) can use different underlaying threading API via the SWIFT_THREADING_PACKAGE setting. The different options (C11 threads, PThreads, Darwin, etc.) have a large effect on what dependencies are expected to be provided by the platform. Given that Embedded Swift needs to support a variety of environments, including ones that do not have any threading APIs, the choice of the threading API should probably be a user-configurable option. Until we flesh that out, let's in the meantime default to building Embedded Concurrency as SWIFT_THREADING_PACKAGE=none -- which does not require any threading API (and e.g. locks are simply no-ops) and assumes we have a single-threaded environment.