### PR TITLE
[6.0][Runtime] Allow disabling/enabling prespecializations library per-process.

### DIFF
--- a/include/swift/Runtime/LibPrespecialized.h
+++ b/include/swift/Runtime/LibPrespecialized.h
@@ -31,9 +31,12 @@ struct LibPrespecializedData {
   uint32_t minorVersion;
 
   TargetPointer<Runtime, const void> metadataMap;
+  TargetPointer<Runtime, const void> disabledProcessesTable;
 
   static constexpr uint32_t currentMajorVersion = 1;
-  static constexpr uint32_t currentMinorVersion = 1;
+  static constexpr uint32_t currentMinorVersion = 2;
+
+  static constexpr uint32_t minorVersionWithDisabledProcessesTable = 2;
 
   // Helpers for retrieving the metadata map in-process.
   static bool stringIsNull(const char *str) { return str == nullptr; }
@@ -42,6 +45,12 @@ struct LibPrespecializedData {
 
   const MetadataMap *getMetadataMap() const {
     return reinterpret_cast<const MetadataMap *>(metadataMap);
+  }
+
+  const char *const *getDisabledProcessesTable() const {
+    if (minorVersion < minorVersionWithDisabledProcessesTable)
+      return nullptr;
+    return reinterpret_cast<const char *const *>(disabledProcessesTable);
   }
 };
 

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -92,9 +92,19 @@ VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED, bool, true,
          "Enable use of prespecializations library.")
 
 VARIABLE(SWIFT_DEBUG_LIB_PRESPECIALIZED_PATH, string, "",
-         "A path to a prespecializations library to use at runtime. In order to"
-         "be used, this library must be loaded into the process by other means"
-         "(such as DYLD_INSERT_LIBRARIES) before Swift tries to use it.")
+         "A path to a prespecializations library to use at runtime. In order "
+         "to be used, this library must be loaded into the process by other "
+         "means (such as DYLD_INSERT_LIBRARIES) before Swift tries to use it.")
+
+VARIABLE(SWIFT_DEBUG_LIB_PRESPECIALIZED_DISABLED_PROCESSES, string, "",
+         "A colon-separated list of process names where the prespecializations "
+         "library will be forcibly disabled.")
+
+VARIABLE(SWIFT_DEBUG_LIB_PRESPECIALIZED_ENABLED_PROCESSES, string, "",
+         "A colon-separated list of process names where the prespecializations "
+         "library will be forcibly enabled. This overrides the disabled "
+         "processes list in the prespecializations library, as well as the "
+         "list in SWIFT_DEBUG_LIB_PRESPECIALIZED_DISABLED_PROCESSES.")
 
 VARIABLE(SWIFT_DEBUG_ENABLE_LIB_PRESPECIALIZED_LOGGING, bool, false,
          "Enable debug logging of prespecializations library use.")


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/72958 to `release/6.0`.

Read a list of disabled process names from the prespecializations library, and turn the feature off if the current process matches. Also allow passing process names in environment variables. Processes can be disabled by name using SWIFT_DEBUG_LIB_PRESPECIALIZED_DISABLED_PROCESSES, and a disable can be overridden with SWIFT_DEBUG_LIB_PRESPECIALIZED_ENABLED_PROCESSES.

rdar://126216786