### PR TITLE
Respect trivially-destructible and copyable for zero-sized enum payloads

### DIFF
--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -153,11 +153,17 @@ protected:
   TypeInfoKind TIK;
   IsFixedSize_t AlwaysFixedSize;
   IsABIAccessible_t ElementsAreABIAccessible;
+  IsTriviallyDestroyable_t TriviallyDestroyable;
+  IsCopyable_t Copyable;
+  IsBitwiseTakable_t BitwiseTakable;
   unsigned NumElements;
   
   EnumImplStrategy(IRGenModule &IGM,
                    TypeInfoKind tik,
                    IsFixedSize_t alwaysFixedSize,
+                   IsTriviallyDestroyable_t triviallyDestroyable,
+                   IsCopyable_t copyable,
+                   IsBitwiseTakable_t bitwiseTakable,
                    unsigned NumElements,
                    std::vector<Element> &&ElementsWithPayload,
                    std::vector<Element> &&ElementsWithNoPayload);

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -388,3 +388,37 @@ func testEnclosesEmptyMoveOnlyWithDeinit() {
   // CHECK: call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
   _ = EnclosesEmptyMoveOnlyWithDeinit(stored: EmptyMoveOnlyWithDeinit())
 }
+
+enum ESingle: ~Copyable {
+  case a(EmptyMoveOnlyWithDeinit)
+}
+
+struct OtherEmptyMoveOnlyWithDeinit: ~Copyable {
+  deinit {}
+}
+
+enum EMulti: ~Copyable {
+  case a(EmptyMoveOnlyWithDeinit)
+  case b(OtherEmptyMoveOnlyWithDeinit)
+}
+
+
+// IR-LABEL: define {{.*}} swiftcc void @"$s16moveonly_deinits14testSingleEnumyyF"()
+func testSingleEnum() {
+  // IR: call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
+  _ = ESingle.a(EmptyMoveOnlyWithDeinit())
+}
+
+
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits13testMultiEnumyyF"()
+func testMultiEnum() {
+  // IR: call void @"$s16moveonly_deinits6EMultiOWOe"(i1 true)
+  _ = EMulti.b(OtherEmptyMoveOnlyWithDeinit())
+}
+
+// IR-LABEL: define {{.*}}void @"$s16moveonly_deinits6EMultiOWOe"
+// IR: br i1
+// IR: 1:
+// IR:  call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
+// IR: 2:
+// IR:  call swiftcc void @"$s16moveonly_deinits28OtherEmptyMoveOnlyWithDeinitVfD"()


### PR DESCRIPTION
Only the non-zero-sized associated values of a type were considered when determining whether an enum is copyable or was trivially-destructible, meaning that a zero-sized, noncopyable type with a `deinit` wouldn't get destroyed. Treat these associated values as if they were a payload, and centralize the logic for figuring out these overall aspects of the enum (copyable, trivially-destructible, bitwise-takable) since the same checks were repeated.

Fixes rdar://118449507.
