### PR TITLE
[embedded] Don't retain subclass vtable entries if the base method was DCE'd

### DIFF
--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -556,6 +556,12 @@ class DeadFunctionAndGlobalElimination {
         auto *fd = getBaseMethod(
             cast<AbstractFunctionDecl>(entry.getMethod().getDecl()));
 
+        // In Embedded Swift, we don't expect SILFunction without definitions on
+        // vtable entries. Having one means the base method was DCE'd already,
+        // so let's avoid marking it alive in the subclass vtable either.
+        bool embedded = Module->getOptions().EmbeddedSwift;
+        if (embedded && !F->isDefinition()) { continue; }
+        
         if (// We also have to check the method declaration's access level.
             // Needed if it's a public base method declared in another
             // compilation unit (for this we have no SILFunction).

--- a/test/embedded/modules-subclasses.swift
+++ b/test/embedded/modules-subclasses.swift
@@ -7,6 +7,18 @@
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
+// RUN: %target-swift-frontend -O -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -O -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// RUN: %target-swift-frontend -Osize -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -Osize -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu


### PR DESCRIPTION
The reproducer for this problem is a -O/-Osize version of a testcase we already have, test/embedded/modules-subclasses.swift. What happens is that under -O/-Osize, the module that defines the base class has an unused internal method on the class, that method is proven by DeadFunctionElimination to be unused, and is removed from the base vtable. The client module then defines a subclass, and the subclass vtable references the (removed) base class method.

This PR simply allows DeadFunctionElimination on the client module to remove the entry from the subclass as well.

Fixes https://github.com/apple/swift/issues/72890.

rdar://126044717
