### PR TITLE
[NFC] Mark a concurrency test as unsupported in the freestanding configuration.

### DIFF
--- a/test/Concurrency/actor_data_race_checks_minimal.swift
+++ b/test/Concurrency/actor_data_race_checks_minimal.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
+// UNSUPPORTED: freestanding
 
 @preconcurrency @MainActor
 protocol P {


### PR DESCRIPTION
This test uses a `Task` API that is not available in the task-to-thread configuration.

Resolves: rdar://125512341