### PR TITLE
[6.0] update PrintAsObjC compatibility symbols test to work with condensed clang symbol graphs

### DIFF
--- a/test/PrintAsObjC/compatibility-symbols.swift
+++ b/test/PrintAsObjC/compatibility-symbols.swift
@@ -8,4 +8,6 @@
 // Make sure that any macros or typedefs added to the Clang compatibility header are reflected in
 // the `comptibility-symbols` file that is installed in the toolchain.
 
-// CHECK: "symbols": []
+// Use a regex match here to allow the Clang symbol graph to be pretty-printed or condensed
+
+// CHECK: "symbols":{{ ?}}[]


### PR DESCRIPTION
- **Explanation**: Updates a test to handle a change in behavior in Clang ExtractAPI where it stops pretty-printing symbol graph JSON by default.
- **Scope**: Test-only change.
- **Issue**: None
- **Original PR**: https://github.com/apple/swift/pull/72837
- **Risk**: Very low. This is a test-only change that makes it more resilient to Clang updates.
- **Testing**: Automated testing passes at desk.
- **Reviewer**: @daniel-grumberg 