### PR TITLE
[6.0] Runtime checking for associated types conforming to invertible protocols

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2530,8 +2530,6 @@ void ASTMangler::appendModule(const ModuleDecl *module,
 /// Mangle the name of a protocol as a substitution candidate.
 void ASTMangler::appendProtocolName(const ProtocolDecl *protocol,
                                     bool allowStandardSubstitution) {
-  assert(!protocol->getInvertibleProtocolKind() &&
-          "only inverse requirements are mangled");
   assert(AllowMarkerProtocols || !protocol->isMarkerProtocol());
 
   if (allowStandardSubstitution && tryAppendStandardSubstitution(protocol))

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -6986,6 +6986,27 @@ GenericArgumentMetadata irgen::addGenericRequirements(
     case RequirementKind::Conformance: {
       auto protocol = requirement.getProtocolDecl();
 
+      // If this is an invertible protocol, encode it as an inverted protocol
+      // check with all but this protocol masked off.
+      if (auto invertible = protocol->getInvertibleProtocolKind()) {
+        ++metadata.NumRequirements;
+
+        InvertibleProtocolSet mask(0xFFFF);
+        mask.remove(*invertible);
+
+        auto flags = GenericRequirementFlags(
+            GenericRequirementKind::InvertedProtocols,
+            /*key argument*/ false,
+            /* is parameter pack */false);
+        addGenericRequirement(IGM, B, metadata, sig, flags,
+                              requirement.getFirstType(),
+         [&]{
+          B.addInt16(0xFFFF);
+          B.addInt16(mask.rawBits());
+        });
+        break;
+      }
+
       // Marker protocols do not record generic requirements at all.
       if (protocol->isMarkerProtocol()) {
         break;

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -17,6 +17,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SILOptimizer/Utils/CastOptimizer.h"
+#include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/SubstitutionMap.h"
@@ -1470,6 +1471,10 @@ static bool optimizeStaticallyKnownProtocolConformance(
     // valid conformance will be returned.
     auto Conformance = SM->checkConformance(SourceType, Proto);
     if (Conformance.isInvalid())
+      return false;
+
+    auto layout = TargetType->getExistentialLayout();
+    if (layout.getProtocols().size() != 1)
       return false;
 
     SILBuilderWithScope B(Inst);

--- a/test/Interpreter/moveonly_generics_casting.swift
+++ b/test/Interpreter/moveonly_generics_casting.swift
@@ -125,8 +125,7 @@ func main() {
   attemptCall(Dog<Any>())
 
   // CHECK-FIXME: failed to cast (attemptCall)
-  typealias NoncopyableAny = ~Copyable
-  // FIXME crashes: attemptCall(Dog<any NoncopyableAny>())
+  // FIXME crashes: attemptCall(Dog<any ~Copyable>())
 
   // CHECK: cast succeeded
   test_radar124171788(.nothing)

--- a/test/Interpreter/moveonly_generics_casting_assoctypes.swift
+++ b/test/Interpreter/moveonly_generics_casting_assoctypes.swift
@@ -1,0 +1,36 @@
+// RUN: %target-run-simple-swift(-Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes)
+// RUN: %target-run-simple-swift(-O -Xfrontend -sil-verify-all -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature SuppressedAssociatedTypes)
+
+// REQUIRES: executable_test
+
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+protocol P: ~Copyable {
+  associatedtype A: ~Copyable
+}
+
+protocol Q: ~Copyable { }
+
+struct X<T: P & ~Copyable> { }
+
+extension X: Q where T: ~Copyable, T.A: Copyable { }
+
+struct NC: ~Copyable { }
+
+struct WithCopyable: P {
+  typealias A = Int
+}
+
+struct WithNonCopyable: P {
+  typealias A = NC
+}
+
+func tryCastToQ<T: P>(_: T.Type) -> Q? {
+  let x = X<T>()
+  return x as? Q
+}
+
+precondition(tryCastToQ(_: WithCopyable.self) != nil)
+precondition(tryCastToQ(_: WithNonCopyable.self) == nil)
+


### PR DESCRIPTION
* **Explanation**: Emit metadata for runtime checks of conformances of associated types to invertible protocols, e.g., `T.Assoc: Copyable`. This allows us to correctly handle, e.g., dynamic casting involving conditional conformances that have such constraints. 
* **Original PR**: https://github.com/apple/swift/pull/72788
* **Risk**: Low. The actual compiler functionality is behind an experimental flag (`SuppressedAssociatedTypes`)[https://github.com/apple/swift/pull/72812]), and only when that's enabled will the runtime change have any effect.
* **Testing**: New tests.
