### PR TITLE
[Concurrency] TaskLocal.withValue adopting #isolation

### DIFF
--- a/test/Concurrency/async_task_locals_basic_warnings_bug_isolation.swift
+++ b/test/Concurrency/async_task_locals_basic_warnings_bug_isolation.swift
@@ -7,18 +7,22 @@
 // REQUIRES: concurrency
 // REQUIRES: asserts
 
+// FIXME: rdar://125078448 is resolved
+// XFAIL: *
+
 actor Test {
 
   @TaskLocal static var local: Int?
 
-  func run() async {
-    // This should NOT produce any warnings, the closure withValue uses is @Sendable:
-    await Self.$local.withValue(42) {
-      await work()
+  func withTaskLocal(isolation: isolated (any Actor)? = #isolation,
+                     _ body: (consuming NonSendableValue, isolated (any Actor)?) -> Void) async {
+    Self.$local.withValue(12) {
+      // Unexpected errors here:
+      //  error: unexpected warning produced: transferring 'body' may cause a race; this is an error in the Swift 6 language mode
+      //  error: unexpected note produced: actor-isolated 'body' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses
+      body(NonSendableValue(), isolation)
     }
   }
-
-  func work() async {
-    print("Hello \(Self.local ?? 0)")
-  }
 }
+
+class NonSendableValue {}

--- a/test/abi/macOS/arm64/concurrency.swift
+++ b/test/abi/macOS/arm64/concurrency.swift
@@ -290,3 +290,11 @@ Added: _$sScfsE13checkIsolatedyyF
 Added: _$sScf13checkIsolatedyyFTj
 // method descriptor for Swift.SerialExecutor.checkIsolated() -> ()
 Added: _$sScf13checkIsolatedyyFTq
+
+// #isolated adoption in TaskLocal.withValue
+// Swift.TaskLocal.withValueImpl<A>(_: __owned A, operation: () async throws -> A1, isolation: isolated Swift.Actor?, file: Swift.String, line: Swift.UInt) async throws -> A1
+Added: _$ss9TaskLocalC13withValueImpl_9operation9isolation4file4lineqd__xn_qd__yYaKXEScA_pSgYiSSSutYaKlF
+Added: _$ss9TaskLocalC13withValueImpl_9operation9isolation4file4lineqd__xn_qd__yYaKXEScA_pSgYiSSSutYaKlFTu
+// Swift.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Actor?, file: Swift.String, line: Swift.UInt) async throws -> A1
+Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlF
+Added: _$ss9TaskLocalC9withValue_9operation9isolation4file4lineqd__x_qd__yYaKXEScA_pSgYiSSSutYaKlFTu

--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -87,8 +87,14 @@ Func SerialExecutor.enqueue(_:) has been added as a protocol requirement
 // rdar://106833284 (ABI checker confused with overload getting deprecated)
 Func Executor.enqueue(_:) is a new API without @available attribute
 
-// This function correctly inherits its availability from the TaskLocal struct.
-Func TaskLocal.withValueImpl(_:operation:file:line:) is a new API without @available attribute
+// Adopt #isolation in TaskLocal.withValue APIs
+Func TaskLocal.withValue(_:operation:file:line:) has been renamed to Func withValue(_:operation:isolation:file:line:)
+Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, file: Swift.String, line: Swift.UInt) async throws -> A1' to '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1'
+Func TaskLocal.withValue(_:operation:file:line:) has mangled name changing from '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () throws -> A1, file: Swift.String, line: Swift.UInt) throws -> A1' to '_Concurrency.TaskLocal.withValue<A>(_: A, operation: () async throws -> A1, isolation: isolated Swift.Optional<Swift.Actor>, file: Swift.String, line: Swift.UInt) async throws -> A1'
+Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change from () async throws -> τ_1_0 to () throws -> τ_1_0
+Func TaskLocal.withValue(_:operation:file:line:) has parameter 1 type change from () throws -> τ_1_0 to () async throws -> τ_1_0
+Func TaskLocal.withValue(_:operation:file:line:) has parameter 2 type change from Swift.String to (any _Concurrency.Actor)?
+Func TaskLocal.withValue(_:operation:file:line:) has parameter 3 type change from Swift.UInt to Swift.String
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
 


### PR DESCRIPTION
Another piece of the #isolation adoption and removal of the _unsafeInheritExecutor in stdlib.

Resolves rdar://106853492