### PR TITLE
[embedded] Use 'REQUIRES: swift_test_mode_optimize_none' in executable trap tests

### DIFF
--- a/test/embedded/traps-fatalerror-exec.swift
+++ b/test/embedded/traps-fatalerror-exec.swift
@@ -20,6 +20,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
+// REQUIRES: swift_test_mode_optimize_none
 
 func test() {
      fatalError("task failed successfully")

--- a/test/embedded/traps-precondition-exec.swift
+++ b/test/embedded/traps-precondition-exec.swift
@@ -20,6 +20,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
+// REQUIRES: swift_test_mode_optimize_none
 
 func test(i: Int) {
      precondition(i == 0, "task failed successfully")

--- a/test/embedded/traps-preconditionfailure-exec.swift
+++ b/test/embedded/traps-preconditionfailure-exec.swift
@@ -20,6 +20,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
+// REQUIRES: swift_test_mode_optimize_none
 
 func test() {
      preconditionFailure("task failed successfully")


### PR DESCRIPTION
Fixes CI failure of these tests here: https://ci.swift.org/job/oss-swift_tools-RA_stdlib-RD_test-simulator/3808/

rdar://126242287
