### PR TITLE
[cxx-interop] Support compiling using a custom C++ stdlib

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -697,7 +697,7 @@ protected:
     HasAnyUnavailableDuringLoweringValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -756,7 +756,12 @@ protected:
     HasCxxInteroperability : 1,
 
     /// Whether this module has been built with -experimental-allow-non-resilient-access.
-    AllowNonResilientAccess : 1
+    AllowNonResilientAccess : 1,
+
+    /// Whether this module has been built using a sealed C++ interoperability configuration
+    /// that's broadly incompatible with default C++ interoperability support. For example, this is
+    /// set for modules that use a custom libc++ with C++ interoperability.
+    HasSealedCxxInteroperability : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -131,6 +131,8 @@ WARNING(libstdcxx_modulemap_not_found, none,
         "module map for libstdc++ not found for '%0'; C++ stdlib may be unavailable",
         (StringRef))
 
+ERROR(libcxx_custom_prohibits_system_cxxstdlib_module, none, "transitive import of system's C++ stdlib module '%0' prohibited in custom C++ stdlib mode", (StringRef))
+
 WARNING(api_pattern_attr_ignored, none,
         "'%0' swift attribute ignored on type '%1': type is not copyable or destructible",
         (StringRef, StringRef))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -934,6 +934,13 @@ ERROR(need_cxx_interop_to_import_module,none,
       (Identifier))
 NOTE(enable_cxx_interop_docs,none,
      "visit https://www.swift.org/documentation/cxx-interop/project-build-setup to learn how to enable C++ interoperability", ())
+ERROR(need_custom_cxx_stdlib_to_import_module,none,
+      "module %0 uses system's C++ standard library, but "
+      "current compilation uses a custom C++ standard library",
+      (Identifier))
+ERROR(serialization_import_cant_deserialize_custom_cxx_stdlib_decl,Fatal,
+      "%0 from module %1 cannot be imported because it depends on a custom C++ standard library that is not available in the current compilation",
+      (const Decl *, const ModuleDecl *))
 
 ERROR(modularization_issue_decl_moved,Fatal,
       "reference to %select{top-level declaration|type}0 %1 broken by a context change; "

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -689,6 +689,16 @@ public:
     Bits.ModuleDecl.HasCxxInteroperability = enabled;
   }
 
+  /// Returns true if this module was built with sealed C++ interoperability
+  /// configuration, that's broadly incompatible with default C++
+  /// interoperability support.
+  bool hasSealedCxxInteroperability() const {
+    return Bits.ModuleDecl.HasSealedCxxInteroperability;
+  }
+  void setHasSealedCxxInteroperability(bool enabled = true) {
+    Bits.ModuleDecl.HasSealedCxxInteroperability = enabled;
+  }
+
   /// \returns true if this module is a system module; note that the StdLib is
   /// considered a system module.
   bool isSystemModule() const {

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -328,6 +328,10 @@ namespace swift {
     /// when importing Swift modules that enable C++ interoperability.
     bool RequireCxxInteropToImportCxxInteropModule = true;
 
+    /// Use a custom libc++ at the specified path when importing
+    // and building Clang modules with C++ interoperability enabled.
+    std::string cxxInteropCustomLibcxxPath;
+
     /// On Darwin platforms, use the pre-stable ABI's mark bit for Swift
     /// classes instead of the stable ABI's bit. This is needed when
     /// targeting OSes prior to macOS 10.14.4 and iOS 12.2, where
@@ -763,6 +767,12 @@ namespace swift {
       if (VariantSDKVersion.has_value())
         hashValue = llvm::hash_combine(hashValue, VariantSDKVersion.value().getAsString());
       return hashValue;
+    }
+
+    /// Return true when using a custom C++ standard library for imported
+    /// C and C++ modules.
+    bool isUsingCustomCxxStdLib() const {
+      return !cxxInteropCustomLibcxxPath.empty();
     }
 
   private:

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -939,6 +939,11 @@ def cxx_interop_disable_requirement_at_import :
   HelpText<"Do not require C++ interoperability to be enabled when importing a Swift module that enables C++ interoperability">,
   Flags<[FrontendOption, HelpHidden]>;
 
+def cxx_stdlib_path: JoinedOrSeparate<["-"], "cxx-stdlib-path">,
+  HelpText<"Use a custom C++ runtime as the C++ standard library when importing Clang modules">,
+  MetaVarName<"<path>">,
+  Flags<[FrontendOption, HelpHidden]>;
+
 def use_malloc : Flag<["-"], "use-malloc">,
   HelpText<"Allocate internal data structures using malloc "
            "(for memory debugging)">;

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -141,6 +141,7 @@ class ExtendedValidationInfo {
     unsigned IsConcurrencyChecked : 1;
     unsigned HasCxxInteroperability : 1;
     unsigned AllowNonResilientAccess: 1;
+    unsigned HasSealedCxxInteroperability : 1;
   } Bits;
 public:
   ExtendedValidationInfo() : Bits() {}
@@ -234,6 +235,12 @@ public:
   bool hasCxxInteroperability() const { return Bits.HasCxxInteroperability; }
   void setHasCxxInteroperability(bool val) {
     Bits.HasCxxInteroperability = val;
+  }
+  bool hasSealedCxxInteroperability() const {
+    return Bits.HasSealedCxxInteroperability;
+  }
+  void setHasSealedCxxInteroperability(bool val) {
+    Bits.HasSealedCxxInteroperability = val;
   }
 };
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -723,6 +723,7 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   Bits.ModuleDecl.ObjCNameLookupCachePopulated = 0;
   Bits.ModuleDecl.HasCxxInteroperability = 0;
   Bits.ModuleDecl.AllowNonResilientAccess = 0;
+  Bits.ModuleDecl.HasSealedCxxInteroperability = 0;
 }
 
 void ModuleDecl::setIsSystemModule(bool flag) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1273,6 +1273,12 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.CxxInteropGettersSettersAsProperties = Args.hasArg(OPT_cxx_interop_getters_setters_as_properties);
   Opts.RequireCxxInteropToImportCxxInteropModule =
       !Args.hasArg(OPT_cxx_interop_disable_requirement_at_import);
+  if (const auto *A = Args.getLastArg(OPT_cxx_stdlib_path)) {
+    // Normalize the C++ stdlib path so that it can be compared later.
+    SmallString<256> nativePath;
+    llvm::sys::path::native(A->getValue(), nativePath);
+    Opts.cxxInteropCustomLibcxxPath = nativePath.str();
+  }
 
   Opts.VerifyAllSubstitutionMaps |= Args.hasArg(OPT_verify_all_substitution_maps);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1378,8 +1378,19 @@ ModuleDecl *CompilerInstance::getMainModule() const {
     if (Invocation.getLangOptions().isSwiftVersionAtLeast(6))
       MainModule->setIsConcurrencyChecked(true);
     if (Invocation.getLangOptions().EnableCXXInterop &&
-        Invocation.getLangOptions().RequireCxxInteropToImportCxxInteropModule)
-      MainModule->setHasCxxInteroperability();
+        Invocation.getLangOptions().RequireCxxInteropToImportCxxInteropModule) {
+      // By default, mark this module as using C++ interoperability, which
+      // will require users to also turn on C++ interoperability.
+      if (Invocation.getLangOptions().RequireCxxInteropToImportCxxInteropModule)
+        MainModule->setHasCxxInteroperability();
+      // Using C++ interoperability with a custom C++ stdlib enforces
+      // a best-effort seal that prevents the use of C++ types accross module
+      // boundaries, while ensuring that type layout from such module will
+      // not be constructed incorrectly without correct C++ libraries when used
+      // accross a non-resilient module boundary.
+      if (Invocation.getLangOptions().isUsingCustomCxxStdLib())
+        MainModule->setHasSealedCxxInteroperability();
+    }
     if (Invocation.getLangOptions().AllowNonResilientAccess)
       MainModule->setAllowNonResilientAccess();
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1989,9 +1989,11 @@ swift::getDisallowedOriginKind(const Decl *decl,
   }
 
   // C++ APIs do not support library evolution.
+  // FIXME: switch to seal?
   if (SF->getASTContext().LangOpts.EnableCXXInterop && where.getDeclContext() &&
       where.getDeclContext()->getAsDecl() &&
-      where.getDeclContext()->getAsDecl()->getModuleContext()->isResilient() &&
+      (where.getDeclContext()->getAsDecl()->getModuleContext()->isResilient() ||
+       !SF->getASTContext().LangOpts.cxxInteropCustomLibcxxPath.empty()) &&
       decl->hasClangNode() && !decl->getModuleContext()->isSwiftShimsModule() &&
       isFragileClangNode(decl->getClangNode()))
     return DisallowedOriginKind::FragileCxxAPI;

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -646,6 +646,12 @@ public:
     return Core->Bits.HasCxxInteroperability;
   }
 
+  /// Whether this module was built with sealed C++ interoperability enabled,
+  /// that's broadly incompatible with default C++ interoperability support.
+  bool hasSealedCxxInteroperability() const {
+    return Core->Bits.HasSealedCxxInteroperability;
+  }
+
   /// Whether the module is resilient. ('-enable-library-evolution')
   ResilienceStrategy getResilienceStrategy() const {
     return ResilienceStrategy(Core->Bits.ResilienceStrategy);

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -200,6 +200,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
     case options_block::ALLOW_NON_RESILIENT_ACCESS:
       extendedInfo.setAllowNonResilientAccess(true);
       break;
+    case options_block::HAS_SEALED_CXX_INTEROPERABILITY_ENABLED:
+      extendedInfo.setHasSealedCxxInteroperability(true);
+      break;
     default:
       // Unknown options record, possibly for use by a future version of the
       // module format.
@@ -1448,6 +1451,8 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Bits.IsConcurrencyChecked = extInfo.isConcurrencyChecked();
       Bits.HasCxxInteroperability = extInfo.hasCxxInteroperability();
       Bits.AllowNonResilientAccess = extInfo.allowNonResilientAccess();
+      Bits.HasSealedCxxInteroperability =
+          extInfo.hasSealedCxxInteroperability();
       MiscVersion = info.miscVersion;
       ModuleABIName = extInfo.getModuleABIName();
       ModulePackageName = extInfo.getModulePackageName();

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -391,8 +391,11 @@ private:
     /// Whether this module is built with -experimental-allow-non-resilient-access.
     unsigned AllowNonResilientAccess : 1;
 
+    /// Whether this module is built with sealed C++ interoperability enabled.
+    unsigned HasSealedCxxInteroperability : 1;
+
     // Explicitly pad out to the next word boundary.
-    unsigned : 3;
+    unsigned : 2;
   } Bits = {};
   static_assert(sizeof(ModuleBits) <= 8, "The bit set should be small");
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 870; // borrowed-from instruction
+const uint16_t SWIFTMODULE_VERSION_MINOR = 871; // has sealed c++ interoperability support.
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -941,6 +941,7 @@ namespace options_block {
     PLUGIN_SEARCH_OPTION,
     HAS_CXX_INTEROPERABILITY_ENABLED,
     ALLOW_NON_RESILIENT_ACCESS,
+    HAS_SEALED_CXX_INTEROPERABILITY_ENABLED,
   };
 
   using SDKPathLayout = BCRecordLayout<
@@ -1026,6 +1027,10 @@ namespace options_block {
 
   using AllowNonResilientAccess = BCRecordLayout<
     ALLOW_NON_RESILIENT_ACCESS
+  >;
+
+  using HasSealedCxxInteroperabilityEnabledLayout = BCRecordLayout<
+    HAS_SEALED_CXX_INTEROPERABILITY_ENABLED
   >;
 }
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -855,6 +855,7 @@ void Serializer::writeBlockInfoBlock() {
   BLOCK_RECORD(options_block, MODULE_EXPORT_AS_NAME);
   BLOCK_RECORD(options_block, PLUGIN_SEARCH_OPTION);
   BLOCK_RECORD(options_block, ALLOW_NON_RESILIENT_ACCESS);
+  BLOCK_RECORD(options_block, HAS_SEALED_CXX_INTEROPERABILITY_ENABLED);
 
   BLOCK(INPUT_BLOCK);
   BLOCK_RECORD(input_block, IMPORTED_MODULE);
@@ -1122,6 +1123,12 @@ void Serializer::writeHeader() {
         options_block::HasCxxInteroperabilityEnabledLayout
             CxxInteroperabilityEnabled(Out);
         CxxInteroperabilityEnabled.emit(ScratchRecord);
+
+        if (M->hasSealedCxxInteroperability()) {
+          options_block::HasSealedCxxInteroperabilityEnabledLayout
+              SealedCxxInteroperabilityEnabled(Out);
+          SealedCxxInteroperabilityEnabled.emit(ScratchRecord);
+        }
       }
 
       if (Options.SerializeOptionsForDebugging) {

--- a/test/Interop/Cxx/custom-stdlib/Inputs/c++/__config
+++ b/test/Interop/Cxx/custom-stdlib/Inputs/c++/__config
@@ -1,0 +1,9 @@
+#ifndef CUSTOM_LIBCPP_CONFIG
+#define CUSTOM_LIBCPP_CONFIG
+
+#define CUSTOM_LIBCPP_VERSION 10
+
+#define CUSTOM_LIBCPP_BEGIN_NAMESPACE_STD namespace std { inline namespace v42 {
+#define CUSTOM_LIBCPP_END_NAMESPACE_STD }}
+
+#endif // CUSTOM_LIBCPP_CONFIG

--- a/test/Interop/Cxx/custom-stdlib/Inputs/c++/cstdint
+++ b/test/Interop/Cxx/custom-stdlib/Inputs/c++/cstdint
@@ -1,0 +1,25 @@
+#ifndef CUSTOM_LIBCPP_CSTDINT
+#define CUSTOM_LIBCPP_CSTDINT
+
+#include <__config>
+#include <stdint.h>
+
+#ifndef CUSTOM_LIBCPP_STDINT_H
+#   error <cstdint> tried including <stdint.h> but didn't find libc++'s <stdint.h> header.
+#endif
+
+CUSTOM_LIBCPP_BEGIN_NAMESPACE_STD
+
+using ::int8_t;
+using ::int16_t;
+using ::int32_t;
+using ::int64_t;
+
+using ::uint8_t;
+using ::uint16_t;
+using ::uint32_t;
+using ::uint64_t;
+
+CUSTOM_LIBCPP_END_NAMESPACE_STD
+
+#endif // CUSTOM_LIBCPP_CSTDINT

--- a/test/Interop/Cxx/custom-stdlib/Inputs/c++/module.modulemap
+++ b/test/Interop/Cxx/custom-stdlib/Inputs/c++/module.modulemap
@@ -1,0 +1,24 @@
+module std___config [system] {
+    header "__config"
+    export *
+}
+
+module std_stdint_h [system] {
+    header "stdint.h"
+    export *
+}
+
+module std_cstdint [system] {
+    header "cstdint"
+    export *
+}
+
+module std_string [system] {
+    header "string"
+    export *
+}
+
+module custom_std [system] {
+    header "stdmodule.h"
+    export *
+}

--- a/test/Interop/Cxx/custom-stdlib/Inputs/c++/stdint.h
+++ b/test/Interop/Cxx/custom-stdlib/Inputs/c++/stdint.h
@@ -1,0 +1,10 @@
+#ifndef CUSTOM_LIBCPP_STDINT_H
+#define CUSTOM_LIBCPP_STDINT_H
+
+#include <__config>
+
+#if __has_include_next(<stdint.h>)
+#include_next <stdint.h>
+#endif
+
+#endif // CUSTOM_LIBCPP_STDINT_H

--- a/test/Interop/Cxx/custom-stdlib/Inputs/c++/stdmodule.h
+++ b/test/Interop/Cxx/custom-stdlib/Inputs/c++/stdmodule.h
@@ -1,0 +1,8 @@
+#ifndef CUSTOM_LIBCPP_STD_MODULE
+#define CUSTOM_LIBCPP_STD_MODULE
+
+// Includes all the headers Swift needs!
+#include <cstdint>
+#include <string>
+
+#endif // CUSTOM_LIBCPP_STD_MODULE

--- a/test/Interop/Cxx/custom-stdlib/Inputs/c++/string
+++ b/test/Interop/Cxx/custom-stdlib/Inputs/c++/string
@@ -1,0 +1,39 @@
+#ifndef CUSTOM_LIBCPP_STRING
+#define CUSTOM_LIBCPP_STRING
+
+#include <__config>
+#include <string.h>
+
+CUSTOM_LIBCPP_BEGIN_NAMESPACE_STD
+
+template <class charT>
+class basic_string {
+public:
+    basic_string() = default;
+    basic_string(const charT* str) : size_(strlen(str)) {
+        this->str = new charT[size_];
+        memcpy(this->str, str, size_);
+        this->str[size_] = '\0';
+    }
+    basic_string(const basic_string<charT> &other) : size_(other.size_) {
+        this->str = new charT[size_];
+        memcpy(this->str, other.str, size_);
+        this->str[size_] = '\0';
+    }
+    ~basic_string() {
+        if (str)
+            delete[] str;
+    }
+
+    const charT* c_str() const { return str; }
+    size_t size() const { return size_; }
+private:
+    charT* str = nullptr;
+    size_t size_ = 0;
+};
+
+using string = basic_string<char>;
+
+CUSTOM_LIBCPP_END_NAMESPACE_STD
+
+#endif // CUSTOM_LIBCPP_STRING

--- a/test/Interop/Cxx/custom-stdlib/Inputs/header-system-stdlib.h
+++ b/test/Interop/Cxx/custom-stdlib/Inputs/header-system-stdlib.h
@@ -1,0 +1,9 @@
+#ifndef CxxHeader_System_Stdlib_h
+#define CxxHeader_System_Stdlib_h
+
+struct SimpleStruct {
+  int x;
+  int y;
+};
+
+#endif // CxxHeader_System_Stdlib_h

--- a/test/Interop/Cxx/custom-stdlib/Inputs/header.h
+++ b/test/Interop/Cxx/custom-stdlib/Inputs/header.h
@@ -1,0 +1,16 @@
+#ifndef CxxHeader_h
+#define CxxHeader_h
+
+#ifndef __swift_use_custom_cxx_stdlib__
+#error "This file should only be used with __swift_use_custom_cxx_stdlib__"
+#endif
+
+#include <cstdint>
+#include <string>
+
+struct SimpleStruct {
+  std::int32_t x;
+  std::uint32_t y;
+};
+
+#endif // CxxHeader_h

--- a/test/Interop/Cxx/custom-stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/custom-stdlib/Inputs/module.modulemap
@@ -1,0 +1,9 @@
+module CxxHeader {
+    header "header.h"
+    export *
+}
+
+module CxxHeaderSystemStdlib {
+    header "header-system-stdlib.h"
+    export *
+}

--- a/test/Interop/Cxx/custom-stdlib/custom-stdlib-api-restrictions.swift
+++ b/test/Interop/Cxx/custom-stdlib/custom-stdlib-api-restrictions.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swiftxx-frontend -typecheck -cxx-stdlib-path%S/Inputs/c++ -I %S/Inputs -dump-clang-diagnostics %s -verify
+
+import CxxHeader
+import custom_std
+
+public func testCustomRetStruct() -> SimpleStruct { // expected-error {{cannot use struct 'SimpleStruct' here}}
+    return SimpleStruct(x: 0, y: 0)
+}
+
+public func testCustomString(_ x: std.string) -> Int { // expected-error {{cannot use type alias 'string' here}}
+    return 0
+}
+
+@_alwaysEmitIntoClient
+public func testCustomStringAEIC() -> Int {
+    let c = std.string("hello") // expected-error {{}} expected-error {{}} expected-error {{}}
+    return Int(c.size()) // expected-error {{}}
+}
+
+@inlinable
+public func testCustomStringInlinable() -> Int {
+    let c = std.string("hello") // expected-error {{}} expected-error {{}} expected-error {{}}
+    return Int(c.size()) // expected-error {{}}
+}

--- a/test/Interop/Cxx/custom-stdlib/custom-stdlib-prohibit-system-stdlib-dependent-module.swift
+++ b/test/Interop/Cxx/custom-stdlib/custom-stdlib-prohibit-system-stdlib-dependent-module.swift
@@ -1,0 +1,10 @@
+// RUN: rm -rf %t
+// RUN: %target-swiftxx-frontend -DONE -emit-module -I %S/Inputs %s -module-name One -o %t/One.swiftmodule
+
+// RUN: %target-swiftxx-frontend -typecheck -I %t -cxx-stdlib-path%S/Inputs/c++ -I %S/Inputs -dump-clang-diagnostics %s -verify
+
+#if ONE
+import CxxHeaderSystemStdlib
+#else
+import One // expected-error {{module 'One' uses system's C++ standard library, but current compilation uses a custom C++ standard library}}
+#endif

--- a/test/Interop/Cxx/custom-stdlib/custom-stdlib-sealed-module-typelayout-leak-prevention.swift
+++ b/test/Interop/Cxx/custom-stdlib/custom-stdlib-sealed-module-typelayout-leak-prevention.swift
@@ -1,0 +1,42 @@
+// RUN: rm -rf %t
+// RUN: %target-swiftxx-frontend -DCUSTOM -emit-module -cxx-stdlib-path%S/Inputs/c++ -I %S/Inputs %s -module-name Custom -o %t/Custom.swiftmodule
+// RUN: not %target-swiftxx-frontend -emit-ir -I %t -I %S/Inputs %s -o - 2>&1 | %FileCheck --check-prefix=CHECK-STRUCT %s
+// RUN: not %target-swiftxx-frontend -emit-ir -I %t -I %S/Inputs -DCLASS %s -o - 2>&1 | %FileCheck --check-prefix=CHECK-CLASS %s
+
+#if CUSTOM
+
+@_implementationOnly import CxxHeader
+
+public struct MyStruct {
+    private let s: SimpleStruct = SimpleStruct(x: 0, y: 0)
+    public let i: Int = 0
+
+    public init() {
+    }
+}
+
+public class MyClass {
+    private let s: SimpleStruct = SimpleStruct(x: 0, y: 0)
+    public let i: Int = 0
+
+    public init() {
+    }
+}
+
+
+#else
+
+import Custom
+
+public func m() {
+#if CLASS
+    let c = MyClass()
+#else
+    let s = MyStruct()
+#endif
+}
+// CHECK-STRUCT: 'MyStruct' from module 'Custom' cannot be imported because it depends on a custom C++ standard library that is not available in the current compilation
+// CHECK-CLASS: 'MyClass' from module 'Custom' cannot be imported because it depends on a custom C++ standard library that is not available in the current compilation
+
+
+#endif

--- a/test/Interop/Cxx/custom-stdlib/cxxstdlib-not-importable.swift
+++ b/test/Interop/Cxx/custom-stdlib/cxxstdlib-not-importable.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-swiftxx-frontend -emit-ir -cxx-stdlib-path%S/Inputs/c++ -I %S/Inputs %s 2>&1 | %FileCheck %s
+
+// CHECK: cannot load underlying module for 'CxxStdlib'
+import CxxStdlib

--- a/test/Interop/Cxx/custom-stdlib/import-custom-std.swift
+++ b/test/Interop/Cxx/custom-stdlib/import-custom-std.swift
@@ -1,0 +1,23 @@
+// RUN: %target-swiftxx-frontend -typecheck -cxx-stdlib-path%S/Inputs/c++ -I %S/Inputs -dump-clang-diagnostics %s 2>&1 | %FileCheck -check-prefix=CLANG_DIAGS %s
+// RUN: %target-swiftxx-frontend -emit-ir -cxx-stdlib-path%S/Inputs/c++ -I %S/Inputs -Xcc -fignore-exceptions %s | %FileCheck -check-prefix=IR %s
+
+import CxxHeader
+import custom_std
+
+// CLANG_DIAGS: clang importer driver args:
+// CLANG_DIAGS-SAME: '-D__swift_use_custom_cxx_stdlib__'
+// CLANG_DIAGS-SAME: '-isystem<placeholder-custom-cxx-stdlib-dir>'
+// CLANG_DIAGS-SAME: '-nostdinc++'
+// CLANG_DIAGS: Adjusted include paths to account for custom C++ stdlib:
+// CLANG_DIAGS-SAME: Inputs/c++'
+
+public func testCustomString() -> Int {
+    let s = std.string("hello")
+    return Int(s.size())
+}
+
+// IR: %{{.*}} = call ptr @_ZNSt3v4212basic_stringIcEC1EPKc(ptr %{{.*}}, ptr %{{.*}})
+// IR: call i{{.*}} @_ZNKSt3v4212basic_stringIcE4sizeEv(ptr %{{.*}})
+
+// IR: "-lswiftCxx"
+// IR-NOT: "-lswiftCxxStdlib"

--- a/test/Interop/Cxx/custom-stdlib/import-custom-stdlib-sealed-module.swift
+++ b/test/Interop/Cxx/custom-stdlib/import-custom-stdlib-sealed-module.swift
@@ -1,0 +1,25 @@
+// RUN: rm -rf %t
+// RUN: %target-swiftxx-frontend -DCUSTOM -emit-module -cxx-stdlib-path%S/Inputs/c++ -I %S/Inputs %s -module-name Custom -o %t/Custom.swiftmodule
+// RUN: %target-swiftxx-frontend -emit-ir -I %t -I %S/Inputs %s -o - | %FileCheck %s
+
+#if CUSTOM
+
+@_implementationOnly import CxxHeader
+@_implementationOnly import custom_std
+
+public func testCustomString() -> Int {
+    let s = std.string("hello")
+    return Int(s.size())
+}
+
+#else
+
+import Custom
+
+public func test() -> Int {
+    return testCustomString()
+}
+
+// CHECK: call swiftcc i64 @"$s6Custom04testA6StringSiyF"()
+
+#endif

--- a/test/Interop/Cxx/custom-stdlib/use-custom-std.swift
+++ b/test/Interop/Cxx/custom-stdlib/use-custom-std.swift
@@ -1,0 +1,21 @@
+// RUN: %target-run-simple-swift(-cxx-interoperability-mode=default -Xfrontend -cxx-stdlib-path%S/Inputs/c++ -I %S/Inputs)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import CxxHeader
+import custom_std
+
+var CustomStdTestSuite = TestSuite("CustomStd")
+
+CustomStdTestSuite.test("SimpleStruct") {
+    let s = SimpleStruct(x: 0, y: 0)
+    expectEqual(s.x, 0)
+}
+
+CustomStdTestSuite.test("String") {
+    let s = std.string("hello")
+    expectEqual(s.size(), 5)
+}
+
+runAllTests()


### PR DESCRIPTION
This PR adds a new frontend flag `-clang-libcxx-path`, that lets you specify a path to a custom C++ standard library that should be used when importing C++ modules into Swift. This flag instructs clang importer to ignore system's default stdlib, and instead use the given path for C++ stdlib headers. This also means that it prevents the use of CxxStdlib overlay with the custom stdlib. It also adds a new define `__swift_use_custom_libcxx__` to the clang importer in this mode, to allow C++ headers to enforce that they're being imported with a custom stdlib into Swift.

A swift module that builds with  `-clang-libcxx-path` also provides a mechanism that allows users to effectively seal the module's use of C++ APIs, to prevent leakage of the custom C++ stdlib dependency to other Swift modules. This is done both by prohibiting the import of other modules that use C++ interoperability without a custom stdlib, and also by prohibiting the use of C++ types in public Swift APIs. Additionally, clients can use `@_implementationOnly` imports to further seal the custom C++ stdlib dependency across a non-resilient module boundary, and Swift will validate that the deserialized Swift type layout doesn't leak its custom C++ module dependencies into other Swift modules. 