### PR TITLE
Fix type lowering of ~Copyable and ~Escapable generics.

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1014,7 +1014,10 @@ public:
 
   bool requiresClass() const;
   LayoutConstraint getLayoutConstraint() const;
+  bool conformsToKnownProtocol(
+    CanType substTy, KnownProtocolKind protocolKind) const;
   bool isNoncopyable(CanType substTy) const;
+  bool isEscapable(CanType substTy) const;
 
   /// Return the Swift type which provides structure for this
   /// abstraction pattern.

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -290,7 +290,7 @@ bool AbstractionPattern::isNoncopyable(CanType substTy) const {
     
   auto isDefinitelyCopyable = [&](CanType t) -> bool {
     auto result = copyable->getParentModule()
-      ->checkConformanceWithoutContext(substTy, copyable,
+      ->checkConformanceWithoutContext(t, copyable,
                                        /*allowMissing=*/false);
     return result.has_value() && !result.value().isInvalid();
   };

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -284,39 +284,40 @@ LayoutConstraint AbstractionPattern::getLayoutConstraint() const {
   }
 }
 
-bool AbstractionPattern::isNoncopyable(CanType substTy) const {
-  auto copyable
-    = substTy->getASTContext().getProtocol(KnownProtocolKind::Copyable);
+bool AbstractionPattern::conformsToKnownProtocol(
+  CanType substTy, KnownProtocolKind protocolKind) const {
+  auto suppressible
+    = substTy->getASTContext().getProtocol(protocolKind);
     
-  auto isDefinitelyCopyable = [&](CanType t) -> bool {
-    auto result = copyable->getParentModule()
-      ->checkConformanceWithoutContext(t, copyable,
+  auto definitelyConforms = [&](CanType t) -> bool {
+    auto result = suppressible->getParentModule()
+      ->checkConformanceWithoutContext(t, suppressible,
                                        /*allowMissing=*/false);
     return result.has_value() && !result.value().isInvalid();
   };
     
   // If the substituted type definitely conforms, that's authoritative.
-  if (isDefinitelyCopyable(substTy)) {
-    return false;
+  if (definitelyConforms(substTy)) {
+    return true;
   }
 
   // If the substituted type is fully concrete, that's it. If there are unbound
   // type variables in the type, then we may have to account for the upper
   // abstraction bound from the abstraction pattern.
   if (!substTy->hasTypeParameter()) {
-    return true;
+    return false;
   }
   
   switch (getKind()) {
   case Kind::Opaque: {
     // The abstraction pattern doesn't provide any more specific bounds.
-    return true;
+    return false;
   }
   case Kind::Type:
   case Kind::Discard:
   case Kind::ClangType: {
     // See whether the abstraction pattern's context gives us an upper bound
-    // that ensures the type is copyable.
+    // that ensures the type conforms.
     auto type = getType();
     if (hasGenericSignature() && getType()->hasTypeParameter()) {
       type = GenericEnvironment::mapTypeIntoContext(
@@ -324,22 +325,23 @@ bool AbstractionPattern::isNoncopyable(CanType substTy) const {
         ->getReducedType(getGenericSignature());
     }
     
-    return !isDefinitelyCopyable(type);
+    return definitelyConforms(type);
   }
   case Kind::Tuple: {
-    // A tuple is noncopyable if any element is.
+    // A tuple conforms if all elements do.
     if (doesTupleVanish()) {
       return getVanishingTupleElementPatternType().value()
-        .isNoncopyable(substTy);
+        .conformsToKnownProtocol(substTy, protocolKind);
     }
     auto substTupleTy = cast<TupleType>(substTy);
   
     for (unsigned i = 0, e = getNumTupleElements(); i < e; ++i) {
-      if (getTupleElementType(i).isNoncopyable(substTupleTy.getElementType(i))){
-        return true;
+      if (!getTupleElementType(i).conformsToKnownProtocol(
+            substTupleTy.getElementType(i), protocolKind)) {
+        return false;
       }
     }
-    return false;
+    return true;
   }
   // Functions are, at least for now, always copyable.
   case Kind::CurriedObjCMethodType:
@@ -354,11 +356,19 @@ bool AbstractionPattern::isNoncopyable(CanType substTy) const {
   case Kind::PartialCurriedCXXMethodType:
   case Kind::OpaqueFunction:
   case Kind::OpaqueDerivativeFunction:
-    return false;
+    return true;
   
   case Kind::Invalid:
     llvm_unreachable("asking invalid abstraction pattern");
   }
+}
+
+bool AbstractionPattern::isNoncopyable(CanType substTy) const {
+  return !conformsToKnownProtocol(substTy, KnownProtocolKind::Copyable);
+}
+
+bool AbstractionPattern::isEscapable(CanType substTy) const {
+  return conformsToKnownProtocol(substTy, KnownProtocolKind::Escapable);
 }
 
 bool AbstractionPattern::matchesTuple(CanType substType) const {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2441,7 +2441,9 @@ namespace {
         return new (TC) MoveOnlyLoadableStructTypeLowering(
             structType, properties, Expansion);
       }
-      if (D->canBeEscapable() != TypeDecl::CanBeInvertible::Always) {
+      // Regardless of their member types, Nonescapable values have ownership
+      // for lifetime diagnostics.
+      if (!origType.isEscapable(structType)) {
         properties.setNonTrivial();
       }
       return handleAggregateByProperties<LoadableStructTypeLowering>(structType,
@@ -2538,10 +2540,11 @@ namespace {
         return new (TC)
             MoveOnlyLoadableEnumTypeLowering(enumType, properties, Expansion);
       }
-
-      assert(D->canBeEscapable() == TypeDecl::CanBeInvertible::Always
-             && "missing typelowering case here!");
-
+      // Regardless of their member types, Nonescapable values have ownership
+      // for lifetime diagnostics.
+      if (!origType.isEscapable(enumType)) {
+        properties.setNonTrivial();
+      }
       return handleAggregateByProperties<LoadableEnumTypeLowering>(enumType,
                                                                    properties);
     }

--- a/test/SIL/type_lowering_unit.sil
+++ b/test/SIL/type_lowering_unit.sil
@@ -1,4 +1,7 @@
-// RUN: %target-sil-opt -test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-sil-opt -test-runner \
+// RUN:   -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature BitwiseCopyable \
+// RUN:   %s -o /dev/null 2>&1 | %FileCheck %s
 
 sil_stage raw
 
@@ -6,6 +9,8 @@ import Builtin
 import Swift
 
 struct S : ~Copyable {}
+
+struct SCopyable {}
 
 // CHECK-LABEL: begin {{.*}} print-type-lowering with: @argument[0]
 // CHECK:       isLexical: true
@@ -105,4 +110,201 @@ entry(%addr : $*Builtin.RawPointer):
   %instance = builtin "once"(%ptr : $Builtin.RawPointer, undef : $()) : $Builtin.SILToken
   specify_test "print_ast_type_lowering %instance"
   return undef : $()
+}
+
+struct GSNC<T: ~Copyable>: ~Copyable {
+    var x: T
+}
+
+extension GSNC: Copyable where T: Copyable  {}
+
+struct GSNE<T: ~Escapable>: ~Escapable {
+    var x: T
+}
+
+extension GSNE: Escapable where T: Escapable {}
+
+enum GENC<T: ~Copyable>: ~Copyable {
+    case x(T)
+    case knoll
+}
+
+enum GENE<T: ~Escapable>: ~Escapable {
+    case x(T)
+    case knoll
+}
+
+extension GENC: Copyable where T: Copyable {}
+
+extension GENE: Escapable where T: Escapable {}
+
+// TODO: We should have 'isTrivial: true' for the following four tests: gsnc_argument, gsne_argument, genc_argument,
+// gene_argument. This requires fixing Typelowering visitAnyStructType and visitAnyEnumType to apply the current
+// abstraction pattern for each stored property that refers to an archetype. Similar how TypeLowering handles the
+// aggregate type by calling AbstractionPattern::conformsToKnownProtocol.
+//
+// CHECK-LABEL: begin running test 1 of 1 on gsnc_argument: print-type-lowering with: @argument[0]
+// CHECK: Type Lowering for lowered type: $*GSNC<T>.
+// CHECK: isTrivial: false.
+// CHECK-LABEL: end running test 1 of 1 on gsnc_argument: print-type-lowering with: @argument[0]
+sil [ossa] @gsnc_argument : $@convention(thin) <T: _BitwiseCopyable> (@in_guaranteed GSNC<T>) -> () {
+bb0(%0 : $*GSNC<T>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on gsne_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: false.
+// CHECK-LABEL: end running test 1 of 1 on gsne_argument: print-type-lowering with: @argument[0]
+sil [ossa] @gsne_argument : $@convention(thin) <T: _BitwiseCopyable> (@in_guaranteed GSNE<T>) -> () {
+bb0(%0 : $*GSNE<T>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on genc_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: false.
+// CHECK-LABEL: end running test 1 of 1 on genc_argument: print-type-lowering with: @argument[0]
+sil [ossa] @genc_argument : $@convention(thin) <T: _BitwiseCopyable> (@in_guaranteed GENC<T>) -> () {
+bb0(%0 : $*GENC<T>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on gene_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: false.
+// CHECK-LABEL: end running test 1 of 1 on gene_argument: print-type-lowering with: @argument[0]
+sil [ossa] @gene_argument : $@convention(thin) <T: _BitwiseCopyable> (@in_guaranteed GENE<T>) -> () {
+bb0(%0 : $*GENE<T>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+struct Bitwise<T: _BitwiseCopyable>: _BitwiseCopyable {
+  var x: T
+}
+
+// TODO: This should return 'isTrivial: true'. This is particularly inexcusable because the 'Bitwise' cannot be
+// nontrivial over any 'T', *and* the declaration itself is declared BitwiseCopyable.
+//
+// CHECK-LABEL: begin running test 1 of 1 on bitwise_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: false.
+// CHECK-LABEL: end running test 1 of 1 on bitwise_argument: print-type-lowering with: @argument[0]
+sil [ossa] @bitwise_argument : $@convention(thin) <T: _BitwiseCopyable> (@in_guaranteed Bitwise<T>) -> () {
+bb0(%0 : $*Bitwise<T>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on gsnc_specialized_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: true.
+// CHECK-LABEL: end running test 1 of 1 on gsnc_specialized_argument: print-type-lowering with: @argument[0]
+sil [ossa] @gsnc_specialized_argument : $@convention(thin) (@in_guaranteed GSNC<SCopyable>) -> () {
+bb0(%0 : $*GSNC<SCopyable>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on gsne_specialized_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: true.
+// CHECK-LABEL: end running test 1 of 1 on gsne_specialized_argument: print-type-lowering with: @argument[0]
+sil [ossa] @gsne_specialized_argument : $@convention(thin) (@in_guaranteed GSNE<SCopyable>) -> () {
+bb0(%0 : $*GSNE<SCopyable>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on genc_specialized_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: true.
+// CHECK-LABEL: end running test 1 of 1 on genc_specialized_argument: print-type-lowering with: @argument[0]
+sil [ossa] @genc_specialized_argument : $@convention(thin) (@in_guaranteed GENC<SCopyable>) -> () {
+bb0(%0 : $*GENC<SCopyable>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on gene_specialized_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: true.
+// CHECK-LABEL: end running test 1 of 1 on gene_specialized_argument: print-type-lowering with: @argument[0]
+sil [ossa] @gene_specialized_argument : $@convention(thin) (@in_guaranteed GENE<SCopyable>) -> () {
+bb0(%0 : $*GENE<SCopyable>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+struct GSNCInt<T: ~Copyable>: ~Copyable {
+    var x: Int
+}
+
+extension GSNCInt: Copyable where T: Copyable  {}
+
+struct GSNEInt<T: ~Escapable>: ~Escapable {
+    var x: Int
+    @_unsafeNonescapableResult
+    init() { x = 0 }
+}
+
+extension GSNEInt: Escapable where T: Escapable {}
+
+enum GENCInt<T: ~Copyable>: ~Copyable {
+    case x(Int)
+    case knoll
+}
+
+enum GENEInt<T: ~Escapable>: ~Escapable {
+    case x(Int)
+    case knoll
+}
+
+extension GENCInt: Copyable where T: Copyable {}
+
+extension GENEInt: Escapable where T: Escapable {}
+
+// CHECK-LABEL: begin running test 1 of 1 on gsncint_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: true.
+// CHECK-LABEL: end running test 1 of 1 on gsncint_argument: print-type-lowering with: @argument[0]
+sil [ossa] @gsncint_argument : $@convention(thin) <T: _BitwiseCopyable> (@in_guaranteed GSNCInt<T>) -> () {
+bb0(%0 : $*GSNCInt<T>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on gsneint_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: true.
+// CHECK-LABEL: end running test 1 of 1 on gsneint_argument: print-type-lowering with: @argument[0]
+sil [ossa] @gsneint_argument : $@convention(thin) <T: _BitwiseCopyable> (@in_guaranteed GSNEInt<T>) -> () {
+bb0(%0 : $*GSNEInt<T>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on gencint_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: true.
+// CHECK-LABEL: end running test 1 of 1 on gencint_argument: print-type-lowering with: @argument[0]
+sil [ossa] @gencint_argument : $@convention(thin) <T: _BitwiseCopyable> (@in_guaranteed GENCInt<T>) -> () {
+bb0(%0 : $*GENCInt<T>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on geneint_argument: print-type-lowering with: @argument[0]
+// CHECK: isTrivial: true.
+// CHECK-LABEL: end running test 1 of 1 on geneint_argument: print-type-lowering with: @argument[0]
+sil [ossa] @geneint_argument : $@convention(thin) <T: _BitwiseCopyable> (@in_guaranteed GENEInt<T>) -> () {
+bb0(%0 : $*GENEInt<T>):
+  specify_test "print-type-lowering @argument[0]"
+  %retval = tuple ()
+  return %retval : $()
 }

--- a/test/SILGen/mangling_inverse_generics.swift
+++ b/test/SILGen/mangling_inverse_generics.swift
@@ -110,7 +110,7 @@ public struct A<T: ~Copyable>: ~Copyable {
   public func foo() {}
 
   // DEMANGLED: test.A.weird() -> ()
-  // CHECK: sil [ossa] @$s4test1AV5weirdyyF : $@convention(method) <T> (@guaranteed A<T>) -> () {
+  // CHECK: sil [ossa] @$s4test1AV5weirdyyF : $@convention(method) <T> (A<T>) -> () {
   public func weird() where T: Copyable {}
 
   // DEMANGLED: variable initialization expression of (extension in test):test.A< where A: ~Swift.Copyable>.property : Swift.Int
@@ -155,7 +155,7 @@ extension A where T: ~Copyable {
   func bar() {}
 
   // DEMANGLED: test.A.weird2() -> ()
-  // CHECK: sil hidden [ossa] @$s4test1AV6weird2yyF : $@convention(method) <T> (@guaranteed A<T>) -> () {
+  // CHECK: sil hidden [ossa] @$s4test1AV6weird2yyF : $@convention(method) <T> (A<T>) -> () {
   func weird2() where T: Copyable {}
 }
 
@@ -172,11 +172,11 @@ extension A {
   // requirements must be mangled as if there were no inverse generics.
 
   // DEMANGLED: test.A.baz() -> ()
-  // CHECK: sil hidden [ossa] @$s4test1AV3bazyyF : $@convention(method) <T> (@guaranteed A<T>) -> () {
+  // CHECK: sil hidden [ossa] @$s4test1AV3bazyyF : $@convention(method) <T> (A<T>) -> () {
   func baz() {}
 
   // DEMANGLED: test.A.computedAgain.getter : Swift.Int
-  // CHECK: sil hidden [ossa] @$s4test1AV13computedAgainSivg : $@convention(method) <T> (@guaranteed A<T>) -> Int {
+  // CHECK: sil hidden [ossa] @$s4test1AV13computedAgainSivg : $@convention(method) <T> (A<T>) -> Int {
   var computedAgain: Int {
     123
   }
@@ -188,7 +188,7 @@ extension A where T: CopyableProto {
   // the extra constraints and not any inverses.
 
   // DEMANGLED: (extension in test):test.A<A where A: test.CopyableProto>.something() -> ()
-  // CHECK: sil hidden [ossa] @$s4test1AVA2A13CopyableProtoRzlE9somethingyyF : $@convention(method) <T where T : CopyableProto> (@guaranteed A<T>) -> () {
+  // CHECK: sil hidden [ossa] @$s4test1AVA2A13CopyableProtoRzlE9somethingyyF : $@convention(method) <T where T : CopyableProto> (A<T>) -> () {
   func something() {}
 }
 

--- a/test/SILGen/typelowering_inverses.swift
+++ b/test/SILGen/typelowering_inverses.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -disable-availability-checking -module-name main %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature NonescapableTypes -disable-availability-checking -module-name main %s | %FileCheck %s
 
 protocol NoCopyP: ~Copyable {}
 
@@ -24,7 +24,31 @@ enum CondCopyableEnum<T: ~Copyable>: ~Copyable {
 
 extension CondCopyableEnum: Copyable {}
 
-// MARK: ensure certain types are treated as trivial (no ownership in func signature).
+protocol NoEscapeP: ~Escapable {}
+
+struct NE: ~Escapable {}
+
+struct TooRudeStruct<T: ~Escapable>: Escapable {
+    let thing: Int
+}
+
+enum TooRudeEnum<T: ~Escapable>: Escapable {
+  case holder(Int)
+  case whatever
+}
+
+struct CondEscapableStruct<T: ~Escapable>: ~Escapable {}
+
+extension CondEscapableStruct: Escapable {}
+
+enum CondEscapableEnum<T: ~Escapable>: ~Escapable {
+  case some(T)
+  case none
+}
+
+extension CondEscapableEnum: Escapable {}
+
+// MARK: ensure certain conditionally Copyable types are treated as trivial (no ownership in func signature).
 
 // CHECK: sil hidden [ossa] @$s4main5checkyyAA10RudeStructVySiGF : $@convention(thin) (RudeStruct<Int>) -> () {
 func check(_ t: RudeStruct<Int>) {}
@@ -68,18 +92,68 @@ func check(_ t: consuming any NoCopyP & ~Copyable) {}
 // CHECK: sil hidden [ossa] @$s4main5checkyyAA7NoCopyP_pRi_s_XPzF : $@convention(thin) (@inout any NoCopyP & ~Copyable) -> () {
 func check(_ t: inout any NoCopyP & ~Copyable) {}
 
-struct MyStruct<T: ~Copyable>: ~Copyable {
+// MARK: ensure certain conditionally Escapable types are treated as trivial (no ownership in func signature).
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA13TooRudeStructVySiGF : $@convention(thin) (TooRudeStruct<Int>) -> () {
+func check(_ t: TooRudeStruct<Int>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA13TooRudeStructVyAA2NEVGF : $@convention(thin) (TooRudeStruct<NE>) -> () {
+func check(_ t: TooRudeStruct<NE>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA11TooRudeEnumOySiGF : $@convention(thin) (TooRudeEnum<Int>) -> () {
+func check(_ t: TooRudeEnum<Int>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA11TooRudeEnumOyAA2NEVGF : $@convention(thin) (TooRudeEnum<NE>) -> () {
+func check(_ t: TooRudeEnum<NE>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA19CondEscapableStructVySiGF : $@convention(thin) (CondEscapableStruct<Int>) -> () {
+func check(_ t: CondEscapableStruct<Int>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA19CondEscapableStructVyAA2NEVGF : $@convention(thin) (@guaranteed CondEscapableStruct<NE>) -> () {
+func check(_ t: borrowing CondEscapableStruct<NE>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA17CondEscapableEnumOySiGF : $@convention(thin) (CondEscapableEnum<Int>) -> () {
+func check(_ t: CondEscapableEnum<Int>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA17CondEscapableEnumOyAA2NEVGF : $@convention(thin) (@guaranteed CondEscapableEnum<NE>) -> () {
+func check(_ t: borrowing CondEscapableEnum<NE>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA17CondEscapableEnumOyxGlF : $@convention(thin) <T> (@in_guaranteed CondEscapableEnum<T>) -> () {
+func check<T>(_ t: CondEscapableEnum<T>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA17CondEscapableEnumOyxGRi0_zlF : $@convention(thin) <U where U : ~Escapable> (@in_guaranteed CondEscapableEnum<U>) -> () {
+func check<U: ~Escapable>(_ t: borrowing CondEscapableEnum<U>) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA9NoEscapeP_pF : $@convention(thin) (@in_guaranteed any NoEscapeP) -> () {
+func check(_ t: any NoEscapeP) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA9NoEscapeP_pRi0_s_XPF : $@convention(thin) (@in_guaranteed any NoEscapeP & ~Escapable) -> () {
+func check(_ t: borrowing any NoEscapeP & ~Escapable) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA9NoEscapeP_pRi0_s_XPnF : $@convention(thin) (@in any NoEscapeP & ~Escapable) -> () {
+func check(_ t: consuming any NoEscapeP & ~Escapable) {}
+
+// CHECK: sil hidden [ossa] @$s4main5checkyyAA9NoEscapeP_pRi0_s_XPzF : $@convention(thin) (@inout any NoEscapeP & ~Escapable) -> () {
+func check(_ t: inout any NoEscapeP & ~Escapable) {}
+
+// MARK: conditionally Copyable & Escapable SILGen
+
+struct MyStruct<T: ~Copyable & ~Escapable>: ~Copyable & ~Escapable {
     var x: T
 }
 
-extension MyStruct: Copyable where T: Copyable {}
+extension MyStruct: Copyable where T: Copyable & ~Escapable {}
 
-enum MyEnum<T: ~Copyable>: ~Copyable {
+extension MyStruct: Escapable where T: Escapable & ~Copyable {}
+
+enum MyEnum<T: ~Copyable & ~Escapable>: ~Copyable & ~Escapable {
     case x(T)
     case knoll
 }
 
-extension MyEnum: Copyable where T: Copyable {}
+extension MyEnum: Copyable where T: Copyable & ~Escapable {}
+
+extension MyEnum: Escapable where T: Escapable & ~Copyable {}
 
 enum Trivial {
     case a, b, c


### PR DESCRIPTION
Factor AbstractionPattern::conformsToKnownProtocol and lower ~Escapable using the same logic as ~Copyable.

Adds support for conditionally Escapable enums.

Correctly sets the SILType::isTrivial flags for conditionally escapable structs and enums in environments (extensions) that provide an Escapable conformance, such as:

    struct NE<E: ~Escapable> : ~Escapable {}

    extension NE: Escapable {
      func foo() -> Self {
        // Self is both Escapable and trivial here.
        self
      }
    }

Fixes rdar://125950218 ([nonescapable] support conditionally escapable enums)
