### PR TITLE
Fill in extended existential support for type(of:) and mirror

### DIFF
--- a/test/Casting/TypeOf_ExtendedExistential.swift
+++ b/test/Casting/TypeOf_ExtendedExistential.swift
@@ -40,7 +40,7 @@ CastsTests.test("type(of:) should look through extended existentials (none)") {
   struct C<T>: Box { var t: T }
   func genericErase<T>(_ value: T) -> Any { value }
   let c: any Box<Int> = C(t: 42)
-  if #available(macOS 13.0, *) {
+  if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
     let x = genericErase(c)
     expectEqual("C<Int>", "\(type(of:x))")
   } else {
@@ -60,7 +60,7 @@ CastsTests.test("type(of:) should look through extended existentials (class)") {
   }
   func genericErase<T>(_ value: T) -> Any { value }
   let c: any OBox<Int> = C(t: 42)
-  if #available(macOS 13.0, *) {
+  if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
     let x = genericErase(c)
     expectEqual("C<Int>", "\(type(of:x))")
   } else {
@@ -73,7 +73,7 @@ CastsTests.test("type(of:) should look through extended existentials (metatype)"
   struct C<T>: Box { var t: T }
   func genericErase<T>(_ value: T) -> Any { value }
   let t: any Box<Int>.Type = C<Int>.self
-  if #available(macOS 13.0, *) {
+  if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
     let x = genericErase(t)
     expectEqual("C<Int>.Type", "\(type(of:x))")
   } else {

--- a/test/Casting/TypeOf_ExtendedExistential.swift
+++ b/test/Casting/TypeOf_ExtendedExistential.swift
@@ -1,0 +1,84 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %target-build-swift -swift-version 5 -g -Onone  -module-name a %s -o %t/a.swift5.Onone.out
+// RUN: %target-codesign %t/a.swift5.Onone.out
+// RUN: %target-run %t/a.swift5.Onone.out
+//
+// RUN: %target-build-swift -swift-version 6 -g -Onone  -module-name a %s -o %t/a.swift6.Onone.out
+// RUN: %target-codesign %t/a.swift6.Onone.out
+// RUN: %target-run %t/a.swift6.Onone.out
+//
+// RUN: %target-build-swift -swift-version 5 -g -O  -module-name a %s -o %t/a.swift5.O.out
+// RUN: %target-codesign %t/a.swift5.O.out
+// RUN: %target-run %t/a.swift5.O.out
+//
+// RUN: %target-build-swift -swift-version 6 -g -O  -module-name a %s -o %t/a.swift6.O.out
+// RUN: %target-codesign %t/a.swift6.O.out
+// RUN: %target-run %t/a.swift6.O.out
+//
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+
+func blackhole<T>(_ t: T) { }
+
+private func runtimeCast<T,U>(_ from: T, to: U.Type) -> U? {
+  return from as? U
+}
+
+let CastsTests = TestSuite("Casts")
+
+protocol Box<T> {
+  associatedtype T
+  var t: T { get }
+}
+
+CastsTests.test("type(of:) should look through extended existentials (none)") {
+  struct C<T>: Box { var t: T }
+  func genericErase<T>(_ value: T) -> Any { value }
+  let c: any Box<Int> = C(t: 42)
+  if #available(macOS 13.0, *) {
+    let x = genericErase(c)
+    expectEqual("C<Int>", "\(type(of:x))")
+  } else {
+    expectEqual(0, 1)
+  }
+}
+
+protocol OBox<T> : AnyObject {
+  associatedtype T
+  var t: T { get }
+}
+
+CastsTests.test("type(of:) should look through extended existentials (class)") {
+  class C<T>: OBox {
+    var t: T
+    init(t: T) { self.t = t }
+  }
+  func genericErase<T>(_ value: T) -> Any { value }
+  let c: any OBox<Int> = C(t: 42)
+  if #available(macOS 13.0, *) {
+    let x = genericErase(c)
+    expectEqual("C<Int>", "\(type(of:x))")
+  } else {
+    expectEqual(0, 1)
+  }
+}
+
+
+CastsTests.test("type(of:) should look through extended existentials (metatype)") {
+  struct C<T>: Box { var t: T }
+  func genericErase<T>(_ value: T) -> Any { value }
+  let t: any Box<Int>.Type = C<Int>.self
+  if #available(macOS 13.0, *) {
+    let x = genericErase(t)
+    expectEqual("C<Int>.Type", "\(type(of:x))")
+  } else {
+    expectEqual(0, 1)
+  }
+}
+
+runAllTests()

--- a/test/Casting/TypeOf_ExtendedExistential.swift
+++ b/test/Casting/TypeOf_ExtendedExistential.swift
@@ -43,8 +43,6 @@ CastsTests.test("type(of:) should look through extended existentials (none)") {
   if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
     let x = genericErase(c)
     expectEqual("C<Int>", "\(type(of:x))")
-  } else {
-    expectEqual(0, 1)
   }
 }
 
@@ -63,8 +61,6 @@ CastsTests.test("type(of:) should look through extended existentials (class)") {
   if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
     let x = genericErase(c)
     expectEqual("C<Int>", "\(type(of:x))")
-  } else {
-    expectEqual(0, 1)
   }
 }
 
@@ -76,8 +72,6 @@ CastsTests.test("type(of:) should look through extended existentials (metatype)"
   if #available(macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0, *) {
     let x = genericErase(t)
     expectEqual("C<Int>.Type", "\(type(of:x))")
-  } else {
-    expectEqual(0, 1)
   }
 }
 

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -934,7 +934,7 @@ mirrors.test("Extended Existential (struct)") {
     value
   }
   let container: any Box<Int> = Container(value: 42)
-  if #available(macOS 13, *) {
+  if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
     let subject = genericErase(container)
     let mirror = Mirror(reflecting: subject)
     let children = mirror.children
@@ -959,7 +959,7 @@ mirrors.test("Extended Existential (class)") {
     value
   }
   let container: any OBox<Int> = Container(value: 42)
-  if #available(macOS 13, *) {
+  if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
     let subject = genericErase(container)
     let mirror = Mirror(reflecting: subject)
     let children = mirror.children
@@ -979,7 +979,7 @@ mirrors.test("Extended Existential (metatype)") {
     value
   }
   let t: any Box<Int>.Type = Container<Int>.self
-  if #available(macOS 13, *) {
+  if #available(iOS 16, macOS 13, tvOS 16, watchOS 9, *) {
     let subject = genericErase(t)
     let mirror = Mirror(reflecting: subject)
     let children = mirror.children

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -921,6 +921,72 @@ mirrors.test("class/Cluster") {
 //===--- Miscellaneous ----------------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
+protocol Box<Value> {
+  associatedtype Value
+  var value: Value {get}
+}
+
+mirrors.test("Extended Existential (struct)") {
+  struct Container<Value>: Box {
+    var value: Value
+  }
+  func genericErase<T>(_ value: T) -> Any {
+    value
+  }
+  let container: any Box<Int> = Container(value: 42)
+  if #available(macOS 13, *) {
+    let subject = genericErase(container)
+    let mirror = Mirror(reflecting: subject)
+    let children = mirror.children
+    expectEqual(1, children.count)
+    let first = children.first!
+    expectEqual("value", first.label)
+    expectEqual(42, first.value as! Int)
+  }
+}
+
+protocol OBox<Value>: AnyObject {
+  associatedtype Value
+  var value: Value {get}
+}
+
+mirrors.test("Extended Existential (class)") {
+  class Container<Value>: OBox {
+    var value: Value
+    init(value: Value) { self.value = value }
+  }
+  func genericErase<T>(_ value: T) -> Any {
+    value
+  }
+  let container: any OBox<Int> = Container(value: 42)
+  if #available(macOS 13, *) {
+    let subject = genericErase(container)
+    let mirror = Mirror(reflecting: subject)
+    let children = mirror.children
+    expectEqual(1, children.count)
+    let first = children.first!
+    expectEqual("value", first.label)
+    expectEqual(42, first.value as! Int)
+  }
+}
+
+mirrors.test("Extended Existential (metatype)") {
+  class Container<Value>: Box {
+    var value: Value
+    init(value: Value) { self.value = value }
+  }
+  func genericErase<T>(_ value: T) -> Any {
+    value
+  }
+  let t: any Box<Int>.Type = Container<Int>.self
+  if #available(macOS 13, *) {
+    let subject = genericErase(t)
+    let mirror = Mirror(reflecting: subject)
+    let children = mirror.children
+    expectEqual(0, children.count)
+  }
+}
+
 mirrors.test("Addressing") {
   let m0 = Mirror(reflecting: [1, 2, 3])
   expectEqual(1, m0.descendant(0) as? Int)


### PR DESCRIPTION
type(of:) now returns the dynamic type of the contents of an extended existential (just like it does for a regular existential)

Mirror can now reflect fields of a value stored inside an extended existential (just like it can with a regular existential).  This requires type(of:) support, since Mirror internals use that to determine how to reflect a value.

Resolves rdar://102906195