### PR TITLE
[6.0] Concurrency: Fix a condfail in default `AsyncIteratorProtocol.next()`

### DIFF
--- a/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
+++ b/stdlib/public/Concurrency/AsyncIteratorProtocol.swift
@@ -133,6 +133,10 @@ extension AsyncIteratorProtocol {
   @available(SwiftStdlib 6.0, *)
   @inlinable
   public mutating func next() async throws(Failure) -> Element? {
+#if $OptionalIsolatedParameters
     return try await next(isolation: nil)
+#else
+    fatalError("unsupported compiler")
+#endif
   }
 }


### PR DESCRIPTION
- **Explanation:** Older compilers that do not enable `OptionalIsolatedParameters` by default must be able to build the `_Concurrency` module. Fixes fallout from https://github.com/apple/swift/pull/72675.
- **Scope:** Prevents compilation of the `_Concurrency` module's interface by older, supported compilers, blocking important development workflows.
- **Issue/Radar:** rdar://126215750
- **Original PR:** https://github.com/apple/swift/pull/72956
- **Risk:** Low.
- **Testing:** Built the standard libraries and then manually compiled their `.swiftinterface` files using older Swift 6.0 compilers.
- **Reviewer:** @hborla 
