### PR TITLE
[6.0][Concurrency] Classes nested in actors are not semantically final.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3701,10 +3701,12 @@ bool ValueDecl::isSemanticallyFinal() const {
       return true;
   }
 
-  // As are members of actor types.
-  if (auto classDecl = getDeclContext()->getSelfClassDecl()) {
-    if (classDecl->isAnyActor())
-      return true;
+  // As are methods/accessors of actor types.
+  if (!isa<TypeDecl>(this)) {
+    if (auto classDecl = getDeclContext()->getSelfClassDecl()) {
+      if (classDecl->isAnyActor())
+        return true;
+    }
   }
 
   // For everything else, the same as 'final'.

--- a/test/Concurrency/sendable_conformance_checking.swift
+++ b/test/Concurrency/sendable_conformance_checking.swift
@@ -181,3 +181,9 @@ extension SendableExtSub: @unchecked Sendable {}
 // Still want to know about same-class redundancy
 class MultiConformance: @unchecked Sendable {} // expected-note {{'MultiConformance' declares conformance to protocol 'Sendable' here}}
 extension MultiConformance: @unchecked Sendable {} // expected-error {{redundant conformance of 'MultiConformance' to protocol 'Sendable'}}
+
+@available(SwiftStdlib 5.1, *)
+actor MyActor {
+  // expected-warning@+1 {{non-final class 'Nested' cannot conform to 'Sendable'; use '@unchecked Sendable'; this is an error in the Swift 6 language mode}}
+  class Nested: Sendable {}
+}


### PR DESCRIPTION
* **Explanation**: The check for actor methods in `isSemanticallyFinal` was accidentally kicking in for class members, which avoided `Sendable` checking on classes nested in actors.
* **Scope**: Only impacts non-final classes nested in actors, and the only functional impact is new diagnostics when conforming to `Sendable`.
* **Risk**: Low due to narrow scope.
* **Testing**: Add a test case.
* **Reviewer**: @ktoso @slavapestov 
* **Main branch PR**: https://github.com/apple/swift/pull/72863