### PR TITLE
[6.0🍒] NCGenerics: introduce SuppressedAssociatedTypes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7618,6 +7618,9 @@ ERROR(inverse_but_also_conforms, none,
 ERROR(inverse_generic_but_also_conforms, none,
       "%0 required to be '%1' but is marked with '~%1'",
       (Type, StringRef))
+ERROR(inverse_associatedtype_restriction, none,
+      "cannot suppress '%0' requirement of an associated type",
+      (StringRef))
 ERROR(inverse_on_class, none,
       "classes cannot be '~%0'",
       (StringRef))

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -322,6 +322,9 @@ SUPPRESSIBLE_EXPERIMENTAL_FEATURE(NoncopyableGenerics, true)
 // Alias for NoncopyableGenerics
 EXPERIMENTAL_FEATURE(NoncopyableGenerics2, true)
 
+// Enables ~Copyable and ~Escapable annotations on associatedtype declarations.
+EXPERIMENTAL_FEATURE(SuppressedAssociatedTypes, true)
+
 /// Allow destructuring stored `let` bindings in structs.
 EXPERIMENTAL_FEATURE(StructLetDestructuring, true)
 

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -504,6 +504,7 @@ static bool usesFeatureRawLayout(Decl *decl) {
 }
 
 UNINTERESTING_FEATURE(Embedded)
+UNINTERESTING_FEATURE(SuppressedAssociatedTypes)
 
 static bool usesFeatureNoncopyableGenerics(Decl *decl) {
   if (decl->getAttrs().hasAttribute<PreInverseGenericsAttr>())

--- a/lib/AST/RequirementMachine/Diagnostics.h
+++ b/lib/AST/RequirementMachine/Diagnostics.h
@@ -84,13 +84,15 @@ private:
 
 public:
   Requirement getRequirement() const {
-    assert(!(kind == Kind::InvalidInverseOuterSubject ||
-             kind == Kind::ConflictingInverseRequirement));
+    assert(kind != Kind::InvalidInverseOuterSubject &&
+           kind != Kind::InvalidInverseSubject &&
+           kind != Kind::ConflictingInverseRequirement);
     return requirement;
   }
 
   InverseRequirement getInverse() const {
     assert(kind == Kind::InvalidInverseOuterSubject ||
+           kind == Kind::InvalidInverseSubject ||
            kind == Kind::ConflictingInverseRequirement);
     return inverse;
   }
@@ -107,14 +109,13 @@ public:
     return {Kind::InvalidRequirementSubject, req, loc};
   }
 
-  static RequirementError forInvalidInverseSubject(Requirement req,
-                                                   SourceLoc loc) {
-    return {Kind::InvalidInverseSubject, req, loc};
+  static RequirementError forInvalidInverseSubject(InverseRequirement inv) {
+    return {Kind::InvalidInverseSubject, inv, inv.loc};
   }
 
   static
-  RequirementError forInvalidInverseOuterSubject(InverseRequirement req) {
-    return {Kind::InvalidInverseOuterSubject, req, req.loc};
+  RequirementError forInvalidInverseOuterSubject(InverseRequirement inv) {
+    return {Kind::InvalidInverseOuterSubject, inv, inv.loc};
   }
 
   static RequirementError forConflictingInverseRequirement(

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -622,6 +622,7 @@ function(_compile_swift_files
   endif()
 
   list(APPEND swift_flags "-enable-experimental-feature" "NoncopyableGenerics2")
+  list(APPEND swift_flags "-enable-experimental-feature" "SuppressedAssociatedTypes")
 
   if(SWIFT_ENABLE_EXPERIMENTAL_NONESCAPABLE_TYPES)
     list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")

--- a/test/Generics/inverse_associatedtype_restriction.swift
+++ b/test/Generics/inverse_associatedtype_restriction.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:  -enable-experimental-feature NoncopyableGenerics \
+// RUN:  -enable-experimental-feature NonescapableTypes
+
+// The restriction is that we don't permit suppression requirements on
+// associated types without an experimental feature for that.
+
+protocol P {
+  associatedtype A: ~Copyable // expected-error {{cannot suppress 'Copyable' requirement of an associated type}}
+}
+
+protocol P_Prime: P {}
+
+protocol Primary<T> {
+  associatedtype T: ~Copyable // expected-error {{cannot suppress 'Copyable' requirement of an associated type}}
+}
+
+// This is fine, since T isn't an associatedtype, it's substituted into one.
+typealias AliasPrimary<T> = Primary<T> where T: ~Copyable
+
+protocol S {
+  associatedtype One: ~Copyable // expected-error {{cannot suppress 'Copyable' requirement of an associated type}}
+
+  associatedtype Two: ~Escapable & ~Copyable
+                      // expected-error@-1 {{cannot suppress 'Copyable' requirement of an associated type}}
+                      // expected-error@-2 {{cannot suppress 'Escapable' requirement of an associated type}}
+
+  associatedtype Three: ~Escapable // expected-error {{cannot suppress 'Escapable' requirement of an associated type}}
+}
+
+protocol Base {
+    associatedtype A
+}
+protocol Derived: Base where Self.A: ~Copyable {} // expected-error {{cannot suppress 'Copyable' requirement of an associated type}}
+
+protocol Q {
+  associatedtype A where A: ~Copyable // expected-error {{cannot suppress 'Copyable' requirement of an associated type}}
+}
+
+protocol R where Self.A: ~Copyable { // expected-error {{cannot suppress 'Copyable' requirement of an associated type}}
+  associatedtype A
+}

--- a/test/Generics/inverse_copyable_requirement_newer_errors.swift
+++ b/test/Generics/inverse_copyable_requirement_newer_errors.swift
@@ -17,11 +17,13 @@ func packIt() {
 func packingUniqueHeat_1<each T: ~Copyable>(_ t: repeat each T) {}
 // expected-error@-1{{cannot suppress '~Copyable' on type 'each T'}}
 // expected-note@-2{{generic parameter 'each T' has an implicit Copyable requirement}}
+// expected-error@-3{{'each T' required to be 'Copyable' but is marked with '~Copyable'}}
 
 func packingUniqueHeat_2<each T>(_ t: repeat each T)
    where repeat each T: ~Copyable {}
 // expected-error@-1{{cannot suppress '~Copyable' on type 'each T'}}
 // expected-note@-3{{generic parameter 'each T' has an implicit Copyable requirement}}
+// expected-error@-3{{'each T' required to be 'Copyable' but is marked with '~Copyable'}}
 
 func packItUniquely() {
   packingUniqueHeat_1(MO())

--- a/test/Generics/inverse_extensions.swift
+++ b/test/Generics/inverse_extensions.swift
@@ -1,6 +1,7 @@
 // RUN: %target-typecheck-verify-swift \
 // RUN:   -enable-experimental-feature NoncopyableGenerics \
-// RUN:   -enable-experimental-feature NonescapableTypes
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypes
 
 struct Turtle<T> {}
 extension Turtle where T: ~Copyable {} // expected-error {{'T' required to be 'Copyable' but is marked with '~Copyable'}}

--- a/test/Generics/inverse_generics.swift
+++ b/test/Generics/inverse_generics.swift
@@ -1,4 +1,7 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes
+// RUN: %target-typecheck-verify-swift \
+// RUN: -enable-experimental-feature NoncopyableGenerics \
+// RUN: -enable-experimental-feature NonescapableTypes \
+// RUN: -enable-experimental-feature SuppressedAssociatedTypes
 
 
 

--- a/test/Generics/inverse_scoping.swift
+++ b/test/Generics/inverse_scoping.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes -enable-experimental-feature SuppressedAssociatedTypes
 
 
 

--- a/test/Generics/inverse_signatures.swift
+++ b/test/Generics/inverse_signatures.swift
@@ -1,4 +1,9 @@
-// RUN: %target-swift-frontend -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes -verify -typecheck %s -debug-generic-signatures -debug-inverse-requirements 2>&1 | %FileCheck %s --implicit-check-not "error:"
+// RUN: %target-swift-frontend \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:   -verify -typecheck %s -debug-generic-signatures \
+// RUN:   -debug-inverse-requirements 2>&1 | %FileCheck %s --implicit-check-not "error:"
 
 // CHECK-LABEL: (file).genericFn@
 // CHECK: Generic signature: <T where T : Copyable, T : Escapable>

--- a/test/IRGen/existential_shape_metadata_noncopyable.swift
+++ b/test/IRGen/existential_shape_metadata_noncopyable.swift
@@ -1,4 +1,9 @@
-// RUN: %target-swift-frontend -emit-ir %s -swift-version 5 -disable-availability-checking -enable-experimental-feature NoncopyableGenerics -module-name existential_shape_metadata | %IRGenFileCheck %s
+// RUN: %target-swift-frontend \
+// RUN:    -emit-ir %s -swift-version 5 \
+// RUN:   -disable-availability-checking \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
+// RUN:   -module-name existential_shape_metadata | %IRGenFileCheck %s
 
 // NOTE: Once noncopyable generics are enabled by default, merge this back into existential_shape_metadata.swift
 

--- a/test/IRGen/mangling_inverse_generics_evolution.swift
+++ b/test/IRGen/mangling_inverse_generics_evolution.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-ir -o - %s -module-name test \
 // RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -parse-as-library \
 // RUN:   -enable-library-evolution \

--- a/test/Interpreter/moveonly_generics_associatedtype.swift
+++ b/test/Interpreter/moveonly_generics_associatedtype.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-emit-sil %s -DBAD_COPY -verify -sil-verify-all -enable-experimental-feature NoncopyableGenerics
-// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
-// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
+// RUN: %target-swift-emit-sil %s -DBAD_COPY -verify -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes) | %FileCheck %s
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes) | %FileCheck %s
 
 // REQUIRES: executable_test
 // REQUIRES: asserts

--- a/test/ModuleInterface/invertible_constraints.swift
+++ b/test/ModuleInterface/invertible_constraints.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes
 // RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
 // RUN: %FileCheck %s < %t.swiftinterface
 

--- a/test/ModuleInterface/moveonly_interface_flag.swift
+++ b/test/ModuleInterface/moveonly_interface_flag.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %t
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 
-// XFAIL: noncopyable_generics
+
 
 // this test makes sure that decls containing a move-only type are guarded by the $MoveOnly feature flag
 

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -2,6 +2,7 @@
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -o %t/NoncopyableGenerics_Misc.swiftmodule \
 // RUN:     -emit-module-interface-path %t/NoncopyableGenerics_Misc.swiftinterface \
@@ -9,6 +10,7 @@
 
 // RUN: %target-swift-frontend -swift-version 5 -enable-library-evolution -emit-module \
 // RUN:     -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:     -enable-experimental-feature BorrowingSwitch \
 // RUN:     -o %t/Swiftskell.swiftmodule \
@@ -24,16 +26,19 @@
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
 // RUN:    -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:    %t/NoncopyableGenerics_Misc.swiftinterface -o %t/NoncopyableGenerics_Misc.swiftmodule
 
 // RUN: %target-swift-frontend -compile-module-from-interface \
 // RUN:    -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:     -enable-experimental-feature NonescapableTypes \
 // RUN:    %t/Swiftskell.swiftinterface -o %t/Swiftskell.swiftmodule
 
 // RUN: %target-swift-frontend -emit-silgen -I %t %s \
 // RUN:    -enable-experimental-feature NoncopyableGenerics \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:    -enable-experimental-feature NonescapableTypes \
 // RUN:    -o %t/final.silgen
 

--- a/test/Parse/inverses.swift
+++ b/test/Parse/inverses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes
 
 protocol U {}
 
@@ -58,6 +58,7 @@ struct S: ~U, // expected-error {{type 'U' cannot be suppressed}}
           ~Copyable {}
 
 func greenBay<each T: ~Copyable>(_ r: repeat each T) {} // expected-error{{cannot suppress '~Copyable' on type 'each T'}}
+// expected-error@-1 {{'each T' required to be 'Copyable' but is marked with '~Copyable'}}
 
 typealias Clone = Copyable
 func dup<D: ~Clone>(_ d: D) {}
@@ -105,6 +106,7 @@ typealias Z8 = ~Copyable & Hashable // expected-error {{composition cannot conta
 struct NotAProtocol {}
 
 struct Bad: ~NotAProtocol {} // expected-error {{type 'NotAProtocol' cannot be suppressed}}
+
 
 struct X<T: ~Copyable>: ~Copyable { }
 

--- a/test/Parse/inverses_legacy.swift
+++ b/test/Parse/inverses_legacy.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift
 
-// XFAIL: noncopyable_generics
+
 
 protocol Sando { func make() } // expected-note {{protocol requires function 'make()'}}
                                // expected-note@-1 {{type 'U' does not conform to inherited protocol 'Copyable'}}

--- a/test/Parse/inverses_legacy_ifdef.swift
+++ b/test/Parse/inverses_legacy_ifdef.swift
@@ -1,7 +1,7 @@
 // RUN: %swift-frontend -typecheck %s
 // RUN: %swift-frontend -typecheck %s -verify -DHAVE_NCGENERICS
 
-// XFAIL: noncopyable_generics
+
 
 /// This test checks that you can write ~Copyable in places that were illegal
 /// in Swift 5.9, as long as those illegal appearances are guarded within

--- a/test/SIL/Parser/array_roundtrip.swift
+++ b/test/SIL/Parser/array_roundtrip.swift
@@ -6,6 +6,7 @@
 
 // FIXME(NCG): This produces `cannot suppress conformances here` errors due to
 // all the new <τ_0_0 where τ_0_0 : ~Copyable> clauses
-// XFAIL: !noncopyable_generics
+// rdar://124657305 (@substituted generic signatures need to either include inverses or the Copyable/Escapable conformances)
+// XFAIL: *
 
 var W = [UInt32](repeating: 0, count: 16)

--- a/test/SIL/lifetime_dependence_generics.swift
+++ b/test/SIL/lifetime_dependence_generics.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend %s -emit-sil \
 // RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:   -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
 
 

--- a/test/SILGen/raw_layout.swift
+++ b/test/SILGen/raw_layout.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-feature RawLayout %s | %FileCheck %s
 
-// XFAIL: noncopyable_generics
+
 
 // CHECK: @_rawLayout(size: 4, alignment: 4) @_moveOnly struct Lock
 // CHECK: @_rawLayout(like: T) @_moveOnly struct Cell<T>

--- a/test/SILGen/variadic-generic-reabstract-tuple-result.swift
+++ b/test/SILGen/variadic-generic-reabstract-tuple-result.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-emit-silgen -disable-availability-checking %s | %FileCheck %s
 
-// XFAIL: noncopyable_generics
+
 
 // rdar://110391963
 

--- a/test/SILOptimizer/lifetime_dependence_generic.swift
+++ b/test/SILOptimizer/lifetime_dependence_generic.swift
@@ -4,6 +4,7 @@
 // RUN:   -sil-verify-all \
 // RUN:   -enable-experimental-feature NonescapableTypes \
 // RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypes \
 // RUN:   -parse-stdlib -module-name Swift
 
 // REQUIRES: asserts

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -6,9 +6,7 @@
 // RUN:     -enable-builtin-module                           \
 // RUN:     -debug-diagnostic-names
 
-// XFAIL: noncopyable_generics
-
-// REQUIRES: noncopyable_generics
+// XFAIL: *
 
 //==============================================================================
 //===========================DEPENDENCY-FREE TESTS=(BEGIN)===================={{

--- a/test/Sema/explicit_lifetime_dependence_specifiers2.swift
+++ b/test/Sema/explicit_lifetime_dependence_specifiers2.swift
@@ -1,6 +1,5 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature NonescapableTypes -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature BitwiseCopyable
 // REQUIRES: asserts
-// REQUIRES: noncopyable_generics
 // REQUIRES: nonescapable_types
 
 struct AnotherBufferView : ~Escapable, _BitwiseCopyable {

--- a/test/Serialization/AllowErrors/removed-decls.swift
+++ b/test/Serialization/AllowErrors/removed-decls.swift
@@ -4,7 +4,7 @@
 // RUN: mkdir -p %t/swiftmods %t/objcmods %t/objc
 // RUN: %{python} %utils/split_file.py -o %t %s
 
-// XFAIL: noncopyable_generics
+
 
 // Create a module A, then B that depends on A, replace A with an empty module,
 // and then try make a C that depends on B

--- a/test/Serialization/noncopyable_generics.swift
+++ b/test/Serialization/noncopyable_generics.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/ncgenerics.swift                      \
 // RUN:     -enable-experimental-feature NoncopyableGenerics                   \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypes             \
 // RUN:     -emit-module -module-name ncgenerics                               \
 // RUN:     -o %t
 
@@ -11,6 +12,7 @@
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk)                  \
 // RUN:    -enable-experimental-feature NoncopyableGenerics                    \
+// RUN:     -enable-experimental-feature SuppressedAssociatedTypes             \
 // RUN:    -print-module -module-to-print=ncgenerics                           \
 // RUN:    -I %t -source-filename=%s                                           \
 // RUN:    | %FileCheck -check-prefix=CHECK-PRINT %s

--- a/test/Serialization/noncopyable_generics.swift
+++ b/test/Serialization/noncopyable_generics.swift
@@ -15,8 +15,6 @@
 // RUN:    -I %t -source-filename=%s                                           \
 // RUN:    | %FileCheck -check-prefix=CHECK-PRINT %s
 
-// REQUIRES: noncopyable_generics
-
 // CHECK-NOT: UnknownCode
 
 // CHECK-PRINT-DAG: protocol Generator<Value> {

--- a/test/api-digester/compare-dump-abi-parsable-interface.swift
+++ b/test/api-digester/compare-dump-abi-parsable-interface.swift
@@ -13,5 +13,5 @@
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
 // RUN: diff -u %t.expected %t.result.tmp
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/compare-dump-abi.swift
+++ b/test/api-digester/compare-dump-abi.swift
@@ -21,5 +21,5 @@
 // CHECK: cake_current/cake.swift:39:15: error: ABI breakage: struct C6 is now with @frozen
 // CHECK: cake_current/cake.swift:41:13: error: ABI breakage: enum IceKind is now without @frozen
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/compare-dump-parsable-interface.swift
+++ b/test/api-digester/compare-dump-parsable-interface.swift
@@ -13,5 +13,5 @@
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
 // RUN: diff -u %t.expected %t.result.tmp
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/compare-dump.swift
+++ b/test/api-digester/compare-dump.swift
@@ -32,5 +32,5 @@
 // RUN: %clang -E -P -x c %t.result -o - | sed '/^\s*$/d' > %t.result.tmp
 // RUN: diff -u %t.expected %t.result.tmp
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -20,4 +20,4 @@
 // when automatically evolving the standard library.
 // UNSUPPORTED: swift_evolve
 
-// XFAIL: noncopyable_generics
+

--- a/test/api-digester/internal-extension.swift
+++ b/test/api-digester/internal-extension.swift
@@ -1,6 +1,6 @@
 // REQUIRES: VENDOR=apple
 
-// XFAIL: noncopyable_generics
+
 
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -92,5 +92,5 @@ Func TaskLocal.withValueImpl(_:operation:file:line:) is a new API without @avail
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
-// XFAIL: noncopyable_generics
+
 

--- a/test/api-digester/stability-stdlib-abi-with-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-with-asserts.test
@@ -66,4 +66,4 @@ Struct _RuntimeFunctionCounters is a new API without @available attribute
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 
-// XFAIL: noncopyable_generics
+

--- a/test/api-digester/stability-stdlib-source.swift
+++ b/test/api-digester/stability-stdlib-source.swift
@@ -13,4 +13,3 @@
 // RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' | sort > %t.tmp/changes.txt.tmp
 // RUN: diff -u %t.tmp/stability-stdlib-source.swift.expected %t.tmp/changes.txt.tmp
 
-// XFAIL: noncopyable_generics

--- a/test/stdlib/Noncopyables/MemoryLayout.swift
+++ b/test/stdlib/Noncopyables/MemoryLayout.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-run-simple-swift(-enable-experimental-feature NoncopyableGenerics) | %FileCheck %s
-// REQUIRES: executable_test, noncopyable_generics
+// REQUIRES: executable_test
 
 struct A: ~Copyable {
   let value: Int


### PR DESCRIPTION
6.0 cherry-pick https://github.com/apple/swift/pull/72786 and the test-only rider https://github.com/apple/swift/pull/72746.

- Description: Gates support for `~Copyable` associated types behind an experimental feature flag, `SuppressedAssociatedTypes`. The rationale is that they're not quite ready for prime-time and should be deferred from the current NoncopyableGenerics proposal / feature.
- Scope of the issue: No issue

Reviewed by: @DougGregor