### PR TITLE
[6.0🍒] NCGenerics: restrict conditional Copyable reqs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2791,7 +2791,7 @@ ERROR(protocol_has_missing_requirements_versioned,none,
       (Type, Type, llvm::VersionTuple, llvm::VersionTuple))
 ERROR(requirement_restricts_self,none,
       "%kindonly0 requirement %0 cannot add constraint "
-      "'%1%select{:|:| ==|:}2 %3' on 'Self'",
+      "'%1%select{:|:| ==|:| has same shape as}2 %3' on 'Self'",
       (const ValueDecl *, StringRef, unsigned, StringRef))
 ERROR(witness_argument_name_mismatch,none,
       "%kind0 has different argument labels "
@@ -7634,6 +7634,10 @@ ERROR(inverse_extension, none,
 ERROR(copyable_illegal_deinit, none,
       "deinitializer cannot be declared in %kind0 that conforms to 'Copyable'",
       (const ValueDecl *))
+ERROR(inverse_cannot_be_conditional_on_requirement, none,
+      "conditional conformance to suppressible %kind0 cannot depend on "
+      "'%1%select{:|:| ==|:| has same shape as}2 %3'",
+      (const ProtocolDecl *, StringRef, unsigned, StringRef))
 ERROR(inverse_type_member_in_conforming_type,none,
       "%select{stored property %2|associated value %2}1 of "
       "'%4'-conforming %kind3 has non-%4 type %0",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -7636,8 +7636,8 @@ ERROR(copyable_illegal_deinit, none,
       (const ValueDecl *))
 ERROR(inverse_cannot_be_conditional_on_requirement, none,
       "conditional conformance to suppressible %kind0 cannot depend on "
-      "'%1%select{:|:| ==|:| has same shape as}2 %3'",
-      (const ProtocolDecl *, StringRef, unsigned, StringRef))
+      "'%noformat1%select{:|:| ==|:| has same shape as}2 %noformat3'",
+      (const ProtocolDecl *, Type, unsigned, Type))
 ERROR(inverse_type_member_in_conforming_type,none,
       "%select{stored property %2|associated value %2}1 of "
       "'%4'-conforming %kind3 has non-%4 type %0",

--- a/include/swift/AST/RequirementKind.h
+++ b/include/swift/AST/RequirementKind.h
@@ -36,10 +36,11 @@ enum class RequirementKind : unsigned {
   Layout,
   /// A same-shape requirement shape(T) == shape(U), where T and U are pack
   /// parameters.
-  SameShape
+  SameShape,
 
   // Note: there is code that packs this enum in a 3-bit bitfield.  Audit users
   // when adding enumerators.
+  LAST_KIND=SameShape
 };
 
 } // namespace swift

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -302,6 +302,8 @@ void TypeChecker::checkProtocolSelfRequirements(ValueDecl *decl) {
           req.getFirstType()->is<GenericTypeParamType>())
         continue;
 
+      static_assert((unsigned)RequirementKind::LAST_KIND == 4,
+                    "update %select in diagnostic!");
       ctx.Diags.diagnose(decl, diag::requirement_restricts_self, decl,
                          req.getFirstType().getString(),
                          static_cast<unsigned>(req.getKind()),

--- a/test/Generics/inverse_conditional_conformance_restriction.swift
+++ b/test/Generics/inverse_conditional_conformance_restriction.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift \
+// RUN:   -enable-experimental-feature NoncopyableGenerics \
+// RUN:   -enable-experimental-feature NonescapableTypes \
+// RUN:   -enable-experimental-feature SuppressedAssociatedTypes
+
+protocol P {}
+protocol Q {}
+class DoggoClass {}
+
+struct Blah<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {}
+extension Blah: Copyable {} // expected-error {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'T: Escapable'}}
+extension Blah: Escapable {} // expected-error {{conditional conformance to suppressible protocol 'Escapable' cannot depend on 'T: Copyable'}}
+
+struct Yuck<T: ~Copyable & ~Escapable>: ~Copyable, ~Escapable {}
+extension Yuck: Copyable where T: ~Escapable {}
+extension Yuck: Escapable where T: ~Copyable {}
+
+struct TryConformance<Whatever: ~Copyable>: ~Copyable {}
+extension TryConformance: Copyable
+    where Whatever: P, Whatever: Q, Whatever: Sendable {}
+// expected-error@-2 {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'Whatever: P'}}
+// expected-error@-3 {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'Whatever: Q'}}
+// expected-error@-4 {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'Whatever: Sendable'}}
+
+struct TrySameType<Whatever: ~Copyable>: ~Copyable {}
+extension TrySameType: Copyable
+    where Whatever == Int {}
+// expected-error@-2 {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'Whatever == Int'}}
+
+struct TryClassAndLayoutConstraints<Whatever: ~Copyable, Heckin>: ~Copyable {}
+extension TryClassAndLayoutConstraints: Copyable
+    where Heckin: DoggoClass, Whatever: AnyObject {}
+// expected-error@-2 {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'Whatever: AnyObject'}}
+// expected-error@-3 {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'Heckin: DoggoClass'}}
+
+protocol Queue: ~Copyable { associatedtype Job: ~Copyable }
+struct Scheduler<Q: Queue>: ~Copyable {}
+extension Scheduler: Copyable where Q.Job: Copyable {}
+// expected-error@-1 {{conditional conformance to suppressible protocol 'Copyable' cannot depend on 'Q.Job: Copyable'}}

--- a/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
+++ b/test/ModuleInterface/Inputs/NoncopyableGenerics_Misc.swift
@@ -98,7 +98,7 @@ extension Outer: Copyable {}
 extension Outer.InnerStruct: Copyable {}
 
 extension Outer.InnerVariation1: Copyable {}
-extension Outer.InnerVariation2: Escapable {}
+extension Outer.InnerVariation2: Escapable where A: ~Copyable {}
 
 extension Outer.InnerStruct {
     public func hello<T: ~Escapable>(_ t: T) {}

--- a/test/ModuleInterface/noncopyable_generics.swift
+++ b/test/ModuleInterface/noncopyable_generics.swift
@@ -134,7 +134,7 @@ import NoncopyableGenerics_Misc
 // CHECK-MISC: #endif
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics
-// CHECK-MISC-NEXT: extension {{.*}}.Outer.InnerVariation2 : Swift.Escapable {
+// CHECK-MISC-NEXT: extension {{.*}}.Outer.InnerVariation2 : Swift.Escapable where A : ~Copyable {
 // CHECK-MISC: #endif
 
 // CHECK-MISC: #if compiler(>=5.3) && $NoncopyableGenerics


### PR DESCRIPTION
Explanation: Implements part of the SE-427 proposal where Copyable cannot depend on conditional requirements for other protocols.
Scope: Technically source-breaking but there aren't any known sources that used this yet.
Issue: rdar://124967739
Original PR: https://github.com/apple/swift/pull/72820
Risk: Low.
Testing: Tests included.
Reviewer: @slavapestov 