### PR TITLE
[6.0][Runtime] Exclude logd_helper from tracing.

### DIFF
--- a/include/swift/Runtime/TracingCommon.h
+++ b/include/swift/Runtime/TracingCommon.h
@@ -34,7 +34,8 @@ static inline bool shouldEnableTracing() {
   if (__progname && (strcmp(__progname, "logd") == 0 ||
                      strcmp(__progname, "diagnosticd") == 0 ||
                      strcmp(__progname, "notifyd") == 0 ||
-                     strcmp(__progname, "xpcproxy") == 0))
+                     strcmp(__progname, "xpcproxy") == 0 ||
+                     strcmp(__progname, "logd_helper") == 0))
     return false;
   return true;
 }


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/72951 to `release/6.0`.

logd_helper is part of the log system and we can't safely log from within it.

rdar://126120335