### PR TITLE
[region-isolation] Tweak the main transferring diagnostic.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -973,7 +973,7 @@ NOTE(regionbasedisolation_isolated_since_in_same_region_basename, none,
 //
 
 ERROR(regionbasedisolation_named_transfer_yields_race, none,
-      "transferring %0 may cause a race",
+      "transferring %0 may cause a data race",
       (Identifier))
 
 NOTE(regionbasedisolation_named_info_transfer_yields_race, none,

--- a/test/ClangImporter/transferring_objc.swift
+++ b/test/ClangImporter/transferring_objc.swift
@@ -25,7 +25,7 @@ func methodTestTransferringResult() async {
 func methodTestTransferringArg() async {
   let x = MyType()
   let s = NSObject()
-  let _ = x.getResultWithTransferringArgument(s)  // expected-error {{transferring 's' may cause a race}}
+  let _ = x.getResultWithTransferringArgument(s)  // expected-error {{transferring 's' may cause a data race}}
   // expected-note @-1 {{'s' used after being passed as a transferring parameter; Later uses could race}}
   useValue(s) // expected-note {{use here could race}}
 }
@@ -45,14 +45,14 @@ func funcTestTransferringResult() async {
   // Just to show that without the transferring param, we generate diagnostics.
   let x2 = NSObject()
   let y2 = returnNSObjectFromGlobalFunction(x2)
-  await transferToMain(x2) // expected-error {{transferring 'x2' may cause a race}}
+  await transferToMain(x2) // expected-error {{transferring 'x2' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y2) // expected-note {{use here could race}}
 }
 
 func funcTestTransferringArg() async {
   let x = NSObject()
-  transferNSObjectToGlobalFunction(x) // expected-error {{transferring 'x' may cause a race}}
+  transferNSObjectToGlobalFunction(x) // expected-error {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{'x' used after being passed as a transferring parameter; Later uses could race}}
   useValue(x) // expected-note {{use here could race}}
 }

--- a/test/Concurrency/async_task_locals_basic_warnings_bug_isolation.swift
+++ b/test/Concurrency/async_task_locals_basic_warnings_bug_isolation.swift
@@ -18,7 +18,7 @@ actor Test {
                      _ body: (consuming NonSendableValue, isolated (any Actor)?) -> Void) async {
     Self.$local.withValue(12) {
       // Unexpected errors here:
-      //  error: unexpected warning produced: transferring 'body' may cause a race; this is an error in the Swift 6 language mode
+      //  error: unexpected warning produced: transferring 'body' may cause a data race; this is an error in the Swift 6 language mode
       //  error: unexpected note produced: actor-isolated 'body' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses
       body(NonSendableValue(), isolation)
     }

--- a/test/Concurrency/experimental_feature_strictconcurrency.swift
+++ b/test/Concurrency/experimental_feature_strictconcurrency.swift
@@ -31,7 +31,7 @@ func iterate(stream: AsyncStream<Int>) async {
   // FIXME: Region isolation should consider a value from a 'nonisolated(unsafe)'
   // declaration to be in a disconnected region
 
-  // expected-region-isolation-warning @+3 {{transferring 'it' may cause a race}}
+  // expected-region-isolation-warning @+3 {{transferring 'it' may cause a data race}}
   // expected-region-isolation-note @+2 {{transferring disconnected 'it' to nonisolated callee could cause races in between callee nonisolated and local main actor-isolated uses}}
   // expected-region-isolation-note @+1 {{use here could race}}
   while let element = await it.next() {

--- a/test/Concurrency/isolated_captures.swift
+++ b/test/Concurrency/isolated_captures.swift
@@ -40,7 +40,7 @@ class NotSendable {
   MyActor.ns = ns
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a race}}
+    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a data race}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
@@ -62,7 +62,7 @@ class NotSendable {
   ns.stash()
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a race}}
+    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a data race}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns
@@ -83,7 +83,7 @@ class NotSendable {
   let ns = NotSendable()
 
   await { @YourActor in
-    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a race}}
+    // expected-region-isolation-warning @+3 {{transferring 'ns' may cause a data race}}
     // expected-region-isolation-note @+2 {{global actor 'MyActor'-isolated 'ns' is captured by a global actor 'YourActor'-isolated closure. global actor 'YourActor'-isolated uses in closure may race against later global actor 'MyActor'-isolated uses}}
     // expected-complete-warning@+1 {{capture of 'ns' with non-sendable type 'NotSendable' in an isolated closure; this is an error in the Swift 6 language mode}}
     YourActor.ns = ns

--- a/test/Concurrency/sendable_checking.swift
+++ b/test/Concurrency/sendable_checking.swift
@@ -96,7 +96,7 @@ public actor MyActor: MyProto {
 
   func g(ns1: NS1) async {
     await nonisolatedAsyncFunc1(ns1) // expected-targeted-and-complete-warning{{passing argument of non-sendable type 'NS1' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'ns1' may cause a race}}
+    // expected-tns-warning @-1 {{transferring 'ns1' may cause a data race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'ns1' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
     _ = await nonisolatedAsyncFunc2() // expected-warning{{non-sendable type 'NS1' returned by implicitly asynchronous call to nonisolated function cannot cross actor boundary}}
   }
@@ -253,12 +253,12 @@ final class NonSendable {
   func call() async {
     await update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{transferring 'self' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'self' may cause a data race}}
     // expected-tns-note @-3 {{transferring task-isolated 'self' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 
     await self.update()
     // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-2 {{transferring 'self' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'self' may cause a data race}}
     // expected-tns-note @-3 {{transferring task-isolated 'self' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 
     _ = await x
@@ -277,7 +277,7 @@ func testNonSendableBaseArg() async {
   let t = NonSendable()
   await t.update()
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' into main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 't' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 't' may cause a data race}}
   // expected-tns-note @-3 {{transferring disconnected 't' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   _ = await t.x
@@ -297,13 +297,13 @@ func callNonisolatedAsyncClosure(
 ) async {
   await g(ns)
   // expected-targeted-and-complete-warning @-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'ns' may cause a data race}}
   // expected-tns-note @-3 {{transferring main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 
   let f: (NonSendable) async -> () = globalSendable // okay
   await f(ns)
   // expected-targeted-and-complete-warning@-1 {{passing argument of non-sendable type 'NonSendable' outside of main actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'ns' may cause a data race}}
   // expected-tns-note @-3 {{transferring main actor-isolated 'ns' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -226,7 +226,7 @@ bb0(%0 : @guaranteed $NonSendableStruct):
   debug_value %0 : $NonSendableStruct, var, name "myname"
   %2 = struct_extract %0 : $NonSendableStruct, #NonSendableStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a race}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a data race}}
   // expected-note @-1 {{task-isolated 'myname.ns' cannot be a transferring result. task-isolated uses may race with caller uses}}
 }
 
@@ -235,7 +235,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedStruct):
   debug_value %0 : $MainActorIsolatedStruct, var, name "myname"
   %2 = struct_extract %0 : $MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a race}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -244,7 +244,7 @@ bb0(%0 : $*MainActorIsolatedStruct):
   debug_value %0 : $*MainActorIsolatedStruct, var, name "myname"
   %2 = struct_element_addr %0 : $*MainActorIsolatedStruct, #MainActorIsolatedStruct.ns
   %3 = load [copy] %2 : $*NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a race}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.ns' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -253,7 +253,7 @@ bb0(%0 : @guaranteed $MainActorIsolatedEnum):
   debug_value %0 : $MainActorIsolatedEnum, var, name "myname"
   %2 = unchecked_enum_data %0 : $MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
   %3 = copy_value %2 : $NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.second' may cause a race}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.second' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.second' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -262,7 +262,7 @@ bb0(%0 : $*MainActorIsolatedEnum):
   debug_value %0 : $*MainActorIsolatedEnum, var, name "myname"
   %2 = unchecked_take_enum_data_addr %0 : $*MainActorIsolatedEnum, #MainActorIsolatedEnum.second!enumelt
   %3 = load [take] %2 : $*NonSendableKlass
-  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.second' may cause a race}}
+  return %3 : $NonSendableKlass // expected-warning {{transferring 'myname.second' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.second' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -281,7 +281,7 @@ bb2(%1 : @guaranteed $NonSendableKlass):
   br bb3(%3 : $FakeOptional<NonSendableKlass>)
 
 bb3(%4 : @owned $FakeOptional<NonSendableKlass>):
-  return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{transferring 'myname.some' may cause a race}}
+  return %4 : $FakeOptional<NonSendableKlass> // expected-warning {{transferring 'myname.some' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'myname.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -75,14 +75,14 @@ class TwoFieldKlassClassBox {
 extension Actor {
   func warningIfCallingGetter() async {
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'self.klass' may cause a race}}
+    // expected-tns-warning @-1 {{transferring 'self.klass' may cause a data race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
   }
 
   func warningIfCallingAsyncOnFinalField() async {
     // Since we are calling finalKlass directly, we emit a warning here.
     await self.finalKlass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'self.finalKlass' may cause a race}}
+    // expected-tns-warning @-1 {{transferring 'self.finalKlass' may cause a data race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'self.finalKlass' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
   }
 
@@ -96,7 +96,7 @@ extension FinalActor {
   func warningIfCallingAsyncOnFinalField() async {
     // Since our whole class is final, we emit the error directly here.
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'self.klass' may cause a race}}
+    // expected-tns-warning @-1 {{transferring 'self.klass' may cause a data race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
   }
 }
@@ -126,7 +126,7 @@ func closureInOut(_ a: Actor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{transferring 'ns0' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
   if await booleanFlag {
@@ -152,7 +152,7 @@ func closureInOutDifferentActor(_ a: Actor, _ a2: Actor) async {
 
   await a.useKlass(ns0)
   // expected-complete-warning @-1 {{passing argument of non-sendable type 'NonSendableKlass'}}
-  // expected-tns-warning @-2 {{transferring 'ns0' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
   // We only emit a warning on the first use we see, so make sure we do both
@@ -177,13 +177,13 @@ func closureInOut2(_ a: Actor) async {
 
   var closure = {}
 
-  await a.useKlass(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  await a.useKlass(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
   closure = { useInOut(&contents) } // expected-tns-note {{use here could race}}
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' may cause a race}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
@@ -205,7 +205,7 @@ func closureNonInOut(_ a: Actor) async {
 
   closure = { useValue(contents) }
 
-  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' may cause a race}}
+  await a.useKlass(ns1) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass'}}
 
@@ -237,7 +237,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -268,7 +268,7 @@ extension Actor {
     }
     let x: Any? = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
+    // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -281,7 +281,7 @@ extension Actor {
     // store it all as once.
     let x: Any? = (closure, 1)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
-    // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
+    // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
     // expected-tns-note @-2 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -293,7 +293,7 @@ extension Actor {
     // Error here.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
 
     closure = {}
@@ -319,7 +319,7 @@ extension Actor {
     // Error here.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -329,7 +329,7 @@ extension Actor {
     // We get a transfer after use error.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring disconnected 'closure' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
 
     if await booleanFlag {
@@ -341,7 +341,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-note @-2 {{use here could race}}
-    // expected-tns-warning @-3 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-3 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-4 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -364,7 +364,7 @@ extension Actor {
 
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -393,7 +393,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -404,7 +404,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -415,7 +415,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 }
@@ -504,7 +504,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
@@ -517,7 +517,7 @@ extension Actor {
     }
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 }
@@ -531,7 +531,7 @@ extension Actor {
     // This should error.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
 
     // This doesnt since we re-assign
@@ -545,7 +545,7 @@ extension Actor {
     // But this transfer should.
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{transferring 'closure' may cause a race}}
+    // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
     // expected-tns-note @-3 {{transferring disconnected 'closure' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
 
     // But this will error since we race.
@@ -569,7 +569,7 @@ func testConversionsAndSendable(a: Actor, f: @Sendable () -> Void, f2: () -> Voi
   // Show that we error if we are not sendable.
   await a.useNonSendableFunction(f2) // expected-complete-warning {{passing argument of non-sendable type '() -> Void' into actor-isolated context may introduce data races}}
   // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-  // expected-tns-warning @-2 {{transferring 'f2' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'f2' may cause a data race}}
   // expected-tns-note @-3 {{transferring task-isolated 'f2' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
 }
 
@@ -614,7 +614,7 @@ func singleFieldVarMergeTest() async {
   useValue(box)
   useValue(box.k)
 
-  await transferToMain(box) // expected-tns-warning {{transferring 'box' may cause a race}}
+  await transferToMain(box) // expected-tns-warning {{transferring 'box' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'box' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'SingleFieldKlassBox' into main actor-isolated context may introduce data races}}
   
@@ -629,7 +629,7 @@ func multipleFieldVarMergeTest1() async {
   box = TwoFieldKlassBox()
 
   // This transfers the entire region.
-  await transferToMain(box.k1) // expected-tns-warning {{transferring 'box.k1' may cause a race}}
+  await transferToMain(box.k1) // expected-tns-warning {{transferring 'box.k1' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'box.k1' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   
@@ -670,7 +670,7 @@ func multipleFieldTupleMergeTest1() async {
   box = (NonSendableKlass(), NonSendableKlass())
 
   // This transfers the entire region.
-  await transferToMain(box.0) // expected-tns-warning {{transferring 'box.0' may cause a race}}
+  await transferToMain(box.0) // expected-tns-warning {{transferring 'box.0' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'box.0' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
 
@@ -723,7 +723,7 @@ class ClassFieldTests { // expected-complete-note 6{{}}
 
 func letSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
@@ -732,7 +732,7 @@ func letSendableTrivialClassFieldTest() async {
 
 func letSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
 
@@ -742,7 +742,7 @@ func letSendableNonTrivialClassFieldTest() async {
 
 func letNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -751,7 +751,7 @@ func letNonSendableNonTrivialClassFieldTest() async {
 
 func varSendableTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{use here could race}}
@@ -760,7 +760,7 @@ func varSendableTrivialClassFieldTest() async {
 
 func varSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{use here could race}}
@@ -769,7 +769,7 @@ func varSendableNonTrivialClassFieldTest() async {
 
 func varNonSendableNonTrivialClassFieldTest() async {
   let test = ClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'ClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -791,7 +791,7 @@ final class FinalClassFieldTests { // expected-complete-note 6 {{}}
 
 func letSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
@@ -800,7 +800,7 @@ func letSendableTrivialFinalClassFieldTest() async {
 
 func letSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
@@ -809,7 +809,7 @@ func letSendableNonTrivialFinalClassFieldTest() async {
 
 func letNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -818,7 +818,7 @@ func letNonSendableNonTrivialFinalClassFieldTest() async {
 
 func varSendableTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial // expected-tns-note {{use here could race}}
@@ -827,7 +827,7 @@ func varSendableTrivialFinalClassFieldTest() async {
 
 func varSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial  // expected-tns-note {{use here could race}}
@@ -836,7 +836,7 @@ func varSendableNonTrivialFinalClassFieldTest() async {
 
 func varNonSendableNonTrivialFinalClassFieldTest() async {
   let test = FinalClassFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'FinalClassFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -858,7 +858,7 @@ struct StructFieldTests { // expected-complete-note 31 {{}}
 
 func letSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
@@ -867,7 +867,7 @@ func letSendableTrivialLetStructFieldTest() async {
 
 func letSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
@@ -876,7 +876,7 @@ func letSendableNonTrivialLetStructFieldTest() async {
 
 func letNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -887,7 +887,7 @@ func letNonSendableNonTrivialLetStructFieldTest() async {
 func letSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableTrivial
@@ -897,7 +897,7 @@ func letSendableTrivialVarStructFieldTest() async {
 func letSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.letSendableNonTrivial
@@ -907,7 +907,7 @@ func letSendableNonTrivialVarStructFieldTest() async {
 func letNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letNonSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -927,7 +927,7 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
     print(test)
   }
   _ = cls2
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial
@@ -939,7 +939,7 @@ func letNonSendableNonTrivialLetStructFieldClosureTest() async {
 
 func varSendableTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
@@ -948,7 +948,7 @@ func varSendableTrivialLetStructFieldTest() async {
 
 func varSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
@@ -957,7 +957,7 @@ func varSendableNonTrivialLetStructFieldTest() async {
 
 func varNonSendableNonTrivialLetStructFieldTest() async {
   let test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -968,7 +968,7 @@ func varNonSendableNonTrivialLetStructFieldTest() async {
 func varSendableTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableTrivial
@@ -978,7 +978,7 @@ func varSendableTrivialVarStructFieldTest() async {
 func varSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   _ = test.varSendableNonTrivial
@@ -988,7 +988,7 @@ func varSendableNonTrivialVarStructFieldTest() async {
 func varNonSendableNonTrivialVarStructFieldTest() async {
   var test = StructFieldTests()
   test = StructFieldTests()
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varNonSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -1004,7 +1004,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest1() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -1019,7 +1019,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest2() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -1034,7 +1034,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest3() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
@@ -1050,7 +1050,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest4() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.letSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -1066,7 +1066,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest5() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   let z = test.varSendableNonTrivial // expected-tns-note {{use here could race}}
@@ -1082,7 +1082,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest6() async {
     test = StructFieldTests()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
@@ -1097,7 +1097,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest7() async {
     test.varSendableNonTrivial = SendableKlass()
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
@@ -1112,7 +1112,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest8() async {
     useInOut(&test)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
@@ -1127,7 +1127,7 @@ func varNonSendableNonTrivialLetStructFieldClosureTest9() async {
     useInOut(&test.varSendableNonTrivial)
   }
   _ = cls
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   test.varSendableNonTrivial = SendableKlass() // expected-tns-note {{use here could race}}
@@ -1145,7 +1145,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive1() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
@@ -1166,7 +1166,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive2() async {
     }
     _ = cls
 
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1188,7 +1188,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive3() async {
     }
     _ = cls
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1208,7 +1208,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive4() async {
     // loop carry use and an error due to multiple params. Then we could emit
     // the error on test below. This is still correct though, just not as
     // good... that is QoI though.
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
 
@@ -1237,7 +1237,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive5() async {
   // this. This is a case where we are going to need to be able to have the
   // compiler explain the regions well.
   for _ in 0..<1024 {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
@@ -1261,11 +1261,11 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive6() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1282,7 +1282,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
   var cls = {}
 
   if await booleanFlag {
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   } else {
@@ -1290,7 +1290,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
       useInOut(&test.varSendableNonTrivial)
     }
     _ = cls
-    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+    await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructFieldTests' into main actor-isolated context may introduce data races}}
   }
@@ -1305,7 +1305,7 @@ func varNonSendableNonTrivialLetStructFieldClosureFlowSensitive7() async {
 
 func varSendableTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.0
@@ -1315,7 +1315,7 @@ func varSendableTrivialLetTupleFieldTest() async {
 
 func varSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.1
@@ -1325,7 +1325,7 @@ func varSendableNonTrivialLetTupleFieldTest() async {
 
 func varNonSendableNonTrivialLetTupleFieldTest() async {
   let test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2
@@ -1339,7 +1339,7 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
 func varSendableTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.0
@@ -1349,7 +1349,7 @@ func varSendableTrivialVarTupleFieldTest() async {
 func varSendableTrivialVarTupleFieldTest2() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test.2) // expected-tns-warning {{transferring 'test.2' may cause a race}}
+  await transferToMain(test.2) // expected-tns-warning {{transferring 'test.2' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test.2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   _ = test.0
@@ -1359,7 +1359,7 @@ func varSendableTrivialVarTupleFieldTest2() async {
 func varSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   _ = test.1
@@ -1369,7 +1369,7 @@ func varSendableNonTrivialVarTupleFieldTest() async {
 func varNonSendableNonTrivialVarTupleFieldTest() async {
   var test = (0, SendableKlass(), NonSendableKlass()) 
   test = (0, SendableKlass(), NonSendableKlass())
-  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a race}}
+  await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
   let z = test.2 // expected-tns-note {{use here could race}}
@@ -1385,11 +1385,11 @@ func controlFlowTest1() async {
   let x = NonSendableKlass()
 
   if await booleanFlag {
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   } else {
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
@@ -1409,7 +1409,7 @@ func controlFlowTest2() async {
   var x = NonSendableKlass()
 
   for _ in 0..<1024 {
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -1434,7 +1434,7 @@ actor ActorWithSetter {
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
@@ -1442,7 +1442,7 @@ actor ActorWithSetter {
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
@@ -1450,7 +1450,7 @@ actor ActorWithSetter {
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}    
   }
@@ -1471,7 +1471,7 @@ actor ActorWithSetter {
   func classBox() async {
     let x = NonSendableKlass()
     self.classBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
@@ -1487,7 +1487,7 @@ final actor FinalActorWithSetter {
   func test1() async {
     let x = NonSendableKlass()
     self.field = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
@@ -1495,7 +1495,7 @@ final actor FinalActorWithSetter {
   func test2() async {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
@@ -1503,7 +1503,7 @@ final actor FinalActorWithSetter {
   func test3() async {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
@@ -1524,7 +1524,7 @@ final actor FinalActorWithSetter {
   func classBox() async {
     let x = NonSendableKlass()
     self.classBox.k1 = x
-    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
@@ -1532,7 +1532,7 @@ final actor FinalActorWithSetter {
 
 func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
   let _ = { @MainActor in
-    let _ = x // expected-tns-warning {{transferring 'x' may cause a race}}
+    let _ = x // expected-tns-warning {{transferring 'x' may cause a data race}}
     // expected-tns-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
 }

--- a/test/Concurrency/transfernonsendable_asynclet.swift
+++ b/test/Concurrency/transfernonsendable_asynclet.swift
@@ -65,7 +65,7 @@ struct TwoFieldKlassBox { // expected-complete-note 24{{}}
 
 func asyncLet_Let_ActorIsolated_Simple1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -75,7 +75,7 @@ func asyncLet_Let_ActorIsolated_Simple1() async {
 
 func asyncLet_Let_ActorIsolated_Simple2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -85,7 +85,7 @@ func asyncLet_Let_ActorIsolated_Simple2() async {
 
 func asyncLet_Let_ActorIsolated_Simple3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -105,7 +105,7 @@ func asyncLet_Let_ActorIsolated_Simple3() async {
 
 func asyncLet_Let_ActorIsolated_Simple4() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -119,7 +119,7 @@ func asyncLet_Let_ActorIsolated_Simple4() async {
 
 func asyncLet_Let_ActorIsolated_Simple5() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -135,7 +135,7 @@ func asyncLet_Let_ActorIsolated_Simple5() async {
 // async let rather than the base class.
 func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
@@ -145,7 +145,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass1() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
@@ -155,7 +155,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass2() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
   let x = NonSendableKlass()
-  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.field) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
@@ -167,7 +167,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsClass3() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -177,7 +177,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct1() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -187,7 +187,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct2() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -197,7 +197,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct3() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
   let x = TwoFieldKlassBox()
-  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.k2.field2) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type 'TwoFieldKlassBox' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
@@ -209,7 +209,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsStruct4() async {
 // async let rather than the base struct.
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -220,7 +220,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple1() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -231,7 +231,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple2() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.0.k1) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -242,7 +242,7 @@ func asyncLet_Let_ActorIsolated_AccessFieldsTuple3() async {
 
 func asyncLet_Let_ActorIsolated_AccessFieldsTuple4() async {
   let x = (TwoFieldKlassBox(), TwoFieldKlassBox())
-  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = transferToMainInt(x.1.k1.field2) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{capture of 'x' with non-sendable type '(TwoFieldKlassBox, TwoFieldKlassBox)' in 'async let' binding}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendableKlass?' into main actor-isolated context may introduce data races}}
@@ -255,9 +255,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr1() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{transferring 'x2' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'x2' may cause a data race}}
   // expected-tns-note @-3 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -272,9 +272,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr2() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{transferring 'x2' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'x2' may cause a data race}}
   // expected-tns-note @-3 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -290,9 +290,9 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
   let x = NonSendableKlass()
   let x2 = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x2)) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-2 {{transferring 'x2' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'x2' may cause a data race}}
   // expected-tns-note @-3 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-5 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -311,7 +311,7 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr3() async {
 func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = useValue(transferToMainInt(x) + transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-tns-note @-2:67 {{use here could race}}
 
@@ -327,7 +327,7 @@ func asyncLet_Let_ActorIsolated_CallBuriedInOtherExpr4() async {
 func asyncLet_Let_ActorIsolated_MultipleAsyncLet1() async {
   let x = NonSendableKlass()
 
-  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a race}}
+  async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x)) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-tns-note @-2:53 {{use here could race}}
 
@@ -360,7 +360,7 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet3() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring 'x2' may cause a race}}
+  // expected-tns-warning @-1 {{transferring 'x2' may cause a data race}}
   // expected-tns-note @-2 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-4 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -378,9 +378,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet4() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
+  // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
   // expected-tns-note @-2 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{transferring 'x2' may cause a race}}
+  // expected-tns-warning @-3 {{transferring 'x2' may cause a data race}}
   // expected-tns-note @-4 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}  
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -398,9 +398,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet5() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
+  // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
   // expected-tns-note @-2 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{transferring 'x2' may cause a race}}
+  // expected-tns-warning @-3 {{transferring 'x2' may cause a data race}}
   // expected-tns-note @-4 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-5 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
   // expected-complete-warning @-6 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
@@ -418,9 +418,9 @@ func asyncLet_Let_ActorIsolated_MultipleAsyncLet6() async {
   let x2 = NonSendableKlass()
 
   async let y = useValue(transferToMainInt(x)), z = useValue(transferToMainInt(x2))
-  // expected-tns-warning @-1 {{transferring 'x' may cause a race}}
+  // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
   // expected-tns-note @-2 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-3 {{transferring 'x2' may cause a race}}
+  // expected-tns-warning @-3 {{transferring 'x2' may cause a data race}}
   // expected-tns-note @-4 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // expected-complete-warning @-6 {{capture of 'x' with non-sendable type 'NonSendableKlass' in 'async let' binding}}
@@ -775,7 +775,7 @@ func asyncLetWithoutCapture() async {
   async let x: NonSendableKlass = await returnValueFromMain()
   // expected-warning @-1 {{non-sendable type 'NonSendableKlass' returned by implicitly asynchronous call to main actor-isolated function cannot cross actor boundary}}
   let y = await x
-  await transferToMain(y) // expected-tns-warning {{transferring 'y' may cause a race}}
+  await transferToMain(y) // expected-tns-warning {{transferring 'y' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   useValue(y) // expected-tns-note {{use here could race}}

--- a/test/Concurrency/transfernonsendable_global_actor.swift
+++ b/test/Concurrency/transfernonsendable_global_actor.swift
@@ -53,13 +53,13 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 @CustomActor func useCustomActor1() async {
   let x = firstList
 
-  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedList<Int>' into main actor-isolated context may introduce data races}}
 
   let y = secondList.listHead!.next!
 
-  await transferToMainActor(y) // expected-tns-warning {{transferring 'y' may cause a race}}
+  await transferToMainActor(y) // expected-tns-warning {{transferring 'y' may cause a data race}}
   // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
@@ -71,7 +71,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
     x = secondList.listHead!.next!
   }
 
-  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  await transferToMainActor(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' into main actor-isolated context may introduce data races}}
 }
@@ -97,7 +97,7 @@ private class NonSendableLinkedListNode<T> { // expected-complete-note 3{{}}
 @CustomActor func useCustomActor5() async {
   let x = NonSendableLinkedListNode<Int>()
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to nonisolated callee could cause races in between callee nonisolated and local global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableLinkedListNode<Int>' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
@@ -113,7 +113,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = StructContainingValue()
   x = StructContainingValue()
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to nonisolated callee could cause races in between callee nonisolated and local global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
@@ -124,7 +124,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = StructContainingValue()
   x.x = firstList
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'StructContainingValue' outside of global actor 'CustomActor'-isolated context may introduce data races}}
 
@@ -135,7 +135,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
   var x = (NonSendableLinkedList<Int>(), NonSendableLinkedList<Int>())
   x = (NonSendableLinkedList<Int>(), NonSendableLinkedList<Int>())
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'x' to nonisolated callee could cause races in between callee nonisolated and local global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
@@ -148,7 +148,7 @@ private struct StructContainingValue { // expected-complete-note 2{{}}
 
   x.1 = firstList
 
-  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a race}}
+  await transferToNonIsolated(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
   // expected-tns-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to nonisolated callee could cause races between nonisolated and global actor 'CustomActor'-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-warning @-3 {{passing argument of non-sendable type '(NonSendableLinkedList<Int>, NonSendableLinkedList<Int>)' outside of global actor 'CustomActor'-isolated context may introduce data races}}
@@ -182,7 +182,7 @@ struct Clock {
   let _ = { @MainActor in
     // TODO: The type checker seems to think that the isolation here is
     // nonisolated instead of custom actor isolated.
-    print(ns) // expected-tns-warning {{transferring 'ns' may cause a race}}
+    print(ns) // expected-tns-warning {{transferring 'ns' may cause a data race}}
     // expected-tns-note @-1 {{global actor 'CustomActor'-isolated 'ns' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
     // expected-complete-warning @-2 {{capture of 'ns' with non-sendable type 'NonSendableKlass' in an isolated closure}}
   }
@@ -232,7 +232,7 @@ struct Clock {
 
   let erased: () -> Void = closure
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
   // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -241,7 +241,7 @@ struct Clock {
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
   // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -250,7 +250,7 @@ struct Clock {
 @MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
   let erased: (T) -> Void = useValueMainActor
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
   // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(T) -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -264,7 +264,7 @@ struct Clock {
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
   // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -278,7 +278,7 @@ struct Clock {
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-tns-warning {{transferring 'erased' may cause a data race}}
   // expected-tns-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> Void' outside of main actor-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -289,7 +289,7 @@ struct Clock {
     print(mainActorIsolatedGlobal)
   }
   // Regions: [{(closure), @MainActor}]
-  await transferToCustomActor(closure) // expected-tns-warning {{transferring 'closure' may cause a race}}
+  await transferToCustomActor(closure) // expected-tns-warning {{transferring 'closure' may cause a data race}}
   // expected-tns-note @-1 {{transferring main actor-isolated 'closure' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -299,7 +299,7 @@ struct Clock {
   let closure = {
     mainActorFunction()
   }
-  await transferToCustomActor(closure) // expected-tns-warning {{transferring 'closure' may cause a race}}
+  await transferToCustomActor(closure) // expected-tns-warning {{transferring 'closure' may cause a data race}}
   // expected-tns-note @-1 {{transferring main actor-isolated 'closure' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into global actor 'CustomActor'-isolated context may introduce data races}}
   // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}

--- a/test/Concurrency/transfernonsendable_global_actor_serialization.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_serialization.swift
@@ -15,6 +15,6 @@ func useValueAsync<T>(_ t: T) async {}
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
   // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_global_actor_swift6.swift
+++ b/test/Concurrency/transfernonsendable_global_actor_swift6.swift
@@ -44,21 +44,21 @@ var booleanFlag: Bool { false }
 
   let erased: () -> Void = closure
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
   // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedFunctionError() async {
   let erased: () -> Void = mainActorFunction
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
   // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
 @MainActor func synchronousActorIsolatedGenericFunctionError<T>(_ t: T) async {
   let erased: (T) -> Void = useValueMainActor
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
   // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
@@ -70,7 +70,7 @@ var booleanFlag: Bool { false }
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
   // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }
 
@@ -82,6 +82,6 @@ var booleanFlag: Bool { false }
   let t = Test()
   let erased: () -> Void = t.foo
 
-  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a race}}
+  await useValueAsync(erased) // expected-error {{transferring 'erased' may cause a data race}}
   // expected-note @-1 {{transferring main actor-isolated 'erased' to nonisolated callee could cause races between nonisolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
+++ b/test/Concurrency/transfernonsendable_isolationcrossing_partialapply.swift
@@ -40,7 +40,7 @@ actor ProtectsNonSendable {
     // TODO: This is wrong, we should get an error saying that nsArg is task
     // isolated since this is nonisolated.
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = nsArg // expected-warning {{transferring 'nsArg' may cause a race}}
+      isolatedSelf.ns = nsArg // expected-warning {{transferring 'nsArg' may cause a data race}}
       // expected-note @-1 {{task-isolated 'nsArg' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -49,7 +49,7 @@ actor ProtectsNonSendable {
     let l = NonSendableKlass()
     doSomething(l, nsArg)
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a race}}
+      isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a data race}}
       // expected-note @-1 {{task-isolated 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
   }
@@ -68,7 +68,7 @@ actor ProtectsNonSendable {
 
     // This is not safe since we use l later.
     self.assumeIsolated { isolatedSelf in
-      isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a race}}
+      isolatedSelf.ns = l // expected-warning {{transferring 'l' may cause a data race}}
       // expected-note @-1 {{disconnected 'l' is captured by a actor-isolated closure. actor-isolated uses in closure may race against later nonisolated uses}}
     }
 
@@ -86,7 +86,7 @@ func normalFunc_testLocal_1() {
 func normalFunc_testLocal_2() {
   let x = NonSendableKlass()
   let _ = { @MainActor in
-    useValue(x) // expected-warning {{transferring 'x' may cause a race}}
+    useValue(x) // expected-warning {{transferring 'x' may cause a data race}}
     // expected-note @-1 {{disconnected 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
@@ -98,7 +98,7 @@ func normalFunc_testLocal_2() {
 // diagnostic.
 func transferBeforeCaptureErrors() async {
   let x = NonSendableKlass()
-  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
   let _ = { @MainActor in // expected-note {{use here could race}}
     useValue(x)

--- a/test/Concurrency/transfernonsendable_ownership.swift
+++ b/test/Concurrency/transfernonsendable_ownership.swift
@@ -34,24 +34,24 @@ struct CustomActor {
 /////////////////
 
 func testConsuming(_ x: consuming Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testConsumingError(_ x: consuming Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
   print(x)
 }
 
 @CustomActor func testConsumingErrorGlobalActor(_ x: consuming Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   print(x)
 }
 
 func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
-  await consumeTransferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await consumeTransferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
@@ -59,7 +59,7 @@ func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected
 }
 
 @CustomActor func testConsumingUseAfterConsumeErrorGlobalActor(_ x: consuming Klass) async { // expected-error {{'x' consumed more than once}}
-  await consumeTransferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await consumeTransferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   // expected-note @-2 {{consumed here}}
   print(x)
@@ -67,41 +67,41 @@ func testConsumingUseAfterConsumeError(_ x: consuming Klass) async { // expected
 }
 
 func testBorrowing(_ x: borrowing Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testBorrowingError(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 @CustomActor func testBorrowingErrorGlobalActor(_ x: borrowing Klass) async { // expected-error {{'x' is borrowed and cannot be consumed}}
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and global actor 'CustomActor'-isolated uses}}
   print(x) // expected-note {{consumed here}}
 }
 
 func testInOut(_ x: inout Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testInOutError(_ x: inout Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee}}
   print(x)
 }
 
 @CustomActor func testInOutErrorMainActor(_ x: inout Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee}}
   print(x)
 }
 
 @CustomActor func testInOutErrorMainActor2(_ x: inout Klass) async { // expected-error {{'x' used after consume}}
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring global actor 'CustomActor'-isolated 'x' to main actor-isolated callee}}
   _ = consume x // expected-note {{consumed here}}
 } // expected-note {{used here}}

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -58,7 +58,7 @@ func test_isolation_crossing_sensitivity(a : A) async {
   foo_noniso(ns0);
 
   // This call consumes ns1
-  await a.foo(ns1); // expected-tns-warning {{transferring 'ns1' may cause a race}}
+  await a.foo(ns1); // expected-tns-warning {{transferring 'ns1' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -76,7 +76,7 @@ func test_arg_nonconsumable(a : A, ns_arg : NonSendable) async {
   await a.foo(ns_let); // expected-complete-warning {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
   // Not safe to consume an arg.
-  await a.foo(ns_arg); // expected-tns-warning {{transferring 'ns_arg' may cause a race}}
+  await a.foo(ns_arg); // expected-tns-warning {{transferring 'ns_arg' may cause a data race}}
   // expected-tns-note @-1 {{transferring task-isolated 'ns_arg' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -155,7 +155,7 @@ func test_regions(a : A, b : Bool) async {
   // check for each of the above pairs that consuming half of it consumes the other half
 
   if (b) {
-    await a.foo(ns0_0) // expected-tns-warning {{transferring 'ns0_0' may cause a race}}
+    await a.foo(ns0_0) // expected-tns-warning {{transferring 'ns0_0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -165,7 +165,7 @@ func test_regions(a : A, b : Bool) async {
       print(ns0_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns0_1) // expected-tns-warning {{transferring 'ns0_1' may cause a race}}
+    await a.foo(ns0_1) // expected-tns-warning {{transferring 'ns0_1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -177,7 +177,7 @@ func test_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns1_0) // expected-tns-warning {{transferring 'ns1_0' may cause a race}}
+    await a.foo(ns1_0) // expected-tns-warning {{transferring 'ns1_0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -187,7 +187,7 @@ func test_regions(a : A, b : Bool) async {
       print(ns1_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns1_1) // expected-tns-warning {{transferring 'ns1_1' may cause a race}}
+    await a.foo(ns1_1) // expected-tns-warning {{transferring 'ns1_1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -199,7 +199,7 @@ func test_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns2_0) // expected-tns-warning {{transferring 'ns2_0' may cause a race}}
+    await a.foo(ns2_0) // expected-tns-warning {{transferring 'ns2_0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -209,7 +209,7 @@ func test_regions(a : A, b : Bool) async {
       print(ns2_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns2_1) // expected-tns-warning {{transferring 'ns2_1' may cause a race}}
+    await a.foo(ns2_1) // expected-tns-warning {{transferring 'ns2_1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -260,7 +260,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   // now check for each pair that consuming half of it consumed the other half
 
   if (b) {
-    await a.foo(ns0_0) // expected-tns-warning {{transferring 'ns0_0' may cause a race}}
+    await a.foo(ns0_0) // expected-tns-warning {{transferring 'ns0_0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns0_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -270,7 +270,7 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns0_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns0_1) // expected-tns-warning {{transferring 'ns0_1' may cause a race}}
+    await a.foo(ns0_1) // expected-tns-warning {{transferring 'ns0_1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns0_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -282,7 +282,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns1_0) // expected-tns-warning {{transferring 'ns1_0' may cause a race}}
+    await a.foo(ns1_0) // expected-tns-warning {{transferring 'ns1_0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns1_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -292,7 +292,7 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns1_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns1_1) // expected-tns-warning {{transferring 'ns1_1' may cause a race}}
+    await a.foo(ns1_1) // expected-tns-warning {{transferring 'ns1_1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns1_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -304,7 +304,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns2_0) // expected-tns-warning {{transferring 'ns2_0' may cause a race}}
+    await a.foo(ns2_0) // expected-tns-warning {{transferring 'ns2_0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns2_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -314,7 +314,7 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns2_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns2_1) // expected-tns-warning {{transferring 'ns2_1' may cause a race}}
+    await a.foo(ns2_1) // expected-tns-warning {{transferring 'ns2_1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns2_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -326,7 +326,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns3_0) // expected-tns-warning {{transferring 'ns3_0' may cause a race}}
+    await a.foo(ns3_0) // expected-tns-warning {{transferring 'ns3_0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns3_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -336,7 +336,7 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns3_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns3_1) // expected-tns-warning {{transferring 'ns3_1' may cause a race}}
+    await a.foo(ns3_1) // expected-tns-warning {{transferring 'ns3_1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns3_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -348,7 +348,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns4_0) // expected-tns-warning {{transferring 'ns4_0' may cause a race}}
+    await a.foo(ns4_0) // expected-tns-warning {{transferring 'ns4_0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns4_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -358,7 +358,7 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns4_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns4_1) // expected-tns-warning {{transferring 'ns4_1' may cause a race}}
+    await a.foo(ns4_1) // expected-tns-warning {{transferring 'ns4_1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns4_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -370,7 +370,7 @@ func test_indirect_regions(a : A, b : Bool) async {
   }
 
   if (b) {
-    await a.foo(ns5_0) // expected-tns-warning {{transferring 'ns5_0' may cause a race}}
+    await a.foo(ns5_0) // expected-tns-warning {{transferring 'ns5_0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns5_0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
@@ -380,7 +380,7 @@ func test_indirect_regions(a : A, b : Bool) async {
       print(ns5_1) // expected-tns-note {{use here could race}}
     }
   } else {
-    await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' may cause a race}}
+    await a.foo(ns5_1) // expected-tns-warning {{transferring 'ns5_1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns5_1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'Any' into actor-isolated context may introduce data races}}
 
@@ -404,7 +404,7 @@ class C_NonSendable {
     foo_noniso(captures_self)
 
     // this is a cross-isolation call that captures non-Sendable self, so it should not be permitted
-    await a.foo(captures_self) // expected-tns-warning {{transferring 'captures_self' may cause a race}}
+    await a.foo(captures_self) // expected-tns-warning {{transferring 'captures_self' may cause a data race}}
     // expected-tns-note @-1 {{transferring task-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -441,7 +441,7 @@ actor A_Sendable {
     // actor and is non-Sendable. For now, we ban this since we do not
     // support the ability to dynamically invoke the synchronous closure on
     // the specific actor.
-    await a.foo(captures_self) // expected-tns-warning {{transferring 'captures_self' may cause a race}}
+    await a.foo(captures_self) // expected-tns-warning {{transferring 'captures_self' may cause a data race}}
     // expected-tns-note @-1 {{transferring actor-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and actor-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
@@ -452,7 +452,7 @@ func basic_loopiness(a : A, b : Bool) async {
   let ns = NonSendable()
 
   while (b) {
-    await a.foo(ns) // expected-tns-warning {{transferring 'ns' may cause a race}}
+    await a.foo(ns) // expected-tns-warning {{transferring 'ns' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-complete-warning @-3 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
@@ -470,7 +470,7 @@ func basic_loopiness_unsafe(a : A, b : Bool) async {
     (ns0, ns1, ns2, ns3) = (ns1, ns2, ns3, ns0)
   }
 
-  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns3) // expected-tns-note {{use here could race}}
@@ -535,7 +535,7 @@ func test_class_assign_merges(a : A, b : Bool) async {
   box.contents = ns0
   box.contents = ns1
 
-  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{use here could race}}
@@ -572,7 +572,7 @@ func test_stack_assign_and_capture_merges(a : A, b : Bool) async {
   contents = ns0
   contents = ns1
 
-  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   await a.foo(ns1) // expected-tns-note {{use here could race}}
@@ -590,7 +590,7 @@ func test_tuple_formation(a : A, i : Int) async {
 
   switch (i) {
   case 0:
-    await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+    await a.foo(ns0) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -610,7 +610,7 @@ func test_tuple_formation(a : A, i : Int) async {
       foo_noniso(ns13); // expected-tns-note {{use here could race}}
     }
   case 1:
-    await a.foo(ns1) // expected-tns-warning {{transferring 'ns1' may cause a race}}
+    await a.foo(ns1) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -630,7 +630,7 @@ func test_tuple_formation(a : A, i : Int) async {
       foo_noniso(ns13); // expected-tns-note {{use here could race}}
     }
   case 2:
-    await a.foo(ns2) // expected-tns-warning {{transferring 'ns2' may cause a race}}
+    await a.foo(ns2) // expected-tns-warning {{transferring 'ns2' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -650,7 +650,7 @@ func test_tuple_formation(a : A, i : Int) async {
       foo_noniso(ns13); // expected-tns-note {{use here could race}}
     }
   case 3:
-    await a.foo(ns4) // expected-tns-warning {{transferring 'ns4' may cause a race}}
+    await a.foo(ns4) // expected-tns-warning {{transferring 'ns4' may cause a data race}}
     // expected-tns-note @-1 {{transferring disconnected 'ns4' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -723,11 +723,11 @@ func one_consume_many_require(a : A) async {
 
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns0' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-4 {{transferring 'ns1' may cause a race}}
+  // expected-tns-warning @-4 {{transferring 'ns1' may cause a data race}}
   // expected-tns-note @-5 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-6 {{transferring 'ns2' may cause a race}}
+  // expected-tns-warning @-6 {{transferring 'ns2' may cause a data race}}
   // expected-tns-note @-7 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
   foo_noniso_multi(ns0, ns3, ns4); // expected-tns-note {{use here could race}}
@@ -742,11 +742,11 @@ func one_consume_one_require(a : A) async {
 
   await a.foo_multi(ns0, ns1, ns2);
   // expected-complete-warning @-1 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  // expected-tns-warning @-2 {{transferring 'ns0' may cause a race}}
+  // expected-tns-warning @-2 {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-3 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-4 {{transferring 'ns1' may cause a race}}
+  // expected-tns-warning @-4 {{transferring 'ns1' may cause a data race}}
   // expected-tns-note @-5 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
-  // expected-tns-warning @-6 {{transferring 'ns2' may cause a race}}
+  // expected-tns-warning @-6 {{transferring 'ns2' may cause a data race}}
   // expected-tns-note @-7 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
 
   foo_noniso_multi(ns0, ns1, ns2); // expected-tns-note 3{{use here could race}}
@@ -760,13 +760,13 @@ func many_consume_one_require(a : A) async {
   let ns4 = NonSendable();
   let ns5 = NonSendable();
 
-  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{transferring 'ns1' may cause a race}}
+  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{transferring 'ns2' may cause a race}}
+  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{transferring 'ns2' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
   foo_noniso_multi(ns0, ns1, ns2); //expected-tns-note 3{{use here could race}}
@@ -782,13 +782,13 @@ func many_consume_many_require(a : A) async {
   let ns6 = NonSendable();
   let ns7 = NonSendable();
 
-  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{transferring 'ns0' may cause a race}}
+  await a.foo_multi(ns0, ns3, ns3) // expected-tns-warning {{transferring 'ns0' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns0' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{transferring 'ns1' may cause a race}}
+  await a.foo_multi(ns4, ns1, ns4) // expected-tns-warning {{transferring 'ns1' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
-  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{transferring 'ns2' may cause a race}}
+  await a.foo_multi(ns5, ns5, ns2) // expected-tns-warning {{transferring 'ns2' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'ns2' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 3{{passing argument of non-sendable type 'NonSendable' into actor-isolated context may introduce data races}}
 
@@ -929,7 +929,7 @@ func enum_test(a : A) async {
         foo_noniso(e4);
   }
 
-  await a.foo(e1); // expected-tns-warning {{transferring 'e1' may cause a race}}
+  await a.foo(e1); // expected-tns-warning {{transferring 'e1' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'e1' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type 'E' into actor-isolated context may introduce data races}}
   foo_noniso(e2); // expected-tns-note {{use here could race}}

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -69,7 +69,7 @@ func twoTransferArg(_ x: transferring Klass, _ y: transferring Klass) {}
 
 func testSimpleTransferLet() {
   let k = Klass()
-  transferArg(k) // expected-warning {{transferring 'k' may cause a race}}
+  transferArg(k) // expected-warning {{transferring 'k' may cause a data race}}
   // expected-note @-1 {{'k' used after being passed as a transferring parameter}}
   useValue(k) // expected-note {{use here could race}}
 }
@@ -77,7 +77,7 @@ func testSimpleTransferLet() {
 func testSimpleTransferVar() {
   var k = Klass()
   k = Klass()
-  transferArg(k) // expected-warning {{transferring 'k' may cause a race}}
+  transferArg(k) // expected-warning {{transferring 'k' may cause a data race}}
   // expected-note @-1 {{'k' used after being passed as a transferring parameter}}
   useValue(k) // expected-note {{use here could race}}
 }
@@ -110,12 +110,12 @@ func testNonStrongTransferDoesntMerge() async {
 
 func testTransferringParameter_canTransfer(_ x: transferring Klass, _ y: Klass) async {
   await transferToMain(x)
-  await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
+  await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y: Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // TODO: We should not error on this since we are transferring to the same place.
@@ -123,7 +123,7 @@ func testTransferringParameter_cannotTransferTwice(_ x: transferring Klass, _ y:
 }
 
 func testTransferringParameter_cannotUseAfterTransfer(_ x: transferring Klass, _ y: Klass) async {
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{use here could race}}
 }
@@ -133,18 +133,18 @@ actor MyActor {
 
   func canTransferWithTransferringMethodArg(_ x: transferring Klass, _ y: Klass) async {
     await transferToMain(x)
-    await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
+    await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
     // expected-note @-1 {{transferring actor-isolated 'y' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 
   func getNormalErrorIfTransferTwice(_ x: transferring Klass) async {
-    await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
     // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
     await transferToMain(x) // expected-note {{use here could race}}
   }
 
   func getNormalErrorIfUseAfterTransfer(_ x: transferring Klass) async {
-    await transferToMain(x)  // expected-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x)  // expected-warning {{transferring 'x' may cause a data race}}
     // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local actor-isolated uses}}
     useValue(x) // expected-note {{use here could race}}
   }
@@ -159,7 +159,7 @@ actor MyActor {
   // Once we assign into the actor, we cannot transfer further.
   func assignTransferringIntoActor2(_ x: transferring Klass) async {
     field = x
-    await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+    await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
     // expected-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
   }
 }
@@ -171,7 +171,7 @@ actor MyActor {
 @MainActor func canAssignTransferringIntoGlobalActor2(_ x: transferring Klass) async {
   globalKlass = x
   // TODO: This is incorrect! transferring should be independent of @MainActor.
-  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }
 
@@ -187,7 +187,7 @@ func canTransferAssigningIntoLocal(_ x: transferring Klass) async {
 func canTransferAssigningIntoLocal2(_ x: transferring Klass) async {
 
   let _ = x
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   let _ = x // expected-note {{use here could race}}
 }
@@ -213,7 +213,7 @@ func assigningIsAMergeError(_ x: transferring Klass) async {
   x = y
 
   // We can still transfer y since x is disconnected.
-  await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
+  await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
@@ -234,7 +234,7 @@ func assigningIsAMergeAnyError(_ x: transferring Any) async {
 
   x = y
 
-  await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
+  await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
@@ -260,7 +260,7 @@ func canTransferAfterAssignButUseIsError(_ x: transferring Any) async {
   x = y
 
   // TODO: This should refer to the transferring parameter.
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   useValue(x) // expected-note {{use here could race}}
@@ -290,7 +290,7 @@ func mergeDoesNotEliminateEarlierTransfer(_ x: transferring NonSendableStruct) a
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   // y is assigned into a field of x.
@@ -306,7 +306,7 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
   useValue(x)
 
   // Transfer x
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
 
   x.first = y  // expected-note {{use here could race}}
@@ -314,14 +314,14 @@ func mergeDoesNotEliminateEarlierTransfer2(_ x: transferring NonSendableStruct) 
 
 func doubleArgument() async {
   let x = Klass()
-  twoTransferArg(x, x) // expected-warning {{transferring 'x' may cause a race}}
+  twoTransferArg(x, x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{'x' used after being passed as a transferring parameter}}
   // expected-note @-2 {{use here could race}}
 }
 
 func testTransferSrc(_ x: transferring Klass) async {
   let y = Klass()
-  await transferToMain(y) // expected-warning {{transferring 'y' may cause a race}}
+  await transferToMain(y) // expected-warning {{transferring 'y' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   x = y // expected-note {{use here could race}}
 }
@@ -337,7 +337,7 @@ func testTransferOtherParamTuple(_ x: transferring Klass, y: (Klass, Klass)) asy
 func taskIsolatedError(_ x: @escaping @MainActor () async -> ()) {
   func fakeInit(operation: transferring @escaping () async -> ()) {}
 
-  fakeInit(operation: x) // expected-warning {{transferring 'x' may cause a race}}
+  fakeInit(operation: x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
@@ -345,7 +345,7 @@ func taskIsolatedError(_ x: @escaping @MainActor () async -> ()) {
   func fakeInit(operation: transferring @escaping () async -> ()) {}
 
   // TODO: This needs to say actor-isolated.
-  fakeInit(operation: x) // expected-warning {{transferring 'x' may cause a race}}
+  fakeInit(operation: x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later main actor-isolated uses}}
 }
 
@@ -354,12 +354,12 @@ func taskIsolatedError(_ x: @escaping @MainActor () async -> ()) {
 func testMergeWithTaskIsolated(_ x: transferring Klass, y: Klass) async {
   await transferToMain(x)
   x = y
-  await transferToMain(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 @MainActor func testMergeWithActorIsolated(_ x: transferring Klass, y: Klass) async {
   x = y
-  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToCustom(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring main actor-isolated 'x' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and main actor-isolated uses}}
 }

--- a/test/Concurrency/transfernonsendable_strong_transferring_results.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_results.swift
@@ -85,7 +85,7 @@ func simpleTest() async {
 func simpleTest2() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x)
-  await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y)
   useValue(x) // expected-note {{use here could race}}
@@ -96,14 +96,14 @@ func simpleTest3() async {
   let x = NonSendableKlass()
   let y = transferResultWithArg(x)
   await transferToMainDirect(x)
-  await transferToMainDirect(y) // expected-warning {{transferring 'y' may cause a race}}
+  await transferToMainDirect(y) // expected-warning {{transferring 'y' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'y' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y) // expected-note {{use here could race}}
 }
 
 func transferResult() async -> transferring NonSendableKlass {
   let x = NonSendableKlass()
-  await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a race}}
+  await transferToMainDirect(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   return x // expected-note {{use here could race}}
 }
@@ -114,13 +114,13 @@ func transferInAndOut(_ x: transferring NonSendableKlass) -> transferring NonSen
 
 
 func transferReturnArg(_ x: NonSendableKlass) -> transferring NonSendableKlass {
-  return x // expected-warning {{transferring 'x' may cause a race}}
+  return x // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{task-isolated 'x' cannot be a transferring result. task-isolated uses may race with caller uses}}
 }
 
 // TODO: This will be fixed once I represent @MainActor on func types.
 @MainActor func transferReturnArgMainActor(_ x: NonSendableKlass) -> transferring NonSendableKlass {
-  return x // expected-warning {{transferring 'x' may cause a race}}
+  return x // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'x' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 }
 
@@ -141,7 +141,7 @@ func useTransferredResult() async {
 
 extension MainActorIsolatedStruct {
   func testNonSendableErrorReturnWithTransfer() -> transferring NonSendableKlass {
-    return ns // expected-warning {{transferring 'self.ns' may cause a race}}
+    return ns // expected-warning {{transferring 'self.ns' may cause a data race}}
     // expected-note @-1 {{main actor-isolated 'self.ns' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
   }
   func testNonSendableErrorReturnNoTransfer() -> NonSendableKlass {
@@ -157,7 +157,7 @@ extension MainActorIsolatedEnum {
     case .second(let ns):
       return ns
     }
-  } // expected-warning {{transferring 'ns.some' may cause a race}}
+  } // expected-warning {{transferring 'ns.some' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}}
 
   func testSwitchReturnNoTransfer() -> NonSendableKlass? {
@@ -174,7 +174,7 @@ extension MainActorIsolatedEnum {
       return ns // TODO: The error below should be here.
     }
     return nil
-  } // expected-warning {{transferring 'ns.some' may cause a race}}
+  } // expected-warning {{transferring 'ns.some' may cause a data race}}
   // expected-note @-1 {{main actor-isolated 'ns.some' cannot be a transferring result. main actor-isolated uses may race with caller uses}} 
 
   func testIfLetReturnNoTransfer() -> NonSendableKlass? {

--- a/test/Concurrency/transfernonsendable_unavailable_conformance.swift
+++ b/test/Concurrency/transfernonsendable_unavailable_conformance.swift
@@ -19,7 +19,7 @@ actor Bar {
   }
   func bar() async {
     let ns = NonSendable()
-    _ = Bar(ns) // expected-warning {{transferring 'ns' may cause a race}}
+    _ = Bar(ns) // expected-warning {{transferring 'ns' may cause a data race}}
     // TODO: This needs to be:
     // disconnected 'ns' is transferred to actor-isolated callee. Later local uses could race with uses in callee.
     // expected-note @-3 {{transferring disconnected 'ns' to actor-isolated callee could cause races in between callee actor-isolated and local actor-isolated uses}}

--- a/test/Concurrency/transfernonsendable_warning_until_swift6.swift
+++ b/test/Concurrency/transfernonsendable_warning_until_swift6.swift
@@ -20,18 +20,18 @@ func transferValue<T>(_ t: transferring T) {}
 
 func testIsolationError() async {
   let x = NonSendableType()
-  await transferToMain(x) // expected-error {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-error {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(x) // expected-note {{use here could race}}
 }
 
 func testTransferArgumentError(_ x: NonSendableType) async {
-  await transferToMain(x) // expected-error {{transferring 'x' may cause a race}}
+  await transferToMain(x) // expected-error {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring task-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and task-isolated uses}}
 }
 
 func testPassArgumentAsTransferringParameter(_ x: NonSendableType) async {
-  transferValue(x) // expected-error {{transferring 'x' may cause a race}}
+  transferValue(x) // expected-error {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{task-isolated 'x' is passed as a transferring parameter; Uses in callee may race with later task-isolated uses}}
 }
 
@@ -49,7 +49,7 @@ func testAssigningParameterIntoTransferringParameter(_ x: transferring NonSendab
 func testIsolationCrossingDueToCapture() async {
   let x = NonSendableType()
   let _ = { @MainActor in
-    print(x) // expected-error {{transferring 'x' may cause a race}}
+    print(x) // expected-error {{transferring 'x' may cause a data race}}
     // expected-note @-1 {{disconnected 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x) // expected-note {{use here could race}}
@@ -57,7 +57,7 @@ func testIsolationCrossingDueToCapture() async {
 
 func testIsolationCrossingDueToCaptureParameter(_ x: NonSendableType) async {
   let _ = { @MainActor in
-    print(x) // expected-error {{transferring 'x' may cause a race}}
+    print(x) // expected-error {{transferring 'x' may cause a data race}}
     // expected-note @-1 {{task-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
   }
   useValue(x)


### PR DESCRIPTION
Specifically, I am transforming it from "may cause a race" -> "may cause a data race". Adding data is a small thing, but it adds a bunch of nice clarity.
