### PR TITLE
[6.0][Concurrency] Don't allow erasing global actor isolation when the function value crosses an isolation boundary.

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1903,7 +1903,7 @@ bool swift::isAsyncDecl(ConcreteDeclRef declRef) {
 /// \param ty a function type where \c globalActor was removed from it.
 /// \return true if it is safe to drop the global-actor qualifier.
 static bool safeToDropGlobalActor(
-    DeclContext *dc, Type globalActor, Type ty) {
+    DeclContext *dc, Type globalActor, Type ty, ApplyExpr *call) {
   auto funcTy = ty->getAs<AnyFunctionType>();
   if (!funcTy)
     return false;
@@ -1927,6 +1927,12 @@ static bool safeToDropGlobalActor(
   // in light of SE-338.
   if (funcTy->isAsync())
     return true;
+
+  // If the argument is passed over an isolation boundary, it's not
+  // safe to erase actor isolation, because the callee can call the
+  // function synchronously from outside the isolation domain.
+  if (call && call->getIsolationCrossing())
+    return false;
 
   // fundamentally cannot be sendable if we want to drop isolation info
   if (funcTy->isSendable())
@@ -2350,7 +2356,8 @@ namespace {
               return;
 
             auto dc = const_cast<DeclContext*>(getDeclContext());
-            if (!safeToDropGlobalActor(dc, fromActor, toType)) {
+            if (!safeToDropGlobalActor(dc, fromActor, toType,
+                                       getImmediateApply())) {
               // otherwise, it's not a safe cast.
               dc->getASTContext()
                   .Diags

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -468,6 +468,8 @@ actor Crystal {
   await asyncGlobalActorFunc()
 }
 
+func crossIsolationBoundary(_ closure: () -> Void) async {}
+
 @available(SwiftStdlib 5.1, *)
 func testGlobalActorClosures() {
   let _: Int = acceptAsyncClosure { @SomeGlobalActor in
@@ -480,6 +482,15 @@ func testGlobalActorClosures() {
   }
 
   acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning {{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
+
+  @MainActor func test() async {
+    let closure = { @MainActor @Sendable in
+      MainActor.assertIsolated()
+    }
+
+    await crossIsolationBoundary(closure)
+    // expected-warning@-1 {{converting function value of type '@MainActor @Sendable () -> ()' to '() -> Void' loses global actor 'MainActor'; this is an error in the Swift 6 language mode}}
+  }
 }
 
 @available(SwiftStdlib 5.1, *)


### PR DESCRIPTION
* **Explanation**: The actor isolation checker allows erasing global actor isolation in function conversions when the conversion happens in the same isolation domain and the destination type is not Sendable under the assumption that the function value will never cross an isolation boundary. This is an important rule, because it allows calling synchronous higher order function APIs with global actor isolated function values as long as you're calling from a global actor isolated context. However, the actor isolation checker was allowing the conversion in cases where the function value crosses an isolation boundary:

  ```swift
  func crossIsolationBoundary(_ closure: () -> Void) async { closure() }

  @MainActor func test() async {
    let closure = { @MainActor @Sendable in
      MainActor.assertIsolated()
    }

    await crossIsolationBoundary(closure)
  }
  ```

  This PR diagnoses the function conversion that loses actor isolation if the function conversion is an argument to a call that crosses an isolation boundary.

  We still need to fix this case under region isolation:

  ```swift
  func crossIsolationBoundary(_ closure: () -> Void) async { closure() }

  @MainActor func test() async {
    let closure = { @MainActor @Sendable in
      MainActor.assertIsolated()
    }

    let erased: () -> Void = closure

    await crossIsolationBoundary(erased)
  }
  ```

  Currently, the above code is "fine" because the function conversion itself isn't crossing an isolation boundary, and from the perspective of region analysis, `erased` is in a disconnected region. I think the way to solve this is to merge `erased` to the main actor region due to the function conversion that erases main actor isolation.

* **Scope**: Only impacts isolated-to-non-Sendable function conversions that cross isolation boundaries.
* **Risk**: Low due to narrow scope.
* **Testing**: Add a test case.
* **Reviewer**: @xedin 
* **Main branch PR**: https://github.com/apple/swift/pull/72607