### PR TITLE
🍒[cxx-interop][IRGen] Assign Clang function types to copy constructors

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -603,10 +603,17 @@ namespace {
                                 ParameterConvention::Direct_Unowned);
       SILResultInfo result(T.getASTType(), ResultConvention::Indirect);
 
+      auto clangFnType = T.getASTContext().getCanonicalClangFunctionType(
+          {ptrParam}, result, SILFunctionTypeRepresentation::CFunctionPointer);
+      auto extInfo = SILExtInfoBuilder()
+                         .withClangFunctionType(clangFnType)
+                         .withRepresentation(
+                             SILFunctionTypeRepresentation::CFunctionPointer)
+                         .build();
+
       return SILFunctionType::get(
           GenericSignature(),
-          SILFunctionType::ExtInfo().withRepresentation(
-              SILFunctionTypeRepresentation::CFunctionPointer),
+          extInfo,
           SILCoroutineKind::None,
           /*callee=*/ParameterConvention::Direct_Unowned,
           /*params*/ {ptrParam},

--- a/test/Interop/Cxx/class/Inputs/constructors.h
+++ b/test/Interop/Cxx/class/Inputs/constructors.h
@@ -80,4 +80,10 @@ struct DeletedCopyConstructor {
   DeletedCopyConstructor(const DeletedCopyConstructor &) = delete;
 };
 
+#ifdef ENABLE_PTRAUTH
+struct HasPtrAuthMember {
+  void (*__ptrauth(1, 1, 3) handler)();
+};
+#endif
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_CONSTRUCTORS_H

--- a/test/Interop/Cxx/class/constructors-copy-irgen-macosx-ptrauth.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-macosx-ptrauth.swift
@@ -1,0 +1,11 @@
+// RUN: %swift -emit-ir -module-name CopyConstructorsPtrAuth -target arm64e-apple-macosx11.0 -use-clang-function-types -enable-import-ptrauth-field-function-pointers -Xcc -D -Xcc ENABLE_PTRAUTH -dump-clang-diagnostics -I %S/Inputs -cxx-interoperability-mode=default %s -parse-as-library
+
+// REQUIRES: CPU=arm64e
+// REQUIRES: OS=macosx
+
+import Constructors
+
+public func copyPtrAuthMemberWithDefaultCopyConstructor(_ x: HasPtrAuthMember)
+  -> (HasPtrAuthMember, HasPtrAuthMember) {
+  return (x, x)
+}


### PR DESCRIPTION
**Explanation**: This fixes an assertion failure when compiling for arm64e with `-use-clang-function-types` Swift compiler flag: `Expected non-null Clang type for @convention(c)/@convention(block) function but found nullptr`
**Scope**: IRGen logic for C++ copy constructors is changed.
**Risk**: Low, this only affects projects that explicitly enable C++ interop and use `-use-clang-function-types`.
**Testing**: Added a LIT test.
**Issue**: rdar://121227452
**Reviewer**: @aschwaighofer @kubamracek @hyp approved https://github.com/apple/swift/pull/72770.

(cherry picked from commit 802f20ec00ec35eb60f711d05a858436b631a6ea)
