### PR TITLE
[region-isolation] Include the region -> transferring operand map in the dataflow convergence.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -88,10 +88,13 @@ class BlockPartitionState {
 
   TransferringOperandSetFactory &ptrSetFactory;
 
+  TransferringOperandToStateMap &transferringOpToStateMap;
+
   BlockPartitionState(SILBasicBlock *basicBlock,
                       PartitionOpTranslator &translator,
                       TransferringOperandSetFactory &ptrSetFactory,
-                      IsolationHistory::Factory &isolationHistoryFactory);
+                      IsolationHistory::Factory &isolationHistoryFactory,
+                      TransferringOperandToStateMap &transferringOpToStateMap);
 
 public:
   bool getLiveness() const { return isLive; }
@@ -397,6 +400,8 @@ class RegionAnalysisFunctionInfo {
 
   IsolationHistory::Factory isolationHistoryFactory;
 
+  TransferringOperandToStateMap transferringOpToStateMap;
+
   // We make this optional to prevent an issue that we have seen on windows when
   // capturing a field in a closure that is used to initialize a different
   // field.
@@ -490,6 +495,16 @@ public:
   RegionAnalysisValueMap &getValueMap() {
     assert(supportedFunction && "Unsupported Function?!");
     return valueMap;
+  }
+
+  IsolationHistory::Factory &getIsolationHistoryFactory() {
+    assert(supportedFunction && "Unsupported Function?!");
+    return isolationHistoryFactory;
+  }
+
+  TransferringOperandToStateMap &getTransferringOpToStateMap() {
+    assert(supportedFunction && "Unsupported Function?!");
+    return transferringOpToStateMap;
   }
 
   bool isClosureCaptured(SILValue value, Operand *op);

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -19,6 +19,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include <algorithm>
@@ -689,7 +690,7 @@ private:
   /// multi map here. The implication of this is that when we are performing
   /// dataflow we use a union operation to combine CFG elements and just take
   /// the first instruction that we see.
-  llvm::SmallDenseMap<Region, TransferringOperandSet *, 2>
+  llvm::SmallMapVector<Region, TransferringOperandSet *, 2>
       regionToTransferredOpMap;
 
   /// Label each index with a non-negative (unsigned) label if it is associated

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -2954,10 +2954,12 @@ TranslationSemantics PartitionOpTranslator::visitCheckedCastAddrBranchInst(
 BlockPartitionState::BlockPartitionState(
     SILBasicBlock *basicBlock, PartitionOpTranslator &translator,
     TransferringOperandSetFactory &ptrSetFactory,
-    IsolationHistory::Factory &isolationHistoryFactory)
+    IsolationHistory::Factory &isolationHistoryFactory,
+    TransferringOperandToStateMap &transferringOpToStateMap)
     : entryPartition(isolationHistoryFactory.get()),
       exitPartition(isolationHistoryFactory.get()), basicBlock(basicBlock),
-      ptrSetFactory(ptrSetFactory) {
+      ptrSetFactory(ptrSetFactory),
+      transferringOpToStateMap(transferringOpToStateMap) {
   translator.translateSILBasicBlock(basicBlock, blockPartitionOps);
 }
 
@@ -2971,8 +2973,10 @@ bool BlockPartitionState::recomputeExitFromEntry(
 
     ComputeEvaluator(Partition &workingPartition,
                      TransferringOperandSetFactory &ptrSetFactory,
-                     PartitionOpTranslator &translator)
-        : PartitionOpEvaluatorBaseImpl(workingPartition, ptrSetFactory),
+                     PartitionOpTranslator &translator,
+                     TransferringOperandToStateMap &transferringOpToStateMap)
+        : PartitionOpEvaluatorBaseImpl(workingPartition, ptrSetFactory,
+                                       transferringOpToStateMap),
           translator(translator) {}
 
     SILIsolationInfo getIsolationRegionInfo(Element elt) const {
@@ -2989,7 +2993,8 @@ bool BlockPartitionState::recomputeExitFromEntry(
       return translator.isClosureCaptured(value, op->getUser());
     }
   };
-  ComputeEvaluator eval(workingPartition, ptrSetFactory, translator);
+  ComputeEvaluator eval(workingPartition, ptrSetFactory, translator,
+                        transferringOpToStateMap);
   for (const auto &partitionOp : blockPartitionOps) {
     // By calling apply without providing any error handling callbacks, errors
     // will be surpressed.  will be suppressed
@@ -3074,8 +3079,9 @@ static bool canComputeRegionsForFunction(SILFunction *fn) {
 RegionAnalysisFunctionInfo::RegionAnalysisFunctionInfo(
     SILFunction *fn, PostOrderFunctionInfo *pofi)
     : allocator(), fn(fn), valueMap(fn), translator(), ptrSetFactory(allocator),
-      isolationHistoryFactory(allocator), blockStates(), pofi(pofi),
-      solved(false), supportedFunction(true) {
+      isolationHistoryFactory(allocator),
+      transferringOpToStateMap(isolationHistoryFactory), blockStates(),
+      pofi(pofi), solved(false), supportedFunction(true) {
   // Before we do anything, make sure that we support processing this function.
   //
   // NOTE: See documentation on supportedFunction for criteria.
@@ -3088,7 +3094,8 @@ RegionAnalysisFunctionInfo::RegionAnalysisFunctionInfo(
       PartitionOpTranslator(fn, pofi, valueMap, isolationHistoryFactory);
   blockStates.emplace(fn, [this](SILBasicBlock *block) -> BlockPartitionState {
     return BlockPartitionState(block, *translator, ptrSetFactory,
-                               isolationHistoryFactory);
+                               isolationHistoryFactory,
+                               transferringOpToStateMap);
   });
   // Mark all blocks as needing to be updated.
   for (auto &block : *fn) {

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3001,6 +3001,8 @@ bool BlockPartitionState::recomputeExitFromEntry(
   exitPartition = workingPartition;
   LLVM_DEBUG(llvm::dbgs() << "    Exit Partition: ";
              exitPartition.print(llvm::dbgs()));
+  LLVM_DEBUG(llvm::dbgs() << "    Updated Partition: "
+                          << (exitUpdated ? "yes\n" : "no\n"));
   return exitUpdated;
 }
 

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -332,15 +332,15 @@ void Partition::markTransferred(Element val,
   // Otherwise, we already have this value in the map. Try to insert it.
   auto iter1 = elementToRegionMap.find(val);
   assert(iter1 != elementToRegionMap.end());
-  auto iter2 = regionToTransferredOpMap.try_emplace(iter1->second,
-                                                    transferredOperandSet);
+  auto iter2 =
+      regionToTransferredOpMap.insert({iter1->second, transferredOperandSet});
 
   // If we did insert, just return. We were not tracking any state.
   if (iter2.second)
     return;
 
   // Otherwise, we need to merge the sets.
-  iter2.first->getSecond() = iter2.first->second->merge(transferredOperandSet);
+  iter2.first->second = iter2.first->second->merge(transferredOperandSet);
 }
 
 bool Partition::undoTransfer(Element val) {
@@ -525,11 +525,11 @@ Partition Partition::join(const Partition &fst, Partition &mutableSnd) {
         // mergedRegion is transferred in result.
         auto sndIter = snd.regionToTransferredOpMap.find(sndRegionNumber);
         if (sndIter != snd.regionToTransferredOpMap.end()) {
-          auto resultIter = result.regionToTransferredOpMap.try_emplace(
-              resultRegion, sndIter->second);
+          auto resultIter = result.regionToTransferredOpMap.insert(
+              {resultRegion, sndIter->second});
           if (!resultIter.second) {
-            resultIter.first->getSecond() =
-                resultIter.first->getSecond()->merge(sndIter->second);
+            resultIter.first->second =
+                resultIter.first->second->merge(sndIter->second);
           }
         }
         continue;
@@ -574,11 +574,10 @@ Partition Partition::join(const Partition &fst, Partition &mutableSnd) {
     result.pushNewElementRegion(sndEltNumber);
     auto sndIter = snd.regionToTransferredOpMap.find(sndRegionNumber);
     if (sndIter != snd.regionToTransferredOpMap.end()) {
-      auto fstIter = result.regionToTransferredOpMap.try_emplace(
-          sndRegionNumber, sndIter->second);
+      auto fstIter = result.regionToTransferredOpMap.insert(
+          {sndRegionNumber, sndIter->second});
       if (!fstIter.second)
-        fstIter.first->getSecond() =
-            fstIter.first->second->merge(sndIter->second);
+        fstIter.first->second = fstIter.first->second->merge(sndIter->second);
     }
     if (result.fresh_label <= sndRegionNumber)
       result.fresh_label = Region(sndEltNumber + 1);
@@ -629,7 +628,7 @@ void Partition::print(llvm::raw_ostream &os) const {
     bool isTransferred = iter != regionToTransferredOpMap.end();
     bool isClosureCaptured = false;
     if (isTransferred) {
-      isClosureCaptured = llvm::any_of(iter->getSecond()->range(),
+      isClosureCaptured = llvm::any_of(iter->second->range(),
                                        [](const TransferringOperand *operand) {
                                          return operand->isClosureCaptured();
                                        });
@@ -671,7 +670,7 @@ void Partition::printVerbose(llvm::raw_ostream &os) const {
     bool isTransferred = iter != regionToTransferredOpMap.end();
     bool isClosureCaptured = false;
     if (isTransferred) {
-      isClosureCaptured = llvm::any_of(iter->getSecond()->range(),
+      isClosureCaptured = llvm::any_of(iter->second->range(),
                                        [](const TransferringOperand *operand) {
                                          return operand->isClosureCaptured();
                                        });
@@ -700,7 +699,7 @@ void Partition::printVerbose(llvm::raw_ostream &os) const {
     os << "\n";
     os << "TransferInsts:\n";
     if (isTransferred) {
-      for (auto op : iter->getSecond()->data()) {
+      for (auto op : iter->second->data()) {
         os << "    ";
         op->print(os);
       }
@@ -821,7 +820,7 @@ Region Partition::merge(Element fst, Element snd, bool updateHistory) {
   if (iter != regionToTransferredOpMap.end()) {
     auto operand = iter->second;
     regionToTransferredOpMap.erase(iter);
-    regionToTransferredOpMap.try_emplace(fstRegion, operand);
+    regionToTransferredOpMap.insert({fstRegion, operand});
   }
 
   assert(is_canonical_correct());

--- a/unittests/SILOptimizer/PartitionUtilsTest.cpp
+++ b/unittests/SILOptimizer/PartitionUtilsTest.cpp
@@ -40,8 +40,10 @@ using PartitionTester = Partition::PartitionTester;
 struct MockedPartitionOpEvaluator final
     : PartitionOpEvaluatorBaseImpl<MockedPartitionOpEvaluator> {
   MockedPartitionOpEvaluator(Partition &workingPartition,
-                             TransferringOperandSetFactory &ptrSetFactory)
-      : PartitionOpEvaluatorBaseImpl(workingPartition, ptrSetFactory) {}
+                             TransferringOperandSetFactory &ptrSetFactory,
+                             TransferringOperandToStateMap &operandToStateMap)
+      : PartitionOpEvaluatorBaseImpl(workingPartition, ptrSetFactory,
+                                     operandToStateMap) {}
 
   // Just say that we always have a disconnected value.
   SILIsolationInfo getIsolationRegionInfo(Element elt) const {
@@ -65,17 +67,19 @@ struct MockedPartitionOpEvaluatorWithFailureCallback final
     : PartitionOpEvaluatorBaseImpl<
           MockedPartitionOpEvaluatorWithFailureCallback> {
   using FailureCallbackTy =
-      std::function<void(const PartitionOp &, unsigned, TransferringOperand *)>;
+      std::function<void(const PartitionOp &, unsigned, Operand *)>;
   FailureCallbackTy failureCallback;
 
   MockedPartitionOpEvaluatorWithFailureCallback(
       Partition &workingPartition, TransferringOperandSetFactory &ptrSetFactory,
+      TransferringOperandToStateMap &operandToStateMap,
       FailureCallbackTy failureCallback)
-      : PartitionOpEvaluatorBaseImpl(workingPartition, ptrSetFactory),
+      : PartitionOpEvaluatorBaseImpl(workingPartition, ptrSetFactory,
+                                     operandToStateMap),
         failureCallback(failureCallback) {}
 
   void handleLocalUseAfterTransfer(const PartitionOp &op, Element elt,
-                                   TransferringOperand *transferringOp) const {
+                                   Operand *transferringOp) const {
     failureCallback(op, elt, transferringOp);
   }
 
@@ -122,13 +126,14 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p1(historyFactory.get());
   Partition p2(historyFactory.get());
   Partition p3(historyFactory.get());
 
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
@@ -136,7 +141,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   }
 
   {
-    MockedPartitionOpEvaluator eval(p2, factory);
+    MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(5)),
                 PartitionOp::AssignFresh(Element(6)),
                 PartitionOp::AssignFresh(Element(7)),
@@ -144,7 +149,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   }
 
   {
-    MockedPartitionOpEvaluator eval(p3, factory);
+    MockedPartitionOpEvaluator eval(p3, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3)),
                 PartitionOp::AssignFresh(Element(4)),
@@ -156,7 +161,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   EXPECT_FALSE(Partition::equals(p1, p3));
 
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(4)),
                 PartitionOp::AssignFresh(Element(5)),
                 PartitionOp::AssignFresh(Element(6)),
@@ -165,7 +170,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   }
 
   {
-    MockedPartitionOpEvaluator eval(p2, factory);
+    MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3)),
@@ -174,7 +179,7 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
   }
 
   {
-    MockedPartitionOpEvaluator eval(p3, factory);
+    MockedPartitionOpEvaluator eval(p3, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(6)),
                 PartitionOp::AssignFresh(Element(7)),
                 PartitionOp::AssignFresh(Element(0)),
@@ -193,12 +198,12 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
 
   auto apply_to_p1_and_p3 = [&](PartitionOp op) {
     {
-      MockedPartitionOpEvaluator eval(p1, factory);
+      MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
       eval.apply(op);
     }
 
     {
-      MockedPartitionOpEvaluator eval(p3, factory);
+      MockedPartitionOpEvaluator eval(p3, factory, transferringOpToStateMap);
       eval.apply(op);
     }
     expect_join_eq();
@@ -206,12 +211,12 @@ TEST(PartitionUtilsTest, TestMergeAndJoin) {
 
   auto apply_to_p2_and_p3 = [&](PartitionOp op) {
     {
-      MockedPartitionOpEvaluator eval(p2, factory);
+      MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
       eval.apply(op);
     }
 
     {
-      MockedPartitionOpEvaluator eval(p3, factory);
+      MockedPartitionOpEvaluator eval(p3, factory, transferringOpToStateMap);
       eval.apply(op);
     }
     expect_join_eq();
@@ -239,6 +244,7 @@ TEST(PartitionUtilsTest, Join1) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
@@ -246,7 +252,7 @@ TEST(PartitionUtilsTest, Join1) {
                                             historyFactory.get());
 
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
                 PartitionOp::Assign(Element(1), Element(0)),
                 PartitionOp::Assign(Element(2), Element(2)),
@@ -258,7 +264,7 @@ TEST(PartitionUtilsTest, Join1) {
   Partition p2 = Partition::separateRegions(fakeLoc, llvm::ArrayRef(data1),
                                             historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p2, factory);
+    MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
                 PartitionOp::Assign(Element(1), Element(0)),
                 PartitionOp::Assign(Element(2), Element(2)),
@@ -281,6 +287,7 @@ TEST(PartitionUtilsTest, Join2) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
@@ -288,7 +295,7 @@ TEST(PartitionUtilsTest, Join2) {
                                             historyFactory.get());
 
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
                 PartitionOp::Assign(Element(1), Element(0)),
                 PartitionOp::Assign(Element(2), Element(2)),
@@ -302,7 +309,7 @@ TEST(PartitionUtilsTest, Join2) {
   Partition p2 = Partition::separateRegions(fakeLoc, llvm::ArrayRef(data2),
                                             historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p2, factory);
+    MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(4), Element(4)),
                 PartitionOp::Assign(Element(5), Element(5)),
                 PartitionOp::Assign(Element(6), Element(4)),
@@ -329,6 +336,7 @@ TEST(PartitionUtilsTest, Join2Reversed) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Element data1[] = {Element(0), Element(1), Element(2),
                      Element(3), Element(4), Element(5)};
@@ -336,7 +344,7 @@ TEST(PartitionUtilsTest, Join2Reversed) {
                                             historyFactory.get());
 
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(0), Element(0)),
                 PartitionOp::Assign(Element(1), Element(0)),
                 PartitionOp::Assign(Element(2), Element(2)),
@@ -350,7 +358,7 @@ TEST(PartitionUtilsTest, Join2Reversed) {
   Partition p2 = Partition::separateRegions(fakeLoc, llvm::ArrayRef(data2),
                                             historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p2, factory);
+    MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(4), Element(4)),
                 PartitionOp::Assign(Element(5), Element(5)),
                 PartitionOp::Assign(Element(6), Element(4)),
@@ -377,6 +385,7 @@ TEST(PartitionUtilsTest, JoinLarge) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Element data1[] = {
       Element(0),  Element(1),  Element(2),  Element(3),  Element(4),
@@ -388,7 +397,7 @@ TEST(PartitionUtilsTest, JoinLarge) {
   Partition p1 = Partition::separateRegions(fakeLoc, llvm::ArrayRef(data1),
                                             historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(0), Element(29)),
                 PartitionOp::Assign(Element(1), Element(17)),
                 PartitionOp::Assign(Element(2), Element(0)),
@@ -431,7 +440,7 @@ TEST(PartitionUtilsTest, JoinLarge) {
   Partition p2 = Partition::separateRegions(fakeLoc, llvm::ArrayRef(data2),
                                             historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p2, factory);
+    MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(15), Element(31)),
                 PartitionOp::Assign(Element(16), Element(34)),
                 PartitionOp::Assign(Element(17), Element(35)),
@@ -517,24 +526,25 @@ TEST(PartitionUtilsTest, TestAssign) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p1(historyFactory.get());
   Partition p2(historyFactory.get());
   Partition p3(historyFactory.get());
 
-  MockedPartitionOpEvaluator evalP1(p1, factory);
+  MockedPartitionOpEvaluator evalP1(p1, factory, transferringOpToStateMap);
   evalP1.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3))});
 
-  MockedPartitionOpEvaluator evalP2(p2, factory);
+  MockedPartitionOpEvaluator evalP2(p2, factory, transferringOpToStateMap);
   evalP2.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3))});
 
-  MockedPartitionOpEvaluator evalP3(p3, factory);
+  MockedPartitionOpEvaluator evalP3(p3, factory, transferringOpToStateMap);
   evalP3.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
@@ -607,11 +617,12 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p(historyFactory.get());
 
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
@@ -644,17 +655,18 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
 
   // expected: p: ({0 1 2 6 7 10} (3 4 5) (8 9) (Element(11)))
 
-  auto never_called = [](const PartitionOp &, unsigned, TransferringOperand *) {
+  auto never_called = [](const PartitionOp &, unsigned, Operand *) {
     EXPECT_TRUE(false);
   };
 
   int times_called = 0;
-  auto increment_times_called = [&](const PartitionOp &, unsigned,
-                                    TransferringOperand *) { times_called++; };
+  auto increment_times_called = [&](const PartitionOp &, unsigned, Operand *) {
+    times_called++;
+  };
 
   {
-    MockedPartitionOpEvaluatorWithFailureCallback eval(p, factory,
-                                                       increment_times_called);
+    MockedPartitionOpEvaluatorWithFailureCallback eval(
+        p, factory, transferringOpToStateMap, increment_times_called);
     eval.apply({PartitionOp::Require(Element(0)),
                 PartitionOp::Require(Element(1)),
                 PartitionOp::Require(Element(2))});
@@ -662,36 +674,36 @@ TEST(PartitionUtilsTest, TestConsumeAndRequire) {
   EXPECT_EQ(times_called, 3);
 
   {
-    MockedPartitionOpEvaluatorWithFailureCallback eval(p, factory,
-                                                       never_called);
+    MockedPartitionOpEvaluatorWithFailureCallback eval(
+        p, factory, transferringOpToStateMap, never_called);
     eval.apply({PartitionOp::Require(Element(3)),
                 PartitionOp::Require(Element(4)),
                 PartitionOp::Require(Element(5))});
   }
 
   {
-    MockedPartitionOpEvaluatorWithFailureCallback eval(p, factory,
-                                                       increment_times_called);
+    MockedPartitionOpEvaluatorWithFailureCallback eval(
+        p, factory, transferringOpToStateMap, increment_times_called);
     eval.apply(
         {PartitionOp::Require(Element(6)), PartitionOp::Require(Element(7))});
   }
 
   {
-    MockedPartitionOpEvaluatorWithFailureCallback eval(p, factory,
-                                                       never_called);
+    MockedPartitionOpEvaluatorWithFailureCallback eval(
+        p, factory, transferringOpToStateMap, never_called);
     eval.apply(
         {PartitionOp::Require(Element(8)), PartitionOp::Require(Element(9))});
   }
 
   {
-    MockedPartitionOpEvaluatorWithFailureCallback eval(p, factory,
-                                                       increment_times_called);
+    MockedPartitionOpEvaluatorWithFailureCallback eval(
+        p, factory, transferringOpToStateMap, increment_times_called);
     eval.apply(PartitionOp::Require(Element(10)));
   }
 
   {
-    MockedPartitionOpEvaluatorWithFailureCallback eval(p, factory,
-                                                       never_called);
+    MockedPartitionOpEvaluatorWithFailureCallback eval(
+        p, factory, transferringOpToStateMap, never_called);
     eval.apply(PartitionOp::Require(Element(11)));
   }
 
@@ -704,10 +716,11 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p1(historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply(PartitionOp::AssignFresh(Element(0)));
   }
 
@@ -716,25 +729,23 @@ TEST(PartitionUtilsTest, TestCopyConstructor) {
 
   // Change p1 again.
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply(PartitionOp::Transfer(Element(0), transferSingletons[0]));
   }
 
   {
     bool failure = false;
     MockedPartitionOpEvaluatorWithFailureCallback eval(
-        p1, factory, [&](const PartitionOp &, unsigned, TransferringOperand *) {
-          failure = true;
-        });
+        p1, factory, transferringOpToStateMap,
+        [&](const PartitionOp &, unsigned, Operand *) { failure = true; });
     eval.apply(PartitionOp::Require(Element(0)));
     EXPECT_TRUE(failure);
   }
 
   {
     MockedPartitionOpEvaluatorWithFailureCallback eval(
-        p2, factory, [](const PartitionOp &, unsigned, TransferringOperand *) {
-          EXPECT_TRUE(false);
-        });
+        p2, factory, transferringOpToStateMap,
+        [](const PartitionOp &, unsigned, Operand *) { EXPECT_TRUE(false); });
     eval.apply(PartitionOp::Require(Element(0)));
   }
 }
@@ -743,12 +754,12 @@ TEST(PartitionUtilsTest, TestUndoTransfer) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p(historyFactory.get());
   MockedPartitionOpEvaluatorWithFailureCallback eval(
-      p, factory, [&](const PartitionOp &, unsigned, TransferringOperand *) {
-        EXPECT_TRUE(false);
-      });
+      p, factory, transferringOpToStateMap,
+      [&](const PartitionOp &, unsigned, Operand *) { EXPECT_TRUE(false); });
 
   // Shouldn't error on this.
   eval.apply({PartitionOp::AssignFresh(Element(0)),
@@ -761,11 +772,12 @@ TEST(PartitionUtilsTest, TestLastEltInTransferredRegion) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   // First make sure that we do this correctly with an assign fresh.
   Partition p(historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
@@ -777,7 +789,7 @@ TEST(PartitionUtilsTest, TestLastEltInTransferredRegion) {
   // Now make sure that we do this correctly with assign.
   Partition p2(historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p2, factory);
+    MockedPartitionOpEvaluator eval(p2, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2)),
@@ -792,11 +804,12 @@ TEST(PartitionUtilsTest, TestHistory_CreateVariable) {
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
   SmallVector<IsolationHistory, 8> joinedHistories;
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   // First make sure that we do this correctly with an assign fresh.
   Partition p(historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1))});
   }
@@ -804,7 +817,7 @@ TEST(PartitionUtilsTest, TestHistory_CreateVariable) {
   Partition pSnapshot = p;
 
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(2))});
   }
 
@@ -818,12 +831,13 @@ TEST(PartitionUtilsTest, TestHistory_AssignRegion) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
   SmallVector<IsolationHistory, 8> joinedHistories;
 
   // First make sure that we do this correctly with an assign fresh.
   Partition p(historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(0)),
                 PartitionOp::AssignFresh(Element(1)),
                 PartitionOp::AssignFresh(Element(2))});
@@ -832,13 +846,13 @@ TEST(PartitionUtilsTest, TestHistory_AssignRegion) {
   Partition pSnapshot = p;
 
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(1), Element(2))});
   }
 
   Partition pSnapshot2 = p;
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(0), Element(2))});
   }
 
@@ -857,11 +871,12 @@ TEST(PartitionUtilsTest, TestHistory_BuildNewRegionRepIsMergee) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
   SmallVector<IsolationHistory, 8> joinedHistories;
 
   Partition p(historyFactory.get());
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3)),
                 PartitionOp::AssignFresh(Element(10)),
@@ -874,13 +889,13 @@ TEST(PartitionUtilsTest, TestHistory_BuildNewRegionRepIsMergee) {
   Partition pSnapshot = p;
 
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(1), Element(2))});
   }
 
   Partition pSnapshot2 = p;
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::Assign(Element(0), Element(2))});
   }
 
@@ -905,6 +920,7 @@ TEST(PartitionUtilsTest, TestHistory_ReturnFalseWhenNoneLeft) {
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
   SmallVector<IsolationHistory, 8> joinedHistories;
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p(historyFactory.get());
 
@@ -912,7 +928,7 @@ TEST(PartitionUtilsTest, TestHistory_ReturnFalseWhenNoneLeft) {
   EXPECT_TRUE(joinedHistories.empty());
 
   {
-    MockedPartitionOpEvaluator eval(p, factory);
+    MockedPartitionOpEvaluator eval(p, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(2)),
                 PartitionOp::AssignFresh(Element(3))});
   }
@@ -945,12 +961,13 @@ TEST(PartitionUtilsTest, TestHistory_JoiningNotEmptyAndEmpty) {
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
   SmallVector<IsolationHistory, 8> joinedHistories;
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
 
   Partition p1(historyFactory.get());
   Partition p2(historyFactory.get());
 
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(2))});
   }
 
@@ -968,13 +985,14 @@ TEST(PartitionUtilsTest, TestHistory_JoiningEmptyAndNotEmpty) {
   llvm::BumpPtrAllocator allocator;
   Partition::TransferringOperandSetFactory factory(allocator);
   IsolationHistory::Factory historyFactory(allocator);
+  TransferringOperandToStateMap transferringOpToStateMap(historyFactory);
   SmallVector<IsolationHistory, 8> joinedHistories;
 
   Partition p1(historyFactory.get());
   Partition p2(historyFactory.get());
 
   {
-    MockedPartitionOpEvaluator eval(p1, factory);
+    MockedPartitionOpEvaluator eval(p1, factory, transferringOpToStateMap);
     eval.apply({PartitionOp::AssignFresh(Element(2))});
   }
 


### PR DESCRIPTION
This PR contains a few different that add up to doing the title of the PR.

Specifically:

#### Changing the representation of the region -> transferring operand map from a SmallDenseMap to a SmallMapVector

The first commit changes our representation of the region -> transferring
operand map from a SmallDenseMap to a SmallMapVector. I am doing this since to
do the dataflow convergence, I need to check for equality implying I would need
to traverse the map and iterating over a hash table can lead to performance
issues.

#### Refactoring the region -> transferring operand map to use bare Operand * instead of TransferringOperand *.

In the second commit, I refactored the region -> transferring operand map such
that it just tracks bare operands and eliminated the transferring operand
abstraction in favor of just storing a global map from operand -> extra
transferring state.

Originally, we mapped a region number to an immutable pointer set containing
Operand * where the region was tranferred. This worked great for a time... until
I began to need to propagate other information from the transferring code in the
analysis to the actual diagnostic emitter.

To be able to do that, my thought was to make a wrapper type around Operand
called TransferringOperand that contained the operand and the other information
I needed. This seemed to provide me what I wanted but I later found that since
the immutable pointer set was tracking TransferringOperands which were always
newly wrapped with an Operand *, we actually always created new pointer
sets. This is of course wasteful from a memory perspective, but also prevents me
from tracking transferring operand sets during the dataflow since we would never
converge.

#### Include the region -> transferring operand map in the dataflow convergence.

The reason why I am doing this is that really we are running two different
dataflow equations at the same time... one for propagating tracking transferring
sets and the other for propagating regions. Since at the source level the two
dataflow problems are very interrelated, I was unable to come up with an example
where we fail to iterate because of this, but I would like to be sure that we do
not hit one, so I am fixing this here.

rdar://126170014
