### PR TITLE
Add the experimental attribute `@sensitive` for struct declarations

### DIFF
--- a/include/swift/AST/DeclAttr.def
+++ b/include/swift/AST/DeclAttr.def
@@ -494,6 +494,15 @@ DECL_ATTR_ALIAS(_disallowFeatureSuppression, AllowFeatureSuppression)
 SIMPLE_DECL_ATTR(_preInverseGenerics, PreInverseGenerics,
   OnAbstractFunction | OnSubscript | OnVar | OnExtension | UserInaccessible | ABIBreakingToAdd | ABIBreakingToRemove | APIStableToAdd | APIStableToRemove,
   158)
+
+// Declares that a struct contains "sensitive" data. It enforces that the contents of such a struct value
+// is zeroed out at the end of its lifetime. In other words: the content of such a value is not observable
+// in memory after the value's lifetime.
+// TODO: enable @sensitive also for other nominal types than structs, e.g. for enums
+SIMPLE_DECL_ATTR(sensitive, Sensitive,
+  OnStruct | UserInaccessible | ABIStableToAdd | ABIStableToRemove | APIBreakingToAdd | APIStableToRemove,
+  159)
+
 LAST_DECL_ATTR(PreInverseGenerics)
 
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1983,6 +1983,10 @@ ERROR(attr_static_exclusive_only_mutating,none,
 ERROR(attr_extractConstantsFromMembers_experimental,none,
       "@extractConstantsFromMembers requires '-enable-experimental-feature ExtractConstantsFromMembers'", ())
 
+// @sensitive
+ERROR(attr_sensitive_experimental,none,
+      "@sensitive requires '-enable-experimental-feature Sensitive'", ())
+
 ERROR(c_func_variadic, none,
       "cannot declare variadic argument %0 in %kind1",
       (DeclName, const ValueDecl *))

--- a/include/swift/AST/FeatureAvailability.def
+++ b/include/swift/AST/FeatureAvailability.def
@@ -74,6 +74,7 @@ FEATURE(IsolatedAny,                                    (5, 11))
 FEATURE(TaskExecutor,                                   FUTURE)
 FEATURE(Differentiation,                                FUTURE)
 FEATURE(InitRawStructMetadata,                          FUTURE)
+FEATURE(ClearSensitive,                                 FUTURE)
 
 #undef FEATURE
 #undef FUTURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -384,6 +384,8 @@ EXPERIMENTAL_FEATURE(ObjCImplementation, true)
 // Enable @implementation on @_cdecl functions.
 EXPERIMENTAL_FEATURE(CImplementation, true)
 
+// Enable @sensitive attribute.
+EXPERIMENTAL_FEATURE(Sensitive, true)
 
 #undef EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE
 #undef EXPERIMENTAL_FEATURE

--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -42,6 +42,9 @@ void *swift_slowAllocTyped(size_t bytes, size_t alignMask, MallocTypeId typeId);
 SWIFT_RUNTIME_EXPORT
 void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask);
 
+SWIFT_RUNTIME_EXPORT
+void swift_clearSensitive(void *ptr, size_t bytes);
+
 /// Allocate and construct an instance of type \c T.
 ///
 /// \param args The arguments to pass to the constructor for \c T.

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2832,6 +2832,13 @@ FUNCTION(ClearSensitive, swift_clearSensitive, C_CC, ClearSensitiveAvailability,
          EFFECT(NoEffect),
          UNKNOWN_MEMEFFECTS)
 
+FUNCTION(MemsetS, memset_s, C_CC, AlwaysAvailable,
+         RETURNS(Int32Ty),
+         ARGS(PtrTy, SizeTy, Int32Ty, SizeTy),
+         ATTRS(NoUnwind),
+         EFFECT(NoEffect),
+         UNKNOWN_MEMEFFECTS)
+
 #undef RETURNS
 #undef ARGS
 #undef ATTRS

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -2825,6 +2825,13 @@ FUNCTION(ExceptionPersonality,
          EFFECT(NoEffect),
          UNKNOWN_MEMEFFECTS)
 
+FUNCTION(ClearSensitive, swift_clearSensitive, C_CC, ClearSensitiveAvailability,
+         RETURNS(VoidTy),
+         ARGS(PtrTy, SizeTy),
+         ATTRS(NoUnwind),
+         EFFECT(NoEffect),
+         UNKNOWN_MEMEFFECTS)
+
 #undef RETURNS
 #undef ARGS
 #undef ATTRS

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -481,7 +481,13 @@ public:
   bool hasParameterizedExistential() const {
     return getASTType()->hasParameterizedExistential();
   }
-  
+
+  bool isSensitive() const {
+    if (auto *nom = getNominalOrBoundGenericNominal())
+      return nom->getAttrs().hasAttribute<SensitiveAttr>();
+    return false;
+  }
+
   /// Returns the representation used by an existential type. If the concrete
   /// type is provided, this may return a specialized representation kind that
   /// can be used for that type. Otherwise, returns the most general

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -694,6 +694,10 @@ static bool usesFeatureGlobalActorIsolatedTypesUsability(Decl *decl) {
 UNINTERESTING_FEATURE(ObjCImplementation)
 UNINTERESTING_FEATURE(CImplementation)
 
+static bool usesFeatureSensitive(Decl *decl) {
+  return decl->getAttrs().hasAttribute<SensitiveAttr>();
+}
+
 // ----------------------------------------------------------------------------
 // MARK: - FeatureSet
 // ----------------------------------------------------------------------------

--- a/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
+++ b/lib/ASTGen/Sources/ASTGen/DeclAttrs.swift
@@ -167,6 +167,8 @@ extension ASTGenVisitor {
         return self.generateSectionAttr(attribute: node)?.asDeclAttribute
       case .semantics:
         return self.generateSemanticsAttr(attribute: node)?.asDeclAttribute
+      case .sensitive:
+        fatalError("unimplemented")
       case .silGenName:
         return self.generateSILGenNameAttr(attribute: node)?.asDeclAttribute
       case .specialize:

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8075,6 +8075,14 @@ ClangImporter::Implementation::importSwiftAttrAttributes(Decl *MappedDecl) {
         continue;
       }
 
+      if (swiftAttr->getAttribute() == "sensitive") {
+        if (!SwiftContext.LangOpts.hasFeature(Feature::Sensitive))
+          continue;
+        auto attr = new (SwiftContext) SensitiveAttr(/*implicit=*/true);
+        MappedDecl->getAttrs().add(attr);
+        continue;
+      }
+
       // Dig out a buffer with the attribute text.
       unsigned bufferID = getClangSwiftAttrSourceBuffer(
           swiftAttr->getAttribute());

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -91,7 +91,8 @@ public:
   // We can give these reasonable default implementations.
 
   void initializeWithTake(IRGenFunction &IGF, Address destAddr, Address srcAddr,
-                          SILType T, bool isOutlined) const override;
+                          SILType T, bool isOutlined,
+                          bool zeroizeIfSensitive) const override;
 
   llvm::Value *getSize(IRGenFunction &IGF, SILType T) const override;
   llvm::Value *getAlignmentMask(IRGenFunction &IGF, SILType T) const override;

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1229,7 +1229,8 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
       case BuiltinValueKind::TakeArrayNoAlias:
       case BuiltinValueKind::TakeArrayFrontToBack:
       case BuiltinValueKind::TakeArrayBackToFront:
-        elemTI.initializeWithTake(IGF, destAddr, srcAddr, elemTy, isOutlined);
+        elemTI.initializeWithTake(IGF, destAddr, srcAddr, elemTy, isOutlined,
+                                  /*zeroizeIfSensitive=*/ true);
         break;
       case BuiltinValueKind::AssignCopyArrayNoAlias:
       case BuiltinValueKind::AssignCopyArrayFrontToBack:

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -50,7 +50,10 @@ clang::CanQualType IRGenModule::getClangType(SILParameterInfo params,
     if (params.isIndirectMutating()) {
       return getClangASTContext().getPointerType(clangType);
     }
-    if (params.isFormalIndirect()) {
+    if (params.isFormalIndirect() &&
+        // Sensitive return types are represented as indirect return value in SIL,
+        // but are returned as values (if small) in LLVM IR.
+        !paramTy.isSensitive()) {
       auto constTy =
         getClangASTContext().getCanonicalType(clangType.withConst());
       return getClangASTContext().getPointerType(constTy);

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -408,7 +408,8 @@ public:
   virtual void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                                   SILType T, bool isOutlined) const = 0;
   virtual void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                                  SILType T, bool isOutlined) const = 0;
+                                  SILType T, bool isOutlined,
+                                  bool zeroizeIfSensitive) const = 0;
 
   virtual void initializeMetadata(IRGenFunction &IGF,
                                   llvm::Value *metadata,

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -291,7 +291,8 @@ namespace {
     }
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T, bool isOutlined) const override {
+                            SILType T, bool isOutlined,
+                            bool zeroizeIfSensitive) const override {
       if (isOutlined || T.hasLocalArchetype()) {
         Address destValue = projectValue(IGF, dest);
         Address srcValue = projectValue(IGF, src);
@@ -976,7 +977,8 @@ public:
   }
 
   void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                          SILType T, bool isOutlined) const override {
+                          SILType T, bool isOutlined,
+                          bool zeroizeIfSensitive) const override {
     if (isOutlined || T.hasLocalArchetype()) {
       // memcpy the existential container. This is safe because: either the
       // value is stored inline and is therefore by convention bitwise takable

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2309,7 +2309,8 @@ std::optional<StackAddress> irgen::emitFunctionPartialApplication(
           auto addr =
               fieldLayout.getType().getAddressForPointer(args.claimNext());
           fieldLayout.getType().initializeWithTake(IGF, fieldAddr, addr,
-                                                   fieldTy, isOutlined);
+                                                   fieldTy, isOutlined,
+                                                   /*zeroizeIfSensitive=*/ true);
         }
         break;
       }

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -82,7 +82,7 @@ namespace {
     } \
     void initializeWithTake(IRGenFunction &IGF, Address destAddr, \
                             Address srcAddr, SILType T, \
-                            bool isOutlined) const override { \
+                            bool isOutlined, bool zeroizeIfSensitive) const override { \
       IGF.emit##Nativeness##Name##TakeInit(destAddr, srcAddr); \
     } \
     void assignWithCopy(IRGenFunction &IGF, Address destAddr, Address srcAddr, \

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -114,5 +114,9 @@ void TemporarySet::destroyAll(IRGenFunction &IGF) const {
 
 void Temporary::destroy(IRGenFunction &IGF) const {
   auto &ti = IGF.getTypeInfo(Type);
+  if (Type.isSensitive()) {
+    llvm::Value *size = ti.getSize(IGF, Type);
+    IGF.emitClearSensitive(Addr.getAddress(), size);
+  }
   ti.deallocateStack(IGF, Addr, Type);
 }

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -536,7 +536,7 @@ getInitializerForComputedComponent(IRGenModule &IGM,
       // buffer.
       if (&component == operands[index.Operand].LastUser) {
         ti.initializeWithTake(IGF, destAddr, srcAddresses[index.Operand], ty,
-                              false);
+                              false, /*zeroizeIfSensitive=*/ true);
       } else {
         ti.initializeWithCopy(IGF, destAddr, srcAddresses[index.Operand], ty,
                               false);
@@ -1364,7 +1364,7 @@ std::pair<llvm::Value *, llvm::Value *> irgen::emitKeyPathArgument(
         IGF.Builder.CreateBitCast(ptr, ti.getStorageType()->getPointerTo()));
     if (operandTy.isAddress()) {
       ti.initializeWithTake(IGF, addr, ti.getAddressForPointer(indiceValues.claimNext()),
-                            operandTy, false);
+                            operandTy, false, /*zeroizeIfSensitive=*/ true);
     } else {
       cast<LoadableTypeInfo>(ti).initialize(IGF, indiceValues, addr, false);
     }

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -141,6 +141,13 @@ protected:
                             this->template getTrailingObjects<FieldImpl>());
   }
 
+  void fillWithZerosIfSensitive(IRGenFunction &IGF, Address address, SILType T) const {
+    if (T.isSensitive()) {
+      llvm::Value *size = asImpl().getSize(IGF, T);
+      IGF.emitClearSensitive(address, size);
+    }
+  }
+
 public:
   /// Allocate and initialize a type info of this type.
   template <class... As>
@@ -206,6 +213,7 @@ public:
         field.getTypeInfo().assignWithTake(
             IGF, destField, srcField, field.getType(IGF.IGM, T), isOutlined);
       }
+      fillWithZerosIfSensitive(IGF, src, T);
     } else {
       this->callOutlinedCopy(IGF, dest, src, T, IsNotInitialization, IsTake);
     }
@@ -242,22 +250,19 @@ public:
   }
 
   void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                          SILType T, bool isOutlined) const override {
+                          SILType T, bool isOutlined,
+                          bool zeroizeIfSensitive) const override {
     // If we're bitwise-takable, use memcpy.
     if (this->isBitwiseTakable(ResilienceExpansion::Maximal)) {
       IGF.Builder.CreateMemCpy(
           dest.getAddress(), llvm::MaybeAlign(dest.getAlignment().getValue()),
           src.getAddress(), llvm::MaybeAlign(src.getAlignment().getValue()),
           asImpl().Impl::getSize(IGF, T));
-      return;
-    }
-
-    // If the fields are not ABI-accessible, use the value witness table.
-    if (!AreFieldsABIAccessible) {
+    } else if (!AreFieldsABIAccessible) {
+      // If the fields are not ABI-accessible, use the value witness table.
       return emitInitializeWithTakeCall(IGF, T, dest, src);
-    }
 
-    if (isOutlined || T.hasParameterizedExistential()) {
+    } else if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
         if (field.isEmpty())
@@ -266,11 +271,14 @@ public:
         Address destField = field.projectAddress(IGF, dest, offsets);
         Address srcField = field.projectAddress(IGF, src, offsets);
         field.getTypeInfo().initializeWithTake(
-            IGF, destField, srcField, field.getType(IGF.IGM, T), isOutlined);
+            IGF, destField, srcField, field.getType(IGF.IGM, T), isOutlined,
+              zeroizeIfSensitive);
       }
     } else {
       this->callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsTake);
     }
+    if (zeroizeIfSensitive)
+      fillWithZerosIfSensitive(IGF, src, T);
   }
 
   void destroy(IRGenFunction &IGF, Address addr, SILType T,
@@ -283,12 +291,15 @@ public:
     if (isOutlined || T.hasParameterizedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
-        if (field.isTriviallyDestroyable())
+        SILType fieldType = field.getType(IGF.IGM, T);
+        if (field.isTriviallyDestroyable() &&
+            !((bool)fieldType && fieldType.isSensitive())) {
           continue;
+        }
 
         field.getTypeInfo().destroy(IGF,
                                     field.projectAddress(IGF, addr, offsets),
-                                    field.getType(IGF.IGM, T), isOutlined);
+                                    fieldType, isOutlined);
       }
     } else {
       this->callOutlinedDestroy(IGF, addr, T);

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -271,12 +271,11 @@ namespace {
                  bool isOutlined) const override {
       // If the struct has a deinit declared, then call it to destroy the
       // value.
-      if (tryEmitDestroyUsingDeinit(IGF, address, T)) {
-        return;
+      if (!tryEmitDestroyUsingDeinit(IGF, address, T)) {
+        // Otherwise, perform elementwise destruction of the value.
+        super::destroy(IGF, address, T, isOutlined);
       }
-      
-      // Otherwise, perform elementwise destruction of the value.
-      return super::destroy(IGF, address, T, isOutlined);
+      super::fillWithZerosIfSensitive(IGF, address, T);
     }
 
     void verify(IRGenTypeVerifierFunction &IGF,
@@ -519,7 +518,8 @@ namespace {
     }
 
     void initializeWithTake(IRGenFunction &IGF, Address dst, Address src,
-                            SILType T, bool isOutlined) const override {
+                            SILType T, bool isOutlined,
+                            bool zeroizeIfSensitive) const override {
       emitCopyWithCopyFunction(IGF, T, src, dst);
       destroy(IGF, src, T, isOutlined);
     }
@@ -801,7 +801,8 @@ namespace {
     }
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                            SILType T, bool isOutlined) const override {
+                            SILType T, bool isOutlined,
+                            bool zeroizeIfSensitive) const override {
       if (auto moveConstructor = findMoveConstructor()) {
         emitCopyWithCopyConstructor(IGF, T, moveConstructor,
                                     src.getAddress(),
@@ -820,7 +821,7 @@ namespace {
 
       StructTypeInfoBase<AddressOnlyCXXClangRecordTypeInfo, FixedTypeInfo,
                          ClangFieldInfo>::initializeWithTake(IGF, dest, src, T,
-                                                             isOutlined);
+                                                             isOutlined, zeroizeIfSensitive);
     }
 
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -555,7 +555,8 @@ static void buildValueWitnessFunction(IRGenModule &IGM,
             conditionallyGetTypeLayoutEntry(IGM, concreteType)) {
       typeLayoutEntry->initWithTake(IGF, dest, src);
     } else {
-      type.initializeWithTake(IGF, dest, src, concreteType, true);
+      type.initializeWithTake(IGF, dest, src, concreteType, true,
+                              /*zeroizeIfSensitive=*/ true);
     }
     dest = IGF.Builder.CreateElementBitCast(dest, IGF.IGM.OpaqueTy);
     IGF.Builder.CreateRet(dest.getAddress());

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -203,6 +203,8 @@ public:
   void emitResumeAsyncContinuationThrowing(llvm::Value *continuation,
                                            llvm::Value *error);
 
+  void emitClearSensitive(Address address, llvm::Value *size);
+
   FunctionPointer
   getFunctionPointerForResumeIntrinsic(llvm::Value *resumeIntrinsic);
 

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -969,6 +969,14 @@ namespace RuntimeConstants {
     return RuntimeAvailability::AlwaysAvailable;
   }
 
+  RuntimeAvailability ClearSensitiveAvailability(ASTContext &Context) {
+    auto featureAvailability = Context.getClearSensitiveAvailability();
+    if (!isDeploymentAvailabilityContainedIn(Context, featureAvailability)) {
+      return RuntimeAvailability::ConditionallyAvailable;
+    }
+    return RuntimeAvailability::AlwaysAvailable;
+  }
+
 } // namespace RuntimeConstants
 
 // We don't use enough attributes to justify generalizing the

--- a/lib/IRGen/IndirectTypeInfo.h
+++ b/lib/IRGen/IndirectTypeInfo.h
@@ -53,13 +53,15 @@ public:
   void initializeFromParams(IRGenFunction &IGF, Explosion &params, Address dest,
                             SILType T, bool isOutlined) const override {
     Address src = this->getAddressForPointer(params.claimNext());
-    asDerived().Derived::initializeWithTake(IGF, dest, src, T, isOutlined);
+    asDerived().Derived::initializeWithTake(IGF, dest, src, T, isOutlined,
+                                            /*zeroizeIfSensitive=*/ true);
   }
 
   void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,
                       bool isOutlined) const override {
     asDerived().Derived::destroy(IGF, dest, T, isOutlined);
-    asDerived().Derived::initializeWithTake(IGF, dest, src, T, isOutlined);
+    asDerived().Derived::initializeWithTake(IGF, dest, src, T, isOutlined,
+                                            /*zeroizeIfSensitive=*/ true);
   }
 };
 

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -152,7 +152,8 @@ public:
   }
 
   void initializeWithTake(IRGenFunction &IGF, Address destAddr, Address srcAddr,
-                          SILType T, bool isOutlined) const override {
+                          SILType T, bool isOutlined,
+                          bool zeroizeIfSensitive) const override {
     bitwiseCopy(IGF, destAddr, srcAddr, T, isOutlined);
   }
 

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -402,7 +402,7 @@ llvm::Constant *IRGenModule::getOrCreateOutlinedInitializeWithTakeFunction(
          const TypeInfo &ti) {
         if (!IGF.outliningCanCallValueWitnesses() ||
             T.hasArchetype() || !canUseValueWitnessForValueOp(*this, T)) {
-          ti.initializeWithTake(IGF, dest, src, T, true);
+          ti.initializeWithTake(IGF, dest, src, T, true, /*zeroizeIfSensitive=*/ true);
         } else {
           emitInitializeWithTakeCall(IGF, T, dest, src);
         }

--- a/lib/IRGen/ResilientTypeInfo.h
+++ b/lib/IRGen/ResilientTypeInfo.h
@@ -104,7 +104,8 @@ public:
   }
 
   void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
-                          SILType T, bool isOutlined) const override {
+                          SILType T, bool isOutlined,
+                          bool zeroizeIfSensitive) const override {
     emitInitializeWithTakeCall(IGF, T, dest, src);
   }
 

--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -67,10 +67,16 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
     builder.addHeapHeader();
   }
 
-  auto deinit = (decl && decl->getValueTypeDestructor())
+  auto triviallyDestroyable = (decl && decl->getValueTypeDestructor())
     ? IsNotTriviallyDestroyable : IsTriviallyDestroyable;
   auto copyable = (decl && !decl->canBeCopyable())
     ? IsNotCopyable : IsCopyable;
+  IsBitwiseTakable_t bitwiseTakable = IsBitwiseTakable;
+
+  if (decl && decl->getAttrs().hasAttribute<SensitiveAttr>()) {
+    triviallyDestroyable = IsNotTriviallyDestroyable;
+    bitwiseTakable = IsNotBitwiseTakable;
+  }
 
   // Handle a raw layout specification on a struct.
   RawLayoutAttr *rawLayout = nullptr;
@@ -79,8 +85,8 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
   }
   if (rawLayout && type) {
     auto sd = cast<StructDecl>(decl);
-    IsKnownTriviallyDestroyable = deinit;
-    IsKnownBitwiseTakable = IsBitwiseTakable;
+    IsKnownTriviallyDestroyable = triviallyDestroyable;
+    IsKnownBitwiseTakable = bitwiseTakable;
     SpareBits.clear();
     assert(!copyable);
     IsKnownCopyable = copyable;
@@ -178,7 +184,7 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
       SpareBits.clear();
       IsFixedLayout = true;
       IsLoadable = true;
-      IsKnownTriviallyDestroyable = deinit & builder.isTriviallyDestroyable();
+      IsKnownTriviallyDestroyable = triviallyDestroyable & builder.isTriviallyDestroyable();
       IsKnownBitwiseTakable = builder.isBitwiseTakable();
       IsKnownAlwaysFixedSize = builder.isAlwaysFixedSize();
       IsKnownCopyable = copyable & builder.isCopyable();
@@ -190,8 +196,8 @@ StructLayout::StructLayout(IRGenModule &IGM, std::optional<CanType> type,
       SpareBits = builder.getSpareBits();
       IsFixedLayout = builder.isFixedLayout();
       IsLoadable = builder.isLoadable();
-      IsKnownTriviallyDestroyable = deinit & builder.isTriviallyDestroyable();
-      IsKnownBitwiseTakable = builder.isBitwiseTakable();
+      IsKnownTriviallyDestroyable = triviallyDestroyable & builder.isTriviallyDestroyable();
+      IsKnownBitwiseTakable = bitwiseTakable & builder.isBitwiseTakable();
       IsKnownAlwaysFixedSize = builder.isAlwaysFixedSize();
       IsKnownCopyable = copyable & builder.isCopyable();
       if (typeToFill) {

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -375,7 +375,8 @@ public:
   /// the old object is actually no longer permitted to be destroyed.
   virtual void initializeWithTake(IRGenFunction &IGF, Address destAddr,
                                   Address srcAddr, SILType T,
-                                  bool isOutlined) const = 0;
+                                  bool isOutlined,
+                                  bool zeroizeIfSensitive) const = 0;
 
   /// Perform a copy-initialization from the given object.
   virtual void initializeWithCopy(IRGenFunction &IGF, Address destAddr,

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -1471,7 +1471,8 @@ void ScalarTypeLayoutEntry::initWithTake(IRGenFunction &IGF, Address dest,
                  storageTy, alignment);
   src = Address(Builder.CreateBitCast(src.getAddress(), addressType), storageTy,
                 alignment);
-  typeInfo.initializeWithTake(IGF, dest, src, representative, true);
+  typeInfo.initializeWithTake(IGF, dest, src, representative, true,
+                              /*zeroizeIfSensitive=*/ true);
 }
 
 llvm::Value *ScalarTypeLayoutEntry::getEnumTagSinglePayload(
@@ -3775,7 +3776,8 @@ void TypeInfoBasedTypeLayoutEntry::initWithTake(IRGenFunction &IGF,
       Address(Builder.CreateBitCast(src.getAddress(),
                                     addressType->getPointerTo()),
               addressType, alignment);
-  typeInfo.initializeWithTake(IGF, dest, src, representative, true);
+  typeInfo.initializeWithTake(IGF, dest, src, representative, true,
+                              /*zeroizeIfSensitive=*/ true);
 }
 
 llvm::Value *TypeInfoBasedTypeLayoutEntry::getEnumTagSinglePayload(

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -3561,6 +3561,9 @@ public:
           }
         }
       }
+      SILType silTy = SILType::getPrimitiveObjectType(type.getType());
+      if (silTy.isSensitive())
+        return ParameterConvention::Indirect_In_Guaranteed;
     }
     return getIndirectCParameterConvention(getParamType(index));
   }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2400,6 +2400,13 @@ namespace {
         return handleMoveOnlyAddressOnly(structType, properties);
       }
 
+      if (D->getAttrs().hasAttribute<SensitiveAttr>()) {
+        properties.setAddressOnly();
+        properties.setNonTrivial();
+        properties.setLexical(IsLexical);
+        return handleAddressOnly(structType, properties);
+      }
+
       auto subMap = structType->getContextSubstitutionMap(&TC.M, D);
 
       // Classify the type according to its stored properties.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -343,6 +343,8 @@ public:
 
   void visitExtractConstantsFromMembersAttr(ExtractConstantsFromMembersAttr *attr);
 
+  void visitSensitiveAttr(SensitiveAttr *attr);
+
   void visitUnavailableFromAsyncAttr(UnavailableFromAsyncAttr *attr);
 
   void visitUnsafeInheritExecutorAttr(UnsafeInheritExecutorAttr *attr);
@@ -448,6 +450,13 @@ void AttributeChecker::visitExtractConstantsFromMembersAttr(ExtractConstantsFrom
   if (!Ctx.LangOpts.hasFeature(Feature::ExtractConstantsFromMembers)) {
     diagnoseAndRemoveAttr(attr,
                           diag::attr_extractConstantsFromMembers_experimental);
+  }
+}
+
+void AttributeChecker::visitSensitiveAttr(SensitiveAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::Sensitive)) {
+    diagnoseAndRemoveAttr(attr,
+                          diag::attr_sensitive_experimental);
   }
 }
 

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1627,6 +1627,7 @@ namespace  {
     UNINTERESTING_ATTR(CompilerInitialized)
     UNINTERESTING_ATTR(AlwaysEmitConformanceMetadata)
     UNINTERESTING_ATTR(ExtractConstantsFromMembers)
+    UNINTERESTING_ATTR(Sensitive)
 
     UNINTERESTING_ATTR(EagerMove)
     UNINTERESTING_ATTR(NoEagerMove)

--- a/stdlib/public/core/EmbeddedRuntime.swift
+++ b/stdlib/public/core/EmbeddedRuntime.swift
@@ -338,3 +338,16 @@ func arc4random_buf(buf: UnsafeMutableRawPointer, nbytes: Int)
 public func swift_stdlib_random(_ buf: UnsafeMutableRawPointer, _ nbytes: Int) {
   arc4random_buf(buf: buf, nbytes: nbytes)
 }
+
+@_cdecl("swift_clearSensitive")
+@inline(never)
+public func swift_clearSensitive(buf: UnsafeMutableRawPointer, nbytes: Int) {
+  // TODO: use memset_s if available
+  // Though, it shouldn't make too much difference because the `@inline(never)` should prevent
+  // the optimizer from removing the loop below.
+  let bytePtr = buf.assumingMemoryBound(to: UInt8.self)
+  for i in 0..<nbytes {
+    bytePtr[i] = 0
+  }
+}
+

--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -21,6 +21,7 @@
 #include "swift/shims/RuntimeShims.h"
 #include <algorithm>
 #include <stdlib.h>
+#include <string.h>
 #if defined(__APPLE__) && SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
 #include "swift/Basic/Lazy.h"
 #include <malloc/malloc.h>
@@ -145,4 +146,11 @@ static void swift_slowDeallocImpl(void *ptr, size_t alignMask) {
 
 void swift::swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask) {
   swift_slowDeallocImpl(ptr, alignMask);
+}
+
+void swift::swift_clearSensitive(void *ptr, size_t bytes) {
+  // TODO: use memset_s if available
+  // Though, it shouldn't make too much difference because the optimizer cannot remove
+  // the following memset without inlining this library function.
+  memset(ptr, 0, bytes);
 }

--- a/test/IRGen/Inputs/sensitive.h
+++ b/test/IRGen/Inputs/sensitive.h
@@ -1,0 +1,25 @@
+
+struct __attribute__((swift_attr("sensitive"))) SmallCStruct {
+    unsigned a;
+    unsigned b;
+    unsigned c;
+};
+
+struct __attribute__((swift_attr("sensitive"))) LargeCStruct {
+    unsigned a;
+    unsigned b;
+    unsigned c;
+    unsigned d;
+    unsigned e;
+    unsigned f;
+    unsigned g;
+};
+
+struct SmallCStruct getSmallStruct(int x);
+struct LargeCStruct getLargeStruct(int x);
+
+void printSmallStruct(int x, struct SmallCStruct s, int y);
+struct SmallCStruct forwardSmallStruct(struct SmallCStruct s);
+void printLargeStruct(int x, struct LargeCStruct s, int y);
+struct LargeCStruct forwardLargeStruct(struct LargeCStruct s);
+

--- a/test/IRGen/Inputs/sensitive_c_functions.c
+++ b/test/IRGen/Inputs/sensitive_c_functions.c
@@ -1,0 +1,47 @@
+
+#include "sensitive.h"
+
+#include <stdio.h>
+
+struct SmallCStruct getSmallStruct(int x) {
+  printf("x = %d\n", x);
+
+  struct SmallCStruct s;
+  s.a = 0xdeadbeaf;
+  s.b = 0xdeadbeaf;
+  s.c = 0xdeadbeaf;
+  return s;
+}
+
+struct LargeCStruct getLargeStruct(int x) {
+  printf("x = %d\n", x);
+
+  struct LargeCStruct s;
+  s.a = 0xdeadbeaf;
+  s.b = 0xdeadbeaf;
+  s.c = 0xdeadbeaf;
+  s.d = 0xdeadbeaf;
+  s.e = 0xdeadbeaf;
+  s.f = 0xdeadbeaf;
+  s.g = 0xdeadbeaf;
+  return s;
+}
+
+void printSmallStruct(int x, struct SmallCStruct s, int y) {
+  printf("x = %d, y = %d\n", x, y);
+  printf("s = (%u, %u, %u)\n", s.a, s.b, s.c);
+}
+
+struct SmallCStruct forwardSmallStruct(struct SmallCStruct s) {
+  return s;
+}
+
+void printLargeStruct(int x, struct LargeCStruct s, int y) {
+  printf("x = %d, y = %d\n", x, y);
+  printf("s = (%u, %u, %u, %u, %u, %u, %u)\n", s.a, s.b, s.c, s.e, s.e, s.f, s.g);
+}
+
+struct LargeCStruct forwardLargeStruct(struct LargeCStruct s) {
+  return s;
+}
+

--- a/test/IRGen/sensitive.sil
+++ b/test/IRGen/sensitive.sil
@@ -1,0 +1,47 @@
+// RUN: %target-swift-frontend -enable-experimental-feature Sensitive -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -target %module-target-future -enable-experimental-feature Sensitive -emit-ir %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+@sensitive struct SensitiveStruct {
+  @_hasStorage @_hasInitialValue var a: Int64
+  @_hasStorage @_hasInitialValue var b: Int64
+  @_hasStorage @_hasInitialValue var c: Int64
+}
+
+
+// CHECK-LABEL: define{{.*}}void @testDestroy
+// CHECK:         call {{(i[0-9]+ @memset_s|void @swift_clearSensitive)\(ptr %0, i[0-9]+ 24}}
+// CHECK:         ret void
+sil @testDestroy : $@convention(thin) (@in SensitiveStruct) -> () {
+bb0(%0 : $*SensitiveStruct):
+  destroy_addr %0 : $*SensitiveStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: define{{.*}}void @testCopyAddrTake
+// CHECK:         call void @llvm.memcpy
+// CHECK-NEXT:    call {{(i[0-9]+ @memset_s|void @swift_clearSensitive)\(ptr %1, i[0-9]+ 24}}
+// CHECK:         ret void
+sil @testCopyAddrTake : $@convention(thin) (@in SensitiveStruct) -> @out SensitiveStruct {
+bb0(%0 : $*SensitiveStruct, %1 : $*SensitiveStruct):
+  copy_addr [take] %1 to [init] %0 : $*SensitiveStruct
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: define{{.*}}void @testCopyAddrCopy
+// CHECK-NOT:     memset_s
+// CHECK-NOT:     swift_clearSensitive
+// CHECK:         ret void
+sil @testCopyAddrCopy : $@convention(thin) (@in_guaranteed SensitiveStruct) -> @out SensitiveStruct {
+bb0(%0 : $*SensitiveStruct, %1 : $*SensitiveStruct):
+  copy_addr %1 to [init] %0 : $*SensitiveStruct
+  %r = tuple ()
+  return %r : $()
+}
+

--- a/test/IRGen/sensitive.swift
+++ b/test/IRGen/sensitive.swift
@@ -1,0 +1,150 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-clang -x c %S/Inputs/sensitive_c_functions.c -c -o %t/sensitive_c_functions.o
+//
+// RUN: %target-build-swift -target %module-target-future -module-name=test -enable-experimental-feature Sensitive -parse-as-library -Onone -import-objc-header %S/Inputs/sensitive.h %s %t/sensitive_c_functions.o -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+//
+// RUN: %target-build-swift -target %module-target-future -module-name=test -enable-experimental-feature Sensitive -parse-as-library -O -import-objc-header %S/Inputs/sensitive.h %s %t/sensitive_c_functions.o -o %t/ao.out
+// RUN: %target-codesign %t/ao.out
+// RUN: %target-run %t/ao.out | %FileCheck %s
+//
+// Test with memset_s which uses the compiler if of swift_clearSensitive is not available:
+// RUN: %target-build-swift -module-name=test -enable-experimental-feature Sensitive -parse-as-library -Onone -import-objc-header %S/Inputs/sensitive.h %s %t/sensitive_c_functions.o -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+//
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+var checkBuffer: UnsafeBufferPointer<UInt32>?
+
+@inline(never)
+func checkLater<T>(_ t: inout T) {
+  withUnsafePointer(to: &t) {
+    let size = MemoryLayout<T>.size / MemoryLayout<UInt32>.size
+    $0.withMemoryRebound(to: UInt32.self, capacity: size) {
+      checkBuffer = UnsafeBufferPointer(start: $0, count: size)
+    }
+  }
+}
+
+@inline(never)
+func printit<T>(_ t: inout T) {
+  print(t)
+}
+
+@inline(never)
+func consumeAndPrint<T>(_ t: consuming T) {
+  print(t)
+}
+
+@inline(never)
+func check() {
+  for b in checkBuffer! {
+    precondition(b != 0xdeadbeaf)
+  }
+}
+
+@inline(never)
+func printSensitive<T>(_ t: T) {
+  do {
+    var x: T = t
+    checkLater(&x)
+    printit(&x)
+  }
+  check()
+  print() // to prevent tail call of `check()`
+}
+
+@inline(never)
+func printConsumed<T>(_ t: T) {
+  do {
+    var x: T = t
+    checkLater(&x)
+    consumeAndPrint(x)
+  }
+  check()
+  print() // to prevent tail call of `check()`
+}
+
+
+@inline(never)
+func checkSmallCStructs() {
+  do {
+    var x = getSmallStruct(27)
+    checkLater(&x)
+    x = forwardSmallStruct(x);
+    printSmallStruct(27, x, 28)
+  }
+  check()
+  print() // to prevent tail call of `check()`
+}
+
+@inline(never)
+func checkLargeCStructs() {
+  do {
+    var x = getLargeStruct(29)
+    checkLater(&x)
+    x = forwardLargeStruct(x);
+    printLargeStruct(30, x, 31)
+  }
+  check()
+  print() // to prevent tail call of `check()`
+}
+
+protocol P {}
+
+@sensitive
+struct SensitiveStruct {
+  var a = 0xdeadbeaf
+  var b = 0xdeadbeaf
+  var c = 0xdeadbeaf
+}
+
+// A struct which would be address-only also without @sensitive
+@sensitive
+struct NonLoadableSensitiveStruct {
+  var a = 0xdeadbeaf
+  var b = 0xdeadbeaf
+  var c = 0xdeadbeaf
+  let p: P
+}
+
+struct X : P {}
+
+struct Container<T> {
+  var x = 123
+  let t: T
+  var y = 456
+}
+
+@main struct Main {
+  static func main() {
+    // CHECK: SensitiveStruct(a: 3735928495, b: 3735928495, c: 3735928495)
+    printSensitive(SensitiveStruct())
+
+    // CHECK: SensitiveStruct(a: 3735928495, b: 3735928495, c: 3735928495)
+    printConsumed(SensitiveStruct())
+
+    // CHECK: Optional(test.SensitiveStruct(a: 3735928495, b: 3735928495, c: 3735928495))
+    printSensitive(Optional(SensitiveStruct()))
+
+    // CHECK: NonLoadableSensitiveStruct(a: 3735928495, b: 3735928495, c: 3735928495, p: test.X())
+    printSensitive(NonLoadableSensitiveStruct(p: X()))
+
+    // CHECK: Container<SensitiveStruct>(x: 123, t: test.SensitiveStruct(a: 3735928495, b: 3735928495, c: 3735928495), y: 456)
+    printSensitive(Container(t: SensitiveStruct()))
+
+    // CHECK: x = 27
+    // CHECK-NEXT: x = 27, y = 28
+    // CHECK-NEXT: s = (3735928495, 3735928495, 3735928495)
+    checkSmallCStructs();
+
+    // CHECK: x = 29
+    // CHECK-NEXT: x = 30, y = 31
+    // CHECK-NEXT: s = (3735928495, 3735928495, 3735928495, 3735928495, 3735928495, 3735928495, 3735928495)
+    checkLargeCStructs();
+  }
+}

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -562,6 +562,7 @@ Added: __swift_exceptionPersonality
 Added: _swift_willThrowTypedImpl
 Added: __swift_willThrowTypedImpl
 Added: __swift_enableSwizzlingOfAllocationAndRefCountingFunctions_forInstrumentsOnly
+Added: _swift_clearSensitive
 
 // Runtime bincompat functions for Concurrency runtime to detect legacy mode
 Added: _swift_bincompat_useLegacyNonCrashingExecutorChecks

--- a/test/abi/macOS/x86_64/stdlib-asserts.swift
+++ b/test/abi/macOS/x86_64/stdlib-asserts.swift
@@ -60,3 +60,5 @@ Added: _OBJC_CLASS_$__TtCs20__StaticArrayStorage
 Added: _OBJC_METACLASS_$__TtCs20__StaticArrayStorage
 
 // Runtime Symbols
+Added: _swift_clearSensitive
+

--- a/test/embedded/sensitive.swift
+++ b/test/embedded/sensitive.swift
@@ -1,0 +1,59 @@
+// RUN: %target-run-simple-swift(   -parse-as-library -enable-experimental-feature Sensitive -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none)
+// RUN: %target-run-simple-swift(-O -parse-as-library -enable-experimental-feature Sensitive -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none)
+// RUN: %target-run-simple-swift(-target %module-target-future -parse-as-library -enable-experimental-feature Sensitive -enable-experimental-feature Embedded -wmo -Xfrontend -disable-access-control -runtime-compatibility-version none)
+
+// REQUIRES: swift_in_compiler
+// REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+var checkBuffer: UnsafeBufferPointer<UInt32>?
+
+@inline(never)
+func checkLater<T>(_ t: inout T) {
+  withUnsafePointer(to: &t) {
+    let size = MemoryLayout<T>.size / MemoryLayout<UInt32>.size
+    $0.withMemoryRebound(to: UInt32.self, capacity: size) {
+      checkBuffer = UnsafeBufferPointer(start: $0, count: size)
+    }
+  }
+}
+
+@inline(never)
+func check() {
+  for b in checkBuffer! {
+    precondition(b != 0xdeadbeaf)
+  }
+}
+
+@inline(never)
+func testSensitive<T>(_ t: T) {
+  do {
+    var x: T = t
+    checkLater(&x)
+  }
+  check()
+  print(0) // to prevent tail call of `check()`
+}
+
+@sensitive
+struct SensitiveStruct {
+  var a = 0xdeadbeaf
+  var b = 0xdeadbeaf
+  var c = 0xdeadbeaf
+}
+
+struct Container<T> {
+  var x = 123
+  let t: T
+  var y = 456
+}
+
+@main struct Main {
+  static func main() {
+    testSensitive(SensitiveStruct())
+    testSensitive(Optional(SensitiveStruct()))
+    testSensitive(Container(t: SensitiveStruct()))
+  }
+}
+


### PR DESCRIPTION
The attribute declares that a struct contains "sensitive" data.
It enforces that the contents of such a struct value is zeroed out at the end of its lifetime.
In other words: the content of such a value is not observable in memory after the value's lifetime.

Also,  import `__attribute__((swift_attr("sensitive")))` on C structs as `@sensitive` attributes.

The attribute is mainly implemented in IRGen: IRGen emits a `swift_clearSensitive` runtime call after destroying or taking "sensitive" struct types.

Also, IRGen supports calling C-functions with "sensitive" parameters or return values. In SIL, sensitive types are address-only and so are sensitive parameters/return values. Though, (small) sensitive C-structs are passed directly to/from C-functions. We need re-abstract such parameter and return values for C-functions.
