### PR TITLE
[CodeCompletion] Parse multiple `catch` clauses if the `do` body contains the code completion token

### DIFF
--- a/test/IDE/complete_do_with_multiple_catch_in_closure.swift
+++ b/test/IDE/complete_do_with_multiple_catch_in_closure.swift
@@ -1,0 +1,15 @@
+// RUN: %batch-code-completion
+
+func takeClosure(_ body: () -> Void) {}
+
+func test() {
+  let myVar = 1
+  takeClosure {
+    do {
+      #^COMPLETE^#
+// COMPLETE: Decl[LocalVar]/Local: myVar[#Int#];
+    } catch let error as Int {
+    } catch let error {
+    }
+  }
+}


### PR DESCRIPTION
* **Explanation**: If a `do` statement’s body contained a code completion token, we would only parse a single `catch` clause for it, which would leave the second catch clause to be parsed as a standalone pattern without an initializer. Such a standalone pattern can cause type checking of closures to fail, resulting in no code completion results inside the `do` body.
* **Scope**: Parsing of `do` statements with a code completion token in the `do` body and multiple catch clauses
* **Risk**: Low, only affects code completion
* **Testing**: Added test case
* **Issue**: rdar://125303959
* **Reviewer**:  @rintaro and @hamishknight on https://github.com/apple/swift/pull/72910