### PR TITLE
[6.0 cherry-pick] [embedded] Relax verifier check on hidden-external functions in embedded mode

### DIFF
--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -7006,7 +7006,7 @@ public:
               "package-external function definition must be serialized");
       break;
     case SILLinkage::HiddenExternal:
-      require(F->isExternalDeclaration(),
+      require(F->isExternalDeclaration() || embedded,
               "hidden-external function cannot have a body");
       break;
     }

--- a/test/embedded/modules-subclasses.swift
+++ b/test/embedded/modules-subclasses.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+// BEGIN MyModule.swift
+
+open class Foo {
+    public init() {}
+    func test() {}
+}
+
+// BEGIN Main.swift
+
+import MyModule
+
+class Bar: Foo {}
+
+print("OK!")
+
+// CHECK: OK!


### PR DESCRIPTION
* **Explanation**: Relaxing a SIL verified check on Embedded Swift, to allow a linkage type that's expected in Embedded Swift, but otherwise illegal in regular Swift. https://github.com/apple/swift/pull/72690
* **Scope**: Embedded Swift only.
* **Risk**: Low, all changes only apply to Embedded Swift.
* **Testing**: Added test case.
* **Issue**: rdar://125791910, https://github.com/apple/swift/issues/72531
* **Reviewer**: @eeckstein, @DougGregor on https://github.com/apple/swift/pull/72690
