### PR TITLE
[stdlib] overload some `Sequence` extensions for `Array`

### DIFF
--- a/stdlib/public/core/ArrayType.swift
+++ b/stdlib/public/core/ArrayType.swift
@@ -77,3 +77,26 @@ extension _ArrayProtocol {
     return try _filter(isIncluded)
   }
 }
+
+// This would be an extension of `_ArrayProtocol` if it were public
+extension RandomAccessCollection where SubSequence == ArraySlice<Element> {
+  @_alwaysEmitIntoClient
+  public __consuming func suffix(_ maxLength: Int) -> [Element] {
+    let slice: SubSequence = suffix(maxLength)
+    return Array(slice)
+  }
+
+  @_alwaysEmitIntoClient
+  public __consuming func dropLast(_ k: Int = 1) -> [Element] {
+    let slice: SubSequence = dropLast(k)
+    return Array(slice)
+  }
+
+  @_alwaysEmitIntoClient
+  public __consuming func prefix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> [Element] {
+    let slice: SubSequence = try prefix(while: predicate)
+    return Array(slice)
+  }
+}


### PR DESCRIPTION
Mitigates some runtime performance issues involving `Array.suffix(_:)` and two other functions that are overloaded by their return values between `Sequence` and `Collection`.

In the case of `Array`, `ContiguousArray` and `ArraySlice`, an expression such as `Array(0..<10000000).suffix(3) == [1,2,3]` unintuitively uses `Sequence`'s definition of `suffix(_:)` rather than `Collection`'s, because the array literal on the right pushes the constraint solver into picking the overload that returns a concrete `Array` (as in the `Sequence` extension) instead of `SubSequence` (as in the `Collection` extension.) As a result, the suffix function that gets executed has an O(n) runtime complexity instead the expected O(1) complexity.

This PR adds an extension for `Array`, `ContiguousArray` and `ArraySlice`, adding the functions:
- `public func suffix(_ maxLength: Int) -> [Element]`
- `public func dropLast(_ k: Int = 1) -> [Element]`
- `public func prefix(while: (Element) throws -> Bool) rethrows -> [Element]`

The main speedup here is their use of a bulk copy rather than an element-by-element append. The first two also benefit by copying fewer elements than the `Sequence` version needs to.

The ideal fix may be to change the behaviour of the constraint solver; when this happens this addition can be removed.

Addresses rdar://125812415