### PR TITLE
Update SimplifyCFG's replacement of phi with its incoming value

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -8401,7 +8401,7 @@ switch_value
   // FIXME: All destination labels currently must take no arguments
 
 Conditionally branches to one of several destination basic blocks based on a
-value of builtin integer or function type. If the operand value matches one of the ``case``
+value of builtin integer. If the operand value matches one of the ``case``
 values of the instruction, control is transferred to the corresponding basic
 block. If there is a ``default`` basic block, control is transferred to it if
 the value does not match any of the ``case`` values. It is undefined behavior

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -10224,7 +10224,7 @@ public:
   std::optional<unsigned> getUniqueCaseForDestination(SILBasicBlock *bb) const {
     for (unsigned i = 0; i < getNumCases(); ++i) {
       if (getCase(i).second == bb) {
-        return i + 1;
+        return i;
       }
     }
     return std::nullopt;

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -228,6 +228,13 @@ bool MemoryLifetimeVerifier::isTrivialEnumSuccessor(SILBasicBlock *block,
   } else if (auto *switchEnumAddr = dyn_cast<SwitchEnumAddrInst>(term)) {
     elem = switchEnumAddr->getUniqueCaseForDestination(succ);
     enumTy = switchEnumAddr->getOperand()->getType();
+  } else if (auto *switchValue = dyn_cast<SwitchValueInst>(term)) {
+    auto destCase = switchValue->getUniqueCaseForDestination(succ);
+    assert(destCase.has_value());
+    auto caseValue =
+        cast<IntegerLiteralInst>(switchValue->getCase(*destCase).first);
+    auto testValue = dyn_cast<IntegerLiteralInst>(switchValue->getOperand());
+    return testValue ? testValue->getValue() != caseValue->getValue() : true;
   } else {
     return false;
   }

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5227,9 +5227,8 @@ public:
   void checkSwitchValueInst(SwitchValueInst *SVI) {
     // TODO: Type should be either integer or function
     auto Ty = SVI->getOperand()->getType();
-    require(Ty.is<BuiltinIntegerType>() || Ty.is<SILFunctionType>(),
-            "switch_value operand should be either of an integer "
-            "or function type");
+    require(Ty.is<BuiltinIntegerType>(),
+            "switch_value operand should be an integer");
 
     auto ult = [](const SILValue &a, const SILValue &b) { 
       return a == b || a < b; 

--- a/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
+++ b/lib/SILOptimizer/Mandatory/YieldOnceCheck.cpp
@@ -496,7 +496,7 @@ class YieldOnceCheck : public SILFunctionTransform {
             switchValue->getUniqueCaseForDestination(noYieldTarget);
         assert(caseNumberOpt.has_value());
 
-        auto caseNumber = caseNumberOpt.value();
+        auto caseNumber = caseNumberOpt.value() + 1;
         diagnose(
             astCtx, enumCaseLoc, diag::switch_value_case_doesnt_yield,
             (Twine(caseNumber) + llvm::getOrdinalSuffix(caseNumber)).str());

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -3794,12 +3794,24 @@ static void tryToReplaceArgWithIncomingValue(SILBasicBlock *BB, unsigned i,
   if (!A->getIncomingPhiValues(Incoming) || Incoming.empty())
     return;
   
-  SILValue V = Incoming[0];
-  for (size_t Idx = 1, Size = Incoming.size(); Idx < Size; ++Idx) {
-    if (Incoming[Idx] != V)
+  SILValue V;
+  for (size_t Idx = 0; Idx < Incoming.size(); ++Idx) {
+    if (Incoming[Idx] == A) {
+      continue;
+    }
+    if (!V) {
+      V = Incoming[Idx];
+      continue;
+    }
+    if (Incoming[Idx] != V) {
       return;
+    }
   }
   
+  if (!V) {
+    return;
+  }
+
   // If the incoming values of all predecessors are equal usually this means
   // that the common incoming value dominates the BB. But: this might be not
   // the case if BB is unreachable. Therefore we still have to check it.

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -973,51 +973,6 @@ bb3:
   return %t : $()
 }
 
-// CHECK-LABEL: sil @test_switch_value : $@convention(thin) (Builtin.Word) -> ()
-sil @test_switch_value : $@convention(thin) (Builtin.Word) -> () {
-bb0(%0 : $Builtin.Word):
-  // CHECK: switch_value %{{.*}} : $Builtin.Word, case %1: bb1, case %2: bb2
-  %1 = integer_literal $Builtin.Word, 1
-  %2 = integer_literal $Builtin.Word, 2
-  switch_value %0 : $Builtin.Word, case %1: bb1, case %2: bb2
-
-bb1:
-  %7 = function_ref @_T6switch1aFT_T_ : $@convention(thin) () -> () // CHECK: function_ref
-  %8 = apply %7() : $@convention(thin) () -> ()
-  br bb3
-
-bb2:
-  %12 = function_ref @_T6switch1bFT_T_ : $@convention(thin) () -> () // CHECK: function_ref
-  %13 = apply %12() : $@convention(thin) () -> ()
-  br bb3
-
-bb3:
-  // CHECK: [[FUNC1:%.*]] = function_ref @_T6switch1aFT_T_
-  // CHECK: [[FUNC2:%.*]] = function_ref @_T6switch1bFT_T_
-  // CHECK: switch_value %{{.*}} : $@convention(thin) () -> (), case [[FUNC1]]: bb4, case [[FUNC2]]: bb5
-  %20 = function_ref @_T6switch1bFT_T_ : $@convention(thin) () -> ()
-  %21 = function_ref @_T6switch1aFT_T_ : $@convention(thin) () -> ()
-  %22 = function_ref @_T6switch1bFT_T_ : $@convention(thin) () -> ()
-  switch_value %20 : $@convention(thin) () -> (), case %21: bb4, case %22: bb5
-
-bb4:
-  // CHECK: function_ref
-  %37 = function_ref @_T6switch1aFT_T_ : $@convention(thin) () -> ()
-  %38 = apply %37() : $@convention(thin) () -> ()
-  br bb6
-
-bb5:
-  // CHECK: function_ref
-  %42 = function_ref @_T6switch1bFT_T_ : $@convention(thin) () -> ()
-  %43 = apply %42() : $@convention(thin) () -> ()
-  br bb6
-
-bb6:
-  %18 = tuple ()
-  // CHECK: return
-  return %18 : $()
-}
-
 class ConcreteClass : ClassP {
 }
 struct Spoon : Bendable {

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -287,17 +287,6 @@ bb2:
   return undef : $()
 }
 
-sil @switch_value_test : $() -> () {
-bb0:
-  // CHECK: switch_value undef : $Builtin.Int1, case undef: bb1
-  switch_value undef : $Builtin.Int1, case undef: bb1
-bb1:
-  // CHECK: switch_value undef : $() -> (), case undef: bb2
-  switch_value undef : $() -> (), case undef: bb2
-bb2:
-  return undef : $()
-}
-
 sil @switch_enum_test : $() -> () {
 bb0:
   // CHECK: switch_enum undef : $E, case #E.Case!enumelt: bb1, default bb2

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -781,3 +781,28 @@ bb0:
   %7 = tuple ()
   return %7 : $()
 }
+
+sil [ossa] @test_init_enum_switch_value : $@convention(thin) (@in_guaranteed Optional<T>, @in_guaranteed T) -> () {
+bb0(%0 : $*Optional<T>, %1 : $*T):
+  %stk = alloc_stack $Optional<T>
+  %2 = init_enum_data_addr %stk : $*Optional<T>, #Optional.some!enumelt
+  copy_addr %1 to [init] %2 : $*T
+  inject_enum_addr %stk : $*Optional<T>, #Optional.some!enumelt
+  %one = integer_literal $Builtin.Word, 1
+  %two = integer_literal $Builtin.Word, 2
+  switch_value %one : $Builtin.Word, case %one: bb1, case %two: bb2
+
+bb1:
+  destroy_addr %stk : $*Optional<T>
+  dealloc_stack %stk : $*Optional<T>
+  br bb3
+
+bb2:
+  dealloc_stack %stk : $*Optional<T>
+  br bb3
+
+bb3:
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1347,20 +1347,20 @@ bb3(%16 : $Int32):                                  // Preds: bb1 bb2
 }
 
 // CHECK-LABEL: sil [ossa] @enum_promotion_of_concrete_types
-// XHECK: bb0([[INT_PTR:%[0-9]+]]
-// XHECK-NEXT: [[ALLOCA1:%[0-9]+]] = alloc_stack $FakeOptional<Builtin.Int1>
-// XHECK-NEXT: [[ENUM1:%[0-9]+]] = enum $FakeOptional<Builtin.Int1>, #FakeOptional.none!enumelt
-// XHECK-NEXT: store [[ENUM1]] to [trivial] [[ALLOCA1]]
-// XHECK-NEXT: [[ALLOCA2:%[0-9]+]] = alloc_stack $FakeOptional<Builtin.Int1>
-// XHECK-NEXT: [[INT:%[0-9]+]] = load [trivial] [[INT_PTR]] : $*Builtin.Int1
-// XHECK-NEXT: [[ENUM2:%[0-9]+]] = enum $FakeOptional<Builtin.Int1>, #FakeOptional.some!enumelt, [[INT]] : $Builtin.Int1
-// XHECK-NEXT: store [[ENUM2]] to [trivial] [[ALLOCA2]] : $*FakeOptional<Builtin.Int1>
-// XHECK-NEXT: [[RESULT1:%[0-9]+]] = load [trivial] [[ALLOCA1]]
-// XHECK-NEXT: [[RESULT2:%[0-9]+]] = load [trivial] [[ALLOCA2]]
-// XHECK-NEXT: [[RESULT:%[0-9]+]] = tuple ([[RESULT1]] : $FakeOptional<Builtin.Int1>, [[RESULT2]] : $FakeOptional<Builtin.Int1>)
-// XHECK-NEXT: dealloc_stack
-// XHECK-NEXT: dealloc_stack
-// XHECK-NEXT: return [[RESULT]]
+// CHECK: bb0([[INT_PTR:%[0-9]+]]
+// CHECK-NEXT: [[ALLOCA1:%[0-9]+]] = alloc_stack $FakeOptional<Builtin.Int1>
+// CHECK-NEXT: [[ENUM1:%[0-9]+]] = enum $FakeOptional<Builtin.Int1>, #FakeOptional.none!enumelt
+// CHECK-NEXT: store [[ENUM1]] to [trivial] [[ALLOCA1]]
+// CHECK-NEXT: [[ALLOCA2:%[0-9]+]] = alloc_stack $FakeOptional<Builtin.Int1>
+// CHECK-NEXT: [[INT:%[0-9]+]] = load [trivial] [[INT_PTR]] : $*Builtin.Int1
+// CHECK-NEXT: [[ENUM2:%[0-9]+]] = enum $FakeOptional<Builtin.Int1>, #FakeOptional.some!enumelt, [[INT]] : $Builtin.Int1
+// CHECK-NEXT: store [[ENUM2]] to [trivial] [[ALLOCA2]] : $*FakeOptional<Builtin.Int1>
+// CHECK-NEXT: [[RESULT1:%[0-9]+]] = load [trivial] [[ALLOCA1]]
+// CHECK-NEXT: [[RESULT2:%[0-9]+]] = load [trivial] [[ALLOCA2]]
+// CHECK-NEXT: [[RESULT:%[0-9]+]] = tuple ([[RESULT1]] : $FakeOptional<Builtin.Int1>, [[RESULT2]] : $FakeOptional<Builtin.Int1>)
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: return [[RESULT]]
 sil [ossa] @enum_promotion_of_concrete_types : $@convention(thin) (@in Builtin.Int1) -> (FakeOptional<Builtin.Int1>, FakeOptional<Builtin.Int1>) {
 bb0(%0 : $*Builtin.Int1):
   %1 = alloc_stack $FakeOptional<Builtin.Int1>
@@ -1384,24 +1384,24 @@ bb0(%0 : $*Builtin.Int1):
 }
 
 // CHECK-LABEL: sil [ossa] @enum_promotion_case2
-// XHECK: bb0([[B_PTR:%[0-9]+]]
-// XHECK-NEXT: [[ALLOCA:%[0-9]+]] = alloc_stack $FakeOptional<B>
-// XHECK-NEXT: [[B_PTR_COPY_FOR_ENUM:%.*]] = copy_value [[B_PTR]]
+// CHECK: bb0([[B_PTR:%[0-9]+]]
+// CHECK-NEXT: [[ALLOCA:%[0-9]+]] = alloc_stack $FakeOptional<B>
+// CHECK-NEXT: [[B_PTR_COPY_FOR_ENUM:%.*]] = copy_value [[B_PTR]]
 // This copy is the copy that was between the init_enum_data_addr/inject_enum_addr
-// XHECK-NEXT: [[B_PTR_COPY_NOT_OBSTRUCTING:%.*]] = copy_value [[B_PTR]]
-// XHECK-NEXT: [[ENUM:%[0-9]+]] = enum $FakeOptional<B>, #FakeOptional.some!enumelt, [[B_PTR_COPY_FOR_ENUM]] : $B
-// XHECK-NEXT: store [[ENUM]] to [init] [[ALLOCA]]
-// XHECK-NEXT: [[RESULT:%[0-9]+]] = load [take] [[ALLOCA]]
-// XHECK-NEXT: dealloc_stack
-// XHECK-NEXT: destroy_value [[B_PTR]]
-// XHECK-NEXT: br bb1
-// XHECK: bb1:
-// XHECK-NEXT: // function_ref
-// XHECK-NEXT: function_ref
-// XHECK-NEXT: apply
-// XHECK-NEXT: destroy_value [[B_PTR_COPY_NOT_OBSTRUCTING]]
-// XHECK-NEXT: return [[RESULT]]
-// XHECK: } // end sil function 'enum_promotion_case2'
+// CHECK-NEXT: [[B_PTR_COPY_NOT_OBSTRUCTING:%.*]] = copy_value [[B_PTR]]
+// CHECK-NEXT: [[ENUM:%[0-9]+]] = enum $FakeOptional<B>, #FakeOptional.some!enumelt, [[B_PTR_COPY_FOR_ENUM]] : $B
+// CHECK-NEXT: store [[ENUM]] to [init] [[ALLOCA]]
+// CHECK-NEXT: [[RESULT:%[0-9]+]] = load [take] [[ALLOCA]]
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: destroy_value [[B_PTR]]
+// CHECK-NEXT: br bb1
+// CHECK: bb1:
+// CHECK-NEXT: // function_ref
+// CHECK-NEXT: function_ref
+// CHECK-NEXT: apply
+// CHECK-NEXT: destroy_value [[B_PTR_COPY_NOT_OBSTRUCTING]]
+// CHECK-NEXT: return [[RESULT]]
+// CHECK: } // end sil function 'enum_promotion_case2'
 sil [ossa] @enum_promotion_case2 : $@convention(thin) (@owned B) -> @owned FakeOptional<B> {
 bb0(%0 : @owned $B):
   %2 = alloc_stack $FakeOptional<B>
@@ -1428,27 +1428,27 @@ bb1:
 
 // Negative test corresponding to the previous test.
 // CHECK-LABEL: sil [ossa] @no_enum_promotion_of_non_concrete_types
-// XHECK: bb0
-// XHECK-NEXT: alloc_stack $FakeOptional<T>
-// XHECK-NEXT: inject_enum_addr {{%[0-9]+}} : $*FakeOptional<T>, #FakeOptional.none!enumelt
-// XHECK-NEXT: alloc_stack $FakeOptional<T>
-// XHECK-NEXT: init_enum_data_addr {{%[0-9]+}} : $*FakeOptional<T>, #FakeOptional.some!enumelt
-// XHECK-NEXT: copy_addr
-// XHECK-NEXT: inject_enum_addr
-// XHECK-NEXT: cond_br
-// XHECK: bb1:
-// XHECK-NEXT: copy_addr
-// XHECK-NEXT: destroy_addr
-// XHECK-NEXT: br bb3
-// XHECK: bb2:
-// XHECK-NEXT: copy_addr
-// XHECK-NEXT: destroy_addr
-// XHECK-NEXT: br bb3
-// XHECK: bb3
-// XHECK-NEXT: tuple
-// XHECK-NEXT: dealloc_stack
-// XHECK-NEXT: dealloc_stack
-// XHECK-NEXT: return
+// CHECK: bb0
+// CHECK-NEXT: alloc_stack $FakeOptional<T>
+// CHECK-NEXT: inject_enum_addr {{%[0-9]+}} : $*FakeOptional<T>, #FakeOptional.none!enumelt
+// CHECK-NEXT: alloc_stack $FakeOptional<T>
+// CHECK-NEXT: init_enum_data_addr {{%[0-9]+}} : $*FakeOptional<T>, #FakeOptional.some!enumelt
+// CHECK-NEXT: copy_addr
+// CHECK-NEXT: inject_enum_addr
+// CHECK-NEXT: cond_br
+// CHECK: bb1:
+// CHECK-NEXT: copy_addr
+// CHECK-NEXT: destroy_addr
+// CHECK-NEXT: br bb3
+// CHECK: bb2:
+// CHECK-NEXT: copy_addr
+// CHECK-NEXT: destroy_addr
+// CHECK-NEXT: br bb3
+// CHECK: bb3
+// CHECK-NEXT: tuple
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: dealloc_stack
+// CHECK-NEXT: return
 sil [ossa] @no_enum_promotion_of_non_concrete_types : $@convention(thin) <T> (@inout T, Builtin.Int1) -> @out FakeOptional<T> {
 bb0(%0 : $*FakeOptional<T>, %1 : $*T, %2 : $Builtin.Int1):
   %3 = alloc_stack $FakeOptional<T>

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1474,7 +1474,7 @@ bb7(%r : $Builtin.Int32, %carg2 : $Builtin.Int32):
 // CHECK-LABEL: sil @jumpthread_switch_enum5
 // CHECK:      bb0:
 // CHECK:        br bb1
-// CHECK:      bb1({{.*}}):
+// CHECK:      bb1:
 // CHECK-NEXT:   cond_br undef, bb2, bb3
 // CHECK:      bb2:
 // CHECK:        br bb1
@@ -2190,9 +2190,9 @@ sil @f_use : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb3
 
 // CHECK: bb3{{.*}}
-// CHECK:  br bb5({{.*}} : $Builtin.Int32, %2 : $Builtin.Int32, [[EXT]]
+// CHECK:  br bb5(%2 : $Builtin.Int32, [[EXT]]
 
-// CHECK: bb5({{.*}} : $Builtin.Int32, [[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
+// CHECK: bb5([[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
 // CHECK:  [[F:%.*]] = function_ref @f
 // CHECK:  apply [[F]]([[CUR]])
 // CHECK:  cond_br {{.*}}, bb7, bb6
@@ -2200,7 +2200,7 @@ sil @f_use : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK: bb7:
 // CHECK:   [[VARADD:%.*]] = builtin "sadd_with_overflow_Int32"([[NEXT]] : $Builtin.Int32
 // CHECK:   [[NEXT2:%.*]] = tuple_extract [[VARADD]]
-// CHECK:   br bb5({{.*}} : $Builtin.Int32, [[NEXT]] : $Builtin.Int32, [[NEXT2]]
+// CHECK:   br bb5([[NEXT]] : $Builtin.Int32, [[NEXT2]]
 
 
 sil @switch_enum_jumpthreading_bug : $@convention(thin) (Optional<Builtin.Int32>, Builtin.Int1, Builtin.Int32, Builtin.Int1) -> Builtin.Int32 {

--- a/test/SILOptimizer/simplify_cfg_args_crash.sil
+++ b/test/SILOptimizer/simplify_cfg_args_crash.sil
@@ -48,16 +48,33 @@ struct Pair {
 // CHECK-LABEL: @simplify_args_crash
 sil @simplify_args_crash : $@convention(thin) (Pair) -> () {
 bb0(%1 : $Pair):
-  // CHECK: [[SECOND:%.*]] = struct_extract %0 : $Pair, #Pair.second
-  // CHECK: [[FIRST:%.*]] = struct_extract %0 : $Pair, #Pair.first
-  // CHECK: br bb1([[FIRST]] : $C, [[SECOND]] : $C)
+// CHECK: bb0
+// CHECK-NEXT: br bb1
   br bb1(%1 : $Pair)
 
-// CHECK: bb1([[FIRST2:%.*]] : $C, [[SECOND2:%.*]] : $C):
 bb1(%2 : $Pair):
-  // CHECK: [[STRUCT:%.*]] = struct $Pair ([[FIRST2]] : $C, [[SECOND2]] : $C)
-  // CHECK: [[SECOND3:%.*]] = struct_extract [[STRUCT]] : $Pair, #Pair.second
-  // CHECK: [[FIRST3:%.*]] = struct_extract [[STRUCT]] : $Pair, #Pair.first
-  // CHECK: br bb1([[FIRST3]] : $C, [[SECOND3]] : $C)
   br bb1(%2 : $Pair)
 }
+
+// CHECK-LABEL: sil [ossa] @redundant_phi_unreachable : $@convention(thin) () -> () {
+// CHECK: bb1({{.*}}):
+// CHECK-LABEL: } // end sil function 'redundant_phi_unreachable'
+sil [ossa] @redundant_phi_unreachable : $@convention(thin) () -> () {
+bb0:
+  %1 = integer_literal $Builtin.Int32, 37
+  br bb3
+
+bb1(%3 : $Builtin.Int32):
+  cond_br undef, bb2, bb4
+
+bb2:
+  br bb1(%3 : $Builtin.Int32)
+
+bb4:
+  br bb3
+
+bb3:
+  %r = tuple()
+  return %r : $()
+}
+

--- a/test/SILOptimizer/simplify_cfg_args_ossa.sil
+++ b/test/SILOptimizer/simplify_cfg_args_ossa.sil
@@ -790,3 +790,22 @@ bb8:
   %25 = tuple ()
   return %25 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @replace_with_incoming_value : $@convention(thin) () -> () {
+// CHECK: bb1:
+// CHECK-LABEL: } // end sil function 'replace_with_incoming_value'
+sil [ossa] @replace_with_incoming_value : $@convention(thin) () -> () {
+bb0:
+  %1 = integer_literal $Builtin.Int32, 37
+  br bb1(%1 : $Builtin.Int32)
+
+bb1(%3 : $Builtin.Int32):
+  cond_br undef, bb2, bb3
+
+bb2:
+  br bb1(%3 : $Builtin.Int32)
+
+bb3:
+  %r = tuple()
+  return %r : $()
+}

--- a/test/SILOptimizer/simplify_cfg_ossa_dom_jumpthread.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_dom_jumpthread.sil
@@ -506,11 +506,11 @@ bb7(%r : $Builtin.Int32, %carg2 : $Builtin.Int32):
 
 // CHECK-LABEL: sil [ossa] @jumpthread_switch_enum5
 // CHECK:      bb0:
-// CHECK:        br bb1
-// CHECK:      bb1({{.*}}):
-// CHECK-NEXT:   cond_br undef, bb2, bb3
+// CHECK:        br bb2
+// CHECK:      bb1:
+// CHECK-NEXT:   br bb2
 // CHECK:      bb2:
-// CHECK:        br bb1
+// CHECK:        cond_br undef, bb1, bb3
 // CHECK:      bb3:
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
@@ -650,9 +650,9 @@ sil [ossa] @f_use : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK:  switch_enum {{.*}} case #Optional.some!enumelt: bb2
 
 // CHECK: bb2{{.*}}
-// CHECK:  br bb4({{.*}} : $Builtin.Int32, %2 : $Builtin.Int32, [[EXT]]
+// CHECK:  br bb4(%2 : $Builtin.Int32, [[EXT]]
 
-// CHECK: bb4({{.*}} : $Builtin.Int32, [[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
+// CHECK: bb4([[CUR:%.*]] : $Builtin.Int32, [[NEXT:%.*]] : $Builtin.Int32
 // CHECK:  [[F:%.*]] = function_ref @f
 // CHECK:  apply [[F]]([[CUR]])
 // CHECK:  cond_br {{.*}}, bb5, bb7
@@ -660,7 +660,7 @@ sil [ossa] @f_use : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK: bb5:
 // CHECK:   [[VARADD:%.*]] = builtin "sadd_with_overflow_Int32"([[NEXT]] : $Builtin.Int32
 // CHECK:   [[NEXT2:%.*]] = tuple_extract [[VARADD]]
-// CHECK:   br bb4({{.*}} : $Builtin.Int32, [[NEXT]] : $Builtin.Int32, [[NEXT2]]
+// CHECK:   br bb4([[NEXT]] : $Builtin.Int32, [[NEXT2]]
 sil [ossa] @switch_enum_jumpthreading_bug : $@convention(thin) (Optional<Builtin.Int32>, Builtin.Int1, Builtin.Int32, Builtin.Int1) -> Builtin.Int32 {
 bb0(%0 : $Optional<Builtin.Int32>, %1 : $Builtin.Int1, %2: $Builtin.Int32, %3 : $Builtin.Int1):
   cond_br %1, bb2, bb10a

--- a/test/SILOptimizer/string_optimization.swift
+++ b/test/SILOptimizer/string_optimization.swift
@@ -6,7 +6,6 @@
 
 // REQUIRES: executable_test,swift_stdlib_no_asserts
 // REQUIRES: swift_in_compiler
-
 // Test needs to be updated for 32bit.
 // rdar://74810823
 // UNSUPPORTED: PTRSIZE=32
@@ -88,9 +87,10 @@ public func testQualifiedTypeName() -> String {
   return _typeName(Outer.Inner.self, qualified: true)
 }
 
+// This test needs an updated SimplifyCFG optimization. Disable until we have that.
 // CHECK-LABEL: sil [noinline] @$s4test0A20UnqualifiedLocalTypeSSyF
-// CHECK-NOT: apply
-// CHECK-NOT: bb1
+// TODO-CHECK-NOT: apply
+// TODO-CHECK-NOT: bb1
 // CHECK: } // end sil function '$s4test0A20UnqualifiedLocalTypeSSyF'
 @inline(never)
 public func testUnqualifiedLocalType() -> String {

--- a/test/SILOptimizer/string_optimization.swift
+++ b/test/SILOptimizer/string_optimization.swift
@@ -87,10 +87,9 @@ public func testQualifiedTypeName() -> String {
   return _typeName(Outer.Inner.self, qualified: true)
 }
 
-// This test needs an updated SimplifyCFG optimization. Disable until we have that.
 // CHECK-LABEL: sil [noinline] @$s4test0A20UnqualifiedLocalTypeSSyF
-// TODO-CHECK-NOT: apply
-// TODO-CHECK-NOT: bb1
+// CHECK-NOT: apply
+// CHECK-NOT: bb1
 // CHECK: } // end sil function '$s4test0A20UnqualifiedLocalTypeSSyF'
 @inline(never)
 public func testUnqualifiedLocalType() -> String {


### PR DESCRIPTION

Previously we replaced phi with its incoming values when all incoming values were the same.
If the phi had itself as incoming value, it wasn't optimized. This PR handles such cases.