### PR TITLE
[region-isolation] Do not look through begin_borrow or move_value if they are marked as a var_decl.

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -917,7 +917,15 @@ public:
 
   bool isMarkedAsImmortal() const;
 
+  /// Returns true if this type is an actor type. Returns false if this is any
+  /// other type. This includes distributed actors. To check for distributed
+  /// actors and actors, use isAnyActor().
   bool isActor() const { return getASTType()->isActorType(); }
+
+  bool isDistributedActor() const { return getASTType()->isDistributedActor(); }
+
+  /// Returns true if this type is an actor or a distributed actor.
+  bool isAnyActor() const { return getASTType()->isAnyActorType(); }
 
   /// Returns true if this function conforms to the Sendable protocol.
   bool isSendable(SILFunction *fn) const;

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -28,7 +28,7 @@ class RegionAnalysisFunctionInfo;
 namespace regionanalysisimpl {
 
 using TransferringOperandSetFactory = Partition::TransferringOperandSetFactory;
-using TrackableValueID = PartitionPrimitives::Element;
+using Element = PartitionPrimitives::Element;
 using Region = PartitionPrimitives::Region;
 
 /// Check if the passed in type is NonSendable.
@@ -175,7 +175,7 @@ public:
 
   SILIsolationInfo getIsolationRegionInfo() const { return regionInfo; }
 
-  TrackableValueID getID() const { return TrackableValueID(id); }
+  Element getID() const { return Element(id); }
 
   void addFlag(TrackableValueFlag flag) { flagSet |= flag; }
 
@@ -276,9 +276,7 @@ public:
     return valueState.getIsolationRegionInfo();
   }
 
-  TrackableValueID getID() const {
-    return TrackableValueID(valueState.getID());
-  }
+  Element getID() const { return Element(valueState.getID()); }
 
   /// Return the representative value of this equivalence class of values.
   RepresentativeValue getRepresentative() const { return representativeValue; }
@@ -320,7 +318,6 @@ public:
   using Region = PartitionPrimitives::Region;
   using TrackableValue = regionanalysisimpl::TrackableValue;
   using TrackableValueState = regionanalysisimpl::TrackableValueState;
-  using TrackableValueID = Element;
   using RepresentativeValue = regionanalysisimpl::RepresentativeValue;
 
 private:
@@ -374,14 +371,14 @@ public:
       SILInstruction *introducingInst) const;
 
 private:
-  std::optional<TrackableValue> getValueForId(TrackableValueID id) const;
+  std::optional<TrackableValue> getValueForId(Element id) const;
   std::optional<TrackableValue> tryToTrackValue(SILValue value) const;
   TrackableValue
   getActorIntroducingRepresentative(SILInstruction *introducingInst,
                                     SILIsolationInfo isolation) const;
   bool mergeIsolationRegionInfo(SILValue value, SILIsolationInfo isolation);
   bool valueHasID(SILValue value, bool dumpIfHasNoID = false);
-  TrackableValueID lookupValueID(SILValue value);
+  Element lookupValueID(SILValue value);
 };
 
 class RegionAnalysisFunctionInfo {

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -186,7 +186,7 @@ public:
        << "][is_no_alias: " << (isNoAlias() ? "yes" : "no")
        << "][is_sendable: " << (isSendable() ? "yes" : "no")
        << "][region_value_kind: ";
-    getIsolationRegionInfo().print(os);
+    getIsolationRegionInfo().printForDiagnostics(os);
     os << "].";
   }
 

--- a/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RegionAnalysis.h
@@ -289,6 +289,11 @@ public:
   /// parameter.
   bool isTransferringParameter() const;
 
+  void printIsolationInfo(SmallString<64> &outString) const {
+    llvm::raw_svector_ostream os(outString);
+    getIsolationRegionInfo().printForDiagnostics(os);
+  }
+
   void print(llvm::raw_ostream &os) const {
     os << "TrackableValue. State: ";
     valueState.print(os);

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -670,7 +670,7 @@ private:
 
   /// Track a label that is guaranteed to be strictly larger than all in use,
   /// and therefore safe for use as a fresh label.
-  Region fresh_label = Region(0);
+  Region freshLabel = Region(0);
 
   /// An immutable data structure that we use to push/pop isolation history.
   IsolationHistory history;
@@ -841,7 +841,7 @@ public:
     llvm::dbgs() << "Partition";
     if (canonical)
       llvm::dbgs() << "(canonical)";
-    llvm::dbgs() << "(fresh=" << fresh_label << "){";
+    llvm::dbgs() << "(fresh=" << freshLabel << "){";
     for (const auto &[i, label] : elementToRegionMap)
       llvm::dbgs() << "[" << i << ": " << label << "] ";
     llvm::dbgs() << "}\n";

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -130,7 +130,7 @@ private:
         isolatedValue(isolatedValue), actorInstance(actorInstance) {
     assert((!actorInstance ||
             (actorIsolation.getKind() == ActorIsolation::ActorInstance &&
-             actorInstance->getType().isActor())) &&
+             actorInstance->getType().isAnyActor())) &&
            "actorInstance must be an actor if it is non-empty");
   }
 
@@ -211,7 +211,7 @@ public:
   static SILIsolationInfo getActorIsolated(SILValue isolatedValue,
                                            SILValue actorInstance,
                                            NominalTypeDecl *typeDecl) {
-    if (typeDecl->isActor())
+    if (typeDecl->isAnyActor())
       return {ActorIsolation::forActorInstanceSelf(typeDecl), isolatedValue,
               actorInstance};
     auto isolation = swift::getActorIsolation(typeDecl);

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -161,6 +161,11 @@ public:
 
   void printForDiagnostics(llvm::raw_ostream &os) const;
 
+  SWIFT_DEBUG_DUMPER(dumpForDiagnostics()) {
+    printForDiagnostics(llvm::dbgs());
+    llvm::dbgs() << '\n';
+  }
+
   ActorIsolation getActorIsolation() const {
     assert(kind == Actor);
     return actorIsolation;

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -207,11 +207,11 @@ public:
   static SILIsolationInfo get(SILInstruction *inst);
 
   /// Attempt to infer the isolation region info for \p arg.
-  static SILIsolationInfo get(SILFunctionArgument *arg);
+  static SILIsolationInfo get(SILArgument *arg);
 
   static SILIsolationInfo get(SILValue value) {
-    if (auto *fArg = dyn_cast<SILFunctionArgument>(value))
-      return get(fArg);
+    if (auto *arg = dyn_cast<SILArgument>(value))
+      return get(arg);
     if (auto *inst = dyn_cast<SingleValueInstruction>(value))
       return get(inst);
     return {};

--- a/include/swift/SILOptimizer/Utils/PartitionUtils.h
+++ b/include/swift/SILOptimizer/Utils/PartitionUtils.h
@@ -209,6 +209,14 @@ public:
   /// Attempt to infer the isolation region info for \p arg.
   static SILIsolationInfo get(SILFunctionArgument *arg);
 
+  static SILIsolationInfo get(SILValue value) {
+    if (auto *fArg = dyn_cast<SILFunctionArgument>(value))
+      return get(fArg);
+    if (auto *inst = dyn_cast<SingleValueInstruction>(value))
+      return get(inst);
+    return {};
+  }
+
   bool hasSameIsolation(ActorIsolation actorIsolation) const;
 
   /// Returns true if \p this and \p other have the same isolation. It allows

--- a/include/swift/SILOptimizer/Utils/VariableNameUtils.h
+++ b/include/swift/SILOptimizer/Utils/VariableNameUtils.h
@@ -192,6 +192,15 @@ public:
 
   StringRef getName() const { return resultingString; }
 
+  /// Given a specific SILValue, construct a VariableNameInferrer and use it to
+  /// attempt to infer an identifier for the value.
+  static std::optional<Identifier> inferName(SILValue value);
+
+  /// Given a specific SILValue, construct a VariableNameInferrer and use it to
+  /// attempt to infer an identifier for the value and a named value.
+  static std::optional<std::pair<Identifier, SILValue>>
+  inferNameAndRoot(SILValue value);
+
 private:
   void drainVariableNamePath();
   void popSingleVariableName();

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -36,6 +36,7 @@
 #include "swift/SIL/Test.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/PartitionUtils.h"
+#include "swift/SILOptimizer/Utils/VariableNameUtils.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/Debug.h"
 
@@ -615,6 +616,12 @@ void SILIsolationInfo::printForDiagnostics(llvm::raw_ostream &os) const {
     os << "disconnected";
     return;
   case Actor:
+    if (SILValue instance = getActorInstance()) {
+      if (auto name = VariableNameInferrer::inferName(instance)) {
+        os << "'" << *name << "'-isolated";
+        return;
+      }
+    }
     getActorIsolation().printForDiagnostics(os);
     return;
   case Task:

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -604,33 +604,6 @@ static bool isTransferrableFunctionArgument(SILFunctionArgument *arg) {
 }
 
 //===----------------------------------------------------------------------===//
-//                           MARK: SILIsolationInfo
-//===----------------------------------------------------------------------===//
-
-void SILIsolationInfo::printForDiagnostics(llvm::raw_ostream &os) const {
-  switch (Kind(*this)) {
-  case Unknown:
-    llvm::report_fatal_error("Printing unknown for diagnostics?!");
-    return;
-  case Disconnected:
-    os << "disconnected";
-    return;
-  case Actor:
-    if (SILValue instance = getActorInstance()) {
-      if (auto name = VariableNameInferrer::inferName(instance)) {
-        os << "'" << *name << "'-isolated";
-        return;
-      }
-    }
-    getActorIsolation().printForDiagnostics(os);
-    return;
-  case Task:
-    os << "task-isolated";
-    return;
-  }
-}
-
-//===----------------------------------------------------------------------===//
 //                            MARK: TrackableValue
 //===----------------------------------------------------------------------===//
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3292,28 +3292,8 @@ TrackableValue RegionAnalysisValueMap::getTrackableValue(
         iter.first->getSecond().removeFlag(TrackableValueFlag::isMayAlias);
       }
 
-      // Then see if the memory base is a ref_element_addr from an address. If
-      // so, add the actor derived flag.
-      //
-      // This is important so we properly handle setters.
-      if (auto *rei = dyn_cast<RefElementAddrInst>(storage.base)) {
-        auto *nomDecl =
-            rei->getOperand()->getType().getNominalOrBoundGenericNominal();
-        iter.first->getSecond().mergeIsolationRegionInfo(
-            SILIsolationInfo::getActorIsolated(rei, nomDecl));
-      }
-
-      // See if the memory base is a global_addr from a global actor protected global.
-      if (auto *ga = dyn_cast<GlobalAddrInst>(storage.base)) {
-        if (auto *global = ga->getReferencedGlobal()) {
-          if (auto *globalDecl = global->getDecl()) {
-            auto isolation = getActorIsolation(globalDecl);
-            if (isolation.isGlobalActor()) {
-              iter.first->getSecond().mergeIsolationRegionInfo(
-                  SILIsolationInfo::getActorIsolated(ga, isolation));
-            }
-          }
-        }
+      if (auto isolation = SILIsolationInfo::get(storage.base)) {
+        iter.first->getSecond().mergeIsolationRegionInfo(isolation);
       }
     }
   }

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3336,12 +3336,8 @@ TrackableValue RegionAnalysisValueMap::getTrackableValue(
 
     auto storage = AccessStorageWithBase::compute(svi->getOperand(0));
     if (storage.storage) {
-      if (auto *reai = dyn_cast<RefElementAddrInst>(storage.base)) {
-        auto *nomDecl = reai->getOperand()
-                            ->getType()
-                            .getNominalOrBoundGenericNominal();
-        iter.first->getSecond().mergeIsolationRegionInfo(
-            SILIsolationInfo::getActorIsolated(reai->getOperand(), nomDecl));
+      if (auto isolation = SILIsolationInfo::get(storage.base)) {
+        iter.first->getSecond().mergeIsolationRegionInfo(isolation);
       }
     }
   }

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3262,7 +3262,7 @@ TrackableValue RegionAnalysisValueMap::getTrackableValue(
     // underlying object, use that. It is never wrong.
     if (info.actorIsolation) {
       SILValue actorInstance =
-          info.value->getType().isActor() ? info.value : SILValue();
+          info.value->getType().isAnyActor() ? info.value : SILValue();
       iter.first->getSecond().mergeIsolationRegionInfo(
           SILIsolationInfo::getActorIsolated(value, actorInstance,
                                              *info.actorIsolation));

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -3281,8 +3281,11 @@ TrackableValue RegionAnalysisValueMap::getTrackableValue(
     // If we were able to find this was actor isolated from finding our
     // underlying object, use that. It is never wrong.
     if (info.actorIsolation) {
+      SILValue actorInstance =
+          info.value->getType().isActor() ? info.value : SILValue();
       iter.first->getSecond().mergeIsolationRegionInfo(
-          SILIsolationInfo::getActorIsolated(value, *info.actorIsolation));
+          SILIsolationInfo::getActorIsolated(value, actorInstance,
+                                             *info.actorIsolation));
     }
 
     auto storage = AccessStorageWithBase::compute(value);
@@ -3332,7 +3335,7 @@ TrackableValue RegionAnalysisValueMap::getTrackableValue(
     auto parentAddrInfo = getUnderlyingTrackedValue(svi);
     if (parentAddrInfo.actorIsolation) {
       iter.first->getSecond().mergeIsolationRegionInfo(
-          SILIsolationInfo::getActorIsolated(svi,
+          SILIsolationInfo::getActorIsolated(svi, parentAddrInfo.value,
                                              *parentAddrInfo.actorIsolation));
     }
 

--- a/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/RegionAnalysis.cpp
@@ -1145,11 +1145,10 @@ struct PartitionOpBuilder {
     currentInstPartitionOps.clear();
   }
 
-  TrackableValueID lookupValueID(SILValue value);
+  Element lookupValueID(SILValue value);
   bool valueHasID(SILValue value, bool dumpIfHasNoID = false);
 
-  TrackableValueID
-  getActorIntroducingRepresentative(SILIsolationInfo actorIsolation);
+  Element getActorIntroducingRepresentative(SILIsolationInfo actorIsolation);
 
   void addAssignFresh(SILValue value) {
     currentInstPartitionOps.emplace_back(
@@ -1160,7 +1159,7 @@ struct PartitionOpBuilder {
     assert(valueHasID(src, /*dumpIfHasNoID=*/true) &&
            "source value of assignment should already have been encountered");
 
-    TrackableValueID srcID = lookupValueID(src);
+    Element srcID = lookupValueID(src);
     if (lookupValueID(tgt) == srcID) {
       LLVM_DEBUG(llvm::dbgs() << "    Skipping assign since tgt and src have "
                                  "the same representative.\n");
@@ -1501,7 +1500,7 @@ public:
     return partialApplyReachabilityDataflow.isReachable(value, inst);
   }
 
-  std::optional<TrackableValue> getValueForId(TrackableValueID id) const {
+  std::optional<TrackableValue> getValueForId(Element id) const {
     return valueMap.getValueForId(id);
   }
 
@@ -1542,7 +1541,7 @@ private:
     return valueMap.valueHasID(value, dumpIfHasNoID);
   }
 
-  TrackableValueID lookupValueID(SILValue value) {
+  Element lookupValueID(SILValue value) {
     return valueMap.lookupValueID(value);
   }
 
@@ -2288,11 +2287,11 @@ public:
 } // namespace regionanalysisimpl
 } // namespace swift
 
-TrackableValueID PartitionOpBuilder::lookupValueID(SILValue value) {
+Element PartitionOpBuilder::lookupValueID(SILValue value) {
   return translator->lookupValueID(value);
 }
 
-TrackableValueID PartitionOpBuilder::getActorIntroducingRepresentative(
+Element PartitionOpBuilder::getActorIntroducingRepresentative(
     SILIsolationInfo actorIsolation) {
   return translator
       ->getActorIntroducingRepresentative(currentInst, actorIsolation)
@@ -2332,17 +2331,17 @@ void PartitionOpBuilder::print(llvm::raw_ostream &os) const {
 
   // Now print out a translation from region to equivalence class value.
   llvm::dbgs() << " └─────╼ Used Values\n";
-  llvm::SmallVector<TrackableValueID, 8> opsToPrint;
+  llvm::SmallVector<Element, 8> opsToPrint;
   SWIFT_DEFER { opsToPrint.clear(); };
   for (const PartitionOp &op : ops) {
     // Now dump our the root value we map.
     for (unsigned opArg : op.getOpArgs()) {
       // If we didn't insert, skip this. We only emit this once.
-      opsToPrint.push_back(TrackableValueID(opArg));
+      opsToPrint.push_back(Element(opArg));
     }
   }
   sortUnique(opsToPrint);
-  for (TrackableValueID opArg : opsToPrint) {
+  for (Element opArg : opsToPrint) {
     llvm::dbgs() << "          └╼ ";
     auto trackableValue = translator->getValueForId(opArg);
     assert(trackableValue);
@@ -3202,7 +3201,7 @@ SILInstruction *RegionAnalysisValueMap::maybeGetActorIntroducingInst(
 }
 
 std::optional<TrackableValue>
-RegionAnalysisValueMap::getValueForId(TrackableValueID id) const {
+RegionAnalysisValueMap::getValueForId(Element id) const {
   auto iter = stateIndexToEquivalenceClass.find(id);
   if (iter == stateIndexToEquivalenceClass.end())
     return {};
@@ -3579,7 +3578,7 @@ bool RegionAnalysisValueMap::valueHasID(SILValue value, bool dumpIfHasNoID) {
   return hasID;
 }
 
-TrackableValueID RegionAnalysisValueMap::lookupValueID(SILValue value) {
+Element RegionAnalysisValueMap::lookupValueID(SILValue value) {
   auto state = getTrackableValue(value);
   assert(state.isNonSendable() &&
          "only non-Sendable values should be entered in the map");

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -92,34 +92,6 @@ static Expr *inferArgumentExprFromApplyExpr(ApplyExpr *sourceApply,
   return foundExpr;
 }
 
-static std::optional<Identifier> inferNameFromValue(SILValue value) {
-  auto *fn = value->getFunction();
-  if (!fn)
-    return {};
-  VariableNameInferrer::Options options;
-  options |= VariableNameInferrer::Flag::InferSelfThroughAllAccessors;
-  SmallString<64> resultingName;
-  VariableNameInferrer inferrer(fn, options, resultingName);
-  if (!inferrer.inferByWalkingUsesToDefsReturningRoot(value))
-    return {};
-  return fn->getASTContext().getIdentifier(resultingName);
-}
-
-static std::optional<std::pair<Identifier, SILValue>>
-inferNameAndRootFromValue(SILValue value) {
-  auto *fn = value->getFunction();
-  if (!fn)
-    return {};
-  VariableNameInferrer::Options options;
-  options |= VariableNameInferrer::Flag::InferSelfThroughAllAccessors;
-  SmallString<64> resultingName;
-  VariableNameInferrer inferrer(fn, options, resultingName);
-  SILValue rootValue = inferrer.inferByWalkingUsesToDefsReturningRoot(value);
-  if (!rootValue)
-    return {};
-  return {{fn->getASTContext().getIdentifier(resultingName), rootValue}};
-}
-
 //===----------------------------------------------------------------------===//
 //                             MARK: Diagnostics
 //===----------------------------------------------------------------------===//
@@ -693,7 +665,8 @@ bool UseAfterTransferDiagnosticInferrer::initForIsolatedPartialApply(
     emittedDiagnostic = true;
 
     auto &state = transferringOpToStateMap.get(transferOp);
-    if (auto rootValueAndName = inferNameAndRootFromValue(transferOp->get())) {
+    if (auto rootValueAndName =
+            VariableNameInferrer::inferNameAndRoot(transferOp->get())) {
       diagnosticEmitter.emitNamedIsolationCrossingDueToCapture(
           RegularLocation(std::get<0>(p).getLoc()), rootValueAndName->first,
           state.isolationInfo, std::get<2>(p));
@@ -815,7 +788,7 @@ void UseAfterTransferDiagnosticInferrer::infer() {
 
       // First try to do the named diagnostic if we can find a name.
       if (auto rootValueAndName =
-              inferNameAndRootFromValue(transferOp->get())) {
+              VariableNameInferrer::inferNameAndRoot(transferOp->get())) {
         return diagnosticEmitter.emitNamedUseOfStronglyTransferredValue(
             baseLoc, rootValueAndName->first);
       }
@@ -841,7 +814,8 @@ void UseAfterTransferDiagnosticInferrer::infer() {
   if (auto *sourceApply = loc.getAsASTNode<ApplyExpr>()) {
     // Before we do anything further, see if we can find a name and emit a name
     // error.
-    if (auto rootValueAndName = inferNameAndRootFromValue(transferOp->get())) {
+    if (auto rootValueAndName =
+            VariableNameInferrer::inferNameAndRoot(transferOp->get())) {
       auto &state = transferringOpToStateMap.get(transferOp);
       return diagnosticEmitter.emitNamedIsolationCrossingError(
           baseLoc, rootValueAndName->first, state.isolationInfo,
@@ -1178,7 +1152,7 @@ bool TransferNonTransferrableDiagnosticInferrer::run() {
 
         // See if we can infer a name from the value.
         SmallString<64> resultingName;
-        if (auto varName = inferNameFromValue(op->get())) {
+        if (auto varName = VariableNameInferrer::inferName(op->get())) {
           diagnosticEmitter.emitNamedFunctionArgumentApplyStronglyTransferred(
               loc, *varName);
           return true;
@@ -1218,7 +1192,7 @@ bool TransferNonTransferrableDiagnosticInferrer::run() {
 
     // See if we can infer a name from the value.
     SmallString<64> resultingName;
-    if (auto name = inferNameFromValue(op->get())) {
+    if (auto name = VariableNameInferrer::inferName(op->get())) {
       diagnosticEmitter.emitNamedIsolation(loc, *name, *isolation);
       return true;
     }
@@ -1266,7 +1240,7 @@ bool TransferNonTransferrableDiagnosticInferrer::run() {
              "All result info must be the same... if that changes... update "
              "this code!");
       SmallString<64> resultingName;
-      if (auto name = inferNameFromValue(op->get())) {
+      if (auto name = VariableNameInferrer::inferName(op->get())) {
         diagnosticEmitter.emitNamedTransferringReturn(loc, *name);
         return true;
       }

--- a/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
+++ b/lib/SILOptimizer/Mandatory/TransferNonSendable.cpp
@@ -46,7 +46,7 @@ using namespace swift::regionanalysisimpl;
 namespace {
 
 using TransferringOperandSetFactory = Partition::TransferringOperandSetFactory;
-using TrackableValueID = PartitionPrimitives::Element;
+using Element = PartitionPrimitives::Element;
 using Region = PartitionPrimitives::Region;
 
 } // namespace
@@ -1330,10 +1330,9 @@ struct DiagnosticEvaluator final
         transferredNonTransferrable(transferredNonTransferrable) {}
 
   void handleLocalUseAfterTransfer(const PartitionOp &partitionOp,
-                                   TrackableValueID transferredVal,
+                                   Element transferredVal,
                                    Operand *transferringOp) const {
     auto &operandState = operandToStateMap.get(transferringOp);
-
     // Ignore this if we have a gep like instruction that is returning a
     // sendable type and transferringOp was not set with closure
     // capture.
@@ -1364,7 +1363,7 @@ struct DiagnosticEvaluator final
 
   void
   handleTransferNonTransferrable(const PartitionOp &partitionOp,
-                                 TrackableValueID transferredVal,
+                                 Element transferredVal,
                                  SILIsolationInfo isolationRegionInfo) const {
     LLVM_DEBUG(llvm::dbgs()
                    << "    Emitting TransferNonTransferrable Error!\n"
@@ -1384,8 +1383,8 @@ struct DiagnosticEvaluator final
 
   void
   handleTransferNonTransferrable(const PartitionOp &partitionOp,
-                                 TrackableValueID transferredVal,
-                                 TrackableValueID actualNonTransferrableValue,
+                                 Element transferredVal,
+                                 Element actualNonTransferrableValue,
                                  SILIsolationInfo isolationRegionInfo) const {
     LLVM_DEBUG(llvm::dbgs()
                    << "    Emitting TransferNonTransferrable Error!\n"

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -21,8 +21,6 @@
 
 #include "llvm/Support/CommandLine.h"
 
-#pragma clang optimize off
-
 using namespace swift;
 using namespace swift::PatternMatch;
 using namespace swift::PartitionPrimitives;

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -105,7 +105,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
           for (auto &op : as.getArgumentOperands()) {
             if (as.getArgumentParameterInfo(op).hasOption(
                     SILParameterInfo::Isolated)) {
-              actorInstance = pai->getAllOperands().back().get();
+              actorInstance = op.get();
               break;
             }
           }

--- a/lib/SILOptimizer/Utils/PartitionUtils.cpp
+++ b/lib/SILOptimizer/Utils/PartitionUtils.cpp
@@ -122,7 +122,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
     auto *nomDecl =
         rei->getOperand()->getType().getNominalOrBoundGenericNominal();
     SILValue actorInstance =
-        nomDecl->isActor() ? rei->getOperand() : SILValue();
+        nomDecl->isAnyActor() ? rei->getOperand() : SILValue();
     return SILIsolationInfo::getActorIsolated(rei, actorInstance, nomDecl);
   }
 
@@ -181,7 +181,7 @@ SILIsolationInfo SILIsolationInfo::get(SILInstruction *inst) {
         if (isolation.isActorIsolated() &&
             (isolation.getKind() != ActorIsolation::ActorInstance ||
              isolation.getActorInstanceParameter() == 0)) {
-          auto actor = cmi->getOperand()->getType().isActor()
+          auto actor = cmi->getOperand()->getType().isAnyActor()
                            ? cmi->getOperand()
                            : SILValue();
           return SILIsolationInfo::getActorIsolated(cmi, actor, isolation);

--- a/lib/SILOptimizer/Utils/VariableNameUtils.cpp
+++ b/lib/SILOptimizer/Utils/VariableNameUtils.cpp
@@ -320,6 +320,27 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValuePhiArg(
   return SILValue();
 }
 
+static BeginBorrowInst *hasOnlyBorrowingNonDestroyUse(SILValue searchValue) {
+  BeginBorrowInst *result = nullptr;
+  for (auto *use : searchValue->getUses()) {
+    if (isIncidentalUse(use->getUser()))
+      continue;
+    if (use->isConsuming()) {
+      if (!isa<DestroyValueInst>(use->getUser()))
+        return nullptr;
+      continue;
+    }
+
+    auto *bbi = dyn_cast<BeginBorrowInst>(use->getUser());
+    if (!bbi || !bbi->isFromVarDecl())
+      return nullptr;
+    if (result)
+      return nullptr;
+    result = bbi;
+  }
+  return result;
+}
+
 SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
     SILValue searchValue, ValueSet &visitedValues) {
   assert(searchValue);
@@ -334,6 +355,56 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
       return SILValue();
 
     LLVM_DEBUG(llvm::dbgs() << "Value: " << *searchValue);
+
+    // Before we do anything, lets see if we have an explicit match due to a
+    // debug_value use.
+    if (auto *use = getAnyDebugUse(searchValue)) {
+      if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
+        assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
+        variableNamePath.push_back(use->getUser());
+
+        // We return the value, not the debug_info.
+        return searchValue;
+      }
+    }
+
+    // If we are in Ownership SSA, see if we have an owned value that has one
+    // use, a move_value [var decl]. In such a case, check the move_value [var
+    // decl] for a debug_value.
+    //
+    // This pattern comes up if we are asked to get a name for an apply that is
+    // used to initialize a value. The name will not yet be associated with the
+    // value so we have to compensate.
+    //
+    // NOTE: This is a heuristic. Feel free to tweak accordingly.
+    if (auto *singleUse = searchValue->getSingleUse()) {
+      if (auto *mvi = dyn_cast<MoveValueInst>(singleUse->getUser())) {
+        if (mvi->isFromVarDecl()) {
+          if (auto *debugUse = getAnyDebugUse(mvi)) {
+            if (auto debugVar = DebugVarCarryingInst(debugUse->getUser())) {
+              assert(debugVar.getKind() ==
+                     DebugVarCarryingInst::Kind::DebugValue);
+              variableNamePath.push_back(debugUse->getUser());
+
+              // We return the value, not the debug_info.
+              return searchValue;
+            }
+          }
+        }
+      }
+    }
+
+    if (auto *bbi = hasOnlyBorrowingNonDestroyUse(searchValue)) {
+      if (auto *debugUse = getAnyDebugUse(bbi)) {
+        if (auto debugVar = DebugVarCarryingInst(debugUse->getUser())) {
+          assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
+          variableNamePath.push_back(debugUse->getUser());
+
+          // We return the value, not the debug_info.
+          return searchValue;
+        }
+      }
+    }
 
     if (auto *allocInst = dyn_cast<AllocationInst>(searchValue)) {
       // If the instruction itself doesn't carry any variable info, see
@@ -540,18 +611,6 @@ SILValue VariableNameInferrer::findDebugInfoProvidingValueHelper(
             continue;
           }
         }
-      }
-    }
-
-    // If we do not do an exact match, see if we can find a debug_var inst. If
-    // we do, we always break since we have a root value.
-    if (auto *use = getAnyDebugUse(searchValue)) {
-      if (auto debugVar = DebugVarCarryingInst(use->getUser())) {
-        assert(debugVar.getKind() == DebugVarCarryingInst::Kind::DebugValue);
-        variableNamePath.push_back(use->getUser());
-
-        // We return the value, not the debug_info.
-        return searchValue;
       }
     }
 

--- a/test/ClangImporter/transferring.swift
+++ b/test/ClangImporter/transferring.swift
@@ -27,12 +27,14 @@ func funcTestTransferringResult() async {
   // Just to show that without the transferring param, we generate diagnostics.
   let x2 = NonSendableCStruct()
   let y2 = returnUserDefinedFromGlobalFunction(x2)
-  await transferToMain(x2) // expected-error {{transferring value of non-Sendable type 'NonSendableCStruct' from nonisolated context to main actor-isolated context}}
+  await transferToMain(x2) // expected-error {{transferring 'x2' may cause a data race}}
+  // expected-note @-1 {{transferring disconnected 'x2' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   useValue(y2) // expected-note {{use here could race}}
 }
 
 func funcTestTransferringArg() async {
   let x = NonSendableCStruct()
-  transferUserDefinedIntoGlobalFunction(x) // expected-error {{value of non-Sendable type 'NonSendableCStruct' accessed after being transferred; later accesses could race}}
+  transferUserDefinedIntoGlobalFunction(x) // expected-error {{transferring 'x' may cause a data race}}
+  // expected-note @-1 {{'x' used after being passed as a transferring parameter}}
   useValue(x) // expected-note {{use here could race}}
 }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -3,7 +3,6 @@
 
 // REQUIRES: concurrency
 // REQUIRES: swift_swift_parser
-// REQUIRES: rdar126006489
 
 @available(SwiftStdlib 5.1, *)
 actor A {

--- a/test/Concurrency/transfernonsendable.sil
+++ b/test/Concurrency/transfernonsendable.sil
@@ -292,7 +292,7 @@ bb0(%0 : @guaranteed $MyActor):
   %3 = class_method %0 : $MyActor, #MyActor.klass!getter : (isolated MyActor) -> () -> NonSendableKlass, $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
   %4 = apply %3(%0) : $@convention(method) (@sil_isolated @guaranteed MyActor) -> @owned NonSendableKlass
   %5 = class_method %4 : $NonSendableKlass, #NonSendableKlass.asyncCall : (NonSendableKlass) -> () async -> (), $@convention(method) @async (@guaranteed NonSendableKlass) -> ()
-  %6 = apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %5(%4) : $@convention(method) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{actor-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
+  %6 = apply [caller_isolation=nonisolated] [callee_isolation=actor_instance] %5(%4) : $@convention(method) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{'self'-isolated value of type 'NonSendableKlass' transferred to actor-isolated context; later accesses to value could race}}
   destroy_value %4 : $NonSendableKlass
   hop_to_executor %0 : $MyActor
   %9 = tuple ()
@@ -313,7 +313,7 @@ bb0(%0 : @guaranteed $MyActor):
   %11 = alloc_stack $NonSendableKlass
   %12 = store_borrow %6 to %11 : $*NonSendableKlass
   %13 = function_ref @transferIndirect : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> ()
-  %14 = apply [caller_isolation=actor_instance] [callee_isolation=global_actor] %13<NonSendableKlass>(%12) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{actor-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
+  %14 = apply [caller_isolation=actor_instance] [callee_isolation=global_actor] %13<NonSendableKlass>(%12) : $@convention(thin) @async <τ_0_0> (@in_guaranteed τ_0_0) -> () // expected-warning {{'self'-isolated value of type 'NonSendableKlass' transferred to global actor '<null>'-isolated context}}
   end_borrow %12 : $*NonSendableKlass
   dealloc_stack %11 : $*NonSendableKlass
   hop_to_executor %0 : $MyActor

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -83,14 +83,14 @@ extension Actor {
   func warningIfCallingGetter() async {
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{transferring 'self.klass' may cause a data race}}
-    // expected-tns-note @-2 {{transferring actor-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
+    // expected-tns-note @-2 {{transferring 'self'-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and 'self'-isolated uses}}
   }
 
   func warningIfCallingAsyncOnFinalField() async {
     // Since we are calling finalKlass directly, we emit a warning here.
     await self.finalKlass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{transferring 'self.finalKlass' may cause a data race}}
-    // expected-tns-note @-2 {{transferring actor-isolated 'self.finalKlass' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
+    // expected-tns-note @-2 {{transferring 'self'-isolated 'self.finalKlass' to nonisolated callee could cause races between nonisolated and 'self'-isolated uses}}
   }
 
   // We do not warn on this since we warn in the caller of our getter instead.
@@ -104,7 +104,7 @@ extension FinalActor {
     // Since our whole class is final, we emit the error directly here.
     await self.klass.asyncCall() // expected-complete-warning {{passing argument of non-sendable type 'NonSendableKlass' outside of actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{transferring 'self.klass' may cause a data race}}
-    // expected-tns-note @-2 {{transferring actor-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and actor-isolated uses}}
+    // expected-tns-note @-2 {{transferring 'self'-isolated 'self.klass' to nonisolated callee could cause races between nonisolated and 'self'-isolated uses}}
   }
 }
 
@@ -401,7 +401,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfThroughTuple2() async {
@@ -412,7 +412,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfThroughOptional() async {
@@ -423,7 +423,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
@@ -512,7 +512,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   // Make sure that we properly propagate actor derived from klass into field's
@@ -525,7 +525,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 
@@ -1439,7 +1439,7 @@ actor ActorWithSetter {
     let x = NonSendableKlass()
     self.field = x
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -1447,7 +1447,7 @@ actor ActorWithSetter {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -1455,7 +1455,7 @@ actor ActorWithSetter {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}    
   }
 
@@ -1476,7 +1476,7 @@ actor ActorWithSetter {
     let x = NonSendableKlass()
     self.classBox.k1 = x
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }
@@ -1492,7 +1492,7 @@ final actor FinalActorWithSetter {
     let x = NonSendableKlass()
     self.field = x
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -1500,7 +1500,7 @@ final actor FinalActorWithSetter {
     let x = NonSendableKlass()
     self.twoFieldBox.k1 = x
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -1508,7 +1508,7 @@ final actor FinalActorWithSetter {
     let x = NonSendableKlass()
     self.twoFieldBoxInTuple.1.k1 = x
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 
@@ -1529,7 +1529,7 @@ final actor FinalActorWithSetter {
     let x = NonSendableKlass()
     self.classBox.k1 = x
     await transferToMain(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into main actor-isolated context may introduce data races}}
   }
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -15,7 +15,7 @@
 ////////////////////////
 
 /// Classes are always non-sendable, so this is non-sendable
-class NonSendableKlass { // expected-complete-note 40{{}}
+class NonSendableKlass { // expected-complete-note 41{{}}
   // expected-typechecker-only-note @-1 4{{}}
   // expected-tns-note @-2 2{{}}
   var field: NonSendableKlass? = nil
@@ -245,7 +245,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughTuple() async {
@@ -255,7 +255,7 @@ extension Actor {
     let x = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type '(Int, () -> ())' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
-    // expected-tns-warning @-2 {{actor-isolated value of type '(Int, () -> ())' transferred to main actor-isolated context}}
+    // expected-tns-warning @-2 {{'self'-isolated value of type '(Int, () -> ())' transferred to main actor-isolated context}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughTupleBackwards() async {
@@ -264,7 +264,7 @@ extension Actor {
     }
 
     let x = (closure, 1)
-    await transferToMain(x) // expected-tns-warning {{actor-isolated value of type '(() -> (), Int)' transferred to main actor-isolated context}}
+    await transferToMain(x) // expected-tns-warning {{'self'-isolated value of type '(() -> (), Int)' transferred to main actor-isolated context}}
     // expected-complete-warning @-1 {{passing argument of non-sendable type '(() -> (), Int)' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-2 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }
@@ -276,7 +276,7 @@ extension Actor {
     let x: Any? = (1, closure)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-2 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-2 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfAndTransferThroughOptionalBackwards() async {
@@ -289,7 +289,7 @@ extension Actor {
     let x: Any? = (closure, 1)
     await transferToMain(x) // expected-complete-warning {{passing argument of non-sendable type 'Any?' into main actor-isolated context may introduce data races}}
     // expected-tns-warning @-1 {{transferring 'x' may cause a data race}}
-    // expected-tns-note @-2 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-2 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfWithReinit() async {
@@ -301,7 +301,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
 
     closure = {}
 
@@ -327,7 +327,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   func simpleClosureCaptureSelfWithReinit3() async {
@@ -349,7 +349,7 @@ extension Actor {
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-note @-2 {{use here could race}}
     // expected-tns-warning @-3 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-4 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-4 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   // In this case, we reinit along both paths, but only one has an actor derived
@@ -372,7 +372,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 
   #if TYPECHECKER_ONLY
@@ -539,7 +539,7 @@ extension Actor {
     await transferToMain(closure) // expected-complete-warning {{passing argument of non-sendable type '() -> ()' into main actor-isolated context may introduce data races}}
     // expected-complete-note @-1 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
     // expected-tns-warning @-2 {{transferring 'closure' may cause a data race}}
-    // expected-tns-note @-3 {{transferring actor-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-3 {{transferring 'self'-isolated 'closure' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
 
     // This doesnt since we re-assign
     closure = {}
@@ -1569,4 +1569,13 @@ func functionArgumentIntoClosure(_ x: @escaping () -> ()) async {
     // expected-complete-warning @-4 {{passing argument of non-sendable type 'NonSendableKlass' outside of main actor-isolated context may introduce data races}}
     c = a.klassLet
   }
+}
+
+func testGetActorName() async {
+  let a = Actor()
+  let x = NonSendableKlass()
+  await a.useKlass(x) // expected-tns-warning {{transferring 'x' may cause a data race}}
+  // expected-tns-note @-1 {{transferring disconnected 'x' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
+  useValue(x) // expected-tns-note {{use here could race}}
 }

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1617,3 +1617,12 @@ extension FinalActor {
     // expected-complete-warning @-2 {{passing argument of non-sendable type 'NonSendableKlass' into actor-isolated context may introduce data races}}
   }
 }
+
+actor DictionaryActorTest {
+  var data: [Int: Int] = [:]
+
+  // We used to crash on this due to isolation merging.
+  func doSomething(_ key: Int) {
+    assert(self.data[key] == 0)
+  }
+}

--- a/test/Concurrency/transfernonsendable.swift
+++ b/test/Concurrency/transfernonsendable.swift
@@ -1325,9 +1325,9 @@ func varSendableNonTrivialLetTupleFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
-  let z = test.1
+  let z = test.1 // expected-tns-note {{use here could race}}
   useValue(z)
-  useValue(test) // expected-tns-note {{use here could race}}
+  useValue(test)
 }
 
 func varNonSendableNonTrivialLetTupleFieldTest() async {
@@ -1335,11 +1335,8 @@ func varNonSendableNonTrivialLetTupleFieldTest() async {
   await transferToMain(test) // expected-tns-warning {{transferring 'test' may cause a data race}}
   // expected-tns-note @-1 {{transferring disconnected 'test' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
   // expected-complete-warning @-2 {{passing argument of non-sendable type '(Int, SendableKlass, NonSendableKlass)' into main actor-isolated context may introduce data races}}
-  let z = test.2
-  // The SIL emitted for the assignment of the tuple is just a jumble of
-  // instructions that are not semantically significant. The result is that we
-  // need a useValue here to actual provide something for the pass to chew on.
-  useValue(z)  // expected-tns-note {{use here could race}}
+  let z = test.2 // expected-tns-note {{use here could race}}
+  useValue(z)
   useValue(test)
 }
 

--- a/test/Concurrency/transfernonsendable_initializers.swift
+++ b/test/Concurrency/transfernonsendable_initializers.swift
@@ -1,0 +1,170 @@
+// RUN: %target-swift-frontend -emit-sil -strict-concurrency=complete -disable-availability-checking -swift-version 6 -verify %s -o /dev/null
+
+// REQUIRES: concurrency
+// REQUIRES: asserts
+
+// This test validates the behavior of transfernonsendable around initializers.
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+class NonSendableKlass {}
+@MainActor func transferToMain<T>(_ t: T) async {}
+
+actor CustomActorInstance {}
+
+@globalActor
+struct CustomActor {
+  static let shared = CustomActorInstance()
+}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+actor ActorWithSynchronousNonIsolatedInit {
+  let k: NonSendableKlass
+
+  init(_ newK: NonSendableKlass) {
+    k = NonSendableKlass()
+
+    helper(newK)
+
+    // TODO: This should say actor isolated.
+    let _ = { @MainActor in
+      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      // expected-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+
+  init(x newK: NonSendableKlass) {
+    k = newK
+
+    helper(newK)
+
+    let _ = { @MainActor in
+      // TODO: Second part should say later 'self'-isolated uses
+      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      // expected-note @-1 {{'self'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+
+  nonisolated func helper(_ newK: NonSendableKlass) {}
+}
+
+func initActorWithSyncNonIsolatedInit() {
+  let k = NonSendableKlass()
+  // TODO: This should say actor isolated.
+  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
+  // expected-note @-1 {{transferring disconnected 'k' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  let _ = { @MainActor in // expected-note {{use here could race}}
+    print(k)
+  }
+}
+
+func initActorWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
+  // TODO: This should say actor isolated.
+  _ = ActorWithSynchronousNonIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
+  // expected-note @-1 {{transferring task-isolated 'k' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  let _ = { @MainActor in
+    print(k) // expected-error {{transferring 'k' may cause a data race}}
+    // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+  }
+}
+
+actor ActorWithAsyncIsolatedInit {
+  init(_ newK: NonSendableKlass) async {
+    let _ = { @MainActor in
+      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      // expected-note @-1 {{actor-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+}
+
+func initActorWithAsyncIsolatedInit() async {
+  let k = NonSendableKlass()
+  // TODO: This should say actor isolated.
+  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
+  // expected-note @-1 {{transferring disconnected 'k' to actor-isolated callee could cause races in between callee actor-isolated and local nonisolated uses}}
+  let _ = { @MainActor in // expected-note {{use here could race}}
+    print(k)
+  }
+}
+
+func initActorWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
+  // TODO: This should say actor isolated.
+  _ = await ActorWithAsyncIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
+  // expected-note @-1 {{transferring task-isolated 'k' to actor-isolated callee could cause races between actor-isolated and task-isolated uses}}
+  let _ = { @MainActor in
+    print(k) // expected-error {{transferring 'k' may cause a data race}}
+    // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+  }
+}
+
+////////////////////////////////
+// MARK: Actor Isolated Class //
+////////////////////////////////
+
+@CustomActor
+class ClassWithSynchronousNonIsolatedInit {
+  nonisolated init(_ newK: NonSendableKlass) {
+    // We do not error on this since helper is nonisolated and newK is
+    // considered task isolated.
+    helper(newK)
+
+    let _ = { @MainActor in
+      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      // expected-note @-1 {{task-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+
+  nonisolated func helper(_ newK: NonSendableKlass) {}
+}
+
+func initClassWithSyncNonIsolatedInit() {
+  let k = NonSendableKlass()
+  _ = ClassWithSynchronousNonIsolatedInit(k)
+  let _ = { @MainActor in
+    print(k)
+  }
+}
+
+func initClassWithSyncNonIsolatedInit2(_ k: NonSendableKlass) {
+  _ = ClassWithSynchronousNonIsolatedInit(k)
+  let _ = { @MainActor in
+    print(k) // expected-error {{transferring 'k' may cause a data race}}
+    // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+  }
+}
+
+@CustomActor
+class ClassWithAsyncIsolatedInit {
+  init(_ newK: NonSendableKlass) async {
+    let _ = { @MainActor in
+      print(newK) // expected-error {{transferring 'newK' may cause a data race}}
+      // expected-note @-1 {{global actor 'CustomActor'-isolated 'newK' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+}
+
+func initClassWithAsyncIsolatedInit() async {
+  let k = NonSendableKlass()
+  // TODO: Might make sense to emit a more specific error here since the closure
+  // is MainActor isolated. The actual capture is initially not isolated to
+  // MainActor.
+  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
+  // expected-note @-1 {{transferring disconnected 'k' to global actor 'CustomActor'-isolated callee could cause races in between callee global actor 'CustomActor'-isolated and local nonisolated uses}}
+  let _ = { @MainActor in // expected-note {{use here could race}}
+    print(k)
+  }
+}
+
+func initClassWithAsyncIsolatedInit2(_ k: NonSendableKlass) async {
+  _ = await ClassWithAsyncIsolatedInit(k) // expected-error {{transferring 'k' may cause a data race}}
+  // expected-note @-1 {{transferring task-isolated 'k' to global actor 'CustomActor'-isolated callee could cause races between global actor 'CustomActor'-isolated and task-isolated uses}}
+  let _ = { @MainActor in
+    print(k) // expected-error {{transferring 'k' may cause a data race}}
+    // expected-note @-1 {{task-isolated 'k' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+  }
+}

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -24,6 +24,7 @@ class NonSendableKlass {}
 sil @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
 sil @useNonSendableKlass : $@convention(thin) (@guaranteed NonSendableKlass) -> ()
 sil @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+sil @constructNonSendableKlassIndirect : $@convention(thin) () -> @out NonSendableKlass
 sil @useUnmanagedNonSendableKlass : $@convention(thin) (@guaranteed @sil_unmanaged NonSendableKlass) -> ()
 
 final class SendableKlass : Sendable {}
@@ -1674,6 +1675,47 @@ bb0(%arg : $Builtin.Word):
   %bridgeUse = function_ref @use_bridge_object : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> ()
   apply %bridgeUse(%b) : $@convention(thin) (@guaranteed Builtin.BridgeObject) -> () // expected-note {{use here could race}}
   destroy_value %b : $Builtin.BridgeObject
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @load_is_lookthrough_test : $@convention(thin) @async () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableKlass
+  %indirectConstruct = function_ref @constructNonSendableKlassIndirect : $@convention(thin) () -> @out NonSendableKlass
+  apply %indirectConstruct(%0) : $@convention(thin) () -> @out NonSendableKlass
+
+  %1 = load_borrow %0 : $*NonSendableKlass
+  %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  end_borrow %1 : $NonSendableKlass
+
+  %2 = load [copy] %0 : $*NonSendableKlass
+  destroy_value %2 : $NonSendableKlass
+  %3 = load [take] %0 : $*NonSendableKlass
+  destroy_value %3 : $NonSendableKlass
+  dealloc_stack %0 : $*NonSendableKlass
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @loadborrow_is_lookthrough_test : $@convention(thin) @async () -> () {
+bb0:
+  %0 = alloc_stack $NonSendableKlass
+  %indirectConstruct = function_ref @constructNonSendableKlassIndirect : $@convention(thin) () -> @out NonSendableKlass
+  apply %indirectConstruct(%0) : $@convention(thin) () -> @out NonSendableKlass
+
+  %1 = load_borrow %0 : $*NonSendableKlass
+  %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%1) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  end_borrow %1 : $NonSendableKlass
+
+  %2 = load_borrow %0 : $*NonSendableKlass
+  end_borrow %2 : $NonSendableKlass
+  destroy_addr %0 : $*NonSendableKlass
+  dealloc_stack %0 : $*NonSendableKlass
+
   %9999 = tuple ()
   return %9999 : $()
 }

--- a/test/Concurrency/transfernonsendable_instruction_matching.sil
+++ b/test/Concurrency/transfernonsendable_instruction_matching.sil
@@ -1694,3 +1694,65 @@ bb0(%0 : @guaranteed $ChildClass):
   destroy_value %8 : $ChildClass
   return %11 : $ChildClass
 }
+
+sil [ossa] @test_move_value_no_var_decl_is_lookthrough : $@convention(thin) @async () -> () {
+bb0:
+  %constructFn = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+  %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
+
+  %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+
+  %value2 = move_value %value : $NonSendableKlass
+  destroy_value %value2 : $NonSendableKlass
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @test_move_value_var_decl_is_assign : $@convention(thin) @async () -> () {
+bb0:
+  %constructFn = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+  %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
+
+  %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+
+  %value2 = move_value [var_decl] %value : $NonSendableKlass // expected-note {{use here could race}}
+  destroy_value %value2 : $NonSendableKlass
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @test_begin_borrow_no_var_decl_is_lookthrough : $@convention(thin) @async () -> () {
+bb0:
+  %constructFn = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+  %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
+
+  %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+
+  %value2 = begin_borrow %value : $NonSendableKlass
+  end_borrow %value2 : $NonSendableKlass
+  destroy_value %value : $NonSendableKlass
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+sil [ossa] @test_begin_borrow_var_decl_is_assign : $@convention(thin) @async () -> () {
+bb0:
+  %constructFn = function_ref @constructNonSendableKlass : $@convention(thin) () -> @owned NonSendableKlass
+  %value = apply %constructFn() : $@convention(thin) () -> @owned NonSendableKlass
+
+  %transferNonSendableKlass = function_ref @transferNonSendableKlass : $@convention(thin) @async (@guaranteed NonSendableKlass) -> ()
+  apply [caller_isolation=nonisolated] [callee_isolation=global_actor] %transferNonSendableKlass(%value) : $@convention(thin) @async (@guaranteed NonSendableKlass) -> () // expected-warning {{transferring value of non-Sendable type 'NonSendableKlass' from nonisolated context to global actor '<null>'-isolated context}}
+
+  %value2 = begin_borrow [var_decl] %value : $NonSendableKlass // expected-note {{use here could race}}
+  end_borrow %value2 : $NonSendableKlass
+  destroy_value %value : $NonSendableKlass
+
+  %9999 = tuple ()
+  return %9999 : $()
+}

--- a/test/Concurrency/transfernonsendable_nonisolated.swift
+++ b/test/Concurrency/transfernonsendable_nonisolated.swift
@@ -19,6 +19,13 @@ actor MyActor {
   nonisolated func syncNonisolatedGeneric<T>(_ t: T) {}
 }
 
+final actor MyFinalActor {
+  nonisolated func asyncNonisolated(_ x: NonSendable) async {}
+  nonisolated func syncNonisolated(_ x: NonSendable) {}
+  nonisolated func asyncNonisolatedGeneric<T>(_ t: T) async {}
+  nonisolated func syncNonisolatedGeneric<T>(_ t: T) {}
+}
+
 @MainActor func transferToMain<T>(_ t: T) async {}
 func useValueAsync<T>(_ t: T) async {}
 func useValueSync<T>(_ t: T) {}
@@ -27,42 +34,84 @@ func useValueSync<T>(_ t: T) {}
 // MARK: Tests //
 /////////////////
 
-func callNonIsolatedAsync_TransferAfter(_ a: MyActor) async {
+func callMyActor_NonIsolatedAsync_TransferAfter(_ a: MyActor) async {
   let x = NonSendable()
   await a.asyncNonisolated(x)
   await a.asyncNonisolated(x)
   await transferToMain(x)
 }
 
-func callNonIsolatedSync_TransferAfter(_ a: MyActor) async {
+func callMyActor_NonIsolatedSync_TransferAfter(_ a: MyActor) async {
   let x = NonSendable()
   a.syncNonisolated(x)
   a.syncNonisolated(x)
   await transferToMain(x)
 }
 
-func callNonIsolatedAsync_AsyncUseAfter(_ a: MyActor) async {
+func callMyActor_NonIsolatedAsync_AsyncUseAfter(_ a: MyActor) async {
   let x = NonSendable()
   await a.asyncNonisolated(x)
   await a.asyncNonisolated(x)
   await useValueAsync(x)
 }
 
-func callNonIsolatedSync_AsyncUseAfter(_ a: MyActor) async {
+func callMyActor_NonIsolatedSync_AsyncUseAfter(_ a: MyActor) async {
   let x = NonSendable()
   a.syncNonisolated(x)
   a.syncNonisolated(x)
   await useValueAsync(x)
 }
 
-func callNonIsolatedAsync_SyncUseAfter(_ a: MyActor) async {
+func callMyActor_NonIsolatedAsync_SyncUseAfter(_ a: MyActor) async {
   let x = NonSendable()
   await a.asyncNonisolated(x)
   await a.asyncNonisolated(x)
   useValueSync(x)
 }
 
-func callNonIsolatedSync_SyncUseAfter(_ a: MyActor) async {
+func callMyActor_NonIsolatedSync_SyncUseAfter(_ a: MyActor) async {
+  let x = NonSendable()
+  a.syncNonisolated(x)
+  a.syncNonisolated(x)
+  useValueSync(x)
+}
+
+func callMyFinalActor_NonIsolatedAsync_TransferAfter(_ a: MyFinalActor) async {
+  let x = NonSendable()
+  await a.asyncNonisolated(x)
+  await a.asyncNonisolated(x)
+  await transferToMain(x)
+}
+
+func callMyFinalActor_NonIsolatedSync_TransferAfter(_ a: MyFinalActor) async {
+  let x = NonSendable()
+  a.syncNonisolated(x)
+  a.syncNonisolated(x)
+  await transferToMain(x)
+}
+
+func callMyFinalActor_NonIsolatedAsync_AsyncUseAfter(_ a: MyFinalActor) async {
+  let x = NonSendable()
+  await a.asyncNonisolated(x)
+  await a.asyncNonisolated(x)
+  await useValueAsync(x)
+}
+
+func callMyFinalActor_NonIsolatedSync_AsyncUseAfter(_ a: MyFinalActor) async {
+  let x = NonSendable()
+  a.syncNonisolated(x)
+  a.syncNonisolated(x)
+  await useValueAsync(x)
+}
+
+func callMyFinalActor_NonIsolatedAsync_SyncUseAfter(_ a: MyFinalActor) async {
+  let x = NonSendable()
+  await a.asyncNonisolated(x)
+  await a.asyncNonisolated(x)
+  useValueSync(x)
+}
+
+func callMyFinalActor_NonIsolatedSync_SyncUseAfter(_ a: MyFinalActor) async {
   let x = NonSendable()
   a.syncNonisolated(x)
   a.syncNonisolated(x)

--- a/test/Concurrency/transfernonsendable_region_based_sendability.swift
+++ b/test/Concurrency/transfernonsendable_region_based_sendability.swift
@@ -442,7 +442,7 @@ actor A_Sendable {
     // support the ability to dynamically invoke the synchronous closure on
     // the specific actor.
     await a.foo(captures_self) // expected-tns-warning {{transferring 'captures_self' may cause a data race}}
-    // expected-tns-note @-1 {{transferring actor-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and actor-isolated uses}}
+    // expected-tns-note @-1 {{transferring 'self'-isolated 'captures_self' to actor-isolated callee could cause races between actor-isolated and 'self'-isolated uses}}
     // expected-complete-warning @-2 {{passing argument of non-sendable type '() -> ()' into actor-isolated context may introduce data races}}
     // expected-complete-note @-3 {{a function type must be marked '@Sendable' to conform to 'Sendable'}}
   }

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -160,7 +160,7 @@ actor MyActor {
   func assignTransferringIntoActor2(_ x: transferring Klass) async {
     field = x
     await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
-    // expected-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+    // expected-note @-1 {{transferring 'self'-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
   }
 }
 

--- a/test/Concurrency/transfernonsendable_strong_transferring_params.swift
+++ b/test/Concurrency/transfernonsendable_strong_transferring_params.swift
@@ -185,13 +185,34 @@ func canTransferAssigningIntoLocal(_ x: transferring Klass) async {
 }
 
 func canTransferAssigningIntoLocal2(_ x: transferring Klass) async {
+  let _ = x
+  await transferToMain(x)
+  // We do not error here since we just load the value and do not do anything
+  // with it.
+  //
+  // TODO: We should change let _ = x so that it has a move_value '_' or
+  // something like that. It will also help move checking as well.
+  let _ = x
+}
 
+func canTransferAssigningIntoLocal2a(_ x: transferring Klass) async {
+  let _ = x
+  await transferToMain(x)
+  // We do not error here since we just load the value and do not do anything
+  // with it.
+  //
+  // TODO: We should change let _ = x so that it has a move_value '_' or
+  // something like that. It will also help move checking as well.
+  _ = x
+}
+
+func canTransferAssigningIntoLocal3(_ x: transferring Klass) async {
   let _ = x
   await transferToMain(x) // expected-warning {{transferring 'x' may cause a data race}}
   // expected-note @-1 {{transferring disconnected 'x' to main actor-isolated callee could cause races in between callee main actor-isolated and local nonisolated uses}}
-  let _ = x // expected-note {{use here could race}}
+  let y = x // expected-note {{use here could race}}
+  _ = y
 }
-
 
 //////////////////////////////////////
 // MARK: Transferring is "var" like //

--- a/test/Distributed/distributed_actor_transfernonsendable.swift
+++ b/test/Distributed/distributed_actor_transfernonsendable.swift
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -swift-version 6 -verify -verify-ignore-unknown -disable-availability-checking -I %t %s -emit-sil
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+////////////////////////
+// MARK: Declarations //
+////////////////////////
+
+@available(SwiftStdlib 5.5, *)
+typealias DefaultDistributedActorSystem = FakeActorSystem
+
+final class NonSendableKlass {}
+
+extension NonSendableKlass : Codable {}
+
+@MainActor func transferToMain<T>(_ t: T) async {}
+
+/////////////////
+// MARK: Tests //
+/////////////////
+
+distributed actor MyDistributedActor {
+  let x: NonSendableKlass
+
+  init(system: FakeActorSystem, y: NonSendableKlass) {
+    x = NonSendableKlass()
+    actorSystem = system
+    _ = { @MainActor in
+      // TODO: This should error saying 'y' is actor isolated.
+      print(y) // expected-error {{transferring 'y' may cause a data race}}
+      // expected-note @-1 {{task-isolated 'y' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+
+  init(system: FakeActorSystem, y2: NonSendableKlass) {
+    x = y2
+    actorSystem = system
+    _ = { @MainActor in
+      print(y2) // expected-error {{transferring 'y2' may cause a data race}}
+      // expected-note @-1 {{'self'-isolated 'y2' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+
+  distributed func transferActorField() async {
+    await transferToMain(x) // expected-error {{transferring 'self.x' may cause a data race}}
+    // expected-note @-1 {{transferring 'self'-isolated 'self.x' to main actor-isolated callee could cause races between main actor-isolated and 'self'-isolated uses}}
+  }
+
+  distributed func transferActorIsolatedArg(_ x: NonSendableKlass) async {
+    await transferToMain(x) // expected-error {{transferring 'x' may cause a data race}}
+    // expected-note @-1 {{transferring actor-isolated 'x' to main actor-isolated callee could cause races between main actor-isolated and actor-isolated uses}}
+  }
+
+  distributed func transferActorIsolatedArgIntoClosure(_ x: NonSendableKlass) async {
+    _ = { @MainActor in
+      // TODO: In 2nd part of message should say actor-isolated instead of later
+      // nonisolated uses in the case of a closure.
+      print(x) // expected-error {{transferring 'x' may cause a data race}}
+      // expected-note @-1 {{actor-isolated 'x' is captured by a main actor-isolated closure. main actor-isolated uses in closure may race against later nonisolated uses}}
+    }
+  }
+}

--- a/test/SILOptimizer/variable_name_inference.sil
+++ b/test/SILOptimizer/variable_name_inference.sil
@@ -772,3 +772,114 @@ bb0(%0 : $*Klass):
   %9999 = tuple ()
   return %9999 : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %2 = move_value [var_decl] %1 : $Klass
+// CHECK: Name: 'MyName'
+// CHECK: Root:   %2 = move_value [var_decl] %1 : $Klass
+// CHECK: end running test 1 of 1 on move_value_var_decl: variable-name-inference with: @trace[0]
+sil [ossa] @move_value_var_decl : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  %2 = move_value [var_decl] %1 : $Klass
+  debug_value %2 : $Klass, let, name "MyName"
+  debug_value [trace] %2 : $Klass
+  destroy_value %2 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl_2: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK: Name: 'MyName'
+// CHECK: Root:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK: end running test 1 of 1 on move_value_var_decl_2: variable-name-inference with: @trace[0]
+sil [ossa] @move_value_var_decl_2 : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  debug_value [trace] %1 : $Klass
+  %2 = move_value [var_decl] %1 : $Klass
+  debug_value %2 : $Klass, let, name "MyName"
+  destroy_value %2 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on move_value_var_decl_3: variable-name-inference with: @trace[0]
+// CHECK-LABEL: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK-LABEL: Name: 'unknown'
+// CHECK-LABEL: Root: 'unknown'
+// CHECK-LABEL: end running test 1 of 1 on move_value_var_decl_3: variable-name-inference with: @trace[0]
+sil [ossa] @move_value_var_decl_3 : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  debug_value [trace] %1 : $Klass
+  %2 = move_value %1 : $Klass
+  debug_value %2 : $Klass, let, name "MyName"
+  destroy_value %2 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %2 = begin_borrow [var_decl] %1 : $Klass
+// CHECK: Name: 'MyName'
+// CHECK: Root:   %2 = begin_borrow [var_decl] %1 : $Klass
+// CHECK: end running test 1 of 1 on begin_borrow_var_decl: variable-name-inference with: @trace[0]
+sil [ossa] @begin_borrow_var_decl : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  %2 = begin_borrow [var_decl] %1 : $Klass
+  debug_value %2 : $Klass, let, name "MyName"
+  debug_value [trace] %2 : $Klass
+  end_borrow %2 : $Klass
+  destroy_value %1 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl_2: variable-name-inference with: @trace[0]
+// CHECK: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK: Name: 'MyName'
+// CHECK: Root:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK: end running test 1 of 1 on begin_borrow_var_decl_2: variable-name-inference with: @trace[0]
+sil [ossa] @begin_borrow_var_decl_2 : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  debug_value [trace] %1 : $Klass
+  %2 = begin_borrow [var_decl] %1 : $Klass
+  debug_value %2 : $Klass, let, name "MyName"
+  end_borrow %2 : $Klass
+  destroy_value %1 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on begin_borrow_var_decl_3: variable-name-inference with: @trace[0]
+// CHECK-LABEL: Input Value:   %1 = apply %0() : $@convention(thin) () -> @owned Klass
+// CHECK-LABEL: Name: 'unknown'
+// CHECK-LABEL: Root: 'unknown'
+// CHECK-LABEL: end running test 1 of 1 on begin_borrow_var_decl_3: variable-name-inference with: @trace[0]
+sil [ossa] @begin_borrow_var_decl_3 : $@convention(thin) () -> () {
+bb0:
+  specify_test "variable-name-inference @trace[0]"
+  %0 = function_ref @getKlass : $@convention(thin) () -> @owned Klass
+  %1 = apply %0() : $@convention(thin) () -> @owned Klass
+  debug_value [trace] %1 : $Klass
+  %2 = begin_borrow %1 : $Klass
+  debug_value %2 : $Klass, let, name "MyName"
+  end_borrow %2 : $Klass
+  destroy_value %1 : $Klass
+  %9999 = tuple ()
+  return %9999 : $()
+}


### PR DESCRIPTION
Just chopping off parts of a larger piece of work while I work at the same time on another piece of work.

----

The reason why we do this is that we want to treat this as a separate value from
their operand since they are the result of defining a new value.

This has a few nice side-effects, one of which is that if a let results in just
a begin_borrow [var_decl], we emit names for it.

I also did a little work around helping variable name utils to lookup names from
applies that are fed into a {move_value,begin_borrow} [var_decl] which then has
the debug_value we are searching for.