### PR TITLE
[6.0] Revert "[TypeChecker] TypeChecker::isSubtypeOf should recognize Sendable/@Sendable subtyping"

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1068,17 +1068,13 @@ bool TypeChecker::typesSatisfyConstraint(Type type1, Type type2,
   }
 
   if (auto solution = cs.solveSingle()) {
-    const auto &score = solution->getFixedScore();
     if (unwrappedIUO)
-      *unwrappedIUO = score.Data[SK_ForceUnchecked] > 0;
+      *unwrappedIUO = solution->getFixedScore().Data[SK_ForceUnchecked] > 0;
 
     // Make sure that Sendable vs. no-Sendable mismatches are
     // failures here to establish subtyping relationship
     // (unlike in the solver where they are warnings until Swift 6).
     if (kind == ConstraintKind::Subtype) {
-      if (score.Data[SK_MissingSynthesizableConformance] > 0)
-        return false;
-
       if (llvm::any_of(solution->Fixes, [](const auto *fix) {
             return fix->getKind() == FixKind::AddSendableAttribute;
           }))

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1071,16 +1071,6 @@ bool TypeChecker::typesSatisfyConstraint(Type type1, Type type2,
     if (unwrappedIUO)
       *unwrappedIUO = solution->getFixedScore().Data[SK_ForceUnchecked] > 0;
 
-    // Make sure that Sendable vs. no-Sendable mismatches are
-    // failures here to establish subtyping relationship
-    // (unlike in the solver where they are warnings until Swift 6).
-    if (kind == ConstraintKind::Subtype) {
-      if (llvm::any_of(solution->Fixes, [](const auto *fix) {
-            return fix->getKind() == FixKind::AddSendableAttribute;
-          }))
-        return false;
-    }
-
     return true;
   }
 

--- a/test/Concurrency/sendable_keypaths.swift
+++ b/test/Concurrency/sendable_keypaths.swift
@@ -223,12 +223,14 @@ do {
     fatalError()
   }
 
+  // TODO(rdar://125948508): This shouldn't be ambiguous (@Sendable version should be preferred)
   func test() -> KeyPath<String, Int> {
-    true ? kp() : kp() // Ok
+    true ? kp() : kp() // expected-error {{type of expression is ambiguous without a type annotation}}
   }
 
   func forward<T>(_ v: T) -> T { v }
-  let _: KeyPath<String, Int> = forward(kp()) // Ok
+  // TODO(rdar://125948508): This shouldn't be ambiguous (@Sendable version should be preferred)
+  let _: KeyPath<String, Int> = forward(kp()) // expected-error {{conflicting arguments to generic parameter 'T' ('any KeyPath<String, Int> & Sendable' vs. 'KeyPath<String, Int>')}}
 }
 
 do {
@@ -237,4 +239,23 @@ do {
   }
 
   _ = \C<Int>.immutable as? ReferenceWritableKeyPath // Ok
+}
+
+// Should be moved back to sendable_methods.swift once ambiguities are fixed
+do {
+  struct Test {
+    static func fn() {}
+    static func otherFn() {}
+  }
+
+  // TODO(rdar://125948508): This shouldn't be ambiguous (@Sendable version should be preferred)
+  func fnRet(cond: Bool) -> () -> Void {
+    cond ? Test.fn : Test.otherFn // expected-error {{type of expression is ambiguous without a type annotation}}
+  }
+
+  func forward<T>(_: T) -> T {
+  }
+
+  // TODO(rdar://125948508): This shouldn't be ambiguous (@Sendable version should be preferred)
+  let _: () -> Void = forward(Test.fn) // expected-error {{conflicting arguments to generic parameter 'T' ('@Sendable () -> ()' vs. '() -> Void')}}
 }

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -260,3 +260,12 @@ do {
     }
   }
 }
+
+// rdar://125932231 - incorrect `error: type of expression is ambiguous without a type annotation`
+do {
+  class C {}
+
+  func test(c: C) -> (any Sendable)? {
+    true ? nil : c // Ok
+  }
+}

--- a/test/Concurrency/sendable_methods.swift
+++ b/test/Concurrency/sendable_methods.swift
@@ -229,23 +229,6 @@ do {
   }
 }
 
-do {
-  struct Test {
-    static func fn() {}
-    static func otherFn() {}
-  }
-
-  func fnRet(cond: Bool) -> () -> Void {
-    cond ? Test.fn : Test.otherFn // Ok
-  }
-
-  func forward<T>(_: T) -> T {
-  }
-
-  let _: () -> Void = forward(Test.fn) // Ok
-}
-
-
 func test_initializer_ref() {
   func test<T>(_: @Sendable (T, T) -> Array<T>) {
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/72868

---

- Explanation:

This approach for ambiguity resolution regressed existing ternary expressions
that join to `any Sendable` and one branch is inferred from the ternary type variable.

The test-cases introduced by the original PR I left in place with error messages and
TODOs to figure out a way to resolve ambiguity.

- Scope: Ranking solutions where the same type variable gets Sendable and non-Sendable type assignments i.e. ternary expressions where branches are Sendable but contextual type isn't and vice versa.

- Main Branch PRs: https://github.com/apple/swift/pull/72868

- Risk: Very Low

- Reviewed By: @hborla  

- Testing: Added test-cases to the test suite.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
