### PR TITLE
stdlib: Adopt `ExtensionImportVisibility` experimental feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -367,7 +367,7 @@ CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedAny, true)
 
 
 // Whether members of extensions respect the enclosing file's imports.
-EXPERIMENTAL_FEATURE(ExtensionImportVisibility, true)
+EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(ExtensionImportVisibility, true)
 
 // Alias for IsolatedAny
 EXPERIMENTAL_FEATURE(IsolatedAny2, true)

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -628,6 +628,8 @@ function(_compile_swift_files
     list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")
   endif()
 
+  list(APPEND swift_flags "-enable-experimental-feature" "ExtensionImportVisiblity")
+
   if (SWIFT_STDLIB_ENABLE_STRICT_CONCURRENCY_COMPLETE)
     list(APPEND swift_flags "-strict-concurrency=complete")
   endif()

--- a/test/NameLookup/Inputs/Categories/Categories_A.h
+++ b/test/NameLookup/Inputs/Categories/Categories_A.h
@@ -1,0 +1,8 @@
+@import Foundation;
+
+@interface X
+@end
+
+@interface X (A)
+- (void)fromA;
+@end

--- a/test/NameLookup/Inputs/Categories/Categories_A.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_A.swift
@@ -1,0 +1,6 @@
+@_exported import Categories_A
+
+extension X {
+  public func fromOverlayForA() {}
+  @objc public func fromOverlayForAObjC() {}
+}

--- a/test/NameLookup/Inputs/Categories/Categories_B.h
+++ b/test/NameLookup/Inputs/Categories/Categories_B.h
@@ -1,0 +1,5 @@
+@import Categories_A;
+
+@interface X (B)
+- (void)fromB;
+@end

--- a/test/NameLookup/Inputs/Categories/Categories_B.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_B.swift
@@ -1,0 +1,6 @@
+@_exported import Categories_B
+
+extension X {
+  public func fromOverlayForB() {}
+  @objc public func fromOverlayForBObjC() {}
+}

--- a/test/NameLookup/Inputs/Categories/Categories_C.h
+++ b/test/NameLookup/Inputs/Categories/Categories_C.h
@@ -1,0 +1,5 @@
+@import Categories_A;
+
+@interface X (C)
+- (void)fromC;
+@end

--- a/test/NameLookup/Inputs/Categories/Categories_C.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_C.swift
@@ -1,0 +1,6 @@
+@_exported import Categories_C
+
+extension X {
+  public func fromOverlayForC() {}
+  @objc public func fromOverlayForCObjC() {}
+}

--- a/test/NameLookup/Inputs/Categories/Categories_D.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_D.swift
@@ -1,0 +1,1 @@
+import Categories_C

--- a/test/NameLookup/Inputs/Categories/module.modulemap
+++ b/test/NameLookup/Inputs/Categories/module.modulemap
@@ -1,0 +1,14 @@
+module Categories_A {
+  header "Categories_A.h"
+  export *
+}
+
+module Categories_B {
+  header "Categories_B.h"
+  export *
+}
+
+module Categories_C {
+  header "Categories_C.h"
+  export *
+}

--- a/test/NameLookup/Inputs/extensions_A.swift
+++ b/test/NameLookup/Inputs/extensions_A.swift
@@ -7,3 +7,11 @@ public struct Y<T> { }
 extension Y: P where T: P { }
 
 public struct Z: P { }
+
+extension X {
+  public func XinA() { }
+}
+
+extension Y {
+  public func YinA() { }
+}

--- a/test/NameLookup/Inputs/extensions_B.swift
+++ b/test/NameLookup/Inputs/extensions_B.swift
@@ -1,10 +1,10 @@
 import extensions_A
 
-public extension X {
+extension X {
   public func XinB() { }
 }
 
-public extension Y {
+extension Y {
   public func YinB() { }
 }
 

--- a/test/NameLookup/Inputs/extensions_C.swift
+++ b/test/NameLookup/Inputs/extensions_C.swift
@@ -1,4 +1,4 @@
-import extensions_A
+@_exported import extensions_A
 import extensions_B
 
 extension X {

--- a/test/NameLookup/Inputs/extensions_C.swift
+++ b/test/NameLookup/Inputs/extensions_C.swift
@@ -1,11 +1,11 @@
 import extensions_A
 import extensions_B
 
-public extension X {
+extension X {
   public func XinC() { }
 }
 
-public extension Y {
+extension Y {
   public func YinC() { }
 }
 

--- a/test/NameLookup/extensions_transitive.swift
+++ b/test/NameLookup/extensions_transitive.swift
@@ -4,10 +4,12 @@
 // RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/extensions_C.swift
 // RUN: %target-swift-frontend -typecheck %s -I %t -verify -enable-experimental-feature ExtensionImportVisibility
 
-import extensions_A
 import extensions_C
 // expected-note 2{{add import of module 'extensions_B'}}{{1-1=import extensions_B\n}}
 func test(x: X, y: Y<Z>) {
+  x.XinA()
+  y.YinA()
+
   x.XinB() // expected-error{{instance method 'XinB()' is not available due to missing import of defining module 'extensions_B'}}
   y.YinB() // expected-error{{instance method 'YinB()' is not available due to missing import of defining module 'extensions_B'}}
 

--- a/test/NameLookup/extensions_transitive_objc.swift
+++ b/test/NameLookup/extensions_transitive_objc.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_A.swift
+// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_B.swift
+// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_C.swift
+// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_D.swift
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/Categories -verify -enable-experimental-feature ExtensionImportVisibility
+
+// REQUIRES: objc_interop
+
+import Categories_B
+import Categories_D
+// expected-note 2 {{add import of module 'Categories_C'}}{{1-1=import Categories_C\n}}
+func test(x: X) {
+  x.fromA()
+  x.fromOverlayForA()
+  x.fromB()
+  x.fromOverlayForB()
+  x.fromC() // expected-error {{class method 'fromC()' is not available due to missing import of defining module 'Categories_C'}}
+  x.fromOverlayForC() // expected-error {{instance method 'fromOverlayForC()' is not available due to missing import of defining module 'Categories_C'}}
+}
+
+func testAnyObject(a: AnyObject) {
+  a.fromA()
+  a.fromOverlayForAObjC()
+  a.fromB()
+  a.fromOverlayForBObjC()
+  // FIXME: Better diagnostics?
+  // Name lookup for AnyObject already ignored transitive imports, so
+  // ExtensionImportVisibility has no effect on these diagnostics.
+  a.fromC() // expected-error {{value of type 'AnyObject' has no member 'fromC'}}
+  a.fromOverlayForCObjC() // expected-error {{value of type 'AnyObject' has no member 'fromOverlayForCObjC'}}
+}


### PR DESCRIPTION
Adopt the `ExtensionImportVisibility` feature when building the all standard library modules so that we're dogfooding the feature. Not very surprisingly, given their low dependency footprint, this has no effect on the sources of any of the stdlib modules.

Also, round out the test coverage for `ExtensionImportVisibility` by adding Obj-C interop tests and specifically testing `AnyObject` lookup. It turns out that `AnyObject` already filters out extension/category members that were not directly imported so the flag has no effect on it. We could potentially improve the diagnostics for `AnyObject` lookup misses that could be fixed by adding an import but that seems like a nice-to-have improvement we can do later.