### PR TITLE
[6.0][region-isolation] Enable region isolation when strict concurrency is enabled

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -111,6 +111,9 @@ function(add_swift_unittest test_dirname)
     endif()
   endif()
 
+  is_build_type_with_debuginfo("${CMAKE_BUILD_TYPE}" HAS_DEBUG_INFO)
+  target_compile_options("${test_dirname}" PRIVATE $<$<BOOL:${HAS_DEBUG_INFO}>:-g>)
+
   file(RELATIVE_PATH relative_lib_path "${CMAKE_CURRENT_BINARY_DIR}" "${SWIFT_LIBRARY_OUTPUT_INTDIR}")
 
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)

--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -111,6 +111,9 @@ public:
 
   static ActorIsolation forActorInstanceSelf(ValueDecl *decl);
 
+  /// Create an ActorIsolation appropriate for a type that is self.
+  static ActorIsolation forActorInstanceSelf(NominalTypeDecl *decl);
+
   static ActorIsolation forActorInstanceParameter(NominalTypeDecl *actor,
                                                   unsigned parameterIndex) {
     return ActorIsolation(ActorInstance, actor, parameterIndex + 1);

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -46,6 +46,9 @@ ERROR(bridging_objcbridgeable_broken,none,
 ERROR(sil_function_redefinition,none,
       "multiple definitions of symbol '%0'",
       (StringRef))
+NOTE(sil_function_redefinition_note,none,
+      "other definition here",
+      ())
 
 ERROR(invalid_sil_builtin,none,
       "INTERNAL ERROR: invalid use of builtin: %0",

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1332,4 +1332,9 @@ def disable_experimental_parser_round_trip : Flag<["-"],
   "disable-experimental-parser-round-trip">,
   HelpText<"Disable round trip through the new swift parser">;
 
+def disable_strict_concurrency_region_based_isolation : Flag<["-"],
+  "disable-region-based-isolation-with-strict-concurrency">,
+  HelpText<"Disable region based isolation when running with strict concurrency enabled. Only enabled with asserts">,
+  Flags<[HelpHidden]>;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -348,7 +348,7 @@ private:
   unsigned BlockListChangeIdx = 0;
 
   /// The isolation of this function.
-  std::optional<ActorIsolation> actorIsolation;
+  ActorIsolation actorIsolation = ActorIsolation::forUnspecified();
 
   /// The function's bare attribute. Bare means that the function is SIL-only
   /// and does not require debug info.
@@ -1374,9 +1374,7 @@ public:
     actorIsolation = newActorIsolation;
   }
 
-  std::optional<ActorIsolation> getActorIsolation() const {
-    return actorIsolation;
-  }
+  ActorIsolation getActorIsolation() const { return actorIsolation; }
 
   //===--------------------------------------------------------------------===//
   // Block List Access

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -162,7 +162,7 @@ public:
   }
 
   ActorIsolation getActorIsolation() const {
-    return regionInfo.getActorIsolation().value();
+    return regionInfo.getActorIsolation();
   }
 
   void mergeIsolationRegionInfo(SILIsolationInfo newRegionInfo) {

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -208,6 +208,10 @@ public:
     return SILIsolationInfo();
   }
 
+  static SILIsolationInfo getGlobalActorIsolated(Type globalActorType) {
+    return getActorIsolated(ActorIsolation::forGlobalActor(globalActorType));
+  }
+
   static SILIsolationInfo getTaskIsolated(SILValue value) {
     return {Kind::Task, value};
   }

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -901,8 +901,8 @@ private:
       // our transferring operand. If so, we can squelch this.
       if (auto functionIsolation =
               transferringOp->getUser()->getFunction()->getActorIsolation()) {
-        if (functionIsolation->isActorIsolated() &&
-            SILIsolationInfo::getActorIsolated(*functionIsolation) ==
+        if (functionIsolation.isActorIsolated() &&
+            SILIsolationInfo::getActorIsolated(functionIsolation) ==
                 SILIsolationInfo::get(transferringOp->getUser()))
           return;
       }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -11387,6 +11387,10 @@ ActorIsolation::forActorInstanceSelf(ValueDecl *decl) {
   return ActorIsolation(ActorInstance, dc->getSelfNominalTypeDecl(), 0);
 }
 
+ActorIsolation ActorIsolation::forActorInstanceSelf(NominalTypeDecl *selfDecl) {
+  return ActorIsolation(ActorInstance, selfDecl, 0);
+}
+
 NominalTypeDecl *ActorIsolation::getActor() const {
   assert(getKind() == ActorInstance ||
          getKind() == GlobalActor);

--- a/lib/DriverTool/sil_opt_main.cpp
+++ b/lib/DriverTool/sil_opt_main.cpp
@@ -534,6 +534,11 @@ struct SILOptOptions {
   llvm::cl::list<std::string> ClangXCC = llvm::cl::list<std::string>(
       "Xcc",
       llvm::cl::desc("option to pass to clang"));
+
+  llvm::cl::opt<bool> DisableRegionBasedIsolationWithStrictConcurrency =
+      llvm::cl::opt<bool>(
+          "disable-region-based-isolation-with-strict-concurrency",
+          llvm::cl::init(false));
 };
 
 /// Regular expression corresponding to the value given in one of the
@@ -698,9 +703,14 @@ int sil_opt_main(ArrayRef<const char *> argv, void *MainAddr) {
 
   Invocation.getLangOptions().UnavailableDeclOptimizationMode =
       options.UnavailableDeclOptimization;
-  if (options.StrictConcurrencyLevel.hasArgStr())
+  if (options.StrictConcurrencyLevel.hasArgStr()) {
     Invocation.getLangOptions().StrictConcurrencyLevel =
         options.StrictConcurrencyLevel;
+    if (options.StrictConcurrencyLevel == StrictConcurrency::Complete &&
+        !options.DisableRegionBasedIsolationWithStrictConcurrency) {
+      Invocation.getLangOptions().enableFeature(Feature::RegionBasedIsolation);
+    }
+  }
 
   Invocation.getDiagnosticOptions().VerifyMode =
     options.VerifyMode ? DiagnosticOptions::Verify : DiagnosticOptions::NoVerify;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1060,6 +1060,16 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   if (Opts.StrictConcurrencyLevel == StrictConcurrency::Complete) {
     Opts.enableFeature(Feature::IsolatedDefaultValues);
     Opts.enableFeature(Feature::GlobalConcurrency);
+
+    // If asserts are enabled, allow for region based isolation to be disabled
+    // with a flag. This is intended only to be used with tests.
+    bool enableRegionIsolation = true;
+#ifndef NDEBUG
+    enableRegionIsolation =
+        !Args.hasArg(OPT_disable_strict_concurrency_region_based_isolation);
+#endif
+    if (enableRegionIsolation)
+      Opts.enableFeature(Feature::RegionBasedIsolation);
   }
 
   Opts.WarnImplicitOverrides =

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -725,6 +725,13 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
         return IGM.getFunction(constant, NotForDefinition);
       });
 
+  // If we have global actor isolation for our constant, put the isolation onto
+  // the function.
+  if (auto isolation =
+          getActorIsolationOfContext(constant.getInnermostDeclContext())) {
+    F->setActorIsolation(isolation);
+  }
+
   assert(F && "SILFunction should have been defined");
 
   emittedFunctions[constant] = F;
@@ -1217,9 +1224,12 @@ void SILGenModule::preEmitFunction(SILDeclRef constant, SILFunction *F,
   if (F->getLoweredFunctionType()->isPolymorphic())
     F->setGenericEnvironment(Types.getConstantGenericEnvironment(constant));
 
-  // Set the actor isolation of the function to its innermost decl context.
-  F->setActorIsolation(
-      getActorIsolationOfContext(constant.getInnermostDeclContext()));
+  // If we have global actor isolation for our constant, put the isolation onto
+  // the function.
+  if (auto isolation =
+          getActorIsolationOfContext(constant.getInnermostDeclContext())) {
+    F->setActorIsolation(isolation);
+  }
 
   // Create a debug scope for the function using astNode as source location.
   F->setDebugScope(new (M) SILDebugScope(Loc, F));

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -813,6 +813,8 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
   if (!f->empty()) {
     diagnose(constant.getAsRegularLocation(), diag::sil_function_redefinition,
              f->getName());
+    if (f->hasLocation())
+      diagnose(f->getLocation(), diag::sil_function_redefinition_note);
     return;
   }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -624,11 +624,7 @@ void SILIsolationInfo::printForDiagnostics(llvm::raw_ostream &os) const {
     os << "disconnected";
     return;
   case Actor:
-    if (hasActorIsolation() && getActorIsolation()) {
-      getActorIsolation()->printForDiagnostics(os);
-    } else {
-      os << "actor-isolated";
-    }
+    getActorIsolation().printForDiagnostics(os);
     return;
   case Task:
     os << "task-isolated";

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -91,7 +91,7 @@ SILIsolationInfo SILIsolationInfo::get(SILFunctionArgument *arg) {
   // should be marked as actor isolated.
   if (auto *self = arg->getFunction()->maybeGetSelfArgument()) {
     if (auto functionIsolation = arg->getFunction()->getActorIsolation()) {
-      if (functionIsolation->isActorIsolated()) {
+      if (functionIsolation.isActorIsolated()) {
         if (auto *nomDecl = self->getType().getNominalOrBoundGenericNominal()) {
           if (auto isolationInfo =
                   SILIsolationInfo::getActorIsolated(nomDecl)) {

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -342,12 +342,10 @@ extension Actor {
   /// - Returns: the return value of the `operation`
   /// - Throws: rethrows the `Error` thrown by the operation if it threw
   @available(SwiftStdlib 5.1, *)
-  #if !$Embedded
-  @backDeployed(before: SwiftStdlib 5.9)
-  #endif
+  @_alwaysEmitIntoClient
   @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
   @_unavailableInEmbedded
-  public nonisolated func assumeIsolated<T>(
+  public nonisolated func assumeIsolated<T : Sendable>(
       _ operation: (isolated Self) throws -> T,
       file: StaticString = #fileID, line: UInt = #line
   ) rethrows -> T {
@@ -372,6 +370,17 @@ extension Actor {
     #else
     fatalError("unsupported compiler")
     #endif
+  }
+
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  @_unavailableInEmbedded
+  @_silgen_name("$sScAsE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKlF")
+  internal nonisolated func __abi__assumeIsolated<T : Sendable>(
+      _ operation: (isolated Self) throws -> T,
+      _ file: StaticString, _ line: UInt
+  ) rethrows -> T {
+    try assumeIsolated(operation, file: file, line: line)
   }
 }
 

--- a/stdlib/public/Concurrency/MainActor.swift
+++ b/stdlib/public/Concurrency/MainActor.swift
@@ -137,13 +137,12 @@ extension MainActor {
   /// - Returns: the return value of the `operation`
   /// - Throws: rethrows the `Error` thrown by the operation if it threw
   @available(SwiftStdlib 5.1, *)
-  @backDeployed(before: SwiftStdlib 5.9)
+  @_alwaysEmitIntoClient
   @_unavailableFromAsync(message: "await the call to the @MainActor closure directly")
-  public static func assumeIsolated<T>(
+  public static func assumeIsolated<T : Sendable>(
       _ operation: @MainActor () throws -> T,
       file: StaticString = #fileID, line: UInt = #line
   ) rethrows -> T {
-
     typealias YesActor = @MainActor () throws -> T
     typealias NoActor = () throws -> T
 
@@ -165,6 +164,16 @@ extension MainActor {
     #else
     fatalError("unsupported compiler")
     #endif
+  }
+
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  @_silgen_name("$sScM14assumeIsolated_4file4linexxyKScMYcXE_s12StaticStringVSutKlFZ")
+  internal static func __abi__assumeIsolated<T : Sendable>(
+      _ operation: @MainActor () throws -> T,
+      _ file: StaticString, _ line: UInt
+  ) rethrows -> T {
+    try assumeIsolated(operation, file: file, line: line)
   }
 }
 #endif

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -153,7 +153,8 @@ extension DistributedActor {
   /// - Throws: rethrows the `Error` thrown by the operation if it threw
   @available(SwiftStdlib 5.9, *)
   @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'distributed actor' instead")
-  public nonisolated func assumeIsolated<T>(
+  @_alwaysEmitIntoClient
+  public nonisolated func assumeIsolated<T : Sendable>(
       _ operation: (isolated Self) throws -> T,
       file: StaticString = #fileID, line: UInt = #line
   ) rethrows -> T {
@@ -180,6 +181,16 @@ extension DistributedActor {
     #else
     fatalError("unsupported compiler")
     #endif
+  }
+
+  @available(SwiftStdlib 5.9, *)
+  @usableFromInline
+  @_silgen_name("$s11Distributed0A5ActorPAAE14assumeIsolated_4file4lineqd__qd__xYiKXE_s12StaticStringVSutKlF")
+  internal nonisolated func __abi__assumeIsolated<T : Sendable>(
+      _ operation: (isolated Self) throws -> T,
+      _ file: StaticString, _ line: UInt
+  ) rethrows -> T {
+    try assumeIsolated(operation, file: file, line: line)
   }
 }
 

--- a/test/Concurrency/Inputs/GlobalActorIsolatedFunction.swift
+++ b/test/Concurrency/Inputs/GlobalActorIsolatedFunction.swift
@@ -1,0 +1,2 @@
+
+@MainActor public func mainActorFunction() {}

--- a/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
+++ b/test/Concurrency/LLDBDebuggerFunctionActorExtension.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking -debugger-support %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_inout_isolation.swift
+++ b/test/Concurrency/actor_inout_isolation.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted-
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix targeted-complete- -verify-additional-prefix minimal-targeted- -strict-concurrency=targeted
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix targeted-complete- -verify-additional-prefix complete-tns- -verify-additional-prefix complete- -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix complete-tns- -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix minimal-targeted- -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix targeted-complete- -verify-additional-prefix minimal-targeted- -strict-concurrency=targeted -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix targeted-complete- -verify-additional-prefix complete-tns- -verify-additional-prefix complete- -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -verify-additional-prefix targeted-complete-tns- -verify-additional-prefix complete-tns- -strict-concurrency=complete
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/actor_keypath_isolation_swift6.swift
+++ b/test/Concurrency/actor_keypath_isolation_swift6.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -swift-version 6 %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/assumeIsolated.swift
+++ b/test/Concurrency/assumeIsolated.swift
@@ -1,0 +1,30 @@
+// RUN: %target-build-swift -swift-version 5 %s -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -Xfrontend -verify
+
+class NonSendableKlass {} // expected-note 3{{class 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+
+@available(macOS 10.15, *)
+actor MyActor {
+  var x = NonSendableKlass()
+
+  nonisolated func doSomething() -> NonSendableKlass {
+    return self.assumeIsolated { isolatedSelf in // expected-warning {{type 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+      let x: NonSendableKlass = isolatedSelf.x
+      return x
+    }
+  }
+
+  nonisolated func doSomething2() -> NonSendableKlass {
+    let r: NonSendableKlass = assumeIsolated { isolatedSelf in // expected-warning {{type 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+      let x: NonSendableKlass = isolatedSelf.x
+      return x
+    }
+    return r
+  }
+}
+
+@available(macOS 10.15, *)
+nonisolated func mainActorAssumeIsolated() -> NonSendableKlass {
+  return MainActor.assumeIsolated { // expected-warning {{type 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
+    NonSendableKlass()
+  }
+}

--- a/test/Concurrency/assumeIsolated.swift
+++ b/test/Concurrency/assumeIsolated.swift
@@ -1,5 +1,8 @@
 // RUN: %target-build-swift -swift-version 5 %s -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -Xfrontend -verify
 
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
 class NonSendableKlass {} // expected-note 3{{class 'NonSendableKlass' does not conform to the 'Sendable' protocol}}
 
 @available(macOS 10.15, *)

--- a/test/Concurrency/async_cancellation.swift
+++ b/test/Concurrency/async_cancellation.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_let_isolation.swift
+++ b/test/Concurrency/async_let_isolation.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrency_warnings.swift
+++ b/test/Concurrency/concurrency_warnings.swift
@@ -1,5 +1,5 @@
+// RUN: %target-swift-frontend -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrent_value_checking.swift
+++ b/test/Concurrency/concurrent_value_checking.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete -parse-as-library %s -emit-sil -o /dev/null -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/concurrent_value_checking_objc.swift
+++ b/test/Concurrency/concurrent_value_checking_objc.swift
@@ -1,5 +1,5 @@
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: objc_interop

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -disable-availability-checking -enable-experimental-feature StrictConcurrency -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -enable-experimental-feature StrictConcurrency=complete -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -enable-upcoming-feature StrictConcurrency -emit-sil -o /dev/null -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -enable-upcoming-feature StrictConcurrency -emit-sil -o /dev/null -verify -verify-additional-prefix region-isolation- -enable-upcoming-feature RegionBasedIsolation %s
+// RUN: %target-swift-frontend -disable-availability-checking -enable-experimental-feature StrictConcurrency -emit-sil -o /dev/null -verify %s -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -disable-availability-checking -enable-experimental-feature StrictConcurrency=complete -emit-sil -o /dev/null -verify %s -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -disable-availability-checking -enable-upcoming-feature StrictConcurrency -emit-sil -o /dev/null -verify %s -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -disable-availability-checking -enable-upcoming-feature StrictConcurrency -emit-sil -o /dev/null -verify -verify-additional-prefix region-isolation- %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/global_actor_from_ordinary_context.swift
+++ b/test/Concurrency/global_actor_from_ordinary_context.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix minimal-and-targeted- -verify -strict-concurrency=targeted -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-tns- -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-tns- -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -disable-availability-checking %s -emit-sil -o /dev/null -verify-additional-prefix complete-and-tns- -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -39,9 +39,9 @@ class NotSendable {
   let ns = NotSendable(x: 0)
   MyActor.ns = ns
 
-  // expected-region-isolation-warning @+2 {{transferring 'ns' may cause a race}}
-  // expected-region-isolation-note @+1 {{transferring global actor 'MyActor'-isolated 'ns' to global actor 'YourActor'-isolated callee could cause races between global actor 'YourActor'-isolated and global actor 'MyActor'-isolated uses}}
   await { @YourActor in
+    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a race}}
+    // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
@@ -61,8 +61,9 @@ class NotSendable {
   let ns = NotSendable(x: 0)
   ns.stash()
 
-  // FIXME: Region isolation should diagnose this (https://github.com/apple/swift/issues/71533)
   await { @YourActor in
+    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a race}}
+    // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()
@@ -81,8 +82,9 @@ class NotSendable {
 @MyActor func exhibitRace3() async {
   let ns = NotSendable()
 
-  // FIXME: Region isolation should diagnose this (https://github.com/apple/swift/issues/71533)
   await { @YourActor in
+    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a race}}
+    // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
   }()

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -verify -disable-availability-checking -strict-concurrency=complete -verify-additional-prefix complete- -emit-sil -o /dev/null %s
-// RUN: %target-swift-frontend -verify -disable-availability-checking -strict-concurrency=complete -verify-additional-prefix region-isolation- -emit-sil -o /dev/null %s -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend -verify -disable-availability-checking -strict-concurrency=complete -verify-additional-prefix complete- -emit-sil -o /dev/null %s -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -verify -disable-availability-checking -strict-concurrency=complete -verify-additional-prefix region-isolation- -emit-sil -o /dev/null %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete-
-// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify -verify-additional-prefix complete- -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -disable-availability-checking -strict-concurrency=complete %s -emit-sil -o /dev/null -verify
 
 // REQUIRES: concurrency
 // REQUIRES: swift_swift_parser

--- a/test/Concurrency/predates_concurrency_import.swift
+++ b/test/Concurrency/predates_concurrency_import.swift
@@ -4,11 +4,12 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
 
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=targeted -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete
-// RUN: %target-swift-frontend  -I %t %s -emit-sil -o /dev/null -verify -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 @preconcurrency import NonStrictModule
 @_predatesConcurrency import StrictModule // expected-warning{{'@_predatesConcurrency' has been renamed to '@preconcurrency'}}

--- a/test/Concurrency/predates_concurrency_swift6.swift
+++ b/test/Concurrency/predates_concurrency_swift6.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify
-// RUN: %target-swift-frontend -disable-availability-checking -swift-version 6 %s -emit-sil -o /dev/null -verify -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend -verify -strict-concurrency=targeted -verify-additional-prefix targeted-and-complete- -emit-sil -o /dev/null %s
-// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix targeted-and-complete- -verify-additional-prefix complete-and-tns- -verify-additional-prefix complete- -emit-sil -o /dev/null %s
-// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix tns- -verify-additional-prefix complete-and-tns- -emit-sil -o /dev/null %s -enable-upcoming-feature RegionBasedIsolation 
+// RUN: %target-swift-frontend -verify -strict-concurrency=targeted -verify-additional-prefix targeted-and-complete- -emit-sil -o /dev/null %s -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix targeted-and-complete- -verify-additional-prefix complete-and-tns- -verify-additional-prefix complete- -emit-sil -o /dev/null %s -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -verify -strict-concurrency=complete -verify-additional-prefix tns- -verify-additional-prefix complete-and-tns- -emit-sil -o /dev/null %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/sendable_without_preconcurrency_2.swift
+++ b/test/Concurrency/sendable_without_preconcurrency_2.swift
@@ -3,8 +3,8 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/NonStrictModule.swiftmodule -module-name NonStrictModule %S/Inputs/NonStrictModule.swift
 // RUN: %target-swift-frontend -strict-concurrency=minimal -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
 // RUN: %target-swift-frontend -strict-concurrency=targeted -verify-additional-prefix targeted-complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted-complete- -verify-additional-prefix complete- -disable-availability-checking -I %t %s -verify -emit-sil -o /dev/null -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 

--- a/test/Concurrency/strict_concurrency_minimal.swift
+++ b/test/Concurrency/strict_concurrency_minimal.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -strict-concurrency=minimal -o /dev/null -emit-sil %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=targeted -verify-additional-prefix targeted- -o /dev/null -emit-sil %s -verify
+// RUN: %target-swift-frontend -strict-concurrency=minimal -o /dev/null -emit-sil %s -verify -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -strict-concurrency=targeted -verify-additional-prefix targeted- -o /dev/null -emit-sil %s -verify -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted- -o /dev/null -emit-sil %s -verify -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted- -o /dev/null -emit-sil %s -verify
-// RUN: %target-swift-frontend -strict-concurrency=complete -verify-additional-prefix targeted- -enable-upcoming-feature RegionBasedIsolation -o /dev/null -emit-sil %s -verify
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1,11 +1,11 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
 
 // This run validates that for specific test cases around closures, we properly
 // emit errors in the type checker before we run sns. This ensures that we know that
 // these cases can't happen when SNS is enabled.
 //
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking -verify -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix typechecker-only- -DTYPECHECKER_ONLY %s -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -enable-experimental-feature TransferringArgsAndResults -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null -parse-as-library
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -parse-as-library
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix complete- %s -o /dev/null -parse-as-library -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify -verify-additional-prefix tns-  %s -o /dev/null -parse-as-library
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_global_actor_serialization.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_serialization.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/GlobalActorIsolatedFunction.swiftmodule -module-name GlobalActorIsolatedFunction -strict-concurrency=complete %S/Inputs/GlobalActorIsolatedFunction.swift
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null -parse-as-library -I %t
+
+// README: This is testing that we properly serialize ActorIsolation on
+// SILFunctions. We do not print it yet on SILFunctions, but we can observe it
+// behaviorally.
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+import GlobalActorIsolatedFunction
+
+func useValueAsync<T>(_ t: T) async {}
+
+@MainActor func synchronousActorIsolatedFunctionError() async {
+  let erased: () -> Void = mainActorFunction
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}

--- a/test/Concurrency/transfernonsendable_global_actor_swift6.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_swift6.swift
@@ -1,0 +1,87 @@
+// RUN: %target-swift-frontend -emit-sil -swift-version 6 -disable-availability-checking -verify %s -o /dev/null -parse-as-library
+
+// README: This is testing specific patterns around global actors that are
+// slightly different in between swift 5 and swift 6. The normal global actor
+// test is in swift 5, so any tests that work with swift 5 need to be there.
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+final class SendableKlass : Sendable {}
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+func transferToNonIsolated<T>(_ t: T) async {}
+@MainActor func transferToMainActor<T>(_ t: T) async {}
+@CustomActor func transferToCustomActor<T>(_ t: T) async {}
+func useValue<T>(_ t: T) {}
+func useValueAsync<T>(_ t: T) async {}
+@MainActor func useValueMainActor<T>(_ t: T) {}
+@MainActor func mainActorFunction() {}
+
+var booleanFlag: Bool { false }
+@MainActor var mainActorIsolatedGlobal = NonSendableKlass()
+@CustomActor var customActorIsolatedGlobal = NonSendableKlass()
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+@MainActor func synchronousActorIsolatedClosureError() async {
+  let closure = { @MainActor @Sendable in
+    MainActor.assertIsolated()
+  }
+
+  let erased: () -> Void = closure
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor func synchronousActorIsolatedFunctionError() async {
+  let erased: () -> Void = mainActorFunction
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
+  let erased: (T) -> Void = useValueMainActor
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor func synchronousActorIsolatedClassMethodError() async {
+  @MainActor class Test {
+    func foo() {}
+  }
+
+  let t = Test()
+  let erased: () -> Void = t.foo
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}
+
+@MainActor func synchronousActorIsolatedFinalClassMethodError() async {
+  @MainActor final class Test {
+    func foo() {}
+  }
+
+  let t = Test()
+  let erased: () -> Void = t.foo
+
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
+}

--- a/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching_differentiability.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -transfer-non-sendable -enable-upcoming-feature RegionBasedIsolation -strict-concurrency=complete %s -verify -o /dev/null
+// RUN: %target-sil-opt -transfer-non-sendable -strict-concurrency=complete %s -verify -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_nonisolated.swift
+++ b/test/Concurrency/transfernonsendable_nonisolated.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation -disable-availability-checking -verify %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -verify %s -o /dev/null
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -16,30 +16,30 @@
  */
 
 class NonSendable { // expected-complete-note 73{{}}
-    var x : Any
-    var y : Any
+  var x : Any
+  var y : Any
 
-    init() {
-        x = 0;
-        y = 0;
-    }
+  init() {
+    x = 0;
+    y = 0;
+  }
 
-    init(_ z : Any) {
-        x = z;
-        y = z;
-    }
+  init(_ z : Any) {
+    x = z;
+    y = z;
+  }
 }
 
 actor A {
-    func run_closure(_ closure : () -> ()) async {
-        closure();
-    }
+  func run_closure(_ closure : () -> ()) async {
+    closure();
+  }
 
-    func foo(_ ns : Any) {}
+  func foo(_ ns : Any) {}
 
-    func foo_multi(_ : Any, _ : Any, _ : Any) {}
+  func foo_multi(_ : Any, _ : Any, _ : Any) {}
 
-    func foo_vararg(_ : Any ...) {}
+  func foo_vararg(_ : Any ...) {}
 }
 
 func foo_noniso(_ ns : Any) {}
@@ -51,850 +51,888 @@ func foo_noniso_vararg(_ : Any ...) {}
 var bool : Bool { false }
 
 func test_isolation_crossing_sensitivity(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
 
-    //this call does not consume ns0
-    foo_noniso(ns0);
+  // This call does not consume ns0
+  foo_noniso(ns0);
 
-    //this call consumes ns1
-    await a.foo(ns1); // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // This call consumes ns1
+  await a.foo(ns1); // expected-tns-warning {{transferring 'ns1' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    print(ns0);
-    print(ns1); // expected-tns-note {{use here could race}}
+  print(ns0);
+  print(ns1); // expected-tns-note {{use here could race}}
 }
 
 func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
-    let ns_let = NonSendable();
+  let ns_let = NonSendable();
 
-    // Safe to consume an rvalue.
-    await a.foo(NonSendable()); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // Safe to consume an rvalue.
+  await a.foo(NonSendable()); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    // Safe to consume an lvalue.
-    await a.foo(ns_let); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // Safe to consume an lvalue.
+  await a.foo(ns_let); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    // Not safe to consume an arg.
-    await a.foo(ns_arg); // expected-tns-warning {{task-isolated value of type 'NonSendable' transferred to actor-isolated context; later accesses to value could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // Not safe to consume an arg.
+  await a.foo(ns_arg); // expected-tns-warning {{transferring 'ns_arg' may cause a race}}
+  // expected-tns-note @-1 {{transferring task-isolated 'ns_arg' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    // Check for no duplicate warnings once self is "consumed"
-    await a.foo(NonSendable()); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // Check for no duplicate warnings once self is "consumed"
+  await a.foo(NonSendable()); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func test_closure_capture(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
-    let ns3 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
+  let ns3 = NonSendable();
 
-    let captures0 = { print(ns0) };
-    let captures12 = { print(ns1); print(ns2)};
+  let captures0 = { print(ns0) };
+  let captures12 = { print(ns1); print(ns2)};
 
-    let captures3 = { print(ns3) };
-    let captures3indirect = { captures3() };
+  let captures3 = { print(ns3) };
+  let captures3indirect = { captures3() };
 
-    // all lets should still be accessible - no consumed have happened yet
-    print(ns0)
-    print(ns1)
-    print(ns2)
-    print(ns3)
+  // all lets should still be accessible - no consumed have happened yet
+  print(ns0)
+  print(ns1)
+  print(ns2)
+  print(ns3)
 
-    // this should consume ns0
-    await a.run_closure(captures0) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
-    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  // this should consume ns0
+  await a.run_closure(captures0) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-    print(ns0) // expected-tns-note {{use here could race}}
-    print(ns1)
-    print(ns2)
-    print(ns3)
+  print(ns0) // expected-tns-note {{use here could race}}
+  print(ns1)
+  print(ns2)
+  print(ns3)
 
-    // this should consume ns1 and ns2
-    await a.run_closure(captures12) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
-    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  // this should consume ns1 and ns2
+  await a.run_closure(captures12) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-    // This only touches ns1/ns2 so we get an error on ns1 since it is first.
-    print(ns0)
-    print(ns1) // expected-tns-note {{use here could race}}
-    print(ns2)
-    print(ns3)
+  // This only touches ns1/ns2 so we get an error on ns1 since it is first.
+  print(ns0)
+  print(ns1) // expected-tns-note {{use here could race}}
+  print(ns2)
+  print(ns3)
 
-    // this should consume ns3
-    await a.run_closure(captures3indirect) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
-    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  // this should consume ns3
+  await a.run_closure(captures3indirect) // expected-tns-warning {{transferring value of non-Sendable type '() -> ()' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+  // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
 
-    // This only uses ns3 so we should only emit an error on ns3.
-    print(ns0)
-    print(ns1)
-    print(ns2)
-    print(ns3) // expected-tns-note {{use here could race}}
+  // This only uses ns3 so we should only emit an error on ns3.
+  print(ns0)
+  print(ns1)
+  print(ns2)
+  print(ns3) // expected-tns-note {{use here could race}}
 }
 
 func test_regions(a : A, b : Bool) async {
-    // definitely aliases - should be in the same region
-    let ns0_0 = NonSendable();
-    let ns0_1 = ns0_0;
+  // definitely aliases - should be in the same region
+  let ns0_0 = NonSendable();
+  let ns0_1 = ns0_0;
 
-    // possibly aliases - should be in the same region
-    let ns1_0 = NonSendable();
-    var ns1_1 = NonSendable();
+  // possibly aliases - should be in the same region
+  let ns1_0 = NonSendable();
+  var ns1_1 = NonSendable();
+  if (b) {
+    ns1_1 = ns1_0;
+  }
+
+  // accessible via pointer - should be in the same region
+  let ns2_0 = NonSendable();
+  let ns2_1 = NonSendable();
+  ns2_0.x = ns2_1;
+
+  // check for each of the above pairs that consuming half of it consumes the other half
+
+  if (b) {
+    await a.foo(ns0_0) // expected-tns-warning {{transferring 'ns0_0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
     if (b) {
-        ns1_1 = ns1_0;
-    }
-
-    // accessible via pointer - should be in the same region
-    let ns2_0 = NonSendable();
-    let ns2_1 = NonSendable();
-    ns2_0.x = ns2_1;
-
-    // check for each of the above pairs that consuming half of it consumes the other half
-
-    if (b) {
-        await a.foo(ns0_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if (b) {
-          print(ns0_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns0_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns0_0) // expected-tns-note {{use here could race}}
     } else {
-        await a.foo(ns0_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns0_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns0_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns0_1) // expected-tns-note {{use here could race}}
     }
+  } else {
+    await a.foo(ns0_1) // expected-tns-warning {{transferring 'ns0_1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    if (b) {
-        await a.foo(ns1_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns1_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns1_1) // expected-tns-note {{use here could race}}
-        }
+    if b {
+      print(ns0_0) // expected-tns-note {{use here could race}}
     } else {
-        await a.foo(ns1_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-      // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns1_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns1_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns0_1) // expected-tns-note {{use here could race}}
     }
+  }
 
-    if (b) {
-        await a.foo(ns2_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  if (b) {
+    await a.foo(ns1_0) // expected-tns-warning {{transferring 'ns1_0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        if b {
-          print(ns2_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns2_1) // expected-tns-note {{use here could race}}
-        }
+    if b {
+      print(ns1_0) // expected-tns-note {{use here could race}}
     } else {
-        await a.foo(ns2_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns2_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns2_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns1_1) // expected-tns-note {{use here could race}}
     }
+  } else {
+    await a.foo(ns1_1) // expected-tns-warning {{transferring 'ns1_1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    if b {
+      print(ns1_0) // expected-tns-note {{use here could race}}
+    } else {
+      print(ns1_1) // expected-tns-note {{use here could race}}
+    }
+  }
+
+  if (b) {
+    await a.foo(ns2_0) // expected-tns-warning {{transferring 'ns2_0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    if b {
+      print(ns2_0) // expected-tns-note {{use here could race}}
+    } else {
+      print(ns2_1) // expected-tns-note {{use here could race}}
+    }
+  } else {
+    await a.foo(ns2_1) // expected-tns-warning {{transferring 'ns2_1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    if b {
+      print(ns2_0) // expected-tns-note {{use here could race}}
+    } else {
+      print(ns2_1) // expected-tns-note {{use here could race}}
+    }
+  }
 }
 
 func test_indirect_regions(a : A, b : Bool) async {
-    // in each of the following, nsX_0 and nsX_1 should be in the same region for various reasons
+  // in each of the following, nsX_0 and nsX_1 should be in the same region for various reasons
 
-    // 1 constructed using 0
-    let ns0_0 = NonSendable();
-    let ns0_1 = NonSendable(NonSendable(ns0_0));
+  // 1 constructed using 0
+  let ns0_0 = NonSendable();
+  let ns0_1 = NonSendable(NonSendable(ns0_0));
 
-    // 1 constructed using 0, indirectly
-    let ns1_0 = NonSendable();
-    let ns1_aux = NonSendable(ns1_0);
-    let ns1_1 = NonSendable(ns1_aux);
+  // 1 constructed using 0, indirectly
+  let ns1_0 = NonSendable();
+  let ns1_aux = NonSendable(ns1_0);
+  let ns1_1 = NonSendable(ns1_aux);
 
-    // 1 and 0 constructed with same aux value
-    let ns2_aux = NonSendable();
-    let ns2_0 = NonSendable(ns2_aux);
-    let ns2_1 = NonSendable(ns2_aux);
+  // 1 and 0 constructed with same aux value
+  let ns2_aux = NonSendable();
+  let ns2_0 = NonSendable(ns2_aux);
+  let ns2_1 = NonSendable(ns2_aux);
 
-    // 0 points to aux, which points to 1
-    let ns3_aux = NonSendable();
-    let ns3_0 = NonSendable();
-    let ns3_1 = NonSendable();
-    ns3_0.x = ns3_aux;
-    ns3_aux.x = ns3_1;
+  // 0 points to aux, which points to 1
+  let ns3_aux = NonSendable();
+  let ns3_0 = NonSendable();
+  let ns3_1 = NonSendable();
+  ns3_0.x = ns3_aux;
+  ns3_aux.x = ns3_1;
 
-    // 1 and 0 point to same aux value
-    let ns4_aux = NonSendable();
-    let ns4_0 = NonSendable();
-    let ns4_1 = NonSendable();
-    ns4_0.x = ns4_aux;
-    ns4_1.x = ns4_aux;
+  // 1 and 0 point to same aux value
+  let ns4_aux = NonSendable();
+  let ns4_0 = NonSendable();
+  let ns4_1 = NonSendable();
+  ns4_0.x = ns4_aux;
+  ns4_1.x = ns4_aux;
 
-    // same aux value points to both 0 and 1
-    let ns5_aux = NonSendable();
-    let ns5_0 = ns5_aux.x;
-    let ns5_1 = ns5_aux.y;
+  // same aux value points to both 0 and 1
+  let ns5_aux = NonSendable();
+  let ns5_0 = ns5_aux.x;
+  let ns5_1 = ns5_aux.y;
 
-    // now check for each pair that consuming half of it consumed the other half
+  // now check for each pair that consuming half of it consumed the other half
 
-    if (b) {
-        await a.foo(ns0_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  if (b) {
+    await a.foo(ns0_0) // expected-tns-warning {{transferring 'ns0_0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        if b {
-          print(ns0_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns0_1) // expected-tns-note {{use here could race}}
-        }
+    if b {
+      print(ns0_0) // expected-tns-note {{use here could race}}
     } else {
-        await a.foo(ns0_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns0_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns0_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns0_1) // expected-tns-note {{use here could race}}
     }
+  } else {
+    await a.foo(ns0_1) // expected-tns-warning {{transferring 'ns0_1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    if (b) {
-        await a.foo(ns1_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns1_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns1_1) // expected-tns-note {{use here could race}}
-        }
+    if b {
+      print(ns0_0) // expected-tns-note {{use here could race}}
     } else {
-        await a.foo(ns1_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns1_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns1_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns0_1) // expected-tns-note {{use here could race}}
     }
+  }
 
-    if (b) {
-        await a.foo(ns2_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  if (b) {
+    await a.foo(ns1_0) // expected-tns-warning {{transferring 'ns1_0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        if b {
-          print(ns2_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns2_1) // expected-tns-note {{use here could race}}
-        }
+    if b {
+      print(ns1_0) // expected-tns-note {{use here could race}}
     } else {
-        await a.foo(ns2_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns2_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns2_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns1_1) // expected-tns-note {{use here could race}}
     }
+  } else {
+    await a.foo(ns1_1) // expected-tns-warning {{transferring 'ns1_1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    if (b) {
-        await a.foo(ns3_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns3_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns3_1) // expected-tns-note {{use here could race}}
-        }
+    if b {
+      print(ns1_0) // expected-tns-note {{use here could race}}
     } else {
-        await a.foo(ns3_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns3_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns3_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns1_1) // expected-tns-note {{use here could race}}
     }
+  }
 
-    if (b) {
-        await a.foo(ns4_0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  if (b) {
+    await a.foo(ns2_0) // expected-tns-warning {{transferring 'ns2_0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        if b {
-          print(ns4_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns4_1) // expected-tns-note {{use here could race}}
-        }
+    if b {
+      print(ns2_0) // expected-tns-note {{use here could race}}
     } else {
-        await a.foo(ns4_1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns4_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns4_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns2_1) // expected-tns-note {{use here could race}}
     }
+  } else {
+    await a.foo(ns2_1) // expected-tns-warning {{transferring 'ns2_1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    if (b) {
-        await a.foo(ns5_0) // expected-tns-warning {{transferring 'ns5_0' may cause a race}}
-        // expected-tns-note @-1 {{transferring disconnected 'ns5_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-        // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns5_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns5_1) // expected-tns-note {{use here could race}}
-        }
+    if b {
+      print(ns2_0) // expected-tns-note {{use here could race}}
     } else {
-        await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' may cause a race}}
-        // expected-tns-note @-1 {{transferring disconnected 'ns5_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-        // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
-
-        if b {
-          print(ns5_0) // expected-tns-note {{use here could race}}
-        } else {
-          print(ns5_1) // expected-tns-note {{use here could race}}
-        }
+      print(ns2_1) // expected-tns-note {{use here could race}}
     }
+  }
+
+  if (b) {
+    await a.foo(ns3_0) // expected-tns-warning {{transferring 'ns3_0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns3_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    if b {
+      print(ns3_0) // expected-tns-note {{use here could race}}
+    } else {
+      print(ns3_1) // expected-tns-note {{use here could race}}
+    }
+  } else {
+    await a.foo(ns3_1) // expected-tns-warning {{transferring 'ns3_1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns3_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    if b {
+      print(ns3_0) // expected-tns-note {{use here could race}}
+    } else {
+      print(ns3_1) // expected-tns-note {{use here could race}}
+    }
+  }
+
+  if (b) {
+    await a.foo(ns4_0) // expected-tns-warning {{transferring 'ns4_0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns4_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    if b {
+      print(ns4_0) // expected-tns-note {{use here could race}}
+    } else {
+      print(ns4_1) // expected-tns-note {{use here could race}}
+    }
+  } else {
+    await a.foo(ns4_1) // expected-tns-warning {{transferring 'ns4_1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns4_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    if b {
+      print(ns4_0) // expected-tns-note {{use here could race}}
+    } else {
+      print(ns4_1) // expected-tns-note {{use here could race}}
+    }
+  }
+
+  if (b) {
+    await a.foo(ns5_0) // expected-tns-warning {{transferring 'ns5_0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns5_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
+
+    if b {
+      print(ns5_0) // expected-tns-note {{use here could race}}
+    } else {
+      print(ns5_1) // expected-tns-note {{use here could race}}
+    }
+  } else {
+    await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns5_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
+
+    if b {
+      print(ns5_0) // expected-tns-note {{use here could race}}
+    } else {
+      print(ns5_1) // expected-tns-note {{use here could race}}
+    }
+  }
 }
 
 // class methods in general cannot consume self, check that this is true except for Sendable classes (and actors)
 
 class C_NonSendable {
-    func bar() {}
+  func bar() {}
 
-    func bar(a : A) async {
-        let captures_self = { self.bar() }
+  func bar(a : A) async {
+    let captures_self = { self.bar() }
 
-        // this is not a cross-isolation call, so it should be permitted
-        foo_noniso(captures_self)
+    // this is not a cross-isolation call, so it should be permitted
+    foo_noniso(captures_self)
 
-        // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
-        await a.foo(captures_self) // expected-tns-warning {{task-isolated value of type '() -> ()' transferred to actor-isolated context; later accesses to value could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
-        // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    }
+    // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
+    await a.foo(captures_self) // expected-tns-warning {{transferring 'captures_self' may cause a race}}
+    // expected-tns-note @-1 {{transferring task-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+    // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
 }
 
 final class C_Sendable : Sendable {
-    func bar() {}
+  func bar() {}
 
-    func bar(a : A) async {
-        let captures_self = { self.bar() }
+  func bar(a : A) async {
+    let captures_self = { self.bar() }
 
-        // this is not a cross-isolation call, so it should be permitted
-        foo_noniso(captures_self)
+    // this is not a cross-isolation call, so it should be permitted
+    foo_noniso(captures_self)
 
-        // this is a cross-isolation, but self is Sendable, so it should be permitted
-        await a.foo(captures_self)
-        // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
-        // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    }
+    // this is a cross-isolation, but self is Sendable, so it should be permitted
+    await a.foo(captures_self)
+    // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+    // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
 }
 
 actor A_Sendable {
-    func bar() {}
+  func bar() {}
 
-    func bar(a : A) async {
-        let captures_self = { self.bar() }
+  func bar(a : A) async {
+    let captures_self = { self.bar() }
 
-        // This is not a cross-isolation call, so it should be permitted
-        foo_noniso(captures_self)
+    // This is not a cross-isolation call, so it should be permitted
+    foo_noniso(captures_self)
 
-        // This is a cross-isolation call passing a call that should be treated
-        // as isolated to self since it captures self which is isolated to our
-        // actor and is non-Sendable. For now, we ban this since we do not
-        // support the ability to dynamically invoke the synchronous closure on
-        // the specific actor.
-        await a.foo(captures_self) // expected-tns-warning {{actor-isolated value of type '() -> ()' transferred to actor-isolated context}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
-        // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    }
+    // This is a cross-isolation call passing a call that should be treated
+    // as isolated to self since it captures self which is isolated to our
+    // actor and is non-Sendable. For now, we ban this since we do not
+    // support the ability to dynamically invoke the synchronous closure on
+    // the specific actor.
+    await a.foo(captures_self) // expected-tns-warning {{transferring 'captures_self' may cause a race}}
+    // expected-tns-note @-1 {{transferring actor-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and actor-isolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
+    // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
+  }
 }
 
 func basic_loopiness(a : A, b : Bool) async {
-    let ns = NonSendable()
+  let ns = NonSendable()
 
-    while (b) {
-        await a.foo(ns)
-        // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-tns-note @-2 {{use here could race}}
-        // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    }
+  while (b) {
+    await a.foo(ns) // expected-tns-warning {{transferring 'ns' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-tns-note @-2 {{use here could race}}
+    // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  }
 }
 
 func basic_loopiness_unsafe(a : A, b : Bool) async {
-    var ns0 = NonSendable()
-    var ns1 = NonSendable()
-    var ns2 = NonSendable()
-    var ns3 = NonSendable()
+  var ns0 = NonSendable()
+  var ns1 = NonSendable()
+  var ns2 = NonSendable()
+  var ns3 = NonSendable()
 
-    //should merge all vars
-    while (b) {
-        (ns0, ns1, ns2, ns3) = (ns1, ns2, ns3, ns0)
-    }
+  //should merge all vars
+  while (b) {
+    (ns0, ns1, ns2, ns3) = (ns1, ns2, ns3, ns0)
+  }
 
-    await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns3) // expected-tns-note {{use here could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns3) // expected-tns-note {{use here could race}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func basic_loopiness_safe(a : A, b : Bool) async {
-    var ns0 = NonSendable()
-    var ns1 = NonSendable()
-    var ns2 = NonSendable()
-    var ns3 = NonSendable()
+  var ns0 = NonSendable()
+  var ns1 = NonSendable()
+  var ns2 = NonSendable()
+  var ns3 = NonSendable()
 
-    //should keep ns0 and ns3 separate
-    while (b) {
-        (ns0, ns1, ns2, ns3) = (ns1, ns0, ns3, ns2)
-    }
+  //should keep ns0 and ns3 separate
+  while (b) {
+    (ns0, ns1, ns2, ns3) = (ns1, ns0, ns3, ns2)
+  }
 
-    await a.foo(ns0)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns3)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns0)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns3)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 struct StructBox {
-    var contents : NonSendable
+  var contents : NonSendable
 
-    init() {
-        contents = NonSendable()
-    }
+  init() {
+    contents = NonSendable()
+  }
 }
 
 func test_struct_assign_doesnt_merge(a : A, b : Bool) async {
-    let ns0 = NonSendable()
-    let ns1 = NonSendable()
+  let ns0 = NonSendable()
+  let ns1 = NonSendable()
 
-    //this should merge ns0 and ns1
-    var box = StructBox()
-    box.contents = ns0
-    box.contents = ns1
+  //this should merge ns0 and ns1
+  var box = StructBox()
+  box.contents = ns0
+  box.contents = ns1
 
-    await a.foo(ns0)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns1)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns0)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns1)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 class ClassBox {
-    var contents : NonSendable
+  var contents : NonSendable
 
-    init() {
-        contents = NonSendable()
-    }
+  init() {
+    contents = NonSendable()
+  }
 }
 
 func test_class_assign_merges(a : A, b : Bool) async {
-    let ns0 = NonSendable()
-    let ns1 = NonSendable()
+  let ns0 = NonSendable()
+  let ns1 = NonSendable()
 
-    // This should merge ns0 and ns1.
-    var box = ClassBox()
-    box = ClassBox()
-    box.contents = ns0
-    box.contents = ns1
+  // This should merge ns0 and ns1.
+  var box = ClassBox()
+  box = ClassBox()
+  box.contents = ns0
+  box.contents = ns1
 
-    await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns1) // expected-tns-note {{use here could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns1) // expected-tns-note {{use here could race}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func test_stack_assign_doesnt_merge(a : A, b : Bool) async {
-    let ns0 = NonSendable()
-    let ns1 = NonSendable()
+  let ns0 = NonSendable()
+  let ns1 = NonSendable()
 
-    //this should NOT merge ns0 and ns1
-    var contents : NonSendable
-    contents = ns0
-    contents = ns1
+  //this should NOT merge ns0 and ns1
+  var contents : NonSendable
+  contents = ns0
+  contents = ns1
 
-    foo_noniso(contents) //must use var to avoid warning
+  foo_noniso(contents) //must use var to avoid warning
 
-    await a.foo(ns0)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns1)
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns0)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns1)
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
-    let ns0 = NonSendable()
-    let ns1 = NonSendable()
+  let ns0 = NonSendable()
+  let ns1 = NonSendable()
 
-    //this should NOT merge ns0 and ns1
-    var contents = NonSendable()
+  //this should NOT merge ns0 and ns1
+  var contents = NonSendable()
 
-    let closure = { print(contents) }
-    foo_noniso(closure) //must use let to avoid warning
+  let closure = { print(contents) }
+  foo_noniso(closure) //must use let to avoid warning
 
-    contents = ns0
-    contents = ns1
+  contents = ns0
+  contents = ns1
 
-    await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo(ns1) // expected-tns-note {{use here could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo(ns1) // expected-tns-note {{use here could race}}
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func test_tuple_formation(a : A, i : Int) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
-    let ns3 = NonSendable();
-    let ns4 = NonSendable();
-    let ns012 = (ns0, ns1, ns2);
-    let ns13 = (ns1, ns3);
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
+  let ns3 = NonSendable();
+  let ns4 = NonSendable();
+  let ns012 = (ns0, ns1, ns2);
+  let ns13 = (ns1, ns3);
 
-    switch (i) {
-    case 0:
-        await a.foo(ns0) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  switch (i) {
+  case 0:
+    await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-        if bool {
-          foo_noniso(ns0); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns4);
-        } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{use here could race}}
-        } else {
-          foo_noniso(ns13); // expected-tns-note {{use here could race}}
-        }
-    case 1:
-        await a.foo(ns1) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if bool {
-          foo_noniso(ns0); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns4);
-        } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{use here could race}}
-        } else {
-          foo_noniso(ns13); // expected-tns-note {{use here could race}}
-        }
-    case 2:
-        await a.foo(ns2) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        if bool {
-          foo_noniso(ns0); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns4);
-        } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{use here could race}}
-        } else {
-          foo_noniso(ns13); // expected-tns-note {{use here could race}}
-        }
-    case 3:
-        await a.foo(ns4) // expected-tns-warning {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-
-        foo_noniso(ns0);
-        foo_noniso(ns1);
-        foo_noniso(ns2);
-        foo_noniso(ns4); // expected-tns-note {{use here could race}}
-        foo_noniso(ns012);
-        foo_noniso(ns13);
-    case 4:
-        await a.foo(ns012) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendable, NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
-        // TODO: Interestingly with complete, we emit this error 3 times?!
-        // expected-complete-warning @-2 3{{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
-
-        if bool {
-          foo_noniso(ns0); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns4);
-        } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{use here could race}}
-        } else {
-          foo_noniso(ns13); // expected-tns-note {{use here could race}}
-        }
-    default:
-        await a.foo(ns13) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
-        // expected-complete-warning @-1 2{{passing argument of non-sendable type '(NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
-
-        if bool {
-          foo_noniso(ns0); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns1); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns2); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns3); // expected-tns-note {{use here could race}}
-        } else if bool {
-          foo_noniso(ns4);
-        } else if bool {
-          foo_noniso(ns012); // expected-tns-note {{use here could race}}
-        } else  {
-          foo_noniso(ns13); // expected-tns-note {{use here could race}}
-        }
+    if bool {
+      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns4);
+    } else if bool {
+      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+    } else {
+      foo_noniso(ns13); // expected-tns-note {{use here could race}}
     }
+  case 1:
+    await a.foo(ns1) // expected-tns-warning {{transferring 'ns1' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    if bool {
+      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns4);
+    } else if bool {
+      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+    } else {
+      foo_noniso(ns13); // expected-tns-note {{use here could race}}
+    }
+  case 2:
+    await a.foo(ns2) // expected-tns-warning {{transferring 'ns2' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    if bool {
+      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns4);
+    } else if bool {
+      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+    } else {
+      foo_noniso(ns13); // expected-tns-note {{use here could race}}
+    }
+  case 3:
+    await a.foo(ns4) // expected-tns-warning {{transferring 'ns4' may cause a race}}
+    // expected-tns-note @-1 {{transferring disconnected 'ns4' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+    // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+
+    foo_noniso(ns0);
+    foo_noniso(ns1);
+    foo_noniso(ns2);
+    foo_noniso(ns4); // expected-tns-note {{use here could race}}
+    foo_noniso(ns012);
+    foo_noniso(ns13);
+  case 4:
+    await a.foo(ns012) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendable, NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
+    // TODO: Interestingly with complete, we emit this error 3 times?!
+    // expected-complete-warning @-2 3{{passing argument of non-sendable type '(NonSendable, NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
+
+    if bool {
+      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns4);
+    } else if bool {
+      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+    } else {
+      foo_noniso(ns13); // expected-tns-note {{use here could race}}
+    }
+  default:
+    await a.foo(ns13) // expected-tns-warning {{transferring value of non-Sendable type '(NonSendable, NonSendable)' from nonisolated context to actor-isolated context; later accesses could race}}
+    // expected-complete-warning @-1 2{{passing argument of non-sendable type '(NonSendable, NonSendable)' into actor-isolated context may introduce data races}}
+
+    if bool {
+      foo_noniso(ns0); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns1); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns2); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns3); // expected-tns-note {{use here could race}}
+    } else if bool {
+      foo_noniso(ns4);
+    } else if bool {
+      foo_noniso(ns012); // expected-tns-note {{use here could race}}
+    } else  {
+      foo_noniso(ns13); // expected-tns-note {{use here could race}}
+    }
+  }
 }
 
 func reuse_args_safe(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
 
-    // this should be perfectly legal - arguments are assumed to come from the same region
-    await a.foo_multi(ns0, ns0, ns0);
-    // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo_multi(ns1, ns2, ns1);
-    // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // this should be perfectly legal - arguments are assumed to come from the same region
+  await a.foo_multi(ns0, ns0, ns0);
+  // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo_multi(ns1, ns2, ns1);
+  // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 }
 
 func one_consume_many_require(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
-    let ns3 = NonSendable();
-    let ns4 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
+  let ns3 = NonSendable();
+  let ns4 = NonSendable();
 
-    await a.foo_multi(ns0, ns1, ns2);
-    // expected-tns-warning @-1 3{{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo_multi(ns0, ns1, ns2);
+  // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-2 {{transferring 'ns0' may cause a race}}
+  // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-4 {{transferring 'ns1' may cause a race}}
+  // expected-tns-note @-5 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-6 {{transferring 'ns2' may cause a race}}
+  // expected-tns-note @-7 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
-    foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
-    foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
-    foo_noniso_multi(ns4, ns3, ns2); // expected-tns-note {{use here could race}}
+  foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
+  foo_noniso_multi(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
+  foo_noniso_multi(ns4, ns3, ns2); // expected-tns-note {{use here could race}}
 }
 
 func one_consume_one_require(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
 
-    await a.foo_multi(ns0, ns1, ns2);
-    // expected-tns-warning @-1 3{{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo_multi(ns0, ns1, ns2);
+  // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  // expected-tns-warning @-2 {{transferring 'ns0' may cause a race}}
+  // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-4 {{transferring 'ns1' may cause a race}}
+  // expected-tns-note @-5 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-tns-warning @-6 {{transferring 'ns2' may cause a race}}
+  // expected-tns-note @-7 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
-    foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
+  foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
 }
 
 func many_consume_one_require(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
-    let ns3 = NonSendable();
-    let ns4 = NonSendable();
-    let ns5 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
+  let ns3 = NonSendable();
+  let ns4 = NonSendable();
+  let ns5 = NonSendable();
 
-    await a.foo_multi(ns0, ns3, ns3)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo_multi(ns4, ns1, ns4)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo_multi(ns5, ns5, ns2)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{use here could race}}
+  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{transferring 'ns1' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{transferring 'ns2' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{use here could race}}
 }
 
 func many_consume_many_require(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
-    let ns3 = NonSendable();
-    let ns4 = NonSendable();
-    let ns5 = NonSendable();
-    let ns6 = NonSendable();
-    let ns7 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
+  let ns3 = NonSendable();
+  let ns4 = NonSendable();
+  let ns5 = NonSendable();
+  let ns6 = NonSendable();
+  let ns7 = NonSendable();
 
-    await a.foo_multi(ns0, ns3, ns3)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo_multi(ns4, ns1, ns4)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-    await a.foo_multi(ns5, ns5, ns2)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'NonSendable' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{transferring 'ns1' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
+  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{transferring 'ns2' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
-    foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
-    foo_noniso_multi(ns6, ns1, ns7); // expected-tns-note {{use here could race}}
-    foo_noniso_multi(ns7, ns6, ns2); // expected-tns-note {{use here could race}}
+  foo_noniso_multi(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
+  foo_noniso_multi(ns6, ns1, ns7); // expected-tns-note {{use here could race}}
+  foo_noniso_multi(ns7, ns6, ns2); // expected-tns-note {{use here could race}}
 }
 
 
 func reuse_args_safe_vararg(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
 
-    // this should be perfectly legal - arguments are assumed to come from the same region
-    await a.foo_vararg(ns0, ns0, ns0);
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
-    await a.foo_vararg(ns1, ns2, ns1);
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  // this should be perfectly legal - arguments are assumed to come from the same region
+  await a.foo_vararg(ns0, ns0, ns0);
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  await a.foo_vararg(ns1, ns2, ns1);
+  // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 }
 
 func one_consume_many_require_varag(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
-    let ns3 = NonSendable();
-    let ns4 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
+  let ns3 = NonSendable();
+  let ns4 = NonSendable();
 
-    //TODO: find a way to make the type used in the diagnostic more specific than the signature type
-    await a.foo_vararg(ns0, ns1, ns2);
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  //TODO: find a way to make the type used in the diagnostic more specific than the signature type
+  await a.foo_vararg(ns0, ns1, ns2);
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    if bool {
-      foo_noniso_vararg(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
-    } else if bool {
-      foo_noniso_vararg(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
-    } else {
-      foo_noniso_vararg(ns4, ns3, ns2); // expected-tns-note {{use here could race}}
-    }
+  if bool {
+    foo_noniso_vararg(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
+  } else if bool {
+    foo_noniso_vararg(ns3, ns1, ns4); // expected-tns-note {{use here could race}}
+  } else {
+    foo_noniso_vararg(ns4, ns3, ns2); // expected-tns-note {{use here could race}}
+  }
 }
 
 func one_consume_one_require_vararg(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
 
-    await a.foo_vararg(ns0, ns1, ns2);
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  await a.foo_vararg(ns0, ns1, ns2);
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 1{{use here could race}}
+  foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 1{{use here could race}}
 }
 
 func many_consume_one_require_vararg(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
-    let ns3 = NonSendable();
-    let ns4 = NonSendable();
-    let ns5 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
+  let ns3 = NonSendable();
+  let ns4 = NonSendable();
+  let ns5 = NonSendable();
 
-    await a.foo_vararg(ns0, ns3, ns3)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
-    await a.foo_vararg(ns4, ns1, ns4)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
-    await a.foo_vararg(ns5, ns5, ns2)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  await a.foo_vararg(ns0, ns3, ns3)
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  await a.foo_vararg(ns4, ns1, ns4)
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  await a.foo_vararg(ns5, ns5, ns2)
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
+  foo_noniso_vararg(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
 }
 
 func many_consume_many_require_vararg(a : A) async {
-    let ns0 = NonSendable();
-    let ns1 = NonSendable();
-    let ns2 = NonSendable();
-    let ns3 = NonSendable();
-    let ns4 = NonSendable();
-    let ns5 = NonSendable();
-    let ns6 = NonSendable();
-    let ns7 = NonSendable();
+  let ns0 = NonSendable();
+  let ns1 = NonSendable();
+  let ns2 = NonSendable();
+  let ns3 = NonSendable();
+  let ns4 = NonSendable();
+  let ns5 = NonSendable();
+  let ns6 = NonSendable();
+  let ns7 = NonSendable();
 
-    await a.foo_vararg(ns0, ns3, ns3)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
-    await a.foo_vararg(ns4, ns1, ns4)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
-    await a.foo_vararg(ns5, ns5, ns2)
-    // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  await a.foo_vararg(ns0, ns3, ns3)
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  await a.foo_vararg(ns4, ns1, ns4)
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
+  await a.foo_vararg(ns5, ns5, ns2)
+  // expected-tns-warning @-1 {{transferring value of non-Sendable type 'Any...' from nonisolated context to actor-isolated context; later accesses could race}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any...' into actor-isolated context may introduce data races}}
 
-    if bool {
-      foo_noniso_vararg(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
-    } else if bool {
-      foo_noniso_vararg(ns6, ns1, ns7);  // expected-tns-note {{use here could race}}
-    } else {
-      foo_noniso_vararg(ns7, ns6, ns2);  // expected-tns-note {{use here could race}}
-    }
+  if bool {
+    foo_noniso_vararg(ns0, ns6, ns7); // expected-tns-note {{use here could race}}
+  } else if bool {
+    foo_noniso_vararg(ns6, ns1, ns7);  // expected-tns-note {{use here could race}}
+  } else {
+    foo_noniso_vararg(ns7, ns6, ns2);  // expected-tns-note {{use here could race}}
+  }
 }
 
 enum E { // expected-complete-note {{consider making enum 'E' conform to the 'Sendable' protocol}}
-    case E1(NonSendable)
-    case E2(NonSendable)
-    case E3(NonSendable)
+  case E1(NonSendable)
+  case E2(NonSendable)
+  case E3(NonSendable)
 }
 
 func enum_test(a : A) async {
-    let e1 = E.E1(NonSendable())
-    let e2 = E.E2(NonSendable())
-    let e3 = E.E3(NonSendable())
-    let e4 = E.E1(NonSendable())
+  let e1 = E.E1(NonSendable())
+  let e2 = E.E2(NonSendable())
+  let e3 = E.E3(NonSendable())
+  let e4 = E.E1(NonSendable())
 
-    switch (e1) {
+  switch (e1) {
 
     //this case merges e1 and e2
-    case let .E1(ns1):
-        switch (e2) {
-        case let .E2(ns2):
-            ns1.x = ns2.x
-        default: ()
-        }
+  case let .E1(ns1):
+    switch (e2) {
+    case let .E2(ns2):
+      ns1.x = ns2.x
+    default: ()
+    }
 
     //this case consumes e3
     case .E2:
-        switch (e3) {
-        case let .E3(ns3):
-            await a.foo(ns3.x); // expected-tns-warning {{transferring value of non-Sendable type 'Any' from nonisolated context to actor-isolated context; later accesses could race}}
-            // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
-        default: ()
-        }
+      switch (e3) {
+      case let .E3(ns3):
+        await a.foo(ns3.x); // expected-tns-warning {{transferring value of non-Sendable type 'Any' from nonisolated context to actor-isolated context; later accesses could race}}
+        // expected-complete-warning @-1 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
+      default: ()
+      }
 
-    //this case does nothing
-    case .E3:
+      //this case does nothing
+      case .E3:
         foo_noniso(e4);
-    }
+  }
 
-    await a.foo(e1); // expected-tns-warning {{transferring value of non-Sendable type 'E' from nonisolated context to actor-isolated context; later accesses could race}}
-    // expected-complete-warning @-1 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
-    foo_noniso(e2); // expected-tns-note {{use here could race}}
-    foo_noniso(e3); // expected-tns-note {{use here could race}}
-    foo_noniso(e4);
+  await a.foo(e1); // expected-tns-warning {{transferring 'e1' may cause a race}}
+  // expected-tns-note @-1 {{transferring disconnected 'e1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
+  foo_noniso(e2); // expected-tns-note {{use here could race}}
+  foo_noniso(e3); // expected-tns-note {{use here could race}}
+  foo_noniso(e4);
 }

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix complete- %s
-// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix tns- -enable-upcoming-feature RegionBasedIsolation %s
+// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix complete- %s -disable-region-based-isolation-with-strict-concurrency
+// RUN: %target-swift-frontend  -strict-concurrency=complete -disable-availability-checking -parse-as-library -emit-sil -o /dev/null -verify -verify-additional-prefix tns- %s
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -1,5 +1,6 @@
-// RUN: %target-swift-frontend -emit-sil -parse-as-library -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -verify -enable-upcoming-feature RegionBasedIsolation %s -o /dev/null
+// RUN: %target-swift-frontend -emit-sil -parse-as-library -disable-availability-checking -strict-concurrency=complete -enable-experimental-feature TransferringArgsAndResults -verify %s -o /dev/null
 
+// REQUIRES: concurrency
 // REQUIRES: asserts
 
 ////////////////////////

--- a/test/Concurrency/unavailable_from_async.swift
+++ b/test/Concurrency/unavailable_from_async.swift
@@ -2,8 +2,8 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/UnavailableFunction.swiftmodule -module-name UnavailableFunction -strict-concurrency=complete %S/Inputs/UnavailableFunction.swift
 // RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null
 // RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=targeted
+// RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=complete
-// RUN: %target-swift-frontend -verify -I %t %s -emit-sil -o /dev/null -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
 // REQUIRES: concurrency
 // REQUIRES: asserts

--- a/test/Concurrency/unsafe_inherit_executor_lib.swift
+++ b/test/Concurrency/unsafe_inherit_executor_lib.swift
@@ -1,6 +1,7 @@
+// RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -disable-availability-checking %s -strict-concurrency=complete -disable-region-based-isolation-with-strict-concurrency
 // RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -disable-availability-checking %s -strict-concurrency=complete
-// RUN: %target-swift-frontend -emit-sil -verify -o /dev/null -disable-availability-checking %s -strict-concurrency=complete -enable-upcoming-feature RegionBasedIsolation
 
+// REQUIRES: concurrency
 // REQUIRES: asserts
 
 actor A {

--- a/test/IDE/complete_cache_notrecommended.swift
+++ b/test/IDE/complete_cache_notrecommended.swift
@@ -41,7 +41,7 @@ func testSyncMember(obj: MyActor) -> Int {
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()
 // MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated({#(message): String#})[#Void#]; name=assertIsolated(:)
-// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> T##(isolated MyActor) throws -> T#})[' rethrows'][#T#]; name=assumeIsolated(:)
+// MEMBER_IN_SYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> Sendable##(isolated MyActor) throws -> Sendable#})[' rethrows'][#Sendable#]; name=assumeIsolated(:)
 }
 
 func testSyncMember(obj: MyActor) async -> Int {
@@ -55,7 +55,7 @@ func testSyncMember(obj: MyActor) async -> Int {
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: preconditionIsolated({#(message): String#})[#Void#]; name=preconditionIsolated(:)
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated()[#Void#]; name=assertIsolated()
 // MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assertIsolated({#(message): String#})[#Void#]; name=assertIsolated(:)
-// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> T##(isolated MyActor) throws -> T#})[' rethrows'][#T#]; name=assumeIsolated(:)
+// MEMBER_IN_ASYNC-DAG: Decl[InstanceMethod]/Super/IsSystem: assumeIsolated({#(operation): (isolated MyActor) throws -> Sendable##(isolated MyActor) throws -> Sendable#})[' rethrows'][#Sendable#]; name=assumeIsolated(:)
 }
 
 // RUN: %empty-directory(%t)

--- a/test/SILGen/diagnose_duplicate_functions.swift
+++ b/test/SILGen/diagnose_duplicate_functions.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-emit-silgen %s -o /dev/null -verify
 
 @_silgen_name("foo")
-func a(_ x: Int) -> Int {
+func a(_ x: Int) -> Int { // expected-note {{other definition here}}
   return x
 }
 
@@ -11,7 +11,7 @@ func b(_ x: Int) -> Int { // expected-error {{multiple definitions of symbol 'fo
 }
 
 @_cdecl("bar")
-func c(_ x: Int) -> Int {
+func c(_ x: Int) -> Int { // expected-note {{other definition here}}
   return x
 }
 

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -734,3 +734,41 @@ bb0:
   %54 = tuple ()
   return %54 : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_temporary: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %2 = alloc_stack $Any
+// CHECK: Name: 'my arg'
+// CHECK: Root: %0 = argument of bb0
+// CHECK: end running test 1 of 1 on init_existential_addr_temporary: variable-name-inference with: @trace[0]
+sil [ossa] @init_existential_addr_temporary : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  specify_test "variable-name-inference @trace[0]"
+  debug_value %0 : $Klass, var, name "my arg"
+  %1 = alloc_stack $Any
+  %2 = init_existential_addr %1 : $*Any, $Klass
+  store %0 to [init] %2 : $*Klass
+  debug_value [trace] %1 : $*Any
+  destroy_addr %1 : $*Any
+  dealloc_stack %1 : $*Any
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on init_existential_addr_temporary_copy_addr: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %2 = alloc_stack $Any
+// CHECK: Name: 'my arg'
+// CHECK: Root: %0 = argument of bb0
+// CHECK: end running test 1 of 1 on init_existential_addr_temporary_copy_addr: variable-name-inference with: @trace[0]
+sil [ossa] @init_existential_addr_temporary_copy_addr : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  specify_test "variable-name-inference @trace[0]"
+  debug_value %0 : $*Klass, var, name "my arg"
+  %1 = alloc_stack $Any
+  %2 = init_existential_addr %1 : $*Any, $Klass
+  copy_addr [take] %0 to [init] %2 : $*Klass
+  debug_value [trace] %1 : $*Any
+  destroy_addr %1 : $*Any
+  dealloc_stack %1 : $*Any
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -1,6 +1,8 @@
+// RUN: %target-typecheck-verify-swift -strict-concurrency=complete -disable-availability-checking -disable-region-based-isolation-with-strict-concurrency -verify-additional-prefix complete-
 // RUN: %target-typecheck-verify-swift -strict-concurrency=complete -disable-availability-checking
 
 // REQUIRES: concurrency
+// REQUIRES: asserts
 
 
 struct CopyableStruct {}
@@ -18,7 +20,8 @@ enum MaybeFile { // should implicitly conform
 }
 
 @_moveOnly
-struct NotSendableMO { // expected-note 2{{consider making struct 'NotSendableMO' conform to the 'Sendable' protocol}}
+struct NotSendableMO { // expected-note {{consider making struct 'NotSendableMO' conform to the 'Sendable' protocol}}
+  // expected-complete-note @-1 {{consider making struct 'NotSendableMO' conform to the 'Sendable' protocol}}
   var ref: Ref
 }
 
@@ -50,7 +53,7 @@ func processFiles(_ a: A, _ anotherFile: borrowing FileDescriptor) async {
   _ = A(.available(anotherFile))
 
   let ns = await a.getRef() // expected-warning {{non-sendable type 'NotSendableMO' returned by call to actor-isolated function cannot cross actor boundary}}
-  await takeNotSendable(ns) // expected-warning {{passing argument of non-sendable type 'NotSendableMO' outside of main actor-isolated context may introduce data races}}
+  await takeNotSendable(ns) // expected-complete-warning {{passing argument of non-sendable type 'NotSendableMO' outside of main actor-isolated context may introduce data races}}
 
   switch (await a.giveFileDescriptor()) {
   case let .available(fd):


### PR DESCRIPTION
Explanation: A bunch of work that culminates in enabling region isolation by default when strict concurrency is enabled.
Issue: This is fixing a bunch of different issues. Radars:

- rdar://125918028
- rdar://122030520
- rdar://125452372
- rdar://121954871
- rdar://121955895
- rdar://122692698

Original PRs:
- #72851
- #72763
- #72760
- #72721
- #72710
- #72548

Risk: Low. Only affects region isolation.
Testing: Added many functional and unit tests.
Reviewer: N/A