### PR TITLE
Request-ify TypeChecker::computeCaptures()

### DIFF
--- a/include/swift/AST/CaptureInfo.h
+++ b/include/swift/AST/CaptureInfo.h
@@ -185,24 +185,19 @@ public:
   }
 
   bool isTrivial() const {
+    assert(hasBeenComputed());
     return getCaptures().empty() && !hasGenericParamCaptures() &&
            !hasDynamicSelfCapture() && !hasOpaqueValueCapture();
   }
 
   ArrayRef<CapturedValue> getCaptures() const {
-    // FIXME: Ideally, everywhere that synthesizes a function should include
-    // its capture info.
-    if (!hasBeenComputed())
-      return std::nullopt;
+    assert(hasBeenComputed());
     return StorageAndFlags.getPointer()->getCaptures();
   }
 
   /// \returns true if the function captures any generic type parameters.
   bool hasGenericParamCaptures() const {
-    // FIXME: Ideally, everywhere that synthesizes a function should include
-    // its capture info.
-    if (!hasBeenComputed())
-      return false;
+    assert(hasBeenComputed());
     return StorageAndFlags.getInt().contains(Flags::HasGenericParamCaptures);
   }
 
@@ -213,22 +208,17 @@ public:
 
   /// \returns the captured dynamic Self type, if any.
   DynamicSelfType *getDynamicSelfType() const {
-    // FIXME: Ideally, everywhere that synthesizes a function should include
-    // its capture info.
-    if (!hasBeenComputed())
-      return nullptr;
+    assert(hasBeenComputed());
     return StorageAndFlags.getPointer()->getDynamicSelfType();
   }
 
   bool hasOpaqueValueCapture() const {
+    assert(hasBeenComputed());
     return getOpaqueValue() != nullptr;
   }
 
   OpaqueValueExpr *getOpaqueValue() const {
-    // FIXME: Ideally, everywhere that synthesizes a function should include
-    // its capture info.
-    if (!hasBeenComputed())
-      return nullptr;
+    assert(hasBeenComputed());
     return StorageAndFlags.getPointer()->getOpaqueValue();
   }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -7755,7 +7755,11 @@ public:
   SourceRange getSignatureSourceRange() const;
 
   CaptureInfo getCaptureInfo() const { return Captures; }
-  void setCaptureInfo(CaptureInfo captures) { Captures = captures; }
+
+  void setCaptureInfo(CaptureInfo captures) {
+    assert(captures.hasBeenComputed());
+    Captures = captures;
+  }
 
   /// Retrieve the Objective-C selector that names this method.
   ObjCSelector getObjCSelector(DeclName preferredName = DeclName(),

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6814,9 +6814,14 @@ public:
 
   void setDefaultArgumentInitContext(Initializer *initContext);
 
-  CaptureInfo getDefaultArgumentCaptureInfo() const {
+  CaptureInfo getDefaultArgumentCaptureInfo() const;
+
+  std::optional<CaptureInfo> getCachedDefaultArgumentCaptureInfo() const {
     assert(DefaultValueAndFlags.getPointer());
-    return DefaultValueAndFlags.getPointer()->Captures;
+    const auto &captures = DefaultValueAndFlags.getPointer()->Captures;
+    if (!captures.hasBeenComputed())
+      return std::nullopt;
+    return captures;
   }
 
   void setDefaultArgumentCaptureInfo(CaptureInfo captures);
@@ -7754,7 +7759,13 @@ public:
   /// Retrieve the source range of the function declaration name + patterns.
   SourceRange getSignatureSourceRange() const;
 
-  CaptureInfo getCaptureInfo() const { return Captures; }
+  CaptureInfo getCaptureInfo() const;
+
+  std::optional<CaptureInfo> getCachedCaptureInfo() const {
+    if (!Captures.hasBeenComputed())
+      return std::nullopt;
+    return Captures;
+  }
 
   void setCaptureInfo(CaptureInfo captures) {
     assert(captures.hasBeenComputed());

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3913,7 +3913,11 @@ public:
           &foundIsolationCrossings);
 
   CaptureInfo getCaptureInfo() const { return Captures; }
-  void setCaptureInfo(CaptureInfo captures) { Captures = captures; }
+
+  void setCaptureInfo(CaptureInfo captures) {
+    assert(captures.hasBeenComputed());
+    Captures = captures;
+  }
 
   /// Retrieve the parameters of this closure.
   ParameterList *getParameters() { return parameterList; }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3912,7 +3912,16 @@ public:
           std::tuple<CapturedValue, unsigned, ApplyIsolationCrossing>>
           &foundIsolationCrossings);
 
-  CaptureInfo getCaptureInfo() const { return Captures; }
+  CaptureInfo getCaptureInfo() const {
+    assert(Captures.hasBeenComputed());
+    return Captures;
+  }
+
+  std::optional<CaptureInfo> getCachedCaptureInfo() const {
+    if (!Captures.hasBeenComputed())
+      return std::nullopt;
+    return Captures;
+  }
 
   void setCaptureInfo(CaptureInfo captures) {
     assert(captures.hasBeenComputed());

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4949,6 +4949,47 @@ private:
 public:
   // Caching.
   bool isCached() const { return true; }
+
+};
+
+class CaptureInfoRequest :
+    public SimpleRequest<CaptureInfoRequest,
+                         CaptureInfo(AbstractFunctionDecl *),
+                         RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  CaptureInfo evaluate(Evaluator &evaluator, AbstractFunctionDecl *func) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  std::optional<CaptureInfo> getCachedResult() const;
+  void cacheResult(CaptureInfo value) const;
+};
+
+class ParamCaptureInfoRequest :
+    public SimpleRequest<ParamCaptureInfoRequest,
+                         CaptureInfo(ParamDecl *),
+                         RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  CaptureInfo evaluate(Evaluator &evaluator, ParamDecl *param) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  std::optional<CaptureInfo> getCachedResult() const;
+  void cacheResult(CaptureInfo value) const;
 };
 
 class SuppressesConformanceRequest

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -571,3 +571,10 @@ SWIFT_REQUEST(TypeChecker, LifetimeDependenceInfoRequest,
 SWIFT_REQUEST(TypeChecker, SuppressesConformanceRequest,
               bool(NominalTypeDecl *decl, KnownProtocolKind kp),
               SeparatelyCached, NoLocationInfo)
+
+SWIFT_REQUEST(TypeChecker, CaptureInfoRequest,
+              CaptureInfo(AbstractFunctionDecl *),
+              SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ParamCaptureInfoRequest,
+              CaptureInfo(ParamDecl *),
+              SeparatelyCached, NoLocationInfo)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1402,10 +1402,10 @@ namespace {
         printField(PD->getDefaultArgumentKind(), "default_arg");
       }
       if (PD->hasDefaultExpr() &&
-          PD->getDefaultArgumentCaptureInfo().hasBeenComputed() &&
-          !PD->getDefaultArgumentCaptureInfo().isTrivial()) {
+          PD->getCachedDefaultArgumentCaptureInfo() &&
+          !PD->getCachedDefaultArgumentCaptureInfo()->isTrivial()) {
         printFieldRaw([&](raw_ostream &OS) {
-          PD->getDefaultArgumentCaptureInfo().print(OS);
+          PD->getCachedDefaultArgumentCaptureInfo()->print(OS);
         }, "", CapturesColor);
       }
       
@@ -1489,11 +1489,12 @@ namespace {
 
     void printCommonAFD(AbstractFunctionDecl *D, const char *Type, StringRef Label) {
       printCommon(D, Type, Label, FuncColor);
-      if (D->getCaptureInfo().hasBeenComputed() &&
-          !D->getCaptureInfo().isTrivial()) {
-        printFlagRaw([&](raw_ostream &OS) {
-          D->getCaptureInfo().print(OS);
-        });
+      if (auto captureInfo = D->getCachedCaptureInfo()) {
+        if (!captureInfo->isTrivial()) {
+          printFlagRaw([&](raw_ostream &OS) {
+            captureInfo->print(OS);
+          });
+        }
       }
 
       if (auto *attr = D->getAttrs().getAttribute<NonisolatedAttr>()) {
@@ -2828,11 +2829,12 @@ public:
       break;
     }
 
-    if (E->getCaptureInfo().hasBeenComputed() &&
-        !E->getCaptureInfo().isTrivial()) {
-      printFieldRaw([&](raw_ostream &OS) {
-        E->getCaptureInfo().print(OS);
-      }, "", CapturesColor);
+    if (auto captureInfo = E->getCachedCaptureInfo()) {
+      if (!captureInfo->isTrivial()) {
+        printFieldRaw([&](raw_ostream &OS) {
+          captureInfo->print(OS);
+        }, "", CapturesColor);
+      }
     }
     // Printing a function type doesn't indicate whether it's escaping because it doesn't 
     // matter in 99% of contexts. AbstractClosureExpr nodes are one of the only exceptions.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8718,6 +8718,7 @@ void ParamDecl::setDefaultArgumentInitContext(Initializer *initContext) {
 
 void ParamDecl::setDefaultArgumentCaptureInfo(CaptureInfo captures) {
   assert(DefaultValueAndFlags.getPointer());
+  assert(captures.hasBeenComputed());
   DefaultValueAndFlags.getPointer()->Captures = captures;
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8716,6 +8716,16 @@ void ParamDecl::setDefaultArgumentInitContext(Initializer *initContext) {
   defaultInfo->InitContextAndIsTypeChecked.setPointer(initContext);
 }
 
+CaptureInfo ParamDecl::getDefaultArgumentCaptureInfo() const {
+  if (!DefaultValueAndFlags.getPointer())
+    return CaptureInfo::empty();
+
+  auto &ctx = getASTContext();
+  return evaluateOrDefault(ctx.evaluator,
+                           ParamCaptureInfoRequest{const_cast<ParamDecl *>(this)},
+                           CaptureInfo::empty());
+}
+
 void ParamDecl::setDefaultArgumentCaptureInfo(CaptureInfo captures) {
   assert(DefaultValueAndFlags.getPointer());
   assert(captures.hasBeenComputed());
@@ -9169,6 +9179,13 @@ const ParamDecl *swift::getParameterAt(const DeclContext *source,
     return index < params->size() ? params->get(index) : nullptr;
   }
   return nullptr;
+}
+
+CaptureInfo AbstractFunctionDecl::getCaptureInfo() const {
+  auto &ctx = getASTContext();
+  return evaluateOrDefault(ctx.evaluator,
+                           CaptureInfoRequest{const_cast<AbstractFunctionDecl *>(this)},
+                           CaptureInfo::empty());
 }
 
 Type AbstractFunctionDecl::getMethodInterfaceType() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3468,6 +3468,7 @@ void SourceFile::typeCheckDelayedFunctions() {
     auto *AFD = DelayedFunctions[i];
     assert(!AFD->getDeclContext()->isLocalContext());
     AFD->getTypecheckedBody();
+    (void) AFD->getCaptureInfo();
   }
 
   DelayedFunctions.clear();

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -2258,3 +2258,25 @@ void ExpandBodyMacroRequest::noteCycleStep(DiagnosticEngine &diags) const {
                  "body",
                  decl->getName());
 }
+
+std::optional<CaptureInfo>
+CaptureInfoRequest::getCachedResult() const {
+  auto *func = std::get<0>(getStorage());
+  return func->getCachedCaptureInfo();
+}
+
+void CaptureInfoRequest::cacheResult(CaptureInfo info) const {
+  auto *func = std::get<0>(getStorage());
+  return func->setCaptureInfo(info);
+}
+
+std::optional<CaptureInfo>
+ParamCaptureInfoRequest::getCachedResult() const {
+  auto *param = std::get<0>(getStorage());
+  return param->getCachedDefaultArgumentCaptureInfo();
+}
+
+void ParamCaptureInfoRequest::cacheResult(CaptureInfo info) const {
+  auto *param = std::get<0>(getStorage());
+  param->setDefaultArgumentCaptureInfo(info);
+}

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -4169,8 +4169,6 @@ TypeConverter::getLoweredLocalCaptures(SILDeclRef fn) {
   };
 
   collectCaptures = [&](CaptureInfo captureInfo) {
-    assert(captureInfo.hasBeenComputed());
-
     if (captureInfo.hasGenericParamCaptures())
       capturesGenericParams = true;
     if (captureInfo.hasDynamicSelfCapture())

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -1002,7 +1002,7 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
   // If we're in top-level code, we don't need to physically capture script
   // globals, but we still need to mark them as escaping so that DI can flag
   // uninitialized uses.
-  if (isEmittingTopLevelCode()) {
+  if (isEmittingTopLevelCode() && dc->getParentSourceFile()) {
     auto captureInfo = closure.getCaptureInfo();
     emitMarkFunctionEscapeForTopLevelCodeGlobals(loc, captureInfo);
   }

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -1235,9 +1235,6 @@ void SILGenFunction::emitProlog(
     SourceLoc throwsLoc) {
   // Emit the capture argument variables. These are placed last because they
   // become the first curry level of the SIL function.
-  assert(captureInfo.hasBeenComputed() &&
-         "can't emit prolog of function with uncomputed captures");
-
   bool hasErasedIsolation =
     (TypeContext && TypeContext->ExpectedLoweredType->hasErasedIsolation());
 

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -369,6 +369,8 @@ static void emitMarkFunctionEscape(SILGenFunction &SGF,
   if (AFD->getDeclContext()->isLocalContext())
     return;
   auto CaptureInfo = AFD->getCaptureInfo();
+  if (!CaptureInfo.hasBeenComputed())
+    return;
   SGF.emitMarkFunctionEscapeForTopLevelCodeGlobals(AFD, std::move(CaptureInfo));
 }
 

--- a/lib/SILGen/SILGenTopLevel.cpp
+++ b/lib/SILGen/SILGenTopLevel.cpp
@@ -335,6 +335,9 @@ void SILGenFunction::emitCallToMain(FuncDecl *mainFunc) {
 }
 
 void SILGenModule::emitEntryPoint(SourceFile *SF) {
+  if (getASTContext().SILOpts.SkipFunctionBodies != FunctionBodySkipping::None)
+    return;
+
   assert(!M.lookUpFunction(getASTContext().getEntryPointFunctionName()) &&
          "already emitted toplevel?!");
 
@@ -366,6 +369,11 @@ void SILGenFunction::emitMarkFunctionEscapeForTopLevelCodeGlobals(
 /// uninitialized global variable
 static void emitMarkFunctionEscape(SILGenFunction &SGF,
                                    AbstractFunctionDecl *AFD) {
+  auto &Ctx = SGF.getASTContext();
+  if (Ctx.TypeCheckerOpts.DeferToRuntime &&
+      Ctx.LangOpts.hasFeature(Feature::LazyImmediate))
+    return;
+
   if (AFD->getDeclContext()->isLocalContext())
     return;
   auto CaptureInfo = AFD->getCaptureInfo();

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -623,8 +623,10 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   if (AFR.getCaptureInfo().hasBeenComputed())
     return;
 
-  if (!AFR.getBody())
+  if (!AFR.getBody()) {
+    AFR.setCaptureInfo(CaptureInfo::empty());
     return;
+  }
 
   PrettyStackTraceAnyFunctionRef trace("computing captures for", AFR);
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/Basic/Defer.h"
 #include "llvm/ADT/SmallPtrSet.h"
@@ -393,8 +394,13 @@ public:
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {
+    // Don't walk into extensions because they only appear nested inside other
+    // things in invalid code, and we'll find all kinds of weird stuff inside.
+    if (isa<ExtensionDecl>(D)) {
+      return Action::SkipNode();
+    }
+
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
-      TypeChecker::computeCaptures(AFD);
       propagateCaptures(AFD->getCaptureInfo(), AFD->getLoc());
       return Action::SkipNode();
     }
@@ -619,62 +625,26 @@ public:
 
 } // end anonymous namespace
 
-void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
-  if (AFR.getCaptureInfo().hasBeenComputed())
-    return;
+CaptureInfo CaptureInfoRequest::evaluate(Evaluator &evaluator,
+                                         AbstractFunctionDecl *AFD) const {
+  BraceStmt *body = AFD->getTypecheckedBody();
 
-  if (!AFR.getBody()) {
-    AFR.setCaptureInfo(CaptureInfo::empty());
-    return;
-  }
+  auto type = AFD->getInterfaceType();
+  if (type->is<ErrorType>() || body == nullptr)
+    return CaptureInfo::empty();
 
-  PrettyStackTraceAnyFunctionRef trace("computing captures for", AFR);
+  bool isNoEscape = type->castTo<AnyFunctionType>()->isNoEscape();
+  FindCapturedVars finder(AFD->getLoc(), AFD, isNoEscape,
+                          AFD->isObjC(), AFD->isGeneric());
+  body->walk(finder);
 
-  // A generic function always captures outer generic parameters.
-  bool isGeneric = false;
-  auto *AFD = AFR.getAbstractFunctionDecl();
-  if (AFD)
-    isGeneric = (AFD->getGenericParams() != nullptr);
-
-  auto &Context = AFR.getAsDeclContext()->getASTContext();
-  FindCapturedVars finder(AFR.getLoc(),
-                          AFR.getAsDeclContext(),
-                          AFR.isKnownNoEscape(),
-                          AFR.isObjC(),
-                          isGeneric);
-  AFR.getBody()->walk(finder);
-
-  if (AFR.hasType() && !AFR.isObjC()) {
-    finder.checkType(AFR.getType(), AFR.getLoc());
-  }
-
-  AFR.setCaptureInfo(finder.getCaptureInfo());
-
-  // Compute captures for default argument expressions.
-  if (auto *AFD = AFR.getAbstractFunctionDecl()) {
-    for (auto *P : *AFD->getParameters()) {
-      if (auto E = P->getTypeCheckedDefaultExpr()) {
-        FindCapturedVars finder(E->getLoc(),
-                                AFD,
-                                /*isNoEscape=*/false,
-                                /*isObjC=*/false,
-                                /*IsGeneric*/isGeneric);
-        E->walk(finder);
-
-        if (!AFD->getDeclContext()->isLocalContext() &&
-            finder.getDynamicSelfCaptureLoc().isValid()) {
-          Context.Diags.diagnose(finder.getDynamicSelfCaptureLoc(),
-                                 diag::dynamic_self_default_arg);
-        }
-
-        P->setDefaultArgumentCaptureInfo(finder.getCaptureInfo());
-      }
-    }
+  if (!AFD->isObjC()) {
+    finder.checkType(type, AFD->getLoc());
   }
 
   // Extensions of generic ObjC functions can't use generic parameters from
   // their context.
-  if (AFD && finder.hasGenericParamCaptures()) {
+  if (finder.hasGenericParamCaptures()) {
     if (auto clazz = AFD->getParent()->getSelfClassDecl()) {
       if (clazz->isTypeErasedGenericClass()) {
         AFD->diagnose(diag::objc_generic_extension_using_type_parameter);
@@ -690,12 +660,64 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
             .fixItInsert(AFD->getAttributeInsertionLoc(false), "@objc ");
         }
 
-        Context.Diags.diagnose(
+        AFD->getASTContext().Diags.diagnose(
             finder.getGenericParamCaptureLoc(),
             diag::objc_generic_extension_using_type_parameter_here);
       }
     }
   }
+
+  return finder.getCaptureInfo();
+}
+
+void TypeChecker::computeCaptures(AbstractClosureExpr *ACE) {
+  if (ACE->getCachedCaptureInfo())
+    return;
+
+  BraceStmt *body = ACE->getBody();
+
+  auto type = ACE->getType();
+  if (!type || type->is<ErrorType>() || body == nullptr) {
+    ACE->setCaptureInfo(CaptureInfo::empty());
+    return;
+  }
+
+  bool isNoEscape = type->castTo<FunctionType>()->isNoEscape();
+  FindCapturedVars finder(ACE->getLoc(), ACE, isNoEscape,
+                          /*isObjC=*/false, /*isGeneric=*/false);
+  body->walk(finder);
+
+  finder.checkType(type, ACE->getLoc());
+
+  auto info = finder.getCaptureInfo();
+  ACE->setCaptureInfo(info);
+}
+
+CaptureInfo ParamCaptureInfoRequest::evaluate(Evaluator &evaluator,
+                                              ParamDecl *P) const {
+  auto E = P->getTypeCheckedDefaultExpr();
+  if (E == nullptr)
+    return CaptureInfo::empty();
+
+  auto *DC = P->getDeclContext();
+
+  // A generic function always captures outer generic parameters.
+  bool isGeneric = DC->isInnermostContextGeneric();
+
+  FindCapturedVars finder(E->getLoc(),
+                          DC,
+                          /*isNoEscape=*/false,
+                          /*isObjC=*/false,
+                          /*IsGeneric*/isGeneric);
+  E->walk(finder);
+
+  if (!DC->getParent()->isLocalContext() &&
+      finder.getDynamicSelfCaptureLoc().isValid()) {
+    P->getASTContext().Diags.diagnose(finder.getDynamicSelfCaptureLoc(),
+                                      diag::dynamic_self_default_arg);
+  }
+
+  return finder.getCaptureInfo();
 }
 
 static bool isLazy(PatternBindingDecl *PBD) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1170,6 +1170,9 @@ static void checkDefaultArguments(ParameterList *params) {
     auto ifacety = param->getInterfaceType();
     auto *expr = param->getTypeCheckedDefaultExpr();
 
+    // Force captures since this can emit diagnostics.
+    (void) param->getDefaultArgumentCaptureInfo();
+
     // If the default argument has isolation, it must match the
     // isolation of the decl context.
     (void)param->getInitializerIsolation();
@@ -3621,8 +3624,8 @@ public:
     
     if (FD->getDeclContext()->isLocalContext()) {
       // Check local function bodies right away.
-      (void)FD->getTypecheckedBody();
-      TypeChecker::computeCaptures(FD);
+      (void) FD->getTypecheckedBody();
+      (void) FD->getCaptureInfo();
     } else if (!FD->isBodySkipped()) {
       addDelayedFunction(FD);
     }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2954,7 +2954,6 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &eval,
   if (!hadError)
     performAbstractFuncDeclDiagnostics(AFD);
 
-  TypeChecker::computeCaptures(AFD);
   if (!AFD->getDeclContext()->isLocalContext()) {
     checkFunctionActorIsolation(AFD);
     TypeChecker::checkFunctionEffects(AFD);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -759,8 +759,8 @@ bool typeCheckPatternBinding(PatternBindingDecl *PBD, unsigned patternNumber,
 bool typeCheckForEachPreamble(DeclContext *dc, ForEachStmt *stmt,
                               GenericEnvironment *packElementEnv);
 
-/// Compute the set of captures for the given function or closure.
-void computeCaptures(AnyFunctionRef AFR);
+/// Compute the set of captures for the given closure.
+void computeCaptures(AbstractClosureExpr *ACE);
 
 /// Check for invalid captures from stored property initializers.
 void checkPatternBindingCaptures(IterableDeclContext *DC);

--- a/test/SILGen/skip_function_bodies_guard.swift
+++ b/test/SILGen/skip_function_bodies_guard.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -experimental-skip-non-inlinable-function-bodies-without-types -emit-module %s
+
+let s: Int? = nil
+guard let m = s else { fatalError() }
+
+let x = m
+
+public func f(_: Int = m, _: String = "") {}
+
+f()

--- a/test/decl/func/dynamic_self.swift
+++ b/test/decl/func/dynamic_self.swift
@@ -443,5 +443,9 @@ class MathClass {
   func invalidDefaultArg(s: Int = Self.intMethod()) {}
   // expected-error@-1 {{covariant 'Self' type cannot be referenced from a default argument expression}}
 
+  // Make sure we check subscripts too.
+  subscript(_: Int = Self.intMethod()) -> Int { return 0 }
+  // expected-error@-1 {{covariant 'Self' type cannot be referenced from a default argument expression}}
+
   static func intMethod() -> Int { return 0 }
 }


### PR DESCRIPTION
We now compute captures of functions, closures and default arguments lazily, instead of as a side effect of primary file checking.

This fixes a specific issue with the `-experimental-skip-*` flags, where functions declared after a top-level `guard` statement are considered to have local captures, but nothing was forcing these captures to be computed.

Fixes rdar://problem/125981663.