### PR TITLE
[Runtime] Disable prespecialized metadata if we have overridden images.

### DIFF
--- a/include/swift/Runtime/LibPrespecialized.h
+++ b/include/swift/Runtime/LibPrespecialized.h
@@ -48,6 +48,7 @@ struct LibPrespecializedData {
 const LibPrespecializedData<InProcess> *getLibPrespecializedData();
 Metadata *getLibPrespecializedMetadata(const TypeContextDescriptor *description,
                                        const void *const *arguments);
+void libPrespecializedImageLoaded();
 
 } // namespace swift
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -29,6 +29,7 @@
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/HeapObject.h"
+#include "swift/Runtime/LibPrespecialized.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Strings.h"
 #include "swift/Threading/Mutex.h"
@@ -346,6 +347,8 @@ void swift::addImageTypeMetadataRecordBlockCallbackUnsafe(
     const void *records, uintptr_t recordsSize) {
   assert(recordsSize % sizeof(TypeMetadataRecord) == 0
          && "weird-sized type metadata section?!");
+
+  libPrespecializedImageLoaded();
 
   // If we have a section, enqueue the type metadata for lookup.
   auto recordBytes = reinterpret_cast<const char *>(records);


### PR DESCRIPTION
We need to check for overridden images on every image load, otherwise XCTest (among others) may `dlopen()` an image that pulls in something that is overridden, at which point the prespecialized metadata won't match the image we loaded.

rdar://125727356
