### PR TITLE
[6.0 cherry-pick][embedded] Don't retain subclass vtable entries if the base method was DCE'd

### DIFF
--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -556,6 +556,12 @@ class DeadFunctionAndGlobalElimination {
         auto *fd = getBaseMethod(
             cast<AbstractFunctionDecl>(entry.getMethod().getDecl()));
 
+        // In Embedded Swift, we don't expect SILFunction without definitions on
+        // vtable entries. Having one means the base method was DCE'd already,
+        // so let's avoid marking it alive in the subclass vtable either.
+        bool embedded = Module->getOptions().EmbeddedSwift;
+        if (embedded && !F->isDefinition()) { continue; }
+        
         if (// We also have to check the method declaration's access level.
             // Needed if it's a public base method declared in another
             // compilation unit (for this we have no SILFunction).

--- a/test/embedded/modules-subclasses.swift
+++ b/test/embedded/modules-subclasses.swift
@@ -7,6 +7,18 @@
 // RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 
+// RUN: %target-swift-frontend -O -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -O -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// RUN: %target-swift-frontend -Osize -emit-module -o %t/MyModule.swiftmodule %t/MyModule.swift -enable-experimental-feature Embedded -parse-as-library
+// RUN: %target-swift-frontend -Osize -c -I %t %t/Main.swift -enable-experimental-feature Embedded -o %t/a.o
+// RUN: %target-clang -x c -c %S/Inputs/print.c -o %t/print.o
+// RUN: %target-clang %t/a.o %t/print.o -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu


### PR DESCRIPTION
* **Explanation**: Under -O/-Osize, subclasses defined across modules in Embedded Swift can result in missing symbols at link time, when an unused base class method is eliminated by dead function elimination. To fix this, we allow dead function elimination to correctly eliminate the method in the subclass too. https://github.com/apple/swift/pull/72898
* **Scope**: Embedded Swift only.
* **Risk**: Low, all changes only apply to Embedded Swift.
* **Testing**: Added test case.
* **Issue**: rdar://126044717, https://github.com/apple/swift/issues/72890
* **Reviewer**: @eeckstein on https://github.com/apple/swift/pull/72898
