### PR TITLE
Runtime checking for associated types conforming to invertible protocols

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2530,8 +2530,6 @@ void ASTMangler::appendModule(const ModuleDecl *module,
 /// Mangle the name of a protocol as a substitution candidate.
 void ASTMangler::appendProtocolName(const ProtocolDecl *protocol,
                                     bool allowStandardSubstitution) {
-  assert(!protocol->getInvertibleProtocolKind() &&
-          "only inverse requirements are mangled");
   assert(AllowMarkerProtocols || !protocol->isMarkerProtocol());
 
   if (allowStandardSubstitution && tryAppendStandardSubstitution(protocol))

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -153,11 +153,17 @@ protected:
   TypeInfoKind TIK;
   IsFixedSize_t AlwaysFixedSize;
   IsABIAccessible_t ElementsAreABIAccessible;
+  IsTriviallyDestroyable_t TriviallyDestroyable;
+  IsCopyable_t Copyable;
+  IsBitwiseTakable_t BitwiseTakable;
   unsigned NumElements;
   
   EnumImplStrategy(IRGenModule &IGM,
                    TypeInfoKind tik,
                    IsFixedSize_t alwaysFixedSize,
+                   IsTriviallyDestroyable_t triviallyDestroyable,
+                   IsCopyable_t copyable,
+                   IsBitwiseTakable_t bitwiseTakable,
                    unsigned NumElements,
                    std::vector<Element> &&ElementsWithPayload,
                    std::vector<Element> &&ElementsWithNoPayload);

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SILOptimizer/Utils/CastOptimizer.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/SubstitutionMap.h"
@@ -1470,6 +1471,10 @@ static bool optimizeStaticallyKnownProtocolConformance(
     // valid conformance will be returned.
     auto Conformance = SM->checkConformance(SourceType, Proto);
     if (Conformance.isInvalid())
+      return false;
+
+    auto layout = TargetType->getExistentialLayout();
+    if (layout.getProtocols().size() != 1)
       return false;
 
     SILBuilderWithScope B(Inst);

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -388,3 +388,37 @@ func testEnclosesEmptyMoveOnlyWithDeinit() {
   // CHECK: call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
   _ = EnclosesEmptyMoveOnlyWithDeinit(stored: EmptyMoveOnlyWithDeinit())
 }
+
+enum ESingle: ~Copyable {
+  case a(EmptyMoveOnlyWithDeinit)
+}
+
+struct OtherEmptyMoveOnlyWithDeinit: ~Copyable {
+  deinit {}
+}
+
+enum EMulti: ~Copyable {
+  case a(EmptyMoveOnlyWithDeinit)
+  case b(OtherEmptyMoveOnlyWithDeinit)
+}
+
+
+// IR-LABEL: define {{.*}} swiftcc void @"$s16moveonly_deinits14testSingleEnumyyF"()
+func testSingleEnum() {
+  // IR: call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
+  _ = ESingle.a(EmptyMoveOnlyWithDeinit())
+}
+
+
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits13testMultiEnumyyF"()
+func testMultiEnum() {
+  // IR: call void @"$s16moveonly_deinits6EMultiOWOe"(i1 true)
+  _ = EMulti.b(OtherEmptyMoveOnlyWithDeinit())
+}
+
+// IR-LABEL: define {{.*}}void @"$s16moveonly_deinits6EMultiOWOe"
+// IR: br i1
+// IR: 1:
+// IR:  call swiftcc void @"$s16moveonly_deinits23EmptyMoveOnlyWithDeinitVfD"()
+// IR: 2:
+// IR:  call swiftcc void @"$s16moveonly_deinits28OtherEmptyMoveOnlyWithDeinitVfD"()

--- a/test/Interpreter/moveonly_generics_casting.swift
+++ b/test/Interpreter/moveonly_generics_casting.swift
@@ -125,8 +125,7 @@ func main() {
   attemptCall(Dog<Any>())
 
   // CHECK-FIXME: failed to cast (attemptCall)
-  typealias NoncopyableAny = ~Copyable
-  // FIXME crashes: attemptCall(Dog<any NoncopyableAny>())
+  // FIXME crashes: attemptCall(Dog<any ~Copyable>())
 
   // CHECK: cast succeeded
   test_radar124171788(.nothing)

--- a/test/Interpreter/moveonly_generics_casting_assoctypes.swift
+++ b/test/Interpreter/moveonly_generics_casting_assoctypes.swift
@@ -1,0 +1,36 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes)
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+protocol P: ~Copyable {
+  associatedtype A: ~Copyable
+}
+
+protocol Q: ~Copyable { }
+
+struct X<T: P & ~Copyable> { }
+
+extension X: Q where T: ~Copyable, T.A: Copyable { }
+
+struct NC: ~Copyable { }
+
+struct WithCopyable: P {
+  typealias A = Int
+}
+
+struct WithNonCopyable: P {
+  typealias A = NC
+}
+
+func tryCastToQ<T: P>(_: T.Type) -> Q? {
+  let x = X<T>()
+  return x as? Q
+}
+
+precondition(tryCastToQ(_: WithCopyable.self) != nil)
+precondition(tryCastToQ(_: WithNonCopyable.self) == nil)
+


### PR DESCRIPTION
Emit metadata for runtime checks of conformances of associated types to
invertible protocols, e.g., `T.Assoc: Copyable`. This allows us to
correctly handle, e.g., dynamic casting involving conditional
conformances that have such constraints.

The model we use here is to emit an invertible-protocol constraint
that leaves only the specific bit clear in the invertible protocol
set.