### PR TITLE
[CodeCompletion] Parse multiple `catch` clauses if the `do` body contains the code completion token

### DIFF
--- a/test/IDE/complete_do_with_multiple_catch_in_closure.swift
+++ b/test/IDE/complete_do_with_multiple_catch_in_closure.swift
@@ -1,0 +1,15 @@
+// RUN: %batch-code-completion
+
+func takeClosure(_ body: () -> Void) {}
+
+func test() {
+  let myVar = 1
+  takeClosure {
+    do {
+      #^COMPLETE^#
+// COMPLETE: Decl[LocalVar]/Local: myVar[#Int#];
+    } catch let error as Int {
+    } catch let error {
+    }
+  }
+}


### PR DESCRIPTION
rdar://125303959
