### PR TITLE
[embedded] Conditionalize assert printing to debug assert config

### DIFF
--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -111,8 +111,10 @@ internal func _assertionFailure(
     }
   }
 #else
-  _embeddedReportFatalErrorInFile(prefix: prefix, message: message, file: file,
-    line: line)
+  if _isDebugAssertConfiguration() {
+    _embeddedReportFatalErrorInFile(prefix: prefix, message: message,
+      file: file, line: line)
+  }
 #endif
   Builtin.int_trap()
 }
@@ -186,7 +188,9 @@ internal func _assertionFailure(
   _ prefix: StaticString, _ message: StaticString,
   flags: UInt32
 ) -> Never {
-  _embeddedReportFatalError(prefix: prefix, message: message)
+  if _isDebugAssertConfiguration() {
+    _embeddedReportFatalError(prefix: prefix, message: message)
+  }
 
   Builtin.int_trap()
 }


### PR DESCRIPTION
See <https://github.com/apple/swift/pull/72817>. Turns out these are more codepaths that end up calling `_assertionFailure`, so let's conditionalize printing (in Embedded Swift) to the debug assert config directly inside`_assertionFailure`.