### PR TITLE
[SwiftSyntax] Test adjustments because no space is inserted between `#available` and `(` by SwiftSyntax anymore

### DIFF
--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_inheritance.swift
@@ -25,7 +25,7 @@ protocol Base: DistributedActor where ActorSystem: DistributedActorSystem<any Co
 
 // CHECK: extension Base where Self: Distributed._DistributedActorStub {
 // CHECK:   distributed func base() -> Int {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()
@@ -49,14 +49,14 @@ protocol G3<ActorSystem>: DistributedActor, Base where ActorSystem: DistributedA
 
 // CHECK: extension G3 where Self: Distributed._DistributedActorStub {
 // CHECK:   distributed func get() -> String {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()
 // CHECK:     }
 // CHECK:   }
 // CHECK:   distributed func greet(name: String) -> String {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_simple.swift
@@ -26,7 +26,7 @@ protocol Greeter: DistributedActor where ActorSystem: DistributedActorSystem<any
 
 // CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
 // CHECK-NEXT:   distributed func greet(name: String) -> String {
-// CHECK-NEXT:     if #available (SwiftStdlib 6.0, *) {
+// CHECK-NEXT:     if #available(SwiftStdlib 6.0, *) {
 // CHECK-NEXT:       Distributed._distributedStubFatalError()
 // CHECK-NEXT:     } else {
 // CHECK-NEXT:       fatalError()

--- a/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
+++ b/test/Distributed/Macros/distributed_macro_expansion_DistributedProtocol_various_requirements.swift
@@ -24,7 +24,7 @@ protocol Greeter: DistributedActor where ActorSystem == FakeActorSystem {
 
 // CHECK: extension Greeter where Self: Distributed._DistributedActorStub {
 // CHECK:   distributed func greet(name: String) -> String {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()
@@ -44,7 +44,7 @@ protocol Greeter2: DistributedActor where ActorSystem: DistributedActorSystem<an
 
 // CHECK: extension Greeter2 where Self: Distributed._DistributedActorStub {
 // CHECK:   distributed func greet(name: String) -> String {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()
@@ -69,7 +69,7 @@ protocol Greeter3: DistributedActor where ActorSystem: DistributedActorSystem<an
 
 // CHECK: extension Greeter3 where Self: Distributed._DistributedActorStub {
 // CHECK:   distributed func greet(name: String) -> String {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()
@@ -89,7 +89,7 @@ public protocol Greeter4: DistributedActor where ActorSystem == FakeActorSystem 
 
 // CHECK: extension Greeter4 where Self: Distributed._DistributedActorStub {
 // CHECK:   public distributed func greet(name: String) -> String {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()
@@ -112,28 +112,28 @@ public protocol GreeterMore: DistributedActor where ActorSystem == FakeActorSyst
 
 // CHECK: extension GreeterMore where Self: Distributed._DistributedActorStub {
 // CHECK:   public distributed var  name : String {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()
 // CHECK:     }
 // CHECK:   }
 // CHECK:   public distributed func greet(name: String) -> String {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()
 // CHECK:     }
 // CHECK:   }
 // CHECK:   public distributed func another(string: String, int: Int) async throws -> Double {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()
 // CHECK:     }
 // CHECK:   }
 // CHECK:   public distributed func generic<T: Codable>(value: T, int: Int) async throws -> T {
-// CHECK:     if #available (SwiftStdlib 6.0, *) {
+// CHECK:     if #available(SwiftStdlib 6.0, *) {
 // CHECK:       Distributed._distributedStubFatalError()
 // CHECK:     } else {
 // CHECK:       fatalError()


### PR DESCRIPTION
- **Explanation**: There are only a few cases where `(` should be preceded by a space: closure parameters, function types and tuples. Instead of defaulting to add whitespace before `(`, check for those cases and if we are not in one of them, don’t require whitespace. This has become important since we diagnose a space between an attribute name an it’s opening `(` as a warning in Swift 5 and as an error in Swift 6 mode.
- **Scope**: Running `BasicFormat` on source code that contains a non-keyword token followed by `(`.
- **Risk**: I don’t see any case where not emitting a space in front of `(` could break something apart from the cases that we have covered. And without this fix, a lot of code generated by macros does not compile in Swift 6 mode.
- **Testing**: Added tests
- **Issue**: rdar://124569733
- **Reviewer**:   @bnbarham on https://github.com/apple/swift-syntax/pull/2592