### PR TITLE
[6.0] AST: Fix availability checking for macros as default arguments

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -624,6 +624,11 @@ public:
   /// enclosed in.
   SourceFile *getEnclosingSourceFile() const;
 
+  /// If this file has an enclosing source file (because it is the result of
+  /// expanding a macro or default argument), returns the node in the enclosing
+  /// file that this file's contents were expanded from.
+  ASTNode getNodeInEnclosingSourceFile() const;
+
   /// If this buffer corresponds to a file on disk, returns the path.
   /// Otherwise, return an empty string.
   StringRef getFilename() const;

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -193,8 +193,8 @@ private:
 public:
   
   /// Create the root refinement context for the given SourceFile.
-  static TypeRefinementContext *createRoot(SourceFile *SF,
-                                           const AvailabilityContext &Info);
+  static TypeRefinementContext *
+  createForSourceFile(SourceFile *SF, const AvailabilityContext &Info);
 
   /// Create a refinement context for the given declaration.
   static TypeRefinementContext *createForDecl(ASTContext &Ctx, Decl *D,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1179,9 +1179,7 @@ ASTNode SourceFile::getMacroExpansion() const {
   if (Kind != SourceFileKind::MacroExpansion)
     return nullptr;
 
-  auto genInfo =
-      *getASTContext().SourceMgr.getGeneratedSourceInfo(*getBufferID());
-  return ASTNode::getFromOpaqueValue(genInfo.astNode);
+  return getNodeInEnclosingSourceFile();
 }
 
 SourceRange SourceFile::getMacroInsertionRange() const {
@@ -1231,6 +1229,16 @@ SourceFile *SourceFile::getEnclosingSourceFile() const {
       *getASTContext().SourceMgr.getGeneratedSourceInfo(*getBufferID());
   auto sourceLoc = genInfo.originalSourceRange.getStart();
   return getParentModule()->getSourceFileContainingLocation(sourceLoc);
+}
+
+ASTNode SourceFile::getNodeInEnclosingSourceFile() const {
+  if (Kind != SourceFileKind::MacroExpansion &&
+      Kind != SourceFileKind::DefaultArgument)
+    return nullptr;
+
+  auto genInfo =
+      *getASTContext().SourceMgr.getGeneratedSourceInfo(*getBufferID());
+  return ASTNode::getFromOpaqueValue(genInfo.astNode);
 }
 
 void ModuleDecl::lookupClassMember(ImportPath::Access accessPath,

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1279,7 +1279,7 @@ void TypeChecker::buildTypeRefinementContextHierarchy(SourceFile &SF) {
     // the source file are guaranteed to be executing on at least the minimum
     // platform version for inlining.
     auto MinPlatformReq = AvailabilityContext::forInliningTarget(Context);
-    RootTRC = TypeRefinementContext::createRoot(&SF, MinPlatformReq);
+    RootTRC = TypeRefinementContext::createForSourceFile(&SF, MinPlatformReq);
     SF.setTypeRefinementContext(RootTRC);
   }
 

--- a/test/Concurrency/isolation_macro_availability.swift
+++ b/test/Concurrency/isolation_macro_availability.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift
+
+// REQUIRES: concurrency
+// REQUIRES: swift_swift_parser
+// REQUIRES: VENDOR=apple
+
+@available(SwiftStdlib 5.1, *)
+func isolatedFunc(isolation: isolated (any Actor)? = #isolation) {}
+
+func test() { // expected-note 3 {{add @available attribute to enclosing global function}}
+  _ = #isolation // expected-error {{'isolation()' is only available in}} expected-note {{add 'if #available' version check}}
+  isolatedFunc() // expected-error {{'isolatedFunc(isolation:)' is only available in}} expected-note {{add 'if #available' version check}}
+  // expected-error@-1 {{'isolation()' is only available in}}
+
+  if #available(SwiftStdlib 5.1, *) {
+    _ = #isolation
+    isolatedFunc()
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func testAvailable5_1() {
+  _ = #isolation
+  isolatedFunc()
+}


### PR DESCRIPTION
- **Explanation:** Adoption of the `#isolation` macro as a default argument in the standard library exposed that the availbility of contents of default argument macro expansions were being mis-diagnosed. The nodes for auxilary files generated for default argument expansions were not being added to the enclosing file's `TypeRefinementContext` hierarchy, so the contents of the expansion would be diagnosed as if it were located in a context with the minimum availability for the compilation.
- **Scope:** Affects any API adopting macros as default arguments. Fixing this for 6.0 is important because it unblocks adoption of the `#isolation` macro in various standard library APIs.
- **Issue/Radar:** rdar://125812256
- **Original PR:** https://github.com/apple/swift/pull/72813
- **Risk:** Low.
- **Testing:** Added a new test to the compiler test suite.
- **Reviewer:** @ktoso 