### PR TITLE
Runtime: add a non-Darwin error message storage

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -127,6 +127,11 @@ void swift_reportError(uint32_t flags, const char *message);
 SWIFT_RUNTIME_EXPORT
 void swift_reportWarning(uint32_t flags, const char *message);
 
+#if !defined(SWIFT_HAVE_CRASHREPORTERCLIENT)
+SWIFT_RUNTIME_EXPORT
+std::atomic<const char *> *swift_getFatalErrorMessageBuffer();
+#endif
+
 // Halt due to an overflow in swift_retain().
 SWIFT_RUNTIME_ATTRIBUTE_NORETURN SWIFT_RUNTIME_ATTRIBUTE_NOINLINE
 void swift_abortRetainOverflow();

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -34,6 +34,7 @@
 
 #include "ImageInspection.h"
 #include "swift/Demangling/Demangle.h"
+#include "swift/Runtime/Atomic.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Portability.h"
 #include "swift/Runtime/Win32.h"
@@ -64,13 +65,14 @@
 #include <inttypes.h>
 
 #ifdef SWIFT_HAVE_CRASHREPORTERCLIENT
-#include <atomic>
 #include <malloc/malloc.h>
-
-#include "swift/Runtime/Atomic.h"
+#else
+static std::atomic<const char *> kFatalErrorMessage;
 #endif // SWIFT_HAVE_CRASHREPORTERCLIENT
 
 #include "BacktracePrivate.h"
+
+#include <atomic>
 
 namespace FatalErrorFlags {
 enum: uint32_t {
@@ -297,7 +299,23 @@ reportOnCrash(uint32_t flags, const char *message)
              std::memory_order_release,
              SWIFT_MEMORY_ORDER_CONSUME));
 #else
-  // empty
+  const char *previous = nullptr;
+  char *current = nullptr;
+  previous =
+      std::atomic_load_explicit(&kFatalErrorMessage, SWIFT_MEMORY_ORDER_CONSUME);
+
+  do {
+    ::free(current);
+    current = nullptr;
+
+    if (previous)
+      swift_asprintf(&current, "%s%s", current, message);
+    else
+      current = ::strdup(message);
+  } while (!std::atomic_compare_exchange_strong_explicit(&kFatalErrorMessage,
+                                                         &previous, current,
+                                                         std::memory_order_release,
+                                                         SWIFT_MEMORY_ORDER_CONSUME));
 #endif // SWIFT_HAVE_CRASHREPORTERCLIENT
 }
 
@@ -420,6 +438,12 @@ swift::warning(uint32_t flags, const char *format, ...)
 void swift::swift_reportWarning(uint32_t flags, const char *message) {
   warning(flags, "%s", message);
 }
+
+#if !defined(SWIFT_HAVE_CRASHREPORTERCLIENT)
+std::atomic<const char *> *swift::swift_getFatalErrorMessageBuffer() {
+  return &kFatalErrorMessage;
+}
+#endif
 
 // Crash when a deleted method is called by accident.
 SWIFT_RUNTIME_EXPORT SWIFT_NORETURN void swift_deletedMethodError() {


### PR DESCRIPTION
This introduces a non-Darwin (non-CrashReporter) storage for error messages to allow extraction for crash reporting. This is initially meant to be used on Windows, though it is generic enough to be used on any platform.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
