### PR TITLE
[6.0][ASTGen/Macros] Ensure 'offset' from plugin response is valid

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -349,6 +349,10 @@ class PluginDiagnosticsEngine {
     guard let bufferBaseAddress = exportedSourceFile.pointee.buffer.baseAddress else {
       return nil
     }
+    // Ensure 'offset' is within the buffer.
+    guard offset <= exportedSourceFile.pointee.buffer.count else {
+      return nil
+    }
     return BridgedSourceLoc(raw: bufferBaseAddress).advanced(by: offset)
   }
 


### PR DESCRIPTION
Cherry-pick #72714 into `release/6.0`

* **Explanation**:  We see some crashes presumably caused by invalid `offset` returned from macro plugins. Although we haven't been able to find a reproducer, guard not to generate invalid source location by checking `offfset` is within the buffer length.
* **Scope**: Macro expansion
* **Risk**: Low, just adding a guard
* **Testing**: Passes current test cases. No additional test cases because we haven't found a reproducer
* **Issues**: rdar://125625879
* **Reviewer**: Ben Barham (@bnbarham)