### PR TITLE
[embedded] Re-enable executable trap tests on Linux

### DIFF
--- a/test/embedded/traps-fatalerror-exec.swift
+++ b/test/embedded/traps-fatalerror-exec.swift
@@ -19,7 +19,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_test_mode_optimize_none
 
 func test() {

--- a/test/embedded/traps-fatalerror-exec.swift
+++ b/test/embedded/traps-fatalerror-exec.swift
@@ -20,6 +20,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
+// REQUIRES: swift_test_mode_optimize_none
 
 func test() {
      fatalError("task failed successfully")

--- a/test/embedded/traps-precondition-exec.swift
+++ b/test/embedded/traps-precondition-exec.swift
@@ -20,6 +20,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
+// REQUIRES: swift_test_mode_optimize_none
 
 func test(i: Int) {
      precondition(i == 0, "task failed successfully")

--- a/test/embedded/traps-precondition-exec.swift
+++ b/test/embedded/traps-precondition-exec.swift
@@ -19,7 +19,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_test_mode_optimize_none
 
 func test(i: Int) {

--- a/test/embedded/traps-preconditionfailure-exec.swift
+++ b/test/embedded/traps-preconditionfailure-exec.swift
@@ -20,6 +20,7 @@
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx
+// REQUIRES: swift_test_mode_optimize_none
 
 func test() {
      preconditionFailure("task failed successfully")

--- a/test/embedded/traps-preconditionfailure-exec.swift
+++ b/test/embedded/traps-preconditionfailure-exec.swift
@@ -19,7 +19,7 @@
 // REQUIRES: swift_in_compiler
 // REQUIRES: executable_test
 // REQUIRES: optimized_stdlib
-// REQUIRES: OS=macosx
+// REQUIRES: OS=macosx || OS=linux-gnu
 // REQUIRES: swift_test_mode_optimize_none
 
 func test() {


### PR DESCRIPTION
After <https://github.com/apple/swift/pull/72971>, they should pass now.