### PR TITLE
[6.0][Tests] Update for "swift" diagnostic style change

### DIFF
--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -283,10 +283,10 @@ func testNested() {
 
   // PRETTY-DIAGS: 1:8: error: cannot convert value of type 'Nested' to expected argument type 'Bool'
   // PRETTY-DIAGS: macro_expand.swift:{{.*}}:39: note: expanded code originates here
-  // PRETTY-DIAGS: ─── macro expansion #stringify
-  // PRETTY-DIAGS: ─── macro expansion #assertAny
-  // PRETTY-DIAGS-NEXT: 1 │ assert(Nested())
-  // PRETTY-DIAGS-NEXT:   │        ╰─ error: cannot convert value
+  // PRETTY-DIAGS: --- macro expansion #stringify
+  // PRETTY-DIAGS: --- macro expansion #assertAny
+  // PRETTY-DIAGS-NEXT: 1 | assert(Nested())
+  // PRETTY-DIAGS-NEXT:   |        `- error: cannot convert value
 }
 #endif
 

--- a/test/diagnostics/extra-newlines.swift
+++ b/test/diagnostics/extra-newlines.swift
@@ -11,11 +11,11 @@
 // Check that there are no extra newlines between diagnostics lines
 
 // CHECK:      SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}extra-newlines.swift:[[#LINE:]]:5
-// CHECK-NEXT: [[#LINE-2]] │
-// CHECK-NEXT: [[#LINE-1]] │ func foo(a: Int, b: Int) {
-// CHECK-NEXT: [[#LINE]]   │   a + b
-// CHECK-NEXT:             │   ╰─ warning: result of operator '+' is unused
-// CHECK-NEXT: [[#LINE+1]] │ }
+// CHECK-NEXT: [[#LINE-2]] |
+// CHECK-NEXT: [[#LINE-1]] | func foo(a: Int, b: Int) {
+// CHECK-NEXT: [[#LINE]]   |   a + b
+// CHECK-NEXT:             |   `- warning: result of operator '+' is unused
+// CHECK-NEXT: [[#LINE+1]] | }
 
 func foo(a: Int, b: Int) {
   a + b

--- a/test/diagnostics/pretty-printed-diagnostics.swift
+++ b/test/diagnostics/pretty-printed-diagnostics.swift
@@ -69,19 +69,19 @@ foo(b:
 
 // Test fallback for non-ASCII characters.
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:11
-// CHECK: [[#LINE-2]] │
-// CHECK: [[#LINE]]   │ let abc = "👍
-// CHECK:             │ ╰─  error: unterminated string literal
-// CHECK: [[#LINE+1]] │
+// CHECK: [[#LINE-2]] |
+// CHECK: [[#LINE]]   | let abc = "👍
+// CHECK:             | `-  error: unterminated string literal
+// CHECK: [[#LINE+1]] |
 
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:3
-// CHECK: [[#LINE-1]] │
-// CHECK: [[#LINE]]   │ 1 + 2
-// CHECK:             │ ╰─ warning: result of operator '+' is unused
-// CHECK: [[#LINE+1]] │
+// CHECK: [[#LINE-1]] |
+// CHECK: [[#LINE]]   | 1 + 2
+// CHECK:             | `- warning: result of operator '+' is unused
+// CHECK: [[#LINE+1]] |
 
 // CHECK: SOURCE_DIR{{[/\]+}}test{{[/\]+}}diagnostics{{[/\]+}}pretty-printed-diagnostics.swift:[[#LINE:]]:11
-// CHECK:  [[#LINE-1]] │
-// CHECK:  [[#LINE]] │ foo(b: 1, a: 2)
-// CHECK:              │         ╰─ error: argument 'a' must precede argument 'b'
-// CHECK: [[#LINE+1]]  │
+// CHECK:  [[#LINE-1]] |
+// CHECK:  [[#LINE]] | foo(b: 1, a: 2)
+// CHECK:              |         `- error: argument 'a' must precede argument 'b'
+// CHECK: [[#LINE+1]]  |


### PR DESCRIPTION
Cherry-pick #72754 into `release/6.0`

(copied from https://github.com/apple/swift-syntax/pull/2587)
* **Explanation**: Previously, diagnostics were printed with Unicode line characters e.g. `├` `╰` `─`. It looked nice, but it caused numerous issues, for example viewing a build log with text editor / browser often don't work. That was because auto text-encoding detection didn't work as those characters only appeared at the tail end of the log. So using ASCII characters are more stable and reliable.
* **Scope**: diagnostics priiting
* **Risk**: Low, the diagnostic style is new and nobody should be relying on it
* **Testing**: Updated regression test cases
* **Issues**: N/A
* **Reviewer**: Doug Gregor (@DougGregor), Ben Barham(@bnbarham)