### PR TITLE
[6.0][NFC] Mark a concurrency test as unsupported in the freestanding configuration.

### DIFF
--- a/test/Concurrency/actor_data_race_checks_minimal.swift
+++ b/test/Concurrency/actor_data_race_checks_minimal.swift
@@ -3,6 +3,7 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
+// UNSUPPORTED: freestanding
 
 @preconcurrency @MainActor
 protocol P {


### PR DESCRIPTION
* **Explanation**: This test uses a `Task` API that is not available in the task-to-thread configuration. Disable it in the `freestanding` configuration, which uses task-to-thread concurrency.
* **Scope**: N/A
* **Risk**: N/A
* **Testing**: N/A
* **Reviewer**: @ktoso
* **Main branch PR**: https://github.com/apple/swift/pull/72824