### PR TITLE
6.0: [BitwiseCopyable] Don't infer for noncopyable.

### DIFF
--- a/lib/Sema/TypeCheckBitwise.cpp
+++ b/lib/Sema/TypeCheckBitwise.cpp
@@ -229,6 +229,12 @@ void BitwiseCopyableStorageVisitor::emitNonconformingMemberTypeDiagnostic(
 static bool checkBitwiseCopyableInstanceStorage(NominalTypeDecl *nominal,
                                                 DeclContext *dc,
                                                 BitwiseCopyableCheck check) {
+  if (dc->mapTypeIntoContext(nominal->getDeclaredInterfaceType())
+          ->isNoncopyable()) {
+    // Already separately diagnosed when explicit.
+    return true;
+  }
+
   assert(dc->getParentModule()->getASTContext().getProtocol(
       KnownProtocolKind::BitwiseCopyable));
 

--- a/test/ModuleInterface/bitwise_copyable.swift
+++ b/test/ModuleInterface/bitwise_copyable.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -module-name Test -enable-experimental-feature BitwiseCopyable
+// RUN: %FileCheck %s < %t.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface) -module-name Test
+
+
+@frozen
+@_moveOnly
+public struct S_Implicit_Noncopyable {}
+
+// CHECK-NOT: extension Test.S_Implicit_Noncopyable : Swift._BitwiseCopyable {}


### PR DESCRIPTION
**Explanation**: Restore an incorrectly removed bailout for BitwiseCopyable inference.

When removing a bespoke diagnostic, the bailout that would occur under the same circumstances that the diagnostic would be emitted was removed.  This change restores the bailout.
**Scope**: Affects BitwiseCopyable checking.
**Issue**: rdar://126135770
**Original PR**: https://github.com/apple/swift/pull/72929
**Risk**: Very low.
**Testing**: Added a test case.
**Reviewer**: Kavon Farvardin ( @kavon )
