### PR TITLE
SILGen: Ignore placeholders and missing methods during conformance emission

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -554,11 +554,7 @@ public:
     PrettyStackTraceConformance trace("generating SIL witness table",
                                       Conformance);
 
-    // Check whether the conformance is valid first.
     Conformance->resolveValueWitnesses();
-    if (Conformance->isInvalid())
-      return nullptr;
-
     auto *proto = Conformance->getProtocol();
     visitProtocolDecl(proto);
 
@@ -619,13 +615,12 @@ public:
     return Conformance->getWitness(decl);
   }
 
-  void addPlaceholder(MissingMemberDecl *placeholder) {
-    llvm_unreachable("generating a witness table with placeholders in it");
-  }
-
-  void addMissingMethod(SILDeclRef requirement) {
-    llvm_unreachable("generating a witness table with placeholders in it");
-  }
+  // Treat placeholders and missing methods as no-ops. These may be encountered
+  // during lazy typechecking when SILGen triggers witness resolution and
+  // discovers and invalid conformance. The diagnostics emitted during witness
+  // resolution should cause compilation to fail.
+  void addPlaceholder(MissingMemberDecl *placeholder) {}
+  void addMissingMethod(SILDeclRef requirement) {}
 
   void addMethodImplementation(SILDeclRef requirementRef,
                                SILDeclRef witnessRef,


### PR DESCRIPTION
Builds on https://github.com/apple/swift/pull/72286.

Use a more forgiving strategy when handling potentially invalid conformances during SILGen. Conformances may be erroneously marked invalid during witness resolution, even when they can still be successfully emitted, so we can't bail out of witness table emission if the invalid bit is set. Instead, just ignore placeholders and missing methods in the witness table emitter and trust that if an error was diagnosed during resolution that compilation will be aborted.

Resolves rdar://125947349
