### PR TITLE
update PrintAsObjC compatibility symbols test to work with condensed clang symbol graphs

### DIFF
--- a/test/PrintAsObjC/compatibility-symbols.swift
+++ b/test/PrintAsObjC/compatibility-symbols.swift
@@ -8,4 +8,6 @@
 // Make sure that any macros or typedefs added to the Clang compatibility header are reflected in
 // the `comptibility-symbols` file that is installed in the toolchain.
 
-// CHECK: "symbols": []
+// Use a regex match here to allow the Clang symbol graph to be pretty-printed or condensed
+
+// CHECK: "symbols":{{ ?}}[]


### PR DESCRIPTION
The Clang PR https://github.com/llvm/llvm-project/pull/86676 updated ExtractAPI to condense the symbol graph JSON by default. This causes a problem with the `PrintAsObjC/compatibility-symbols` test, which assumed a pretty-printed JSON file. This PR updates that test to handle either a condensed symbol graph (which will be the default in the future) and a pretty-printed symbol graph (which is currently the default).