### PR TITLE
Concurrency: Fix a condfail in default `AsyncIteratorProtocol.next()`

### DIFF
--- a/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
+++ b/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
@@ -133,6 +133,10 @@ extension AsyncIteratorProtocol {
   @available(SwiftStdlib 6.0, *)
   @inlinable
   public mutating func next() async throws(Failure) -> Element? {
+#if $OptionalIsolatedParameters
     return try await next(isolation: nil)
+#else
+    fatalError("unsupported compiler")
+#endif
   }
 }


### PR DESCRIPTION
Older compilers that do not enable `OptionalIsolatedParameters` by default must be able to build the `_Concurrency` module. Fixes fallout from https://github.com/apple/swift/pull/72675.

Resolves rdar://126215750
