### PR TITLE
AST: Remove incorrect optimization from ASTContext::getOpenedExistentialSignature()

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5866,18 +5866,6 @@ ASTContext::getOpenedExistentialSignature(Type type, GenericSignature parentSig)
   assert(parentSig || !constraint->hasTypeParameter() &&
          "Interface type here requires a parent signature");
 
-  // The opened archetype signature for a protocol type is identical
-  // to the protocol's own canonical generic signature if there aren't any
-  // outer generic parameters to worry about.
-  if (parentSig.isNull()) {
-    if (const auto protoTy = dyn_cast<ProtocolType>(constraint)) {
-      return protoTy->getDecl()->getGenericSignature().getCanonicalSignature();
-    }
-  }
-
-  // Otherwise we need to build a generic signature that captures any outer
-  // generic parameters. This ensures that we keep e.g. generic superclass
-  // existentials contained in a well-formed generic context.
   auto canParentSig = parentSig.getCanonicalSignature();
   auto key = std::make_pair(constraint, canParentSig.getPointer());
   auto found = getImpl().ExistentialSignatures.find(key);

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -792,18 +792,6 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
       parentSig = extendedNominal->getGenericSignatureOfContext();
       genericParams = nullptr;
     }
-
-    // Re-use the signature of the type being extended by default.
-    // For tuple extensions, always build a new signature to get
-    // the right sugared types, since we don't want to expose the
-    // name of the generic parameter of BuiltinTupleDecl itself.
-    if (extraReqs.empty() && !ext->getTrailingWhereClause() &&
-        !isa<BuiltinTupleDecl>(extendedNominal) &&
-        false/*!ctx.LangOpts.hasFeature(Feature::NoncopyableGenerics)*/) {
-      // FIXME: Recover this optimization even with NoncopyableGenerics on.
-      return parentSig;
-    }
-
   } else {
     llvm_unreachable("Unknown generic declaration kind");
   }

--- a/test/SILOptimizer/sil_combine_concrete_existential_noncopyable.swift
+++ b/test/SILOptimizer/sil_combine_concrete_existential_noncopyable.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-frontend -emit-sil -O %s -enable-experimental-feature NoncopyableGenerics | %FileCheck %s
+
+protocol P: ~Copyable {}
+
+@_optimize(none)
+func f<T: P>(_: T) {}
+
+public struct S: P {
+  @_optimize(none)
+  init() {}
+}
+
+// CHECK-LABEL: sil @$s44sil_combine_concrete_existential_noncopyable1gyyF : $@convention(thin) () -> () {
+// CHECK: [[S_ADDR:%.*]] =  alloc_stack $S
+// CHECK: [[INIT_FN:%.*]] = function_ref @$s44sil_combine_concrete_existential_noncopyable1SVACycfC : $@convention(method) (@thin S.Type) -> S
+// CHECK: [[S:%.*]] = apply [[INIT_FN]]({{%.*}}) : $@convention(method) (@thin S.Type) -> S
+// CHECK: store [[S]] to [[S_ADDR]]
+// CHECK: [[CALLEE_FN:%.*]] = function_ref @$s44sil_combine_concrete_existential_noncopyable1fyyxAA1PRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+// CHECK: apply [[CALLEE_FN]]<S>([[S_ADDR]])
+// CHECK: return
+
+public func g() {
+  let e: any P = S()
+  f(e)
+}


### PR DESCRIPTION
It is no longer true that the existential signature of `any P` is
always just `<Self where Self: P>`, because `P` might be `~Copyable`,
in which case `any P` is really `any P & Copyable`.

Just remove the micro-optimization here, because if we're building
an existential signature, we're likely going to be doing generic
signature queries, and then we'll need a Requirement Machine anyway.

This happened to manifest in the SIL optimizer when performing the
concrete existential peephole with `any Sendable`, since Sendable is
now ~Copyable.

Fixes rdar://problem/126079282.