### PR TITLE
[6.0] Alternative noncopyable switch design based on expression kind.

### DIFF
--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -777,6 +777,9 @@ Pattern::getOwnership(
     void visitNamedPattern(NamedPattern *p) {
       switch (p->getDecl()->getIntroducer()) {
       case VarDecl::Introducer::Let:
+        // `let` defaults to the prevailing ownership of the switch.
+        break;
+      
       case VarDecl::Introducer::Var:
         // If the subpattern type is copyable, then we can bind the variable
         // by copying without requiring more than a borrow of the original.
@@ -786,7 +789,7 @@ Pattern::getOwnership(
         // TODO: An explicit `consuming` binding kind consumes regardless of
         // type.
       
-        // Noncopyable `let` and `var` consume the bound value to move it into
+        // Noncopyable `var` consumes the bound value to move it into
         // a new independent variable.
         increaseOwnership(ValueOwnership::Owned, p);
         break;
@@ -797,8 +800,8 @@ Pattern::getOwnership(
         break;
         
       case VarDecl::Introducer::Borrowing:
-        // `borrow` bindings borrow parts of the value in-place so they don't
-        // need stronger access to the subject value.
+        // `borrow` bindings borrow parts of the value in-place.
+        increaseOwnership(ValueOwnership::Shared, p);        
         break;
       }
     }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -846,7 +846,7 @@ public func ?? <T: ~Copyable>(
   optional: consuming T?,
   defaultValue: @autoclosure () throws -> T?
 ) rethrows -> T? {
-  switch optional {
+  switch consume optional {
   case .some(let value):
     return value
   case .none:

--- a/test/SILGen/borrowing_switch_return_on_all_paths.swift
+++ b/test/SILGen/borrowing_switch_return_on_all_paths.swift
@@ -25,7 +25,7 @@ extension NoncopyableList.Link {
     func find(where predicate: (Element)->Bool) -> Maybe<Element> {
         switch self {
         case .empty: return .none
-        case .more(_borrowing box):
+        case .more(let box):
             if predicate(box.wrapped.element) { return .some(box.wrapped.element) }
             return box.wrapped.next.find(where: predicate)
         }

--- a/test/SILGen/borrowing_switch_subjects.swift
+++ b/test/SILGen/borrowing_switch_subjects.swift
@@ -25,7 +25,7 @@ func borrowParam(x: borrowing Outer) {
     // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [strict] [no_consume_or_assign]
     // CHECK: [[BORROW:%.*]] = begin_borrow [[MARK]]
     switch x {
-    case _borrowing y:
+    case let y:
         // CHECK: apply {{.*}}([[BORROW]])
         use(y)
     }
@@ -39,7 +39,7 @@ func borrowParam(x: borrowing Outer) {
     // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [strict] [no_consume_or_assign] [[COPY_INNER]]
     // CHECK: [[BORROW:%.*]] = begin_borrow [[MARK]]
     switch x.storedInner {
-    case _borrowing y:
+    case let y:
         // CHECK: apply {{.*}}([[BORROW]])
         use(y)
     }
@@ -56,22 +56,24 @@ func borrowParam(x: borrowing Outer) {
     // CHECK: [[MARK2:%.*]] = mark_unresolved_non_copyable_value [strict] [no_consume_or_assign] [[COPY2]]
     // CHECK: [[BORROW2:%.*]] = begin_borrow [[MARK2]]
     switch x.readInner {
-    case _borrowing y:
+    case let y:
         // CHECK: apply {{.*}}([[BORROW2]])
         use(y)
     }
     // CHECK: end_apply [[TOKEN]]
     // CHECK: end_borrow [[BORROW_OUTER]]
 
+    // `temporary()` is an rvalue, so we 
     // CHECK: [[FN:%.*]] = function_ref @{{.*}}9temporary
     // CHECK: [[TMP:%.*]] = apply [[FN]]()
     // CHECK: [[BORROW_OUTER:%.*]] = begin_borrow [fixed] [[TMP]]
-    // CHECK: [[COPY:%.*]] = copy_value [[BORROW_OUTER]]
-    // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [strict] [no_consume_or_assign] [[COPY]]
-    // CHECK: [[BORROW:%.*]] = begin_borrow [[MARK]]
+    // CHECK: end_borrow [[BORROW_OUTER]]
+    // CHECK: store [[TMP]] to [init] [[Y:%.*]] :
+    // CHECK: [[MARK:%.*]] = mark_unresolved_non_copyable_value [no_consume_or_assign] [[Y]]
     switch temporary() {
-    case _borrowing y:
-        // CHECK: apply {{.*}}([[BORROW]])
+    case let y:
+        // CHECK: [[LOAD_BORROW:%.*]] = load_borrow [[MARK]]
+        // CHECK: apply {{.*}}([[LOAD_BORROW]])
         use(y)
     }
 }

--- a/test/SILOptimizer/moveonly_borrowing_switch.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch.swift
@@ -56,15 +56,15 @@ func eat(payload: consuming AOBas) {}
 
 func test(consuming foo: consuming Bar) { // expected-error{{'foo' used after consume}}
     switch foo {
-    case .payload(.payload(_borrowing x))
+    case .payload(.payload(let x))
       where condition(x):
         nibble(payload: x)
-    // can't consume _borrowing bindings in either `where` condition 
+    // can't consume borrowed bindings in either `where` condition 
     // or body
-    case .payload(.payload(_borrowing x)) // expected-error{{cannot be consumed}}
+    case .payload(.payload(let x)) // expected-error{{cannot be consumed}}
       where hungryCondition(x): // expected-note{{consumed here}}
         eat(payload: x) // expected-note{{consumed here}}
-    case .payload(.payload(_borrowing x)): // expected-warning{{}}
+    case .payload(.payload(let x)): // expected-warning{{}}
         break
     case .payload(.noPayload):
         ()
@@ -72,7 +72,7 @@ func test(consuming foo: consuming Bar) { // expected-error{{'foo' used after co
         ()
     }
 
-    switch foo { // expected-note{{consumed here}}
+    switch consume foo { // expected-note{{consumed here}}
     case .payload(.payload(let x))
       where condition(x):
         nibble(payload: x)
@@ -90,7 +90,7 @@ func test(consuming foo: consuming Bar) { // expected-error{{'foo' used after co
     }
 
     switch foo { // expected-note{{used here}}
-    case _borrowing x: // expected-warning{{}}
+    case let x: // expected-warning{{}}
         break
     }
 }
@@ -101,23 +101,23 @@ func nibble(bar: borrowing Bar)
 func test(borrowing foo: borrowing Bar) { // expected-error{{'foo' is borrowed and cannot be consumed}}
     // can't use consuming patterns on a borrow
     // TODO: improve diagnostic
-    switch foo {
-    case .payload(.payload(let x)): // expected-note{{consumed here}} expected-warning{{}}
+    switch consume foo { // expected-note{{consumed here}}
+    case .payload(.payload(let x)): // expected-warning{{}}
         break
-    case .payload(.noPayload): // expected-note{{consumed here}}
+    case .payload(.noPayload):
         ()
     case .noPayload:
         ()
     }
 
     switch foo {
-    case .payload(.payload(_borrowing x))
+    case .payload(.payload(let x))
       where condition(x):
         nibble(payload: x)
-    case .payload(.payload(_borrowing x)) // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(.payload(let x)) // expected-error{{'x' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note{{consumed here}}
         eat(payload: x) // expected-note{{consumed here}}
-    case .payload(.payload(_borrowing x)): // expected-warning{{}}
+    case .payload(.payload(let x)): // expected-warning{{}}
         break
     case .payload(.noPayload):
         ()
@@ -128,35 +128,35 @@ func test(borrowing foo: borrowing Bar) { // expected-error{{'foo' is borrowed a
 
 func testOuterAO(borrowing bas: borrowing AOBas) {
     switch bas {
-    case _borrowing x // expected-error{{'x' is borrowed and cannot be consumed}}
+    case let x // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
-    case _borrowing x // expected-error 2 {{'x' is borrowed and cannot be consumed}}
+    case let x // expected-error 2 {{'x' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note {{consumed here}}
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
-    case .payload(_borrowing x)  // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(let x)  // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
-    case .payload(_borrowing x) // expected-error 2 {{'x' is borrowed and cannot be consumed}}
+    case .payload(let x) // expected-error 2 {{'x' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note {{consumed here}}
         nibble(payload: x)
         eat(payload: x)  // expected-note {{consumed here}}
-    case .payload(.loadablePayload(_borrowing x)) // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(.loadablePayload(let x)) // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note{{consumed here}}
-    case .payload(.loadablePayload(.payload(_borrowing x))) // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(.loadablePayload(.payload(let x))) // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note{{consumed here}}
-    case .payload(.aoPayload(_borrowing x)) // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(.aoPayload(let x)) // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
-    case .payload(_borrowing x): // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(let x): // expected-error{{'x' is borrowed and cannot be consumed}}
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
     case .noPayload:
@@ -166,42 +166,42 @@ func testOuterAO(borrowing bas: borrowing AOBas) {
 
 func testOuterAO(consuming bas: consuming AOBas) { // expected-error{{'bas' used after consume}}
     switch bas {
-    case _borrowing x // expected-error{{'x' is borrowed and cannot be consumed}}
+    case let x // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
-    case _borrowing x // expected-error 2 {{'x' is borrowed and cannot be consumed}}
+    case let x // expected-error 2 {{'x' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note {{consumed here}}
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
-    case .payload(_borrowing x)  // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(let x)  // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
-    case .payload(_borrowing x) // expected-error 2 {{'x' is borrowed and cannot be consumed}}
+    case .payload(let x) // expected-error 2 {{'x' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note {{consumed here}}
         nibble(payload: x)
         eat(payload: x)  // expected-note {{consumed here}}
-    case .payload(.loadablePayload(_borrowing x)) // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(.loadablePayload(let x)) // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note{{consumed here}}
-    case .payload(.loadablePayload(.payload(_borrowing x))) // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(.loadablePayload(.payload(let x))) // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note{{consumed here}}
-    case .payload(.aoPayload(_borrowing x)) // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(.aoPayload(let x)) // expected-error{{'x' is borrowed and cannot be consumed}}
       where condition(x):
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
-    case .payload(_borrowing x): // expected-error{{'x' is borrowed and cannot be consumed}}
+    case .payload(let x): // expected-error{{'x' is borrowed and cannot be consumed}}
         nibble(payload: x)
         eat(payload: x) // expected-note {{consumed here}}
     case .noPayload:
         break
     }
 
-    switch bas { // expected-note {{consumed here}}
+    switch consume bas { // expected-note {{consumed here}}
     case let x
       where condition(x):
         nibble(payload: x)
@@ -214,7 +214,8 @@ func testOuterAO(consuming bas: consuming AOBas) { // expected-error{{'bas' used
       where condition(x):
         nibble(payload: x)
         eat(payload: x)
-    case .payload(let x) // expected-error {{'bas.payload' is borrowed and cannot be consumed}}
+    // TODO: look through `consume` expression when finding component path to diagnose
+    case .payload(let x) // expected-error {{'unknown' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note {{consumed here}}
         nibble(payload: x)
         eat(payload: x)
@@ -222,7 +223,7 @@ func testOuterAO(consuming bas: consuming AOBas) { // expected-error{{'bas' used
       where condition(x):
         nibble(payload: x)
         eat(payload: x)
-    case .payload(.loadablePayload(.payload(let x))) // expected-error{{'bas.payload.loadablePayload' is borrowed and cannot be consumed}}
+    case .payload(.loadablePayload(.payload(let x))) // expected-error{{'unknown' is borrowed and cannot be consumed}}
       where hungryCondition(x): // expected-note{{consumed here}}
         nibble(payload: x)
         eat(payload: x)
@@ -238,7 +239,7 @@ func testOuterAO(consuming bas: consuming AOBas) { // expected-error{{'bas' used
     }
 
     switch bas { // expected-note{{used here}}
-    case _borrowing x: // expected-warning{{}}
+    case let x: // expected-warning{{}}
         break
     }
 }
@@ -257,7 +258,7 @@ extension E {
 
     func g() {
         switch self {
-        case .a(_borrowing t): // expected-warning{{}}
+        case .a(let t): // expected-warning{{}}
             print("a")
         }
     }
@@ -294,7 +295,7 @@ extension List {
             switch self {
             case .end:
                 fatalError()
-            case .more(_, _borrowing box):
+            case .more(_, let box):
                 yield box
             }
         }
@@ -305,7 +306,7 @@ extension List {
             switch self {
             case .end:
                 fatalError()
-            case .more(_borrowing head, _):
+            case .more(let head, _):
                 yield head
             }
         }
@@ -325,7 +326,7 @@ extension ChonkyList {
             switch self {
             case .end:
                 fatalError()
-            case .more(_, _borrowing box):
+            case .more(_, let box):
                 yield box
             }
         }
@@ -336,7 +337,7 @@ extension ChonkyList {
             switch self {
             case .end:
                 fatalError()
-            case .more(_borrowing head, _):
+            case .more(let head, _):
                 yield head
             }
         }

--- a/test/SILOptimizer/moveonly_borrowing_switch_copyable_subpattern.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_copyable_subpattern.swift
@@ -19,7 +19,7 @@ func nibble(_: borrowing String) {}
 
 func test(borrowing foo: borrowing Foo) {
     switch foo {
-    case .nonCopyablePayload(_borrowing x): // expected-warning{{}}
+    case .nonCopyablePayload(let x): // expected-warning{{}}
         break
 
     // OK to form a normal `let` binding when the payload is copyable.

--- a/test/SILOptimizer/moveonly_borrowing_switch_yield.swift
+++ b/test/SILOptimizer/moveonly_borrowing_switch_yield.swift
@@ -5,7 +5,7 @@ extension List {
         _read {
             switch self.head {
             case .empty: fatalError()
-            case .more(_borrowing box):
+            case .more(let box):
                 yield box.wrapped.element
             }
             //yield head.peek
@@ -76,7 +76,7 @@ enum Link<Element>: ~Copyable {
         _read {
             switch self {
             case .empty: fatalError()
-            case .more(_borrowing box):
+            case .more(let box):
                 yield box.wrapped.element
             }
         }
@@ -103,7 +103,7 @@ extension List {
     
     mutating func pop() -> Element {
         let h = self.head
-        switch h {
+        switch consume h {
         case .empty: fatalError()
         case .more(let box):
             let node = box.move()

--- a/test/SILOptimizer/moveonly_consuming_switch.swift
+++ b/test/SILOptimizer/moveonly_consuming_switch.swift
@@ -57,7 +57,7 @@ extension List {
     }
         
     mutating func pop() -> Element {
-        switch self {
+        switch consume self {
         case .node(let element, let box):
             self = box.move()
             return element


### PR DESCRIPTION
**Explanation:** Pre-review discussion of the noncopyable borrowing switch feature raised a preference for an alternative design where the ownership of a switch is driven by what the expression refers to: If an expression refers to noncopyable storage, then default to performing a borrowing switch, where `let` bindings in patterns borrow out of the matched value. If an expression refers to a temporary value or explicitly uses the `consume` keyword, then perform a consuming switch, where `let` bindings take ownership of corresponding parts of the matched value. Allow `_borrowing` to still be used to explicitly bind a pattern variable as a borrow, with no-implicit-copy semantics for copyable values.

**Scope:** Changes behavior of a pre-release experimental feature.
**Issue:** rdar://126212597
**Original PR:** https://github.com/apple/swift/pull/72647
**Risk:** Low. This should have no effect on code using released features only. For early adopters of the feature, the necessary source changes are also minimal; one only needs to explicitly write `switch consume x` when `x` is a local variable binding that would otherwise be borrowed by default.
**Testing:** Swift CI
**Reviewer:** @kavon 