### PR TITLE
[6.0] Sema: Fix existential-metatype-to-Any conversion

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -126,17 +126,6 @@ public:
                                     ProtocolDecl *conformedProtocol) const;
 };
 
-/// Functor class suitable for use as a \c LookupConformanceFn that provides
-/// only abstract conformances, or builtin conformances for invertible protocols
-/// for generic types. Asserts that the replacement
-/// type is an opaque generic type.
-class MakeAbstractOrBuiltinConformanceForGenericType {
-public:
-  ProtocolConformanceRef operator()(CanType dependentType,
-                                    Type conformingReplacementType,
-                                    ProtocolDecl *conformedProtocol) const;
-};
-
 /// Functor class suitable for use as a \c LookupConformanceFn that fetches
 /// conformances from a generic signature.
 class LookUpConformanceInSignature {

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -196,7 +196,7 @@ public:
         // If we found a type containing a local archetype, substitute
         // open existentials throughout the substitution map.
         Subs = Subs.subst(QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-                          MakeAbstractOrBuiltinConformanceForGenericType());
+                          MakeAbstractConformanceForGenericType());
       }
     }
 
@@ -219,7 +219,7 @@ public:
     return Ty.subst(
       Builder.getModule(),
       QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-      MakeAbstractOrBuiltinConformanceForGenericType(),
+      MakeAbstractConformanceForGenericType(),
       CanGenericSignature());
   }
   SILType getOpType(SILType Ty) {
@@ -239,7 +239,7 @@ public:
 
     return ty.subst(
       QueryTypeSubstitutionMapOrIdentity{LocalArchetypeSubs},
-      MakeAbstractOrBuiltinConformanceForGenericType()
+      MakeAbstractConformanceForGenericType()
     )->getCanonicalType();
   }
 
@@ -352,7 +352,7 @@ public:
         conformance.subst(ty,
                           QueryTypeSubstitutionMapOrIdentity{
                                                         LocalArchetypeSubs},
-                          MakeAbstractOrBuiltinConformanceForGenericType());
+                          MakeAbstractConformanceForGenericType());
     }
 
     return asImpl().remapConformance(getASTTypeInClonedContext(ty),

--- a/lib/AST/TypeSubstitution.cpp
+++ b/lib/AST/TypeSubstitution.cpp
@@ -230,22 +230,6 @@ operator()(CanType dependentType, Type conformingReplacementType,
   return Subs.lookupConformance(dependentType, conformedProtocol);
 }
 
-ProtocolConformanceRef MakeAbstractOrBuiltinConformanceForGenericType::
-operator()(CanType dependentType, Type conformingReplacementType,
-           ProtocolDecl *conformedProtocol) const {
-  // Workaround for rdar://125460667
-  if (conformedProtocol->getInvertibleProtocolKind()) {
-    auto &ctx = conformedProtocol->getASTContext();
-    return ProtocolConformanceRef(
-        ctx.getBuiltinConformance(conformingReplacementType, conformedProtocol,
-                                  BuiltinConformanceKind::Synthesized));
-  }
-
-  return MakeAbstractConformanceForGenericType()(dependentType,
-                                                 conformingReplacementType,
-                                                 conformedProtocol);
-}
-
 ProtocolConformanceRef MakeAbstractConformanceForGenericType::
 operator()(CanType dependentType, Type conformingReplacementType,
            ProtocolDecl *conformedProtocol) const {

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -833,9 +833,6 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     [&, concreteFormalType, F](SGFContext C) -> ManagedValue {
       auto concreteValue = F(SGFContext());
       assert(concreteFormalType->isBridgeableObjectType());
-      auto *M = SGM.M.getSwiftModule();
-      auto conformances = M->collectExistentialConformances(
-          concreteFormalType, anyObjectTy);
       return B.createInitExistentialRef(
           loc, SILType::getPrimitiveObjectType(anyObjectTy), concreteFormalType,
           concreteValue, conformances);
@@ -844,6 +841,12 @@ ManagedValue SILGenFunction::emitExistentialErasure(
     if (this->F.getLoweredFunctionType()->isPseudogeneric()) {
       if (anyObjectTy && concreteFormalType->is<ArchetypeType>()) {
         concreteFormalType = anyObjectTy;
+
+        // The original conformances are no good because they have the wrong
+        // (pseudogeneric) subject type.
+        auto *M = SGM.M.getSwiftModule();
+        conformances = M->collectExistentialConformances(
+            concreteFormalType, anyObjectTy);
         F = eraseToAnyObject;
       }
     }

--- a/test/Generics/rdar124697829.swift
+++ b/test/Generics/rdar124697829.swift
@@ -1,0 +1,41 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+// This is a generics test, but only IRGen exercised the substitution of
+// an abstract conformance with a type parameter -- in the type checker and
+// SIL, we only deal with archetypes.
+
+public protocol IteratorProtocol {
+  associatedtype Element
+}
+
+public protocol Sequence {
+  associatedtype Iterator: IteratorProtocol
+  associatedtype Element where Element == Iterator.Element
+}
+
+public struct IndexingIterator<S: Sequence>: IteratorProtocol {
+  public typealias Element = S.Element
+}
+
+public struct Array<Element>: Sequence {
+  public typealias Iterator = IndexingIterator<Self>
+}
+
+public protocol Publisher {
+  associatedtype Output
+}
+
+public struct SequencePublisher<Elements: Sequence>: Publisher {
+  public typealias Output = Elements.Element
+}
+
+public struct Map<Pub: Publisher, Output>: Publisher {}
+
+public func foo<T>(_: T) -> some Publisher {
+  bar(SequencePublisher<Array<T>>())
+}
+
+public func bar<Pub: Publisher>(_: Pub) -> some Publisher {
+  Map<Pub, Pub.Output>()
+}
+

--- a/test/SILOptimizer/rdar125460667.swift
+++ b/test/SILOptimizer/rdar125460667.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-sil %s
+
+@_transparent func f(a: Any.Type) -> Any {
+  return a
+}
+
+func g(a: Any.Type) {
+  f(a: a)
+}

--- a/test/Serialization/Inputs/protocol_with_self_conforming_existential_other.swift
+++ b/test/Serialization/Inputs/protocol_with_self_conforming_existential_other.swift
@@ -1,0 +1,5 @@
+public protocol P1 {
+  associatedtype A: Sendable
+}
+
+public protocol P2: P1, Sendable where A == any P2 {}

--- a/test/Serialization/protocol_with_self_conforming_existential.swift
+++ b/test/Serialization/protocol_with_self_conforming_existential.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/protocol_with_self_conforming_existential_other.swift -emit-module-path %t/protocol_with_self_conforming_existential_other.swiftmodule
+// RUN: %target-swift-frontend -emit-silgen %s -I %t
+
+import protocol_with_self_conforming_existential_other
+
+// Declare a type conforming to P2, to force deserializing its
+// requirement signature.
+
+struct MyP2: P2 {}
+


### PR DESCRIPTION
6.0 cherry-pick of https://github.com/apple/swift/pull/72762 and https://github.com/apple/swift/pull/72789.

* Description: The type checker incorrectly used the instance type of a metatype instead of the metatype itself when looking up a conformance, which caused an invariant violation in the SILCloner. This PR supersedes an earlier workaround. This PR also cherry-picks some regression tests for bugs that are already fixed on the 6.0 branch.

* Scope of the issue: Various projects hit this specifically with the `any Any.Type` to `Any` conversion.

* Origination: This was a regression since enablement of non copyable generics and didn't ship in a release.

* Radar: rdar://125460667

* Reviewed by: @kavon 