### PR TITLE
[6.0] Enable failable initializers of noncopyable types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7727,8 +7727,6 @@ ERROR(noncopyable_enums_do_not_support_indirect,none,
       "noncopyable enum %0 cannot be marked indirect or have indirect cases yet", (Identifier))
 ERROR(noncopyable_cast,none,
       "noncopyable types cannot be conditionally cast", ())
-ERROR(noncopyable_failable_init,none,
-      "noncopyable types cannot have failable initializers yet", ())
 ERROR(noncopyable_objc_enum, none,
       "noncopyable enums cannot be marked '@objc'", ())
 ERROR(moveOnly_not_allowed_here,none,

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -153,11 +153,17 @@ protected:
   TypeInfoKind TIK;
   IsFixedSize_t AlwaysFixedSize;
   IsABIAccessible_t ElementsAreABIAccessible;
+  IsTriviallyDestroyable_t TriviallyDestroyable;
+  IsCopyable_t Copyable;
+  IsBitwiseTakable_t BitwiseTakable;
   unsigned NumElements;
   
   EnumImplStrategy(IRGenModule &IGM,
                    TypeInfoKind tik,
                    IsFixedSize_t alwaysFixedSize,
+                   IsTriviallyDestroyable_t triviallyDestroyable,
+                   IsCopyable_t copyable,
+                   IsBitwiseTakable_t bitwiseTakable,
                    unsigned NumElements,
                    std::vector<Element> &&ElementsWithPayload,
                    std::vector<Element> &&ElementsWithNoPayload);

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -178,10 +178,10 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
       SpareBits.clear();
       IsFixedLayout = true;
       IsLoadable = true;
-      IsKnownTriviallyDestroyable = deinit;
-      IsKnownBitwiseTakable = IsBitwiseTakable;
-      IsKnownAlwaysFixedSize = IsFixedSize;
-      IsKnownCopyable = copyable;
+      IsKnownTriviallyDestroyable = deinit & builder.isTriviallyDestroyable();
+      IsKnownBitwiseTakable = builder.isBitwiseTakable();
+      IsKnownAlwaysFixedSize = builder.isAlwaysFixedSize();
+      IsKnownCopyable = copyable & builder.isCopyable();
       Ty = (typeToFill ? typeToFill : IGM.OpaqueTy);
     } else {
       MinimumAlign = builder.getAlignment();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -4035,16 +4035,6 @@ public:
       addDelayedFunction(CD);
     }
 
-    // a move-only / noncopyable type cannot have a failable initializer, since
-    // that would require the ability to wrap one inside an optional
-    if (CD->isFailable()) {
-      if (auto *nom = CD->getDeclContext()->getSelfNominalTypeDecl()) {
-        if (!nom->canBeCopyable()) {
-          CD->diagnose(diag::noncopyable_failable_init);
-        }
-      }
-    }
-
     checkDefaultArguments(CD->getParameters());
     checkVariadicParameters(CD->getParameters(), CD);
 

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -109,7 +109,7 @@ struct NeverCopyableDeinit<T: ~Copyable>: ~Copyable {
 }
 
 protocol Test: ~Copyable {
-  init?() // expected-error {{noncopyable types cannot have failable initializers yet}}
+  init?()
 }
 
 struct NoncopyableAndSendable: ~Copyable, Sendable {}

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -388,3 +388,37 @@ func testEnclosesEmptyMoveOnlyWithDeinit() {
   // CHECK: call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
   _ = EnclosesEmptyMoveOnlyWithDeinit(stored: EmptyMoveOnlyWithDeinit())
 }
+
+enum ESingle: ~Copyable {
+  case a(EmptyMoveOnlyWithDeinit)
+}
+
+struct OtherEmptyMoveOnlyWithDeinit: ~Copyable {
+  deinit {}
+}
+
+enum EMulti: ~Copyable {
+  case a(EmptyMoveOnlyWithDeinit)
+  case b(OtherEmptyMoveOnlyWithDeinit)
+}
+
+
+// IR-LABEL: define {{.*}} swiftcc void @"$s16moveonly_deinits14testSingleEnumyyF"()
+func testSingleEnum() {
+  // IR: call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
+  _ = ESingle.a(EmptyMoveOnlyWithDeinit())
+}
+
+
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits13testMultiEnumyyF"()
+func testMultiEnum() {
+  // IR: call void @"$s16moveonly_deinits6EMultiOWOe"(i1 true)
+  _ = EMulti.b(OtherEmptyMoveOnlyWithDeinit())
+}
+
+// IR-LABEL: define {{.*}}void @"$s16moveonly_deinits6EMultiOWOe"
+// IR: br i1
+// IR: 1:
+// IR:  call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
+// IR: 2:
+// IR:  call swiftcc void @"$s16moveonly_deinits28OtherEmptyMoveOnlyWithDeinitVfD"()

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -373,3 +373,18 @@ public func testKlassEnumPairWithDeinit() {
         consumeKlassEnumPairWithDeinit(f)
     }
 }
+
+struct EmptyMoveOnlyWithDeinit: ~Copyable {
+  deinit {}
+}
+
+struct EnclosesEmptyMoveOnlyWithDeinit: ~Copyable {
+  var stored: EmptyMoveOnlyWithDeinit
+}
+
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits35testEnclosesEmptyMoveOnlyWithDeinityyF"()
+func testEnclosesEmptyMoveOnlyWithDeinit() {
+  // CHECK-NOT: ret
+  // CHECK: call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
+  _ = EnclosesEmptyMoveOnlyWithDeinit(stored: EmptyMoveOnlyWithDeinit())
+}

--- a/test/SILGen/moveonly_failable_init.swift
+++ b/test/SILGen/moveonly_failable_init.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-emit-sil -module-name test %s | %FileCheck %s --enable-var-scope
+
+struct MoveWithDeinit: ~Copyable {
+  deinit { }
+}
+
+struct MyType: ~Copyable {
+  var handle: MoveWithDeinit
+
+  // CHECK-LABEL: sil hidden @$s4test6MyTypeV6handleACSgAA14MoveWithDeinitVSg_tcfC : $@convention(method) (@owned Optional<MoveWithDeinit>, @thin MyType.Type) -> @owned Optional<MyType>
+  // CHECK: bb0(%0 : $Optional<MoveWithDeinit>, %1 : $@thin MyType.Type):
+  init?(handle: consuming MoveWithDeinit?) {
+    // CHECK: switch_enum [[SUBJECT:%.*]] : $Optional<MoveWithDeinit>, case #Optional.some!enumelt: bb2, case #Optional.none!enumelt: bb1
+    guard let handle = consume handle else {
+      // CHECK: bb1:
+      // CHECK: [[NONE:%.*]] = enum $Optional<MyType>, #Optional.none!enumelt
+      // CHECK: br bb3([[NONE]] : $Optional<MyType>)
+      return nil
+    }
+
+    // CHECK: bb2([[WRAPPED:%.*]] : $MoveWithDeinit):
+    // CHECK: br bb3
+    self.handle = handle
+  }
+}
+
+func test() -> MyType? {
+  return MyType(handle: MoveWithDeinit())
+}

--- a/test/Sema/moveonly_restrictions.swift
+++ b/test/Sema/moveonly_restrictions.swift
@@ -6,13 +6,13 @@ class CopyableKlass {}
 
 @_moveOnly
 class MoveOnlyKlass { // expected-note 6{{class 'MoveOnlyKlass' has '~Copyable' constraint preventing 'Copyable' conformance}}
-    init?() {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init?() {}
 }
 
 @_moveOnly
 struct MoveOnlyStruct { // expected-note {{struct 'MoveOnlyStruct' has '~Copyable' constraint preventing 'Copyable' conformance}}
-    init?(one: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
-    init!(two: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init?(one: Bool) {}
+    init!(two: Bool) {}
 }
 
 class C {
@@ -78,19 +78,19 @@ enum EMoveOnly {
     case lhs(CopyableKlass)
     case rhs(MoveOnlyKlass)
 
-    init?() {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init?() {}
 }
 
 extension EMoveOnly {
-    init!(three: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init!(three: Bool) {}
 }
 
 extension MoveOnlyKlass {
-    convenience init?(three: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    convenience init?(three: Bool) {}
 }
 
 extension MoveOnlyStruct {
-    init?(three: Bool) {} // expected-error {{noncopyable types cannot have failable initializers yet}}
+    init?(three: Bool) {}
 }
 
 func foo() {


### PR DESCRIPTION
* **Explanation**: Failable initializers (e.g., `init?`) were disabled on noncopyable types early on because `Optional` couldn't support noncopyable types. Now that it does, lift this restriction, fixing two miscompiles involving empty noncopyable types with `deinit`s along the way.
* **Issue**: rdar://118449507
* **Original PR**: https://github.com/apple/swift/pull/72757, https://github.com/apple/swift/pull/72778
* **Reviewers**: @kavon, @slavapestov 
* **Risk**: Low. Lifting a restriction on a new feature doesn't affect any existing code. There is some refactoring in the enum layout code for the bug fix of rdar://118449507, but it's narrowly focused.
* **Testing**: New tests.
