### PR TITLE
6.0: [BitwiseCopyable] Remove bespoke diagnostic.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7664,8 +7664,6 @@ ERROR(non_bitwise_copyable_type_indirect_enum_element,none,
       "enum with indirect case cannot conform to 'BitwiseCopyable'", ())
 NOTE(note_non_bitwise_copyable_type_indirect_enum_element,none,
      "indirect case is here", ())
-ERROR(non_bitwise_copyable_type_noncopyable,none,
-      "noncopyable type cannot conform to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_type_cxx_nontrivial,none,
       "non-trivial C++ type cannot conform to 'BitwiseCopyable'", ())
 ERROR(non_bitwise_copyable_c_type_nontrivial,none,

--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -232,13 +232,6 @@ static bool checkBitwiseCopyableInstanceStorage(NominalTypeDecl *nominal,
   assert(dc->getParentModule()->getASTContext().getProtocol(
       KnownProtocolKind::BitwiseCopyable));
 
-  if (dc->mapTypeIntoContext(nominal->getDeclaredInterfaceType())->isNoncopyable()) {
-    if (!isImplicit(check)) {
-      nominal->diagnose(diag::non_bitwise_copyable_type_noncopyable);
-    }
-    return true;
-  }
-
   if (isa<ClassDecl>(nominal)) {
     if (!isImplicit(check)) {
       nominal->diagnose(diag::non_bitwise_copyable_type_class);

--- a/test/Sema/bitwise_copyable.swift
+++ b/test/Sema/bitwise_copyable.swift
@@ -6,8 +6,6 @@
 // RUN:     -enable-builtin-module                           \
 // RUN:     -debug-diagnostic-names
 
-// XFAIL: *
-
 //==============================================================================
 //===========================DEPENDENCY-FREE TESTS=(BEGIN)===================={{
 //==============================================================================
@@ -145,7 +143,7 @@ func passInt(_ i: Int) { take3(i) }
 
 func passTupleIntInt(_ t: (Int, Int)) { take3(t) }
 
-func passFWI<T : FixedWidthInteger>(_ t: T) { take3(t) }
+
 
 func passFloat(_ f: Float) { take3(f) }
 
@@ -190,9 +188,11 @@ struct S_Explicit_With_2_BitwiseCopyable_Generic_Optional<T : _BitwiseCopyable> 
   var o2: T?
 }
 
-struct S_Explicit_Nonescapable : ~Escapable, _BitwiseCopyable {} // expected-error{{non_bitwise_copyable_type_nonescapable}}
+// TODO: When the standard library is built with NonescapableTypes, this should
+//       be uncommented.
+//struct S_Explicit_Nonescapable : ~Escapable, _BitwiseCopyable {}
 
-struct S_Explicit_Noncopyable : ~Copyable, _BitwiseCopyable {} // expected-error{{non_bitwise_copyable_type_noncopyable}}
+struct S_Explicit_Noncopyable : ~Copyable, _BitwiseCopyable {} // expected-error{{type_does_not_conform}}
 
 struct S_Implicit_Nonescapable : ~Escapable {}
 
@@ -256,7 +256,7 @@ func passUnsafeContinuation<T : _BitwiseCopyable, U : Error & _BitwiseCopyable>(
   take4(c)
 }
 
-extension UnsafeContinuation : @retroactive _BitwiseCopyable {}
+extension UnsafeContinuation : @retroactive _BitwiseCopyable {} // expected-error{{conformance to 'BitwiseCopyable' must occur in the same module as generic struct 'UnsafeContinuation'}}
 
 //==============================================================================
 //========================_CONCURRENCY-DEPENDENCY TESTS=(END)=================}}


### PR DESCRIPTION
**Explanation**: Remove a bespoke diagnostic that is now duplicative.
**Scope**: Affects BitwiseCopyable checking.
**Issue**: rdar://125934050
**Original PR**: https://github.com/apple/swift/pull/72856
**Risk**: Very low.
**Testing**: Reenabled test cases that had been disabled.
**Reviewer**: Kavon Farvardin ( @kavon )
