### PR TITLE
Introduce a (temporary) `dlsym` check for `swift_willThrowTypedImpl`.

### DIFF
--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -50,6 +50,7 @@
 Func _prespecialize() is a new API without @available attribute
 Func _stdlib_isOSVersionAtLeastOrVariantVersionAtLeast(_:_:_:_:_:_:) is a new API without @available attribute
 Func _diagnoseUnavailableCodeReached() is a new API without @available attribute
+Func _dlsym(handle:symbol:) is a new API without @available attribute
 
 // These functions are not actually added to the ABI, but they had been a part of
 // the ABI exposed by the runtime library, so this is not breakage.


### PR DESCRIPTION
Inlined code using the special `9999` availability is always getting executed, even on older standard library implementations, causing a runtime failure due to a missing symbol. Avoid this problem by doing an extra `dlsym` check for the symbol before calling it.

This issue will go away when we can remove the `9999` availability.

Fixes rdar://124388996.
