### PR TITLE
[wasm] Enable Synchronization module build

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
+++ b/utils/swift_build_support/swift_build_support/products/wasmstdlib.py
@@ -95,6 +95,7 @@ class WasmStdlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SWIFT_PATH_TO_STRING_PROCESSING_SOURCE:PATH',
                                   os.path.join(self.source_dir, '..',
                                                'swift-experimental-string-processing'))
+        self.cmake_options.define('SWIFT_ENABLE_SYNCHRONIZATION:BOOL', 'TRUE')
 
         self.add_extra_cmake_options()
 


### PR DESCRIPTION
Build `Synchronization` module for WebAssembly target. Atomic builtin operations used in the module are no-op unless atomics feature is enabled by`-Xcc -matomics`, so the module is available for both `wasm32-unknown-wasi` and `wasm32-unknown-wasip1-threads`.