### PR TITLE
runtime: add an explicit cast for older C++ runtimes

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -313,7 +313,8 @@ reportOnCrash(uint32_t flags, const char *message)
     else
       current = ::strdup(message);
   } while (!std::atomic_compare_exchange_strong_explicit(&kFatalErrorMessage,
-                                                         &previous, current,
+                                                         &previous,
+                                                         static_cast<const char *>(current),
                                                          std::memory_order_release,
                                                          SWIFT_MEMORY_ORDER_CONSUME));
 #endif // SWIFT_HAVE_CRASHREPORTERCLIENT


### PR DESCRIPTION
The older C++ runtime seems to be unhappy with the implicit conversion of the parameters:

~~~
FAILED: stdlib/public/runtime/CMakeFiles/swiftRuntime-linux-x86_64.dir/Errors.cpp.o /home/build-user/build/buildbot_incremental_lsan/llvm-linux-x86_64/./bin/clang++ -DCMARK_STATIC_DEFINE -DGTEST_HAS_RTTI=0 -DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -DSWIFT_BUILD_SWIFT_SYNTAX -DSWIFT_INLINE_NAMESPACE=__runtime -D_DEBUG -D_GLIBCXX_ASSERTIONS -D_LIBCPP_ENABLE_HARDENED_MODE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -I/home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/stdlib/public/runtime -I/home/build-user/swift/stdlib/public/runtime -I/home/build-user/swift/stdlib/include -I/home/build-user/swift/stdlib/public/SwiftShims -I/home/build-user/build/buildbot_incremental_lsan/swift-linux-x86_64/include -I/home/build-user/swift/include -I/home/build-user/build/buildbot_incremental_lsan/llvm-linux-x86_64/include -I/home/build-user/llvm-project/clang/include -I/home/build-user/build/buildbot_incremental_lsan/llvm-linux-x86_64/tools/clang/include -I/home/build-user/cmark/src/include -I/home/build-user/build/buildbot_incremental_lsan/cmark-linux-x86_64/src -I/home/build-user/swift-corelibs-libdispatch/src/BlocksRuntime -I/home/build-user/swift-corelibs-libdispatch -gline-tables-only -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -Wall -Wextra -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wimplicit-fallthrough -Wcovered-switch-default -Wno-noexcept-type -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wsuggest-override -Wstring-conversion -Wmisleading-indentation -Wctad-maybe-unsupported -fno-omit-frame-pointer -fsanitize=leak -fdiagnostics-color -ffunction-sections -fdata-sections -O2 -DNDEBUG -fvisibility=hidden -fvisibility-inlines-hidden -fno-exceptions -funwind-tables -fno-rtti -Werror=gnu -Werror=c++98-compat-extra-semi -UNDEBUG -Werror=switch -Wimplicit-fallthrough -Wunreachable-code -Woverloaded-virtual -Wno-nested-anon-types -fno-sanitize=all -Wall -Wformat-nonliteral -Werror=format-nonliteral -Wglobal-constructors -Werror=global-constructors -Wexit-time-destructors -Werror=exit-time-destructors -DSWIFT_RUNTIME_CLOBBER_FREED_OBJECTS=1 -DswiftCore_EXPORTS -I/home/build-user/swift/stdlib/include/llvm/Support -I/home/build-user/swift/include -DSWIFT_TARGET_LIBRARY_NAME=swiftRuntime -DSWIFT_RUNTIME -DSWIFT_LIB_SUBDIR="linux" -DSWIFT_ARCH="x86_64" -target x86_64-unknown-linux-gnu -fno-omit-frame-pointer -O0 -g -mcx16 -DSWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS -march=core2 -DSWIFT_OBJC_INTEROP=0 -DSWIFT_LIBRARY_EVOLUTION=1 -DSWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT -DSWIFT_ENABLE_REFLECTION -DSWIFT_STDLIB_HAS_DLADDR -DSWIFT_STDLIB_HAS_DLSYM=1 -DSWIFT_STDLIB_HAS_FILESYSTEM -DSWIFT_STDLIB_HAS_DARWIN_LIBMALLOC=1 -DSWIFT_STDLIB_HAS_STDIN -DSWIFT_STDLIB_HAS_ENVIRON -DSWIFT_STDLIB_HAS_LOCALE -DSWIFT_THREADING_LINUX -DSWIFT_RUNTIME_OS_VERSIONING -DSWIFT_STDLIB_SHORT_MANGLING_LOOKUPS -DSWIFT_STDLIB_ENABLE_VECTOR_TYPES -DSWIFT_STDLIB_HAS_TYPE_PRINTING -DSWIFT_STDLIB_SUPPORTS_BACKTRACE_REPORTING -DSWIFT_STDLIB_ENABLE_UNICODE_DATA -DSWIFT_STDLIB_OVERRIDABLE_RETAIN_RELEASE -std=c++17 -MD -MT stdlib/public/runtime/CMakeFiles/swiftRuntime-linux-x86_64.dir/Errors.cpp.o -MF stdlib/public/runtime/CMakeFiles/swiftRuntime-linux-x86_64.dir/Errors.cpp.o.d -o stdlib/public/runtime/CMakeFiles/swiftRuntime-linux-x86_64.dir/Errors.cpp.o -c /home/build-user/swift/stdlib/public/runtime/Errors.cpp /home/build-user/swift/stdlib/public/runtime/Errors.cpp:315:13: error: no matching function for call to 'atomic_compare_exchange_strong_explicit' 315 | } while (!std::atomic_compare_exchange_strong_explicit(&kFatalErrorMessage, | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/lib/gcc/x86_64-linux-gnu/7/../../../../include/c++/7/atomic:1121:5: note: candidate template ignored: deduced conflicting types for parameter '_ITp' ('const char ' vs. 'char ') 1121 | atomic_compare_exchange_strong_explicit(atomic<_ITp> __a, | ^
/usr/lib/gcc/x86_64-linux-gnu/7/../../../../include/c++/7/atomic:1129:5: note: candidate template ignored: deduced conflicting types for parameter '_ITp' ('const char ' vs. 'char ') 1129 | atomic_compare_exchange_strong_explicit(volatile atomic<_ITp> __a, | ^
/usr/lib/gcc/x86_64-linux-gnu/7/../../../../include/c++/7/bits/shared_ptr_atomic.h:220:5: note: candidate template ignored: could not match 'shared_ptr' against 'atomic' 220 | atomic_compare_exchange_strong_explicit(shared_ptr<_Tp> __p, | ^
/usr/lib/gcc/x86_64-linux-gnu/7/../../../../include/c++/7/bits/shared_ptr_atomic.h:272:5: note: candidate template ignored: could not match '__shared_ptr' against 'atomic' 272 | atomic_compare_exchange_strong_explicit(__shared_ptr<_Tp, _Lp> __p, | ^
1 error generated.
~~~

Use an explicit cast to resolve the ambiguity.