### PR TITLE
[embedded][wasm] Fix missing putchar symbol in test 

### DIFF
--- a/stdlib/public/core/EmbeddedPrint.swift
+++ b/stdlib/public/core/EmbeddedPrint.swift
@@ -16,7 +16,7 @@ import SwiftShims
 // embedded Swift, in an embedded-programming friendly way (we mainly need
 // printing to not need to heap allocate).
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/array-to-pointer.swift
+++ b/test/embedded/array-to-pointer.swift
@@ -9,7 +9,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/arrays.swift
+++ b/test/embedded/arrays.swift
@@ -9,7 +9,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/classes-wasm.swift
+++ b/test/embedded/classes-wasm.swift
@@ -13,6 +13,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+int putchar(int c) { return c; }
 void free(void *ptr) {}
 
 int posix_memalign(void **memptr, size_t alignment, size_t size) {

--- a/test/embedded/collection.swift
+++ b/test/embedded/collection.swift
@@ -9,7 +9,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/custom-print.swift
+++ b/test/embedded/custom-print.swift
@@ -7,7 +7,7 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/dependencies-no-allocations.swift
+++ b/test/embedded/dependencies-no-allocations.swift
@@ -26,7 +26,7 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/dependencies-random.swift
+++ b/test/embedded/dependencies-random.swift
@@ -32,7 +32,7 @@
 
 // REQUIRES: rdar121923818
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/dependencies.swift
+++ b/test/embedded/dependencies.swift
@@ -28,7 +28,7 @@
 // REQUIRES: OS=macosx || OS=linux-gnu
 // UNSUPPORTED: OS=linux-gnu && CPU=aarch64
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/deserialize-vtables.swift
+++ b/test/embedded/deserialize-vtables.swift
@@ -21,7 +21,7 @@ extension StaticString {
     }
 }
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/lto.swift
+++ b/test/embedded/lto.swift
@@ -12,7 +12,7 @@
 // loaded too late").
 // REQUIRES: no_asan
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/modules-globals-exec.swift
+++ b/test/embedded/modules-globals-exec.swift
@@ -24,7 +24,7 @@ public func foo() {
 
 import MyModule
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/modules-print-exec.swift
+++ b/test/embedded/modules-print-exec.swift
@@ -13,7 +13,7 @@
 
 // BEGIN MyModule.swift
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/runtime.swift
+++ b/test/embedded/runtime.swift
@@ -7,7 +7,7 @@
 // REQUIRES: optimized_stdlib
 // REQUIRES: OS=macosx || OS=linux-gnu
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/test/embedded/volatile-exec.swift
+++ b/test/embedded/volatile-exec.swift
@@ -7,7 +7,7 @@
 
 import _Volatile
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 @discardableResult
 func putchar(_: CInt) -> CInt
 

--- a/validation-test/stdlib/MicroStdlib/Inputs/Swift.swift
+++ b/validation-test/stdlib/MicroStdlib/Inputs/Swift.swift
@@ -84,7 +84,7 @@ public struct UnsafeMutablePointer<T> {
 public typealias CInt = Int32
 public typealias CChar = Int8
 
-@_silgen_name("putchar")
+@_extern(c, "putchar")
 public func putchar(_: CChar)
 
 public func printHello() {


### PR DESCRIPTION
Baremetal Wasm targets do not have stdio, so we need to provide a stub putchar. Also use `@_extern(c)` instead of `@_silgen_name` for putchar to fix signature mismatch