### PR TITLE
[6.0 🍒] Add mandatory SIL pass implementing `@_alwaysEmitConformanceMetadata` protocol attribute

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -98,6 +98,8 @@ PASS(AccessEnforcementSelection, "access-enforcement-selection",
      "Access Enforcement Selection")
 PASS(AccessEnforcementWMO, "access-enforcement-wmo",
      "Access Enforcement Whole Module Optimization")
+PASS(AlwaysEmitConformanceMetadataPreservation, "preserve-always-emit-conformance-metadata",
+     "Mark conformances to @_alwaysEmitConformanceMetadata protocols as externally visible")
 PASS(CrossModuleOptimization, "cmo",
      "Perform cross-module optimization")
 PASS(AccessSummaryDumper, "access-summary-dump",

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1354,6 +1354,11 @@ bool IRGenerator::canEmitWitnessTableLazily(SILWitnessTable *wt) {
   if (wt->getLinkage() == SILLinkage::Shared)
     return true;
 
+  // Check if this type is set to be explicitly externally visible
+  NominalTypeDecl *ConformingTy = wt->getConformingNominal();
+  if (PrimaryIGM->getSILModule().isExternallyVisibleDecl(ConformingTy))
+    return false;
+
   switch (wt->getConformingNominal()->getEffectiveAccess()) {
     case AccessLevel::Private:
     case AccessLevel::FilePrivate:

--- a/lib/SILOptimizer/Mandatory/AlwaysEmitConformanceMetadataPreservation.cpp
+++ b/lib/SILOptimizer/Mandatory/AlwaysEmitConformanceMetadataPreservation.cpp
@@ -1,0 +1,108 @@
+//===--- AlwaysEmitConformanceMetadataPreservation.cpp -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// Some frameworks may rely on conformances to protocols they provide
+/// to be present in binary product they are compiled into even if
+/// such conformances are not otherwise referenced in user code.
+/// Such conformances may then, for example, be queried and used by the
+/// runtime.
+///
+/// The developer may not ever explicitly reference or instantiate this type in
+/// their code, as it is effectively defining an XPC endpoint. However, when
+/// optimizations are enabled, the type may be stripped from the binary as it is
+/// never referenced. `@_alwaysEmitConformanceMetadata` can be used to mark
+/// a protocol to ensure that its conformances are always marked as externally
+/// visible even if not `public` to ensure they do not get optimized away.
+/// This mandatory pass makes it so.
+///
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/Attr.h"
+#define DEBUG_TYPE "always-emit-conformance-metadata-preservation"
+#include "swift/AST/ASTWalker.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/AST/ProtocolConformance.h"
+#include "swift/AST/SourceFile.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+
+using namespace swift;
+
+namespace {
+
+/// A helper class to collect all nominal type declarations that conform to
+/// `@_alwaysEmitConformanceMetadata` protocols.
+class AlwaysEmitMetadataConformanceCollector : public ASTWalker {
+  std::vector<NominalTypeDecl *> &AlwaysEmitMetadataConformanceDecls;
+
+public:
+  AlwaysEmitMetadataConformanceCollector(
+      std::vector<NominalTypeDecl *> &AlwaysEmitMetadataConformanceDecls)
+      : AlwaysEmitMetadataConformanceDecls(AlwaysEmitMetadataConformanceDecls) {
+  }
+
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    auto hasAlwaysEmitMetadataConformance =
+        [&](llvm::PointerUnion<const TypeDecl *, const ExtensionDecl *> Decl) {
+          bool anyObject = false;
+          InvertibleProtocolSet Inverses;
+          for (const auto &found :
+               getDirectlyInheritedNominalTypeDecls(Decl, Inverses, anyObject))
+            if (auto Protocol = dyn_cast<ProtocolDecl>(found.Item))
+              if (Protocol->getAttrs()
+                      .hasAttribute<AlwaysEmitConformanceMetadataAttr>())
+                return true;
+          return false;
+        };
+
+    if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
+      if (hasAlwaysEmitMetadataConformance(NTD))
+        AlwaysEmitMetadataConformanceDecls.push_back(NTD);
+    } else if (auto *ETD = dyn_cast<ExtensionDecl>(D)) {
+      if (hasAlwaysEmitMetadataConformance(ETD))
+        AlwaysEmitMetadataConformanceDecls.push_back(ETD->getExtendedNominal());
+    }
+
+    return Action::Continue();
+  }
+};
+
+class AlwaysEmitConformanceMetadataPreservation : public SILModuleTransform {
+  void run() override {
+    auto &M = *getModule();
+    std::vector<NominalTypeDecl *> AlwaysEmitMetadataConformanceDecls;
+    AlwaysEmitMetadataConformanceCollector Walker(
+        AlwaysEmitMetadataConformanceDecls);
+
+    SmallVector<Decl *> TopLevelDecls;
+    if (M.getSwiftModule()->isMainModule()) {
+      if (M.isWholeModule()) {
+        for (const auto File : M.getSwiftModule()->getFiles())
+          File->getTopLevelDecls(TopLevelDecls);
+      } else {
+        for (const auto Primary : M.getSwiftModule()->getPrimarySourceFiles())
+          Primary->getTopLevelDecls(TopLevelDecls);
+      }
+    }
+    for (auto *TLD : TopLevelDecls)
+      TLD->walk(Walker);
+
+    for (auto &NTD : AlwaysEmitMetadataConformanceDecls)
+      M.addExternallyVisibleDecl(NTD);
+  }
+};
+} // end anonymous namespace
+
+SILTransform *swift::createAlwaysEmitConformanceMetadataPreservation() {
+  return new AlwaysEmitConformanceMetadataPreservation();
+}

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(swiftSILOptimizer PRIVATE
   AccessEnforcementSelection.cpp
   AccessMarkerElimination.cpp
+  AlwaysEmitConformanceMetadataPreservation.cpp
   AddressLowering.cpp
   CapturePromotion.cpp
   ClosureLifetimeFixup.cpp

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -900,6 +900,7 @@ SILPassPipelinePlan::getLoweringPassPipeline(const SILOptions &Options) {
   P.startPipeline("Lowering");
   P.addLowerHopToActor(); // FIXME: earlier for more opportunities?
   P.addOwnershipModelEliminator();
+  P.addAlwaysEmitConformanceMetadataPreservation();
   P.addIRGenPrepare();
 
   return P;

--- a/test/Reflection/Inputs/PreservedConformanceProtocols.swift
+++ b/test/Reflection/Inputs/PreservedConformanceProtocols.swift
@@ -1,0 +1,2 @@
+@_alwaysEmitConformanceMetadata
+public protocol TestEntity {}

--- a/test/Reflection/preserve_conformance_metadata_attr.swift
+++ b/test/Reflection/preserve_conformance_metadata_attr.swift
@@ -1,0 +1,31 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/includes)
+
+// Build support Protocols module
+// RUN: %target-build-swift %S/Inputs/PreservedConformanceProtocols.swift -parse-as-library -emit-module -emit-library -module-name PreservedConformanceProtocols -o %t/includes/PreservedConformanceProtocols.o
+
+// Build the test into a binary
+// RUN: %target-build-swift %s -parse-as-library -emit-module -emit-library -module-name PreservedConformances -O -whole-module-optimization -I %t/includes -o %t/PreservedConformances -Xlinker %t/includes/PreservedConformanceProtocols.o
+
+// RUN: %target-swift-reflection-dump %t/PreservedConformances | %FileCheck %s
+
+import PreservedConformanceProtocols
+
+struct internalTestEntity : TestEntity {
+    struct internalNestedTestEntity : TestEntity {}
+}
+private struct privateTestEntity : TestEntity {
+    private struct privateNestedTestEntity : TestEntity {}
+}
+fileprivate struct filePrivateTestEntity : TestEntity {}
+public struct publicTestEntity : TestEntity {}
+
+// CHECK: CONFORMANCES:
+// CHECK: =============
+// CHECK-DAG: 21PreservedConformances16publicTestEntityV (PreservedConformances.publicTestEntity) : PreservedConformanceProtocols.TestEntity
+// CHECK-DAG: 21PreservedConformances21filePrivateTestEntity5${{[0-9a-f]+}}LLV (PreservedConformances.(filePrivateTestEntity in ${{[0-9a-f]+}})) : PreservedConformanceProtocols.TestEntity
+// CHECK-DAG: 21PreservedConformances17privateTestEntity5${{[0-9a-f]+}}LLV (PreservedConformances.(privateTestEntity in ${{[0-9a-f]+}})) : PreservedConformanceProtocols.TestEntity
+// CHECK-DAG: 21PreservedConformances17privateTestEntity5${{[0-9a-f]+}}LLV0c6NesteddE0V (PreservedConformances.(privateTestEntity in ${{[0-9a-f]+}}).privateNestedTestEntity) : PreservedConformanceProtocols.TestEntity
+// CHECK-DAG: 21PreservedConformances18internalTestEntityV (PreservedConformances.internalTestEntity) : PreservedConformanceProtocols.TestEntity
+// CHECK-DAG: 21PreservedConformances18internalTestEntityV0c6NesteddE0V (PreservedConformances.internalTestEntity.internalNestedTestEntity) : PreservedConformanceProtocols.TestEntity


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/69609
----------------------
This change was originally reverted in https://github.com/apple/swift/pull/69689 and re-landed in https://github.com/apple/swift/pull/69694

**Explanation**: This change adds an implementation of a protocol attribute for ensuring that conformances to such protocols must have their type metadata always emitted into the binary, regardless of whether they are used or public. Implementing semantics of the attribute added in:
https://github.com/apple/swift/pull/60367

**Risk**: Low. The change is additive and adds an implementation of an attribute (`@_alwaysEmitConformanceMetadata`) that previously had no effect. It will not affect existing code-paths which do not use this attribute, and we do not expect there to be any uses of it in the wild. 

**Testing**: Automated test added to the compiler test suite. 

**Reviewed By**: @aschwaighofer 