### PR TITLE
Optimizer/OptUtils: Don't trivially remove dead-looking `unchecked_enum_data`.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -289,6 +289,10 @@ extension Instruction {
       if bi.id == .OnFastPath {
         return false
       }
+    case is UncheckedEnumDataInst:
+      // Don't remove UncheckedEnumDataInst in OSSA in case it is responsible
+      // for consuming an enum value.
+      return !parentFunction.hasOwnership
     default:
       break
     }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -O -sil-verify-all -verify -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -O -sil-verify-all -verify -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -enable-experimental-feature NoImplicitCopy -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify -enable-experimental-feature MoveOnlyClasses %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -enable-experimental-feature MoveOnlyPartialReinitialization -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-emit-sil -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
-// RUN: %target-swift-emit-sil -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
+// RUN: %target-swift-emit-sil -enable-experimental-feature BorrowingSwitch -enable-experimental-feature NoncopyableGenerics -enable-experimental-feature MoveOnlyPartialConsumption -sil-verify-all -verify %s
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/onone_simplifications_trivial_enum.sil
+++ b/test/SILOptimizer/onone_simplifications_trivial_enum.sil
@@ -1,0 +1,45 @@
+// RUN: %target-sil-opt --onone-simplification %s | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+import Builtin
+
+class Klass {}
+
+enum EnumTy: ~Copyable {
+    case klass(Klass)
+    case int(Builtin.Word)
+}
+
+// CHECK-LABEL: sil [ossa] @test_switch_trivial_arm
+sil [ossa] @test_switch_trivial_arm : $@convention(thin) (@guaranteed EnumTy) -> () {
+entry(%a : @guaranteed $EnumTy):
+  %b = explicit_copy_value %a : $EnumTy
+  // CHECK: [[MOVE:%.*]] = move_value
+  %c = move_value %b : $EnumTy
+  // CHECK: [[BORROW:%.*]] = begin_borrow [[MOVE]]
+  %d = begin_borrow %c : $EnumTy
+  // CHECK: switch_enum [[BORROW]] : {{.*}}, case #EnumTy.int!enumelt: [[INTBB:bb[0-9]+]]
+  switch_enum %d : $EnumTy, case #EnumTy.klass!enumelt: klass, case #EnumTy.int!enumelt: int
+
+klass(%e : @guaranteed $Klass):
+  end_borrow %d : $EnumTy
+  %f = unchecked_enum_data %c : $EnumTy, #EnumTy.klass!enumelt
+  destroy_value %f : $Klass
+  br end
+
+// We shouldn't remove the `unchecked_enum_data` here because it consumes the
+// original enum, even though it otherwise appears dead.
+// CHECK: [[INTBB]]({{.*}}):
+int(%p : $Builtin.Word):
+  // CHECK: end_borrow [[BORROW]]
+  end_borrow %d : $EnumTy
+  // CHECK: unchecked_enum_data [[MOVE]]
+  %q = unchecked_enum_data %c : $EnumTy, #EnumTy.int!enumelt
+  br end
+
+end:
+  return undef : $()
+}
+
+


### PR DESCRIPTION
Under OSSA, the instruction may still be structurally responsible for consuming its operand even if the result is dead, so we can't remove it without breaking invariants.

More generally, this should probably apply to any instruction which consumes one or more of its operands, has no side effects, and doesn't produce any nontrivial results that require further consumption to keep the value alive. I went with this targeted fix, since it addresses a problem that shows up in practice (rdar://125381446) and the more general change appears to disturb the optimizer pipeline while building the standard library.