### PR TITLE
[test] Pass wasi-sysroot to the `%target-clang`

### DIFF
--- a/test/IRGen/sensitive.swift
+++ b/test/IRGen/sensitive.swift
@@ -98,17 +98,17 @@ protocol P {}
 
 @sensitive
 struct SensitiveStruct {
-  var a = 0xdeadbeaf
-  var b = 0xdeadbeaf
-  var c = 0xdeadbeaf
+  var a: UInt32 = 0xdeadbeaf
+  var b: UInt32 = 0xdeadbeaf
+  var c: UInt32 = 0xdeadbeaf
 }
 
 // A struct which would be address-only also without @sensitive
 @sensitive
 struct NonLoadableSensitiveStruct {
-  var a = 0xdeadbeaf
-  var b = 0xdeadbeaf
-  var c = 0xdeadbeaf
+  var a: UInt32 = 0xdeadbeaf
+  var b: UInt32 = 0xdeadbeaf
+  var c: UInt32 = 0xdeadbeaf
   let p: P
 }
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1939,8 +1939,8 @@ elif run_os == 'wasi':
         '%s -emit-pcm -target %s' %
         (config.swiftc, config.variant_triple))
     config.target_clang = (
-        "%s -target %s %s -fobjc-runtime=ios-5.0" %
-        (config.clang, config.variant_triple, clang_mcp_opt))
+        "%s -target %s %s -fobjc-runtime=ios-5.0 --sysroot %s" %
+        (config.clang, config.variant_triple, clang_mcp_opt, config.variant_sdk))
     config.target_ld = (
         "%s -L%r" %
         (config.wasm_ld, make_path(test_resource_dir, config.target_sdk_name)))


### PR DESCRIPTION
`test/IRGen/sensitive.swift` failed on the WebAssembly bot because it tries to include stdio.h, but `--sysroot` was not passed to the `%target-clang`.
