### PR TITLE
[6.0] Fixes two bugs with parameter packs and parameterized existentials

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -247,7 +247,7 @@ namespace {
 
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src, SILType T,
                         bool isOutlined) const override {
-      if (isOutlined) {
+      if (isOutlined || T.hasLocalArchetype()) {
         Address destValue = projectValue(IGF, dest);
         Address srcValue = projectValue(IGF, src);
         asDerived().emitValueAssignWithCopy(IGF, destValue, srcValue);
@@ -262,7 +262,7 @@ namespace {
 
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined) const override {
-      if (isOutlined) {
+      if (isOutlined || T.hasLocalArchetype()) {
         Address destValue = projectValue(IGF, dest);
         Address srcValue = projectValue(IGF, src);
         asDerived().emitValueInitializeWithCopy(IGF, destValue, srcValue);
@@ -277,7 +277,7 @@ namespace {
 
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,
                         bool isOutlined) const override {
-      if (isOutlined) {
+      if (isOutlined || T.hasLocalArchetype()) {
         Address destValue = projectValue(IGF, dest);
         Address srcValue = projectValue(IGF, src);
         asDerived().emitValueAssignWithTake(IGF, destValue, srcValue);
@@ -292,7 +292,7 @@ namespace {
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined) const override {
-      if (isOutlined) {
+      if (isOutlined || T.hasLocalArchetype()) {
         Address destValue = projectValue(IGF, dest);
         Address srcValue = projectValue(IGF, src);
         asDerived().emitValueInitializeWithTake(IGF, destValue, srcValue);
@@ -307,7 +307,7 @@ namespace {
 
     void destroy(IRGenFunction &IGF, Address existential, SILType T,
                  bool isOutlined) const override {
-      if (isOutlined) {
+      if (isOutlined || T.hasLocalArchetype()) {
         Address valueAddr = projectValue(IGF, existential);
         asDerived().emitValueDestroy(IGF, valueAddr);
       } else {
@@ -955,7 +955,7 @@ public:
 
   void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                           SILType T, bool isOutlined) const override {
-    if (isOutlined) {
+    if (isOutlined || T.hasLocalArchetype()) {
       llvm::Value *metadata = copyType(IGF, dest, src);
 
       auto layout = getLayout();
@@ -977,7 +977,7 @@ public:
 
   void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                           SILType T, bool isOutlined) const override {
-    if (isOutlined) {
+    if (isOutlined || T.hasLocalArchetype()) {
       // memcpy the existential container. This is safe because: either the
       // value is stored inline and is therefore by convention bitwise takable
       // or the value is stored in a reference counted heap buffer, in which

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3294,7 +3294,7 @@ TypeConverter::computeLoweredRValueType(TypeExpansionContext forExpansion,
                              AbstractionPattern origType)
         : TC(TC), forExpansion(forExpansion), origType(origType) {
       if (auto origEltType = origType.getVanishingTupleElementPatternType())
-        origType = *origEltType;
+        this->origType = *origEltType;
     }
 
     // AST function types are turned into SIL function types:

--- a/test/IRGen/parameterized_existential_with_element_archetype.swift
+++ b/test/IRGen/parameterized_existential_with_element_archetype.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+public protocol P1<A> {
+    associatedtype A
+}
+
+public protocol P2<A>: class {
+    associatedtype A
+}
+
+public func f1<each T>(p: repeat any P1<each T>) {
+  let _ = (repeat each p)
+}
+
+public func f2<each T>(p: repeat any P2<each T>) {
+  let _ = (repeat each p)
+}

--- a/test/IRGen/parameterized_existential_with_opened_archetype.swift
+++ b/test/IRGen/parameterized_existential_with_opened_archetype.swift
@@ -1,0 +1,35 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+public protocol P {}
+
+extension P {
+  @_transparent
+  public func f() {
+    let x: any Q<Self> = S<Self>()
+
+    // force a copy
+    g(x, x)
+  }
+}
+
+@_optimize(none)
+public func g<T>(_: consuming T, _: consuming T) {}
+
+public enum G<T> {
+  case ok(String)
+  case bar
+}
+
+public func h(e: any P) {
+  // We inline P.f(), because it is transparent, so we end
+  // up working with an `any Q<@opened ...>`.
+  e.f()
+}
+
+public protocol Q<A> {
+  associatedtype A
+}
+
+public struct S<A>: Q {
+  public init() {}
+}

--- a/test/SILGen/variadic-generic-lowering.swift
+++ b/test/SILGen/variadic-generic-lowering.swift
@@ -1,0 +1,43 @@
+// RUN: %target-swift-emit-silgen %s -disable-availability-checking
+
+// Make sure we can lower all of these types without crashing.
+
+public struct G1<each T> {
+  public let t: (repeat each T)
+}
+
+public struct S1 {
+  public let g: G1< >
+  public let gg: G1<Int>
+  public let ggg: G1<Int, Float>
+}
+
+public struct G2<each T> {
+  public let t: (repeat (each T).Type)
+}
+
+public struct S2 {
+  public let g: G2< >
+  public let gg: G2<Int>
+  public let ggg: G2<Int, Float>
+}
+
+public struct G3<each T> {
+  public let t: (repeat (each T) -> ())
+}
+
+public struct S3 {
+  public let g: G3< >
+  public let gg: G3<Int>
+  public let ggg: G3<Int, Float>
+}
+
+public struct G4<each T> {
+  public let t: (repeat ((each T).Type) -> ())
+}
+
+public struct S4 {
+  public let g: G4< >
+  public let gg: G4<Int>
+  public let ggg: G4<Int, Float>
+}


### PR DESCRIPTION
* Description: One-element tuple unwrapping was not performed in some cases due to a typo, and we would crash in SIL type lowering. Another bug resulted in an IRGen crash if parameterized existentials were combined with packs, eg `repeat any P<each T>`.

* Risk: Low.

* Radar: rdar://problem/123978349, rdar://problem/118437883.

* Reviewed by: @hborla 