### PR TITLE
AST: Fix a couple `_diagnoseUnavailableCodeReached()` crashes for zippered libraries 

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1306,6 +1306,11 @@ public:
   std::optional<std::pair<const AvailableAttr *, const Decl *>>
   getSemanticUnavailableAttr(bool ignoreAppExtensions = false) const;
 
+  /// Returns true if code associated with this declaration should be considerd
+  /// unreachable at runtime because the declaration is unavailable in all
+  /// execution contexts in which the code may run.
+  bool isUnreachableAtRuntime() const;
+
   /// Returns true if this declaration should be considered available during
   /// SIL/IR lowering. A declaration would not be available during lowering if,
   /// for example, it is annotated as unavailable with `@available` and

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -350,6 +350,17 @@ static bool shouldStubOrSkipUnavailableDecl(const Decl *D) {
   if (!unavailableAttr->isUnconditionallyUnavailable())
     return false;
 
+  // Universally unavailable declarations are always unreachable.
+  if (unavailableAttr->Platform == PlatformKind::none)
+    return true;
+
+  // FIXME: Support zippered frameworks (rdar://125371621)
+  // If we have a target variant (e.g. we're building a zippered macOS
+  // framework) then the decl is only unreachable if it is unavailable for both
+  // the primary target and the target variant.
+  if (D->getASTContext().LangOpts.TargetVariant.has_value())
+    return false;
+
   return true;
 }
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -932,11 +932,8 @@ CaseStmt *DerivedConformance::unavailableEnumElementCaseStmt(
   assert(subPatternCount > 0);
 
   ASTContext &C = parentDC->getASTContext();
-  auto availableAttr = elt->getAttrs().getUnavailable(C);
-  if (!availableAttr)
-    return nullptr;
-
-  if (!availableAttr->isUnconditionallyUnavailable())
+  if (!elt->isUnreachableAtRuntime() ||
+      elt->getParentEnum()->isUnreachableAtRuntime())
     return nullptr;
 
   // If the stdlib isn't new enough to contain the helper function for

--- a/test/SILGen/unavailable_decl_optimization_stub_macos.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos.swift
@@ -30,7 +30,7 @@ public func unavailableFunc() {}
 public func unavailableOnMacOSFunc() {}
 
 // CHECK-LABEL:     sil{{.*}}@$s4Test31unavailableOnMacOSExtensionFuncyyF
-// CHECK-NOT:         function_ref @$ss36_diagnoseUnavailableCodeReached{{.*}} : $@convention(thin) () -> Never
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
 // CHECK:           } // end sil function '$s4Test31unavailableOnMacOSExtensionFuncyyF'
 @available(macOSApplicationExtension, unavailable)
 public func unavailableOnMacOSExtensionFunc() {}

--- a/test/SILGen/unavailable_decl_optimization_stub_macos_zippered.swift
+++ b/test/SILGen/unavailable_decl_optimization_stub_macos_zippered.swift
@@ -1,0 +1,58 @@
+// RUN: %target-swift-emit-silgen -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=stub | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test15unavailableFuncyyF
+// CHECK:             [[FNREF:%.*]] = function_ref @$ss36_diagnoseUnavailableCodeReached_aeics5NeverOyF : $@convention(thin) () -> Never
+// CHECK-NEXT:        [[APPLY:%.*]] = apply [[FNREF]]()
+// CHECK:           } // end sil function '$s4Test15unavailableFuncyyF'
+@available(*, unavailable)
+public func unavailableFunc() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test22unavailableOnMacOSFuncyyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test22unavailableOnMacOSFuncyyF'
+@available(macOS, unavailable)
+public func unavailableOnMacOSFunc() {}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test20unavailableOniOSFuncyyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test20unavailableOniOSFuncyyF'
+@available(iOS, unavailable)
+public func unavailableOniOSFunc() {}
+
+// FIXME: This function should diagnose (rdar://125930716)
+// CHECK-LABEL:     sil{{.*}}@$s4Test28unavailableOnMacCatalystFuncyyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test28unavailableOnMacCatalystFuncyyF'
+@available(macCatalyst, unavailable)
+public func unavailableOnMacCatalystFunc() {}
+
+// FIXME: This function should diagnose (rdar://125930716)
+// CHECK-LABEL:     sil{{.*}}@$s4Test28unavailableOnMacOSAndiOSFuncyyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test28unavailableOnMacOSAndiOSFuncyyF'
+@available(macOS, unavailable)
+@available(iOS, unavailable)
+public func unavailableOnMacOSAndiOSFunc() {}
+
+@available(iOS, unavailable)
+public struct UnavailableOniOS {
+  // CHECK-LABEL:     sil{{.*}}@$s4Test16UnavailableOniOSV15availableMethodyyF
+  // CHECK-NOT:         _diagnoseUnavailableCodeReached
+  // CHECK:           } // end sil function '$s4Test16UnavailableOniOSV15availableMethodyyF'
+  public func availableMethod() {}
+
+  // FIXME: This function should diagnose (rdar://125930716)
+  // CHECK-LABEL:     sil{{.*}}@$s4Test16UnavailableOniOSV24unavailableOnMacOSMethodyyF
+  // CHECK-NOT:         _diagnoseUnavailableCodeReached
+  // CHECK:           } // end sil function '$s4Test16UnavailableOniOSV24unavailableOnMacOSMethodyyF'
+  @available(macOS, unavailable)
+  public func unavailableOnMacOSMethod() {}
+}
+
+// CHECK-LABEL:     sil{{.*}}@$s4Test37unavailableOnMacCatalystExtensionFuncyyF
+// CHECK-NOT:         _diagnoseUnavailableCodeReached
+// CHECK:           } // end sil function '$s4Test37unavailableOnMacCatalystExtensionFuncyyF'
+@available(macCatalystApplicationExtension, unavailable)
+public func unavailableOnMacCatalystExtensionFunc() {}

--- a/test/decl/enum/derived_hashable_equatable_macos.swift
+++ b/test/decl/enum/derived_hashable_equatable_macos.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-PRE-SWIFT5_9
+// RUN: %target-swift-frontend -application-extension -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-PRE-SWIFT5_9
 // RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.51 -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-PRE-SWIFT5_9
 // RUN: %target-swift-frontend -target %target-cpu-apple-macosx14 -print-ast %s | %FileCheck %s --check-prefixes=CHECK,CHECK-SWIFT5_9
 // REQUIRES: OS=macosx
@@ -23,6 +24,10 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:  case introduced10_50
   @available(macOS, introduced: 10.50)
   case introduced10_50
+  // CHECK:       @available(macOSApplicationExtension, unavailable)
+  // CHECK-NEXT:  case unavailableMacOSAppExtension
+  @available(macOSApplicationExtension, unavailable)
+  case unavailableMacOSAppExtension
 
   // CHECK:       @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: HasElementsWithAvailability, _ b: HasElementsWithAvailability) -> Bool {
   // CHECK-NEXT:    var index_a: Int
@@ -39,6 +44,8 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:      index_a = 1
   // CHECK-NEXT:    case .introduced10_50:
   // CHECK-NEXT:      index_a = 2
+  // CHECK-NEXT:    case .unavailableMacOSAppExtension:
+  // CHECK-NEXT:      index_a = 3
   // CHECK-NEXT:    }
   // CHECK-NEXT:    var index_b: Int
   // CHECK-NEXT:    switch b {
@@ -54,6 +61,8 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:      index_b = 1
   // CHECK-NEXT:    case .introduced10_50:
   // CHECK-NEXT:      index_b = 2
+  // CHECK-NEXT:    case .unavailableMacOSAppExtension:
+  // CHECK-NEXT:      index_b = 3
   // CHECK-NEXT:    }
   // CHECK-NEXT:    return index_a == index_b
   // CHECK-NEXT:  }
@@ -73,6 +82,8 @@ enum HasElementsWithAvailability: Hashable {
   // CHECK-NEXT:      discriminator = 1
   // CHECK-NEXT:    case .introduced10_50:
   // CHECK-NEXT:      discriminator = 2
+  // CHECK-NEXT:    case .unavailableMacOSAppExtension:
+  // CHECK-NEXT:      discriminator = 3
   // CHECK-NEXT:    }
   // CHECK-NEXT:    hasher.combine(discriminator)
   // CHECK-NEXT:  }

--- a/test/decl/enum/derived_hashable_equatable_macos_zippered.swift
+++ b/test/decl/enum/derived_hashable_equatable_macos_zippered.swift
@@ -1,0 +1,107 @@
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx13 -target-variant %target-cpu-apple-ios16-macabi -print-ast %s | %FileCheck %s
+// REQUIRES: OS=macosx
+
+// CHECK-LABEL: internal enum HasElementsWithAvailability : Hashable
+enum HasElementsWithAvailability: Hashable {
+  // CHECK:       case alwaysAvailable
+  case alwaysAvailable
+  // CHECK:       @available(*, unavailable)
+  // CHECK-NEXT:  case neverAvailable
+  @available(*, unavailable)
+  case neverAvailable
+  // CHECK:       @available(macOS, unavailable)
+  // CHECK-NEXT:  case unavailableMacOS
+  @available(macOS, unavailable)
+  case unavailableMacOS
+  // CHECK:       @available(iOS, unavailable)
+  // CHECK-NEXT:  case unavailableiOS
+  @available(iOS, unavailable)
+  case unavailableiOS
+  // CHECK:       @available(macCatalyst, unavailable)
+  // CHECK-NEXT:  case unavailableMacCatalyst
+  @available(macCatalyst, unavailable)
+  case unavailableMacCatalyst
+  // CHECK:       @available(macOS, unavailable)
+  // CHECK-NEXT:  @available(iOS, unavailable)
+  // CHECK-NEXT:  case unavailableMacOSAndiOS
+  @available(macOS, unavailable)
+  @available(iOS, unavailable)
+  case unavailableMacOSAndiOS
+  // CHECK:       @available(macOS, unavailable)
+  // CHECK-NEXT:  @available(macCatalyst, unavailable)
+  // CHECK-NEXT:  case unavailableMacOSAndMacCatalyst
+  @available(macOS, unavailable)
+  @available(macCatalyst, unavailable)
+  case unavailableMacOSAndMacCatalyst
+
+  // CHECK:       @_implements(Equatable, ==(_:_:)) internal static func __derived_enum_equals(_ a: HasElementsWithAvailability, _ b: HasElementsWithAvailability) -> Bool {
+  // CHECK-NEXT:    var index_a: Int
+  // CHECK-NEXT:    switch a {
+  // CHECK-NEXT:    case .alwaysAvailable:
+  // CHECK-NEXT:      index_a = 0
+  // CHECK-NEXT:    case .neverAvailable:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}
+  // CHECK-NEXT:    case .unavailableMacOS:
+  // CHECK-NEXT:      index_a = 1
+  // CHECK-NEXT:    case .unavailableiOS:
+  // CHECK-NEXT:      index_a = 2
+  // CHECK-NEXT:    case .unavailableMacCatalyst:
+  // CHECK-NEXT:      index_a = 3
+  // FIXME: This case should diagnose (rdar://125930716)
+  // CHECK-NEXT:    case .unavailableMacOSAndiOS:
+  // CHECK-NEXT:      index_a = 4
+  // FIXME: This case should diagnose (rdar://125930716)
+  // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
+  // CHECK-NEXT:      index_a = 5
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    var index_b: Int
+  // CHECK-NEXT:    switch b {
+  // CHECK-NEXT:    case .alwaysAvailable:
+  // CHECK-NEXT:      index_b = 0
+  // CHECK-NEXT:    case .neverAvailable:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}
+  // CHECK-NEXT:    case .unavailableMacOS:
+  // CHECK-NEXT:      index_b = 1
+  // CHECK-NEXT:    case .unavailableiOS:
+  // CHECK-NEXT:      index_b = 2
+  // CHECK-NEXT:    case .unavailableMacCatalyst:
+  // CHECK-NEXT:      index_b = 3
+  // FIXME: This case should diagnose (rdar://125930716)
+  // CHECK-NEXT:    case .unavailableMacOSAndiOS:
+  // CHECK-NEXT:      index_b = 4
+  // FIXME: This case should diagnose (rdar://125930716)
+  // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
+  // CHECK-NEXT:      index_b = 5
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    return index_a == index_b
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal func hash(into hasher: inout Hasher) {
+  // CHECK-NEXT:    var discriminator: Int
+  // CHECK-NEXT:    switch self {
+  // CHECK-NEXT:    case .alwaysAvailable:
+  // CHECK-NEXT:      discriminator = 0
+  // CHECK-NEXT:    case .neverAvailable:
+  // CHECK-NEXT:      _diagnoseUnavailableCodeReached{{.*}}
+  // CHECK-NEXT:    case .unavailableMacOS:
+  // CHECK-NEXT:      discriminator = 1
+  // CHECK-NEXT:    case .unavailableiOS:
+  // CHECK-NEXT:      discriminator = 2
+  // CHECK-NEXT:    case .unavailableMacCatalyst:
+  // CHECK-NEXT:      discriminator = 3
+  // FIXME: This case should diagnose (rdar://125930716)
+  // CHECK-NEXT:    case .unavailableMacOSAndiOS:
+  // CHECK-NEXT:      discriminator = 4
+  // FIXME: This case should diagnose (rdar://125930716)
+  // CHECK-NEXT:    case .unavailableMacOSAndMacCatalyst:
+  // CHECK-NEXT:      discriminator = 5
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:    hasher.combine(discriminator)
+  // CHECK-NEXT:  }
+
+  // CHECK:       internal var hashValue: Int {
+  // CHECK-NEXT:    get {
+  // CHECK-NEXT:      return _hashValue(for: self)
+  // CHECK-NEXT:    }
+  // CHECK-NEXT:  }
+}


### PR DESCRIPTION
The declarations in a zippered macOS library may be referenced by clients that build either for macOS or for macCatalyst. It is therefore inappropriate to stub functions in zippered libraries as "unreachable" when they are only unavailable on macOS. The same issue also affects the derived `Hashable` and `Equatable` conformances for enums with unavailable elements. Making this logic correct is a larger project, so for now we're more conservative about classifying a declaration as unreachable when a target variant is present during compilation.

Resolves rdar://125371621