### PR TITLE
[6.0] Implement proper visibility rules for imported extensions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -165,6 +165,12 @@ ERROR(init_candidate_inaccessible,none,
       "'%select{private|fileprivate|internal|package|@_spi|@_spi}1' protection level",
       (Type, AccessLevel))
 
+ERROR(candidate_from_missing_import,none,
+      "%0 %1 is not available due to missing import of defining module %2",
+      (DescriptiveDeclKind, DeclName, DeclName))
+NOTE(candidate_add_import,none,
+     "add import of module %0", (DeclName))
+
 ERROR(cannot_pass_rvalue_mutating_subelement,none,
       "cannot use mutating member on immutable value: %0",
       (StringRef))

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -628,6 +628,15 @@ SelfBounds getSelfBoundsFromWhereClause(
 /// given protocol or protocol extension.
 SelfBounds getSelfBoundsFromGenericSignature(const ExtensionDecl *extDecl);
 
+/// Determine whether the given declaration is visible to name lookup when
+/// found from the given module scope context.
+///
+/// Note that this routine does not check ASTContext::isAccessControlDisabled();
+/// that's left for the caller.
+bool declIsVisibleToNameLookup(
+    const ValueDecl *decl, const DeclContext *moduleScopeContext,
+    NLOptions options);
+
 namespace namelookup {
 
 /// The bridge between the legacy UnqualifiedLookupFactory and the new ASTScope

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -418,6 +418,11 @@ public:
     ImportedUnderlyingModule = module;
   }
 
+  /// Finds the import declaration that effectively imports a given module in
+  /// this source file.
+  std::optional<AttributedImport<ImportedModule>>
+  findImport(const ModuleDecl *mod) const;
+
   /// Whether the given import has used @preconcurrency.
   bool hasImportUsedPreconcurrency(
       AttributedImport<ImportedModule> import) const;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4845,6 +4845,27 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Finds the import declaration that effectively imports a given module in a
+/// source file.
+class ImportDeclRequest
+    : public SimpleRequest<ImportDeclRequest,
+                           std::optional<AttributedImport<ImportedModule>>(
+                               const SourceFile *sf, const ModuleDecl *mod),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  std::optional<AttributedImport<ImportedModule>>
+  evaluate(Evaluator &evaluator, const SourceFile *sf,
+           const ModuleDecl *mod) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 #define SWIFT_TYPEID_ZONE TypeChecker
 #define SWIFT_TYPEID_HEADER "swift/AST/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -562,4 +562,7 @@ SWIFT_REQUEST(TypeChecker, LocalTypeDeclsRequest,
 SWIFT_REQUEST(TypeChecker, ObjCRequirementMapRequest,
               ObjCRequirementMap(const ProtocolDecl *proto),
               Cached, NoLocationInfo)
-
+SWIFT_REQUEST(TypeChecker, ImportDeclRequest,
+              std::optional<AttributedImport<ImportedModule>>(
+                  const SourceFile *sf, const ModuleDecl *mod),
+              Cached, NoLocationInfo)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -365,7 +365,7 @@ EXPERIMENTAL_FEATURE(ClosureIsolation, true)
 CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedAny, true)
 
 // Whether members of extensions respect the enclosing file's imports.
-EXPERIMENTAL_FEATURE(ExtensionImportVisibility, true)
+EXPERIMENTAL_FEATURE_EXCLUDED_FROM_MODULE_INTERFACE(ExtensionImportVisibility, true)
 
 // Alias for IsolatedAny
 EXPERIMENTAL_FEATURE(IsolatedAny2, true)

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -364,6 +364,9 @@ EXPERIMENTAL_FEATURE(ClosureIsolation, true)
 // Enable isolated(any) attribute on function types.
 CONDITIONALLY_SUPPRESSIBLE_EXPERIMENTAL_FEATURE(IsolatedAny, true)
 
+// Whether members of extensions respect the enclosing file's imports.
+EXPERIMENTAL_FEATURE(ExtensionImportVisibility, true)
+
 // Alias for IsolatedAny
 EXPERIMENTAL_FEATURE(IsolatedAny2, true)
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3853,24 +3853,7 @@ ValueDecl::findImport(const DeclContext *fromDC) {
   if (!fromSourceFile)
     return std::nullopt;
 
-  // Look to see if the owning module was directly imported.
-  for (const auto &import : fromSourceFile->getImports()) {
-    if (import.module.importedModule == module)
-      return import;
-  }
-
-  // Now look for transitive imports.
-  auto &importCache = getASTContext().getImportCache();
-  for (const auto &import : fromSourceFile->getImports()) {
-    auto &importSet = importCache.getImportSet(import.module.importedModule);
-    for (const auto &transitive : importSet.getTransitiveImports()) {
-      if (transitive.importedModule == module) {
-        return import;
-      }
-    }
-  }
-
-  return std::nullopt;
+  return fromSourceFile->findImport(module);
 }
 
 bool ValueDecl::isProtocolRequirement() const {

--- a/lib/AST/FeatureSet.cpp
+++ b/lib/AST/FeatureSet.cpp
@@ -682,6 +682,7 @@ static bool usesFeatureIsolatedAny(Decl *decl) {
   });
 }
 
+UNINTERESTING_FEATURE(ExtensionImportVisibility)
 UNINTERESTING_FEATURE(IsolatedAny2)
 
 UNINTERESTING_FEATURE(ObjCImplementation)

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2580,6 +2580,38 @@ SourceFile::setImports(ArrayRef<AttributedImport<ImportedModule>> imports) {
   Imports = getASTContext().AllocateCopy(imports);
 }
 
+std::optional<AttributedImport<ImportedModule>>
+SourceFile::findImport(const ModuleDecl *module) const {
+  return evaluateOrDefault(getASTContext().evaluator,
+                           ImportDeclRequest{this, module}, std::nullopt);
+}
+
+std::optional<AttributedImport<ImportedModule>>
+ImportDeclRequest::evaluate(Evaluator &evaluator, const SourceFile *sf,
+                            const ModuleDecl *module) const {
+  auto &ctx = sf->getASTContext();
+  auto imports = sf->getImports();
+
+  // Look to see if the owning module was directly imported.
+  for (const auto &import : imports) {
+    if (import.module.importedModule == module)
+      return import;
+  }
+
+  // Now look for transitive imports.
+  auto &importCache = ctx.getImportCache();
+  for (const auto &import : imports) {
+    auto &importSet = importCache.getImportSet(import.module.importedModule);
+    for (const auto &transitive : importSet.getTransitiveImports()) {
+      if (transitive.importedModule == module) {
+        return import;
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
 bool SourceFile::hasImportUsedPreconcurrency(
     AttributedImport<ImportedModule> import) const {
   return PreconcurrencyImportsUsed.count(import) != 0;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6188,49 +6188,60 @@ bool InaccessibleMemberFailure::diagnoseAsError() {
   auto loc = nameLoc.isValid() ? nameLoc.getStartLoc() : ::getLoc(anchor);
   auto accessLevel = Member->getFormalAccessScope().accessLevelForDiagnostics();
   bool suppressDeclHereNote = false;
-  if (accessLevel == AccessLevel::Public) {
+  if (accessLevel == AccessLevel::Public &&
+      !Member->findImport(getDC())) {
     auto definingModule = Member->getDeclContext()->getParentModule();
     emitDiagnosticAt(loc, diag::candidate_from_missing_import,
                      Member->getDescriptiveKind(), Member->getName(),
                      definingModule->getName());
 
-    if (auto enclosingSF = getDC()->getParentSourceFile()) {
-      SourceLoc bestLoc;
-      SourceManager &srcMgr = Member->getASTContext().SourceMgr;
-      for (auto item : enclosingSF->getTopLevelItems()) {
-        // If we found an import declaration, we want to insert after it.
-        if (auto importDecl =
-                dyn_cast_or_null<ImportDecl>(item.dyn_cast<Decl *>())) {
-          SourceLoc loc = importDecl->getEndLoc();
-          if (loc.isValid()) {
-            bestLoc = Lexer::getLocForEndOfLine(srcMgr, loc);
-          }
-
-          // Keep looking for more import declarations.
-          continue;
-        }
-
-        // If we got a location based on import declarations, we're done.
-        if (bestLoc.isValid())
-          break;
-        
-        // For any other item, we want to insert before it.
-        SourceLoc loc = item.getStartLoc();
+    auto enclosingSF = getDC()->getParentSourceFile();
+    SourceLoc bestLoc;
+    SourceManager &srcMgr = Member->getASTContext().SourceMgr;
+    for (auto item : enclosingSF->getTopLevelItems()) {
+      // If we found an import declaration, we want to insert after it.
+      if (auto importDecl =
+              dyn_cast_or_null<ImportDecl>(item.dyn_cast<Decl *>())) {
+        SourceLoc loc = importDecl->getEndLoc();
         if (loc.isValid()) {
-          bestLoc = Lexer::getLocForStartOfLine(srcMgr, loc);
-          break;
+          bestLoc = Lexer::getLocForEndOfLine(srcMgr, loc);
+        }
+
+        // Keep looking for more import declarations.
+        continue;
+      }
+
+      // If we got a location based on import declarations, we're done.
+      if (bestLoc.isValid())
+        break;
+
+      // For any other item, we want to insert before it.
+      SourceLoc loc = item.getStartLoc();
+      if (loc.isValid()) {
+        bestLoc = Lexer::getLocForStartOfLine(srcMgr, loc);
+        break;
+      }
+    }
+
+    if (bestLoc.isValid()) {
+      llvm::SmallString<64> importText;
+
+      // @_spi imports.
+      if (Member->isSPI()) {
+        auto spiGroups = Member->getSPIGroups();
+        if (!spiGroups.empty()) {
+          importText += "@_spi(";
+          importText += spiGroups[0].str();
+          importText += ") ";
         }
       }
 
-      if (bestLoc.isValid()) {
-        llvm::SmallString<64> importText;
-        importText += "import ";
-        importText += definingModule->getName().str();
-        importText += "\n";
-        emitDiagnosticAt(bestLoc, diag::candidate_add_import,
-                         definingModule->getName())
-          .fixItInsert(bestLoc, importText);
-      }
+      importText += "import ";
+      importText += definingModule->getName().str();
+      importText += "\n";
+      emitDiagnosticAt(bestLoc, diag::candidate_add_import,
+                       definingModule->getName())
+        .fixItInsert(bestLoc, importText);
     }
 
     suppressDeclHereNote = true;
@@ -6244,7 +6255,8 @@ bool InaccessibleMemberFailure::diagnoseAsError() {
         .highlight(nameLoc.getSourceRange());
   }
 
-  emitDiagnosticAt(Member, diag::decl_declared_here, Member);
+  if (!suppressDeclHereNote)
+    emitDiagnosticAt(Member, diag::decl_declared_here, Member);
   return true;
 }
 

--- a/stdlib/cmake/modules/SwiftSource.cmake
+++ b/stdlib/cmake/modules/SwiftSource.cmake
@@ -628,6 +628,8 @@ function(_compile_swift_files
     list(APPEND swift_flags "-enable-experimental-feature" "NonescapableTypes")
   endif()
 
+  list(APPEND swift_flags "-enable-experimental-feature" "ExtensionImportVisiblity")
+
   if (SWIFT_STDLIB_ENABLE_STRICT_CONCURRENCY_COMPLETE)
     list(APPEND swift_flags "-strict-concurrency=complete")
   endif()

--- a/test/NameLookup/Inputs/Categories/Categories_A.h
+++ b/test/NameLookup/Inputs/Categories/Categories_A.h
@@ -1,0 +1,8 @@
+@import Foundation;
+
+@interface X
+@end
+
+@interface X (A)
+- (void)fromA;
+@end

--- a/test/NameLookup/Inputs/Categories/Categories_A.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_A.swift
@@ -1,0 +1,6 @@
+@_exported import Categories_A
+
+extension X {
+  public func fromOverlayForA() {}
+  @objc public func fromOverlayForAObjC() {}
+}

--- a/test/NameLookup/Inputs/Categories/Categories_B.h
+++ b/test/NameLookup/Inputs/Categories/Categories_B.h
@@ -1,0 +1,5 @@
+@import Categories_A;
+
+@interface X (B)
+- (void)fromB;
+@end

--- a/test/NameLookup/Inputs/Categories/Categories_B.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_B.swift
@@ -1,0 +1,6 @@
+@_exported import Categories_B
+
+extension X {
+  public func fromOverlayForB() {}
+  @objc public func fromOverlayForBObjC() {}
+}

--- a/test/NameLookup/Inputs/Categories/Categories_C.h
+++ b/test/NameLookup/Inputs/Categories/Categories_C.h
@@ -1,0 +1,5 @@
+@import Categories_A;
+
+@interface X (C)
+- (void)fromC;
+@end

--- a/test/NameLookup/Inputs/Categories/Categories_C.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_C.swift
@@ -1,0 +1,6 @@
+@_exported import Categories_C
+
+extension X {
+  public func fromOverlayForC() {}
+  @objc public func fromOverlayForCObjC() {}
+}

--- a/test/NameLookup/Inputs/Categories/Categories_D.h
+++ b/test/NameLookup/Inputs/Categories/Categories_D.h
@@ -1,0 +1,1 @@
+// Intentionally empty

--- a/test/NameLookup/Inputs/Categories/Categories_D.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_D.swift
@@ -1,1 +1,0 @@
-import Categories_C

--- a/test/NameLookup/Inputs/Categories/Categories_D.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_D.swift
@@ -1,0 +1,1 @@
+import Categories_C

--- a/test/NameLookup/Inputs/Categories/Categories_E.swift
+++ b/test/NameLookup/Inputs/Categories/Categories_E.swift
@@ -1,0 +1,2 @@
+import Categories_C
+import Categories_D.Submodule

--- a/test/NameLookup/Inputs/Categories/Submodule.h
+++ b/test/NameLookup/Inputs/Categories/Submodule.h
@@ -1,0 +1,5 @@
+@import Categories_A;
+
+@interface X (SubmoduleOfD)
+- (void)fromSubmoduleOfD;
+@end

--- a/test/NameLookup/Inputs/Categories/module.modulemap
+++ b/test/NameLookup/Inputs/Categories/module.modulemap
@@ -1,0 +1,14 @@
+module Categories_A {
+  header "Categories_A.h"
+  export *
+}
+
+module Categories_B {
+  header "Categories_B.h"
+  export *
+}
+
+module Categories_C {
+  header "Categories_C.h"
+  export *
+}

--- a/test/NameLookup/Inputs/Categories/module.modulemap
+++ b/test/NameLookup/Inputs/Categories/module.modulemap
@@ -12,3 +12,14 @@ module Categories_C {
   header "Categories_C.h"
   export *
 }
+
+module Categories_D {
+  header "Categories_D.h"
+  export *
+
+  explicit module Submodule {
+    header "Submodule.h"
+    export *
+  }
+}
+

--- a/test/NameLookup/Inputs/extensions_A.swift
+++ b/test/NameLookup/Inputs/extensions_A.swift
@@ -8,10 +8,18 @@ extension Y: P where T: P { }
 
 public struct Z: P { }
 
+infix operator <<<
+infix operator >>>
+infix operator <>
+
 extension X {
   public func XinA() { }
+
+  public static func <<<(a: Self, b: Self) -> Self { a }
 }
 
 extension Y {
   public func YinA() { }
+
+  public static func <<<(a: Self, b: Self) -> Self { a }
 }

--- a/test/NameLookup/Inputs/extensions_A.swift
+++ b/test/NameLookup/Inputs/extensions_A.swift
@@ -1,0 +1,9 @@
+public struct X { }
+
+public protocol P { }
+
+public struct Y<T> { }
+
+extension Y: P where T: P { }
+
+public struct Z: P { }

--- a/test/NameLookup/Inputs/extensions_A.swift
+++ b/test/NameLookup/Inputs/extensions_A.swift
@@ -7,3 +7,11 @@ public struct Y<T> { }
 extension Y: P where T: P { }
 
 public struct Z: P { }
+
+extension X {
+  public func XinA() { }
+}
+
+extension Y {
+  public func YinA() { }
+}

--- a/test/NameLookup/Inputs/extensions_B.swift
+++ b/test/NameLookup/Inputs/extensions_B.swift
@@ -1,0 +1,10 @@
+import extensions_A
+
+public extension X {
+  public func XinB() { }
+}
+
+public extension Y {
+  public func YinB() { }
+}
+

--- a/test/NameLookup/Inputs/extensions_B.swift
+++ b/test/NameLookup/Inputs/extensions_B.swift
@@ -1,10 +1,10 @@
 import extensions_A
 
-public extension X {
+extension X {
   public func XinB() { }
 }
 
-public extension Y {
+extension Y {
   public func YinB() { }
 }
 

--- a/test/NameLookup/Inputs/extensions_B.swift
+++ b/test/NameLookup/Inputs/extensions_B.swift
@@ -1,10 +1,15 @@
 import extensions_A
 
+
 extension X {
   public func XinB() { }
+
+  public static func >>>(a: Self, b: Self) -> Self { b }
 }
 
 extension Y {
   public func YinB() { }
+
+  public static func >>>(a: Self, b: Self) -> Self { b }
 }
 

--- a/test/NameLookup/Inputs/extensions_C.swift
+++ b/test/NameLookup/Inputs/extensions_C.swift
@@ -1,11 +1,15 @@
 @_exported import extensions_A
 import extensions_B
 
+
 extension X {
   public func XinC() { }
+
+  public static func <>(a: Self, b: Self) -> Self { a }
 }
 
 extension Y {
   public func YinC() { }
-}
 
+  public static func <>(a: Self, b: Self) -> Self { a }
+}

--- a/test/NameLookup/Inputs/extensions_C.swift
+++ b/test/NameLookup/Inputs/extensions_C.swift
@@ -1,0 +1,11 @@
+import extensions_A
+import extensions_B
+
+public extension X {
+  public func XinC() { }
+}
+
+public extension Y {
+  public func YinC() { }
+}
+

--- a/test/NameLookup/Inputs/extensions_C.swift
+++ b/test/NameLookup/Inputs/extensions_C.swift
@@ -1,4 +1,4 @@
-import extensions_A
+@_exported import extensions_A
 import extensions_B
 
 extension X {

--- a/test/NameLookup/Inputs/extensions_C.swift
+++ b/test/NameLookup/Inputs/extensions_C.swift
@@ -1,11 +1,11 @@
 import extensions_A
 import extensions_B
 
-public extension X {
+extension X {
   public func XinC() { }
 }
 
-public extension Y {
+extension Y {
   public func YinC() { }
 }
 

--- a/test/NameLookup/extensions_transitive.swift
+++ b/test/NameLookup/extensions_transitive.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/extensions_A.swift
+// RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/extensions_B.swift
+// RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/extensions_C.swift
+// RUN: %target-swift-frontend -typecheck %s -I %t -verify -enable-experimental-feature ExtensionImportVisibility
+
+import extensions_A
+import extensions_C
+// expected-note 2{{add import of module 'extensions_B'}}{{1-1=import extensions_B\n}}
+func test(x: X, y: Y<Z>) {
+  x.XinB() // expected-error{{instance method 'XinB()' is not available due to missing import of defining module 'extensions_B'}}
+  y.YinB() // expected-error{{instance method 'YinB()' is not available due to missing import of defining module 'extensions_B'}}
+
+  x.XinC()
+  y.YinC()
+}

--- a/test/NameLookup/extensions_transitive.swift
+++ b/test/NameLookup/extensions_transitive.swift
@@ -4,10 +4,12 @@
 // RUN: %target-swift-frontend -emit-module -I %t -o %t %S/Inputs/extensions_C.swift
 // RUN: %target-swift-frontend -typecheck %s -I %t -verify -enable-experimental-feature ExtensionImportVisibility
 
-import extensions_A
 import extensions_C
 // expected-note 2{{add import of module 'extensions_B'}}{{1-1=import extensions_B\n}}
 func test(x: X, y: Y<Z>) {
+  x.XinA()
+  y.YinA()
+
   x.XinB() // expected-error{{instance method 'XinB()' is not available due to missing import of defining module 'extensions_B'}}
   y.YinB() // expected-error{{instance method 'YinB()' is not available due to missing import of defining module 'extensions_B'}}
 

--- a/test/NameLookup/extensions_transitive.swift
+++ b/test/NameLookup/extensions_transitive.swift
@@ -7,12 +7,21 @@
 import extensions_C
 // expected-note 2{{add import of module 'extensions_B'}}{{1-1=import extensions_B\n}}
 func test(x: X, y: Y<Z>) {
+  // Declared in extensions_A
   x.XinA()
   y.YinA()
+  _ = x <<< x
+  _ = y <<< y
 
+  // Declared in extensions_B
   x.XinB() // expected-error{{instance method 'XinB()' is not available due to missing import of defining module 'extensions_B'}}
   y.YinB() // expected-error{{instance method 'YinB()' is not available due to missing import of defining module 'extensions_B'}}
+  _ = x >>> x // expected-error{{cannot find operator '>>>' in scope}}
+  _ = y >>> y // expected-error{{cannot find operator '>>>' in scope}}
 
+  // Declared in extensions_C
   x.XinC()
   y.YinC()
+  _ = x <> x
+  _ = y <> y
 }

--- a/test/NameLookup/extensions_transitive_objc.swift
+++ b/test/NameLookup/extensions_transitive_objc.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_A.swift
+// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_B.swift
+// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_C.swift
+// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_D.swift
+// RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/Categories -verify -enable-experimental-feature ExtensionImportVisibility
+
+// REQUIRES: objc_interop
+
+import Categories_B
+import Categories_D
+// expected-note 2 {{add import of module 'Categories_C'}}{{1-1=import Categories_C\n}}
+func test(x: X) {
+  x.fromA()
+  x.fromOverlayForA()
+  x.fromB()
+  x.fromOverlayForB()
+  x.fromC() // expected-error {{class method 'fromC()' is not available due to missing import of defining module 'Categories_C'}}
+  x.fromOverlayForC() // expected-error {{instance method 'fromOverlayForC()' is not available due to missing import of defining module 'Categories_C'}}
+}
+
+func testAnyObject(a: AnyObject) {
+  a.fromA()
+  a.fromOverlayForAObjC()
+  a.fromB()
+  a.fromOverlayForBObjC()
+  // FIXME: Better diagnostics?
+  // Name lookup for AnyObject already ignored transitive imports, so
+  // ExtensionImportVisibility has no effect on these diagnostics.
+  a.fromC() // expected-error {{value of type 'AnyObject' has no member 'fromC'}}
+  a.fromOverlayForCObjC() // expected-error {{value of type 'AnyObject' has no member 'fromOverlayForCObjC'}}
+}

--- a/test/NameLookup/extensions_transitive_objc.swift
+++ b/test/NameLookup/extensions_transitive_objc.swift
@@ -2,14 +2,16 @@
 // RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_A.swift
 // RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_B.swift
 // RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_C.swift
-// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_D.swift
+// RUN: %target-swift-frontend -emit-module -I %t -I %S/Inputs/Categories -o %t %S/Inputs/Categories/Categories_E.swift
 // RUN: %target-swift-frontend -typecheck %s -I %t -I %S/Inputs/Categories -verify -enable-experimental-feature ExtensionImportVisibility
 
 // REQUIRES: objc_interop
 
 import Categories_B
-import Categories_D
-// expected-note 2 {{add import of module 'Categories_C'}}{{1-1=import Categories_C\n}}
+import Categories_E
+
+// expected-note@-1 2 {{add import of module 'Categories_C'}}{{1-1=import Categories_C\n}}
+// expected-note@-2 {{add import of module 'Categories_D'}}{{1-1=import Categories_D\n}}
 func test(x: X) {
   x.fromA()
   x.fromOverlayForA()
@@ -17,6 +19,7 @@ func test(x: X) {
   x.fromOverlayForB()
   x.fromC() // expected-error {{class method 'fromC()' is not available due to missing import of defining module 'Categories_C'}}
   x.fromOverlayForC() // expected-error {{instance method 'fromOverlayForC()' is not available due to missing import of defining module 'Categories_C'}}
+  x.fromSubmoduleOfD() // expected-error {{class method 'fromSubmoduleOfD()' is not available due to missing import of defining module 'Categories_D'}}
 }
 
 func testAnyObject(a: AnyObject) {

--- a/test/SPI/client_reuse_spi.swift
+++ b/test/SPI/client_reuse_spi.swift
@@ -6,7 +6,7 @@
 // RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -DLIB_C %s -I %t
 
 #if LIB_A
-
+// expected-note@-1{{add import of module 'A'}}{{1-1=@_spi(A) import A\n}}
 @_spi(A) public struct SecretStruct {
   @_spi(A) public func bar() {}
 }
@@ -22,7 +22,7 @@
 @_spi(B) import B
 
 var a = foo() // OK
-a.bar() // expected-error{{'bar' is inaccessible due to '@_spi' protection level}}
+a.bar() // expected-error{{instance method 'bar()' is not available due to missing import of defining module 'A'}}
 
 var b = SecretStruct() // expected-error{{cannot find 'SecretStruct' in scope}}
 


### PR DESCRIPTION
- **Explanation:** If an extension isn't imported either directly or via a transitive (`@_exported`) import, its members should not be visible to name lookup. Implement this behavior behind the experimental flag `ExtensionImportVisibility`. This feature will be pitched on Swift Evolution as a potential source breaking change to make in a future language mode.
- **Scope:** This feature addresses a common pain point for Swift projects. Extension members declared in different modules can sometimes conflict, and without the control that this feature affords it can be difficult to resolve the conflict.
- **Issue/Radar:** rdar://16154294, https://github.com/apple/swift/issues/46493
- **Original PRs:** https://github.com/apple/swift/pull/72060, https://github.com/apple/swift/pull/72871, https://github.com/apple/swift/pull/72969
- **Risk:** Low. The new behavior is gated behind an experimental feature flag.
- **Testing:** New tests added that exercise behavior with the experimental feature enabled.
- **Reviewer:** @DougGregor 